### PR TITLE
Fix bad include path for OSD headers.

### DIFF
--- a/pxr/imaging/lib/hd/codeGen.cpp
+++ b/pxr/imaging/lib/hd/codeGen.cpp
@@ -46,7 +46,7 @@
 
 #include <sstream>
 
-#include <opensubdiv3/osd/glslPatchShaderSource.h>
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,

--- a/pxr/imaging/lib/hd/subdivision3.cpp
+++ b/pxr/imaging/lib/hd/subdivision3.cpp
@@ -36,15 +36,15 @@
 
 #include "pxr/base/gf/vec4i.h"
 
-#include <opensubdiv3/version.h>
-#include <opensubdiv3/far/patchTable.h>
-#include <opensubdiv3/far/patchTableFactory.h>
-#include <opensubdiv3/far/stencilTable.h>
-#include <opensubdiv3/far/stencilTableFactory.h>
-#include <opensubdiv3/osd/cpuVertexBuffer.h>
-#include <opensubdiv3/osd/cpuEvaluator.h>
-#include <opensubdiv3/osd/glVertexBuffer.h>
-#include <opensubdiv3/osd/mesh.h>
+#include <opensubdiv/version.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/osd/cpuVertexBuffer.h>
+#include <opensubdiv/osd/cpuEvaluator.h>
+#include <opensubdiv/osd/glVertexBuffer.h>
+#include <opensubdiv/osd/mesh.h>
 
 #include <boost/scoped_ptr.hpp>
 
@@ -55,14 +55,14 @@ typedef OpenSubdiv::Osd::CpuVertexBuffer Hd_OsdCpuVertexBuffer;
 
 #if OPENSUBDIV_HAS_GLSL_COMPUTE
 
-#include <opensubdiv3/osd/glComputeEvaluator.h>
+#include <opensubdiv/osd/glComputeEvaluator.h>
 #define HD_ENABLE_GPU_SUBDIVISION 1
 typedef OpenSubdiv::Osd::GLStencilTableSSBO Hd_OsdGpuStencilTable;
 typedef OpenSubdiv::Osd::GLComputeEvaluator Hd_OsdGpuEvaluator;
 
 #elif OPENSUBDIV_HAS_GLSL_TRANSFORM_FEEDBACK
 
-#include <opensubdiv3/osd/glXFBEvaluator.h>
+#include <opensubdiv/osd/glXFBEvaluator.h>
 #define HD_ENABLE_GPU_SUBDIVISION 1
 typedef OpenSubdiv::Osd::GLStencilTableTBO Hd_OsdGpuStencilTable;
 typedef OpenSubdiv::Osd::GLXFBEvaluator Hd_OsdGpuEvaluator;

--- a/pxr/imaging/lib/pxOsd/refinerCache.cpp
+++ b/pxr/imaging/lib/pxOsd/refinerCache.cpp
@@ -24,10 +24,10 @@
 #include "pxr/imaging/pxOsd/refinerCache.h"
 #include "pxr/imaging/pxOsd/tokens.h"
 
-#include <opensubdiv3/far/stencilTable.h>
-#include <opensubdiv3/far/stencilTableFactory.h>
-#include <opensubdiv3/far/patchTable.h>
-#include <opensubdiv3/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/far/patchTableFactory.h>
 
 
 #include "pxr/base/tf/diagnostic.h"

--- a/pxr/imaging/lib/pxOsd/refinerCache.h
+++ b/pxr/imaging/lib/pxOsd/refinerCache.h
@@ -31,10 +31,10 @@
 #include "meshTopology.h"
 #include "refinerFactory.h"
 
-#include <opensubdiv3/far/stencilTable.h>
-#include <opensubdiv3/far/stencilTableFactory.h>
-#include <opensubdiv3/far/patchTable.h>
-#include <opensubdiv3/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/far/patchTableFactory.h>
 
 
 #include "pxr/base/tf/diagnostic.h"

--- a/pxr/imaging/lib/pxOsd/refinerFactory.cpp
+++ b/pxr/imaging/lib/pxOsd/refinerFactory.cpp
@@ -29,7 +29,7 @@
 #include "pxr/imaging/pxOsd/tokens.h"
 #include "pxr/base/tf/diagnostic.h"
 
-#include <opensubdiv3/far/topologyRefinerFactory.h>
+#include <opensubdiv/far/topologyRefinerFactory.h>
 
 #include <boost/bind.hpp>
 

--- a/pxr/imaging/lib/pxOsd/refinerFactory.h
+++ b/pxr/imaging/lib/pxOsd/refinerFactory.h
@@ -31,7 +31,7 @@
 #include "pxr/imaging/pxOsd/meshTopology.h"
 #include "pxr/base/vt/array.h"
 
-#include <opensubdiv3/far/topologyRefiner.h>
+#include <opensubdiv/far/topologyRefiner.h>
 #include <vector>
 
 typedef boost::shared_ptr<class OpenSubdiv::Far::TopologyRefiner> PxOsdTopologyRefinerSharedPtr;

--- a/pxr/imaging/lib/pxOsd/stencilPerVertex.cpp
+++ b/pxr/imaging/lib/pxOsd/stencilPerVertex.cpp
@@ -27,11 +27,11 @@
 #include "stencilPerVertex.h"
 #include "refinerCache.h"
 
-#include <opensubdiv3/far/stencilTable.h>
-#include <opensubdiv3/far/stencilTableFactory.h>
-#include <opensubdiv3/far/patchTable.h>
-#include <opensubdiv3/far/patchTableFactory.h>
-#include <opensubdiv3/far/ptexIndices.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/far/patchTableFactory.h>
+#include <opensubdiv/far/ptexIndices.h>
 
 #include "pxr/base/tracelite/trace.h"
 

--- a/pxr/imaging/lib/pxOsd/stencilPerVertex.h
+++ b/pxr/imaging/lib/pxOsd/stencilPerVertex.h
@@ -30,7 +30,7 @@
 #include "pxr/imaging/pxOsd/meshTopology.h"
 
 #include <boost/shared_ptr.hpp>
-#include <opensubdiv3/far/stencilTable.h>
+#include <opensubdiv/far/stencilTable.h>
 
 class PxOsdStencilPerVertex {
 public:    

--- a/pxr/imaging/lib/pxOsd/uniformEvaluator.cpp
+++ b/pxr/imaging/lib/pxOsd/uniformEvaluator.cpp
@@ -23,11 +23,11 @@
 //
 #include "uniformEvaluator.h"
 
-#include <opensubdiv3/far/stencilTable.h>
-#include <opensubdiv3/far/stencilTableFactory.h>
-#include <opensubdiv3/far/patchParam.h>
-#include <opensubdiv3/far/patchTable.h>
-#include <opensubdiv3/far/patchTableFactory.h>
+#include <opensubdiv/far/stencilTable.h>
+#include <opensubdiv/far/stencilTableFactory.h>
+#include <opensubdiv/far/patchParam.h>
+#include <opensubdiv/far/patchTable.h>
+#include <opensubdiv/far/patchTableFactory.h>
 
 #include <fstream>
 #include <iostream>

--- a/pxr/imaging/lib/pxOsd/uniformEvaluator.h
+++ b/pxr/imaging/lib/pxOsd/uniformEvaluator.h
@@ -28,7 +28,7 @@
 #include "pxr/imaging/pxOsd/refinerFactory.h"
 #include "pxr/imaging/pxOsd/tokens.h"
 
-#include <opensubdiv3/far/stencilTable.h>
+#include <opensubdiv/far/stencilTable.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Current (3.0.5) OSD build puts its headers into `<install_path>/include/opensubdiv`, not into `<install_path>/include/opensubdiv3`...

I guess this comes from dev env where you have several versions of OSD installed, but... not nice for common case. ;)