### PR TITLE
Python janitorial work

### DIFF
--- a/pxr/base/lib/gf/testenv/testGfFrustum.py
+++ b/pxr/base/lib/gf/testenv/testGfFrustum.py
@@ -56,8 +56,8 @@ class TestGfFrustum(unittest.TestCase):
     def test_Position(self):
         f1 = Gf.Frustum()
         f2 = Gf.Frustum()
-        f1.position = Gf.Vec3d(1, 0, 0);
-        f2.position = Gf.Vec3d(0, 1, 0);
+        f1.position = Gf.Vec3d(1, 0, 0)
+        f2.position = Gf.Vec3d(0, 1, 0)
         self.assertNotEqual(f1, f2)
 
     def test_Properties(self):
@@ -314,7 +314,7 @@ class TestGfFrustum(unittest.TestCase):
                             0.0, 4.2418940586972074, 0.0, 0.0,
                             0.0, 0.0, -1, -1.0,
                             0.0, 0.0, -20, 0.0)
-        viewProjMat = viewMat * projMat;
+        viewProjMat = viewMat * projMat
 
         # a typical box entirely in the view
         b = Gf.BBox3d( Gf.Range3d( Gf.Vec3d( 0, 0, 0 ), Gf.Vec3d( 1, 1, 1 ) ) )

--- a/pxr/base/lib/gf/testenv/testGfMatrix.py
+++ b/pxr/base/lib/gf/testenv/testGfMatrix.py
@@ -126,7 +126,7 @@ class TestGfMatrix(unittest.TestCase):
             v = Vec()
             for i in range(v.dimension):
                 v[i] = i
-            m1 = Matrix().SetDiagonal(v);
+            m1 = Matrix().SetDiagonal(v)
             m2 = Matrix(0)
             for i in range(m2.dimension[0]):
                 m2[i,i] = i

--- a/pxr/base/lib/gf/testenv/testGfRange.py
+++ b/pxr/base/lib/gf/testenv/testGfRange.py
@@ -52,9 +52,9 @@ class TestGfRange(unittest.TestCase):
 
             v = makeValue(Value, [1, 2, 3, 4])
             r = Range()
-            r.min = v;
+            r.min = v
             self.assertEqual(r.min, v)
-            r.max = v;
+            r.max = v
             self.assertEqual(r.max, v)
 
             r = Range()

--- a/pxr/base/lib/gf/testenv/testGfRay.py
+++ b/pxr/base/lib/gf/testenv/testGfRay.py
@@ -308,7 +308,7 @@ class TestGfRay(unittest.TestCase):
 
         # Ray behind cylinder, orthogonal to surface
         x = radius * (1 + random.uniform(epsilon, 1))
-        distance = x - radius;
+        distance = x - radius
         ray = Gf.Ray(Gf.Vec3d(-x, 0, 0), Gf.Vec3d().XAxis())
         (hit, enter, exit) = ray.Intersect(origin, axis, radius)
 
@@ -434,7 +434,7 @@ class TestGfRay(unittest.TestCase):
             self.assertAlmostEqual(exit, radius, delta=epsilon)
             
             # Ray behind cone, orthogonal to axis
-            distance = x - radius;
+            distance = x - radius
             ray = Gf.Ray(Gf.Vec3d(-x, 0, 0), Gf.Vec3d().XAxis())
             (hit, enter, exit) = ray.Intersect(origin, axis, radius, height)
 

--- a/pxr/base/lib/gf/testenv/testGfSize.py
+++ b/pxr/base/lib/gf/testenv/testGfSize.py
@@ -46,12 +46,12 @@ class TestGfSize(unittest.TestCase):
             if Size.dimension == 2:
                 self.assertIsInstance(Size(Gf.Vec2i()), Size)
                 self.assertIsInstance(Size(3, 4), Size)
-                s = Size();
+                s = Size()
                 self.assertEqual(s.Set(3,4), Size(3,4))
             elif Size.dimension == 3:
                 self.assertIsInstance(Size(Gf.Vec3i()), Size)
                 self.assertIsInstance(Size(3, 4, 5), Size)
-                s = Size();
+                s = Size()
                 self.assertEqual(s.Set(3,4,5), Size(3,4,5))
 
             s = makeValue(Size, (1,2,3))

--- a/pxr/base/lib/gf/testenv/testGfVec.py
+++ b/pxr/base/lib/gf/testenv/testGfVec.py
@@ -297,18 +297,18 @@ class TestGfVec(unittest.TestCase):
 
             # Normalize...
             SetVec( v1, [3, 1, 4, 1] )
-            v2 = Vec(v1);
+            v2 = Vec(v1)
             v2.Normalize()
             nv = Gf.GetNormalized( v1 )
             nv2 = v1.GetNormalized()
-            nvcheck = v1 / Gf.GetLength(v1);
+            nvcheck = v1 / Gf.GetLength(v1)
             self.assertTrue(Gf.IsClose(nv, nvcheck, eps))
             self.assertTrue(Gf.IsClose(nv2, nvcheck, eps))
             self.assertTrue(Gf.IsClose(v2, nvcheck, eps))
 
             SetVec( v1, [3, 1, 4, 1] )
             nv = v1.GetNormalized()
-            nvcheck = v1 / Gf.GetLength(v1);
+            nvcheck = v1 / Gf.GetLength(v1)
             self.assertEqual(nv, nvcheck)
 
             SetVec(v1, [0,0,0,0])
@@ -357,7 +357,7 @@ class TestGfVec(unittest.TestCase):
             for i in range(Vec.dimension):
                 v1 = Vec.Axis(i)
                 v2 = Vec()
-                v2[i] = 1;
+                v2[i] = 1
                 self.assertEqual(v1, v2)
 
             v1 = Vec.XAxis()

--- a/pxr/base/lib/plug/testPlug.py
+++ b/pxr/base/lib/plug/testPlug.py
@@ -252,24 +252,24 @@ class TestPlug(unittest.TestCase):
         # try to register a non-existent plugin path
         self.assertFalse(os.path.exists('/nowhere'))
         Plug.Registry().RegisterPlugins('/nowhere')
-        self.assertEqual(listener.numReceived, 0);
+        self.assertEqual(listener.numReceived, 0)
 
         # try to register an incomplete plugin
         badPluginPath = testPluginsDso + '/TestPlugDsoIncomplete.framework/Resources/'
         Plug.Registry().RegisterPlugins(badPluginPath)
-        self.assertEqual(listener.numReceived, 0);
+        self.assertEqual(listener.numReceived, 0)
 
         # try to register an incomplete python plugin path
         badPluginPath = testPluginsPython + '/TestPlugModuleIncomplete'
         Plug.Registry().RegisterPlugins(badPluginPath)
-        self.assertEqual(listener.numReceived, 0);
+        self.assertEqual(listener.numReceived, 0)
 
         # try to find a plugin for a Tf type which doesn't exist
         unknownPlug = None
         with self.assertRaises(RuntimeError):
             unknownPlug = Plug.Registry().GetPluginForType(Tf.Type.FindByName('Bad'))
         self.assertFalse(unknownPlug)
-        self.assertEqual(listener.numReceived, 0);
+        self.assertEqual(listener.numReceived, 0)
 
         # try to load an unloadable plugin
         badPlugin = Plug.Registry().GetPluginForType('TestPlugUnloadable')
@@ -318,4 +318,4 @@ class TestPlug(unittest.TestCase):
         Plug.Registry().RegisterPlugins(testPluginsDsoSearch)
         Plug.Registry().RegisterPlugins(testPluginsPythonSearch)
         self.assertEqual(allplugins, Plug.Registry().GetAllPlugins())
-        self.assertEqual(listener.numReceived, 0);
+        self.assertEqual(listener.numReceived, 0)

--- a/pxr/base/lib/tf/testenv/testTfPyDiagnosticNotices.py
+++ b/pxr/base/lib/tf/testenv/testTfPyDiagnosticNotices.py
@@ -96,24 +96,24 @@ class TestDiagnosticNotices(unittest.TestCase):
         self.log.info("Issuing a couple of different types of errors.")
 
         try:
-            Tf.RaiseRuntimeError("Runtime error!");
+            Tf.RaiseRuntimeError("Runtime error!")
             assert False, "expected exception"
         except Tf.ErrorException:
             pass
 
         try:
-            Tf.RaiseCodingError("Coding error!");
+            Tf.RaiseCodingError("Coding error!")
             assert False, "expected exception"
         except Tf.ErrorException:
             pass
 
         self.log.info("Issuing a few generic warnings.")
-        Tf.Warn("Warning 1");
-        Tf.Warn("Warning 2");
-        Tf.Warn("Warning 3");
+        Tf.Warn("Warning 1")
+        Tf.Warn("Warning 2")
+        Tf.Warn("Warning 3")
 
         self.log.info("Issuing a status message.")
-        Tf.Status("Status: Almost done testing.");
+        Tf.Status("Status: Almost done testing.")
 
         # Assert that two errors, three warnings and one status message were
         # issued.

--- a/pxr/base/lib/tf/testenv/testTfType.py
+++ b/pxr/base/lib/tf/testenv/testTfType.py
@@ -198,7 +198,7 @@ class TestTfType(unittest.TestCase):
     def test_PythonSubclassOfCppClass(self):
         class TestPyDerived( Tf.TestCppBase ):
             def TestVirtual(self):
-                return 123;
+                return 123
 
         tTestCppBase = Tf.Type.Find( Tf.TestCppBase )
         tTestPyDerived = Tf.Type.Define( TestPyDerived )

--- a/pxr/base/lib/vt/testenv/testVtArray.py
+++ b/pxr/base/lib/vt/testenv/testVtArray.py
@@ -106,7 +106,7 @@ class TestVtArray(unittest.TestCase):
         for start in range(-2, 7):
             for stop in range(-2, 7):
                 for step in range(-5, 6):
-                    if step == 0 : break;
+                    if step == 0 : break
                     sub_a = a[start:stop:step]
                     sub_l = l[start:stop:step]
                     self.assertEqual(len(a), len(l))

--- a/pxr/usd/bin/usdcat/usdcat.py
+++ b/pxr/usd/bin/usdcat/usdcat.py
@@ -25,7 +25,7 @@
 import argparse, sys, signal, os
 
 def _Err(msg):
-    sys.stderr.write(msg + '\n');
+    sys.stderr.write(msg + '\n')
 
 def GetUsdData(filePath):
     from pxr import Sdf

--- a/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
+++ b/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
@@ -201,4 +201,4 @@ class AttributeValueEditor(QtGui.QWidget):
 
     def _revertAll(self):
         self._revert(True)
-        
+

--- a/pxr/usdImaging/lib/usdviewq/attributeViewContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/attributeViewContextMenu.py
@@ -21,9 +21,8 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from PySide import QtGui
 from usdviewContextMenuItem import UsdviewContextMenuItem  
-import os
 
 #
 # Specialized context menu for running commands in the attribute viewer.

--- a/pxr/usdImaging/lib/usdviewq/common.py
+++ b/pxr/usdImaging/lib/usdviewq/common.py
@@ -61,7 +61,7 @@ NormalFont.setWeight(35)
 AbstractPrimFont = NormalFont
 
 # Keys for destinguishing items in the attribute inspector
-class AttributeStatus:
+class AttributeStatus(object):
     DEFAULT, CLAMPED, KEYFRAME, FALLBACK, NOVALUE = range(5)
 
 def PrintWarning(title, description):
@@ -121,7 +121,7 @@ def GetAttributeColor(attribute, frame, hasValue=None, hasAuthoredValue=None,
 
 # Gathers information about a layer used as a subLayer, including its
 # position in the layerStack hierarchy.
-class SubLayerInfo:
+class SubLayerInfo(object):
     def __init__(self, sublayer, offset, containingLayer, prefix):
         self.layer = sublayer
         self.offset = offset
@@ -183,7 +183,7 @@ def PrettyFormatSize(sz):
         return "%db" % sz
 
 
-class Timer:
+class Timer(object):
     """Use as a context object with python's "with" statement, like so:
        with Timer() as t:
            doSomeStuff()
@@ -204,7 +204,7 @@ class Timer:
         print "Time to %s: %2.3fs" % (action, self.interval)
         
 
-class BusyContext:
+class BusyContext(object):
     """When used as a context object with python's "with" statement,
     will set Qt's busy cursor upon entry and pop it on exit.
     """

--- a/pxr/usdImaging/lib/usdviewq/common.py
+++ b/pxr/usdImaging/lib/usdviewq/common.py
@@ -384,4 +384,3 @@ def DumpMallocTags(stage, contextStr):
         print "Unable to accumulate memory usage since the Pxr MallocTag system was not initialized"
 
         
-        

--- a/pxr/usdImaging/lib/usdviewq/customAttributes.py
+++ b/pxr/usdImaging/lib/usdviewq/customAttributes.py
@@ -21,10 +21,6 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
-from pxr import Tf
-from pxr import UsdGeom
-from datetime import datetime
 
 #
 # Edit the following to alter the set of custom attributes.

--- a/pxr/usdImaging/lib/usdviewq/customAttributes.py
+++ b/pxr/usdImaging/lib/usdviewq/customAttributes.py
@@ -46,18 +46,18 @@ def _GetCustomAttributes(currentNode, bboxCache, xformCache):
 #
 class CustomAttribute:
     def __init__(self, currentNode):
-    	self._currentNode = currentNode
+        self._currentNode = currentNode
 
     def IsVisible(self):
-	return True
+        return True
 
     # GetName function to match UsdAttribute API
     def GetName(self):
-    	return ""
+        return ""
 
     # Get function to match UsdAttribute API
     def Get(self, frame):
-	return ""
+        return ""
 
     # convenience function to make this look more like a UsdAttribute
     def GetTypeName(self):
@@ -74,16 +74,16 @@ class BoundingBoxAttribute(CustomAttribute):
         self._bboxCache = bboxCache
 
     def GetName(self):
-	return "World Bounding Box"
-	
+        return "World Bounding Box"
+
     def Get(self, frame):
-    	try:
+        try:
             bbox = self._bboxCache.ComputeWorldBound(self._currentNode)
             
         except RuntimeError, err:
-    	    bbox = "Invalid: " + str(err)
-	
-	return bbox
+            bbox = "Invalid: " + str(err)
+
+        return bbox
 
 #
 # Displays the Local to world xform of a node
@@ -96,15 +96,15 @@ class LocalToWorldXformAttribute(CustomAttribute):
         self._xformCache = xformCache
 
     def GetName(self):
-	return "Local to World Xform"
-	
+        return "Local to World Xform"
+
     def Get(self, frame):
-    	try:
-    	    pwt = self._xformCache.GetLocalToWorldTransform(self._currentNode)
-    	except RuntimeError, err:
-    	    pwt = "Invalid: " + str(err)
-	
-	return pwt
+        try:
+            pwt = self._xformCache.GetLocalToWorldTransform(self._currentNode)
+        except RuntimeError, err:
+            pwt = "Invalid: " + str(err)
+
+        return pwt
 
 # 
 # Displays a relationship on the node

--- a/pxr/usdImaging/lib/usdviewq/headerContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/headerContextMenu.py
@@ -33,7 +33,7 @@ class HeaderContextMenu(QtGui.QMenu):
     def __init__(self, parent):
         QtGui.QMenu.__init__(self, parent)
         self._menuItems = _GetContextMenuItems(parent)
-	
+
         for menuItem in self._menuItems:
             if menuItem.isValid():
                 # create menu actions

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -1270,7 +1270,7 @@ class MainWindow(QtGui.QMainWindow):
                 action = self._ui.menuRenderGraph.addAction(name)
                 action.setCheckable(True)
                 action.pluginType = pluginType
-                self._ui.renderGraphActionGroup.addAction(action);
+                self._ui.renderGraphActionGroup.addAction(action)
 
                 QtCore.QObject.connect(
                     action,
@@ -3094,7 +3094,7 @@ class MainWindow(QtGui.QMainWindow):
                 tableWidget.item(attributeCount,0).setSelected(True)
                 tableWidget.setCurrentItem(tableWidget.item(attributeCount, 0))
 
-            attributeCount += 1;
+            attributeCount += 1
 
         tableWidget.resizeColumnToContents(0)
 

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -2839,7 +2839,7 @@ class MainWindow(QtGui.QMainWindow):
         import re
         newPaths = self._ui.currentPathWidget.text()
         pathList = re.split(", ?", newPaths)
-	pathList = filter(lambda path: len(path) != 0, pathList)
+        pathList = filter(lambda path: len(path) != 0, pathList)
 
         itemList = []
         for primPath in pathList:

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -32,9 +32,7 @@ from attributeViewContextMenu import AttributeViewContextMenu
 from customAttributes import _GetCustomAttributes
 from nodeViewItem import NodeViewItem
 from pxr import Usd, UsdGeom, UsdUtils, UsdImaging
-from pxr import Gf
 from pxr import Glf
-from pxr import Pcp
 from pxr import Sdf
 from pxr import Tf
 from pxr import Plug
@@ -44,7 +42,7 @@ from ._usdviewq import Utils
 from collections import deque
 from collections import OrderedDict
 from time import time, sleep
-import re, sys, os, uuid, tempfile
+import re, sys, os
 
 import prettyPrint
 import watchWindow
@@ -52,9 +50,9 @@ import adjustClipping
 import referenceEditor
 from settings import Settings
 
-from common import FallbackTextColor, ClampedTextColor, KeyframeTextColor,\
-                   DefaultTextColor, HeaderColor, RedColor, BoldFont, \
-                   GetAttributeColor, Timer, BusyContext, DumpMallocTags
+from common import (FallbackTextColor, ClampedTextColor, KeyframeTextColor,
+                    DefaultTextColor, HeaderColor, RedColor, BoldFont,
+                    GetAttributeColor, Timer, BusyContext, DumpMallocTags)
 
 # Upper HUD entries (declared in variables for abstraction)
 PRIM = "Prims"
@@ -1087,11 +1085,6 @@ class MainWindow(QtGui.QMainWindow):
             return None
 
         if self._mallocTags != 'none':
-            if self._mallocTags == 'stageAndImaging':
-                # we want as little python overhead showing up as possible,
-                # so pre-import what we'll use in a bit before initializing
-                from pxr import UsdImaging
-            from pxr import Tf
             Tf.MallocTag.Initialize()
 
         with Timer() as t:

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -472,7 +472,7 @@ class MainWindow(QtGui.QMainWindow):
                             [str(a.text()) for a in
                                     self._ui.pickModeActionGroup.actions()]:
             print "Warning: Unknown pick mode '%s', falling back to '%s'" % (
-                        pickMode,
+                        self._stageView.pickMode,
                         str(self._ui.pickModeActionGroup.actions()[0].text()))
 
             self._ui.pickModeActionGroup.actions()[0].setChecked(True)

--- a/pxr/usdImaging/lib/usdviewq/nodeContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeContextMenu.py
@@ -21,8 +21,8 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
-from nodeContextMenuItems import NodeContextMenuItem, _GetContextMenuItems
+from PySide import QtGui
+from nodeContextMenuItems import _GetContextMenuItems
 
 #
 # Specialized context menu for node selection.

--- a/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
@@ -94,7 +94,7 @@ class JumpToEnclosingModelItem(NodeContextMenuItem):
 
     def IsEnabled(self):
         from common import GetEnclosingModelPrim
-	
+
         for p in self._currentNodes:
             if GetEnclosingModelPrim(p) is not None:
                 return True
@@ -102,7 +102,7 @@ class JumpToEnclosingModelItem(NodeContextMenuItem):
 
     def GetText(self):
         return "Jump to Enclosing Model"
-	
+
     def RunCommand(self):
         self._mainWindow.jumpToEnclosingModelSelectedPrims()
 
@@ -114,16 +114,16 @@ class JumpToBoundLookMenuItem(NodeContextMenuItem):
 
     def IsEnabled(self):
         from common import GetClosestBoundLook
-	
+
         for p in self._currentNodes:
             look, bound = GetClosestBoundLook(p)
             if look is not None:
                 return True
-	return False
+        return False
 
     def GetText(self):
         return "Jump to Bound Look"
-	
+
     def RunCommand(self):
         self._mainWindow.jumpToBoundLookSelectedPrims()
 
@@ -136,11 +136,11 @@ class JumpToMasterMenuItem(NodeContextMenuItem):
         for p in self._currentNodes:
             if p.IsInstance():
                 return True
-	return False
+        return False
 
     def GetText(self):
         return "Jump to Master"
-	
+
     def RunCommand(self):
         self._mainWindow.jumpToMasterSelectedPrims()
 
@@ -169,7 +169,7 @@ class ActiveMenuItem(NodeContextMenuItem):
 class ToggleVisibilityMenuItem(NodeContextMenuItem):
 
     def __init__(self, mainWindow, item):
-    	NodeContextMenuItem.__init__(self, mainWindow, item)
+        NodeContextMenuItem.__init__(self, mainWindow, item)
         from pxr import UsdGeom
         self._imageable = False
         self._isVisible = False
@@ -238,7 +238,7 @@ class RemoveVisMenuItem(NodeContextMenuItem):
 class LoadOrUnloadMenuItem(NodeContextMenuItem):
 
     def __init__(self, mainWindow, item):
-    	NodeContextMenuItem.__init__(self, mainWindow, item)
+        NodeContextMenuItem.__init__(self, mainWindow, item)
         from common import GetPrimsLoadability
         # Use the descendent-pruned selection set to avoid redundant
         # traversal of the stage to answer isLoaded...
@@ -267,14 +267,14 @@ class CopyPrimPathMenuItem(NodeContextMenuItem):
         if len(self._currentNodes) > 1:
             return "Copy Prim Paths"
         return "Copy Prim Path"
-	
+
     def RunCommand(self):
-	pathlist = [str(p.GetPath()) for p in self._currentNodes]
-	pathStrings = '\n'.join(pathlist)
+        pathlist = [str(p.GetPath()) for p in self._currentNodes]
+        pathStrings = '\n'.join(pathlist)
 
         cb = QtGui.QApplication.clipboard()
-	cb.setText(pathStrings, QtGui.QClipboard.Selection )
-	cb.setText(pathStrings, QtGui.QClipboard.Clipboard )
+        cb.setText(pathStrings, QtGui.QClipboard.Selection )
+        cb.setText(pathStrings, QtGui.QClipboard.Clipboard )
 
 #
 #  Copies the path of the first-selected prim's enclosing model
@@ -283,25 +283,25 @@ class CopyPrimPathMenuItem(NodeContextMenuItem):
 class CopyModelPathMenuItem(NodeContextMenuItem):
 
     def __init__(self, mainWindow, item):
-    	NodeContextMenuItem.__init__(self, mainWindow, item)
+        NodeContextMenuItem.__init__(self, mainWindow, item)
         from common import GetEnclosingModelPrim
-	
+
         self._modelPrim = GetEnclosingModelPrim(self._currentNodes[0]) if \
             len(self._currentNodes) == 1 else None
     
     def IsEnabled(self):
-	return self._modelPrim
+        return self._modelPrim
 
     def GetText(self):
         name = ( "(%s)" % self._modelPrim.GetName() ) if self._modelPrim else ""
         return "Copy Enclosing Model %s Path" % name
-	
+
     def RunCommand(self):
         modelPath = str(self._modelPrim.GetPath())
         cb = QtGui.QApplication.clipboard()
-	cb.setText(modelPath, QtGui.QClipboard.Selection )
-	cb.setText(modelPath, QtGui.QClipboard.Clipboard )
-    	
+        cb.setText(modelPath, QtGui.QClipboard.Selection )
+        cb.setText(modelPath, QtGui.QClipboard.Clipboard )
+
 
 
 #
@@ -315,32 +315,32 @@ class IsolateCopyNodeMenuItem(NodeContextMenuItem):
         return "Isolate Copy of Prim..."
 	
     def RunCommand(self):
-    	inFile = self._currentNodes[0].GetScene().GetUsdFile()
-	
-    	guessOutFile = os.getcwd() + "/" + self._currentNodes[0].GetName() + "_copy.usd"
+        inFile = self._currentNodes[0].GetScene().GetUsdFile()
+
+        guessOutFile = os.getcwd() + "/" + self._currentNodes[0].GetName() + "_copy.usd"
         (outFile, _) = QtGui.QFileDialog.getSaveFileName(None,
                                                          "Specify the Usd file to create",
                                                          guessOutFile,
                                                          'Usd files (*.usd)')
         if (outFile.rsplit('.')[-1] != 'usd'):
             outFile += '.usd'
-	
-	if inFile == outFile:
-	    sys.stderr.write( "Cannot isolate a copy to the source usd!\n" )
-    	    return
 
-    	sys.stdout.write( "Writing copy to new file '%s' ... " % outFile )
-	sys.stdout.flush()
-	
-    	os.system( 'usdcopy -inUsd ' + inFile +
-		   ' -outUsd ' + outFile + ' ' +
-		   ' -sourcePath ' + self._currentNodes[0].GetPath() + '; ' +
-		   'usdview ' + outFile + ' &')
-		   
-	sys.stdout.write( "Done!\n" )
-    	
+        if inFile == outFile:
+            sys.stderr.write( "Cannot isolate a copy to the source usd!\n" )
+            return
+
+        sys.stdout.write( "Writing copy to new file '%s' ... " % outFile )
+        sys.stdout.flush()
+
+        os.system( 'usdcopy -inUsd ' + inFile +
+                ' -outUsd ' + outFile + ' ' +
+                ' -sourcePath ' + self._currentNodes[0].GetPath() + '; ' +
+                'usdview ' + outFile + ' &')
+
+        sys.stdout.write( "Done!\n" )
+
     def IsEnabled(self):
-	return len(self._currentNodes) == 1 and self._currentNodes[0].GetActive()
+        return len(self._currentNodes) == 1 and self._currentNodes[0].GetActive()
 
 	
 #
@@ -350,8 +350,8 @@ class IsolateCopyNodeMenuItem(NodeContextMenuItem):
 class IsolateAssetMenuItem(NodeContextMenuItem):
 
     def __init__(self, mainWindow, item):
-    	NodeContextMenuItem.__init__(self, mainWindow, item)
-	
+        NodeContextMenuItem.__init__(self, mainWindow, item)
+
         self._assetName = None
         if len(self._currentNodes) == 1:
             from pxr import Usd
@@ -369,14 +369,13 @@ class IsolateAssetMenuItem(NodeContextMenuItem):
                     self._filePath = layer.realPath
     
     def IsEnabled(self):
-	return self._assetName
+        return self._assetName
 
     def GetText(self):
         name = ( " '%s'" % self._assetName ) if self._assetName else ""
         return "usdview asset%s" % name
-	
+
     def RunCommand(self):
         print "Spawning usdview %s" % self._filePath
         os.system("usdview %s &" % self._filePath)
 
-    	

--- a/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
@@ -21,11 +21,8 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
-from datetime import datetime
-from nodeViewItem import NodeViewItem
+from PySide import QtGui
 from usdviewContextMenuItem import UsdviewContextMenuItem
-from pxr import Tf
 import os
 import sys
 

--- a/pxr/usdImaging/lib/usdviewq/nodeViewItem.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeViewItem.py
@@ -176,8 +176,7 @@ class NodeViewItem(QtGui.QTreeWidgetItem):
             elif self.isInstance:
                 toolTip = 'Instanced ' + toolTip
             if self.hasArcs:
-                toolTip = toolTip + \
-                    "<br>Has composition arcs"
+                toolTip = toolTip + "<br>Has composition arcs"
             return toolTip
         else:
             return None

--- a/pxr/usdImaging/lib/usdviewq/prettyPrint.py
+++ b/pxr/usdImaging/lib/usdviewq/prettyPrint.py
@@ -26,7 +26,6 @@ Hopefully we can deprecate this since most of the array stuff is handled by the
 arrayAttributeView
 '''
 from PySide import QtGui
-from pxr import Gf
 
 def progressDialog(title, value):
     dialog = QtGui.QProgressDialog(title, "Cancel", 0, value)

--- a/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
+++ b/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
@@ -726,7 +726,7 @@ class View(QtGui.QTextEdit):
     def mouseDoubleClickEvent(self, e):
         self.Parent.mouseDoubleClickEvent(self, e)
         app = QtGui.QApplication.instance()
-        self.tripleClickTimer.start(app.doubleClickInterval(), self);
+        self.tripleClickTimer.start(app.doubleClickInterval(), self)
         # make a copy here, otherwise tripleClickPoint will always = globalPos
         self.tripleClickPoint = QtCore.QPoint(e.globalPos())
 

--- a/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
+++ b/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
@@ -637,6 +637,7 @@ class View(QtGui.QTextEdit):
     """
 
     def __init__(self, parent=None):
+        QtGui.QTextEdit.__init__(self, parent)
         self.Parent = QtGui.QTextEdit
         self.Parent.__init__(self, parent)
         self.promptLength = 0

--- a/pxr/usdImaging/lib/usdviewq/scalarTypes.py
+++ b/pxr/usdImaging/lib/usdviewq/scalarTypes.py
@@ -43,7 +43,6 @@ def ToString(v, typeName=None):
     This string is used in the watch window"""
 
     from pxr import Tf, Gf
-    import pprint
 
     if v is None:
         return 'None'

--- a/pxr/usdImaging/lib/usdviewq/scalarTypes.py
+++ b/pxr/usdImaging/lib/usdviewq/scalarTypes.py
@@ -22,10 +22,10 @@
 # language governing permissions and limitations under the Apache License.
 #
 def GetScalarTypeFromAttr(attr):
-    ''' 
+    '''
     returns the (scalar, isArray) where isArray is True if it was an array type
     '''
-    # Usd.Attribute and customAttributes.CustomAttribute have a 
+    # Usd.Attribute and customAttributes.CustomAttribute have a
     # GetTypeName function, while Sdf.AttributeSpec has a typeName attr.
     if hasattr(attr, 'GetTypeName'):
         typeName = attr.GetTypeName()
@@ -62,7 +62,7 @@ def ToString(v, typeName=None):
 
     # Pretty-print a bounding box
     if isinstance(v, Gf.BBox3d):
-        prettyMatrix = ("%s\n%s\n%s\n%s" % (v.matrix[0], v.matrix[1], 
+        prettyMatrix = ("%s\n%s\n%s\n%s" % (v.matrix[0], v.matrix[1],
             v.matrix[2], v.matrix[3])).replace("(","").replace(")","")
         result = "Endpts of box diagonal:\n%s\n%s\n\nTransform matrix:\n%s\n" \
                  % (v.box.GetCorner(0), v.box.GetCorner(7), prettyMatrix)
@@ -93,22 +93,23 @@ def ToString(v, typeName=None):
     # Pretty-print a TfTimeStamp
     elif isinstance(v, Tf.TimeStamp):
         from datetime import datetime
-	dt = datetime.fromtimestamp( v.Get() )
-	result = dt.isoformat(' ')
+        dt = datetime.fromtimestamp( v.Get() )
+        result = dt.isoformat(' ')
 
-    # pretty print an int 
+    # pretty print an int
     elif isinstance(v, int):
         result = "{:,d}".format(v)
 
-    # pretty print a float 
+    # pretty print a float
     elif isinstance(v, float):
         result =  "{:,.6f}".format(v)
 
     # print a string as-is
     elif isinstance(v, str):
-	result = v
+        result = v
 
     else:
+        import pprint
         result = pprint.pformat(v)
 
     return result

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -63,8 +63,8 @@ class FreeCamera(QtCore.QObject):
     # is close to camera
     maxGoodZResolution = 5e4
 
-    """FreeCamera can be either a Z up or Y up camera, based on 'zUp'"""
     def __init__(self, isZUp):
+        """FreeCamera can be either a Z up or Y up camera, based on 'zUp'"""
         super(FreeCamera, self).__init__()
 
         self._camera = Gf.Camera()
@@ -1126,6 +1126,7 @@ class StageView(QtOpenGL.QGLWidget):
             self._freeCamera = None
             self._cameraPrim = cameraPrim
         else:
+            from common import PrintWarning
             PrintWarning("Incorrect Prim Type",
                          "Attempted to view the scene using the prim '%s', but "
                          "the prim is not a UsdGeom.Camera." %(cameraPrim.GetName()))

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -1004,11 +1004,11 @@ class StageView(QtOpenGL.QGLWidget):
     # XXX Why aren't these @properties?
     def setDisplayGuides(self, enabled):
         self._displayGuides = enabled
-        self._updateBboxGuides();
+        self._updateBboxGuides()
 
     def setDisplayRenderingGuides(self, enabled):
         self._displayRenderingGuides = enabled
-        self._updateBboxGuides();
+        self._updateBboxGuides()
 
     def setDisplayCameraOracles(self, enabled):
         self._displayCameraOracles = enabled
@@ -1052,7 +1052,7 @@ class StageView(QtOpenGL.QGLWidget):
                     if self._bbox.GetRange().IsEmpty():
                         self._selectionBBox = self._getDefaultBBox()
                     else:
-                        self._selectionBBox = self._bbox;
+                        self._selectionBBox = self._bbox
                 else:
                     self._selectionBBox = self.getSelectionBBox()
 
@@ -1306,7 +1306,7 @@ class StageView(QtOpenGL.QGLWidget):
         GL.glEnable(GL.GL_DEPTH_TEST)
         GL.glDepthFunc(GL.GL_LESS)
 
-        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA);
+        GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA)
         GL.glEnable(GL.GL_BLEND)
 
         frustum = self.computeGfCamera().frustum
@@ -1697,7 +1697,7 @@ class StageView(QtOpenGL.QGLWidget):
         FreeCamera.  Then reset the near/far clipping planes based on
         distance to closest geometry."""
         if not self._freeCamera:
-            self.switchToFreeCamera();
+            self.switchToFreeCamera()
         else:
             self.computeAndSetClosestDistance()
         

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -25,13 +25,9 @@
 Module that provides the StageView class.
 '''
 
-import logging
-import math
-from math import tan, sqrt, atan, degrees
-from math import radians as rad
+from math import tan, atan, radians as rad
 import os
 from time import time
-import traceback
 
 from PySide import QtGui, QtCore, QtOpenGL
 
@@ -304,7 +300,7 @@ class FreeCamera(QtCore.QObject):
         else:
             halfFov = self.fov*0.5 or 0.5 # don't divide by zero
             self.dist = ((self._selSize * frameFit * 0.5)
-                         / math.atan(math.radians(halfFov)))
+                         / atan(rad(halfFov)))
         
     def setClosestVisibleDistFromPoint(self, point):
         frustum = self._camera.frustum

--- a/third_party/maya/lib/usdMaya/AEpxrUsdReferenceAssemblyTemplate.py
+++ b/third_party/maya/lib/usdMaya/AEpxrUsdReferenceAssemblyTemplate.py
@@ -111,7 +111,7 @@ def variantSets_Replace(nodeAttr, new):
     if new == True:
         cmds.frameLayout(frameLayoutName, label='VariantSets', collapse=False)
     else:
-        cmds.setParent(frameLayoutName);
+        cmds.setParent(frameLayoutName)
 
     # Remove existing children of layout
     children = cmds.frameLayout(frameLayoutName, q=True, childArray=True)
@@ -131,8 +131,8 @@ def variantSets_Replace(nodeAttr, new):
             for regVarSet in UsdUtils.GetRegisteredVariantSets()]
 
     if usdPrim:
-        variantSets = usdPrim.GetVariantSets();
-        variantSetNames = variantSets.GetNames();
+        variantSets = usdPrim.GetVariantSets()
+        variantSetNames = variantSets.GetNames()
         for variantSetName in variantSetNames:
 
             if regVarSetNames and (variantSetName not in regVarSetNames):


### PR DESCRIPTION
This trivial stream of fixes attempts to do the following:
- Replace tab indents with spaces
- Remove trailing semicolons
- Fix a few undefined variables and missing imports
- Remove redundant or unused imports
- Derive all classes from object

I've attempted to break the changes into logical commits. None of these really improve the software, but a couple unlikely warning messages will now show up properly.