### PR TITLE
usdObj: Clean up build and plugInfo for proper installation into examples.

### DIFF
--- a/extras/usd/examples/usdObj/CMakeLists.txt
+++ b/extras/usd/examples/usdObj/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(PXR_PREFIX pxr/usd)
 set(PXR_PACKAGE usdObj)
 
 pxr_plugin(${PXR_PACKAGE}

--- a/extras/usd/examples/usdObj/plugInfo.json
+++ b/extras/usd/examples/usdObj/plugInfo.json
@@ -17,10 +17,10 @@
                     }
                 }
             },
-            "LibraryPath": "usdObj",
+            "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@",
             "Name": "usdObj",
-            "ResourcePath": "Resources",
-            "Root": "..",
+            "ResourcePath": "@PLUG_INFO_RESOURCE_PATH@",
+            "Root": "@PLUG_INFO_ROOT@",
             "Type": "library"
         }
     ]


### PR DESCRIPTION
…PXR_PLUGINPATH_NAME bootstrapping. Otherwise the user must manually edit the usdObj plugInfo.json , etc., in order for Plug to find what it needs.