### PR TITLE
Remove unnecessary null pointer check from meshTopology.cpp

### DIFF
--- a/pxr/imaging/lib/hd/meshTopology.cpp
+++ b/pxr/imaging/lib/hd/meshTopology.cpp
@@ -198,7 +198,7 @@ HdMeshTopology::ComputeHash() const
 void
 HdMeshTopology::SetQuadInfo(Hd_QuadInfo const *quadInfo)
 {
-    if (_quadInfo) delete _quadInfo;
+    delete _quadInfo;
     _quadInfo = quadInfo;
 }
 


### PR DESCRIPTION
This is an issue which was brought up by issue #6 .
