### PR TITLE
Fix static GLEW linkage

### DIFF
--- a/cmake/modules/FindGLEW.cmake
+++ b/cmake/modules/FindGLEW.cmake
@@ -51,7 +51,7 @@ if (WIN32)
 
     find_library(GLEW_LIBRARY
         NAMES
-            glew GLEW glew32s glew32
+            glew GLEW glew32s glew32 glew32sd glew32d
         HINTS
             "${GLEW_LOCATION}/lib"
             "$ENV{GLEW_LOCATION}/lib"
@@ -62,6 +62,12 @@ if (WIN32)
         PATH_SUFFIXES
             Release/${ARCH}
         DOC "The GLEW library")
+
+    if ("${GLEW_LIBRARY}" MATCHES "glew32s(d|)")
+        add_definitions("/DGLEW_STATIC")
+        MESSAGE(STATUS "Glew API: GLEW_STATIC " ${GLEW_LIBRARY})
+    endif()
+
 endif ()
 
 if (${CMAKE_HOST_UNIX})


### PR DESCRIPTION
In glew.h, it is required to define GLEW_STATIC when using the static library,
however USD never sets this flag, thus previously all glew linkage was assumed
to be dynamic with "dllimport" linkage.

Now the CMake FindGlew module sets this flag when running in Win32 and the
static library is discovered (this is determined by convention of the "s" or "sd"
suffix).

Also, GLEW debug libraries are now supported (e.g. glew32[s]d.lib).

Addresses Issue #53
