### PR TITLE
Use std::isnan instead of isnan in rgb and rgba.h

### DIFF
--- a/pxr/base/lib/gf/rgb.h
+++ b/pxr/base/lib/gf/rgb.h
@@ -77,7 +77,7 @@ class GfRGB {
     
     //! Returns whether or not the color is valid. By convention, a color
     //  is valid if the first color component is not NAN.
-    bool IsValid() const { return !isnan(_rgb[0]); }
+    bool IsValid() const { return !std::isnan(_rgb[0]); }
 
     //! Returns the RGB color as a \c GfVec3f.
     const GfVec3f &GetVec() const { return _rgb; }

--- a/pxr/base/lib/gf/rgba.h
+++ b/pxr/base/lib/gf/rgba.h
@@ -107,7 +107,7 @@ class GfRGBA {
 
     //! Returns whether or not the color is valid. By convention, a color
     //  is valid if the first color component is not NAN.
-    bool IsValid() const { return !isnan(_rgba[0]); }
+    bool IsValid() const { return !std::isnan(_rgba[0]); }
 
     //! Accesses indexed component of color as a modifiable l-value.
     float &operator [](int i) { return _rgba[i]; }


### PR DESCRIPTION
Fix issue #52 for popey. Use std::isnan instead of just isnan, std was already used in `pxr/usd/lib/usd/timeCode.h` so it should be fine.
