### PR TITLE
[Tf] Add wrapTestPyAnnotatedBoolResult to build, fixing linking errors.

### DIFF
--- a/pxr/base/lib/tf/CMakeLists.txt
+++ b/pxr/base/lib/tf/CMakeLists.txt
@@ -174,6 +174,7 @@ pxr_shared_library(tf
         wrapStopwatch.cpp
         wrapStringUtils.cpp
         wrapTemplateString.cpp
+        wrapTestPyAnnotatedBoolResult.cpp
         wrapTestPyContainerConversions.cpp
         wrapTestPyDateTime.cpp
         wrapTestPyStaticTokens.cpp


### PR DESCRIPTION
Fixes issue #66 by adding wrapTestPyAnnotatedBoolResult to build.