### PR TITLE
Alternative executable name for uic

### DIFF
--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -26,7 +26,7 @@ if (NOT PYTHON_EXECUTABLE)
 endif()
 
 find_program(PYSIDEUICBINARY
-    NAMES pyside-uic
+    NAMES pyside-uic python2-pyside-uic
     HINTS ${PYSIDE_BIN_DIR}
 )
 


### PR DESCRIPTION
Add support for 'python2-pyside-uic' as a searched executable
name for pyside. This is the executable name used on Arch Linux.