### PR TITLE
Windows: Fixed path separators for usdview stylesheet 

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -152,15 +152,17 @@ class Launcher(object):
             MainWindow.clearSettings()
 
         # Find the resource directory
-        resourceDir = os.path.dirname(
-            os.path.realpath(__file__)).replace("\\", "/")
+        resourceDir = os.path.dirname(os.path.realpath(__file__)) + "/"
 
         # Create the Qt application
         app = QApplication(sys.argv)
 
-        # apply the style sheet to it
+        # Apply the style sheet to it
         sheet = open(os.path.join(resourceDir, 'usdviewstyle.qss'), 'r')
-        sheetString = sheet.read().replace('RESOURCE_DIR', resourceDir)
+        
+        # Qt style sheet accepts only forward slashes as path separators
+        sheetString = sheet.read().replace('RESOURCE_DIR',
+                                           resourceDir.replace("\\", "/"))
         app.setStyleSheet(sheetString)
 
         mainWindow = MainWindow(None, arg_parse_result)

--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -150,9 +150,10 @@ class Launcher(object):
         from mainWindow import MainWindow
         if arg_parse_result.clearSettings:
             MainWindow.clearSettings()
-            
-        # find the resource directory
-        resourceDir = os.path.dirname(os.path.realpath(__file__)) + "/"
+
+        # Find the resource directory
+        resourceDir = os.path.dirname(
+            os.path.realpath(__file__)).replace("\\", "/")
 
         # Create the Qt application
         app = QApplication(sys.argv)


### PR DESCRIPTION
Replaced Windows style slashes with forward slashes so that the path can be digested correctly in the Qt style sheet.

Also removed redundant slash at the end of `resourceDir` variable, since this separator is added in usdviewstyle.qss