### PR TITLE
Logic clean-up for finding Maya package on Windows

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -223,10 +223,10 @@ endif()
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 
-if (${PXR_MAYA_API_ONLY} AND NOT ${PXR_MAYA_API_ONLY})
+# Allow Maya plug-in to compiled without having Maya installed
+if (${PXR_MAYA_API_ONLY})
     find_package_handle_standard_args(Maya
         REQUIRED_VARS
-            MAYA_EXECUTABLE
             MAYA_INCLUDE_DIRS
             MAYA_LIBRARIES
         VERSION_VAR
@@ -235,6 +235,7 @@ if (${PXR_MAYA_API_ONLY} AND NOT ${PXR_MAYA_API_ONLY})
 else()
     find_package_handle_standard_args(Maya
         REQUIRED_VARS
+            MAYA_EXECUTABLE
             MAYA_INCLUDE_DIRS
             MAYA_LIBRARIES
         VERSION_VAR


### PR DESCRIPTION
Currently if we try to configure build with USD Maya plug-in on Windows we need to have `PXR_MAYA_API_ONLY` set, otherwise cmake will fail at line 226. Not only that, if we do have it set the statement will anyway evaluate to false, which is not very useful.

The proposed fix amends the logic so that it's optional for the user to have this variable set.

I imagine `PXR_MAYA_API_ONLY` is still present in this branch for convenience purposes only and will go away at some point.