### PR TITLE
Ptex prefer static

### DIFF
--- a/cmake/modules/FindPTex.cmake
+++ b/cmake/modules/FindPTex.cmake
@@ -14,7 +14,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-option(PTEX_PREFER_STATIC "Prefer static library when linking pTex" OFF)
+option(PTEX_PREFER_STATIC "Prefer static library when linking pTex on linux or osx" OFF)
 
 if (WIN32)
     find_path( PTEX_INCLUDE_DIR
@@ -52,9 +52,14 @@ elseif (APPLE)
             "$ENV{PTEX_LOCATION}/include"
         PATHS
             DOC "The directory where Ptexture.h resides")
+    if (${PTEX_PREFER_STATIC})
+        set(PTEX_LIBRARY_NAMES libPtex.a Ptex)
+    else ()
+        set(PTEX_LIBRARY_NAMES Ptex libPtex.a)
+    endif ()
     find_library( PTEX_LIBRARY
         NAMES
-            Ptex libPtex.a
+            ${PTEX_LIBRARY_NAMES}
         PATHS
             "${PTEX_LOCATION}/lib"
             "$ENV{PTEX_LOCATION}/lib"

--- a/cmake/modules/FindPTex.cmake
+++ b/cmake/modules/FindPTex.cmake
@@ -14,6 +14,7 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
+option(PTEX_PREFER_STATIC "Prefer static library when linking pTex" OFF)
 
 if (WIN32)
     find_path( PTEX_INCLUDE_DIR
@@ -71,9 +72,14 @@ else ()
             /usr/include
             /usr/local/include
             DOC "The directory where Ptexture.h resides")
+    if (${PTEX_PREFER_STATIC})
+        set(PTEX_LIBRARY_NAMES libPtex.a libwdasPtex.a Ptex wdasPtex)
+    else ()
+        set(PTEX_LIBRARY_NAMES Ptex wdasPtex libPtex.a libwdasPtex.a)
+    endif ()
     find_library( PTEX_LIBRARY
         NAMES
-            Ptex wdasPtex
+            ${PTEX_LIBRARY_NAMES}
         HINTS
             "${PTEX_LOCATION}/lib64"
             "${PTEX_LOCATION}/lib"


### PR DESCRIPTION
### Description of Change(s)

Adds a cmake option, PTEX_PREFER_STATIC, which for linux and osx will make FindPTex.cmake use static versions of the ptex libraries preferentially to dynamic ones

### Included Commit(s)
- aa36361a1e22af427c06ac2f2cd2f01ff036845c
- ~~8885d0c5176a5a061825f910a00bbc71005c6921~~
- b0f253f8b53e3bbd4f054d3c41b0900bce568f2d
### Fixes Issue(s)
- none

