### PR TITLE
Fix symbol visibility for UsdShadeParameter::GetConnectionRelName.

### DIFF
--- a/pxr/usd/lib/usdShade/parameter.h
+++ b/pxr/usd/lib/usdShade/parameter.h
@@ -298,6 +298,7 @@ public:
 
     /// Return the name of the sibling relationship that would encode
     /// the connection for this parameter.
+    USDSHADE_API
     TfToken GetConnectionRelName(int element=-1) const;
     
     // TODO:


### PR DESCRIPTION
Fixes issue #120.