### PR TITLE
Iterating maya underworld when exporting

### DIFF
--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -71,6 +71,23 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+namespace {
+    static
+    bool _HasParent(const MDagPath& curDagPath, const MDagPath& curLeafDagPath) {
+        MFnDagNode dagNode(curDagPath);
+        if (dagNode.inUnderWorld()) {
+            for (auto dagPathCopy = curDagPath; dagPathCopy.pathCount(); dagPathCopy.pop()) {
+                MFnDagNode dagNodeCopy(dagPathCopy);
+                if (!dagNodeCopy.inUnderWorld()) {
+                    return dagNodeCopy.hasParent(curLeafDagPath.node());
+                }
+            }
+            return false;
+        } else {
+            return dagNode.hasParent(curLeafDagPath.node());
+        }
+    }
+}
 
 usdWriteJob::usdWriteJob(const JobExportArgs & iArgs) :
     mArgs(iArgs), mModelKindWriter(iArgs)
@@ -201,7 +218,9 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
     // Now do a depth-first traversal of the Maya DAG from the world root.
     // We keep a reference to arg dagPaths as we encounter them.
     MDagPath curLeafDagPath;
-    for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
+    MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid);
+    itDag.traverseUnderWorld(true);
+    for (; !itDag.isDone(); itDag.next()) {
         MDagPath curDagPath;
         itDag.getPath(curDagPath);
         std::string curDagPathStr(curDagPath.partialPathName().asChar());
@@ -214,9 +233,8 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
             // This dagPath IS one of the arg dagPaths. It AND all of its
             // children should be included in the export.
             curLeafDagPath = curDagPath;
-        } else if (!MFnDagNode(curDagPath).hasParent(curLeafDagPath.node())) {
-            // This dagPath is not a child of one of the arg dagPaths, so prune
-            // it and everything below it from the traversal.
+        } else if (!_HasParent(curDagPath, curLeafDagPath)) {
+            // The lowest-level, non-underworld dagNode from the dagPath is not one of the arg dagPaths, so prune
             itDag.prune();
             continue;
         }
@@ -375,9 +393,8 @@ TfToken usdWriteJob::writeVariants(const UsdPrim &usdRootPrim)
 
     // Get the usdVariantRootPrimPath (optionally filter by renderLayer prefix)
     MayaPrimWriterPtr firstPrimWriterPtr = *mMayaPrimWriterList.begin();
-    std::string firstPrimWriterPathStr( firstPrimWriterPtr->getDagPath().fullPathName().asChar() );
-    std::replace( firstPrimWriterPathStr.begin(), firstPrimWriterPathStr.end(), '|', '/');
-    std::replace( firstPrimWriterPathStr.begin(), firstPrimWriterPathStr.end(), ':', '_'); // replace namespace ":" with "_"
+    std::string firstPrimWriterPathStr(PxrUsdMayaUtil::MDagPathToUsdPathString(
+        firstPrimWriterPtr->getDagPath()));
     SdfPath usdVariantRootPrimPath(firstPrimWriterPathStr);
     usdVariantRootPrimPath = usdVariantRootPrimPath.GetPrefixes()[0];
 

--- a/third_party/maya/lib/usdMaya/util.h
+++ b/third_party/maya/lib/usdMaya/util.h
@@ -308,6 +308,9 @@ void Connect(
         const MPlug& dstPlug,
         bool clearDstPlug);
 
+PXRUSDMAYA_API
+std::string MDagPathToUsdPathString(const MDagPath& dagPath);
+
 /// For \p dagPath, returns a UsdPath corresponding to it.  
 /// If \p mergeTransformAndShape and the dagPath is a shapeNode, it will return
 /// the same value as MDagPathToUsdPath(transformPath) where transformPath is


### PR DESCRIPTION
### Description of Change(s)
The change adds the ability to iterate objects in the Maya underworld during USD export from Maya.

### Fixes Issue(s)
Objects are not exported from the underworld. This happens if somebody writes an exporter plugin for imagePlane.
