### PR TITLE
Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}"
 # build files readable.
 include(CXXDefaults)
 add_definitions(${_PXR_CXX_DEFINITIONS})
-set(CMAKE_CXX_FLAGS ${_PXR_CXX_FLAGS})
+set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 include(Public)
 

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -24,8 +24,8 @@
 # Core USD Package Requirements 
 # ----------------------------------------------
 # --Python.  We are generally but not completely 2.6 compliant.
-find_package(PythonLibs 2.7 REQUIRED)
 find_package(PythonInterp 2.7 REQUIRED)
+find_package(PythonLibs 2.7 REQUIRED)
 
 # --Boost
 find_package(Boost

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -412,8 +412,8 @@ function(pxr_static_library LIBRARY_NAME)
         ${ARGN}
     )
 
-    _classes(${LIBRARY_NAME} ${sl_PRIVATE_CLASSES} PRIVATE)
     _classes(${LIBRARY_NAME} ${sl_PUBLIC_CLASSES} PUBLIC)
+    _classes(${LIBRARY_NAME} ${sl_PRIVATE_CLASSES} PRIVATE)
 
     set(PXR_ALL_LIBS
         "${PXR_ALL_LIBS} ${LIBRARY_NAME}"


### PR DESCRIPTION
Fixes #117 on OS X and allow user to specify CMAKE_CXX_FLAGS when building.