### PR TITLE
Add inlined ArchEnviron function for OS X.

### DIFF
--- a/pxr/base/lib/arch/debugger.cpp
+++ b/pxr/base/lib/arch/debugger.cpp
@@ -26,6 +26,7 @@
 #include "pxr/pxr.h"
 #include "pxr/base/arch/debugger.h"
 #include "pxr/base/arch/daemon.h"
+#include "pxr/base/arch/env.h"
 #include "pxr/base/arch/error.h"
 #include "pxr/base/arch/export.h"
 #include "pxr/base/arch/stackTrace.h"
@@ -325,18 +326,12 @@ Arch_DebuggerRunUnrelatedProcessPosix(bool (*cb)(void*), void* data)
     _exit(0);
 }
 
-PXR_NAMESPACE_CLOSE_SCOPE
-
-extern char** environ;
-
-PXR_NAMESPACE_OPEN_SCOPE
-
 static
 bool
 Arch_DebuggerAttachExecPosix(void* data)
 {
     char** args = (char**)data;
-    execve(args[0], args, environ);
+    execve(args[0], args, ArchEnviron());
     return false;
 }
 

--- a/pxr/base/lib/arch/env.cpp
+++ b/pxr/base/lib/arch/env.cpp
@@ -30,6 +30,12 @@
 
 #include <stdlib.h>
 
+#if defined(ARCH_OS_DARWIN)
+#include <crt_externs.h>
+#else
+extern "C" char** environ;
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 bool
@@ -122,6 +128,14 @@ ArchExpandEnvironmentVariables(const std::string& value)
     }
 
     return result;
+}
+
+char** ArchEnviron() {
+#if defined(ARCH_OS_DARWIN)
+    return *_NSGetEnviron();
+#else
+    return environ;
+#endif
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/lib/arch/env.h
+++ b/pxr/base/lib/arch/env.h
@@ -76,6 +76,14 @@ ARCH_API
 std::string
 ArchExpandEnvironmentVariables(const std::string& str);
 
+///
+/// Return an array of the environment variables.
+/// \ingroup group_arch_SystemFunctions
+///
+ARCH_API
+char**
+ArchEnviron();
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // ARCH_ENV_H

--- a/pxr/base/lib/arch/stackTrace.cpp
+++ b/pxr/base/lib/arch/stackTrace.cpp
@@ -28,6 +28,7 @@
 #include "pxr/base/arch/debugger.h"
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/demangle.h"
+#include "pxr/base/arch/env.h"
 #include "pxr/base/arch/error.h"
 #include "pxr/base/arch/errno.h"
 #include "pxr/base/arch/export.h"
@@ -223,13 +224,6 @@ static const char* const* stackTraceArgv = nullptr;
 
 static long _GetAppElapsedTime();
 
-PXR_NAMESPACE_CLOSE_SCOPE
-
-// asgetenv() want's this but we can't declare it inside the namespace.
-extern char **environ;
-
-PXR_NAMESPACE_OPEN_SCOPE
-
 namespace {
 
 // Return the length of s.
@@ -292,7 +286,7 @@ const char* asgetenv(const char* name)
 {
     if (name) {
         const size_t len = asstrlen(name);
-        for (char** i = environ; *i; ++i) {
+        for (char** i = ArchEnviron(); *i; ++i) {
             const char* var = *i;
             if (asstrneq(var, name, len)) {
                 if (var[len] == '=') {


### PR DESCRIPTION
Trying to link to **environ** variable fails when OS X SDK < 10.11