### PR TITLE
Fixes for building with clang.

### DIFF
--- a/cmake/defaults/gccclangshareddefaults.cmake
+++ b/cmake/defaults/gccclangshareddefaults.cmake
@@ -43,7 +43,13 @@ _disable_warning("deprecated")
 _disable_warning("deprecated-declarations")
 
 # Suppress unused typedef warnings emanating from boost.
-_disable_warning("unused-local-typedefs")
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+    NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+    if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
+        NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.1)
+            _disable_warning("unused-local-typedefs")
+    endif()
+endif()
 
 if (${PXR_MAYA_TBB_BUG_WORKAROUND})
     set(_PXR_GCC_CLANG_SHARED_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS} -Wl,-Bsymbolic")

--- a/pxr/base/lib/arch/attributes.h
+++ b/pxr/base/lib/arch/attributes.h
@@ -271,7 +271,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     Arch_ConstructorInit _arch_constructor_init;
     }
 
-#elif defined(ARCH_COMPILER_GCC)
+#elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
 
     // The used attribute is required to prevent these apparently unused
     // functions from being removed by the linker.

--- a/pxr/base/lib/arch/nap.cpp
+++ b/pxr/base/lib/arch/nap.cpp
@@ -80,7 +80,8 @@ ArchThreadYield()
 void
 ArchThreadPause()
 {
-#if defined (ARCH_CPU_INTEL) && defined(ARCH_COMPILER_GCC)
+#if defined (ARCH_CPU_INTEL) && (defined(ARCH_COMPILER_GCC) || \
+                                 defined(ARCH_COMPILER_CLANG))
     __asm__ __volatile__ ("pause");
 #elif defined(ARCH_OS_WINDOWS)
     YieldProcessor();

--- a/pxr/base/lib/tf/testenv/SIGFPE.cpp
+++ b/pxr/base/lib/tf/testenv/SIGFPE.cpp
@@ -45,8 +45,9 @@ main(int argc, char **argv)
     // as we leave them off by default.
     TfInstallTerminateAndCrashHandlers();
 
-    int a = 1;
-    int b = 0;
+    // Avoid compiler doing the constant math expression
+    volatile int a = 1;
+    volatile int b = 0;
     int c = a/b;
     printf("%d",c);
 }


### PR DESCRIPTION
### Description of Change(s)
Use constructor/destructor attributes to add to ELF's .init .fini sections.
Enable pause instruction on Intel CPU built with clang.
Only add -Wno-unused-local-typedefs if clang version is > 3.5.

### Fixes Issue(s)
ARCH_CONSTRUCTOR/ARCH_DESTRUCTOR not being called when built with clang on Linux.
ArchThreadPause doing nothing built with clang.
Tons of warning related to -Wno-unused-local-typedefs not being understood.