### PR TITLE
[usdAbc] Fix build for Alembic 1.7 .

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -652,6 +652,9 @@ public:
     /// Returns the archive.
     const OArchive& GetArchive() const { return _archive; }
 
+    /// Returns the archive.
+    OArchive& GetArchive() { return _archive; }
+
     /// Sets the writer schema.
     void SetSchema(const _WriterSchema* schema) { _schema = schema; }
 
@@ -840,6 +843,9 @@ public:
     /// Returns the archive.
     const OArchive& GetArchive() const;
 
+    /// Returns the archive.
+    OArchive& GetArchive();
+
     /// Returns the writer schema.
     const _WriterSchema& GetSchema() const;
 
@@ -970,6 +976,12 @@ _PrimWriterContext::GetPropertyField(
 
 const OArchive&
 _PrimWriterContext::GetArchive() const
+{
+    return _context.GetArchive();
+}
+
+OArchive&
+_PrimWriterContext::GetArchive()
 {
     return _context.GetArchive();
 }


### PR DESCRIPTION
Const-correct use of OArchive for alembicWriter, required by Alembic 1.7 compilation, and verified backwards compatible with earlier Alembic as well.

Fixes issue #106 .