### PR TITLE
add PXR_SYMLINK_HEADER_FILES cmake option

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -36,6 +36,7 @@ option(PXR_ENABLE_HDF5_SUPPORT "Enable HDF5 backend in the Alembic plugin for US
 option(PXR_ENABLE_PTEX_SUPPORT "Enable Ptex support" ON)
 option(PXR_MAYA_TBB_BUG_WORKAROUND "Turn on linker flag (-Wl,-Bsymbolic) to work around a Maya TBB bug" OFF)
 option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
+option(PXR_SYMLINK_HEADER_FILES "Symlink the header files from, ie, pxr/base/lib/tf to CMAKE_DIR/pxr/base/tf, instead of copying; ensures that you may edit the header file in either location, and improves experience in IDEs which find normally the \"copied\" header, ie, CLion; has no effect on windows" OFF)
 
 # Precompiled headers are a win on Windows, not on gcc.
 set(pxr_enable_pch "OFF")

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -48,17 +48,36 @@ function(_install_headers LIBRARY_NAME)
             set(infile "${CMAKE_CURRENT_SOURCE_DIR}/${f}")
             set(outfile "${header_dest_dir}/${f}")
             list(APPEND files_copied ${outfile})
-            add_custom_command(
+            if(PXR_SYMLINK_HEADER_FILES AND NOT WIN32)
+                # cmake -E create_symlink doesn't create parent directories, while
+                # copy does... so need an extra command to make dir
+
+                # Also, if ${f} has a directory, header_parent_dir will be
+                # different than header_dest_dir                
+                get_filename_component(header_parent_dir ${outfile} DIRECTORY)
+                add_custom_command(
+                        OUTPUT ${outfile}
+                        COMMAND "${CMAKE_COMMAND}"
+                        ARGS -E make_directory "${header_parent_dir}"
+                        COMMAND "${CMAKE_COMMAND}"
+                        ARGS -E create_symlink "${infile}" "${outfile}"
+                        MAIN_DEPENDENCY "${infile}"
+                        COMMENT "Symlinking ${f} ..."
+                        VERBATIM
+                )
+            else()
+                add_custom_command(
                 OUTPUT ${outfile}
-                COMMAND
-                    "${PYTHON_EXECUTABLE}"
-                    "${PROJECT_SOURCE_DIR}/cmake/macros/copyHeaderForBuild.py"
-                    "${infile}"
-                    "${outfile}"
-                MAIN_DEPENDENCY "${infile}"
-                COMMENT "Copying ${f} ..."
-                VERBATIM
-        )
+                        COMMAND
+                            "${PYTHON_EXECUTABLE}"
+                            "${PROJECT_SOURCE_DIR}/cmake/macros/copyHeaderForBuild.py"
+                            "${infile}"
+                            "${outfile}"
+                        MAIN_DEPENDENCY "${infile}"
+                        COMMENT "Copying ${f} ..."
+                        VERBATIM
+                )
+            endif()
         endforeach()
     endif()
 endfunction() # _install_headers


### PR DESCRIPTION
### Description of Change(s)

On build, CMake automatically copies the header files into a slightly different location in the cmake build directory (ie, from pxr/base/lib/tf to CMAKE_DIR/pxr/base/tf).  Unfortunately, this plays havoc with certain IDEs (ie, CLion), which find the "copied" headers instead of the "source" headers.

This change adds a  PXR_SYMLINK_HEADER_FILES  option which makes CMake symlink these headers to the cmake build dir, instead of copying, so that you can freely edit the headers in either location without having to worry which header you have.

On install, the headers are still properly copied, not symlinked.

### Included Commit(s)
- ~~c9301a7e3d78858bf81849f22bdf898ae4dca195~~
- ~~https://github.com/PixarAnimationStudios/USD/pull/150/commits/7b45b91ffa5807231cca4210a92ccfc8e5f98c14~~
- ~~acf470c71a525eff8cca84c02d753c66e7ff5169~~
- ~~https://github.com/PixarAnimationStudios/USD/pull/150/commits/6dd67544918dd8a8d54c0ab36cae000796ece9ff~~
- https://github.com/PixarAnimationStudios/USD/pull/150/commits/a23b785ef91a245c55e21da04d7d504a244e209d

### Fixes Issue(s)
- none

