### PR TITLE
get rid of unnecessary tmpBool vars

### DIFF
--- a/third_party/maya/lib/usdMaya/usdExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdExport.cpp
@@ -119,21 +119,15 @@ try
     JobExportArgs jobArgs;
 
     if (argData.isFlagSet("mergeTransformAndShape")) {
-        bool tmpBool = true;
-        argData.getFlagArgument("mergeTransformAndShape", 0, tmpBool);
-        jobArgs.mergeTransformAndShape = tmpBool;
+        argData.getFlagArgument("mergeTransformAndShape", 0, jobArgs.mergeTransformAndShape);
     }
 
     if (argData.isFlagSet("exportRefsAsInstanceable")) {
-        bool tmpBool = false;
-        argData.getFlagArgument("exportRefsAsInstanceable", 0, tmpBool);
-        jobArgs.exportRefsAsInstanceable = tmpBool;
+        argData.getFlagArgument("exportRefsAsInstanceable", 0, jobArgs.exportRefsAsInstanceable);
     }
 
     if (argData.isFlagSet("exportDisplayColor")) {
-        bool tmpBool = true;
-        argData.getFlagArgument("exportDisplayColor", 0, tmpBool);
-        jobArgs.exportDisplayColor = tmpBool;
+        argData.getFlagArgument("exportDisplayColor", 0, jobArgs.exportDisplayColor);
     }
     
     if (argData.isFlagSet("shadingMode")) {
@@ -159,22 +153,16 @@ try
     }
 
     if (argData.isFlagSet("exportUVs")) {
-        bool tmpBool = true;
-        argData.getFlagArgument("exportUVs", 0, tmpBool);
-        jobArgs.exportMeshUVs = tmpBool;
-        jobArgs.exportNurbsExplicitUV = tmpBool;
+        argData.getFlagArgument("exportUVs", 0, jobArgs.exportMeshUVs);
+        jobArgs.exportNurbsExplicitUV = jobArgs.exportMeshUVs;
     }
 
     if (argData.isFlagSet("normalizeMeshUVs")) {
-        bool tmpBool = false;
-        argData.getFlagArgument("normalizeMeshUVs", 0, tmpBool);
-        jobArgs.normalizeMeshUVs = tmpBool;
+        argData.getFlagArgument("normalizeMeshUVs", 0, jobArgs.normalizeMeshUVs);
     }
 
     if (argData.isFlagSet("normalizeNurbs")) {
-        bool tmpBool = false;
-        argData.getFlagArgument("normalizeNurbs", 0, tmpBool);
-        jobArgs.normalizeNurbs = tmpBool;
+        argData.getFlagArgument("normalizeNurbs", 0, jobArgs.normalizeNurbs);
     }
 
     if (argData.isFlagSet("nurbsExplicitUVType")) {
@@ -186,9 +174,7 @@ try
     }
 
     if (argData.isFlagSet("exportColorSets")) {
-        bool tmpBool = true;
-        argData.getFlagArgument("exportColorSets", 0, tmpBool);
-        jobArgs.exportColorSets = tmpBool;
+        argData.getFlagArgument("exportColorSets", 0, jobArgs.exportColorSets);
     }
 
     if (argData.isFlagSet("defaultMeshScheme")) {
@@ -210,9 +196,7 @@ try
     }
 
     if (argData.isFlagSet("exportVisibility")) {
-        bool tmpBool = true;
-        argData.getFlagArgument("exportVisibility", 0, tmpBool);
-        jobArgs.exportVisibility = tmpBool;
+        argData.getFlagArgument("exportVisibility", 0, jobArgs.exportVisibility);
     }
 
     bool append = false;

--- a/third_party/maya/lib/usdMaya/usdImport.cpp
+++ b/third_party/maya/lib/usdMaya/usdImport.cpp
@@ -147,9 +147,7 @@ MStatus usdImport::doIt(const MArgList & args)
 
     if (argData.isFlagSet("readAnimData"))
     {   
-        bool tmpBool = false;
-        argData.getFlagArgument("readAnimData", 0, tmpBool);
-        jobArgs.readAnimData = tmpBool;
+        argData.getFlagArgument("readAnimData", 0, jobArgs.readAnimData);
     }
 
     // Specify usd PrimPath.  Default will be "/<useFileBasename>"


### PR DESCRIPTION
### Description of Change(s)

The usdImport / usdExport modules contain a lot of sections like this:

```cpp
    if (argData.isFlagSet("mergeTransformAndShape")) {
        bool tmpBool = true;
        argData.getFlagArgument("mergeTransformAndShape", 0, tmpBool);
        jobArgs.mergeTransformAndShape = tmpBool;
    }
```

As far as I can tell, there is no need for the "tmpBool" variables, so I've made a small code-cleanup pull request which changes these sections to:

```cpp
    if (argData.isFlagSet("mergeTransformAndShape")) {
        argData.getFlagArgument("mergeTransformAndShape", 0, jobArgs.mergeTransformAndShape);
    }
```

### Included Commit(s)
- 3a55dc24c5f6a1b10087a430627f88f9a2d8a3b1

### Fixes Issue(s)
- none

