### PR TITLE
Refactor maya plugin to use UsdStage::IsSupportedFile

### DIFF
--- a/third_party/maya/lib/usdMaya/JobArgs.h
+++ b/third_party/maya/lib/usdMaya/JobArgs.h
@@ -30,12 +30,20 @@
 
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/usd/usd/usdFileFormat.h"
+#include "pxr/usd/usd/usdaFileFormat.h"
+#include "pxr/usd/usd/usdcFileFormat.h"
 
 #define PXRUSDMAYA_TRANSLATOR_TOKENS \
-    ((UsdFileExtensionDefault, "usd")) \
-    ((UsdFileExtensionASCII, "usda")) \
-    ((UsdFileExtensionCrate, "usdc")) \
-    ((UsdFileFilter, "*.usd *.usda *.usdc"))
+    ((UsdFileExtensionDefault, \
+        SdfFileFormat::FindById(UsdUsdFileFormatTokens->Id)->GetPrimaryFileExtension())) \
+    ((UsdFileFilter, \
+        std::string("*.") \
+            + SdfFileFormat::FindById(UsdUsdFileFormatTokens->Id)->GetPrimaryFileExtension() \
+            + " *." \
+            + SdfFileFormat::FindById(UsdUsdaFileFormatTokens->Id)->GetPrimaryFileExtension() \
+            + " *." \
+            + SdfFileFormat::FindById(UsdUsdcFileFormatTokens->Id)->GetPrimaryFileExtension()))
 
 TF_DECLARE_PUBLIC_TOKENS(PxrUsdMayaTranslatorTokens,
         PXRUSDMAYA_TRANSLATOR_TOKENS);

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
@@ -204,22 +204,10 @@ usdTranslatorExport::identifyFile(
         const char* buffer,
         short size) const
 {
-    MFileKind retValue = kNotMyFileType;
-    const MString fileName = file.fullName();
-    const int lastIndex = fileName.length() - 1;
-
-    const int periodIndex = fileName.rindex('.');
-    if (periodIndex < 0 || periodIndex >= lastIndex) {
-        return retValue;
+    std::string fileName(file.fullName().asChar());
+    if(UsdStage::IsSupportedFile(fileName))
+    {
+        return kIsMyFileType;
     }
-
-    const MString fileExtension = fileName.substring(periodIndex + 1, lastIndex);
-
-    if (fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText() || 
-        fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText()   || 
-        fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText()) {
-        retValue = kIsMyFileType;
-    }
-
-    return retValue;
+    return kNotMyFileType;
 }

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
@@ -119,22 +119,10 @@ usdTranslatorImport::identifyFile(
         const char* buffer,
         short size) const
 {
-    MFileKind retValue = kNotMyFileType;
-    const MString fileName = file.fullName();
-    const int lastIndex = fileName.length() - 1;
-
-    const int periodIndex = fileName.rindex('.');
-    if (periodIndex < 0 || periodIndex >= lastIndex) {
-        return retValue;
+    std::string fileName(file.fullName().asChar());
+    if(UsdStage::IsSupportedFile(fileName))
+    {
+        return kIsMyFileType;
     }
-
-    const MString fileExtension = fileName.substring(periodIndex + 1, lastIndex);
-
-    if (fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText() || 
-        fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText() || 
-        fileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText()) {
-        retValue = kIsMyFileType;
-    }
-
-    return retValue;
+    return kNotMyFileType;
 }

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -105,9 +105,7 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
 
     // Make sure the file name is a valid one with a proper USD extension.
     const std::string iFileExtension = TfStringGetSuffix(iFileName, '.');
-    if (iFileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionDefault   || 
-            iFileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionASCII || 
-            iFileExtension == PxrUsdMayaTranslatorTokens->UsdFileExtensionCrate) {
+    if (UsdStage::IsSupportedFile(iFileName)) {
         mFileName = iFileName;
     } else {
         mFileName = TfStringPrintf("%s.%s",


### PR DESCRIPTION
### Description of Change(s)

There's some code in the maya plugin that re-implements the functionality of UsdStage::IsSupportedFile - this PR standardizes on that method.  It also eliminates some repeated string constants.

### Included Commit(s)
- 63b7f8c0b09992f05f38e9ef5c14d2036e68e36e

### Fixes Issue(s)
-

