### PR TITLE
Installing generated pxr.h.

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -98,7 +98,10 @@ function(_pxrNamespace_subst)
     # Generate the pxr.h file at configuration time
     configure_file(${CMAKE_SOURCE_DIR}/pxr/pxr.h.in
         ${CMAKE_BINARY_DIR}/include/pxr/pxr.h     
-    )  
+    )
+    install(FILES ${CMAKE_BINARY_DIR}/include/pxr/pxr.h
+            DESTINATION include/pxr
+    )
 endfunction()
 
 # Install compiled python files alongside the python object,


### PR DESCRIPTION
### Description of Change(s)
Installing the generated pxr.h.

### Fixes Issue(s)
No reported issues. Pxr.h is simply not installed, and it breaks external projects relying on the installed usd distribution.

