### PR TITLE
[Hd] Fix assignment typo as equivalence.

### DIFF
--- a/pxr/imaging/lib/hd/engine.cpp
+++ b/pxr/imaging/lib/hd/engine.cpp
@@ -184,7 +184,7 @@ HdEngine::CreateContextWithDefaults()
     GalDelegate *galDelegate = nullptr;
     // Gal is optional, so default could be empty.
     if (defaultGalId.IsEmpty()) {
-        defaultGalId == HdDelegateTokens->none;
+        defaultGalId = HdDelegateTokens->none;
     } else {
         // Gal could be explicitly disabled.
         if (defaultGalId != HdDelegateTokens->none)


### PR DESCRIPTION
Fixes a typo that compares rather than assigns.
