### PR TITLE
usdMaya: warn if falling back to pseudoRoot due to failed primPath

### DIFF
--- a/third_party/maya/lib/usdMaya/usdReadJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdReadJob.cpp
@@ -153,6 +153,10 @@ bool usdReadJob::doIt(std::vector<MDagPath>* addedDagPaths)
     UsdPrim usdRootPrim = mPrimPath.empty() ? stage->GetDefaultPrim() :
         stage->GetPrimAtPath(SdfPath(mPrimPath));
     if (!usdRootPrim && !(mPrimPath.empty() || mPrimPath == "/")) {
+        std::string errorMsg = TfStringPrintf(
+            "Unable to set root prim to \"%s\" for USD file \"%s\" - using pseudo-root \"/\" instead",
+            mPrimPath.c_str(), mFileName.c_str());
+        MGlobal::displayError(errorMsg.c_str());
         usdRootPrim = stage->GetPseudoRoot();
     }
 


### PR DESCRIPTION
### Description of Change(s)
Currently, when the maya plugin is passed an invalid primPath (either one that has bad syntax, like "bad;primPath", or one that doesn't exist in the scene, like "/prim/doesnt/exist"), the plugin silently just converts this to a pseudoRoot ("/").  I feel that it should, at minimum, print a warning - so I've made a commit / pull request that does that.

It think it would be still more preferable to have it "abort" and return false, similar to the behavior if the stage has an invalid defaultPrim (the handling of which is a few lines below).  However, I was hesitant to change existing behavior without sanction.  If returning false would be preferable, though, it's an easy addition.

### Included Commit(s)
- https://github.com/PixarAnimationStudios/USD/commit/efaec0a98654e8d2eb001b0668f95fbff86aaa60

### Fixes Issue(s)
- None reported, but the silent conversion of an invalid input could be considered an issue...

