### PR TITLE
GetSessionLayerForVariantSelections takes full path, not model name

### DIFF
--- a/pxr/usd/lib/usdUtils/stageCache.cpp
+++ b/pxr/usd/lib/usdUtils/stageCache.cpp
@@ -62,7 +62,7 @@ UsdUtilsStageCache::Get()
 
 SdfLayerRefPtr 
 UsdUtilsStageCache::GetSessionLayerForVariantSelections(
-        const TfToken& modelName,
+        const SdfPath& primPath,
         const std::vector<std::pair<std::string, std::string> >&variantSelections)
 {
     // Sort so that the key is deterministic.
@@ -70,7 +70,7 @@ UsdUtilsStageCache::GetSessionLayerForVariantSelections(
         variantSelections.begin(), variantSelections.end());
     std::sort(variantSelectionsSorted.begin(), variantSelectionsSorted.end());
 
-    std::string sessionKey = modelName;
+    std::string sessionKey = primPath.GetString();
     TF_FOR_ALL(itr, variantSelectionsSorted) {
         sessionKey += ":" + itr->first + "=" + itr->second;
     }
@@ -85,10 +85,9 @@ UsdUtilsStageCache::GetSessionLayerForVariantSelections(
         if (itr == sessionLayerMap.end()) {
             SdfLayerRefPtr layer = SdfLayer::CreateAnonymous();
             if (!variantSelections.empty()) {
-                SdfPrimSpecHandle over = SdfPrimSpec::New(
+                SdfPrimSpecHandle over = SdfCreatePrimInLayer(
                     layer,
-                    modelName,
-                    SdfSpecifierOver);
+                    primPath);
                 TF_FOR_ALL(varSelItr, variantSelections) {
                     // Construct the variant opinion for the session layer.
                     over->GetVariantSelections()[varSelItr->first] =

--- a/pxr/usd/lib/usdUtils/stageCache.h
+++ b/pxr/usd/lib/usdUtils/stageCache.h
@@ -33,6 +33,7 @@
 
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/usd/sdf/path.h"
 
 #include <string>
 #include <vector>
@@ -61,7 +62,7 @@ public:
     /// session layer with those opinions.
     USDUTILS_API
     static SdfLayerRefPtr GetSessionLayerForVariantSelections(
-        const TfToken& modelName,
+        const SdfPath& primPath,
         const std::vector<std::pair<std::string, std::string> > &variantSelections);
 };
 

--- a/third_party/maya/lib/usdMaya/proxyShape.cpp
+++ b/third_party/maya/lib/usdMaya/proxyShape.cpp
@@ -518,12 +518,10 @@ UsdMayaProxyShape::computeInStageDataCached(MDataBlock& dataBlock)
                 dataBlock.inputValue(_psData.primPath, &retValue).asString();
             CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
-            std::vector<std::string> primPathEltStrs =
-                TfStringTokenize(primPathMString.asChar(),"/");
-            if (primPathEltStrs.size() > 0) {
+            if (primPathMString.length() > 0) {
                 sessionLayer =
                     UsdUtilsStageCache::GetSessionLayerForVariantSelections(
-                        TfToken(primPathEltStrs[0]), variantSelections);
+                        SdfPath(primPathMString.asChar()), variantSelections);
             }
         }
 

--- a/third_party/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/third_party/maya/lib/usdMaya/referenceAssembly.cpp
@@ -271,6 +271,7 @@ MStatus UsdMayaReferenceAssembly::initialize(
 
     status = attributeAffects(psData->inStageDataCached, psData->outStageData);
 
+    status = attributeAffects(psData->primPath, psData->inStageDataCached);
     status = attributeAffects(psData->primPath, psData->outStageData);
 
 
@@ -657,10 +658,18 @@ MStatus UsdMayaReferenceAssembly::computeInStageDataCached(MDataBlock& dataBlock
         SdfPath        primPath;
 
         if (SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(fileString)) {
+            // Get the primPath
+            primPath = getPrimPath(dataBlock, rootLayer);
+            if (primPath.IsEmpty()) {
+                // XXX:
+                // Preserving prior behavior for now-- eventually might make
+                // more sense to bail in this case.
+                primPath = SdfPath::AbsoluteRootPath();
+            }
+
             SdfLayerRefPtr sessionLayer;
             std::vector<std::pair<std::string, std::string> > varSelsVec;
             MFnDependencyNode depNodeFn(thisMObject());
-            TfToken modelName = UsdUtilsGetModelNameFromRootLayer(rootLayer);
             const std::set<std::string> varSetNamesForCache = _GetVariantSetNamesForStageCache(depNodeFn);
             TF_FOR_ALL(variantSet, varSetNamesForCache) {
                 MString variantSetPlugName(PxrUsdMayaVariantSetTokens->PlugNamePrefix.GetText());
@@ -671,12 +680,13 @@ MStatus UsdMayaReferenceAssembly::computeInStageDataCached(MDataBlock& dataBlock
                     if (varSetVal.length() > 0) {
                         varSelsVec.push_back(
                             std::make_pair(*variantSet, varSetVal.asChar()));
+
                     }
                 }
             }
             
             sessionLayer = UsdUtilsStageCache::GetSessionLayerForVariantSelections(
-                modelName, varSelsVec);
+                primPath, varSelsVec);
 
             // If we have assembly edits, do not share session layers with
             // other models that have our same set of variant selections,
@@ -776,13 +786,8 @@ MStatus UsdMayaReferenceAssembly::computeOutStageData(MDataBlock& dataBlock)
     // Get the prim
     // If no primPath string specified, then use the pseudo-root.
     UsdPrim usdPrim;
-    std::string primPathStr = aPrimPath.asChar();
-    if (primPathStr.empty() && usdStage->GetDefaultPrim()) {
-        usdPrim = usdStage->GetDefaultPrim();
-    }
-    if (!usdPrim && !primPathStr.empty()) {
-        SdfPath primPath(primPathStr);
-
+    SdfPath primPath = getPrimPath(dataBlock, usdStage->GetRootLayer());
+    if (!primPath.IsEmpty()) {
         // Validate assumption: primPath is descendent of passed-in stage primPath
         //   Make sure that the primPath is a child of the passed in stage's primpath
         //   This allows data for variants to flow down the hierarchy as expected
@@ -792,10 +797,10 @@ MStatus UsdMayaReferenceAssembly::computeOutStageData(MDataBlock& dataBlock)
         else {
             MGlobal::displayWarning("UsdMayaReferenceAssembly::computeOutStageData" + MPxNode::name() + ": Stage primPath '" + 
                                     MString(inData->primPath.GetText()) + "'' not a parent of primPath '" +
-                                    MString(primPathStr.c_str()) + "'. Skipping variant assignment.");
+                                    MString(primPath.GetText()) + "'. Skipping variant assignment.");
         }
     } else {
-        MGlobal::displayWarning(MPxNode::name() + ": Stage primPath MISSING");
+        MGlobal::displayWarning(MPxNode::name() + ": Stage primPath invalid, or empty and no default prim defined");
     }
 
     // Handle UsdPrim variant overrides for subassemblies (i.e., assemblies
@@ -851,6 +856,28 @@ MStatus UsdMayaReferenceAssembly::computeOutStageData(MDataBlock& dataBlock)
     return MS::kSuccess;
 }
 
+SdfPath UsdMayaReferenceAssembly::getPrimPath(
+        MDataBlock& dataBlock,
+        SdfLayerRefPtr rootLayer)
+{
+    MStatus retValue = MS::kSuccess;
+    const MString aPrimPath = dataBlock.inputValue(_psData.primPath, &retValue).asString();
+    CHECK_MSTATUS_AND_RETURN(retValue, SdfPath());
+
+    if (aPrimPath.length() == 0) {
+        TfToken name = rootLayer->GetDefaultPrim();
+        if (SdfPath::IsValidIdentifier(name)) {
+            return SdfPath::AbsoluteRootPath().AppendChild(name);
+        }
+    }
+    else {
+        // Note that if aPrimPath is an invalid path, this will just return
+        // and empty SdfPath
+        return SdfPath(aPrimPath.asChar());
+    }
+    return SdfPath();
+
+}
 
 bool UsdMayaReferenceAssembly::setInternalValueInContext( const MPlug& plug,
                                              const MDataHandle& dataHandle,

--- a/third_party/maya/lib/usdMaya/referenceAssembly.h
+++ b/third_party/maya/lib/usdMaya/referenceAssembly.h
@@ -240,6 +240,7 @@ public:
     // Private Class functions
     MStatus computeInStageDataCached(MDataBlock& dataBlock);
     MStatus computeOutStageData(MDataBlock& dataBlock);
+    SdfPath getPrimPath(MDataBlock& dataBlock, SdfLayerRefPtr rootLayer);
 
     // After discussion with Autodesk, we've decided to adopt the namespace
     // handling functionality from their sample assembly reference


### PR DESCRIPTION
This makes the variant-selections cache key more accurate, as the variants are tied to a particular prim-path, not a root name.

This necessitated some other changes - for instance, pxrUsdReferenceAssembly.inStageDataCached is now affected by .primPath.  Also, it allowed us to eliminate a double-setting of variants that was (potentially) occuring in usdReadJob::doIt

### Description of Change(s)

The current args to GetSessionLayerForVariantSelections seemed to make it re-used cached session layers inappropriately in some cases (as well as set variant overrides incorrectly), as the variant selections often do NOT apply to a root-level prim.  This fixes this by making it take a full SdfPath as the arg to build the key (and apply the variant overs).

### Included Commit(s)
- ~~187718eaadd37b1f42b82787a197ce736f69fbda~~
- ~~https://github.com/PixarAnimationStudios/USD/pull/161/commits/059d7947917bb7b3c5f22437a95d0b39e97965ed~~
- https://github.com/PixarAnimationStudios/USD/pull/161/commits/318372e917d19c176df0e7e96380f180fe1a7fd7

### Fixes Issue(s)
- None filed

