### PR TITLE
missing python import

### DIFF
--- a/third_party/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/third_party/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -333,7 +333,7 @@ PxrUsdMayaTranslatorModelAssembly::Read(
     // seems to be the only way to ensure that the assembly's namespace and
     // container are setup correctly.
     const std::string assemblyCmd =
-        TfStringPrintf("cmds.assembly(name=\'%s\', type=\'%s\')",
+        TfStringPrintf("import maya.cmds; maya.cmds.assembly(name=\'%s\', type=\'%s\')",
                        prim.GetName().GetText(),
                        assemblyTypeName.c_str());
     MString newAssemblyName;


### PR DESCRIPTION
### Description of Change(s)

Small fix for assembly creation - python command was missing import

### Included Commit(s)
- f10b832e25e17c6b849d5594da2fdab8f2ca358f

### Fixes Issue(s)
- Would fail creating assemblies if used in a fresh / stock maya, with no userSetup.py, etc.

