### PR TITLE
Setting up the shading mode option menu dynamically.

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -72,6 +72,7 @@ pxr_shared_library(${PXR_PACKAGE}
         referenceAssembly
         usdImport
         usdExport
+        usdListShadingModes
         usdTranslatorExport
         usdTranslatorImport
 

--- a/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
@@ -70,6 +70,28 @@ PxrUsdMayaShadingModeRegistry::_GetImporter(const TfToken& name)
     return _importReg[name];
 }
 
+TfTokenVector
+PxrUsdMayaShadingModeRegistry::_ListExporters() {
+    TfRegistryManager::GetInstance().SubscribeTo<PxrUsdMayaShadingModeExportContext>();
+    TfTokenVector ret;
+    ret.reserve(_exportReg.size());
+    for (const auto& e : _exportReg) {
+        ret.push_back(e.first);
+    }
+    return ret;
+}
+
+TfTokenVector
+PxrUsdMayaShadingModeRegistry::_ListImporters() {
+    TfRegistryManager::GetInstance().SubscribeTo<PxrUsdMayaShadingModeImportContext>();
+    TfTokenVector ret;
+    ret.reserve(_importReg.size());
+    for (const auto& e : _importReg) {
+        ret.push_back(e.first);
+    }
+    return ret;
+}
+
 TF_INSTANTIATE_SINGLETON(PxrUsdMayaShadingModeRegistry);
 
 PxrUsdMayaShadingModeRegistry&

--- a/third_party/maya/lib/usdMaya/shadingModeRegistry.h
+++ b/third_party/maya/lib/usdMaya/shadingModeRegistry.h
@@ -65,6 +65,12 @@ public:
     static PxrUsdMayaShadingModeImporter GetImporter(const TfToken& name) {
         return GetInstance()._GetImporter(name);
     }
+    static TfTokenVector ListExporters() {
+        return GetInstance()._ListExporters();
+    }
+    static TfTokenVector ListImporters() {
+        return GetInstance()._ListImporters();
+    }
 
     PXRUSDMAYA_API
     static PxrUsdMayaShadingModeRegistry& GetInstance();
@@ -81,6 +87,9 @@ public:
 private:
     PxrUsdMayaShadingModeExporterCreator _GetExporter(const TfToken& name);
     PxrUsdMayaShadingModeImporter _GetImporter(const TfToken& name);
+
+    TfTokenVector _ListExporters();
+    TfTokenVector _ListImporters();
 
     PxrUsdMayaShadingModeRegistry();
     ~PxrUsdMayaShadingModeRegistry();

--- a/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
+++ b/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
@@ -1,0 +1,73 @@
+#include "usdMaya/usdListShadingModes.h"
+
+#include "usdMaya/shadingModeRegistry.h"
+
+#include <maya/MSyntax.h>
+#include <maya/MStatus.h>
+#include <maya/MArgList.h>
+#include <maya/MArgDatabase.h>
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+usdListShadingModes::usdListShadingModes() {
+
+}
+
+usdListShadingModes::~usdListShadingModes() {
+
+}
+
+MStatus
+usdListShadingModes::doIt(const MArgList& args) {
+    MStatus status;
+    MArgDatabase argData(syntax(), args, &status);
+
+    if (status != MS::kSuccess) {
+        MGlobal::displayError("Invalid parameters detected. Exiting.");
+        return status;
+    }
+
+    TfTokenVector v;
+    if (argData.isFlagSet("export")) {
+        v = PxrUsdMayaShadingModeRegistry::ListExporters();
+    } else if (argData.isFlagSet("import")) {
+        v = PxrUsdMayaShadingModeRegistry::ListImporters();
+    }
+
+    // This is remapped in JobArgs.cpp manually
+    appendToResult("None");
+
+    for (const auto& e : v) {
+        // Manual remappings
+        if (e == PxrUsdMayaShadingModeTokens->displayColor) {
+            appendToResult("GPrim Colors");
+            appendToResult("Material Colors");
+        } else if (e == "pxrRis") {
+            appendToResult("RfM Shaders");
+        } else {
+            appendToResult(e.GetString().c_str());
+        }
+    }
+
+    return MS::kSuccess;
+}
+
+MSyntax
+usdListShadingModes::createSyntax() {
+    MSyntax syntax;
+    syntax.addFlag("-ex", "-export", MSyntax::kNoArg);
+    syntax.addFlag("-im", "-import", MSyntax::kNoArg);
+
+    syntax.enableQuery(false);
+    syntax.enableEdit(false);
+
+    return syntax;
+}
+
+void* usdListShadingModes::creator() {
+    return new usdListShadingModes();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/usdListShadingModes.h
+++ b/third_party/maya/lib/usdMaya/usdListShadingModes.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef _usdListShadingModes_usdListShadingModes_h_
+#define _usdListShadingModes_usdListShadingModes_h_
+
+#include "pxr/pxr.h"
+#include <maya/MPxCommand.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class usdListShadingModes : public MPxCommand
+{
+public:
+    usdListShadingModes();
+    virtual ~usdListShadingModes();
+
+    virtual MStatus doIt(const MArgList& args);
+    virtual bool  isUndoable () const { return false; };
+
+    static MSyntax  createSyntax();
+    static void* creator();
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // _usdListShadingModes_usdListShadingModes_h_

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
@@ -91,7 +91,16 @@ usdTranslatorExport::writer(const MFileObject &file,
                     if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode)) {
                         jobArgs.shadingMode = shadingMode;
                     }
-                }
+                } else { 
+                    TfToken modeToken(theOption[1].asChar()); 
+                    if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(modeToken)) { 
+                        jobArgs.shadingMode = modeToken; 
+                    } else { 
+                        MGlobal::displayError( 
+                            TfStringPrintf("No shadingMode '%s' found. Setting shadingMode='none'", modeToken.GetText()).c_str()); 
+                        jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->none; 
+                    }
+                } 
             }
             if (theOption[0] == MString("exportUVs")) {
                 jobArgs.exportMeshUVs = theOption[1].asInt();

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -98,14 +98,14 @@ global proc int usdTranslatorExport (string $parent,
     if ($action == "post") {
         setParent $parent;
 
-        columnLayout -adj true usdOptsCol;
-        
-	    optionMenuGrp -l "Shading Mode:" shadingModePopup;
-	        menuItem -l "None";
-	        menuItem -l "GPrim Colors";
-	        menuItem -l "Material Colors";
-	        menuItem -l "RfM Shaders";
-            
+        columnLayout -adj true usdOptsCol;       
+
+        string $exporters[] = `usdListShadingModes -export`;
+        optionMenuGrp -l "Shading Mode:" shadingModePopup;
+        for ($each in $exporters) {
+            menuItem -l $each;
+        }
+
         checkBox -l "Make Instances" exportReferencesAsInstanceableCheckBox;
 
         checkBox -l "Export UVs" exportUVsCheckBox;

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
@@ -95,6 +95,15 @@ MStatus usdTranslatorImport::reader(const MFileObject & file,
                                         shadingMode.GetText()).c_str());
                         jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->none;
                     }
+                } else { 
+                    TfToken modeToken(theOption[1].asChar()); 
+                    if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(modeToken)) { 
+                        jobArgs.shadingMode = modeToken; 
+                    } else { 
+                        MGlobal::displayError( 
+                            TfStringPrintf("No shadingMode '%s' found. Setting shadingMode='none'", modeToken.GetText()).c_str()); 
+                        jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->none; 
+                    }
                 }
             } else if (theOption[0] == MString("readAnimData")) {
                 jobArgs.readAnimData = theOption[1].asInt();

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
@@ -73,13 +73,13 @@ global proc int usdTranslatorImport (string $parent,
         setParent $parent;
 
         columnLayout -adj true usdOptsCol;
-        
-	    optionMenuGrp -l "Shading Mode:" shadingModePopup;
-	        menuItem -l "None";
-	        menuItem -l "GPrim Colors";
-	        menuItem -l "Material Colors";
-	        menuItem -l "RfM Shaders";
-            
+
+        string $importers[] = `usdListShadingModes -import`;
+        optionMenuGrp -l "Shading Mode:" shadingModePopup;
+        for ($each in $importers) {
+            menuItem -l $each;
+        }
+
         checkBox -l "Read Animation Data" -cc ("usdTranslatorImport_AnimationCB") readAnimDataCheckBox;
 
         checkBox -l "Custom Frame Range" -cc ("usdTranslatorImport_AnimationCB") customFrameRangeCheckBox;

--- a/third_party/maya/plugin/pxrUsd/plugin.cpp
+++ b/third_party/maya/plugin/pxrUsd/plugin.cpp
@@ -33,6 +33,7 @@
 #include "usdMaya/pluginStaticData.h"
 #include "usdMaya/usdImport.h"
 #include "usdMaya/usdExport.h"
+#include "usdMaya/usdListShadingModes.h"
 #include "usdMaya/usdTranslatorImport.h"
 #include "usdMaya/usdTranslatorExport.h"
 
@@ -147,6 +148,14 @@ MStatus initializePlugin(
         status.perror("registerCommand usdImport");
     }
 
+    status = plugin.registerCommand("usdListShadingModes",
+                                    usdListShadingModes::creator,
+                                    usdListShadingModes::createSyntax);
+
+    if (!status) {
+        status.perror("registerCommand usdListShadingModes");
+    }
+    
     status = plugin.registerFileTranslator("pxrUsdImport", 
                                     "", 
                                     []() { 
@@ -200,6 +209,11 @@ MStatus uninitializePlugin(
     status = plugin.deregisterFileTranslator("pxrUsdExport");
     if (!status) {
         status.perror("pxrUsd: unable to deregister USD Export translator.");
+    }
+
+    status = plugin.deregisterFileTranslator("usdListShadingModes");
+    if (!status) {
+        status.perror("deregisterCommand usdListShadingModes");
     }
 
     status = MGlobal::executeCommand("assembly -e -deregister " + _data.referenceAssembly.typeName);


### PR DESCRIPTION
### Description of Change(s)
The change builds the Shading Mode list dynamically, instead of hard coding the values in the Mel scripts. The advantage of this change is adding a new shading mode export won't require manual changes in the UI scripts, and the translatorMaterial will use the right exporter at export time.

To make this work, I needed to add a new command to list the export/import Shading Modes, similar functions to the Registry, and modify the UI scripts to build the optionMenu based on the output of the command.

### Fixes Issue(s)
N/A

