### PR TITLE
Redesigning the shading mode export interface

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -50,6 +50,7 @@ pxr_shared_library(${PXR_PACKAGE}
         translatorUtil
         translatorXformable
         shadingModeExporter
+        shadingModeExporterContext
         shadingModeImporter
         shadingModeRegistry
         util

--- a/third_party/maya/lib/usdMaya/shadingModeExporter.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporter.h
@@ -21,72 +21,34 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
+
 #ifndef PXRUSDMAYA_SHADINGMODEEXPORTER_H
 #define PXRUSDMAYA_SHADINGMODEEXPORTER_H
 
 #include "pxr/pxr.h"
-#include "usdMaya/util.h"
-#include "pxr/usd/usd/stage.h"
 
+#include "usdMaya/shadingModeExporterContext.h"
 
-#include <maya/MObject.h>
-#include <boost/function.hpp>
+#include <functional>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-class PxrUsdMayaShadingModeExportContext
-{
+class PxrUsdMayaShadingModeExporter {
 public:
-    MObject GetShadingEngine() const { return _shadingEngine; }
-    const UsdStageRefPtr& GetUsdStage() const { return _stage; }
+    PxrUsdMayaShadingModeExporter();
+    virtual ~PxrUsdMayaShadingModeExporter();
 
-    MObject GetSurfaceShader() const;
+    virtual void DoExport(const UsdStageRefPtr& stage,
+                          const PxrUsdMayaUtil::ShapeSet& bindableRoots,
+                          bool mergeTransformAndShape,
+                          const SdfPath& overrideRootPath);
 
-    /// An assignment contains a bound prim path and a list of faceIndices. 
-    /// If the list of faceIndices is non-empty, then it is a partial assignment
-    /// targeting a subset of the bound prim's faces. 
-    /// If the list of faceIndices is empty, it means the assignment targets 
-    /// all the faces in the bound prim or the entire bound prim.
-    typedef std::pair<SdfPath, VtIntArray> Assignment;
-    
-    /// Vector of assignments.
-    typedef std::vector<Assignment> AssignmentVector;
-
-    /// Returns a vector of binding assignments associated with the shading 
-    /// engine.
-    AssignmentVector GetAssignments() const;
-
-    /// Use this function to create a UsdShadeMaterial prim at the "standard"
-    /// location.  The "standard" location may change depending on arguments
-    /// that are passed to the export script.
-    UsdPrim MakeStandardMaterialPrim(
-            const AssignmentVector& assignmentsToBind,
-            const std::string& name=std::string()) const;
-
-    /// Use this function to get a "standard" usd attr name for \p attrPlug.
-    /// The definition of "standard" may depend on arguments passed to the
-    /// script (i.e. stripping namespaces, etc.).
-    std::string GetStandardAttrName(const MPlug& attrPlug) const;
-
-    PxrUsdMayaShadingModeExportContext(
-            const MObject& shadingEngine,
-            const UsdStageRefPtr& stage,
-            bool mergeTransformAndShape,
-            const PxrUsdMayaUtil::ShapeSet& bindableRoots,
-            SdfPath overrideRootPath); 
-
-private:
-    MObject _shadingEngine;
-    const UsdStageRefPtr& _stage;
-    bool _mergeTransformAndShape;
-    SdfPath _overrideRootPath;
-
-    SdfPathSet _bindableRoots;
+    virtual void Export(const PxrUsdMayaShadingModeExportContext& context);
 };
 
-typedef boost::function< void (PxrUsdMayaShadingModeExportContext*) > PxrUsdMayaShadingModeExporter;
-
+using PxrUsdMayaShadingModeExporterPtr = std::shared_ptr<PxrUsdMayaShadingModeExporter>;
+using PxrUsdMayaShadingModeExporterCreator = std::function<std::shared_ptr<PxrUsdMayaShadingModeExporter>()>;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
@@ -1,0 +1,264 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/pxr.h"
+#include "usdMaya/shadingModeExporterContext.h"
+
+#include "usdMaya/util.h"
+
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usdGeom/scope.h"
+#include "pxr/usd/usdShade/material.h"
+#include "pxr/usd/usdShade/parameter.h"
+#include "pxr/usd/usdShade/shader.h"
+
+#include <maya/MDagPath.h>
+#include <maya/MFnDagNode.h>
+#include <maya/MItMeshPolygon.h>
+#include <maya/MNamespace.h>
+#include <maya/MObjectArray.h>
+#include <maya/MString.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+
+PxrUsdMayaShadingModeExportContext::PxrUsdMayaShadingModeExportContext(
+        const MObject& shadingEngine,
+        const UsdStageRefPtr& stage,
+        bool mergeTransformAndShape,
+        const PxrUsdMayaUtil::ShapeSet& bindableRoots,
+        SdfPath overrideRootPath) :
+    _shadingEngine(shadingEngine),
+    _stage(stage),
+    _mergeTransformAndShape(mergeTransformAndShape),
+    _overrideRootPath(overrideRootPath)
+{
+    if (bindableRoots.empty()) {
+        // if none specified, push back '/' which encompasses all
+        _bindableRoots.insert(SdfPath::AbsoluteRootPath());
+    }
+    else {
+        TF_FOR_ALL(bindableRootIter, bindableRoots) {
+            const MDagPath& bindableRootDagPath = *bindableRootIter;
+
+
+            SdfPath usdPath = PxrUsdMayaUtil::MDagPathToUsdPath(bindableRootDagPath, 
+                _mergeTransformAndShape);
+
+            // If _overrideRootPath is not empty, replace the root namespace with it
+            if (!_overrideRootPath.IsEmpty() ) {
+                usdPath = usdPath.ReplacePrefix(usdPath.GetPrefixes()[0], _overrideRootPath);
+            }
+
+            _bindableRoots.insert(usdPath);
+        }
+    }
+}
+
+MObject
+PxrUsdMayaShadingModeExportContext::GetSurfaceShader() const
+{
+    MStatus status;
+    MFnDependencyNode seDepNode(_shadingEngine, &status);
+    if (!status) {
+        return MObject();
+    }
+
+    MPlug ssPlug = seDepNode.findPlug("surfaceShader", true, &status);
+    if (!status) {
+        return MObject();
+    }
+
+    MObject ss(ssPlug.asMObject());
+    if (ss.isNull()) {
+        return MObject();
+    }
+
+    return PxrUsdMayaUtil::GetConnected(ssPlug).node();
+}
+
+PxrUsdMayaShadingModeExportContext::AssignmentVector
+PxrUsdMayaShadingModeExportContext::GetAssignments() const
+{
+    AssignmentVector ret;
+
+    MStatus status;
+    MFnDependencyNode seDepNode(_shadingEngine, &status);
+    if (!status) {
+        return ret;
+    }
+
+    MPlug dsmPlug = seDepNode.findPlug("dagSetMembers", true, &status);
+    if (!status) {
+        return ret;
+    }
+
+    SdfPathSet seenBoundPrimPaths;
+    for (unsigned int i = 0; i < dsmPlug.numConnectedElements(); i++) {
+        MPlug dsmElemPlug(dsmPlug.connectionByPhysicalIndex(i));
+        MStatus status = MS::kFailure;
+        MFnDagNode dagNode(PxrUsdMayaUtil::GetConnected(dsmElemPlug).node(), &status);
+        if (!status) {
+            continue;
+        }
+
+        MDagPath dagPath;
+        if (!dagNode.getPath(dagPath))
+            continue;
+
+        SdfPath usdPath = PxrUsdMayaUtil::MDagPathToUsdPath(dagPath, 
+            _mergeTransformAndShape);
+
+        // If _overrideRootPath is not empty, replace the root namespace with it
+        if (!_overrideRootPath.IsEmpty() ) {
+            usdPath = usdPath.ReplacePrefix(usdPath.GetPrefixes()[0], _overrideRootPath);
+        }
+        
+        // If this path has already been processed, skip it.
+        if (!seenBoundPrimPaths.insert(usdPath).second)
+            continue;
+
+        // If the bound prim's path is not below a bindable root, skip it.
+        if (SdfPathFindLongestPrefix(_bindableRoots.begin(), 
+            _bindableRoots.end(), usdPath) == _bindableRoots.end()) {
+            continue;
+        }
+
+        MObjectArray sgObjs, compObjs;
+        // Assuming that instancing is not involved.
+        status = dagNode.getConnectedSetsAndMembers(0, sgObjs, compObjs, true);
+        if (!status)
+            continue;
+
+        for (size_t j = 0; j < sgObjs.length(); j++) {
+            // If the shading group isn't the one we're interested in, skip it.
+            if (sgObjs[j] != _shadingEngine)
+                continue;
+
+            VtIntArray faceIndices;
+            if (!compObjs[j].isNull()) {
+                MItMeshPolygon faceIt(dagPath, compObjs[j]);
+                faceIndices.reserve(faceIt.count());
+                for ( faceIt.reset() ; !faceIt.isDone() ; faceIt.next() ) {
+                    faceIndices.push_back(faceIt.index());
+                }
+            }
+            ret.push_back(std::make_pair(usdPath, faceIndices));
+        }
+    }
+    return ret;
+}
+
+static UsdPrim
+_GetMaterialParent(const UsdStageRefPtr& stage,
+               const PxrUsdMayaShadingModeExportContext::AssignmentVector& assignments)
+{
+    SdfPath commonAncestor;
+    TF_FOR_ALL(iter, assignments) {
+        const SdfPath& assn = iter->first;
+        if (stage->GetPrimAtPath(assn)) {
+            if (commonAncestor.IsEmpty()) {
+                commonAncestor = assn;
+            }
+            else {
+                commonAncestor = commonAncestor.GetCommonPrefix(assn);
+            }
+        }
+    }
+
+    if (commonAncestor.IsEmpty()) {
+        return UsdPrim();
+    }
+
+    if (commonAncestor == SdfPath::AbsoluteRootPath()) {
+        return stage->GetPseudoRoot();
+    }
+
+    SdfPath shaderExportLocation = commonAncestor;
+    while (!shaderExportLocation.IsRootPrimPath()) {
+        shaderExportLocation = shaderExportLocation.GetParentPath();
+    }
+    shaderExportLocation = shaderExportLocation.AppendChild(TfToken("Looks"));
+
+    return UsdGeomScope::Define(stage, shaderExportLocation).GetPrim();
+}
+
+UsdPrim
+PxrUsdMayaShadingModeExportContext::MakeStandardMaterialPrim(
+        const AssignmentVector& assignmentsToBind,
+        const std::string& name) const
+{
+    UsdPrim ret;
+
+    std::string materialName = name;
+    if (materialName.empty()) {
+        MStatus status;
+        MFnDependencyNode seDepNode(_shadingEngine, &status);
+        if (!status) {
+            return ret;
+        }
+        MString seName = seDepNode.name();
+        materialName = MNamespace::stripNamespaceFromName(seName).asChar();
+    }
+
+    materialName = PxrUsdMayaUtil::SanitizeName(materialName);
+    UsdStageRefPtr stage = GetUsdStage();
+    if (UsdPrim materialParent = _GetMaterialParent(stage, assignmentsToBind)) {
+        SdfPath materialPath = materialParent.GetPath().AppendChild(
+                TfToken(materialName));
+        UsdShadeMaterial material = UsdShadeMaterial::Define(
+                GetUsdStage(), materialPath);
+
+        UsdPrim materialPrim = material.GetPrim();
+
+        // could use this to determine where we want to export.  whatever.
+        TF_FOR_ALL(iter, assignmentsToBind) {
+            const SdfPath &boundPrimPath = iter->first;
+            const VtIntArray &faceIndices = iter->second;
+
+            UsdPrim boundPrim = stage->OverridePrim(boundPrimPath);
+            if (faceIndices.empty()) {
+                material.Bind(boundPrim);
+            } else {
+                UsdGeomFaceSetAPI faceSet = material.CreateMaterialFaceSet(
+                        boundPrim);
+                faceSet.AppendFaceGroup(faceIndices, materialPath);
+            }
+        }
+
+        return materialPrim;
+    }
+
+    return UsdPrim();
+}
+
+std::string
+PxrUsdMayaShadingModeExportContext::GetStandardAttrName(const MPlug& attrPlug) const
+{
+    MString mayaPlgName = attrPlug.partialName(false, false, false, false, false, true);
+    return mayaPlgName.asChar();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
@@ -1,0 +1,88 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXRUSDMAYA_SHADINGMODEEXPORTERCONTEXT_H
+#define PXRUSDMAYA_SHADINGMODEEXPORTERCONTEXT_H
+
+#include "pxr/pxr.h"
+#include "usdMaya/util.h"
+#include "pxr/usd/usd/stage.h"
+
+
+#include <maya/MObject.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class PxrUsdMayaShadingModeExportContext
+{
+public:
+    MObject GetShadingEngine() const { return _shadingEngine; }
+    const UsdStageRefPtr& GetUsdStage() const { return _stage; }
+
+    MObject GetSurfaceShader() const;
+
+    /// An assignment contains a bound prim path and a list of faceIndices. 
+    /// If the list of faceIndices is non-empty, then it is a partial assignment
+    /// targeting a subset of the bound prim's faces. 
+    /// If the list of faceIndices is empty, it means the assignment targets 
+    /// all the faces in the bound prim or the entire bound prim.
+    typedef std::pair<SdfPath, VtIntArray> Assignment;
+    
+    /// Vector of assignments.
+    typedef std::vector<Assignment> AssignmentVector;
+
+    /// Returns a vector of binding assignments associated with the shading 
+    /// engine.
+    AssignmentVector GetAssignments() const;
+
+    /// Use this function to create a UsdShadeMaterial prim at the "standard"
+    /// location.  The "standard" location may change depending on arguments
+    /// that are passed to the export script.
+    UsdPrim MakeStandardMaterialPrim(
+            const AssignmentVector& assignmentsToBind,
+            const std::string& name=std::string()) const;
+
+    /// Use this function to get a "standard" usd attr name for \p attrPlug.
+    /// The definition of "standard" may depend on arguments passed to the
+    /// script (i.e. stripping namespaces, etc.).
+    std::string GetStandardAttrName(const MPlug& attrPlug) const;
+
+    PxrUsdMayaShadingModeExportContext(
+            const MObject& shadingEngine,
+            const UsdStageRefPtr& stage,
+            bool mergeTransformAndShape,
+            const PxrUsdMayaUtil::ShapeSet& bindableRoots,
+            SdfPath overrideRootPath);
+private:
+    MObject _shadingEngine;
+    const UsdStageRefPtr& _stage;
+    bool _mergeTransformAndShape;
+    bool _handleUsdNamespaces;
+    SdfPath _overrideRootPath;
+
+    SdfPathSet _bindableRoots;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXRUSDMAYA_SHADINGMODEEXPORTERCONTEXT_H

--- a/third_party/maya/lib/usdMaya/shadingModePxrRis.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModePxrRis.cpp
@@ -27,6 +27,7 @@
 
 #include "usdMaya/shadingModeRegistry.h"
 #include "usdMaya/shadingModeExporter.h"
+#include "usdMaya/shadingModeExporterContext.h"
 
 #include "pxr/usd/usd/prim.h"
 
@@ -51,152 +52,161 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-namespace _exporter {
-
-static std::string
-_GetShaderTypeName(const MFnDependencyNode& depNode)
-{
-    std::string risShaderType(depNode.typeName().asChar());
-    // Now look into the RIS TABLE if the typeName doesn't starts with Pxr
-    if (!TfStringStartsWith(risShaderType, "Pxr")) {
-        for (size_t i=0;i<_RFM_RISNODE_TABLE.size();i++) {
-            if (_RFM_RISNODE_TABLE[i].first==risShaderType) {
-                risShaderType=_RFM_RISNODE_TABLE[i].second;
-                break;
+namespace {
+class PxrRisShadingModeExporter : public PxrUsdMayaShadingModeExporter {
+public:
+    PxrRisShadingModeExporter() {}
+private:
+    std::string
+    _GetShaderTypeName(const MFnDependencyNode& depNode)
+    {
+        std::string risShaderType(depNode.typeName().asChar());
+        // Now look into the RIS TABLE if the typeName doesn't starts with Pxr
+        if (!TfStringStartsWith(risShaderType, "Pxr")) {
+            for (size_t i=0;i<_RFM_RISNODE_TABLE.size();i++) {
+                if (_RFM_RISNODE_TABLE[i].first==risShaderType) {
+                    risShaderType=_RFM_RISNODE_TABLE[i].second;
+                    break;
+                }
             }
         }
-    }
-    return risShaderType;
-}
-
-static UsdPrim
-_ExportShadingNode(const UsdPrim& materialPrim,
-                   const MFnDependencyNode& depNode,
-                   const PxrUsdMayaShadingModeExportContext* context,
-                   SdfPathSet *processedPaths,
-                   bool isFirstNode
-)
-{
-    UsdStagePtr stage = materialPrim.GetStage();
-
-    // XXX: would be nice to write out the current display color as
-    // well.  currently, when we re-import, we don't get the display color so
-    // it shows up as black.
-
-    TfToken shaderPrimName(PxrUsdMayaUtil::SanitizeName(depNode.name().asChar()));
-    SdfPath shaderPath = materialPrim.GetPath().AppendChild(shaderPrimName);
-    if (processedPaths->count(shaderPath) == 1){
-        return stage->GetPrimAtPath(shaderPath);
+        return risShaderType;
     }
 
-    processedPaths->insert(shaderPath);
-    
-    // Determie the risShaderType that will correspont to the USD FilePath
-    std::string risShaderType(_GetShaderTypeName(depNode));
-    
-    if (!TfStringStartsWith(risShaderType, "Pxr")) {
-        MGlobal::displayError(TfStringPrintf(
+    UsdPrim
+    _ExportShadingNode(const UsdPrim& materialPrim,
+                       const MFnDependencyNode& depNode,
+                       const PxrUsdMayaShadingModeExportContext& context,
+                       SdfPathSet *processedPaths,
+                       bool isFirstNode
+    )
+    {
+        UsdStagePtr stage = materialPrim.GetStage();
+
+        // XXX: would be nice to write out the current display color as
+        // well.  currently, when we re-import, we don't get the display color so
+        // it shows up as black.
+
+        TfToken shaderPrimName(PxrUsdMayaUtil::SanitizeName(depNode.name().asChar()));
+        SdfPath shaderPath = materialPrim.GetPath().AppendChild(shaderPrimName);
+        if (processedPaths->count(shaderPath) == 1){
+            return stage->GetPrimAtPath(shaderPath);
+        }
+
+        processedPaths->insert(shaderPath);
+
+        // Determie the risShaderType that will correspont to the USD FilePath
+        std::string risShaderType(_GetShaderTypeName(depNode));
+
+        if (!TfStringStartsWith(risShaderType, "Pxr")) {
+            MGlobal::displayError(TfStringPrintf(
                 "_ExportShadingNode: skipping '%s' because it's type '%s' is not Pxr.\n",
                 depNode.name().asChar(),
                 risShaderType.c_str()).c_str());
-        return UsdPrim();        
-    }
-    
-    // The first node is the Bxdf, subsequent ones are Pattern objects
-    UsdRiRisObject risObj;
-    if (isFirstNode)
-        risObj = UsdRiRisBxdf::Define(stage, shaderPath);
-    else
-        risObj = UsdRiRisPattern::Define(stage, shaderPath);
-
-    risObj.CreateFilePathAttr(VtValue(SdfAssetPath(risShaderType)));
-
-    MStatus status = MS::kFailure;
-    
-    for (unsigned int i = 0; i < depNode.attributeCount(); i++) {
-        MPlug attrPlug = depNode.findPlug(depNode.attribute(i), true);
-        if (attrPlug.isProcedural()) {
-            // maya docs says these should not be saved off.  we skip them
-            // here.
-            continue;
+            return UsdPrim();
         }
 
-        if (attrPlug.isChild()) {
-            continue;
-        }
+        // The first node is the Bxdf, subsequent ones are Pattern objects
+        UsdRiRisObject risObj;
+        if (isFirstNode)
+            risObj = UsdRiRisBxdf::Define(stage, shaderPath);
+        else
+            risObj = UsdRiRisPattern::Define(stage, shaderPath);
 
-        // this is writing out things that live on the MFnDependencyNode.
-        // maybe that's OK?  nothing downstream cares about it.
+        risObj.CreateFilePathAttr(VtValue(SdfAssetPath(risShaderType)));
 
-        TfToken attrName = TfToken(context->GetStandardAttrName(attrPlug));
-        SdfValueTypeName attrTypeName = PxrUsdMayaWriteUtil::GetUsdTypeName(attrPlug);
-        if (!attrTypeName) {
-            // unsupported type
-            continue;
-        }
+        MStatus status = MS::kFailure;
 
-        UsdShadeParameter param = risObj.CreateParameter(attrName, attrTypeName);
-        if (!param) {
-            continue;
-        }
+        for (unsigned int i = 0; i < depNode.attributeCount(); i++) {
+            MPlug attrPlug = depNode.findPlug(depNode.attribute(i), true);
+            if (attrPlug.isProcedural()) {
+                // maya docs says these should not be saved off.  we skip them
+                // here.
+                continue;
+            }
 
-        PxrUsdMayaWriteUtil::SetUsdAttr(
+            if (attrPlug.isChild()) {
+                continue;
+            }
+
+            // this is writing out things that live on the MFnDependencyNode.
+            // maybe that's OK?  nothing downstream cares about it.
+
+            TfToken attrName = TfToken(context.GetStandardAttrName(attrPlug));
+            SdfValueTypeName attrTypeName = PxrUsdMayaWriteUtil::GetUsdTypeName(attrPlug);
+            if (!attrTypeName) {
+                // unsupported type
+                continue;
+            }
+
+            UsdShadeParameter param = risObj.CreateParameter(attrName, attrTypeName);
+            if (!param) {
+                continue;
+            }
+
+            PxrUsdMayaWriteUtil::SetUsdAttr(
                 attrPlug,
                 param.GetAttr(),
                 UsdTimeCode::Default());
 
-        if (attrPlug.isConnected() && attrPlug.isDestination()) {
-            MPlug connected(PxrUsdMayaUtil::GetConnected(attrPlug));
-            MFnDependencyNode c(connected.node(), &status);
-            if (status) {
-                if (UsdPrim cPrim = _ExportShadingNode(materialPrim, 
-                                                       c, 
-                                                       context,
-                                                       processedPaths,
-                                                       false)) {
-                    param.ConnectToSource(
-                            UsdShadeShader(cPrim), 
-                            TfToken(context->GetStandardAttrName(connected)));
+            if (attrPlug.isConnected() && attrPlug.isDestination()) {
+                MPlug connected(PxrUsdMayaUtil::GetConnected(attrPlug));
+                MFnDependencyNode c(connected.node(), &status);
+                if (status) {
+                    if (UsdPrim cPrim = _ExportShadingNode(materialPrim,
+                                                           c,
+                                                           context,
+                                                           processedPaths,
+                                                           false)) {
+                        param.ConnectToSource(
+                            UsdShadeShader(cPrim),
+                            TfToken(context.GetStandardAttrName(connected)));
+                    }
                 }
             }
         }
+
+        return risObj.GetPrim();
     }
 
-    return risObj.GetPrim();
+    void Export(const PxrUsdMayaShadingModeExportContext& context) override {
+        MStatus status;
+        const PxrUsdMayaShadingModeExportContext::AssignmentVector &assignments =
+            context.GetAssignments();
+        if (assignments.empty()) {
+            return;
+        }
+
+        UsdPrim materialPrim = context.MakeStandardMaterialPrim(assignments);
+        if (!materialPrim) {
+            return;
+        }
+
+        MFnDependencyNode ssDepNode(context.GetSurfaceShader(), &status);
+        if (!status) {
+            return;
+        }
+        SdfPathSet  processedShaders;
+        if (UsdPrim shaderPrim = _ExportShadingNode(materialPrim,
+                                                    ssDepNode,
+                                                    context,
+                                                    &processedShaders, true)) {
+            UsdRiLookAPI riLook = UsdRiLookAPI(materialPrim);
+            std::vector<SdfPath> bxdfTargets;
+            bxdfTargets.push_back(shaderPrim.GetPath());
+            riLook.CreateBxdfRel().SetTargets(bxdfTargets);
+        }
+    }
+};
 }
 
-}; // namespace _exporter
-
-DEFINE_SHADING_MODE_EXPORTER(pxrRis, context)
+TF_REGISTRY_FUNCTION_WITH_TAG(PxrUsdMayaShadingModeExportContext, pxrRis)
 {
-    MStatus status;
-    const PxrUsdMayaShadingModeExportContext::AssignmentVector &assignments = 
-        context->GetAssignments();
-    if (assignments.empty()) {
-        return;
-    }
-
-    UsdPrim materialPrim = context->MakeStandardMaterialPrim(assignments);
-    if (!materialPrim) {
-        return;
-    }
-
-    MFnDependencyNode ssDepNode(context->GetSurfaceShader(), &status);
-    if (!status) {
-        return;
-    }
-    SdfPathSet  processedShaders;
-    if (UsdPrim shaderPrim = _exporter::_ExportShadingNode(materialPrim,
-                                                           ssDepNode,
-                                                           context,
-                                                           &processedShaders, true)) {
-        UsdRiLookAPI riLook = UsdRiLookAPI(materialPrim);
-        std::vector<SdfPath> bxdfTargets;
-        bxdfTargets.push_back(shaderPrim.GetPath());
-        riLook.CreateBxdfRel().SetTargets(bxdfTargets);
-    }
+    PxrUsdMayaShadingModeRegistry::GetInstance().RegisterExporter("pxrRis", []() -> PxrUsdMayaShadingModeExporterPtr {
+        return PxrUsdMayaShadingModeExporterPtr(
+            static_cast<PxrUsdMayaShadingModeExporter*>(new PxrRisShadingModeExporter()));
+    });
 }
-
 
 namespace _importer {
 

--- a/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
@@ -31,20 +31,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(PxrUsdMayaShadingModeTokens, PXRUSDMAYA_SHADINGMODE_TOKENS);
 
-typedef std::map<TfToken, PxrUsdMayaShadingModeExporter> _ExportRegistry;
+typedef std::map<TfToken, PxrUsdMayaShadingModeExporterCreator> _ExportRegistry;
 static _ExportRegistry _exportReg;
 
 bool
 PxrUsdMayaShadingModeRegistry::RegisterExporter(
         const std::string& name,
-        PxrUsdMayaShadingModeExporter fn)
+        PxrUsdMayaShadingModeExporterCreator fn)
 {
     std::pair<_ExportRegistry::const_iterator, bool> insertStatus = _exportReg.insert(
             std::make_pair(TfToken(name), fn));
     return insertStatus.second;
 }
 
-PxrUsdMayaShadingModeExporter 
+PxrUsdMayaShadingModeExporterCreator
 PxrUsdMayaShadingModeRegistry::_GetExporter(const TfToken& name)
 {
     TfRegistryManager::GetInstance().SubscribeTo<PxrUsdMayaShadingModeExportContext>();

--- a/third_party/maya/lib/usdMaya/shadingModeRegistry.h
+++ b/third_party/maya/lib/usdMaya/shadingModeRegistry.h
@@ -36,6 +36,7 @@
 
 #include "pxr/pxr.h"
 #include "usdMaya/shadingModeExporter.h"
+#include "usdMaya/shadingModeExporterContext.h"
 #include "usdMaya/shadingModeImporter.h"
 
 #include "pxr/base/tf/registryManager.h"
@@ -57,9 +58,8 @@ class PxrUsdMayaShadingModeRegistry : public TfWeakBase
 {
 public:
 
-    static PxrUsdMayaShadingModeExporter GetExporter(const TfToken& name) {
+    static PxrUsdMayaShadingModeExporterCreator GetExporter(const TfToken& name) {
         return GetInstance()._GetExporter(name);
-
     }
     static PxrUsdMayaShadingModeImporter GetImporter(const TfToken& name) {
         return GetInstance()._GetImporter(name);
@@ -68,27 +68,20 @@ public:
     static PxrUsdMayaShadingModeRegistry& GetInstance();
     bool RegisterExporter(
             const std::string& name, 
-            PxrUsdMayaShadingModeExporter fn);
+            PxrUsdMayaShadingModeExporterCreator fn);
 
     bool RegisterImporter(
             const std::string& name, 
             PxrUsdMayaShadingModeImporter fn);
 
 private:
-    PxrUsdMayaShadingModeExporter _GetExporter(const TfToken& name);
+    PxrUsdMayaShadingModeExporterCreator _GetExporter(const TfToken& name);
     PxrUsdMayaShadingModeImporter _GetImporter(const TfToken& name);
 
     PxrUsdMayaShadingModeRegistry();
     ~PxrUsdMayaShadingModeRegistry();
     friend class TfSingleton<PxrUsdMayaShadingModeRegistry>;
 };
-
-#define DEFINE_SHADING_MODE_EXPORTER(name, contextName) \
-static void _ShadingModeExporter_##name(PxrUsdMayaShadingModeExportContext*); \
-TF_REGISTRY_FUNCTION_WITH_TAG(PxrUsdMayaShadingModeExportContext, name) {\
-    PxrUsdMayaShadingModeRegistry::GetInstance().RegisterExporter(#name, &_ShadingModeExporter_##name); \
-}\
-void _ShadingModeExporter_##name(PxrUsdMayaShadingModeExportContext* contextName)
 
 #define DEFINE_SHADING_MODE_IMPORTER(name, contextName) \
 static MPlug _ShadingModeImporter_##name(PxrUsdMayaShadingModeImportContext*); \

--- a/third_party/maya/lib/usdMaya/translatorMaterial.cpp
+++ b/third_party/maya/lib/usdMaya/translatorMaterial.cpp
@@ -317,21 +317,10 @@ PxrUsdMayaTranslatorMaterial::ExportShadingEngines(
         return;
     }
 
-    if (PxrUsdMayaShadingModeExporter exporter =
+    if (auto exporterCreator =
             PxrUsdMayaShadingModeRegistry::GetExporter(shadingMode)) {
-        MItDependencyNodes shadingEngineIter(MFn::kShadingEngine);
-        for (; !shadingEngineIter.isDone(); shadingEngineIter.next()) {
-            MObject shadingEngine(shadingEngineIter.thisNode());
-            MFnDependencyNode seDepNode(shadingEngine);
-
-            PxrUsdMayaShadingModeExportContext c(
-                    shadingEngine,
-                    stage,
-                    mergeTransformAndShape,
-                    bindableRoots,
-                    overrideRootPath);
-
-            exporter(&c);
+        if (auto exporter = exporterCreator()) {
+            exporter->DoExport(stage, bindableRoots, mergeTransformAndShape, overrideRootPath);
         }
     }
     else {


### PR DESCRIPTION
### Description of Change(s)
This change deals with redesigning the shading mode export/import interface. As a first step, it's a take on the export interface. I tried to create a bit more flexible export process, so exporters can overwrite the whole process too if they don't want to go through the exporter context.

This is just a take on the shading mode export, so feedback can be gathered, before moving on to the importers.

### Fixes Issue(s)
- There is no way to do stateful shading mode export / import interfaces.
- There is no way to include spaces in the shading mode exporter's/importer's name, so lots of manual remapping is required.
- No easy way to link the same exporter to multiple modes.
- Exporters can't take over the whole process themselves, just by one shading node at a time.

