### PR TITLE
Fixing katana plugin linking issues.

### DIFF
--- a/third_party/katana/lib/katanaAttrfncApi/CMakeLists.txt
+++ b/third_party/katana/lib/katanaAttrfncApi/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PXR_PACKAGE katanaAttrfncApi)
 file(GLOB cppFiles
     ${KATANA_API_SOURCE_DIR}/FnAttribute/client/*.cpp
     ${KATANA_API_SOURCE_DIR}/FnPluginManager/client/*.cpp
-    ${KATANA_API_SOURCE_DIR}/FnPluginSystem/client/*.cpp
+    ${KATANA_API_SOURCE_DIR}/FnPluginSystem/*.cpp
     ${KATANA_API_SOURCE_DIR}/FnAttributeFunction/plugin/*.cpp
 )
 

--- a/third_party/katana/lib/katanaOpApi/CMakeLists.txt
+++ b/third_party/katana/lib/katanaOpApi/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB cppFiles
     ${KATANA_API_SOURCE_DIR}/FnGeolibServices/client/*.cpp
     ${KATANA_API_SOURCE_DIR}/FnLogging/client/*.cpp
     ${KATANA_API_SOURCE_DIR}/FnPluginManager/client/*.cpp
-    ${KATANA_API_SOURCE_DIR}/FnPluginSystem/client/*.cpp
+    ${KATANA_API_SOURCE_DIR}/FnPluginSystem/*.cpp
     ${KATANA_API_SOURCE_DIR}/pystring/.cpp
 )
 

--- a/third_party/katana/plugin/pxrUsdInShipped/CMakeLists.txt
+++ b/third_party/katana/plugin/pxrUsdInShipped/CMakeLists.txt
@@ -29,6 +29,7 @@ pxr_plugin(${PXR_PACKAGE}
         mesh.cpp
         model.cpp
         nurbsPatch.cpp
+        pointInstancer.cpp
         points.cpp
         scope.cpp
         uiUtils.cpp


### PR DESCRIPTION
### Description of Change(s)
Fixing Katana plugin linking issues.

### Fixes Issue(s)
- pointInstancer.cpp not included in pxrUsdInShipped.
- typos in katanaAttrfncApi and katanaOpApi CMakeLists.txt, the client subfolder doesn't exists for FnPluginSystem as of Katana 2.5v5.

