### PR TITLE
[usdMaya] Exporting instances from Maya.

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -66,6 +66,7 @@ pxr_shared_library(${PXR_PACKAGE}
         JobArgs
         usdReadJob
         usdWriteJob
+        usdWriteJobCtx
 
         pluginStaticData
         proxyShape

--- a/third_party/maya/lib/usdMaya/FunctorPrimWriter.h
+++ b/third_party/maya/lib/usdMaya/FunctorPrimWriter.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 #include "usdMaya/api.h"
 #include "usdMaya/MayaTransformWriter.h"
-#include "usdMaya/JobArgs.h"
 
 #include "usdMaya/primWriterArgs.h"
 #include "usdMaya/primWriterContext.h"
@@ -58,9 +57,10 @@ public:
 
     PXRUSDMAYA_API
     FunctorPrimWriter(
-            MDagPath& iDag,
-            UsdStageRefPtr& stage,
-            const JobExportArgs& iArgs,
+            const MDagPath& iDag,
+            const SdfPath& uPath,
+            bool instanceSource,
+            usdWriteJobCtx& jobCtx,
             WriterFn plugFn);
 
     PXRUSDMAYA_API
@@ -68,7 +68,7 @@ public:
 
     // Overrides for MayaTransformWriter
     PXRUSDMAYA_API
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
     
     PXRUSDMAYA_API
     virtual bool exportsGprims() const override;
@@ -81,16 +81,18 @@ public:
 
     PXRUSDMAYA_API
     static MayaPrimWriterPtr Create(
-            MDagPath& dag,
-            UsdStageRefPtr& stage,
-            const JobExportArgs& args,
+            const MDagPath& dag,
+            const SdfPath& path,
+            bool instanceSource,
+            usdWriteJobCtx& jobCtx,
             WriterFn plugFn);
 
     PXRUSDMAYA_API
     static std::function< MayaPrimWriterPtr(
-            MDagPath&,
-            UsdStageRefPtr&,
-            const JobExportArgs&) >
+            const MDagPath&,
+            const SdfPath&,
+            bool,
+            usdWriteJobCtx&) >
             CreateFactory(WriterFn plugFn);
 
 private:

--- a/third_party/maya/lib/usdMaya/JobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/JobArgs.cpp
@@ -46,6 +46,7 @@ JobExportArgs::JobExportArgs()
         exportDisplayColor(true),
         shadingMode(PxrUsdMayaShadingModeTokens->displayColor),
         mergeTransformAndShape(true),
+        exportInstances(true),
         exportAnimation(false),
         excludeInvisible(false),
         exportDefaultCameras(false),

--- a/third_party/maya/lib/usdMaya/JobArgs.h
+++ b/third_party/maya/lib/usdMaya/JobArgs.h
@@ -66,6 +66,7 @@ struct JobExportArgs
     TfToken shadingMode;
     
     bool mergeTransformAndShape;
+    bool exportInstances;
 
     bool exportAnimation;
     bool excludeInvisible;

--- a/third_party/maya/lib/usdMaya/MayaCameraWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaCameraWriter.cpp
@@ -40,27 +40,27 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 
-MayaCameraWriter::MayaCameraWriter(MDagPath & iDag, UsdStageRefPtr stage, const JobExportArgs & iArgs) :
-    MayaTransformWriter(iDag, stage, iArgs)
+MayaCameraWriter::MayaCameraWriter(const MDagPath & iDag, const SdfPath& uPath, usdWriteJobCtx& jobCtx) :
+    MayaTransformWriter(iDag, uPath, false, jobCtx) // cameras are not instanced
 {
-}
-
-/* virtual */
-UsdPrim MayaCameraWriter::write(const UsdTimeCode &usdTime)
-{
-    // == Write
     UsdGeomCamera primSchema =
         UsdGeomCamera::Define(getUsdStage(), getUsdPath());
     TF_AXIOM(primSchema);
-    UsdPrim prim = primSchema.GetPrim();
-    TF_AXIOM(prim);
+    mUsdPrim = primSchema.GetPrim();
+    TF_AXIOM(mUsdPrim);
+}
+
+/* virtual */
+void MayaCameraWriter::write(const UsdTimeCode &usdTime)
+{
+    // == Write
+    UsdGeomCamera primSchema(mUsdPrim);
 
     // Write parent class attrs
     writeTransformAttrs(usdTime, primSchema);
 
     // Write the attrs
     writeCameraAttrs(usdTime, primSchema);
-    return prim;
 }
 
 /* virtual */

--- a/third_party/maya/lib/usdMaya/MayaCameraWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaCameraWriter.h
@@ -26,6 +26,7 @@
 
 #include "pxr/pxr.h"
 #include "usdMaya/MayaTransformWriter.h"
+#include "usdMaya/usdWriteJobCtx.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -36,16 +37,16 @@ class UsdGeomCamera;
 class MayaCameraWriter : public MayaTransformWriter
 {
   public:
-    MayaCameraWriter(MDagPath & iDag, UsdStageRefPtr stage, const JobExportArgs & iArgs);
+    MayaCameraWriter(const MDagPath & iDag, const SdfPath& uPath, usdWriteJobCtx& jobCtx);
     virtual ~MayaCameraWriter() {};
 
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
     
   protected:
     bool writeCameraAttrs(const UsdTimeCode &usdTime, UsdGeomCamera &primSchema);
 };
 
-typedef shared_ptr < MayaCameraWriter > MayaCameraWriterPtr;
+typedef std::shared_ptr<MayaCameraWriter> MayaCameraWriterPtr;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/MayaMeshWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaMeshWriter.cpp
@@ -50,30 +50,29 @@ const float MayaMeshWriter::_ColorSetDefaultAlpha = 1.0;
 
 
 MayaMeshWriter::MayaMeshWriter(
-        MDagPath & iDag, 
-        UsdStageRefPtr stage, 
-        const JobExportArgs & iArgs) :
-    MayaTransformWriter(iDag, stage, iArgs)
+        const MDagPath & iDag,
+        const SdfPath& uPath,
+        bool instanceSource,
+        usdWriteJobCtx& jobCtx) :
+    MayaTransformWriter(iDag, uPath, instanceSource, jobCtx)
 {
-}
-
-//virtual 
-UsdPrim MayaMeshWriter::write(const UsdTimeCode &usdTime)
-{
-
     if ( !isMeshValid() ) {
-        return UsdPrim();
+        return;
     }
 
     // Get schema
     UsdGeomMesh primSchema = UsdGeomMesh::Define(getUsdStage(), getUsdPath());
     TF_AXIOM(primSchema);
-    UsdPrim meshPrim = primSchema.GetPrim();
-    TF_AXIOM(meshPrim);
+    mUsdPrim = primSchema.GetPrim();
+    TF_AXIOM(mUsdPrim);
+}
 
+//virtual 
+void MayaMeshWriter::write(const UsdTimeCode &usdTime)
+{
+    UsdGeomMesh primSchema(mUsdPrim);
     // Write the attrs
     writeMeshAttrs(usdTime, primSchema);
-    return meshPrim;
 }
 
 static
@@ -187,7 +186,7 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
 
     // Read usdSdScheme attribute. If not set, we default to defaultMeshScheme
     // flag that can be user defined and initialized to catmullClark
-    TfToken sdScheme = PxrUsdMayaMeshUtil::getSubdivScheme(lMesh, getArgs().defaultMeshScheme);    
+    TfToken sdScheme = PxrUsdMayaMeshUtil::getSubdivScheme(lMesh, getArgs().defaultMeshScheme);
     primSchema.CreateSubdivisionSchemeAttr(VtValue(sdScheme), true);
 
     // Polygonal Mesh Case

--- a/third_party/maya/lib/usdMaya/MayaMeshWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaMeshWriter.h
@@ -42,12 +42,13 @@ class UsdGeomGprim;
 class MayaMeshWriter : public MayaTransformWriter
 {
   public:
-    MayaMeshWriter(MDagPath & iDag, 
-            UsdStageRefPtr stage, 
-            const JobExportArgs & iArgs);
+    MayaMeshWriter(const MDagPath & iDag,
+                   const SdfPath& uPath,
+                   bool instanceSource,
+                   usdWriteJobCtx& jobCtx);
     virtual ~MayaMeshWriter() {};
 
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
     
     /// \override
     virtual bool exportsGprims() const;
@@ -141,7 +142,7 @@ class MayaMeshWriter : public MayaTransformWriter
     static const float _ColorSetDefaultAlpha;
 };
 
-typedef shared_ptr < MayaMeshWriter > MayaMeshWriterPtr;
+typedef std::shared_ptr<MayaMeshWriter> MayaMeshWriterPtr;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/MayaNurbsCurveWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaNurbsCurveWriter.cpp
@@ -37,25 +37,28 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-MayaNurbsCurveWriter::MayaNurbsCurveWriter(MDagPath & iDag, UsdStageRefPtr stage, const JobExportArgs & iArgs) :
-    MayaTransformWriter(iDag, stage, iArgs)
+MayaNurbsCurveWriter::MayaNurbsCurveWriter(const MDagPath & iDag,
+                                           const SdfPath& uPath,
+                                           bool instanceSource,
+                                           usdWriteJobCtx& jobCtx) :
+    MayaTransformWriter(iDag, uPath, instanceSource, jobCtx)
 {
+    UsdGeomNurbsCurves primSchema =
+        UsdGeomNurbsCurves::Define(getUsdStage(), getUsdPath());
+    TF_AXIOM(primSchema);
+    mUsdPrim = primSchema.GetPrim();
+    TF_AXIOM(mUsdPrim);
 }
 
 
 //virtual 
-UsdPrim MayaNurbsCurveWriter::write(const UsdTimeCode &usdTime)
+void MayaNurbsCurveWriter::write(const UsdTimeCode &usdTime)
 {
     // == Write
-    UsdGeomNurbsCurves primSchema =
-        UsdGeomNurbsCurves::Define(getUsdStage(), getUsdPath());
-    TF_AXIOM(primSchema);
-    UsdPrim prim = primSchema.GetPrim();
-    TF_AXIOM(prim);
+    UsdGeomNurbsCurves primSchema(mUsdPrim);
 
     // Write the attrs
     writeNurbsCurveAttrs(usdTime, primSchema);
-    return prim;
 }
 
 // virtual

--- a/third_party/maya/lib/usdMaya/MayaNurbsCurveWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaNurbsCurveWriter.h
@@ -36,10 +36,10 @@ class UsdGeomNurbsCurves;
 class MayaNurbsCurveWriter : public MayaTransformWriter
 {
   public:
-    MayaNurbsCurveWriter(MDagPath & iDag, UsdStageRefPtr stage, const JobExportArgs & iArgs);
+    MayaNurbsCurveWriter(const MDagPath & iDag, const SdfPath& uPath, bool instanceSource, usdWriteJobCtx& jobCtx);
     virtual ~MayaNurbsCurveWriter() {};
 
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
     
     /// \override
     virtual bool exportsGprims() const;
@@ -48,7 +48,7 @@ class MayaNurbsCurveWriter : public MayaTransformWriter
     bool writeNurbsCurveAttrs(const UsdTimeCode &usdTime, UsdGeomNurbsCurves &primSchema);
 };
 
-typedef shared_ptr < MayaNurbsCurveWriter > MayaNurbsCurveWriterPtr;
+typedef std::shared_ptr<MayaNurbsCurveWriter> MayaNurbsCurveWriterPtr;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.cpp
@@ -41,11 +41,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 MayaNurbsSurfaceWriter::MayaNurbsSurfaceWriter(
-        MDagPath & iDag, 
-        UsdStageRefPtr stage, 
-        const JobExportArgs & iArgs) :
-    MayaTransformWriter(iDag, stage, iArgs)
+        const MDagPath & iDag,
+        const SdfPath& uPath,
+        bool instanceSource,
+        usdWriteJobCtx& jobCtx) :
+    MayaTransformWriter(iDag, uPath, instanceSource, jobCtx)
 {
+    UsdGeomNurbsPatch primSchema =
+        UsdGeomNurbsPatch::Define(getUsdStage(), getUsdPath());
+    TF_AXIOM(primSchema);
+    mUsdPrim = primSchema.GetPrim();
+    TF_AXIOM(mUsdPrim);
 }
 
 static void
@@ -81,18 +87,13 @@ _FixNormalizedKnotRange(
 }
 
 //virtual 
-UsdPrim MayaNurbsSurfaceWriter::write(const UsdTimeCode &usdTimeCode)
+void MayaNurbsSurfaceWriter::write(const UsdTimeCode &usdTimeCode)
 {
     // == Write
-    UsdGeomNurbsPatch primSchema =
-        UsdGeomNurbsPatch::Define(getUsdStage(), getUsdPath());
-    TF_AXIOM(primSchema);
-    UsdPrim prim = primSchema.GetPrim();
-    TF_AXIOM(prim);
+    UsdGeomNurbsPatch primSchema(mUsdPrim);
 
     // Write the attrs
     writeNurbsSurfaceAttrs(usdTimeCode, primSchema);
-    return prim;
 }
 
 // virtual

--- a/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.h
@@ -36,12 +36,13 @@ class UsdGeomNurbsPatch;
 class MayaNurbsSurfaceWriter : public MayaTransformWriter
 {
   public:
-    MayaNurbsSurfaceWriter(MDagPath & iDag, 
-            UsdStageRefPtr stage, 
-            const JobExportArgs & iArgs);
+    MayaNurbsSurfaceWriter(const MDagPath & iDag,
+            const SdfPath& uPath,
+            bool instanceSource,
+            usdWriteJobCtx& jobCtx);
     virtual ~MayaNurbsSurfaceWriter() {};
     
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
 
     /// \override
     virtual bool exportsGprims() const;
@@ -50,7 +51,7 @@ class MayaNurbsSurfaceWriter : public MayaTransformWriter
     bool writeNurbsSurfaceAttrs(const UsdTimeCode &usdTime, UsdGeomNurbsPatch &primSchema);
 };
 
-typedef shared_ptr < MayaNurbsSurfaceWriter > MayaNurbsSurfaceWriterPtr;
+typedef std::shared_ptr<MayaNurbsSurfaceWriter> MayaNurbsSurfaceWriterPtr;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/MayaPrimWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaPrimWriter.cpp
@@ -53,22 +53,14 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-MayaPrimWriter::MayaPrimWriter(MDagPath & iDag, 
-                               UsdStageRefPtr stage, 
-                               const JobExportArgs & iArgs) :
+MayaPrimWriter::MayaPrimWriter(const MDagPath& iDag,
+                               const SdfPath& uPath,
+                               usdWriteJobCtx& jobCtx) :
+    mWriteJobCtx(jobCtx),
     mDagPath(iDag),
-    mStage(stage),
-    mIsValid(true),
-    mArgs(iArgs)
+    mUsdPath(uPath),
+    mIsValid(true)
 {
-    // XXX: see MayaTransformWriter where it will eventually muck with
-    // this path to get the right behavior.  Ideally, we should have all the
-    // mergeTransformAndShape logic in one spot.
-    mUsdPath = PxrUsdMayaUtil::MDagPathToUsdPath(iDag, false);
-
-    if (!mArgs.usdModelRootOverridePath.IsEmpty() ) {
-        mUsdPath = mUsdPath.ReplacePrefix(mUsdPath.GetPrefixes()[0], mArgs.usdModelRootOverridePath);
-    }
 }
 
 bool
@@ -78,7 +70,7 @@ MayaPrimWriter::writePrimAttrs(const MDagPath &dagT, const UsdTimeCode &usdTime,
     MFnDependencyNode depFn(getDagPath().node());
     MFnDependencyNode depFnT(dagT.node()); // optionally also scan a shape's transform if merging transforms
 
-    if (getArgs().exportVisibility) {
+    if (mWriteJobCtx.getArgs().exportVisibility) {
         bool isVisible  = true;   // if BOTH shape or xform is animated, then visible
         bool isAnimated = false;  // if either shape or xform is animated, then animated
 

--- a/third_party/maya/lib/usdMaya/MayaTransformWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaTransformWriter.cpp
@@ -24,11 +24,13 @@
 #include "pxr/pxr.h"
 #include "usdMaya/MayaTransformWriter.h"
 #include "usdMaya/util.h"
+#include "usdMaya/usdWriteJob.h"
 
 #include "pxr/usd/usdGeom/xform.h"
 #include "pxr/usd/usdGeom/xformCommonAPI.h"
 #include "pxr/usd/usdGeom/xformable.h"
 #include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usd/inherits.h"
 
 #include <maya/MFnTransform.h>
 #include <maya/MPoint.h>
@@ -153,8 +155,8 @@ _GatherAnimChannel(
         MString parentName, 
         MString xName, MString yName, MString zName, 
         std::vector<AnimChannel>* oAnimChanList, 
-        bool isWritingAnimation, 
-        bool setOpName = true)
+        bool isWritingAnimation,
+        bool setOpName)
 {
     AnimChannel chan;
     chan.opType = opType;
@@ -274,7 +276,7 @@ void MayaTransformWriter::pushTransformStack(
     // additional xform (compensation translates for pivots, rotateAxis or
     // shear) we are not conforming anymore 
     bool conformsToCommonAPI = true;
-    
+
     // Keep track of where we have rotate and scale Pivots and their inverse so
     // that we can combine them later if possible
     unsigned int rotPivotIdx = -1, rotPivotINVIdx = -1, scalePivotIdx = -1, scalePivotINVIdx = -1;
@@ -291,12 +293,12 @@ void MayaTransformWriter::pushTransformStack(
     _GatherAnimChannel(TRANSLATE, iTrans, "translate", "X", "Y", "Z", &mAnimChanList, writeAnim, false);
 
     // inspect the rotate pivot translate
-    if (_GatherAnimChannel(TRANSLATE, iTrans, "rotatePivotTranslate", "X", "Y", "Z", &mAnimChanList, writeAnim)) {
+    if (_GatherAnimChannel(TRANSLATE, iTrans, "rotatePivotTranslate", "X", "Y", "Z", &mAnimChanList, writeAnim, true)) {
         conformsToCommonAPI = false;
     }
 
     // inspect the rotate pivot
-    bool hasRotatePivot = _GatherAnimChannel(TRANSLATE, iTrans, "rotatePivot", "X", "Y", "Z", &mAnimChanList, writeAnim);
+    bool hasRotatePivot = _GatherAnimChannel(TRANSLATE, iTrans, "rotatePivot", "X", "Y", "Z", &mAnimChanList, writeAnim, true);
     if (hasRotatePivot) {
         rotPivotIdx = mAnimChanList.size()-1;
     }
@@ -305,7 +307,7 @@ void MayaTransformWriter::pushTransformStack(
     _GatherAnimChannel(ROTATE, iTrans, "rotate", "X", "Y", "Z", &mAnimChanList, writeAnim, false);
 
     // inspect the rotateAxis/orientation
-    if (_GatherAnimChannel(ROTATE, iTrans, "rotateAxis", "X", "Y", "Z", &mAnimChanList, writeAnim)) {
+    if (_GatherAnimChannel(ROTATE, iTrans, "rotateAxis", "X", "Y", "Z", &mAnimChanList, writeAnim, true)) {
         conformsToCommonAPI = false;
     }
 
@@ -321,18 +323,18 @@ void MayaTransformWriter::pushTransformStack(
     }
 
     // inspect the scale pivot translation
-    if (_GatherAnimChannel(TRANSLATE, iTrans, "scalePivotTranslate", "X", "Y", "Z", &mAnimChanList, writeAnim)) {
+    if (_GatherAnimChannel(TRANSLATE, iTrans, "scalePivotTranslate", "X", "Y", "Z", &mAnimChanList, writeAnim, true)) {
         conformsToCommonAPI = false;
     }
 
     // inspect the scale pivot point
-    bool hasScalePivot = _GatherAnimChannel(TRANSLATE, iTrans, "scalePivot", "X", "Y", "Z", &mAnimChanList, writeAnim);
+    bool hasScalePivot = _GatherAnimChannel(TRANSLATE, iTrans, "scalePivot", "X", "Y", "Z", &mAnimChanList, writeAnim, true);
     if (hasScalePivot) {
         scalePivotIdx = mAnimChanList.size()-1;
     }
 
     // inspect the shear. Even if we have one xform on the xform list, it represents a share so we should name it
-    if (_GatherAnimChannel(SHEAR, iTrans, "shear", "XY", "XZ", "YZ", &mAnimChanList, writeAnim)) {
+    if (_GatherAnimChannel(SHEAR, iTrans, "shear", "XY", "XZ", "YZ", &mAnimChanList, writeAnim, true)) {
         conformsToCommonAPI = false;
     }
 
@@ -407,72 +409,128 @@ void MayaTransformWriter::pushTransformStack(
 }
 
 MayaTransformWriter::MayaTransformWriter(
-        MDagPath& iDag, 
-        UsdStageRefPtr stage, 
-        const JobExportArgs& iArgs) :
-    MayaPrimWriter(iDag, stage, iArgs),
+        const MDagPath& iDag,
+        const SdfPath& uPath,
+        bool instanceSource,
+        usdWriteJobCtx& jobCtx) :
+    MayaPrimWriter(iDag, uPath, jobCtx),
     mXformDagPath(iDag),
-    mIsShapeAnimated(false)
+    mIsShapeAnimated(false),
+    mIsInstanceSource(instanceSource)
+{
+    auto isInstance = false;
+    auto hasTransform = iDag.hasFn(MFn::kTransform);
+    auto setup_merged_shape = [this, &isInstance, &iDag, &hasTransform] () {
+        // Use the parent transform if there is only a single shape under the shape's xform
+        this->mXformDagPath.pop();
+        auto numberOfShapesDirectlyBelow = 0u;
+        this->mXformDagPath.numberOfShapesDirectlyBelow(numberOfShapesDirectlyBelow);
+        if (numberOfShapesDirectlyBelow == 1) {
+            // Use the parent path (xform) instead of the shape path
+            this->setUsdPath( getUsdPath().GetParentPath() );
+            hasTransform = true;
+        } else if (isInstance) {
+            this->mXformDagPath = iDag;
+        } else {
+            this->mXformDagPath = MDagPath(); // make path invalid
+        }
+    };
 
-{    
-    // Merge shape and transform
-    // If is a transform, then do not write
-    // Return if has a single shape directly below xform 
-    if (getArgs().mergeTransformAndShape) {
-        if (iDag.hasFn(MFn::kTransform)) { // if is an actual transform
-            unsigned int numberOfShapesDirectlyBelow = 0;
+    auto invalidate_transform = [this] () {
+        this->setValid(false); // no need to iterate over this Writer, as not writing it out
+        this->mXformDagPath = MDagPath(); // make path invalid
+    };
+
+    // it's more straightforward to separate code
+    if (mIsInstanceSource) {
+        if (!hasTransform) {
+            mXformDagPath = MDagPath();
+        }
+    } else if (getArgs().exportInstances) {
+        if (hasTransform) {
+            auto numberOfShapesDirectlyBelow = 0u;
             iDag.numberOfShapesDirectlyBelow(numberOfShapesDirectlyBelow);
             if (numberOfShapesDirectlyBelow == 1) {
-                setValid(false); // no need to iterate over this Writer, as not writing it out
-                mXformDagPath = MDagPath(); // make path invalid
+                auto copyDag = iDag;
+                copyDag.extendToShapeDirectlyBelow(0);
+                if (copyDag.isInstanced()) {
+                    invalidate_transform();
+                } else if (getArgs().mergeTransformAndShape) {
+                    invalidate_transform();
+                }
             }
-        } else { // must be a shape then
-            // Use the parent transform if there is only a single shape under the shape's xform
-            mXformDagPath.pop();
-            unsigned int numberOfShapesDirectlyBelow = 0;
-            mXformDagPath.numberOfShapesDirectlyBelow(numberOfShapesDirectlyBelow);
-            if (numberOfShapesDirectlyBelow == 1) {
-                // Use the parent path (xform) instead of the shape path
-                setUsdPath( getUsdPath().GetParentPath() );
+        } else {
+            if (iDag.isInstanced()) {
+                isInstance = true;
+                setup_merged_shape();
+            } else if (getArgs().mergeTransformAndShape) {
+                setup_merged_shape();
             } else {
-                mXformDagPath = MDagPath(); // make path invalid
+                mXformDagPath = MDagPath();
             }
         }
     } else {
-        if (!iDag.hasFn(MFn::kTransform)) { // if is NOT an actual transform
-            mXformDagPath = MDagPath(); // make path invalid
+        // Merge shape and transform
+        // If is a transform, then do not write
+        // Return if has a single shape directly below xform
+        if (getArgs().mergeTransformAndShape) {
+            if (hasTransform) { // if is an actual transform
+                unsigned int numberOfShapesDirectlyBelow = 0;
+                iDag.numberOfShapesDirectlyBelow(numberOfShapesDirectlyBelow);
+                if (numberOfShapesDirectlyBelow == 1) {
+                    invalidate_transform();
+                }
+            } else { // must be a shape then
+                setup_merged_shape();
+            }
+        } else {
+            if (!hasTransform) { // if is NOT an actual transform
+                mXformDagPath = MDagPath(); // make path invalid
+            }
         }
     }
 
     // Determine if transform is animated
-    if ( mXformDagPath.isValid()) {
-        MFnTransform transFn(mXformDagPath);
+    if (mXformDagPath.isValid()) {
         UsdGeomXform primSchema = UsdGeomXform::Define(getUsdStage(), getUsdPath());
-        // Create a vector of AnimChannels based on the Maya transformation
-        // ordering
-        pushTransformStack(transFn, primSchema, iArgs.exportAnimation);
+        mUsdPrim = primSchema.GetPrim();
+        if (!mIsInstanceSource) {
+            if (hasTransform) {
+                MFnTransform transFn(mXformDagPath);
+                // Create a vector of AnimChannels based on the Maya transformation
+                // ordering
+                pushTransformStack(transFn, primSchema, getArgs().exportAnimation);
+            }
+
+            if (isInstance) {
+                const auto masterPath = mWriteJobCtx.getMasterPath(getDagPath());
+                if (!masterPath.IsEmpty()){
+                    mUsdPrim.GetInherits().AppendInherit(masterPath);
+                    mUsdPrim.SetInstanceable(true);
+                }
+            }
+        }
     }
 
     // Determine if shape is animated
-    if ( !getDagPath().hasFn(MFn::kTransform)) { // if is a shape
+    // note that we can't use hasTransform, because we need to test the original
+    // dag, not the transform (if mergeTransformAndShape is on)!
+    if (!getDagPath().hasFn(MFn::kTransform)) { // if is a shape
         MObject obj = getDagPath().node();
-        if (iArgs.exportAnimation)
+        if (getArgs().exportAnimation) {
             mIsShapeAnimated = PxrUsdMayaUtil::isAnimated(obj);
+        }
     }
 }
 
 //virtual 
-UsdPrim MayaTransformWriter::write(const UsdTimeCode &usdTime)
+void MayaTransformWriter::write(const UsdTimeCode &usdTime)
 {
-    TF_AXIOM( isValid() ); // should always be true if this code is reached
-    // Write to USD
-    UsdGeomXform primSchema = UsdGeomXform::Define(getUsdStage(), getUsdPath());
-    TF_AXIOM(primSchema);
-    
-    // Set attrs
-    writeTransformAttrs(usdTime, primSchema);
-
-    return primSchema.GetPrim();
+    if (!mIsInstanceSource) {
+        UsdGeomXform primSchema(mUsdPrim);
+        // Set attrs
+        writeTransformAttrs(usdTime, primSchema);
+    }
 }
 
 bool MayaTransformWriter::writeTransformAttrs(

--- a/third_party/maya/lib/usdMaya/MayaTransformWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaTransformWriter.h
@@ -35,7 +35,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
 class UsdGeomXformable;
 class UsdTimeCode;
 
@@ -60,10 +59,10 @@ struct AnimChannel
 // Writes an MFnTransform
 class MayaTransformWriter : public MayaPrimWriter
 {
-  public:
+public:
 
     PXRUSDMAYA_API
-    MayaTransformWriter(MDagPath & iDag, UsdStageRefPtr stage, const JobExportArgs & iArgs);
+    MayaTransformWriter(const MDagPath & iDag, const SdfPath& uPath, bool instanceSource, usdWriteJobCtx& jobCtx);
     virtual ~MayaTransformWriter() {};
 
     PXRUSDMAYA_API
@@ -73,31 +72,32 @@ class MayaTransformWriter : public MayaPrimWriter
             bool writeAnim);
     
     PXRUSDMAYA_API
-    virtual UsdPrim write(const UsdTimeCode &usdTime);
+    virtual void write(const UsdTimeCode &usdTime);
 
     virtual bool isShapeAnimated()     const { return mIsShapeAnimated; };
 
     const MDagPath& getTransformDagPath() { return mXformDagPath; };
 
-  protected:
+protected:
     PXRUSDMAYA_API
     bool writeTransformAttrs(
             const UsdTimeCode& usdTime, 
             UsdGeomXformable& primSchema);
 
-  private:
+private:
     bool mWriteTransformAttrs;
     MDagPath mXformDagPath;
     bool mIsShapeAnimated;
     std::vector<AnimChannel> mAnimChanList;
+    bool mIsInstanceSource;
 
     size_t mJointOrientOpIndex[3];
     size_t mRotateOpIndex[3];
     size_t mRotateAxisOpIndex[3];
-    
+
 };
 
-typedef shared_ptr < MayaTransformWriter > MayaTransformWriterPtr;
+typedef std::shared_ptr<MayaTransformWriter> MayaTransformWriterPtr;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/primWriterRegistry.h
+++ b/third_party/maya/lib/usdMaya/primWriterRegistry.h
@@ -67,9 +67,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 struct PxrUsdMayaPrimWriterRegistry
 {
     typedef std::function< MayaPrimWriterPtr (
-            MDagPath &curDag,
-            UsdStageRefPtr& stage,
-            const JobExportArgs& args) > WriterFactoryFn;
+            const MDagPath&,
+            const SdfPath&, bool,
+            usdWriteJobCtx&) > WriterFactoryFn;
 
     /// \brief Register \p fn as a factory function providing a
     /// \link MayaPrimWriter subclass that can be used to write \p mayaType.
@@ -81,8 +81,9 @@ struct PxrUsdMayaPrimWriterRegistry
     /// class MyWriter : public MayaPrimWriter {
     ///     static MayaPrimWriterPtr Create(
     ///             MDagPath &curDag,
-    ///             UsdStageRefPtr& stage,
-    ///             const JobExportArgs& args);
+    ///             const SdfPath& uPath,
+    ///             bool instanceSource,
+    ///             usdWriteJobCtx& jobCtx);
     /// };
     /// TF_REGISTRY_FUNCTION_WITH_TAG(PxrUsdMayaPrimWriterRegistry, MyWriter) {
     ///     PxrUsdMayaPrimWriterRegistry::Register("MyCustomPrim",

--- a/third_party/maya/lib/usdMaya/usdExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdExport.cpp
@@ -59,6 +59,7 @@ MSyntax usdExport::createSyntax()
     syntax.addFlag("-v"  , "-verbose", MSyntax::kNoArg);
 
     syntax.addFlag("-mt" , "-mergeTransformAndShape", MSyntax::kBoolean);
+    syntax.addFlag("-ein", "-exportInstances", MSyntax::kBoolean);
     syntax.addFlag("-eri", "-exportRefsAsInstanceable", MSyntax::kBoolean);
     syntax.addFlag("-dsp" , "-exportDisplayColor", MSyntax::kBoolean);
     syntax.addFlag("-shd" , "-shadingMode" , MSyntax::kString);
@@ -124,6 +125,10 @@ try
 
     if (argData.isFlagSet("mergeTransformAndShape")) {
         argData.getFlagArgument("mergeTransformAndShape", 0, jobArgs.mergeTransformAndShape);
+    }
+
+    if (argData.isFlagSet("exportInstances")) {
+        argData.getFlagArgument("exportInstances", 0, jobArgs.exportInstances);
     }
 
     if (argData.isFlagSet("exportRefsAsInstanceable")) {

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
@@ -131,6 +131,9 @@ usdTranslatorExport::writer(const MFileObject &file,
             if (theOption[0] == MString("mergeXForm")) {
                 jobArgs.mergeTransformAndShape = theOption[1].asInt();
             }
+            if (theOption[0] == MString("exportInstances")) {
+                jobArgs.exportInstances = theOption[1].asInt();
+            }
             if (theOption[0] == MString("defaultMeshScheme")) {            
                 if (theOption[1]=="Polygonal Mesh") {
                     jobArgs.defaultMeshScheme = UsdGeomTokens->none;

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.h
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.h
@@ -50,6 +50,7 @@ const char* const usdTranslatorExportDefaults =
         "allCameras=0;"
         "renderLayerMode=Use Default Layer;"
         "mergeXForm=1;"
+        "exportInstances=1;"
         "defaultMeshScheme=CatmullClark SDiv;"
         "exportVisibility=1;"
         "animation=0;"

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -106,7 +106,7 @@ global proc int usdTranslatorExport (string $parent,
             menuItem -l $each;
         }
 
-        checkBox -l "Make Instances" exportReferencesAsInstanceableCheckBox;
+        checkBox -l "Make References Instanceable" exportReferencesAsInstanceableCheckBox;
 
         checkBox -l "Export UVs" exportUVsCheckBox;
 
@@ -126,6 +126,7 @@ global proc int usdTranslatorExport (string $parent,
             menuItem -l "Modeling Variant Per Layer";
 
         checkBox -l "Merge Transform and Shape Nodes" mergeXFormCheckBox;
+        checkBox -l "Export Instances" exportInstancesCheckBox;
 
 	    optionMenuGrp -l "Default Mesh Scheme:" defaultMeshSchemePopup;
 	        menuItem -l "Polygonal Mesh";
@@ -167,6 +168,8 @@ global proc int usdTranslatorExport (string $parent,
                     optionMenuGrp -e -value $optionBreakDown[1] renderLayerModePopup;
                 } else if ($optionBreakDown[0] == "mergeXForm") {
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeXFormCheckBox");
+                } else if ($optionBreakDown[0] == "exportInstances") {
+                    usdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportInstancesCheckBox");
                 } else if ($optionBreakDown[0] == "defaultMeshScheme") {
                     optionMenuGrp -e -value $optionBreakDown[1] defaultMeshSchemePopup;
                 } else if ($optionBreakDown[0] == "exportVisibility") {
@@ -208,6 +211,7 @@ global proc int usdTranslatorExport (string $parent,
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "allCameras", "allCamerasCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "renderLayerMode", "renderLayerModePopup");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "mergeXForm", "mergeXFormCheckBox");
+        $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "exportInstances", "exportInstancesCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -25,11 +25,8 @@
 #include "usdMaya/usdWriteJob.h"
 
 #include "usdMaya/JobArgs.h"
-#include "usdMaya/MayaMeshWriter.h"
-#include "usdMaya/MayaNurbsCurveWriter.h"
-#include "usdMaya/MayaNurbsSurfaceWriter.h"
+#include "usdMaya/MayaPrimWriter.h"
 #include "usdMaya/MayaTransformWriter.h"
-#include "usdMaya/MayaCameraWriter.h"
 
 #include "usdMaya/translatorMaterial.h"
 #include "usdMaya/primWriterRegistry.h"
@@ -73,7 +70,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 usdWriteJob::usdWriteJob(const JobExportArgs & iArgs) :
-    mArgs(iArgs), mModelKindWriter(iArgs)
+    mModelKindWriter(iArgs), mJobCtx(iArgs)
 {
 }
 
@@ -90,8 +87,8 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
     // Check for DAG nodes that are a child of an already specified DAG node to export
     // if that's the case, report the issue and skip the export
     PxrUsdMayaUtil::ShapeSet::const_iterator m, n;
-    PxrUsdMayaUtil::ShapeSet::const_iterator endPath = mArgs.dagPaths.end();
-    for (m = mArgs.dagPaths.begin(); m != endPath; ) {
+    PxrUsdMayaUtil::ShapeSet::const_iterator endPath = mJobCtx.mArgs.dagPaths.end();
+    for (m = mJobCtx.mArgs.dagPaths.begin(); m != endPath; ) {
         MDagPath path1 = *m; m++;
         for (n = m; n != endPath; n++) {
             MDagPath path2 = *n;
@@ -120,24 +117,13 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
 
     MGlobal::displayInfo("usdWriteJob::beginJob: Create stage file "+MString(mFileName.c_str()));
 
-    ArResolverContext resolverCtx = ArGetResolver().GetCurrentContext();
-    if (append) {
-        mStage = UsdStage::Open(SdfLayer::FindOrOpen(mFileName), resolverCtx);
-        if (!mStage) {
-            MGlobal::displayError("Failed to open stage file "+MString(mFileName.c_str()));
-            return false;
-            }
-    } else {
-        mStage = UsdStage::CreateNew(mFileName, resolverCtx);
-        if (!mStage) {
-            MGlobal::displayError("Failed to create stage file "+MString(mFileName.c_str()));
-            return false;
-        }
+    if (!mJobCtx.openFile(mFileName, append)) {
+        return false;
     }
 
     // Set time range for the USD file
-    mStage->SetStartTimeCode(startTime);
-    mStage->SetEndTimeCode(endTime);
+    mJobCtx.mStage->SetStartTimeCode(startTime);
+    mJobCtx.mStage->SetEndTimeCode(endTime);
     
     mModelKindWriter.Reset();
 
@@ -156,17 +142,17 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
     MFnRenderLayer currentLayer(MFnRenderLayer::currentLayer());
     mCurrentRenderLayerName = currentLayer.name();
 
-    if (mArgs.renderLayerMode == PxUsdExportJobArgsTokens->modelingVariant) {
+    if (mJobCtx.mArgs.renderLayerMode == PxUsdExportJobArgsTokens->modelingVariant) {
         // Handle usdModelRootOverridePath for USD Variants
         MFnRenderLayer::listAllRenderLayers(mRenderLayerObjs);
         if (mRenderLayerObjs.length() > 1) {
-            mArgs.usdModelRootOverridePath = SdfPath("/_BaseModel_");
+            mJobCtx.mArgs.usdModelRootOverridePath = SdfPath("/_BaseModel_");
         }
     }
 
     // Switch to the default render layer unless the renderLayerMode is
     // 'currentLayer', or the default layer is already the current layer.
-    if (mArgs.renderLayerMode != PxUsdExportJobArgsTokens->currentLayer &&
+    if (mJobCtx.mArgs.renderLayerMode != PxUsdExportJobArgsTokens->currentLayer &&
             MFnRenderLayer::currentLayer() != MFnRenderLayer::defaultRenderLayer()) {
         // Set the RenderLayer to the default render layer
         MFnRenderLayer defaultLayer(MFnRenderLayer::defaultRenderLayer());
@@ -181,8 +167,8 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
     // less work to hash and compare than full path names.
     TfHashSet<std::string, TfHash> argDagPaths;
     TfHashSet<std::string, TfHash> argDagPathParents;
-    PxrUsdMayaUtil::ShapeSet::const_iterator end = mArgs.dagPaths.end();
-    for (PxrUsdMayaUtil::ShapeSet::const_iterator it = mArgs.dagPaths.begin();
+    PxrUsdMayaUtil::ShapeSet::const_iterator end = mJobCtx.mArgs.dagPaths.end();
+    for (PxrUsdMayaUtil::ShapeSet::const_iterator it = mJobCtx.mArgs.dagPaths.begin();
             it != end; ++it) {
         MDagPath curDagPath = *it;
         std::string curDagPathStr(curDagPath.partialPathName().asChar());
@@ -221,36 +207,37 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
             continue;
         }
 
-        MayaPrimWriterPtr primWriter = nullptr;
-        if (!createPrimWriter(curDagPath, &primWriter) &&
-                curDagPath.length() > 0) {
+        if (!needToTraverse(curDagPath) &&
+            curDagPath.length() > 0) {
             // This dagPath and all of its children should be pruned.
             itDag.prune();
-            continue;
-        }
+        } else {
+            MayaPrimWriterPtr primWriter = mJobCtx.createPrimWriter(curDagPath);
 
-        if (primWriter) {
-            mMayaPrimWriterList.push_back(primWriter);
+            if (primWriter) {
+                mJobCtx.mMayaPrimWriterList.push_back(primWriter);
 
-            // Write out data (non-animated/default values).
-            if (UsdPrim usdPrim = primWriter->write(UsdTimeCode::Default())) {
-                MDagPath dag = primWriter->getDagPath();
-                mDagPathToUsdPathMap[dag] = usdPrim.GetPath();
+                // Write out data (non-animated/default values).
+                if (const auto& usdPrim = primWriter->getPrim()) {
+                    primWriter->write(UsdTimeCode::Default());
 
-                // If we are merging transforms and the object derives from
-                // MayaTransformWriter but isn't actually a transform node, we
-                // need to add its parent.
-                if (mArgs.mergeTransformAndShape) {
-                    MayaTransformWriterPtr xformWriter =
-                            boost::dynamic_pointer_cast<MayaTransformWriter>(
-                                    primWriter);
-                    if (xformWriter) {
-                        MDagPath xformDag = xformWriter->getTransformDagPath();
-                        mDagPathToUsdPathMap[xformDag] = usdPrim.GetPath();
+                    MDagPath dag = primWriter->getDagPath();
+                    mDagPathToUsdPathMap[dag] = usdPrim.GetPath();
+
+                    // If we are merging transforms and the object derives from
+                    // MayaTransformWriter but isn't actually a transform node, we
+                    // need to add its parent.
+                    if (mJobCtx.mArgs.mergeTransformAndShape) {
+                        MayaTransformWriterPtr xformWriter =
+                            std::dynamic_pointer_cast<MayaTransformWriter>(primWriter);
+                        if (xformWriter) {
+                            MDagPath xformDag = xformWriter->getTransformDagPath();
+                            mDagPathToUsdPathMap[xformDag] = usdPrim.GetPath();
+                        }
                     }
-                }
 
-                mModelKindWriter.OnWritePrim(usdPrim, primWriter);
+                     mModelKindWriter.OnWritePrim(usdPrim, primWriter);
+                }
 
                 if (primWriter->shouldPruneChildren()) {
                     itDag.prune();
@@ -261,20 +248,20 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
 
     // Writing Materials/Shading
     PxrUsdMayaTranslatorMaterial::ExportShadingEngines(
-                mStage, 
-                mArgs.dagPaths,
-                mArgs.shadingMode,
-                mArgs.mergeTransformAndShape,
-                mArgs.usdModelRootOverridePath);
+                mJobCtx.mStage,
+                mJobCtx.mArgs.dagPaths,
+                mJobCtx.mArgs.shadingMode,
+                mJobCtx.mArgs.mergeTransformAndShape,
+                mJobCtx.mArgs.usdModelRootOverridePath);
 
-    if (!mModelKindWriter.MakeModelHierarchy(mStage)) {
+    if (!mModelKindWriter.MakeModelHierarchy(mJobCtx.mStage)) {
         return false;
     }
 
     // now we populate the chasers and run export default
     mChasers.clear();
-    PxrUsdMayaChaserRegistry::FactoryContext ctx(mStage, mDagPathToUsdPathMap, mArgs);
-    for (const std::string& chaserName : mArgs.chaserNames) {
+    PxrUsdMayaChaserRegistry::FactoryContext ctx(mJobCtx.mStage, mDagPathToUsdPathMap, mJobCtx.mArgs);
+    for (const std::string& chaserName : mJobCtx.mArgs.chaserNames) {
         if (PxrUsdMayaChaserRefPtr fn = 
                 PxrUsdMayaChaserRegistry::GetInstance().Create(chaserName, ctx)) {
             mChasers.push_back(fn);
@@ -300,7 +287,7 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
 //  Frame to process
 void usdWriteJob::evalJob(double iFrame)
 {
-    for ( MayaPrimWriterPtr const & primWriter :  mMayaPrimWriterList) {
+    for ( MayaPrimWriterPtr const & primWriter :  mJobCtx.mMayaPrimWriterList) {
         UsdTimeCode usdTime(iFrame);
         primWriter->write(usdTime);
     }
@@ -313,7 +300,8 @@ void usdWriteJob::evalJob(double iFrame)
 
 void usdWriteJob::endJob()
 {
-    UsdPrimSiblingRange usdRootPrims = mStage->GetPseudoRoot().GetChildren();
+    mJobCtx.processInstances();
+    UsdPrimSiblingRange usdRootPrims = mJobCtx.mStage->GetPseudoRoot().GetChildren();
     
     // Write Variants (to first root prim path)
     UsdPrim usdRootPrim;
@@ -325,7 +313,7 @@ void usdWriteJob::endJob()
     }
 
     if (usdRootPrim && mRenderLayerObjs.length() > 1 && 
-        !mArgs.usdModelRootOverridePath.IsEmpty()) {
+        !mJobCtx.mArgs.usdModelRootOverridePath.IsEmpty()) {
             // Get RenderLayers
             //   mArgs.usdModelRootOverridePath:
             //     Require mArgs.usdModelRootOverridePath to be set so that 
@@ -354,17 +342,17 @@ void usdWriteJob::endJob()
     if (MGlobal::isZAxisUp()){
         upAxis = UsdGeomTokens->z;
     }
-    UsdGeomSetStageUpAxis(mStage, upAxis);
+    UsdGeomSetStageUpAxis(mJobCtx.mStage, upAxis);
     if (usdRootPrim){
         // We have already decided above that 'usdRootPrim' is the important
         // prim for the export... usdVariantRootPrimPath
-        mStage->GetRootLayer()->SetDefaultPrim(defaultPrim);
+        mJobCtx.mStage->GetRootLayer()->SetDefaultPrim(defaultPrim);
     }
-    if (mStage->GetRootLayer()->PermissionToSave()) {
-        mStage->GetRootLayer()->Save();
+    if (mJobCtx.mStage->GetRootLayer()->PermissionToSave()) {
+        mJobCtx.mStage->GetRootLayer()->Save();
     }
-    mStage->Close();
-    mMayaPrimWriterList.clear(); // clear this so that no stage references are left around
+    mJobCtx.mStage->Close();
+    mJobCtx.mMayaPrimWriterList.clear(); // clear this so that no stage references are left around
     MGlobal::displayInfo("usdWriteJob::endJob Saving Stage");
 }
 
@@ -374,7 +362,7 @@ TfToken usdWriteJob::writeVariants(const UsdPrim &usdRootPrim)
     std::string defaultModelingVariant;
 
     // Get the usdVariantRootPrimPath (optionally filter by renderLayer prefix)
-    MayaPrimWriterPtr firstPrimWriterPtr = *mMayaPrimWriterList.begin();
+    MayaPrimWriterPtr firstPrimWriterPtr = *mJobCtx.mMayaPrimWriterList.begin();
     std::string firstPrimWriterPathStr( firstPrimWriterPtr->getDagPath().fullPathName().asChar() );
     std::replace( firstPrimWriterPathStr.begin(), firstPrimWriterPathStr.end(), '|', '/');
     std::replace( firstPrimWriterPathStr.begin(), firstPrimWriterPathStr.end(), ':', '_'); // replace namespace ":" with "_"
@@ -383,7 +371,7 @@ TfToken usdWriteJob::writeVariants(const UsdPrim &usdRootPrim)
 
     // Create a new usdVariantRootPrim and reference the Base Model UsdRootPrim
     //   This is done for reasons as described above under mArgs.usdModelRootOverridePath
-    UsdPrim usdVariantRootPrim = mStage->DefinePrim(usdVariantRootPrimPath);
+    UsdPrim usdVariantRootPrim = mJobCtx.mStage->DefinePrim(usdVariantRootPrimPath);
     TfToken defaultPrim = usdVariantRootPrim.GetName();
     usdVariantRootPrim.GetReferences().AppendInternalReference(usdRootPrim.GetPath());
     usdVariantRootPrim.SetActive(true);
@@ -439,10 +427,10 @@ TfToken usdWriteJob::writeVariants(const UsdPrim &usdRootPrim)
                 modelingVariantSet.SetVariantSelection(variantName);
                 // Set the Edit Context
                 UsdEditTarget editTarget = modelingVariantSet.GetVariantEditTarget();
-                UsdEditContext editContext(mStage, editTarget);
+                UsdEditContext editContext(mJobCtx.mStage, editTarget);
 
                 // == Activate/Deactivate UsdPrims
-                UsdPrimRange rng = UsdPrimRange::AllPrims(mStage->GetPseudoRoot());
+                UsdPrimRange rng = UsdPrimRange::AllPrims(mJobCtx.mStage->GetPseudoRoot());
                 std::vector<UsdPrim> primsToDeactivate;
                 for (auto it = rng.begin(); it != rng.end(); ++it) {
                     UsdPrim usdPrim = *it;
@@ -479,109 +467,43 @@ TfToken usdWriteJob::writeVariants(const UsdPrim &usdRootPrim)
     return defaultPrim;
 }
 
-// This method returns false if the given dagPath should be ignored and
-// its subgraph should be pruned from the traversal. Otherwise, it returns true.
-bool usdWriteJob::createPrimWriter(
-        MDagPath &curDag, MayaPrimWriterPtr* primWriterOut)
+bool usdWriteJob::needToTraverse(const MDagPath& curDag)
 {
     MObject ob = curDag.node();
-
     // NOTE: Already skipping all intermediate objects
     // skip all intermediate nodes (and their children)
-    if (PxrUsdMayaUtil::isIntermediate(ob))
-    {
-        *primWriterOut = nullptr;
+    if (PxrUsdMayaUtil::isIntermediate(ob)) {
         return false;
     }
 
     // skip nodes that aren't renderable (and their children)
-    if (mArgs.excludeInvisible && !PxrUsdMayaUtil::isRenderable(ob))
-    {
-        *primWriterOut = nullptr;
+
+    if (mJobCtx.mArgs.excludeInvisible && !PxrUsdMayaUtil::isRenderable(ob)) {
         return false;
     }
 
-    // Check whether a user prim writer exists for the node first, since plugin
-    // nodes may provide the same function sets as native Maya nodes. If a
-    // writer can't be found, we'll fall back on the standard writers below.
-    if (ob.hasFn(MFn::kPluginDependNode) && ob.hasFn(MFn::kDagNode) && ob.hasFn(MFn::kDependencyNode)) {
-        MFnDependencyNode depNodeFn(ob);
-        MPxNode *pxNode = depNodeFn.userNode();
-
-        std::string mayaTypeName(pxNode->typeName().asChar());
-
-        if (PxrUsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory =
-                PxrUsdMayaPrimWriterRegistry::Find(mayaTypeName)) {
-            MayaPrimWriterPtr primPtr(primWriterFactory(curDag, mStage, mArgs));
-            if (primPtr && primPtr->isValid()) {
-                // We found a registered user prim writer that handles this node
-                // type, so return now.
-                *primWriterOut = primPtr;
-                return true;
-            }
+    if (!mJobCtx.mArgs.exportDefaultCameras && ob.hasFn(MFn::kTransform)) {
+        // Ignore transforms of default cameras 
+        MString fullPathName = curDag.fullPathName();
+        if (fullPathName == "|persp" ||
+            fullPathName == "|top" ||
+            fullPathName == "|front" ||
+            fullPathName == "|side") {
+            return false;
         }
     }
 
-    if (ob.hasFn(MFn::kTransform) || ob.hasFn(MFn::kLocator)) {
-        MayaTransformWriterPtr primPtr(new MayaTransformWriter(curDag, mStage, mArgs));
-        if (primPtr->isValid() ) {
-            *primWriterOut = primPtr;
-            return true;
-        }
-    }
-    else if (ob.hasFn(MFn::kMesh)) {
-        MayaMeshWriterPtr primPtr(new MayaMeshWriter(curDag, mStage, mArgs));
-        if (primPtr->isValid() ) {
-            *primWriterOut = primPtr;
-            return true;
-        }
-    }
-    else if (ob.hasFn(MFn::kNurbsCurve)) {
-        MayaNurbsCurveWriterPtr primPtr(new MayaNurbsCurveWriter(curDag, mStage, mArgs));
-        if (primPtr->isValid() ) {
-            *primWriterOut = primPtr;
-            return true;
-        }
-    }
-    else if (ob.hasFn(MFn::kNurbsSurface)) {
-        MayaNurbsSurfaceWriterPtr primPtr(new MayaNurbsSurfaceWriter(curDag, mStage, mArgs));
-        if (primPtr->isValid() ) {
-            *primWriterOut = primPtr;
-            return true;
-        }
-    }
-    else if (ob.hasFn(MFn::kCamera)) {
-        if (!mArgs.exportDefaultCameras) {
-            // Ignore default cameras
-            MString fullPathName = curDag.fullPathName();
-            if (fullPathName == "|persp|perspShape" ||
-                fullPathName == "|top|topShape"     ||
-                fullPathName == "|front|frontShape" ||
-                fullPathName == "|side|sideShape") {
-                *primWriterOut = nullptr;
-                return false;
-            }
-        }
-        MayaCameraWriterPtr primPtr(new MayaCameraWriter(curDag, mStage, mArgs));
-        if (primPtr->isValid() ) {
-            *primWriterOut = primPtr;
-            return true;
-        }
-    }
-
-    *primWriterOut = nullptr;
     return true;
 }
 
-
 void usdWriteJob::perFrameCallback(double iFrame)
 {
-    if (!mArgs.melPerFrameCallback.empty()) {
-        MGlobal::executeCommand(mArgs.melPerFrameCallback.c_str(), true);
+    if (!mJobCtx.mArgs.melPerFrameCallback.empty()) {
+        MGlobal::executeCommand(mJobCtx.mArgs.melPerFrameCallback.c_str(), true);
     }
 
-    if (!mArgs.pythonPerFrameCallback.empty()) {
-        MGlobal::executePythonCommand(mArgs.pythonPerFrameCallback.c_str(), true);
+    if (!mJobCtx.mArgs.pythonPerFrameCallback.empty()) {
+        MGlobal::executePythonCommand(mJobCtx.mArgs.pythonPerFrameCallback.c_str(), true);
     }
 }
 
@@ -590,12 +512,12 @@ void usdWriteJob::perFrameCallback(double iFrame)
 // Also call the post callbacks
 void usdWriteJob::postCallback()
 {
-    if (!mArgs.melPostCallback.empty()) {
-        MGlobal::executeCommand(mArgs.melPostCallback.c_str(), true);
+    if (!mJobCtx.mArgs.melPostCallback.empty()) {
+        MGlobal::executeCommand(mJobCtx.mArgs.melPostCallback.c_str(), true);
     }
 
-    if (!mArgs.pythonPostCallback.empty()) {
-        MGlobal::executePythonCommand(mArgs.pythonPostCallback.c_str(), true);
+    if (!mJobCtx.mArgs.pythonPostCallback.empty()) {
+        MGlobal::executePythonCommand(mJobCtx.mArgs.pythonPostCallback.c_str(), true);
     }
 }
 

--- a/third_party/maya/lib/usdMaya/usdWriteJob.h
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.h
@@ -31,8 +31,11 @@
 #include "usdMaya/Chaser.h"
 
 #include "usdMaya/util.h"
-#include "usdMaya/MayaPrimWriter.h"
 #include "usdMaya/ModelKindWriter.h"
+
+#include "usdMaya/usdWriteJobCtx.h"
+
+#include <maya/MObjectHandle.h>
 
 #include <string>
 
@@ -65,17 +68,9 @@ class usdWriteJob
   private:
     void perFrameCallback(double iFrame);
     void postCallback();
-    bool createPrimWriter(MDagPath &curDag, MayaPrimWriterPtr* primWriterOut);
+    bool needToTraverse(const MDagPath& curDag);
     
   private:
-    JobExportArgs mArgs;
-
-    // List of the primitive writers to iterate over
-    std::vector<MayaPrimWriterPtr> mMayaPrimWriterList;
-
-    // Stage used to write out USD file
-    UsdStageRefPtr mStage;
-
     // Name of the created/appended USD file
     std::string mFileName;
     
@@ -84,16 +79,17 @@ class usdWriteJob
     
     // List of renderLayerObjects. Currently used for variants
     MObjectArray mRenderLayerObjs;
-    
-    // USD Maya Prim mapping used for variants
+
     PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type mDagPathToUsdPathMap;
 
     PxrUsdMayaChaserRefPtrVector mChasers;
 
     PxrUsdMaya_ModelKindWriter mModelKindWriter;
+
+    usdWriteJobCtx mJobCtx;
 };
 
-typedef shared_ptr < usdWriteJob > usdWriteJobPtr;
+typedef std::shared_ptr<usdWriteJob> usdWriteJobPtr;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/third_party/maya/lib/usdMaya/usdWriteJobCtx.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJobCtx.cpp
@@ -1,0 +1,222 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "usdMaya/usdWriteJobCtx.h"
+
+#include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/resolverContext.h"
+#include "pxr/usd/usdGeom/scope.h"
+
+#include "usdMaya/MayaCameraWriter.h"
+#include "usdMaya/MayaMeshWriter.h"
+#include "usdMaya/MayaNurbsCurveWriter.h"
+#include "usdMaya/MayaNurbsSurfaceWriter.h"
+#include "usdMaya/MayaTransformWriter.h"
+#include "usdMaya/primWriterRegistry.h"
+
+#include <maya/MDagPathArray.h>
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+#include <maya/MPxNode.h>
+
+#include <sstream>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+    inline
+    SdfPath& rootOverridePath(const JobExportArgs& args, SdfPath& path) {
+        if (!args.usdModelRootOverridePath.IsEmpty() ) {
+            path = path.ReplacePrefix(path.GetPrefixes()[0], args.usdModelRootOverridePath);
+        }
+        return path;
+    }
+
+    constexpr auto instancesScopeName = "/InstanceSources";
+}
+
+usdWriteJobCtx::usdWriteJobCtx(const JobExportArgs& args) : mArgs(args), mNoInstances(true)
+{
+
+}
+
+SdfPath usdWriteJobCtx::getMasterPath(const MDagPath& dg)
+{
+    const MObjectHandle handle(dg.node());
+    const auto it = mMasterToUsdPath.find(handle);
+    if (it != mMasterToUsdPath.end()) {
+        return it->second;
+    } else {
+        MDagPathArray allInstances;
+        auto status = MDagPath::getAllPathsTo(dg.node(), allInstances);
+        if (!status || (allInstances.length() == 0)) { return SdfPath(); }
+        // we are looking for the instance with the lowest number here
+        // which is still exported
+        auto dagCopy = allInstances[0];
+        const auto usdPath = getUsdPathFromDagPath(dagCopy, true);
+        dagCopy.pop();
+        // This will get auto destroyed, because we are not storing it in the list
+        MayaTransformWriterPtr transformPrimWriter(new MayaTransformWriter(dagCopy, usdPath.GetParentPath(), true, *this));
+        if (transformPrimWriter != nullptr && transformPrimWriter->isValid()) {
+            transformPrimWriter->write(UsdTimeCode::Default());
+            mMasterToUsdPath.insert(std::make_pair(handle, transformPrimWriter->getUsdPath()));
+        } else {
+            return SdfPath();
+        }
+        auto primWriter = _createPrimWriter(allInstances[0], true);
+        if (primWriter != nullptr) {
+            primWriter->write(UsdTimeCode::Default());
+            mMayaPrimWriterList.push_back(primWriter);
+            return transformPrimWriter->getUsdPath();
+        } else {
+            return SdfPath();
+        }
+    }
+}
+
+SdfPath usdWriteJobCtx::getUsdPathFromDagPath(const MDagPath& dagPath, bool instanceSource /* = false */)
+{
+    SdfPath path;
+    if (instanceSource) {
+        if (mInstancesPrim) {
+            mNoInstances = false;
+            std::stringstream ss;
+            ss << mInstancesPrim.GetPath().GetString();
+            MObject node = dagPath.node();
+            ss << "/" << dagPath.fullPathName().asChar() + 1;
+            if (!node.hasFn(MFn::kTransform)) {
+                ss << "/Shape";
+            }
+            auto pathName = ss.str();
+            std::replace(pathName.begin(), pathName.end(), '|', '_');
+            std::replace(pathName.begin(), pathName.end(), ':', '_');
+            path = SdfPath(pathName);
+        } else {
+            return SdfPath();
+        }
+    } else {
+        path = PxrUsdMayaUtil::MDagPathToUsdPath(dagPath, false);
+    }
+    return rootOverridePath(mArgs, path);
+}
+
+bool usdWriteJobCtx::openFile(const std::string& filename, bool append)
+{
+    ArResolverContext resolverCtx = ArGetResolver().GetCurrentContext();
+    if (append) {
+        mStage = UsdStage::Open(SdfLayer::FindOrOpen(filename), resolverCtx);
+        if (!mStage) {
+            MGlobal::displayError("Failed to open stage file " + MString(filename.c_str()));
+            return false;
+        }
+    } else {
+        mStage = UsdStage::CreateNew(filename, resolverCtx);
+        if (!mStage) {
+            MGlobal::displayError("Failed to create stage file " + MString(filename.c_str()));
+            return false;
+        }
+    }
+
+    if (mArgs.exportInstances) {
+        SdfPath instancesPath(instancesScopeName);
+        mInstancesPrim = mStage->OverridePrim(rootOverridePath(mArgs, instancesPath));
+    }
+
+    return true;
+}
+
+void usdWriteJobCtx::processInstances()
+{
+    if (mArgs.exportInstances) {
+        if (mNoInstances) {
+            mStage->RemovePrim(mInstancesPrim.GetPrimPath());
+        } else {
+            mInstancesPrim.SetSpecifier(SdfSpecifierOver);
+        }
+    }
+}
+
+MayaPrimWriterPtr usdWriteJobCtx::createPrimWriter(
+    const MDagPath& curDag)
+{
+    return _createPrimWriter(curDag, false);
+}
+
+MayaPrimWriterPtr usdWriteJobCtx::_createPrimWriter(
+    const MDagPath& curDag, bool instanceSource)
+{
+    MObject ob = curDag.node();
+
+    // Check whether a user prim writer exists for the node first, since plugin
+    // nodes may provide the same function sets as native Maya nodes. If a
+    // writer can't be found, we'll fall back on the standard writers below.
+    if (ob.hasFn(MFn::kPluginDependNode) && ob.hasFn(MFn::kDagNode) && ob.hasFn(MFn::kDependencyNode)) {
+        MFnDependencyNode depNodeFn(ob);
+        MPxNode *pxNode = depNodeFn.userNode();
+
+        std::string mayaTypeName(pxNode->typeName().asChar());
+
+        if (PxrUsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory =
+                PxrUsdMayaPrimWriterRegistry::Find(mayaTypeName)) {
+            MayaPrimWriterPtr primPtr(primWriterFactory(
+                curDag, getUsdPathFromDagPath(curDag, instanceSource), instanceSource, *this));
+            if (primPtr && primPtr->isValid()) {
+                // We found a registered user prim writer that handles this node
+                // type, so return now.
+                return primPtr;
+            }
+        }
+    }
+
+    if (ob.hasFn(MFn::kTransform) || ob.hasFn(MFn::kLocator) ||
+        (mArgs.exportInstances && curDag.isInstanced() && !instanceSource)) {
+        MayaTransformWriterPtr primPtr(new MayaTransformWriter(curDag, getUsdPathFromDagPath(curDag, instanceSource), instanceSource, *this));
+        if (primPtr->isValid()) {
+            return primPtr;
+        }
+    } else if (ob.hasFn(MFn::kMesh)) {
+        MayaMeshWriterPtr primPtr(new MayaMeshWriter(curDag, getUsdPathFromDagPath(curDag, instanceSource), instanceSource, *this));
+        if (primPtr->isValid()) {
+            return primPtr;
+        }
+    } else if (ob.hasFn(MFn::kNurbsCurve)) {
+        MayaNurbsCurveWriterPtr primPtr(new MayaNurbsCurveWriter(curDag, getUsdPathFromDagPath(curDag, instanceSource), instanceSource, *this));
+        if (primPtr->isValid()) {
+            return primPtr;
+        }
+    } else if (ob.hasFn(MFn::kNurbsSurface)) {
+        MayaNurbsSurfaceWriterPtr primPtr(new MayaNurbsSurfaceWriter(curDag, getUsdPathFromDagPath(curDag, instanceSource), instanceSource, *this));
+        if (primPtr->isValid()) {
+            return primPtr;
+        }
+    } else if (ob.hasFn(MFn::kCamera)) {
+        MayaCameraWriterPtr primPtr(new MayaCameraWriter(curDag, getUsdPathFromDagPath(curDag, false), *this));
+        if (primPtr->isValid()) {
+            return primPtr;
+        }
+    }
+
+    return nullptr;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/usdWriteJobCtx.h
+++ b/third_party/maya/lib/usdMaya/usdWriteJobCtx.h
@@ -1,0 +1,93 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXRUSDMAYA_USDWRITEJOBCTX_H
+#define PXRUSDMAYA_USDWRITEJOBCTX_H
+
+#include "pxr/pxr.h"
+#include "pxr/usd/sdf/path.h"
+#include "usdMaya/api.h"
+#include "usdMaya/JobArgs.h"
+
+#include <maya/MDagPath.h>
+#include <maya/MObjectHandle.h>
+
+#include <memory>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class MayaPrimWriter;
+typedef std::shared_ptr<MayaPrimWriter> MayaPrimWriterPtr;
+
+class usdWriteJob;
+
+/// \class usdWriteJobCtx
+/// \brief Provides basic functionality and access to shared data for MayaPrimWriters.
+///
+/// The main purpose of this class is to handle source prim creation for instancing,
+/// and to avoid storing the JobExportArgs and UsdStage on each prim writer.
+///
+class usdWriteJobCtx {
+protected:
+    friend class usdWriteJob;
+
+    PXRUSDMAYA_API
+    usdWriteJobCtx(const JobExportArgs& args);
+public:
+    const JobExportArgs& getArgs() const { return mArgs; };
+    const UsdStageRefPtr& getUsdStage() const { return mStage; };
+    // Querying the master path for instancing. This also creates the shape if it doesn't exists.
+    PXRUSDMAYA_API
+    SdfPath getMasterPath(const MDagPath& dg);
+protected:
+    PXRUSDMAYA_API
+    bool openFile(const std::string& filename, bool append);
+    PXRUSDMAYA_API
+    void processInstances();
+    PXRUSDMAYA_API
+    MayaPrimWriterPtr createPrimWriter(const MDagPath& curDag);
+
+    JobExportArgs mArgs;
+    // List of the primitive writers to iterate over
+    std::vector<MayaPrimWriterPtr> mMayaPrimWriterList;
+    // Stage used to write out USD file
+    UsdStageRefPtr mStage;
+private:
+    PXRUSDMAYA_API
+    SdfPath getUsdPathFromDagPath(const MDagPath& dagPath, bool instanceSource);
+
+    struct MObjectHandleComp {
+        bool operator()(const MObjectHandle& rhs, const MObjectHandle& lhs) const {
+            return rhs.hashCode() < lhs.hashCode();
+        }
+    };
+    std::map<MObjectHandle, SdfPath, MObjectHandleComp> mMasterToUsdPath;
+    PXRUSDMAYA_API
+    MayaPrimWriterPtr _createPrimWriter(const MDagPath& curDag, bool instanceSource);
+    UsdPrim mInstancesPrim;
+    bool mNoInstances;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/third_party/maya/lib/usdMaya/util.h
+++ b/third_party/maya/lib/usdMaya/util.h
@@ -57,10 +57,8 @@ struct cmpDag
 {
     bool operator()( const MDagPath& lhs, const MDagPath& rhs ) const
     {
-            std::string name1(lhs.fullPathName().asChar());
-            std::string name2(rhs.fullPathName().asChar());
-            return (name1.compare(name2) < 0);
-     }
+        return strcmp(lhs.fullPathName().asChar(), rhs.fullPathName().asChar()) < 0;
+    }
 };
 typedef std::set< MDagPath, cmpDag > ShapeSet;
 


### PR DESCRIPTION
### Description of Change(s)
This PR focuses on export instances from Maya. Right now import is not yet supported since this is a significant change, I want to gather some feedback before implementing the import side of the modification.

A couple of notes.
- I renamed "Make Instances" to "Make References Instanceable" to avoid confusion and make the difference between instances and that flag.
- The central part of the change is creating a new class, usdWriteJobCtx, which is the parent of usdWriteJob. This ctx is meant to be passed to the writers and has common functionality that's useful both in usdWriteJob and each of the writers. The writer creation is also moved here, because in our approach to instances, ever shape is an instance and the instances created in a different scope. The ctx handles this creation process.
- The ctx also has a bunch of shared variables, like the args, and the stage, what was accessible through the prim writer earlier.
- Most of the instancing related logic is done in the MayaTransformWriter. This way, all the shapes can be instanced automatically, no need to add code to each shape.
- I decided to put the instances in a separate scope. This seemed a bit cleaner, but it also lead to using inherits instead of references. (no non-root prims with references)
- The change doesn't support instancing transforms. Instead, it instances the shapes and creates a unique shape / xform for each instance source in the scope.
- The scope is created first, then removed at saving, if it's empty. This way we could have it at the beginning of the file, this is strictly a question of what looks nicer.
- I also removed a bunch of boost code, like using std::shared_ptr for all the writers.
- The MDagPathComparator also changed, using strcmp is simpler than creating two std::strings.