### PR TITLE
readAnimData is on by default for commands

### DIFF
--- a/third_party/maya/lib/usdMaya/JobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/JobArgs.cpp
@@ -67,7 +67,7 @@ JobImportArgs::JobImportArgs()
         shadingMode(PxrUsdMayaShadingModeTokens->displayColor),
         defaultMeshScheme(UsdGeomTokens->catmullClark),
         assemblyRep(PxUsdExportJobArgsTokens->Collapsed),
-        readAnimData(false),
+        readAnimData(true),
         useCustomFrameRange(false),
         startTime(1.0),
         endTime(1.0),


### PR DESCRIPTION
### Description of Change(s)
...this brings it in line with the gui, where it was already changed to true by default
This was made after discussion here (https://github.com/PixarAnimationStudios/USD/pull/164), where it was decided to just make it true by default everywhere (and not have it controlled by an env var option).

### Included Commit(s)
- https://github.com/LumaPictures/USD/commit/cf7b562c2dacb1a38c85ae08247f51d6ea688a33

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/145

