### PR TITLE
Enabling proxy draw overrides for VP2.

### DIFF
--- a/third_party/maya/lib/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/third_party/maya/lib/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -184,6 +184,16 @@ UsdMayaProxyDrawOverride::prepareForDraw(
     return userData;
 }
 
+MHWRender::DrawAPI
+UsdMayaProxyDrawOverride::supportedDrawAPIs() const
+{
+#if MAYA_API_VERSION >= 201600
+    return MHWRender::kOpenGL | MHWRender::kOpenGLCoreProfile;
+#else
+    return MHWRender::kOpenGL;
+#endif
+}
+
 void
 UsdMayaProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUserData *data)
 {

--- a/third_party/maya/lib/pxrUsdMayaGL/proxyDrawOverride.h
+++ b/third_party/maya/lib/pxrUsdMayaGL/proxyDrawOverride.h
@@ -71,6 +71,9 @@ public:
         MUserData* oldData);
 
     PXRUSDMAYAGL_API
+    virtual MHWRender::DrawAPI supportedDrawAPIs() const;
+
+    PXRUSDMAYAGL_API
     static MString sm_drawDbClassification;
     PXRUSDMAYAGL_API
     static MString sm_drawRegistrantId;


### PR DESCRIPTION
### Description of Change(s)
This PR enables Maya VP2 rendering of proxy shapes.

### Fixes Issue(s)
Proxy shapes were not visible in VP2 because of the missing supportedDrawAPIs.

