### PR TITLE
Fix for deregistering usdListShadingModes command

### DIFF
--- a/third_party/maya/plugin/pxrUsd/plugin.cpp
+++ b/third_party/maya/plugin/pxrUsd/plugin.cpp
@@ -201,6 +201,11 @@ MStatus uninitializePlugin(
         status.perror("deregisterCommand usdExport");
     }
 
+    status = plugin.deregisterCommand("usdListShadingModes");
+    if (!status) {
+        status.perror("deregisterCommand usdListShadingModes");
+    }
+
     status = plugin.deregisterFileTranslator("pxrUsdImport");
     if (!status) {
         status.perror("pxrUsd: unable to deregister USD Import translator.");
@@ -209,11 +214,6 @@ MStatus uninitializePlugin(
     status = plugin.deregisterFileTranslator("pxrUsdExport");
     if (!status) {
         status.perror("pxrUsd: unable to deregister USD Export translator.");
-    }
-
-    status = plugin.deregisterFileTranslator("usdListShadingModes");
-    if (!status) {
-        status.perror("deregisterCommand usdListShadingModes");
     }
 
     status = MGlobal::executeCommand("assembly -e -deregister " + _data.referenceAssembly.typeName);


### PR DESCRIPTION
### Description of Change(s)

Was a typo in deregistering usdListShadingModes 

### Included Commit(s)
- https://github.com/PixarAnimationStudios/USD/commit/fac7b79b3e30c5d381e2e176388a13d318f31ed4

### Fixes Issue(s)
- None reported - likely an error on unloading plugin

