### PR TITLE
[usdMaya] [tests] cmake should use $MAYA_BASE_DIR not $MAYA_LOCATION

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -192,7 +192,7 @@ pxr_install_test_dir(
     DEST testUsdExportAssembly
 )
 pxr_register_test(testUsdExportAssembly
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportAssembly"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportAssembly"
     TESTENV testUsdExportAssembly
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -204,7 +204,7 @@ pxr_install_test_dir(
     DEST testUsdExportCamera
 )
 pxr_register_test(testUsdExportCamera
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportCamera"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportCamera"
     TESTENV testUsdExportCamera
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -216,7 +216,7 @@ pxr_install_test_dir(
     DEST testUsdExportColorSets
 )
 pxr_register_test(testUsdExportColorSets
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportColorSets"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportColorSets"
     TESTENV testUsdExportColorSets
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -228,7 +228,7 @@ pxr_install_test_dir(
     DEST testUsdExportDisplayColor
 )
 pxr_register_test(testUsdExportDisplayColor
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportDisplayColor"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportDisplayColor"
     TESTENV testUsdExportDisplayColor
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -240,7 +240,7 @@ pxr_install_test_dir(
     DEST testUsdExportFrameOffset
 )
 pxr_register_test(testUsdExportFrameOffset
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportFrameOffset"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportFrameOffset"
     TESTENV testUsdExportFrameOffset
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -252,7 +252,7 @@ pxr_install_test_dir(
     DEST testUsdExportMesh
 )
 pxr_register_test(testUsdExportMesh
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportMesh"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportMesh"
     TESTENV testUsdExportMesh
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -264,7 +264,7 @@ pxr_install_test_dir(
     DEST testUsdExportRenderLayerMode
 )
 pxr_register_test(testUsdExportRenderLayerMode
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportRenderLayerMode"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportRenderLayerMode"
     TESTENV testUsdExportRenderLayerMode
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -276,7 +276,7 @@ pxr_install_test_dir(
     DEST testUsdExportSelection
 )
 pxr_register_test(testUsdExportSelection
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportSelection"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportSelection"
     TESTENV testUsdExportSelection
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -288,7 +288,7 @@ pxr_install_test_dir(
     DEST testUsdExportUVSets
 )
 pxr_register_test(testUsdExportUVSets
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportUVSets"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdExportUVSets"
     TESTENV testUsdExportUVSets
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -300,7 +300,7 @@ pxr_install_test_dir(
     DEST testUsdImportAsAssemblies
 )
 pxr_register_test(testUsdImportAsAssemblies
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportAsAssemblies"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportAsAssemblies"
     TESTENV testUsdImportAsAssemblies
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -312,7 +312,7 @@ pxr_install_test_dir(
     DEST testUsdImportCamera
 )
 pxr_register_test(testUsdImportCamera
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportCamera"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportCamera"
     TESTENV testUsdImportCamera
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -324,7 +324,7 @@ pxr_install_test_dir(
     DEST testUsdImportColorSets
 )
 pxr_register_test(testUsdImportColorSets
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportColorSets"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportColorSets"
     TESTENV testUsdImportColorSets
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -336,7 +336,7 @@ pxr_install_test_dir(
     DEST testUsdImportFrameRange
 )
 pxr_register_test(testUsdImportFrameRange
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportFrameRange"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportFrameRange"
     TESTENV testUsdImportFrameRange
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -348,7 +348,7 @@ pxr_install_test_dir(
     DEST testUsdImportNestedAssemblyAnimation
 )
 pxr_register_test(testUsdImportNestedAssemblyAnimation
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportNestedAssemblyAnimation"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportNestedAssemblyAnimation"
     TESTENV testUsdImportNestedAssemblyAnimation
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -360,7 +360,7 @@ pxr_install_test_dir(
     DEST testUsdImportSessionLayer
 )
 pxr_register_test(testUsdImportSessionLayer
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportSessionLayer"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportSessionLayer"
     TESTENV testUsdImportSessionLayer
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -372,7 +372,7 @@ pxr_install_test_dir(
     DEST testUsdImportUVSets
 )
 pxr_register_test(testUsdImportUVSets
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportUVSets"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdImportUVSets"
     TESTENV testUsdImportUVSets
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -384,7 +384,7 @@ pxr_install_test_dir(
     DEST testUsdMayaGetVariantSetSelections
 )
 pxr_register_test(testUsdMayaGetVariantSetSelections
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaGetVariantSetSelections"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaGetVariantSetSelections"
     TESTENV testUsdMayaGetVariantSetSelections
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -396,7 +396,7 @@ pxr_install_test_dir(
     DEST testUsdMayaModelKindWriter
 )
 pxr_register_test(testUsdMayaModelKindWriter
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaModelKindWriter"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaModelKindWriter"
     TESTENV testUsdMayaModelKindWriter
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -408,7 +408,7 @@ pxr_install_test_dir(
     DEST testUsdMayaProxyShape
 )
 pxr_register_test(testUsdMayaProxyShape
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaProxyShape"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaProxyShape"
     TESTENV testUsdMayaProxyShape
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -420,7 +420,7 @@ pxr_install_test_dir(
     DEST testUsdMayaUserExportedAttributes
 )
 pxr_register_test(testUsdMayaUserExportedAttributes
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaUserExportedAttributes"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaUserExportedAttributes"
     TESTENV testUsdMayaUserExportedAttributes
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -432,7 +432,7 @@ pxr_install_test_dir(
     DEST testUsdMetadataAttributeConverters
 )
 pxr_register_test(testUsdMetadataAttributeConverters
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataAttributeConverters"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataAttributeConverters"
     TESTENV testUsdMetadataAttributeConverters
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -444,7 +444,7 @@ pxr_install_test_dir(
     DEST testUsdReferenceAssemblyChangeRepresentations
 )
 pxr_register_test(testUsdReferenceAssemblyChangeRepresentations
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdReferenceAssemblyChangeRepresentations"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdReferenceAssemblyChangeRepresentations"
     TESTENV testUsdReferenceAssemblyChangeRepresentations
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
@@ -456,7 +456,7 @@ pxr_install_test_dir(
     DEST testUsdReferenceAssemblySelection
 )
 pxr_register_test(testUsdReferenceAssemblySelection
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdReferenceAssemblySelection"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testUsdReferenceAssemblySelection"
     TESTENV testUsdReferenceAssemblySelection
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin

--- a/third_party/maya/plugin/pxrUsd/CMakeLists.txt
+++ b/third_party/maya/plugin/pxrUsd/CMakeLists.txt
@@ -34,7 +34,7 @@ pxr_install_test_dir(
     DEST testPxrUsdAlembicChaser
 )
 pxr_register_test(testPxrUsdAlembicChaser
-    COMMAND "${MAYA_LOCATION}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testPxrUsdAlembicChaser"
+    COMMAND "${MAYA_BASE_DIR}/bin/mayapy ${CMAKE_INSTALL_PREFIX}/tests/testPxrUsdAlembicChaser"
     TESTENV testPxrUsdAlembicChaser
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin


### PR DESCRIPTION
...as this is the only cmake-variable guaranteed to be set after FindMaya runs

### Description of Change(s)
Makes the CMakeLists.txt use $MAYA_BASE_DIR, since $MAYA_LOCATION may not be defined.

### Included Commit(s)
- https://github.com/PixarAnimationStudios/USD/commit/11ed4f3ebb9283c2fdd555c6c26e3185fc888915

### Fixes Issue(s)
- Allows tests to work properly in situations where cmake was not called with an explicit "-D MAYA_LOCATION=/path/to/maya", but instead relies on setting $MAYA_LOCATION as shell environment variable (where it is then converted to the MAYA_BASE_DIR cmake-variable)

