### PR TITLE
Py_SetProgramName tweak to find python lib dir

### DIFF
--- a/pxr/base/lib/tf/CMakeLists.txt
+++ b/pxr/base/lib/tf/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WIN32)
     set(WINLIBS Shlwapi.lib)
 endif()
 
+add_definitions(-DPXR_PYTHON_EXECUTABLE_STR=\"${PYTHON_EXECUTABLE}\")
+
 pxr_shared_library(tf
     LIBRARIES
         arch


### PR DESCRIPTION
### Description of Change(s)

This fixes some errors with using the embedded python interpretter (ie, pyInterpretter.cpp).  Specfically, it fixes issues with finding the python standard library dir.

### Included Commit(s)
- ~~https://github.com/PixarAnimationStudios/USD/commit/c9c9250a261894ace15b7096b847c4c9247a13cc~~
- https://github.com/PixarAnimationStudios/USD/pull/205/commits/e1f9a76ce1cdd8408d8cc252c02ca4a8220c2d32

### Fixes Issue(s)
- Fixes some test failures

