### PR TITLE
[tests] deal with env vars that have an '=' in them

### DIFF
--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -240,7 +240,7 @@ if __name__ == '__main__':
             sys.stderr.write("Error: use --pre-path or --post-path to edit PATH.")
             sys.exit(1)
         try:
-            k, v = varStr.split('=')
+            k, v = varStr.split('=', 1)
             env[k] = v
         except IndexError:
             sys.stderr.write("Error: envvar '{0}' not of the form "


### PR DESCRIPTION
### Description of Change(s)
Currently running the tests will error in testWrapper.py if you have an environ var (in our case, it was PYTHONPATH) that has an '=' in it. This fixes it deal properly with such vars.

### Included Commit(s)
- https://github.com/PixarAnimationStudios/USD/commit/6f9a52afdcdb09dffbc72a0e872591deec3dfd7a

### Fixes Issue(s)
- running tests when an env var has a '='

