### PR TITLE
set $MAYA_APP_DIR before running tests, to use a default maya profile

### DIFF
--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -78,7 +78,10 @@ def _parseArgs():
     parser.add_argument('--expected-return-code', type=int, default=0,
             help='Expected return code of this test.')
     parser.add_argument('--env-var', dest='envVars', default=[], type=str, 
-            action='append', help='Variable to set in the test environment.')
+            action='append',
+            help=('Variable to set in the test environment, in KEY=VALUE form. '
+                  'If "<PXR_TEST_DIR>" is in the value, it is replaced with the '
+                  'absolute path of the temp directory the tests are run in'))
     parser.add_argument('--pre-path', dest='prePaths', default=[], type=str, 
             action='append', help='Path to prepend to the PATH env var.')
     parser.add_argument('--post-path', dest='postPaths', default=[], type=str, 
@@ -243,6 +246,7 @@ if __name__ == '__main__':
             sys.exit(1)
         try:
             k, v = varStr.split('=', 1)
+            v = v.replace('<PXR_TEST_DIR>', testDir)
             env[k] = v
         except IndexError:
             sys.stderr.write("Error: envvar '{0}' not of the form "

--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -191,6 +191,7 @@ pxr_test_scripts(
         testenv/testUsdImportSkeleton.py
         testenv/testUsdImportUVSets.py
         testenv/testUsdImportXforms.py
+        testenv/testUsdMayaAppDir.py
         testenv/testUsdMayaGetVariantSetSelections.py
         testenv/testUsdMayaModelKindWriter.py
         testenv/testUsdMayaProxyShape.py
@@ -202,6 +203,18 @@ pxr_test_scripts(
         testenv/testUsdReferenceAssemblyChangeRepresentations.py
         testenv/testUsdReferenceAssemblySelection.py
 )
+
+# Note - we set up a maya profile directory ($MAYA_APP_DIR) that's empty, so we
+# can ensure we test with a default profile - had some crashes with 2017 when
+# using an existing user profile (due to some problems with color management
+# settings)
+# Also, maya creates the $MAYA_APP_DIR on demand, so we don't need to bother
+# making the directory ourselves.  We use <PXR_TEST_DIR>, which is expanded
+# to the absolute path of the temporary folder tests are run in, because:
+#   A) we can't use relative paths ("./maya_profile"), because maya in
+#      windows will error
+#   B) we don't know the absolute path to the test directory at cmake-compile
+#      time 
 
 pxr_install_test_dir(
     SRC testenv/UsdExportAssemblyTest
@@ -215,6 +228,7 @@ pxr_register_test(testUsdExportAssembly
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -229,6 +243,7 @@ pxr_register_test(testUsdExportCamera
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -243,6 +258,7 @@ pxr_register_test(testUsdExportColorSets
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -257,6 +273,7 @@ pxr_register_test(testUsdExportDisplayColor
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -271,6 +288,7 @@ pxr_register_test(testUsdExportFrameOffset
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -285,6 +303,7 @@ pxr_register_test(testUsdExportInstances
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -299,6 +318,7 @@ pxr_register_test(testUsdExportLocator
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -313,6 +333,7 @@ pxr_register_test(testUsdExportMesh
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -327,6 +348,7 @@ pxr_register_test(testUsdExportNurbsCurve
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -341,6 +363,7 @@ pxr_register_test(testUsdExportOverImport
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -355,6 +378,7 @@ pxr_register_test(testUsdExportParentScope
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -369,6 +393,7 @@ pxr_register_test(testUsdExportParticles
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -383,6 +408,7 @@ pxr_register_test(testUsdExportPointInstancer
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -397,6 +423,7 @@ pxr_register_test(testUsdExportRenderLayerMode
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
         MAYA_ENABLE_LEGACY_RENDER_LAYERS=1
 )
 
@@ -414,6 +441,7 @@ pxr_register_test(testUsdExportRenderLayerMode
 #         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
 #         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
 #         MAYA_DISABLE_CIP=1
+#         MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 # )
 
 pxr_install_test_dir(
@@ -428,6 +456,7 @@ pxr_register_test(testUsdExportSelection
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -442,6 +471,7 @@ pxr_register_test(testUsdExportShadingModeDisplayColor
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
         USD_RI_WRITE_BXDF_OUTPUT=0
 )
 
@@ -457,6 +487,7 @@ pxr_register_test(testUsdExportShadingModePxrRis
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
         USD_RI_WRITE_BXDF_OUTPUT=0
 )
 
@@ -472,6 +503,7 @@ pxr_register_test(testUsdExportSkeleton
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -486,6 +518,7 @@ pxr_register_test(testUsdExportUVSets
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -500,6 +533,7 @@ pxr_register_test(testUsdImportAsAssemblies
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -514,6 +548,7 @@ pxr_register_test(testUsdImportCamera
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -528,6 +563,7 @@ pxr_register_test(testUsdImportColorSets
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -542,6 +578,7 @@ pxr_register_test(testUsdImportFrameRange
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -556,6 +593,7 @@ pxr_register_test(testUsdImportNestedAssemblyAnimation
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 # XXX: This test is disabled by default since it requires the RenderMan for
@@ -572,6 +610,7 @@ pxr_register_test(testUsdImportNestedAssemblyAnimation
 #         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
 #         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
 #         MAYA_DISABLE_CIP=1
+#         MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 # )
 
 pxr_install_test_dir(
@@ -586,6 +625,7 @@ pxr_register_test(testUsdImportSessionLayer
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -600,6 +640,7 @@ pxr_register_test(testUsdImportShadingModeDisplayColor
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -614,6 +655,7 @@ pxr_register_test(testUsdImportShadingModePxrRis
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -628,6 +670,7 @@ pxr_register_test(testUsdImportSkeleton
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -642,6 +685,7 @@ pxr_register_test(testUsdImportUVSets
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -656,6 +700,22 @@ pxr_register_test(testUsdImportXforms
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
+)
+
+pxr_install_test_dir(
+    SRC testenv/UsdMayaAppDirTest
+    DEST testUsdMayaAppDir
+)
+pxr_register_test(testUsdMayaAppDir
+    CUSTOM_PYTHON "${MAYA_BASE_DIR}/bin/mayapy"
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaAppDir"
+    TESTENV testUsdMayaAppDir
+    ENV
+        MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
+        MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
+        MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -670,6 +730,7 @@ pxr_register_test(testUsdMayaGetVariantSetSelections
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -684,6 +745,7 @@ pxr_register_test(testUsdMayaModelKindWriter
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -698,6 +760,7 @@ pxr_register_test(testUsdMayaProxyShape
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -712,6 +775,7 @@ pxr_register_test(testUsdMayaReferenceAssemblyEdits
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -726,6 +790,7 @@ pxr_register_test(testUsdMayaUserExportedAttributes
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -740,6 +805,7 @@ pxr_register_test(testUsdGeomAttributeConverters
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -754,6 +820,7 @@ pxr_register_test(testUsdMetadataAttributeConverters
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -768,6 +835,7 @@ pxr_register_test(testUsdReferenceAssemblyChangeRepresentations
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_install_test_dir(
@@ -782,6 +850,7 @@ pxr_register_test(testUsdReferenceAssemblySelection
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
 
 pxr_register_test(testUsdMayaXformStack
@@ -792,4 +861,5 @@ pxr_register_test(testUsdMayaXformStack
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )

--- a/third_party/maya/lib/usdMaya/testenv/UsdMayaAppDirTest/maya_profile/scripts/userSetup.py
+++ b/third_party/maya/lib/usdMaya/testenv/UsdMayaAppDirTest/maya_profile/scripts/userSetup.py
@@ -1,0 +1,2 @@
+import os
+os.environ['DUMMY_TEST_VAR'] = 'exists'

--- a/third_party/maya/lib/usdMaya/testenv/testUsdMayaAppDir.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdMayaAppDir.py
@@ -1,0 +1,46 @@
+#!/pxrpythonsubst
+#
+# Copyright 2018 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest, os
+
+from maya import standalone
+
+
+class testUsdMayaAppDir(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        standalone.initialize('usd')
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def testCheckEnvVar(self):
+        self.assertEqual(os.environ.get('DUMMY_TEST_VAR'), 'exists')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/third_party/maya/plugin/pxrUsd/CMakeLists.txt
+++ b/third_party/maya/plugin/pxrUsd/CMakeLists.txt
@@ -45,4 +45,5 @@ pxr_register_test(testPxrUsdAlembicChaser
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
         MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )


### PR DESCRIPTION
### Description of Change(s)
in testWrapper.py, set the $MAYA_APP_DIR env var, so that maya tests run using a default user profile

### Included Commit(s)
- ~~https://github.com/PixarAnimationStudios/USD/commit/718780496f8cfd88492a2f54fb783b348b3be5f3~~
- https://github.com/PixarAnimationStudios/USD/pull/209/commits/f75077e557a7a5c15ccf5ea318076e52237e62e8

### Fixes Issue(s)
- We were experiencing some crashes when running the tests on maya-2017, due to some problems with the color-management settings in the user profile

