### PR TITLE
[usdview] add --camera cmdline arg

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -80,8 +80,13 @@ class Launcher(object):
                             help='A prim path to initially select and frame')
 
         parser.add_argument('--camera', action='store', default="main_cam",
-                            type=str, help='Which camera to set the view to on '
-                            'open')
+                            type=str, help="Which camera to set the view to on "
+                            "open - may be given as either just the camera's "
+                            "prim name (ie, just the last element in the prim "
+                            "path), or as a full prim path.  Note that if only "
+                            "the prim name is used, and more than one camera "
+                            "exists with the name, which is used will be"
+                            "effectively random")
 
         parser.add_argument('--mask', action='store', nargs='+',
                             dest='populationMask', metavar='PRIMPATH',
@@ -145,6 +150,37 @@ class Launcher(object):
             print >> sys.stderr, "WARNING: complexity %.1f is out of range [1.0, 2.0], using %.1f instead" %  \
                                  (arg_parse_result.complexity, newComplexity)
             arg_parse_result.complexity = newComplexity
+
+        # convert the camera result to an sdf path, if possible, and verify
+        # that it is "just" a prim path
+        if arg_parse_result.camera:
+            from pxr import Sdf
+            camPath = Sdf.Path(arg_parse_result.camera)
+            if camPath.isEmpty:
+                print >> sys.stderr, "ERROR: invalid camera path - %r" % \
+                                     (arg_parse_result.camera,)
+                return False
+            if not camPath.IsPrimPath():
+                print >> sys.stderr, "ERROR: invalid camera path - must be a " \
+                                     "raw prim path, without variant " \
+                                     "selections, relational attributes, etc " \
+                                     "- got: %r" % \
+                                     (arg_parse_result.camera,)
+                return False
+
+            # check if it's a path, or just a name...
+            if camPath.name != arg_parse_result.camera:
+                # it's a "real" path, store the SdfPath version
+                if not camPath.IsAbsolutePath():
+                    # perhaps we should error here? For now just pre-pending
+                    # root, and printing warning...
+                    print >> sys.stderr, "WARNING: camera path %r was not " \
+                                         "absolute, prepending %r to make " \
+                                         "it absolute" % \
+                                         (str(camPath),
+                                          str(Sdf.Path.absoluteRootPath))
+                    camPath = camPath.MakeAbsolutePath(Sdf.Path.absoluteRootPath)
+                arg_parse_result.camera = camPath
         return True
             
     def __LaunchProcess(self, arg_parse_result):

--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -79,6 +79,10 @@ class Launcher(object):
                             dest='primPath', type=str,
                             help='A prim path to initially select and frame')
 
+        parser.add_argument('--camera', action='store', default="main_cam",
+                            type=str, help='Which camera to set the view to on '
+                            'open')
+
         parser.add_argument('--mask', action='store', nargs='+',
                             dest='populationMask', metavar='PRIMPATH',
                             help='Limit stage population to these prims, '

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -300,6 +300,7 @@ class MainWindow(QtGui.QMainWindow):
         self._timeSamples = None
         self._stageView = None
         self._startingPrimCamera = None
+        self._startingPrimCameraName = parserData.camera
 
         self.setWindowTitle(parserData.usdFile)
         self._statusBar = QtGui.QStatusBar(self)
@@ -2689,9 +2690,7 @@ class MainWindow(QtGui.QMainWindow):
 
         if not preserveCurrCamera:
             for camera in self._allSceneCameras:
-                # XXX This logic needs to be de-pixarified.  Perhaps
-                # a "primaryCamera" attribute on UsdGeomCamera?
-                if camera.GetName() == "main_cam":
+                if camera.GetName() == self._startingPrimCameraName:
                     self._startingPrimCamera = currCamera = camera
                     if self._stageView:
                         self._stageView.setCameraPrim(camera)


### PR DESCRIPTION
### Description of Change(s)

Allows choosing of what camera to use when opening the scene

### Included Commit(s)
- https://github.com/PixarAnimationStudios/USD/commit/f2f5e997be58d64f76a754ba703c7e0203bc0cc3

### Fixes Issue(s)
- None, perse, but there was a TODO note about not hardcoding the default to be a pixar-specific name, which this effectively does

