### PR TITLE
[usdKatana] Fixing missing symbol from the Katana plugin.

### DIFF
--- a/third_party/katana/plugin/pxrUsdInShipped/CMakeLists.txt
+++ b/third_party/katana/plugin/pxrUsdInShipped/CMakeLists.txt
@@ -24,6 +24,7 @@ pxr_plugin(${PXR_PACKAGE}
         basisCurves.cpp
         camera.cpp
         constraints.cpp
+        light.cpp
         material.cpp
         materialsGroup.cpp
         mesh.cpp


### PR DESCRIPTION
LightOp symbols are missing from the katana plugin build.