### PR TITLE
[katana] Use fileInput widget for PxrUsdIn filename

### DIFF
--- a/third_party/katana/python/nodetypes/PxrUsdIn.py
+++ b/third_party/katana/python/nodetypes/PxrUsdIn.py
@@ -39,6 +39,7 @@ gb = FnAttribute.GroupBuilder()
 
 gb.set('fileName', '')
 nb.setHintsForParameter('fileName', {
+    'widget': 'fileInput',
     'help' : 'The USD file to read.',
 })
 


### PR DESCRIPTION
### Description of Change(s)

Adds a 'widget' hint to the Katana PxrUsdIn node so that a `fileInput` widget is used for the 'fileName' by default.