### PR TITLE
Add formal support for Usd <-> Alembic facesets

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -65,6 +65,7 @@ pxr_test_scripts(
     testenv/testUsdAbcAlembicData.py       
     testenv/testUsdAbcBugs.py              
     testenv/testUsdAbcCamera.py  
+    testenv/testUsdAbcFaceset.py
     testenv/testUsdAbcConversionSubdiv.py 
     testenv/testUsdAbcInstancing.py 
 )
@@ -82,6 +83,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdAbcCamera
     DEST testUsdAbcCamera
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdAbcFaceset
+    DEST testUsdAbcFaceset
 )
 
 pxr_install_test_dir(
@@ -132,6 +138,12 @@ pxr_register_test(testUsdAbcCamera
 pxr_register_test(testUsdAbcConversionSubdiv
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionSubdiv"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdAbcFaceset
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcFaceset"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
@@ -1,0 +1,97 @@
+#!/pxrpythonsubst
+#
+# Copyright 2017 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Usd, UsdAbc, UsdGeom, Gf
+import unittest
+
+class TestUsdAbcFaceset(unittest.TestCase):
+    def test_RoundTrip(self):
+        usdFile = 'original.usda'
+        abcFile = 'converted.abc'
+        self.assertTrue(UsdAbc._WriteAlembic(usdFile, abcFile))
+
+        stage = Usd.Stage.Open(abcFile)
+        prim = stage.GetPrimAtPath('/cube1')
+        self.assertTrue(prim.IsValid())
+
+        faceSets = UsdGeom.FaceSetAPI().GetFaceSets(prim)
+        self.assertEqual(len(faceSets), 2)
+
+        fs0 = faceSets[0]
+        fs1 = faceSets[1]
+        self.assertEqual(fs0.GetFaceSetName(), 'part1')
+        self.assertEqual(fs1.GetFaceSetName(), 'part2')
+
+        # Validate the face counts and values for part1 (which is animated)
+        countsAttr = fs0.GetFaceCountsAttr()
+        timeSamples = countsAttr.GetTimeSamples()
+        expectedTimeSamples = [0.0, 1.0]
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceCounts = {0.0: [3], 1.0: [2]}
+        for time, expectedValue in expectedFaceCounts.items():
+            faceCounts = countsAttr.Get(time)
+            for c, e in zip(faceCounts, expectedValue):
+                self.assertEqual(c, e)
+
+        indicesAttr = fs0.GetFaceIndicesAttr()
+        timeSamples = indicesAttr.GetTimeSamples()
+        expectedTimeSamples = [0.0, 1.0]
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [0, 1, 4], 1.0: [0, 1]}
+        for time, expectedValue in expectedFaceIndices.items():
+            faceIndices = indicesAttr.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+        # Validate the face counts and values for part2 (which was constant,
+        # but promoted to the same samples as part1 during conversion)
+        countsAttr = fs1.GetFaceCountsAttr()
+        timeSamples = countsAttr.GetTimeSamples()
+        expectedTimeSamples = [0.0, 1.0]
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceCounts = {0.0: [3], 1.0: [3]}
+        for time, expectedValue in expectedFaceCounts.items():
+            faceCounts = countsAttr.Get(time)
+            for c, e in zip(faceCounts, expectedValue):
+                self.assertEqual(c, e)
+
+        indicesAttr = fs1.GetFaceIndicesAttr()
+        expectedTimeSamples = [0.0, 1.0]
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [2, 3, 5], 1.0: [2, 3, 5]}
+        for time, expectedValue in expectedFaceIndices.items():
+            faceIndices = indicesAttr.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
@@ -1,0 +1,36 @@
+#usda 1.0
+(
+    defaultPrim = "cube1"
+    upAxis = "Y"
+)
+
+def Mesh "cube1"
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+    int[] faceSet:part1:faceCounts.timeSamples = {
+        0: [3],
+        1: [2],
+    }
+    int[] faceSet:part1:faceIndices.timeSamples = {
+        0: [0, 1, 4],
+        1: [0, 1]
+    }
+    uniform bool faceSet:part1:isPartition = 1
+    int[] faceSet:part2:faceCounts = [3]
+    int[] faceSet:part2:faceIndices = [2, 3, 5]
+    uniform bool faceSet:part2:isPartition = 1
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
+    normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
+        interpolation = "vertex"
+    )
+    float2[] primvars:uv = [(0, 1), (1, 1), (1, 0), (0, 0), (0, 2), (1, 2), (1, 1), (0, 1), (0, 3), (1, 3), (1, 2), (0, 2), (0, 4), (1, 4), (1, 3), (0, 3), (1, 1), (2, 1), (2, 0), (1, 0), (-1, 1), (0, 1), (0, 0), (-1, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token subdivisionScheme = "none"
+}
+


### PR DESCRIPTION
### Description of Change(s)

Modifications to pxrUsdInShipped to support not only facesets which contain UsdShade-based material assignments, but all facesets associated with a given mesh primitive.  This also supports both facesets with a single facegroup and those with multiple facegroups.  As a special case for single facegroups, the faceset name is used without modification, which allows Alembic facesets to come through into USD and into Katana unmodified.

Changes to usdAbc (which is responsible for translating Alembic data structures to USD ones, and vice-versa) so that facesets are properly considered and represented in USD and ALembic.

The changes to alembicReader.cpp means the facesets themselves are represented in USD (not any custom attributes which may be present on the Alembic faceset objects), but this is sufficient for common uses (particularly lookdev assignments implemented in other tools).

The changes to alembicWriter.cpp translate the basic facesets from USD to Alembic, supporting both single facegroup facesets and multi facegroup facesets.  In the single case, the same special handling for names is done as in pxrUsdInShipped, which allows a proper roundtrip of an Alembic cache with facesets to go to USD then back to Alembic with the same structure.

### Fixes Issue(s)
-
