### PR TITLE
[usdMaya] Loading the shading mode plugins.

### DIFF
--- a/third_party/maya/lib/usdMaya/registryHelper.cpp
+++ b/third_party/maya/lib/usdMaya/registryHelper.cpp
@@ -40,6 +40,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DEFINE_PRIVATE_TOKENS(_tokens, 
     (mayaPlugin)
     (providesTranslator)
+    (UsdMaya)
+    (ShadingModePlugin)
 );
 
 template <typename T>
@@ -127,6 +129,26 @@ _ProvidesForType(
     return provides;
 }
 
+static bool
+_HasShadingModePlugin(
+    const PlugPluginPtr& plug,
+    const std::vector<TfToken>& scope,
+    std::string* mayaPluginName)
+{
+    JsObject metadata = plug->GetMetadata();
+    JsObject mayaTranslatorMetadata;
+    if (!_ReadNestedDict(metadata, scope, &mayaTranslatorMetadata)) {
+        return false;
+    }
+
+    JsValue any;
+    if (TfMapLookup(mayaTranslatorMetadata, _tokens->mayaPlugin, &any)) {
+        return _GetData(any, mayaPluginName);
+    }
+
+    return false;
+}
+
 /* static */
 std::string
 _PluginDictScopeToDebugString(
@@ -180,6 +202,37 @@ PxrUsdMaya_RegistryHelper::FindAndLoadMayaPlug(
             break;
         }
     }
+}
+
+/* static */
+void
+PxrUsdMaya_RegistryHelper::LoadShadingModePlugins() {
+    static std::once_flag _shadingModesLoaded;
+    static std::vector<TfToken> scope = {_tokens->UsdMaya, _tokens->ShadingModePlugin};
+    std::call_once(_shadingModesLoaded, [](){        
+        PlugPluginPtrVector plugins = PlugRegistry::GetInstance().GetAllPlugins();
+        std::string mayaPlugin;
+        TF_FOR_ALL(plugIter, plugins) {
+            PlugPluginPtr plug = *plugIter;
+            if (_HasShadingModePlugin(plug, scope, &mayaPlugin) && !mayaPlugin.empty()) {
+                TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg(
+                            "Found usdMaya plugin %s: Loading maya plugin %s.\n", 
+                            plug->GetName().c_str(),
+                            mayaPlugin.c_str());
+                std::string loadPluginCmd = TfStringPrintf(
+                        "loadPlugin -quiet %s", mayaPlugin.c_str());
+                if (MGlobal::executeCommand(loadPluginCmd.c_str())) {
+                    // Need to ensure Python script modules are loaded
+                    // properly for this library (Maya's loadPlugin will not
+                    // load script modules like TfDlopen would).
+                    TfScriptModuleLoader::GetInstance().LoadModules();
+                } else {
+                    TF_CODING_ERROR("Unable to load mayaplugin %s\n",
+                            mayaPlugin.c_str());
+                }
+            }
+        }
+    });
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/registryHelper.h
+++ b/third_party/maya/lib/usdMaya/registryHelper.h
@@ -57,6 +57,18 @@ struct PxrUsdMaya_RegistryHelper
                 const std::vector<TfToken>& scope,
                 const std::string& value);
 
+    /// Searches the plugInfos and looks for ShadingModePlugin.
+    /// 
+    /// "UsdMaya" : {
+    ///     "ShadingModeExport" : {
+    ///         "mayaPlugin" : "arnoldShaderExporter"
+    ///     }
+    /// }
+    ///
+    /// At that scope, it expects a dictionary with one key: "mayaPlugin".
+    /// usdMaya will try to load the "mayaPlugin" when shading modes are first accessed.
+    static void
+        LoadShadingModePlugins();
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeRegistry.cpp
@@ -23,6 +23,7 @@
 //
 #include "pxr/pxr.h"
 #include "usdMaya/shadingModeRegistry.h"
+#include "usdMaya/registryHelper.h"
 
 #include "pxr/base/tf/instantiateSingleton.h"
 
@@ -47,8 +48,10 @@ PxrUsdMayaShadingModeRegistry::RegisterExporter(
 PxrUsdMayaShadingModeExporterCreator
 PxrUsdMayaShadingModeRegistry::_GetExporter(const TfToken& name)
 {
+    PxrUsdMaya_RegistryHelper::LoadShadingModePlugins();
     TfRegistryManager::GetInstance().SubscribeTo<PxrUsdMayaShadingModeExportContext>();
-    return _exportReg[name];
+    const auto it = _exportReg.find(name);
+    return it == _exportReg.end() ? nullptr : it->second;
 }
 
 typedef std::map<TfToken, PxrUsdMayaShadingModeImporter> _ImportRegistry;
@@ -72,6 +75,7 @@ PxrUsdMayaShadingModeRegistry::_GetImporter(const TfToken& name)
 
 TfTokenVector
 PxrUsdMayaShadingModeRegistry::_ListExporters() {
+    PxrUsdMaya_RegistryHelper::LoadShadingModePlugins();
     TfRegistryManager::GetInstance().SubscribeTo<PxrUsdMayaShadingModeExportContext>();
     TfTokenVector ret;
     ret.reserve(_exportReg.size());

--- a/third_party/maya/lib/usdMaya/usdExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdExport.cpp
@@ -148,6 +148,11 @@ try
             jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->displayColor;
         }
         else {
+            if (shadingMode == "Material Colors") {
+                shadingMode = TfToken("displayColor");
+            } else if (shadingMode == "RfM Shaders") {
+                shadingMode = TfToken("pxrRis");
+            }
             if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode)) {
                 jobArgs.shadingMode = shadingMode;
             }

--- a/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
+++ b/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
@@ -1,6 +1,7 @@
 #include "usdMaya/usdListShadingModes.h"
 
 #include "usdMaya/shadingModeRegistry.h"
+#include "usdMaya/registryHelper.h"
 
 #include <maya/MSyntax.h>
 #include <maya/MStatus.h>
@@ -8,6 +9,8 @@
 #include <maya/MArgDatabase.h>
 #include <maya/MGlobal.h>
 #include <maya/MString.h>
+
+#include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -20,7 +23,7 @@ usdListShadingModes::~usdListShadingModes() {
 }
 
 MStatus
-usdListShadingModes::doIt(const MArgList& args) {
+usdListShadingModes::doIt(const MArgList& args) {    
     MStatus status;
     MArgDatabase argData(syntax(), args, &status);
 

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
@@ -82,17 +82,17 @@ usdTranslatorExport::writer(const MFileObject &file,
                 jobArgs.exportDisplayColor = true;
                 jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->none;
                 
-                if (theOption[1]=="None") {
+                if (theOption[1] == MString("None")) {
                     jobArgs.exportDisplayColor = false;
-                }else if (theOption[1]=="Material Colors") {
+                } else if (theOption[1] == MString("Material Colors")) {
                     jobArgs.shadingMode = PxrUsdMayaShadingModeTokens->displayColor;
-                } else if (theOption[1]=="RfM Shaders") {
+                } else if (theOption[1] == MString("RfM Shaders")) {
                     TfToken shadingMode("pxrRis");
                     if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode)) {
                         jobArgs.shadingMode = shadingMode;
                     }
-                } else { 
-                    TfToken modeToken(theOption[1].asChar()); 
+                } else if (theOption[1] != MString("GPrim Colors")) { 
+                    TfToken modeToken(theOption[1].asChar());
                     if (PxrUsdMayaShadingModeRegistry::GetInstance().GetExporter(modeToken)) { 
                         jobArgs.shadingMode = modeToken; 
                     } else { 


### PR DESCRIPTION
This PR is a general improvement for the shading mode exporter plugin interface.

- Previously there was no functionality to load the plugins. I added a function similar to the primWriter plugin loading code, that's run before any of the exporters are accessed.
- The default values caused a bit of confusion. The GPrim Colors -> displayColor remapping was missing from the export code (both the translator and the usdExport call).
- A request to an invalid export appended empty exporter to the list with the same name. This problem was fixed by accessing the exporter through an iterator rather than std::map's operator[].
- If the manual export command was used instead of the file translator, the shading mode worked incorrectly. The shading modes were accessible by their internal names, which are not documented anywhere. I added support for the custom names on the file/export interface.