### PR TITLE
[usdMaya] Passing dagPathToUsdPathMap to the material translator.

### DIFF
--- a/third_party/maya/lib/usdMaya/shadingModeExporter.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeExporter.cpp
@@ -40,7 +40,8 @@ PxrUsdMayaShadingModeExporter::DoExport(
     const UsdStageRefPtr& stage,
     const PxrUsdMayaUtil::ShapeSet& bindableRoots,
     bool mergeTransformAndShape,
-    const SdfPath& overrideRootPath) {
+    const SdfPath& overrideRootPath,
+    const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type&) {
     MItDependencyNodes shadingEngineIter(MFn::kShadingEngine);
     for (; !shadingEngineIter.isDone(); shadingEngineIter.next()) {
         MObject shadingEngine(shadingEngineIter.thisNode());

--- a/third_party/maya/lib/usdMaya/shadingModeExporter.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporter.h
@@ -46,7 +46,8 @@ public:
     virtual void DoExport(const UsdStageRefPtr& stage,
                           const PxrUsdMayaUtil::ShapeSet& bindableRoots,
                           bool mergeTransformAndShape,
-                          const SdfPath& overrideRootPath);
+                          const SdfPath& overrideRootPath,
+                          const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap);
 
     PXRUSDMAYA_API
     virtual void Export(const PxrUsdMayaShadingModeExportContext& context);

--- a/third_party/maya/lib/usdMaya/translatorMaterial.cpp
+++ b/third_party/maya/lib/usdMaya/translatorMaterial.cpp
@@ -393,7 +393,8 @@ PxrUsdMayaTranslatorMaterial::ExportShadingEngines(
         const PxrUsdMayaUtil::ShapeSet& bindableRoots,
         const TfToken& shadingMode,
         bool mergeTransformAndShape,
-        SdfPath overrideRootPath)
+        SdfPath overrideRootPath,
+        const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap)
 {
     if (shadingMode == PxrUsdMayaShadingModeTokens->none) {
         return;
@@ -402,7 +403,7 @@ PxrUsdMayaTranslatorMaterial::ExportShadingEngines(
     if (auto exporterCreator =
             PxrUsdMayaShadingModeRegistry::GetExporter(shadingMode)) {
         if (auto exporter = exporterCreator()) {
-            exporter->DoExport(stage, bindableRoots, mergeTransformAndShape, overrideRootPath);
+            exporter->DoExport(stage, bindableRoots, mergeTransformAndShape, overrideRootPath, dagPathToUsdMap);
         }
     }
     else {

--- a/third_party/maya/lib/usdMaya/translatorMaterial.h
+++ b/third_party/maya/lib/usdMaya/translatorMaterial.h
@@ -79,7 +79,8 @@ struct PxrUsdMayaTranslatorMaterial
             const PxrUsdMayaUtil::ShapeSet& bindableRoots,
             const TfToken& shadingMode,
             bool mergeTransformAndShape,
-            SdfPath overrideRootPath);
+            SdfPath overrideRootPath,
+            const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap);
 };
 
 

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -253,7 +253,8 @@ bool usdWriteJob::beginJob(const std::string &iFileName,
                 mJobCtx.mArgs.dagPaths,
                 mJobCtx.mArgs.shadingMode,
                 mJobCtx.mArgs.mergeTransformAndShape,
-                mJobCtx.mArgs.usdModelRootOverridePath);
+                mJobCtx.mArgs.usdModelRootOverridePath,
+                mDagPathToUsdPathMap);
 
     if (!mModelKindWriter.MakeModelHierarchy(mJobCtx.mStage)) {
         return false;


### PR DESCRIPTION
The following change passes the Maya DagPath to Usd Prim Path map to the shader exporters. This is useful when implementing the material export the other way around, looking up the materials of the existing nodes, rather than iterating through all the existing shading engines in the scene.

We are relying on this in our usd-arnold package.