### PR TITLE
[usdMaya] Clearing out the prim writers before saving the stage.

### DIFF
--- a/third_party/maya/lib/usdMaya/MayaPrimWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaPrimWriter.cpp
@@ -184,6 +184,11 @@ MayaPrimWriter::shouldPruneChildren() const
 }
 
 void
+MayaPrimWriter::postExport()
+{ 
+}
+
+void
 MayaPrimWriter::setExportsVisibility(bool exports)
 {
     mExportsVisibility = exports;

--- a/third_party/maya/lib/usdMaya/MayaPrimWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaPrimWriter.h
@@ -69,6 +69,12 @@ class MayaPrimWriter
     PXRUSDMAYA_API
     virtual bool shouldPruneChildren() const;
 
+    /// Post export function that runs before saving the stage.
+    ///
+    /// Base implementation does nothing.
+    PXRUSDMAYA_API
+    virtual void postExport();
+    
 public:
     const MDagPath&        getDagPath()    const { return mDagPath; }
     const SdfPath&         getUsdPath()    const { return mUsdPath; }

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -382,6 +382,10 @@ void usdWriteJob::endJob()
         // prim for the export... usdVariantRootPrimPath
         mJobCtx.mStage->GetRootLayer()->SetDefaultPrim(defaultPrim);
     }
+    // Running post export function on all the prim writers.
+    for (auto& primWriter: mJobCtx.mMayaPrimWriterList) {
+        primWriter->postExport();
+    }
     if (mJobCtx.mStage->GetRootLayer()->PermissionToSave()) {
         mJobCtx.mStage->GetRootLayer()->Save();
     }


### PR DESCRIPTION
The change is super simple here; we are clearing the prim writers before saving the stage. This change is useful when somebody wants to run cleanup code in a primWriter's destruction. Otherwise, there is no way to track down the last write to get the same effect.

For example, we have been using feature successfully with some of our writers to optimize animation data before saving the stage.