### PR TITLE
[USD] Include codegenTemplates in usdGenSchema.

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -48,6 +48,9 @@ function(pxr_python_bin BIN_NAME)
     # Source file.
     if( "${pb_PYTHON_FILE}" STREQUAL "")
         set(infile ${CMAKE_CURRENT_SOURCE_DIR}/${BIN_NAME}.py)
+    # This way we can specify the full path, if the file is configured before this script.
+    elseif(EXISTS "${pb_PYTHON_FILE}")
+        set(infile ${pb_PYTHON_FILE})
     else()
         set(infile ${CMAKE_CURRENT_SOURCE_DIR}/${pb_PYTHON_FILE})
     endif()

--- a/pxr/usd/lib/usd/CMakeLists.txt
+++ b/pxr/usd/lib/usd/CMakeLists.txt
@@ -125,11 +125,23 @@ pxr_library(usd
 if (NOT JINJA2_FOUND)
     message(WARNING "Skipping building usdGenSchema due to missing dependency: Jinja2")
 else()
+    set(_configuredGenSchema "${CMAKE_CURRENT_BINARY_DIR}/usdGenSchemaConfigured.py")
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/api.h TEMPLATE_API_H)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/plugInfo.json TEMPLATE_PLUGINFO_JSON)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/schemaClass.cpp TEMPLATE_SCHEMA_CLASS_CPP)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/schemaClass.h TEMPLATE_SCHEMA_CLASS_H)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/tokens.cpp TEMPLATE_TOKENS_CPP)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/tokens.h TEMPLATE_TOKENS_H)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/wrapSchemaClass.cpp TEMPLATE_WRAP_SCHEMA_CLASS_CPP)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/codegenTemplates/wrapTokens.cpp TEMPLATE_WRAP_TOKENS_CPP)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/usdGenSchema.py ${_configuredGenSchema})
     pxr_python_bin(usdGenSchema
         DEPENDENCIES
             tf
             sdf
             usd
+        PYTHON_FILE
+            ${_configuredGenSchema}
     )
 endif()
 

--- a/pxr/usd/lib/usd/usdGenSchema.py
+++ b/pxr/usd/lib/usd/usdGenSchema.py
@@ -40,10 +40,25 @@ import sys, os, re, inspect
 from argparse import ArgumentParser
 from collections import namedtuple
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, DictLoader
 from jinja2.exceptions import TemplateSyntaxError
 
 from pxr import Sdf, Usd, Tf
+
+#------------------------------------------------------------------------------#
+# Codegen Templates                                                            #
+#------------------------------------------------------------------------------#
+
+_codegenTemplates = {
+    'api.h': r"""${TEMPLATE_API_H}""",
+    'plugInfo.json': r"""${TEMPLATE_PLUGINFO_JSON}""",
+    'schemaClass.cpp': r"""${TEMPLATE_SCHEMA_CLASS_CPP}""",
+    'schemaClass.h': r"""${TEMPLATE_SCHEMA_CLASS_H}""",
+    'tokens.cpp': r"""${TEMPLATE_TOKENS_CPP}""",
+    'tokens.h': r"""${TEMPLATE_TOKENS_H}""",
+    'wrapSchemaClass.cpp': r"""${TEMPLATE_WRAP_SCHEMA_CLASS_CPP}""",
+    'wrapTokens.cpp': r"""${TEMPLATE_WRAP_TOKENS_CPP}""",
+}
 
 #------------------------------------------------------------------------------#
 # Parsed Objects                                                               #
@@ -807,10 +822,6 @@ if __name__ == '__main__':
         print 'Usage Error: Second positional argument must be a directory to contain generated code.'
         parser.print_help()
         sys.exit(1)
-    if not os.path.isdir(templatePath):
-        print 'Usage Error: templatePath argument must be the path to the codgenTemplates.'
-        parser.print_help()
-        sys.exit(1)
 
     try:
         
@@ -835,8 +846,10 @@ if __name__ == '__main__':
         #
         # Generate Code from Templates
         #
-        j2_env = Environment(loader=FileSystemLoader(templatePath),
-                             trim_blocks=True)
+        if os.path.isdir(templatePath):
+            j2_env = Environment(loader=FileSystemLoader(templatePath), trim_blocks=True)
+        else:
+            j2_env = Environment(loader=DictLoader(_codegenTemplates), trim_blocks=True)
         j2_env.globals.update(Camel=_CamelCase,
                               Proper=_ProperCase,
                               Upper=_UpperCase,


### PR DESCRIPTION
### Description of Change(s)
The change includes codegenTemplates in usdGenSchema during the build process. If the codegenTemplates path does not exist, the code falls back to use the dictionary inside usdGenSchema.

This way external plugin devs can work with the installed usdGenSchema without manually copying codegenTemplates, and USD devs can keep working with usdGenSchema inside the source tree.

### Fixes Issue(s)
#211 

