### PR TITLE
[USD] Installing built-in schemas.

### DIFF
--- a/cmake/macros/replaceSublayerSchemas.py
+++ b/cmake/macros/replaceSublayerSchemas.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2017 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+#
+# Usage:
+#   replaceSublayerSchemas source.py dest.py
+#
+# The command replaces the sublayer schema references so they will point
+# to the proper location once installed. We are not using the python bindings
+# on purpose, otherwise the script would require the libs that are just being built.
+#
+# Each sublayer of the format ../module_name/schema.usda is to be replaced with
+# module_name/resources/schema.usda .
+
+import sys
+
+if len(sys.argv) != 3:
+    print "Usage: %s {source.py dest.py}" % sys.argv[0]
+    sys.exit(1)
+
+with open(sys.argv[1], 'r') as s:
+    with open(sys.argv[2], 'w') as d:
+        import re
+        pattern = re.compile(r"@.*\/([^\/]*)\/schema.usda@")
+        for line in s:
+            m = pattern.search(line)
+            if m:
+                d.write(line.replace(m.group(0), "@%s/resources/schema.usda@" % m.group(1)))
+            else:
+                d.write(line)

--- a/pxr/base/lib/plug/registry.cpp
+++ b/pxr/base/lib/plug/registry.cpp
@@ -250,6 +250,12 @@ Plug_GetPaths()
 
 }
 
+std::vector<std::string>
+PlugRegistry::GetAllRegisteredPluginPaths() const {
+    PlugPlugin::_RegisterAllPlugins();
+    return Plug_GetPaths();
+}
+
 void
 Plug_SetPaths(const std::vector<std::string>& paths)
 {

--- a/pxr/base/lib/plug/registry.h
+++ b/pxr/base/lib/plug/registry.h
@@ -435,6 +435,9 @@ public:
     JsValue GetDataFromPluginMetaData(TfType type,
                                       const std::string &key) const;
 
+    /// Returns all the registered plugin paths.
+    PLUG_API
+    std::vector<std::string> GetAllRegisteredPluginPaths() const;
 private:
     // Private ctor and dtor since this is a constructed as a singleton.
     PLUG_LOCAL

--- a/pxr/base/lib/plug/wrapRegistry.cpp
+++ b/pxr/base/lib/plug/wrapRegistry.cpp
@@ -214,6 +214,8 @@ void wrapRegistry()
         .def("GetPluginForType", &_GetPluginForType)
         .def("GetAllPlugins", &This::GetAllPlugins,
              return_value_policy<TfPySequenceToList>())
+        .def("GetAllRegisteredPluginPaths", &This::GetAllRegisteredPluginPaths,
+             return_value_policy<TfPySequenceToList>())
 
         .def("FindTypeByName", This::FindTypeByName,
              return_value_policy<return_by_value>())

--- a/pxr/usd/lib/usd/CMakeLists.txt
+++ b/pxr/usd/lib/usd/CMakeLists.txt
@@ -120,6 +120,7 @@ pxr_library(usd
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 
 if (NOT JINJA2_FOUND)

--- a/pxr/usd/lib/usd/usdGenSchema.py
+++ b/pxr/usd/lib/usd/usdGenSchema.py
@@ -43,7 +43,7 @@ from collections import namedtuple
 from jinja2 import Environment, FileSystemLoader
 from jinja2.exceptions import TemplateSyntaxError
 
-from pxr import Sdf, Usd, Tf
+from pxr import Sdf, Usd, Tf, Plug, Ar
 
 #------------------------------------------------------------------------------#
 # Parsed Objects                                                               #
@@ -700,7 +700,7 @@ def _MakeFlattenedRegistryLayer(filePath):
     
 
 def GenerateRegistry(codeGenPath, filePath, classes, validate, env):
-
+    
     # Get the flattened layer to work with.
     flatLayer = _MakeFlattenedRegistryLayer(filePath)
 
@@ -813,6 +813,9 @@ if __name__ == '__main__':
         sys.exit(1)
 
     try:
+        # Setting up the default search path for plugins
+        os.environ['PXR_AR_DEFAULT_SEARCH_PATH'] = os.pathsep.join(
+            Plug.Registry().GetAllRegisteredPluginPaths() + [os.getenv('PXR_AR_DEFAULT_SEARCH_PATH', '')])
         
         #
         # Gather Schema Class information

--- a/pxr/usd/lib/usdGeom/CMakeLists.txt
+++ b/pxr/usd/lib/usdGeom/CMakeLists.txt
@@ -97,6 +97,7 @@ pxr_library(usdGeom
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 
 pxr_test_scripts(

--- a/pxr/usd/lib/usdHydra/CMakeLists.txt
+++ b/pxr/usd/lib/usdHydra/CMakeLists.txt
@@ -38,5 +38,7 @@ pxr_library(usdHydra
 
     RESOURCE_FILES
         plugInfo.json
+        generatedSchema.usda
+        schema.usda
 )
 

--- a/pxr/usd/lib/usdLux/CMakeLists.txt
+++ b/pxr/usd/lib/usdLux/CMakeLists.txt
@@ -55,5 +55,6 @@ pxr_library(usdLux
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 

--- a/pxr/usd/lib/usdRi/CMakeLists.txt
+++ b/pxr/usd/lib/usdRi/CMakeLists.txt
@@ -77,6 +77,7 @@ pxr_library(usdRi
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 
 pxr_test_scripts(

--- a/pxr/usd/lib/usdShade/CMakeLists.txt
+++ b/pxr/usd/lib/usdShade/CMakeLists.txt
@@ -48,6 +48,7 @@ pxr_library(usdShade
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 
 pxr_test_scripts(

--- a/pxr/usd/lib/usdUI/CMakeLists.txt
+++ b/pxr/usd/lib/usdUI/CMakeLists.txt
@@ -33,6 +33,7 @@ pxr_library(usdUI
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 
 pxr_test_scripts(

--- a/third_party/katana/lib/usdKatana/CMakeLists.txt
+++ b/third_party/katana/lib/usdKatana/CMakeLists.txt
@@ -68,5 +68,6 @@ pxr_shared_library(${PXR_PACKAGE}
     RESOURCE_FILES
         plugInfo.json
         generatedSchema.usda
+        schema.usda
 )
 


### PR DESCRIPTION
### Description of Change(s)
The following changes are included:
- Installing the schemas next to generatedSchema.usda.
- Massaging the installed schema to work well outside the usd source-tree.
- Adding a new function to PlugRegistry (and its python binding) that allows users to query all the search paths for plugins.
- Modifying usdGenSchema to pass these paths to the default resolver, making the external plugins easier to setup.

### Fixes Issue(s)
#158 
