### PR TITLE
Fix mismatched tags warnings under clang.

### DIFF
--- a/pxr/imaging/lib/hdSt/instancer.h
+++ b/pxr/imaging/lib/hdSt/instancer.h
@@ -37,7 +37,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdDrawItem;
-class HdRprimSharedData;
+struct HdRprimSharedData;
 
 typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 

--- a/pxr/usd/lib/usd/prim.h
+++ b/pxr/usd/lib/usd/prim.h
@@ -1005,7 +1005,7 @@ private:
     friend class UsdPrimRange;
     friend class Usd_PrimData;
     friend class Usd_PrimFlagsPredicate;
-    friend class UsdPrim_RelTargetFinder;
+    friend struct UsdPrim_RelTargetFinder;
     friend struct UsdPrim_AttrConnectionFinder;
 
     // Prim constructor.


### PR DESCRIPTION
Clang issues a warning when forward declarations don't match the
actual declaration about whether something is a struct or class.
