### PR TITLE
Fix warnings about missing 'override'.

### DIFF
--- a/pxr/imaging/lib/hdSt/basisCurvesComputations.h
+++ b/pxr/imaging/lib/hdSt/basisCurvesComputations.h
@@ -44,14 +44,14 @@ class HdSt_BasisCurvesIndexBuilderComputation : public HdComputedBufferSource {
 public:
     HdSt_BasisCurvesIndexBuilderComputation(HdBasisCurvesTopology *topology,
                                             bool supportSmoothCurves);
-    virtual void AddBufferSpecs(HdBufferSpecVector *specs) const;
-    virtual bool Resolve();
+    virtual void AddBufferSpecs(HdBufferSpecVector *specs) const override;
+    virtual bool Resolve() override;
 
     virtual bool HasChainedBuffer() const override;
     virtual HdBufferSourceSharedPtr GetChainedBuffer() const override;
 
 protected:
-    virtual bool _CheckValid() const;
+    virtual bool _CheckValid() const override;
 
 public:
     // For building index and primitive index arrays

--- a/pxr/imaging/lib/hdSt/renderDelegate.h
+++ b/pxr/imaging/lib/hdSt/renderDelegate.h
@@ -63,10 +63,10 @@ public:
     HDST_API
     virtual HdInstancer *CreateInstancer(HdSceneDelegate *delegate,
                                          SdfPath const& id,
-                                         SdfPath const& instancerId);
+                                         SdfPath const& instancerId) override;
 
     HDST_API
-    virtual void DestroyInstancer(HdInstancer *instancer);
+    virtual void DestroyInstancer(HdInstancer *instancer) override;
 
     HDST_API
     virtual HdRprim *CreateRprim(TfToken const& typeId,

--- a/pxr/imaging/lib/hdSt/subdivision3.cpp
+++ b/pxr/imaging/lib/hdSt/subdivision3.cpp
@@ -123,7 +123,7 @@ public:
 
     virtual HdBufferSourceSharedPtr CreateIndexComputation(
         HdSt_MeshTopology *topology,
-        HdBufferSourceSharedPtr const &osdTopology);
+        HdBufferSourceSharedPtr const &osdTopology) override;
 
     virtual HdBufferSourceSharedPtr CreateRefineComputation(
         HdSt_MeshTopology *topology,

--- a/pxr/usd/lib/sdf/layerStateDelegate.h
+++ b/pxr/usd/lib/sdf/layerStateDelegate.h
@@ -248,53 +248,53 @@ protected:
     SdfSimpleLayerStateDelegate();
 
     // SdfLayerStateDelegateBase overrides
-    virtual bool _IsDirty();
-    virtual void _MarkCurrentStateAsClean();
-    virtual void _MarkCurrentStateAsDirty();
+    virtual bool _IsDirty() override;
+    virtual void _MarkCurrentStateAsClean() override;
+    virtual void _MarkCurrentStateAsDirty() override;
 
     virtual void _OnSetLayer(
-        const SdfLayerHandle& layer);
+        const SdfLayerHandle& layer) override;
 
     virtual void _OnSetField(
         const SdfAbstractDataSpecId& id,
         const TfToken& fieldName,
-        const VtValue& value);
+        const VtValue& value) override;
     virtual void _OnSetField(
         const SdfAbstractDataSpecId& id,
         const TfToken& fieldName,
-        const SdfAbstractDataConstValue& value);
+        const SdfAbstractDataConstValue& value) override;
     virtual void _OnSetFieldDictValueByKey(
         const SdfAbstractDataSpecId& id,
         const TfToken& fieldName,
         const TfToken& keyPath,
-        const VtValue& value);
+        const VtValue& value) override;
     virtual void _OnSetFieldDictValueByKey(
         const SdfAbstractDataSpecId& id,
         const TfToken& fieldName,
         const TfToken& keyPath,
-        const SdfAbstractDataConstValue& value);
+        const SdfAbstractDataConstValue& value) override;
 
     virtual void _OnSetTimeSample(
         const SdfAbstractDataSpecId& id,
         double time,
-        const VtValue& value);
+        const VtValue& value) override;
     virtual void _OnSetTimeSample(
         const SdfAbstractDataSpecId& id,
         double time,
-        const SdfAbstractDataConstValue& value);
+        const SdfAbstractDataConstValue& value) override;
 
     virtual void _OnCreateSpec(
         const SdfPath& path,
         SdfSpecType specType,
-        bool inert);
+        bool inert) override;
 
     virtual void _OnDeleteSpec(
         const SdfPath& path,
-        bool inert);
+        bool inert) override;
 
     virtual void _OnMoveSpec(
         const SdfPath& oldPath,
-        const SdfPath& newPath);
+        const SdfPath& newPath) override;
 
     virtual void _OnPushChild(
         const SdfPath& id,


### PR DESCRIPTION
When some declarations in a class use 'override' but not all virtual
methods do, clang issues a warning.
