### PR TITLE
_ExpandSymlinks is only used on Windows, so only build it there.

### DIFF
--- a/pxr/base/lib/tf/pathUtils.cpp
+++ b/pxr/base/lib/tf/pathUtils.cpp
@@ -58,6 +58,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
+#if defined(ARCH_OS_WINDOWS)
 // Expands symlinks in path.  Used on Windows as a partial replacement
 // for realpath(), partial because is doesn't handle /./, /../ and
 // duplicate slashes.
@@ -86,6 +87,7 @@ _ExpandSymlinks(const std::string& path)
     // No links at all.
     return path;
 }
+#endif
 
 void
 _ClearError()


### PR DESCRIPTION
This fixes a warning when building on macOS.