### PR TITLE
Remove unused private field: _fileBufferSize.

### DIFF
--- a/pxr/usd/lib/sdf/textFileFormat.tab.cpp
+++ b/pxr/usd/lib/sdf/textFileFormat.tab.cpp
@@ -6060,7 +6060,6 @@ private:
     yy_buffer_state *_flexBuffer;
 
     std::unique_ptr<char[]> _fileBuffer;
-    size_t _fileBufferSize;
 
     yyscan_t _scanner;
 };

--- a/pxr/usd/lib/sdf/textFileFormat.yy
+++ b/pxr/usd/lib/sdf/textFileFormat.yy
@@ -3139,7 +3139,6 @@ private:
     yy_buffer_state *_flexBuffer;
 
     std::unique_ptr<char[]> _fileBuffer;
-    size_t _fileBufferSize;
 
     yyscan_t _scanner;
 };


### PR DESCRIPTION
This fixes a warning about an unused private field on the class.