### PR TITLE
Remove unused malloc hook functions on non-Linux platforms.

### DIFF
--- a/pxr/base/lib/arch/mallocHook.cpp
+++ b/pxr/base/lib/arch/mallocHook.cpp
@@ -189,7 +189,6 @@ static bool _GetSymbol(T* addr, const char* name, string* errMsg) {
         return false;
     }
 }
-#endif
 
 static bool
 _MallocHookAvailable()
@@ -232,6 +231,7 @@ _GetUnderlyingMallocFunctionNames()
 
     return names;
 }
+#endif
 
 bool
 ArchMallocHook::Initialize(


### PR DESCRIPTION
This code is only used on Linux, so only build it there.
