### PR TITLE
HdChangeTracker const correctness improvements.

### DIFF
--- a/pxr/imaging/lib/hd/changeTracker.cpp
+++ b/pxr/imaging/lib/hd/changeTracker.cpp
@@ -742,9 +742,9 @@ HdChangeTracker::MarkAllCollectionsDirty()
 }
 
 unsigned
-HdChangeTracker::GetCollectionVersion(TfToken const& collectionName)
+HdChangeTracker::GetCollectionVersion(TfToken const& collectionName) const
 {
-    _CollectionStateMap::iterator it = _collectionState.find(collectionName);
+    _CollectionStateMap::const_iterator it = _collectionState.find(collectionName);
     if (!(it != _collectionState.end())) {
         TF_CODING_ERROR("Change Tracker unable to find collection %s",
                         collectionName.GetText());
@@ -754,7 +754,7 @@ HdChangeTracker::GetCollectionVersion(TfToken const& collectionName)
 }
 
 unsigned
-HdChangeTracker::GetVisibilityChangeCount()
+HdChangeTracker::GetVisibilityChangeCount() const
 {
     return _visChangeCount;
 }

--- a/pxr/imaging/lib/hd/changeTracker.h
+++ b/pxr/imaging/lib/hd/changeTracker.h
@@ -472,12 +472,12 @@ public:
 
     /// Returns the current version of the named collection.
     HD_API
-    unsigned GetCollectionVersion(TfToken const& collectionName);
+    unsigned GetCollectionVersion(TfToken const& collectionName) const;
 
     /// Returns the number of changes to visibility. This is intended to be used
     /// to detect when visibility has changed for *any* Rprim.
     HD_API
-    unsigned GetVisibilityChangeCount();
+    unsigned GetVisibilityChangeCount() const;
 
     /// Returns the current version of varying state. This is used to refresh
     /// cached DirtyLists

--- a/pxr/imaging/lib/hdSt/renderPass.cpp
+++ b/pxr/imaging/lib/hdSt/renderPass.cpp
@@ -107,7 +107,7 @@ HdSt_RenderPass::_PrepareCommandBuffer(
     // We know what must be drawn and that the stream needs to be updated, 
     // so iterate over each prim, cull it and schedule it to be drawn.
 
-    HdChangeTracker& tracker = GetRenderIndex()->GetChangeTracker();
+    HdChangeTracker const &tracker = GetRenderIndex()->GetChangeTracker();
     HdRenderContextCaps const &caps = HdRenderContextCaps::GetInstance();
     HdRprimCollection const &collection = GetRprimCollection();
 


### PR DESCRIPTION
This makes a few more methods `const` so that a reference to
the change tracker in the render pass code can also be `const`.
