### PR TITLE
Export and install pxrTargets.cmake.

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1299,13 +1299,29 @@ function(_pxr_library NAME)
     #
 
     if(NOT isObject)
-        install(
-            TARGETS ${NAME}
-            LIBRARY DESTINATION ${libInstallPrefix}
-            ARCHIVE DESTINATION ${libInstallPrefix}
-            RUNTIME DESTINATION ${libInstallPrefix}
-            PUBLIC_HEADER DESTINATION ${headerInstallPrefix}
-        )
+        if(BUILD_SHARED_LIBS AND NOT PXR_BUILD_MONOLITHIC)
+            install(
+                TARGETS ${NAME}
+                EXPORT pxrTargets
+                LIBRARY DESTINATION ${libInstallPrefix}
+                ARCHIVE DESTINATION ${libInstallPrefix}
+                RUNTIME DESTINATION ${libInstallPrefix}
+                PUBLIC_HEADER DESTINATION ${headerInstallPrefix}
+            )
+
+            export(TARGETS ${NAME}
+                APPEND
+                FILE "${PROJECT_BINARY_DIR}/pxrTargets.cmake"
+            )
+        else()
+            install(
+                TARGETS ${NAME}
+                LIBRARY DESTINATION ${libInstallPrefix}
+                ARCHIVE DESTINATION ${libInstallPrefix}
+                RUNTIME DESTINATION ${libInstallPrefix}
+                PUBLIC_HEADER DESTINATION ${headerInstallPrefix}
+            )
+        endif()
     endif()
     _install_resource_files(
         ${NAME}

--- a/pxr/CMakeLists.txt
+++ b/pxr/CMakeLists.txt
@@ -20,3 +20,7 @@ install(FILES
   "${PROJECT_BINARY_DIR}/pxrConfig.cmake"
   DESTINATION "${CMAKE_INSTALL_PREFIX}"
 )
+
+if(BUILD_SHARED_LIBS AND NOT PXR_BUILD_MONOLITHIC)
+	install(EXPORT pxrTargets DESTINATION "cmake")
+endif()


### PR DESCRIPTION
### Description of Change(s)
Since v0.7.6 usd cmake's targets are not exported anymore. Was this intended? We're relying on this at the moment.
Cheers.
### Fixes Issue(s)
-

