### PR TITLE
Allow compilation against PySide or PySide2.

### DIFF
--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -27,25 +27,42 @@ if (NOT PYTHON_EXECUTABLE)
     return()
 endif()
 
-find_program(PYSIDEUICBINARY
-    NAMES pyside-uic python2-pyside-uic pyside-uic-2.7
-    HINTS ${PYSIDE_BIN_DIR}
-)
-
 execute_process(
-    COMMAND 
-        "${PYTHON_EXECUTABLE}" "-c" "import PySide"
-    RESULT_VARIABLE
-        pySideImportResult 
+    COMMAND "${PYTHON_EXECUTABLE}" "-c" "import PySide"
+    RESULT_VARIABLE pySideImportResult 
 )
 
-if (pySideImportResult EQUAL 0)
-    if (EXISTS ${PYSIDEUICBINARY})
-        message(STATUS "Found PySide: with ${PYTHON_EXECUTABLE}, will use ${PYSIDEUICBINARY} for pyside-uic binary")
-        set(PYSIDE_FOUND True)
+if (pySideImportResult EQUAL 1)
+    execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" "-c" "import PySide2"
+        RESULT_VARIABLE pySideImportResult 
+    )
+    if (pySideImportResult EQUAL 0)
+        set(pySideImportResult "PySide2")
+        set(pySideUIC pyside2-uic python2-pyside2-uic pyside2-uic-2.7)
     else()
-        message(STATUS "Found PySide but NOT pyside-uic binary")
-	set(PYSIDE_FOUND False)
+        set(pySideImportResult 0)
+    endif()
+  else()
+    set(pySideImportResult "PySide")
+    set(pySideUIC pyside-uic python2-pyside-uic pyside-uic-2.7)
+endif()
+
+find_program(PYSIDEUICBINARY NAMES ${pySideUIC} HINTS ${PYSIDE_BIN_DIR})
+
+if (pySideImportResult)
+    if (EXISTS ${PYSIDEUICBINARY})
+        message(STATUS "Found ${pySideImportResult}: with ${PYTHON_EXECUTABLE}, will use ${PYSIDEUICBINARY} for pyside-uic binary")
+        set(PYSIDE_FOUND True)
+        if (pySideImportResult STREQUAL "PySide2")
+            message(STATUS "Building against PySide2 is currently experimental.  "
+                           "See https://bugreports.qt.io/browse/PYSIDE-357 if "
+                           "'No module named Compiler' errors are encountered"
+            )
+        endif()
+    else()
+        message(STATUS "Found ${pySideImportResult} but NOT pyside-uic binary")
+        set(PYSIDE_FOUND False)
     endif()
 else()
     message(STATUS "Did not find PySide with ${PYTHON_EXECUTABLE}")

--- a/pxr/usdImaging/lib/usdviewq/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdviewq/CMakeLists.txt
@@ -34,6 +34,7 @@ pxr_library(usdviewq
 
     PYTHON_FILES
         __init__.py
+        pyside.py
         arrayAttributeView.py
         customAttributes.py
         mainWindow.py

--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -24,7 +24,7 @@
 import sys
 import os
 
-from PySide.QtGui import QApplication
+from pyside import QtWidgets
 
 import argparse
 
@@ -210,7 +210,7 @@ class Launcher(object):
         resourceDir = os.path.dirname(os.path.realpath(__file__)) + "/"
 
         # Create the Qt application
-        app = QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
 
         # Apply the style sheet to it
         sheet = open(os.path.join(resourceDir, 'usdviewstyle.qss'), 'r')

--- a/pxr/usdImaging/lib/usdviewq/adjustClipping.py
+++ b/pxr/usdImaging/lib/usdviewq/adjustClipping.py
@@ -21,10 +21,10 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from adjustClippingUI import Ui_AdjustClipping
 
-class AdjustClipping(QtGui.QDialog):
+class AdjustClipping(QtWidgets.QDialog):
     """The dataModel provided to this VC must conform to the following
     interface:
     
@@ -40,7 +40,7 @@ class AdjustClipping(QtGui.QDialog):
                                 may have changed.
     """
     def __init__(self, parent, dataModel):
-        QtGui.QDialog.__init__(self,parent)
+        QtWidgets.QDialog.__init__(self,parent)
         self._ui = Ui_AdjustClipping()
         self._ui.setupUi(self)
 

--- a/pxr/usdImaging/lib/usdviewq/adjustDefaultMaterial.py
+++ b/pxr/usdImaging/lib/usdviewq/adjustDefaultMaterial.py
@@ -21,10 +21,10 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from adjustDefaultMaterialUI import Ui_AdjustDefaultMaterial
 
-class AdjustDefaultMaterial(QtGui.QDialog):
+class AdjustDefaultMaterial(QtWidgets.QDialog):
     """The dataModel provided to this VC must conform to the following
     interface:
     
@@ -40,7 +40,7 @@ class AdjustDefaultMaterial(QtGui.QDialog):
                                         set in the dataModel.
     """
     def __init__(self, parent, dataModel):
-        QtGui.QDialog.__init__(self,parent)
+        QtWidgets.QDialog.__init__(self,parent)
         self._ui = Ui_AdjustDefaultMaterial()
         self._ui.setupUi(self)
 

--- a/pxr/usdImaging/lib/usdviewq/arrayAttributeView.py
+++ b/pxr/usdImaging/lib/usdviewq/arrayAttributeView.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 
 class _ArrayAttributeModel(QtCore.QAbstractListModel):
     def __init__(self, attr, frame):
@@ -49,13 +49,13 @@ class _ArrayAttributeModel(QtCore.QAbstractListModel):
 
         return None
 
-class ArrayAttributeView(QtGui.QListView):
+class ArrayAttributeView(QtWidgets.QListView):
     def __init__(self, parent):
         super(ArrayAttributeView, self).__init__(parent)
 
         # this line makes it so we don't have to query all of the data upfront.
         self.setUniformItemSizes(True)
-        self.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
 
         self._SetupContextMenu()
 
@@ -66,7 +66,7 @@ class ArrayAttributeView(QtGui.QListView):
         if e.matches(QtGui.QKeySequence.Copy):
             self.Copy()
         else:
-            QtGui.QListView.keyPressEvent(self, e)
+            QtWidgets.QListView.keyPressEvent(self, e)
     
     def SetAttribute(self, attr, frame):
         # XXX: probably don't need to reconstruct especially if all
@@ -81,7 +81,7 @@ class ArrayAttributeView(QtGui.QListView):
                 self._ShowContextMenu)
 
     def _ShowContextMenu(self, point):
-        menu = QtGui.QMenu(self)
+        menu = QtWidgets.QMenu(self)
         menu.addAction("Copy", self.Copy)
         menu.addAction("Select All", self.SelectAll)
         menu.exec_(QtGui.QCursor.pos())
@@ -96,7 +96,7 @@ class ArrayAttributeView(QtGui.QListView):
         else:
             copyText = vals
 
-        QtGui.QApplication.clipboard().setText(copyText)
+        QtWidgets.QApplication.clipboard().setText(copyText)
 
     def SelectAll(self):
         self.selectAll()

--- a/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
+++ b/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
@@ -30,6 +30,9 @@ from common import GetAttributeColor, TimeSampleTextColor
 # opening the "Value" tab.
 
 class AttributeValueEditor(QtWidgets.QWidget):
+    kEditCompelte = QtCore.SIGNAL('editComplete(QString)')
+    kClicked = QtCore.SIGNAL('clicked()')
+
     def __init__(self, parent):
         QtWidgets.QWidget.__init__(self, parent)
         self._ui = Ui_AttributeValueEditor()
@@ -47,23 +50,28 @@ class AttributeValueEditor(QtWidgets.QWidget):
 
         self.clear()
 
+    def setMainWindow(self, mainWindow, editComplete):
+        # pass the mainWindow instance from which to retrieve 
+        # variable data.
+        # assert getattr(self, '_mainWindow', None) == None
+        self._mainWindow = mainWindow
+        self._propertyView = mainWindow._ui.propertyView
+
+        QtCore.QObject.connect(self,
+                               AttributeValueEditor.kEditCompelte,
+                               editComplete)
+
         QtCore.QObject.connect(self._ui.editButton,
-                               QtCore.SIGNAL('clicked()'),
+                               AttributeValueEditor.kClicked,
                                self._edit)
 
         QtCore.QObject.connect(self._ui.revertButton,
-                               QtCore.SIGNAL('clicked()'),
+                               AttributeValueEditor.kClicked,
                                self._revert)
 
         QtCore.QObject.connect(self._ui.revertAllButton,
-                               QtCore.SIGNAL('clicked()'),
+                               AttributeValueEditor.kClicked,
                                self._revertAll)
-
-    def setMainWindow(self, mainWindow):
-        # pass the mainWindow instance from which to retrieve 
-        # variable data.
-        self._mainWindow = mainWindow
-        self._propertyView = mainWindow._ui.propertyView
 
     def populate(self, name, node):
         # called when the selected attribute has changed
@@ -150,7 +158,7 @@ class AttributeValueEditor(QtWidgets.QWidget):
             # send a signal to the mainWindow confirming the edit
             msg = 'Successfully edited %s "%s" at frame %s.' \
                     %(type, self._name, frame)
-            self.emit(QtCore.SIGNAL('editComplete(QString)'), msg)
+            self.emit(AttributeValueEditor.kEditCompelte, msg)
 
         except Exception as e:
             # if an error occurs, reopen the interpreter and display it

--- a/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
+++ b/pxr/usdImaging/lib/usdviewq/attributeValueEditor.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from attributeValueEditorUI import Ui_AttributeValueEditor
 from pythonExpressionPrompt import PythonExpressionPrompt
 from common import GetAttributeColor, TimeSampleTextColor
@@ -29,9 +29,9 @@ from common import GetAttributeColor, TimeSampleTextColor
 # This is the widget that appears when selecting an attribute and
 # opening the "Value" tab.
 
-class AttributeValueEditor(QtGui.QWidget):
+class AttributeValueEditor(QtWidgets.QWidget):
     def __init__(self, parent):
-        QtGui.QWidget.__init__(self, parent)
+        QtWidgets.QWidget.__init__(self, parent)
         self._ui = Ui_AttributeValueEditor()
         self._ui.setupUi(self)
 
@@ -169,15 +169,15 @@ class AttributeValueEditor(QtGui.QWidget):
                   Usd.USD_SECTION_INVALID
 
         # ask for confirmation before reverting overrides
-        reply = QtGui.QMessageBox.question(self, "Confirm Revert",
+        reply = QtWidgets.QMessageBox.question(self, "Confirm Revert",
                     "Are you sure you want to revert the %s "
                     "<font color='%s'><b>%s</b></font> at %s?"
                         %(type, TimeSampleTextColor.color().name(), self._name, frameStr),
-                    QtGui.QMessageBox.Cancel | QtGui.QMessageBox.Yes,
-                    QtGui.QMessageBox.Cancel)
+                    QtWidgets.QMessageBox.Cancel | QtWidgets.QMessageBox.Yes,
+                    QtWidgets.QMessageBox.Cancel)
     
         msg = ""
-        if reply == QtGui.QMessageBox.Yes and self._node is not None:
+        if reply == QtWidgets.QMessageBox.Yes and self._node is not None:
             # we got 'yes' as an answer
             try:
                 # this removes only the value written in the top level stage

--- a/pxr/usdImaging/lib/usdviewq/attributeViewContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/attributeViewContextMenu.py
@@ -21,16 +21,16 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui
+from pyside import QtWidgets, QtGui
 from usdviewContextMenuItem import UsdviewContextMenuItem  
 
 #
 # Specialized context menu for running commands in the attribute viewer.
 #
-class AttributeViewContextMenu(QtGui.QMenu):
+class AttributeViewContextMenu(QtWidgets.QMenu):
 
     def __init__(self, parent, item):
-        QtGui.QMenu.__init__(self, parent)
+        QtWidgets.QMenu.__init__(self, parent)
         self._menuItems = _GetContextMenuItems(parent, item)
 
         for menuItem in self._menuItems:
@@ -81,7 +81,7 @@ class CopyAttributeNameMenuItem(AttributeViewContextMenuItem):
 
         # Copy item text
         txt = self._item.text()
-        cb = QtGui.QApplication.clipboard()
+        cb = QtWidgets.QApplication.clipboard()
         cb.setText(txt, QtGui.QClipboard.Selection)
         cb.setText(txt, QtGui.QClipboard.Clipboard)
 

--- a/pxr/usdImaging/lib/usdviewq/common.py
+++ b/pxr/usdImaging/lib/usdviewq/common.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui,QtCore
+from pyside import QtWidgets, QtGui, QtCore
 from pxr import Usd
 from customAttributes import CustomAttribute
 
@@ -212,10 +212,10 @@ class BusyContext(object):
     will set Qt's busy cursor upon entry and pop it on exit.
     """
     def __enter__(self):
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
 
     def __exit__(self, *args):
-        QtGui.QApplication.restoreOverrideCursor()
+        QtWidgets.QApplication.restoreOverrideCursor()
 
 
 def InvisRootPrims(stage):

--- a/pxr/usdImaging/lib/usdviewq/headerContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/headerContextMenu.py
@@ -21,17 +21,17 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from usdviewContextMenuItem import UsdviewContextMenuItem
 
 #
 # Specialized context menu for adding and removing columns
 # in the node browser and attribute inspector.
 #
-class HeaderContextMenu(QtGui.QMenu):
+class HeaderContextMenu(QtWidgets.QMenu):
 
     def __init__(self, parent):
-        QtGui.QMenu.__init__(self, parent)
+        QtWidgets.QMenu.__init__(self, parent)
         self._menuItems = _GetContextMenuItems(parent)
 
         for menuItem in self._menuItems:
@@ -59,7 +59,7 @@ class HeaderContextMenuItem(UsdviewContextMenuItem):
         self._parent = parent
         self._column = column
         
-        if parent.__class__ == QtGui.QTreeWidget:
+        if parent.__class__ == QtWidgets.QTreeWidget:
             self._text = parent.headerItem().text(column)
         else:
             self._text = parent.horizontalHeaderItem(column).text()

--- a/pxr/usdImaging/lib/usdviewq/layerStackContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/layerStackContextMenu.py
@@ -21,17 +21,17 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtGui, QtCore
 from usdviewContextMenuItem import UsdviewContextMenuItem
 import os
 
 #
 # Specialized context menu for running commands in the layer stack view.
 #
-class LayerStackContextMenu(QtGui.QMenu):
+class LayerStackContextMenu(QtWidgets.QMenu):
 
     def __init__(self, parent, item):
-        QtGui.QMenu.__init__(self, parent)
+        QtWidgets.QMenu.__init__(self, parent)
         self._menuItems = _GetContextMenuItems(parent, item)
 
         for menuItem in self._menuItems:
@@ -137,7 +137,7 @@ class CopyLayerPathMenuItem(LayerStackContextMenuItem):
         if not layerPath or not os.path.exists(layerPath):
             return
     
-        cb = QtGui.QApplication.clipboard()
+        cb = QtWidgets.QApplication.clipboard()
         cb.setText(layerPath, QtGui.QClipboard.Selection )
         cb.setText(layerPath, QtGui.QClipboard.Clipboard )
 
@@ -157,7 +157,7 @@ class CopyPathMenuItem(LayerStackContextMenuItem):
             return
         
         path = str(path)
-        cb = QtGui.QApplication.clipboard()
+        cb = QtWidgets.QApplication.clipboard()
         cb.setText(path, QtGui.QClipboard.Selection )
         cb.setText(path, QtGui.QClipboard.Clipboard )
 

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -663,19 +663,19 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Arc path is the most likely to need stretch.
         twh = self._ui.compositionTreeWidget.header()
-        twh.setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
-        twh.setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-        twh.setResizeMode(2, QtGui.QHeaderView.Stretch)
-        twh.setResizeMode(3, QtGui.QHeaderView.ResizeToContents)
+        twh.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
+        twh.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        twh.setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
+        twh.setSectionResizeMode(3, QtWidgets.QHeaderView.ResizeToContents)
 
         # Set the node view header to have a fixed size type and vis columns
         nvh = self._ui.nodeView.header()
-        nvh.setResizeMode(0, QtGui.QHeaderView.Stretch)
-        nvh.setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-        nvh.setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
+        nvh.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        nvh.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeToContents)
+        nvh.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
 
         avh = self._ui.propertyView.horizontalHeader()
-        avh.setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
+        avh.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
 
         # XXX: 
         # To avoid QTBUG-12850 (https://bugreports.qt.io/browse/QTBUG-12850),
@@ -690,7 +690,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._ui.layerStackView.setHorizontalScrollBarPolicy(
             QtCore.Qt.ScrollBarAlwaysOn)
 
-        self._ui.attributeValueEditor.setMainWindow(self)
+        self._ui.attributeValueEditor.setMainWindow(self, self.editComplete)
 
         QtCore.QObject.connect(self._ui.currentPathWidget,
                                QtCore.SIGNAL('editingFinished()'),
@@ -1080,10 +1080,6 @@ class MainWindow(QtWidgets.QMainWindow):
         QtCore.QObject.connect(self._ui.actionDecrementComplexity,
                                QtCore.SIGNAL('triggered()'),
                                self._decrementComplexity)
-
-        QtCore.QObject.connect(self._ui.attributeValueEditor,
-                               QtCore.SIGNAL('editComplete(QString)'),
-                               self.editComplete)
 
         # Edit Prim menu
         QtCore.QObject.connect(self._ui.menuEdit_Node,
@@ -2677,14 +2673,12 @@ class MainWindow(QtWidgets.QMainWindow):
                 targetLayer = Sdf.Layer.FindOrOpen(saveName)
                 UsdUtils.CopyLayerMetadata(rootLayer, targetLayer,
                                            skipSublayers=True)
-
+                
                 # We don't ever store self.realStartTimeCode or 
                 # self.realEndTimeCode in a layer, so we need to author them
                 # here explicitly.
-                if self.realStartTimeCode:
-                    targetLayer.startTimeCode = self.realStartTimeCode
-                if self.realEndTimeCode:
-                    targetLayer.endTimeCode = self.realEndTimeCode
+                targetLayer.startTimeCode = self.realStartTimeCode
+                targetLayer.endTimeCode = self.realEndTimeCode
 
                 targetLayer.subLayerPaths.append(self._stage.GetRootLayer().realPath)
                 targetLayer.RemoveInertSceneDescription()

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtGui, QtCore
 import stageView
 from stageView import StageView
 from mainWindowUI import Ui_MainWindow
@@ -144,9 +144,9 @@ def _settingsWarning(filePath):
     print >> msg, "Attempting to continue... "
     print >> msg, "------------------------------------------------------------"
 
-class VariantComboBox(QtGui.QComboBox):
+class VariantComboBox(QtWidgets.QComboBox):
     def __init__(self, parent, prim, variantSetName, mainWindow):
-        QtGui.QComboBox.__init__(self, parent)
+        QtWidgets.QComboBox.__init__(self, parent)
         self.prim = prim
         self.variantSetName = variantSetName
         self.mainWindow = mainWindow
@@ -204,7 +204,7 @@ def _GetShortString(prop, frame):
     return result[:500]
 
 
-class MainWindow(QtGui.QMainWindow):
+class MainWindow(QtWidgets.QMainWindow):
 
     ###########
     # Signals #
@@ -249,7 +249,7 @@ class MainWindow(QtGui.QMainWindow):
         self._nodeToItemMap.clear()
 
     def __init__(self, parent, parserData):
-        QtGui.QMainWindow.__init__(self, parent)
+        QtWidgets.QMainWindow.__init__(self, parent)
         self._nodeToItemMap = {}
         self._itemsToPush = []
         self._currentNodes = []
@@ -307,7 +307,7 @@ class MainWindow(QtGui.QMainWindow):
             self._startingPrimCameraPath = None
 
         self.setWindowTitle(parserData.usdFile)
-        self._statusBar = QtGui.QStatusBar(self)
+        self._statusBar = QtWidgets.QStatusBar(self)
         self.setStatusBar(self._statusBar)
 
         settingsPathDir = self._outputBaseDirectory()
@@ -347,7 +347,7 @@ class MainWindow(QtGui.QMainWindow):
             except:
                 _settingsWarning(settingsPath)
 
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
 
         self._timer = QtCore.QTimer(self)
         # Timeout interval in ms. We set it to 0 so it runs as fast as
@@ -391,8 +391,8 @@ class MainWindow(QtGui.QMainWindow):
         self._startTime = self._endTime = time()
         
         # Create action groups
-        self._ui.threePointLights = QtGui.QActionGroup(self)
-        self._ui.colorGroup = QtGui.QActionGroup(self)
+        self._ui.threePointLights = QtWidgets.QActionGroup(self)
+        self._ui.colorGroup = QtWidgets.QActionGroup(self)
         
         self._nodeViewResetTimer = QtCore.QTimer(self)
         self._nodeViewResetTimer.setInterval(250)
@@ -428,15 +428,15 @@ class MainWindow(QtGui.QMainWindow):
         self._ui.propertyView.horizontalHeader().setStretchLastSection(True)
 
         self._ui.propertyView.setSelectionBehavior(
-            QtGui.QAbstractItemView.SelectRows)
+            QtWidgets.QAbstractItemView.SelectRows)
         self._ui.nodeView.setSelectionBehavior(
-            QtGui.QAbstractItemView.SelectRows)
+            QtWidgets.QAbstractItemView.SelectRows)
         # This allows ctrl and shift clicking for multi-selecting
         self._ui.propertyView.setSelectionMode(
-            QtGui.QAbstractItemView.ExtendedSelection)
+            QtWidgets.QAbstractItemView.ExtendedSelection)
 
         self._ui.propertyView.setHorizontalScrollMode(
-            QtGui.QAbstractItemView.ScrollPerPixel)
+            QtWidgets.QAbstractItemView.ScrollPerPixel)
 
         self._ui.frameSlider.setTracking(self._ui.redrawOnScrub.isChecked())
         
@@ -454,7 +454,7 @@ class MainWindow(QtGui.QMainWindow):
             self._ui.threePointLights.addAction(action)
         self._ui.threePointLights.setExclusive(False)
 
-        self._ui.renderModeActionGroup = QtGui.QActionGroup(self)
+        self._ui.renderModeActionGroup = QtWidgets.QActionGroup(self)
         for action in (self._ui.actionWireframe,
                        self._ui.actionWireframeOnSurface,
                        self._ui.actionSmooth_Shaded,
@@ -477,7 +477,7 @@ class MainWindow(QtGui.QMainWindow):
             self._ui.renderModeActionGroup.actions()[0].setChecked(True)
             self._changeRenderMode(self._ui.renderModeActionGroup.actions()[0])
 
-        self._ui.pickModeActionGroup = QtGui.QActionGroup(self)
+        self._ui.pickModeActionGroup = QtWidgets.QActionGroup(self)
         for action in (self._ui.actionPick_Prims,
                        self._ui.actionPick_Models,
                        self._ui.actionPick_Instances):
@@ -497,7 +497,7 @@ class MainWindow(QtGui.QMainWindow):
         # The error-checking pattern here seems wrong?  Error checking
         # should happen in the changeXXX methods. All we're checking here
         # is the values we hardcoded ourselves in the init function!
-        self._ui.selHighlightModeActionGroup = QtGui.QActionGroup(self)
+        self._ui.selHighlightModeActionGroup = QtWidgets.QActionGroup(self)
         for action in (self._ui.actionNever,
                        self._ui.actionOnly_when_paused,
                        self._ui.actionAlways):
@@ -505,7 +505,7 @@ class MainWindow(QtGui.QMainWindow):
             action.setChecked(str(action.text()) == self._selHighlightMode)
         self._ui.selHighlightModeActionGroup.setExclusive(True)
             
-        self._ui.highlightColorActionGroup = QtGui.QActionGroup(self)
+        self._ui.highlightColorActionGroup = QtWidgets.QActionGroup(self)
         for action in (self._ui.actionSelYellow,
                        self._ui.actionSelCyan,
                        self._ui.actionSelWhite):
@@ -513,7 +513,7 @@ class MainWindow(QtGui.QMainWindow):
             action.setChecked(str(action.text()) == self._highlightColorName)
         self._ui.highlightColorActionGroup.setExclusive(True)
             
-        self._ui.interpolationActionGroup = QtGui.QActionGroup(self)
+        self._ui.interpolationActionGroup = QtWidgets.QActionGroup(self)
         self._ui.interpolationActionGroup.setExclusive(True)
         for interpolationType in Usd.InterpolationType.allValues:
             action = self._ui.menuInterpolation.addAction(interpolationType.displayName)
@@ -521,7 +521,7 @@ class MainWindow(QtGui.QMainWindow):
             action.setChecked(self._stage.GetInterpolationType() == interpolationType)
             self._ui.interpolationActionGroup.addAction(action)
 
-        self._ui.nodeViewDepthGroup = QtGui.QActionGroup(self)
+        self._ui.nodeViewDepthGroup = QtWidgets.QActionGroup(self)
         for i in range(1,9):
             action = getattr(self._ui,"actionLevel_" + str(i))
             self._ui.nodeViewDepthGroup.addAction(action)
@@ -539,7 +539,7 @@ class MainWindow(QtGui.QMainWindow):
         self._ui.nodeLegendContainer.setContentsMargins(5,0,5,0)
 
         # needed to set color of boxes
-        graphicsScene = QtGui.QGraphicsScene()
+        graphicsScene = QtWidgets.QGraphicsScene()
         self._ui.propertyLegendColorFallback.setScene(graphicsScene)
         self._ui.propertyLegendColorDefault.setScene(graphicsScene)
         self._ui.propertyLegendColorTimeSample.setScene(graphicsScene)
@@ -1185,11 +1185,11 @@ class MainWindow(QtGui.QMainWindow):
 
         self.update()
 
-        QtGui.qApp.processEvents()
+        QtWidgets.qApp.processEvents()
 
         self._drawFirstImage()
 
-        QtGui.QApplication.restoreOverrideCursor()
+        QtWidgets.QApplication.restoreOverrideCursor()
 
     def _drawFirstImage(self):
 
@@ -1216,7 +1216,7 @@ class MainWindow(QtGui.QMainWindow):
             if key == QtCore.Qt.Key_Escape:
                 self.setFocus()
                 return True
-        return QtGui.QMainWindow.eventFilter(self, widget, event)
+        return QtWidgets.QMainWindow.eventFilter(self, widget, event)
 
     def statusMessage(self, msg, timeout = 0):
         self._statusBar.showMessage(msg, timeout * 1000)
@@ -1420,7 +1420,7 @@ class MainWindow(QtGui.QMainWindow):
 
     def _configureRendererPlugins(self):
         if self._stageView:
-            self._ui.rendererPluginActionGroup = QtGui.QActionGroup(self)
+            self._ui.rendererPluginActionGroup = QtWidgets.QActionGroup(self)
             self._ui.rendererPluginActionGroup.setExclusive(True)
 
             pluginTypes = self._stageView.GetRendererPlugins()
@@ -1505,7 +1505,7 @@ class MainWindow(QtGui.QMainWindow):
                 self._ui.nodeStageSplitter.addWidget(self._ui.attributeBrowserFrame)
 
             else:
-                layout = QtGui.QVBoxLayout()
+                layout = QtWidgets.QVBoxLayout()
                 layout.setContentsMargins(0, 0, 0, 0)
                 self._ui.glFrame.setLayout(layout)
                 layout.addWidget(self._stageView)
@@ -1600,7 +1600,7 @@ class MainWindow(QtGui.QMainWindow):
         self._stageView.update()
 
     def _adjustComplexity(self):
-        complexity= QtGui.QInputDialog.getDouble(self, 
+        complexity= QtWidgets.QInputDialog.getDouble(self, 
             "Adjust complexity", "Enter a value between 1 and 2.\n\n" 
             "You can also use ctrl+ or ctrl- to adjust the\n"
             "complexity without invoking this dialog.\n", 
@@ -1610,7 +1610,7 @@ class MainWindow(QtGui.QMainWindow):
             self._stageView.update()
 
     def _adjustFOV(self):
-        fov = QtGui.QInputDialog.getDouble(self, "Adjust FOV", 
+        fov = QtWidgets.QInputDialog.getDouble(self, "Adjust FOV", 
             "Enter a value between 0 and 180", self._stageView.freeCamera.fov, 0, 180)
         if (fov[1]):
             self._stageView.freeCamera.fov = fov[0]
@@ -1720,7 +1720,7 @@ class MainWindow(QtGui.QMainWindow):
                 self._watchWindow._ui.unvaryingEdit.verticalScrollBar().value()
 
             self._watchWindow.clearContents()
-            QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+            QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
 
             for i in self._ui.propertyView.selectedItems():
                 if i.column() == 0:        # make sure first column is selected
@@ -1791,7 +1791,7 @@ class MainWindow(QtGui.QMainWindow):
                     # tell the watch window to print a "====" separator
                     self._watchWindow.appendSeparator()
 
-            QtGui.QApplication.restoreOverrideCursor()
+            QtWidgets.QApplication.restoreOverrideCursor()
             self._watchWindow._ui.varyingEdit.verticalScrollBar().setValue(
                 varyScrollPos)
             self._watchWindow._ui.unvaryingEdit.verticalScrollBar().setValue(
@@ -2061,7 +2061,7 @@ class MainWindow(QtGui.QMainWindow):
 
             self._attrSearchResults = \
                 uniquify_tablewidgetitems(self._attrSearchResults)
-            self._attrSearchResults.sort(cmp, QtGui.QTableWidgetItem.row)
+            self._attrSearchResults.sort(cmp, QtWidgets.QTableWidgetItem.row)
             self._attrSearchResults = deque(self._attrSearchResults)
 
             self._lastNodeSearched = self._currentNodes[0]
@@ -2542,9 +2542,9 @@ class MainWindow(QtGui.QMainWindow):
         from pythonExpressionPrompt import Myconsole
             
         if self._interpreter is None:
-            self._interpreter = QtGui.QDialog(self)
+            self._interpreter = QtWidgets.QDialog(self)
             self._console = Myconsole(self._interpreter)
-            lay = QtGui.QVBoxLayout()
+            lay = QtWidgets.QVBoxLayout()
             lay.addWidget(self._console)
             self._interpreter.setLayout(lay)
 
@@ -2642,7 +2642,7 @@ class MainWindow(QtGui.QMainWindow):
             t.PrintTime('tear down the UI')
 
     def _openFile(self):
-        (filename, _) = QtGui.QFileDialog.getOpenFileName(self, "Select file",".")
+        (filename, _) = QtWidgets.QFileDialog.getOpenFileName(self, "Select file",".")
         if len(filename) > 0:
 
             self._parserData.usdFile = str(filename)
@@ -2653,7 +2653,7 @@ class MainWindow(QtGui.QMainWindow):
     def _saveOverridesAs(self):
         recommendedFilename = self._parserData.usdFile.rsplit('.', 1)[0]
         recommendedFilename += '_overrides.usd'
-        (saveName, _) = QtGui.QFileDialog.getSaveFileName(self,
+        (saveName, _) = QtWidgets.QFileDialog.getSaveFileName(self,
                                                      "Save file (*.usd)",
                                                      "./" + recommendedFilename,
                                                      'Usd Files (*.usd)')
@@ -2693,7 +2693,7 @@ class MainWindow(QtGui.QMainWindow):
                 self._stage.GetRootLayer().Export(saveName, 'Created by UsdView')
 
     def _reopenStage(self):
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
 
         try:
             # Clear out any Usd objects that may become invalid. We will pick
@@ -2722,12 +2722,12 @@ class MainWindow(QtGui.QMainWindow):
             import traceback
             traceback.print_exc()
         finally:
-            QtGui.QApplication.restoreOverrideCursor()
+            QtWidgets.QApplication.restoreOverrideCursor()
 
         self.statusMessage('Stage Reopened')
 
     def _reloadStage(self):
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
 
         try:
             self._stage.Reload()
@@ -2736,7 +2736,7 @@ class MainWindow(QtGui.QMainWindow):
         except Exception as err:
             self.statusMessage('Error occurred rereading all layers for Stage: %s' % err)
         finally:
-            QtGui.QApplication.restoreOverrideCursor()
+            QtWidgets.QApplication.restoreOverrideCursor()
 
         self.statusMessage('All Layers Reloaded.')
 
@@ -3402,7 +3402,7 @@ class MainWindow(QtGui.QMainWindow):
         self._ui.actionHUD.setChecked(False)
 
     def saveFrame(self, fileName):
-        pm =  QtGui.QPixmap.grabWindow(self._stageView.winId())
+        pm =  QtWidgets.QPixmap.grabWindow(self._stageView.winId())
         pm.save(fileName, 'TIFF')
 
     def _getAttributeDict(self):
@@ -3449,13 +3449,13 @@ class MainWindow(QtGui.QMainWindow):
             # Get the attribute's value and display color
             fgColor = GetAttributeColor(attribute, frame)
 
-            attrName = QtGui.QTableWidgetItem(str(key))
+            attrName = QtWidgets.QTableWidgetItem(str(key))
             attrName.setFont(BoldFont)
             attrName.setForeground(fgColor)
             tableWidget.setItem(attributeCount, 0, attrName)
 
             attrText = _GetShortString(attribute, frame)
-            attrVal = QtGui.QTableWidgetItem(attrText)
+            attrVal = QtWidgets.QTableWidgetItem(attrText)
             valTextFont = GetAttributeTextFont(attribute, frame)
             if valTextFont:
                 attrVal.setFont(valTextFont)
@@ -3476,14 +3476,14 @@ class MainWindow(QtGui.QMainWindow):
         """ Sets the contents of the attribute value viewer """
         cursorOverride = not self._timer.isActive()
         if cursorOverride:
-            QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+            QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
         try:
             self._updateAttributeViewInternal()
         except Exception as err:
             print "Problem encountered updating attribute view: %s" % err
         finally:
             if cursorOverride:
-                QtGui.QApplication.restoreOverrideCursor()
+                QtWidgets.QApplication.restoreOverrideCursor()
 
     def _getSelectedObject(self, selectedAttribute=None):
         if selectedAttribute is None:
@@ -3695,7 +3695,7 @@ class MainWindow(QtGui.QMainWindow):
         tableWidget.setRowCount(len(m) + len(variantSets))
 
         for i,key in enumerate(sorted(m.keys())):
-            attrName = QtGui.QTableWidgetItem(str(key))
+            attrName = QtWidgets.QTableWidgetItem(str(key))
             tableWidget.setItem(i, 0, attrName)
 
             # Get metadata value
@@ -3705,14 +3705,14 @@ class MainWindow(QtGui.QMainWindow):
                 val = m[key]
 
             valStr, ttStr = self._formatMetadataValueView(val) 
-            attrVal = QtGui.QTableWidgetItem(valStr)
+            attrVal = QtWidgets.QTableWidgetItem(valStr)
             attrVal.setToolTip(ttStr)
 
             tableWidget.setItem(i, 1, attrVal)
 
         rowIndex = len(m)
         for variantSetName, combo in variantSets.iteritems():
-            attrName = QtGui.QTableWidgetItem(str(variantSetName+ ' variant'))
+            attrName = QtWidgets.QTableWidgetItem(str(variantSetName+ ' variant'))
             tableWidget.setItem(rowIndex, 0, attrName)
             tableWidget.setCellWidget(rowIndex, 1, combo)
             combo.currentIndexChanged.connect(combo.updateVariantSelection)
@@ -3743,7 +3743,7 @@ class MainWindow(QtGui.QMainWindow):
         def WalkSublayers(parent, node, layerTree, sublayer=False):
             layer = layerTree.layer
             spec = layer.GetObjectAtPath(node.path)
-            item = QtGui.QTreeWidgetItem(
+            item = QtWidgets.QTreeWidgetItem(
                 parent,
                 [
                     LabelForLayer(layer),
@@ -3817,7 +3817,7 @@ class MainWindow(QtGui.QMainWindow):
             tableWidget.setRowCount(len(layers))
             
             for i, layer in enumerate(layers):
-                layerItem = QtGui.QTableWidgetItem(layer.GetHierarchicalDisplayString())
+                layerItem = QtWidgets.QTableWidgetItem(layer.GetHierarchicalDisplayString())
                 layerItem.layerPath = layer.layer.realPath
                 toolTip = "<b>identifier:</b> @%s@ <br> <b>resolved path:</b> %s" % \
                     (layer.layer.identifier, layerItem.layerPath)
@@ -3825,7 +3825,7 @@ class MainWindow(QtGui.QMainWindow):
                 layerItem.setToolTip(toolTip)
                 tableWidget.setItem(i, 0, layerItem)
 
-                offsetItem = QtGui.QTableWidgetItem(layer.GetOffsetString())
+                offsetItem = QtWidgets.QTableWidgetItem(layer.GetOffsetString())
                 offsetItem.layerPath = layer.layer.realPath
                 toolTip = self._limitToolTipSize(str(layer.offset)) 
                 offsetItem.setToolTip(toolTip)
@@ -3836,9 +3836,9 @@ class MainWindow(QtGui.QMainWindow):
             specs = []
             tableWidget.setColumnCount(3)
             header = tableWidget.horizontalHeader()
-            header.setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
-            header.setResizeMode(1, QtGui.QHeaderView.Stretch)
-            header.setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
+            header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
+            header.setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+            header.setSectionResizeMode(2, QtWidgets.QHeaderView.ResizeToContents)
             tableWidget.horizontalHeaderItem(1).setText('Path')
 
             if path.IsPropertyPath():
@@ -3849,27 +3849,27 @@ class MainWindow(QtGui.QMainWindow):
                 c3 = "Value" if (len(specs) == 0 or 
                                  isinstance(specs[0], Sdf.AttributeSpec)) else "Target Paths"
                 tableWidget.setHorizontalHeaderItem(2,
-                                                    QtGui.QTableWidgetItem(c3))
+                                                    QtWidgets.QTableWidgetItem(c3))
             else:
                 specs = obj.GetPrim().GetPrimStack()
                 tableWidget.setHorizontalHeaderItem(2,
-                    QtGui.QTableWidgetItem('Metadata'))
+                    QtWidgets.QTableWidgetItem('Metadata'))
 
             tableWidget.setRowCount(len(specs))
 
             for i, spec in enumerate(specs):
-                layerItem = QtGui.QTableWidgetItem(spec.layer.GetDisplayName())
+                layerItem = QtWidgets.QTableWidgetItem(spec.layer.GetDisplayName())
                 layerItem.setToolTip(self._limitToolTipSize(spec.layer.realPath))
                 tableWidget.setItem(i, 0, layerItem)
 
-                pathItem = QtGui.QTableWidgetItem(spec.path.pathString)
+                pathItem = QtWidgets.QTableWidgetItem(spec.path.pathString)
                 pathItem.setToolTip(self._limitToolTipSize(spec.path.pathString))
                 tableWidget.setItem(i, 1, pathItem)
 
                 if path.IsPropertyPath():
                     valStr = _GetShortString(spec, self._currentFrame)
                     ttStr = valStr
-                    valueItem = QtGui.QTableWidgetItem(valStr)
+                    valueItem = QtWidgets.QTableWidgetItem(valStr)
                     sampleBased = (spec.HasInfo('timeSamples') and
                         spec.layer.GetNumTimeSamplesForPath(path) != -1)
                     valueItemColor = (TimeSampleTextColor if 
@@ -3884,7 +3884,7 @@ class MainWindow(QtGui.QMainWindow):
                         if spec.HasInfo(mykey):
                             metadataDict[mykey] = spec.GetInfo(mykey)
                     valStr, ttStr = self._formatMetadataValueView(metadataDict)
-                    valueItem = QtGui.QTableWidgetItem(valStr)
+                    valueItem = QtWidgets.QTableWidgetItem(valStr)
                     valueItem.setToolTip(ttStr)
 
                 tableWidget.setItem(i, 2, valueItem)
@@ -4064,7 +4064,7 @@ class MainWindow(QtGui.QMainWindow):
 
         # This is expensive enough that we should give the user feedback 
         # that something is happening...
-        QtGui.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)
         try:
             thisDict = {CV: 0, VERT: 0, FACE: 0}
 
@@ -4095,7 +4095,7 @@ class MainWindow(QtGui.QMainWindow):
         except Exception as err:
             print "Error encountered while computing prim subtree HUD info: %s" % err
         finally:
-            QtGui.QApplication.restoreOverrideCursor()
+            QtWidgets.QApplication.restoreOverrideCursor()
 
 
     def _setupDebugMenu(self):
@@ -4329,12 +4329,12 @@ class MainWindow(QtGui.QMainWindow):
                 # context menu steals mouse release event from the StageView.
                 # We need to give it one so it can track its interaction
                 # mode properly
-                mrEvent = QtGui.QMouseEvent(QtCore.QEvent.MouseButtonRelease,
+                mrEvent = QtWidgets.QMouseEvent(QtCore.QEvent.MouseButtonRelease,
                                             QtGui.QCursor.pos(),
                                             QtCore.Qt.RightButton, 
                                             QtCore.Qt.MouseButtons(QtCore.Qt.RightButton),
                                             QtCore.Qt.KeyboardModifiers())
-                QtGui.QApplication.sendEvent(self._stageView, mrEvent)
+                QtWidgets.QApplication.sendEvent(self._stageView, mrEvent)
 
     def onRollover(self, path, instanceIndex, modifiers):
         from common import GetEnclosingModelPrim, GetClosestBoundMaterial
@@ -4484,4 +4484,4 @@ class MainWindow(QtGui.QMainWindow):
             
         else:
             tip = ""
-        QtGui.QToolTip.showText(QtGui.QCursor.pos(), tip, self._stageView)
+        QtWidgets.QToolTip.showText(QtGui.QCursor.pos(), tip, self._stageView)

--- a/pxr/usdImaging/lib/usdviewq/nodeContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeContextMenu.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui
+from pyside import QtWidgets
 from nodeContextMenuItems import _GetContextMenuItems
 
 #
@@ -31,10 +31,10 @@ from nodeContextMenuItems import _GetContextMenuItems
 # function in nodeContextMenuItems. To add a new context menu item,
 # see comments in that file.
 #
-class NodeContextMenu(QtGui.QMenu):
+class NodeContextMenu(QtWidgets.QMenu):
 
     def __init__(self, parent, item):
-        QtGui.QMenu.__init__(self, parent)
+        QtWidgets.QMenu.__init__(self, parent)
         self._menuItems = _GetContextMenuItems(parent, item)
         
         for menuItem in self._menuItems:

--- a/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeContextMenuItems.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui
+from pyside import QtWidgets, QtGui
 from usdviewContextMenuItem import UsdviewContextMenuItem
 import os
 import sys
@@ -258,7 +258,7 @@ class CopyPrimPathMenuItem(NodeContextMenuItem):
         pathlist = [str(p.GetPath()) for p in self._currentNodes]
         pathStrings = '\n'.join(pathlist)
 
-        cb = QtGui.QApplication.clipboard()
+        cb = QtWidgets.QApplication.clipboard()
         cb.setText(pathStrings, QtGui.QClipboard.Selection )
         cb.setText(pathStrings, QtGui.QClipboard.Clipboard )
 
@@ -284,7 +284,7 @@ class CopyModelPathMenuItem(NodeContextMenuItem):
 
     def RunCommand(self):
         modelPath = str(self._modelPrim.GetPath())
-        cb = QtGui.QApplication.clipboard()
+        cb = QtWidgets.QApplication.clipboard()
         cb.setText(modelPath, QtGui.QClipboard.Selection )
         cb.setText(modelPath, QtGui.QClipboard.Clipboard )
 
@@ -304,7 +304,7 @@ class IsolateCopyNodeMenuItem(NodeContextMenuItem):
         inFile = self._currentNodes[0].GetScene().GetUsdFile()
 
         guessOutFile = os.getcwd() + "/" + self._currentNodes[0].GetName() + "_copy.usd"
-        (outFile, _) = QtGui.QFileDialog.getSaveFileName(None,
+        (outFile, _) = QtWidgets.QFileDialog.getSaveFileName(None,
                                                          "Specify the Usd file to create",
                                                          guessOutFile,
                                                          'Usd files (*.usd)')

--- a/pxr/usdImaging/lib/usdviewq/nodeViewItem.py
+++ b/pxr/usdImaging/lib/usdviewq/nodeViewItem.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from pxr import Usd, UsdGeom
 from ._usdviewq import Utils
 
@@ -36,7 +36,7 @@ def _GetPrimInfo(prim, time):
 # This class extends QTreeWidgetItem to also contain all the stage 
 # node data associated with it and populate itself with that data.
 
-class NodeViewItem(QtGui.QTreeWidgetItem):
+class NodeViewItem(QtWidgets.QTreeWidgetItem):
     def __init__(self, node, mainWindow, nodeHasChildren):
         # Do *not* pass a parent.  The client must build the hierarchy.
         # This can dramatically improve performance when building a
@@ -56,9 +56,9 @@ class NodeViewItem(QtGui.QTreeWidgetItem):
 
         # If we know we'll have children show a norgie, otherwise don't.
         if nodeHasChildren:
-            self.setChildIndicatorPolicy(QtGui.QTreeWidgetItem.ShowIndicator)
+            self.setChildIndicatorPolicy(QtWidgets.QTreeWidgetItem.ShowIndicator)
         else:
-            self.setChildIndicatorPolicy(QtGui.QTreeWidgetItem.DontShowIndicator)
+            self.setChildIndicatorPolicy(QtWidgets.QTreeWidgetItem.DontShowIndicator)
 
     def push(self):
         """Pushes prim data to the UI."""

--- a/pxr/usdImaging/lib/usdviewq/overridableLineEdit.py
+++ b/pxr/usdImaging/lib/usdviewq/overridableLineEdit.py
@@ -21,17 +21,17 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 
 # simple class to have a "clear" button on a line edit when the line edit
 # contains an override. Clicking the clear button returns to the default value.
 
-class OverridableLineEdit(QtGui.QLineEdit):
+class OverridableLineEdit(QtWidgets.QLineEdit):
     def __init__(self, parent):
-        QtGui.QLineEdit.__init__(self, parent)
+        QtWidgets.QLineEdit.__init__(self, parent)
 
         # create the clear button.
-        self._clearButton = QtGui.QToolButton(self)
+        self._clearButton = QtWidgets.QToolButton(self)
         self._clearButton.setText('x')
         self._clearButton.setCursor(QtCore.Qt.ArrowCursor)
         self._clearButton.setFixedSize(16, 16)
@@ -46,7 +46,7 @@ class OverridableLineEdit(QtGui.QLineEdit):
     # properly place the button
     def resizeEvent(self, event):
         sz = QtCore.QSize(self._clearButton.size())
-        frameWidth = self.style().pixelMetric(QtGui.QStyle.PM_DefaultFrameWidth)
+        frameWidth = self.style().pixelMetric(QtWidgets.QStyle.PM_DefaultFrameWidth)
         self._clearButton.move(self.rect().right() - frameWidth - sz.width(),
                                (self.rect().bottom() + 1 - sz.height())/2)
 
@@ -56,7 +56,7 @@ class OverridableLineEdit(QtGui.QLineEdit):
 
     # called programatically to reset the default text
     def setText(self, text):
-        QtGui.QLineEdit.setText(self, text)
+        QtWidgets.QLineEdit.setText(self, text)
         self._defaultText = text
 
         self._clearButton.setVisible(False)

--- a/pxr/usdImaging/lib/usdviewq/prettyPrint.py
+++ b/pxr/usdImaging/lib/usdviewq/prettyPrint.py
@@ -25,10 +25,10 @@
 Hopefully we can deprecate this since most of the array stuff is handled by the
 arrayAttributeView
 '''
-from PySide import QtGui
+from pyside import QtWidgets
 
 def progressDialog(title, value):
-    dialog = QtGui.QProgressDialog(title, "Cancel", 0, value)
+    dialog = QtWidgets.QProgressDialog(title, "Cancel", 0, value)
     dialog.setModal(True)
     dialog.setMinimumDuration(500)
     return dialog

--- a/pxr/usdImaging/lib/usdviewq/pyside.py
+++ b/pxr/usdImaging/lib/usdviewq/pyside.py
@@ -1,0 +1,5 @@
+try:
+  from PySide import QtGui, QtCore, QtOpenGL
+  QtWidgets = QtGui
+except ImportError:
+  from PySide2 import QtWidgets, QtGui, QtOpenGL, QtCore

--- a/pxr/usdImaging/lib/usdviewq/pyside.py
+++ b/pxr/usdImaging/lib/usdviewq/pyside.py
@@ -1,5 +1,15 @@
+#
+# USD builds against PySide before PySide2, so try to import PySide first.
+# However, assume PySide2 is the way forward and adjust PySide to match PySide2
+#
 try:
   from PySide import QtGui, QtCore, QtOpenGL
   QtWidgets = QtGui
+  assert getattr(QtWidgets.QHeaderView, 'setSectionResizeMode', None) == None
+  assert getattr(QtWidgets.QApplication, 'devicePixelRatio', None) == None
+  QtWidgets.QHeaderView.setSectionResizeMode = QtGui.QHeaderView.setResizeMode
+  QtWidgets.QApplication.devicePixelRatio = lambda self: 1
+
 except ImportError:
   from PySide2 import QtWidgets, QtGui, QtOpenGL, QtCore
+

--- a/pxr/usdImaging/lib/usdviewq/pythonExpressionPrompt.py
+++ b/pxr/usdImaging/lib/usdviewq/pythonExpressionPrompt.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from pythonExpressionPromptUI import Ui_PythonExpressionPrompt
 from prettyPrint import prettyPrint
 
@@ -32,10 +32,10 @@ import sys, copy, pythonInterpreter
 # python prompt and returning the last value or "_" upon confirmation.
 # The widget can be invoked using 'getValueFromPython' which will return
 # the value of "_"
-class PythonExpressionPrompt(QtGui.QDialog):
+class PythonExpressionPrompt(QtWidgets.QDialog):
 
     def __init__(self, parent, exception = None, val = None):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         self._ui = Ui_PythonExpressionPrompt()
         self._ui.setupUi(self)
         self._mainWindow = parent._mainWindow     # get mainWindow instance
@@ -49,7 +49,7 @@ class PythonExpressionPrompt(QtGui.QDialog):
             print >> sys.stderr, exception
 
         QtCore.QObject.connect(self._ui.buttonBox.button(
-                               QtGui.QDialogButtonBox.Apply),
+                               QtWidgets.QDialogButtonBox.Apply),
                                QtCore.SIGNAL('clicked()'),
                                self,
                                QtCore.SLOT('accept()'))
@@ -91,18 +91,18 @@ class PythonExpressionPrompt(QtGui.QDialog):
         # called when clicking the Save button
         # grab the value of "_" and save it in self._val
         self._val = self._console.getLastValue()
-        QtGui.QDialog.accept(self)
+        QtWidgets.QDialog.accept(self)
 
     def reject(self):
         # called when clicking the Close Without Saving button
         self._val = None
-        QtGui.QDialog.reject(self)
+        QtWidgets.QDialog.reject(self)
 
     def exec_(self):
         # called to "execute" the dialog process
         # we override this function to make sure to return I/O to stdin and
         # stdout, and make exec_ return the last value of "_"
-        QtGui.QDialog.exec_(self)
+        QtWidgets.QDialog.exec_(self)
         return self._val
     
     def __del__(self):

--- a/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
+++ b/pxr/usdImaging/lib/usdviewq/pythonInterpreter.py
@@ -23,7 +23,7 @@
 #
 from pxr import Tf
 
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtGui, QtCore
 
 from code import InteractiveInterpreter
 import os, sys, keyword
@@ -268,7 +268,7 @@ class Controller(QtCore.QObject):
         self.connect(self.textEdit, QtCore.SIGNAL("requestPrev()"),
                      self._PrevSlot)
 
-        appInstance = QtGui.QApplication.instance()
+        appInstance = QtWidgets.QApplication.instance()
         self.connect(appInstance,
                      QtCore.SIGNAL("appControllerQuit()"),
                      self._QuitSlot)
@@ -469,10 +469,10 @@ class Controller(QtCore.QObject):
             # how many rows do we need to fit our data
             numRows = (len(completions) / numCols) + 1
 
-            columnWidth = QtGui.QTextLength(QtGui.QTextLength.FixedLength,
+            columnWidth = QtWidgets.QTextLength(QtWidgets.QTextLength.FixedLength,
                                             maxLength)
 
-            tableFormat = QtGui.QTextTableFormat()
+            tableFormat = QtWidgets.QTextTableFormat()
             tableFormat.setAlignment(QtCore.Qt.AlignLeft)          
             tableFormat.setCellPadding(0)
             tableFormat.setCellSpacing(0)
@@ -627,7 +627,7 @@ class Controller(QtCore.QObject):
         self._ClearLine()
         self.write(self.history[self.historyPointer])
 
-class View(QtGui.QTextEdit):
+class View(QtWidgets.QTextEdit):
     """View is a QTextEdit which provides some extra
     facilities to help implement an interpreter console.  In particular,
     QTextEdit does not provide for complete control over the buffer being
@@ -696,7 +696,7 @@ class View(QtGui.QTextEdit):
         return (self._PositionInInputArea(self.textCursor().position()) > 0)
 
     def mousePressEvent(self, e):
-        app = QtGui.QApplication.instance()        
+        app = QtWidgets.QApplication.instance()        
 
         # is this a triple click?        
         if ((e.button() & QtCore.Qt.LeftButton) and
@@ -724,7 +724,7 @@ class View(QtGui.QTextEdit):
         
     def mouseDoubleClickEvent(self, e):
         super(View, self).mouseDoubleClickEvent(e)
-        app = QtGui.QApplication.instance()
+        app = QtWidgets.QApplication.instance()
         self.tripleClickTimer.start(app.doubleClickInterval(), self)
         # make a copy here, otherwise tripleClickPoint will always = globalPos
         self.tripleClickPoint = QtCore.QPoint(e.globalPos())

--- a/pxr/usdImaging/lib/usdviewq/referenceEditor.py
+++ b/pxr/usdImaging/lib/usdviewq/referenceEditor.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtCore
 from referenceEditorUI import Ui_ReferenceEditor
 
 import mainWindow
@@ -29,9 +29,9 @@ import mainWindow
 # XXX USD REFERENCE EDITOR DISABLED
 # Dialog window to edit reference asset path, reference path and offset/scale
 
-class ReferenceEditor(QtGui.QDialog):
+class ReferenceEditor(QtWidgets.QDialog):
     def __init__(self, parent, stage, node):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         self._ui = Ui_ReferenceEditor()
         self._ui.setupUi(self)
 
@@ -89,19 +89,19 @@ class ReferenceEditor(QtGui.QDialog):
         if self._writable:  # dont save if not writable!
             # generate a backup directory, offer a backup option to the user
             backupfile = mainWindow.getBackupFile(self._refSrc)
-            question = QtGui.QMessageBox("Confirm Reference Edit",
+            question = QtWidgets.QMessageBox("Confirm Reference Edit",
                 "Your changes will be permanently committed to the reference "
                 "source stage %s\n\n"\
                 "Do you want to save a backup of that stage at %s "\
                 "before continuing?" %(self._refSrc, backupfile),
-                QtGui.QMessageBox.Question,
-                QtGui.QMessageBox.Yes,
-                QtGui.QMessageBox.No,
-                QtGui.QMessageBox.Cancel)
+                QtWidgets.QMessageBox.Question,
+                QtWidgets.QMessageBox.Yes,
+                QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.Cancel)
             
-            yesButton = question.button(QtGui.QMessageBox.Yes)
-            noButton =  question.button(QtGui.QMessageBox.No)
-            cancelButton = question.button(QtGui.QMessageBox.Cancel)
+            yesButton = question.button(QtWidgets.QMessageBox.Yes)
+            noButton =  question.button(QtWidgets.QMessageBox.No)
+            cancelButton = question.button(QtWidgets.QMessageBox.Cancel)
 
             yesButton.setText("Save With Backup")
             noButton.setText("Save Without Backup")
@@ -138,7 +138,7 @@ class ReferenceEditor(QtGui.QDialog):
 
             # alert user if the reference could not be found
             if not refNode:
-                QtGui.QMessageBox.critical(self, 'Failed To Edit Reference',
+                QtWidgets.QMessageBox.critical(self, 'Failed To Edit Reference',
                         'The reference with assetPath "%s", reference path "%s", '
                         'and offset/scale "(%f,%f)" could not be found in stage "%s".'
                         %(self._assetPath.Get(), self._referencePath,\
@@ -163,5 +163,5 @@ class ReferenceEditor(QtGui.QDialog):
 
             refSrcScene.Flush()
 
-        QtGui.QDialog.accept(self)
+        QtWidgets.QDialog.accept(self)
 

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -29,7 +29,7 @@ from math import tan, atan, floor, ceil, radians as rad
 import os
 from time import time
 
-from PySide import QtGui, QtCore, QtOpenGL
+from pyside import QtWidgets, QtCore, QtGui, QtOpenGL
 
 from pxr import Tf
 from pxr import Gf

--- a/pxr/usdImaging/lib/usdviewq/watchWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/watchWindow.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from PySide import QtGui, QtCore
+from pyside import QtWidgets, QtGui, QtCore
 from watchWindowUI import Ui_WatchWindow
 import re
 import os
@@ -31,9 +31,9 @@ import os
 separatorColor = QtGui.QColor(255, 255, 255)
 separatorString = "\n==================================\n"
 
-class WatchWindow(QtGui.QDialog):
+class WatchWindow(QtWidgets.QDialog):
     def __init__(self, parent):
-        QtGui.QDialog.__init__(self,parent)
+        QtWidgets.QDialog.__init__(self,parent)
         self._ui = Ui_WatchWindow()
         self._ui.setupUi(self)
 
@@ -105,7 +105,7 @@ class WatchWindow(QtGui.QDialog):
         self._boxWithFocus = self._ui.unvaryingEdit
 
     def _find(self):
-        searchString = QtGui.QInputDialog.getText(self, "Find", 
+        searchString = QtWidgets.QInputDialog.getText(self, "Find", 
             "Enter search string\nUse Ctrl+G to \"Find Next\"\n" + \
             "Use Ctrl+Shift+G to \"Find Previous\"")
         if searchString[1]:
@@ -125,10 +125,10 @@ class WatchWindow(QtGui.QDialog):
         if (self._searchString == ""):
             return
         if (not self._boxWithFocus.find(self._searchString,
-            QtGui.QTextDocument.FindBackward)):
+            QtWidgets.QTextDocument.FindBackward)):
             self._boxWithFocus.moveCursor(QtGui.QTextCursor.End)
             self._boxWithFocus.find(self._searchString, 
-                                      QtGui.QTextDocument.FindBackward)
+                                      QtWidgets.QTextDocument.FindBackward)
 
     def _diff(self):
         import tempfile


### PR DESCRIPTION
There are actually few changes necessary to get usdview working with Pyside2.

The majority of changes simply have to do with importing the proper [sub]modules for Qt5.
e6b7824 contains the source-level changes necessary, to support HDPI viewport, forwarding to newer method names, and create signal/slots in the sorted order that Qt5 requires.
