### PR TITLE
usdview: add "Copy Layer identifier" menu item

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/layerStackContextMenu.py
+++ b/pxr/usdImaging/lib/usdviewq/layerStackContextMenu.py
@@ -48,6 +48,7 @@ def _GetContextMenuItems(mainWindow, item):
     return [OpenLayerMenuItem(mainWindow, item), 
             UsdviewLayerMenuItem(mainWindow, item),
             CopyLayerPathMenuItem(mainWindow, item),
+            CopyLayerIdentifierMenuItem(mainWindow, item),
             CopyPathMenuItem(mainWindow, item)]
 
 #
@@ -160,6 +161,25 @@ class CopyLayerPathMenuItem(LayerStackContextMenuItem):
         cb = QtGui.QApplication.clipboard()
         cb.setText(layerPath, QtGui.QClipboard.Selection )
         cb.setText(layerPath, QtGui.QClipboard.Clipboard )
+
+#
+# Copy the layer identifier to clipboard
+# 
+class CopyLayerIdentifierMenuItem(LayerStackContextMenuItem):
+    def GetText(self):
+        return "Copy Layer Identifier"
+
+    def RunCommand(self):
+        if not self._item:
+            return 
+
+        identifier = getattr(self._item, "identifier")
+        if not identifier:
+            return
+    
+        cb = QtGui.QApplication.clipboard()
+        cb.setText(identifier, QtGui.QClipboard.Selection )
+        cb.setText(identifier, QtGui.QClipboard.Clipboard )
 
 #
 # Copy the prim path to clipboard, if there is one

--- a/pxr/usdImaging/lib/usdviewq/mainWindow.py
+++ b/pxr/usdImaging/lib/usdviewq/mainWindow.py
@@ -3767,6 +3767,7 @@ class MainWindow(QtGui.QMainWindow):
             # attributes for selection:
             item.layer = layer
             item.spec = spec
+            item.identifier = layer.identifier
 
             # attributes for LayerStackContextMenu:
             if layer.realPath:
@@ -3831,6 +3832,7 @@ class MainWindow(QtGui.QMainWindow):
             for i, layer in enumerate(layers):
                 layerItem = QtGui.QTableWidgetItem(layer.GetHierarchicalDisplayString())
                 layerItem.layerPath = layer.layer.realPath
+                layerItem.identifier = layer.layer.identifier
                 toolTip = "<b>identifier:</b> @%s@ <br> <b>resolved path:</b> %s" % \
                     (layer.layer.identifier, layerItem.layerPath)
                 toolTip = self._limitToolTipSize(toolTip)
@@ -3839,6 +3841,7 @@ class MainWindow(QtGui.QMainWindow):
 
                 offsetItem = QtGui.QTableWidgetItem(layer.GetOffsetString())
                 offsetItem.layerPath = layer.layer.realPath
+                offsetItem.identifier = layer.layer.identifier
                 toolTip = self._limitToolTipSize(str(layer.offset)) 
                 offsetItem.setToolTip(toolTip)
                 tableWidget.setItem(i, 1, offsetItem)
@@ -3905,6 +3908,7 @@ class MainWindow(QtGui.QMainWindow):
                     item = tableWidget.item(i, j)
                     item.layerPath = spec.layer.realPath
                     item.path = spec.path.pathString
+                    item.identifier = spec.layer.identifier
 
     def _isHUDVisible(self):
         """Checks if the upper HUD is visible by looking at the global HUD


### PR DESCRIPTION
useful when using Assest Resolvers, where the "real path" may be less useful than the unresolved identifier

### Description of Change(s)
Adds in a new right-click menu item that will copy the layer identifier (ie, unresolved asset path) to the clipboard

### Fixes Issue(s)
- None

