### PR TITLE
[usdMaya] Adding a new registry to handle user attribute writer plugins.

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -78,6 +78,7 @@ pxr_shared_library(${PXR_PACKAGE}
         translatorXformable
         util
         usdPrimProvider
+        userAttributeWriterRegistry
         writeJobContext
         writeUtil
         xformStack
@@ -90,6 +91,7 @@ pxr_shared_library(${PXR_PACKAGE}
         proxyShape
         referenceAssembly
         undoHelperCommand
+        listUserAttributeWritersCommand
 
         chaser
         chaserRegistry

--- a/third_party/maya/lib/usdMaya/listUserAttributeWritersCommand.cpp
+++ b/third_party/maya/lib/usdMaya/listUserAttributeWritersCommand.cpp
@@ -1,0 +1,64 @@
+//
+// Copyright 2019 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "usdMaya/listUserAttributeWritersCommand.h"
+
+#include "usdMaya/userAttributeWriterRegistry.h"
+#include "usdMaya/registryHelper.h"
+
+#include <maya/MSyntax.h>
+#include <maya/MStatus.h>
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+usdListUserAttributeWriters::usdListUserAttributeWriters()
+{
+
+}
+
+usdListUserAttributeWriters::~usdListUserAttributeWriters()
+{
+
+}
+
+MStatus
+usdListUserAttributeWriters::doIt(const MArgList& args)
+{
+    for (const auto& e : UsdMayaUserAttributeWriterRegistry::ListWriters()) {
+        appendToResult(e.GetString().c_str());
+    }
+
+    return MS::kSuccess;
+}
+
+void* usdListUserAttributeWriters::creator()
+{
+    return new usdListUserAttributeWriters();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/listUserAttributeWritersCommand.h
+++ b/third_party/maya/lib/usdMaya/listUserAttributeWritersCommand.h
@@ -1,0 +1,51 @@
+//
+// Copyright 2019 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXRUSDMAYA_USD_LIST_USER_ATTRIBUTE_WRITERS_H
+#define PXRUSDMAYA_USD_LIST_USER_ATTRIBUTE_WRITERS_H
+
+#include "pxr/pxr.h"
+#include "usdMaya/api.h"
+#include <maya/MPxCommand.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class usdListUserAttributeWriters : public MPxCommand
+{
+public:
+    PXRUSDMAYA_API
+    usdListUserAttributeWriters();
+    PXRUSDMAYA_API
+    virtual ~usdListUserAttributeWriters();
+
+    PXRUSDMAYA_API
+    virtual MStatus doIt(const MArgList& args);
+    virtual bool  isUndoable () const { return false; };
+
+    PXRUSDMAYA_API
+    static void* creator();
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // PXRUSDMAYA_USD_LIST_SHADING_MODES_H

--- a/third_party/maya/lib/usdMaya/registryHelper.cpp
+++ b/third_party/maya/lib/usdMaya/registryHelper.cpp
@@ -46,6 +46,7 @@ TF_DEFINE_PRIVATE_TOKENS(_tokens,
     (providesTranslator)
     (UsdMaya)
     (ShadingModePlugin)
+    (UserAttributeWriterPlugin)
 );
 
 template <typename T>
@@ -134,7 +135,7 @@ _ProvidesForType(
 }
 
 static bool
-_HasShadingModePlugin(
+_HasPlugin(
     const PlugPluginPtr& plug,
     const std::vector<TfToken>& scope,
     std::string* mayaPluginName)
@@ -151,6 +152,35 @@ _HasShadingModePlugin(
     }
 
     return false;
+}
+
+static void
+_LoadAllPlugins(std::once_flag& once_flag, const std::vector<TfToken>& scope)
+{
+    std::call_once(once_flag, [&scope](){
+        PlugPluginPtrVector plugins = PlugRegistry::GetInstance().GetAllPlugins();
+        std::string mayaPlugin;
+        TF_FOR_ALL(plugIter, plugins) {
+            PlugPluginPtr plug = *plugIter;
+            if (_HasPlugin(plug, scope, &mayaPlugin) && !mayaPlugin.empty()) {
+                TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg(
+                            "Found usdMaya plugin %s: Loading maya plugin %s.\n", 
+                            plug->GetName().c_str(),
+                            mayaPlugin.c_str());
+                std::string loadPluginCmd = TfStringPrintf(
+                        "loadPlugin -quiet %s", mayaPlugin.c_str());
+                if (MGlobal::executeCommand(loadPluginCmd.c_str())) {
+                    // Need to ensure Python script modules are loaded
+                    // properly for this library (Maya's loadPlugin will not
+                    // load script modules like TfDlopen would).
+                    TfScriptModuleLoader::GetInstance().LoadModules();
+                } else {
+                    TF_CODING_ERROR("Unable to load mayaplugin %s\n",
+                            mayaPlugin.c_str());
+                }
+            }
+        }
+    });
 }
 
 /* static */
@@ -213,30 +243,15 @@ void
 UsdMaya_RegistryHelper::LoadShadingModePlugins() {
     static std::once_flag _shadingModesLoaded;
     static std::vector<TfToken> scope = {_tokens->UsdMaya, _tokens->ShadingModePlugin};
-    std::call_once(_shadingModesLoaded, [](){        
-        PlugPluginPtrVector plugins = PlugRegistry::GetInstance().GetAllPlugins();
-        std::string mayaPlugin;
-        TF_FOR_ALL(plugIter, plugins) {
-            PlugPluginPtr plug = *plugIter;
-            if (_HasShadingModePlugin(plug, scope, &mayaPlugin) && !mayaPlugin.empty()) {
-                TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg(
-                            "Found usdMaya plugin %s: Loading maya plugin %s.\n", 
-                            plug->GetName().c_str(),
-                            mayaPlugin.c_str());
-                std::string loadPluginCmd = TfStringPrintf(
-                        "loadPlugin -quiet %s", mayaPlugin.c_str());
-                if (MGlobal::executeCommand(loadPluginCmd.c_str())) {
-                    // Need to ensure Python script modules are loaded
-                    // properly for this library (Maya's loadPlugin will not
-                    // load script modules like TfDlopen would).
-                    TfScriptModuleLoader::GetInstance().LoadModules();
-                } else {
-                    TF_CODING_ERROR("Unable to load mayaplugin %s\n",
-                            mayaPlugin.c_str());
-                }
-            }
-        }
-    });
+    _LoadAllPlugins(_shadingModesLoaded, scope);
+}
+
+void
+UsdMaya_RegistryHelper::LoadUserAttributeWriterPlugins()
+{
+    static std::once_flag _userAttributeWritersLoaded;
+    static std::vector<TfToken> scope = {_tokens->UsdMaya, _tokens->UserAttributeWriterPlugin};
+    _LoadAllPlugins(_userAttributeWritersLoaded, scope);
 }
 
 /* static */

--- a/third_party/maya/lib/usdMaya/registryHelper.h
+++ b/third_party/maya/lib/usdMaya/registryHelper.h
@@ -76,6 +76,20 @@ struct UsdMaya_RegistryHelper
     static void
         LoadShadingModePlugins();
 
+    /// Searches the plugInfos and looks for UserAttributeWriters.
+    /// 
+    /// "UsdMaya" : {
+    ///     "UserAttributeWriter" : {
+    ///         "mayaPlugin" : "customAttributeWriter"
+    ///     }
+    /// }
+    ///
+    /// At that scope, it expects a dictionary with one key: "mayaPlugin".
+    /// usdMaya will try to load the "mayaPlugin" when user attribute
+    /// writers are first accessed.
+    static void
+    LoadUserAttributeWriterPlugins();
+
     /// Searches the plugInfos for metadata dictionaries at the given \p scope,
     /// and composes them together. 
     /// The scope are the nested keys to search through in the plugInfo (for

--- a/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
+++ b/third_party/maya/lib/usdMaya/usdListShadingModes.cpp
@@ -1,0 +1,89 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "usdMaya/usdListShadingModes.h"
+
+#include "usdMaya/shadingModeRegistry.h"
+#include "usdMaya/registryHelper.h"
+
+#include <maya/MSyntax.h>
+#include <maya/MStatus.h>
+#include <maya/MArgList.h>
+#include <maya/MArgDatabase.h>
+#include <maya/MString.h>
+
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+usdListShadingModes::usdListShadingModes() {
+
+}
+
+usdListShadingModes::~usdListShadingModes() {
+
+}
+
+MStatus
+usdListShadingModes::doIt(const MArgList& args) {    
+    MStatus status;
+    MArgDatabase argData(syntax(), args, &status);
+
+    if (status != MS::kSuccess) {
+        return status;
+    }
+
+    TfTokenVector v;
+    if (argData.isFlagSet("export")) {
+        v = PxrUsdMayaShadingModeRegistry::ListExporters();
+    } else if (argData.isFlagSet("import")) {
+        v = PxrUsdMayaShadingModeRegistry::ListImporters();
+    }
+
+    // Always include the "none" shading mode.
+    appendToResult(PxrUsdMayaShadingModeTokens->none.GetText());
+
+    for (const auto& e : v) {
+        appendToResult(e.GetText());
+    }
+
+    return MS::kSuccess;
+}
+
+MSyntax
+usdListShadingModes::createSyntax() {
+    MSyntax syntax;
+    syntax.addFlag("-ex", "-export", MSyntax::kNoArg);
+    syntax.addFlag("-im", "-import", MSyntax::kNoArg);
+
+    syntax.enableQuery(false);
+    syntax.enableEdit(false);
+
+    return syntax;
+}
+
+void* usdListShadingModes::creator() {
+    return new usdListShadingModes();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/userAttributeWriterRegistry.cpp
+++ b/third_party/maya/lib/usdMaya/userAttributeWriterRegistry.cpp
@@ -1,0 +1,84 @@
+//
+// Copyright 2019 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "usdMaya/userAttributeWriterRegistry.h"
+
+#include "usdMaya/registryHelper.h"
+
+#include "pxr/base/tf/instantiateSingleton.h"
+#include "pxr/base/tf/registryManager.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+    using _WriterRegistry = std::map<TfToken, UsdMayaUserAttributeWriterRegistry::UserAttributeWriter>;
+    _WriterRegistry _writerReg;
+}
+
+TfTokenVector UsdMayaUserAttributeWriterRegistry::_ListWriters()
+{
+    UsdMaya_RegistryHelper::LoadUserAttributeWriterPlugins();
+    TfRegistryManager::GetInstance().SubscribeTo<UsdMayaUserAttributeWriterRegistry>();
+    TfTokenVector ret;
+    ret.reserve(_writerReg.size());
+    for (const auto& nameAndWriter : _writerReg) {
+        ret.push_back(nameAndWriter.first);
+    }
+    return ret;
+}
+
+void UsdMayaUserAttributeWriterRegistry::RegisterWriter(
+    const std::string& name,
+    const UserAttributeWriter& fn)
+{
+    _writerReg.insert(std::make_pair(TfToken(name), fn));
+}
+
+UsdMayaUserAttributeWriterRegistry::UserAttributeWriter UsdMayaUserAttributeWriterRegistry::_GetWriter(const TfToken& name)
+{
+    UsdMaya_RegistryHelper::LoadUserAttributeWriterPlugins();
+    TfRegistryManager::GetInstance().SubscribeTo<UsdMayaUserAttributeWriterRegistry>();
+    const auto it = _writerReg.find(name);
+    return it == _writerReg.end() ? nullptr : it->second;
+}
+
+TF_INSTANTIATE_SINGLETON(UsdMayaUserAttributeWriterRegistry);
+
+UsdMayaUserAttributeWriterRegistry&
+UsdMayaUserAttributeWriterRegistry::GetInstance()
+{
+    return TfSingleton<UsdMayaUserAttributeWriterRegistry>::GetInstance();
+}
+
+UsdMayaUserAttributeWriterRegistry::UsdMayaUserAttributeWriterRegistry()
+{
+
+}
+
+UsdMayaUserAttributeWriterRegistry::~UsdMayaUserAttributeWriterRegistry()
+{
+
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/userAttributeWriterRegistry.h
+++ b/third_party/maya/lib/usdMaya/userAttributeWriterRegistry.h
@@ -1,0 +1,85 @@
+//
+// Copyright 2019 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#ifndef PXRUSDMAYA_USERATTRIBUTEWRITERREGISTRY_H
+#define PXRUSDMAYA_USERATTRIBUTEWRITERREGISTRY_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/weakBase.h"
+#include "pxr/base/tf/singleton.h"
+#include "pxr/usd/usd/prim.h"
+
+#include "usdMaya/api.h"
+
+#include <maya/MPlug.h>
+
+#include <functional>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DECLARE_WEAK_PTRS(UsdMayaUserAttributeWriterRegistry);
+
+/// \class UsdMayaUserAttributeWriterRegistry
+/// \brief This class provides access to the registered
+/// userAttributeWriters.
+class UsdMayaUserAttributeWriterRegistry : public TfWeakBase {
+public:
+    using UserAttributeWriter = std::function<UsdAttribute(
+        const MPlug&,
+        const UsdPrim&,
+        const std::string&,
+        const std::string&,
+        const bool)>;
+
+    PXRUSDMAYA_API
+    static UsdMayaUserAttributeWriterRegistry& GetInstance();
+
+    /// \brief registers a new user attribute writer.
+    PXRUSDMAYA_API
+    static void RegisterWriter(
+        const std::string& name,
+        const UserAttributeWriter& fn);
+
+    /// \brief returns a list of available writers.
+    static TfTokenVector ListWriters() {
+        return GetInstance()._ListWriters();
+    }
+
+    /// \brief returns a writer registered to \p name or
+    /// or a nullptr std::function of none available.
+    static UserAttributeWriter GetWriter(const TfToken& name) {
+        return GetInstance()._GetWriter(name);
+    }
+private:
+    TfTokenVector _ListWriters();
+    UserAttributeWriter _GetWriter(const TfToken& name);
+
+    UsdMayaUserAttributeWriterRegistry();
+    ~UsdMayaUserAttributeWriterRegistry();
+    friend class TfSingleton<UsdMayaUserAttributeWriterRegistry>;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXRUSDMAYA_USERATTRIBUTEWRITERREGISTRY_H

--- a/third_party/maya/lib/usdMaya/writeUtil.cpp
+++ b/third_party/maya/lib/usdMaya/writeUtil.cpp
@@ -27,6 +27,7 @@
 #include "usdMaya/adaptor.h"
 #include "usdMaya/colorSpace.h"
 #include "usdMaya/translatorUtil.h"
+#include "usdMaya/userAttributeWriterRegistry.h"
 #include "usdMaya/userTaggedAttribute.h"
 
 #include "pxr/base/gf/gamma.h"
@@ -973,11 +974,21 @@ UsdMayaWriteUtil::WriteUserExportedAttributes(
                                                                "user",
                                                                translateMayaDoubleToUsdSinglePrecision);
         } else {
-            usdAttr = UsdMayaWriteUtil::GetOrCreateUsdAttr(attrPlug,
-                                                              usdPrim,
-                                                              usdAttrName,
-                                                              true,
-                                                              translateMayaDoubleToUsdSinglePrecision);
+            auto attributeWriter = UsdMayaUserAttributeWriterRegistry::GetWriter(usdAttrType);
+            if (attributeWriter != nullptr) {
+                usdAttr = attributeWriter(attrPlug,
+                                          usdPrim,
+                                          usdAttrName,
+                                          "user",
+                                          translateMayaDoubleToUsdSinglePrecision);
+            } else {
+                usdAttr =
+                    UsdMayaWriteUtil::GetOrCreateUsdAttr(attrPlug,
+                                                         usdPrim,
+                                                         usdAttrName,
+                                                         true,
+                                                         translateMayaDoubleToUsdSinglePrecision);
+            }
         }
 
         if (usdAttr) {

--- a/third_party/maya/plugin/pxrUsd/plugin.cpp
+++ b/third_party/maya/plugin/pxrUsd/plugin.cpp
@@ -43,6 +43,7 @@
 #include "usdMaya/stageData.h"
 #include "usdMaya/stageNode.h"
 #include "usdMaya/undoHelperCommand.h"
+#include "usdMaya/listUserAttributeWritersCommand.h"
 
 #include <maya/MDrawRegistry.h>
 #include <maya/MFnPlugin.h>
@@ -184,6 +185,14 @@ initializePlugin(MObject obj)
     }
 
     status = plugin.registerCommand(
+        "usdListUserAttributeWriters",
+        usdListUserAttributeWriters::creator);
+
+    if (!status) {
+        status.perror("registerCommand usdListUserAttributeWriters");
+    }
+
+    status = plugin.registerCommand(
         "usdUndoHelperCmd",
         UsdMayaUndoHelperCommand::creator,
         UsdMayaUndoHelperCommand::createSyntax);
@@ -239,6 +248,11 @@ uninitializePlugin(MObject obj)
     status = plugin.deregisterCommand("usdListShadingModes");
     if (!status) {
         status.perror("deregisterCommand usdListShadingModes");
+    }
+
+    status = plugin.deregisterCommand("usdListUserAttributeWriters");
+    if (!status) {
+        status.perror("deregisterCommand usdListUserAttributeWriters");
     }
 
     status = plugin.deregisterCommand("usdUndoHelperCmd");


### PR DESCRIPTION
### Description of Change(s)
Adding a new plugin registry to be able to specify user attribute plugins for usdMaya. Also moved usdRi to the new interface.

Note, I accidentally left in a change that adds a copyright notice to usdListShadingModes, that was left out from one of our PRs last year. I can move that to a separate PR if you prefer.

### Fixes Issue(s)
None.

