### PR TITLE
[maya] factor out matching of xforms into PxrUsdMayaXformStack

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -59,6 +59,7 @@ pxr_shared_library(${PXR_PACKAGE}
         util
         usdPrimProvider
         writeUtil
+        xformStack
 
         MayaPrimWriter
         MayaTransformWriter
@@ -124,6 +125,7 @@ pxr_shared_library(${PXR_PACKAGE}
         wrapRoundTripUtil.cpp
         wrapStageCache.cpp
         wrapUserTaggedAttribute.cpp
+        wrapXformStack.cpp
 
     PYMODULE_FILES
         __init__.py
@@ -167,6 +169,7 @@ pxr_test_scripts(
         testenv/testUsdMayaProxyShape.py
         testenv/testUsdMayaReferenceAssemblyEdits.py
         testenv/testUsdMayaUserExportedAttributes.py
+        testenv/testUsdMayaXformStack.py
         testenv/testUsdMetadataAttributeConverters.py
         testenv/testUsdReferenceAssemblyChangeRepresentations.py
         testenv/testUsdReferenceAssemblySelection.py
@@ -566,3 +569,12 @@ pxr_register_test(testUsdReferenceAssemblySelection
         MAYA_DISABLE_CIP=1
 )
 
+pxr_register_test(testUsdMayaXformStack
+    CUSTOM_PYTHON "${MAYA_BASE_DIR}/bin/mayapy"
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMayaXformStack"
+    TESTENV testUsdMayaXformStack
+    ENV
+        MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
+        MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
+        MAYA_DISABLE_CIP=1
+)

--- a/third_party/maya/lib/usdMaya/module.cpp
+++ b/third_party/maya/lib/usdMaya/module.cpp
@@ -34,4 +34,5 @@ TF_WRAP_MODULE {
     TF_WRAP(RoundTripUtil);
     TF_WRAP(StageCache);
     TF_WRAP(UserTaggedAttribute);
+    TF_WRAP(XformStack);
 }

--- a/third_party/maya/lib/usdMaya/testenv/UsdImportXformsTest/UsdImportXformsTestRotateAxis.usda
+++ b/third_party/maya/lib/usdMaya/testenv/UsdImportXformsTest/UsdImportXformsTestRotateAxis.usda
@@ -1,0 +1,82 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World" (
+    kind = "component"
+)
+{
+    def Xform "X"
+    {
+            float xformOp:rotateX:rotateAxis = 60
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateX:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "Y"
+    {
+            float xformOp:rotateY:rotateAxis = 60
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateY:rotateAxis", "xformOp:scale"]
+    }
+    
+    def Xform "Z"
+    {
+            float xformOp:rotateZ:rotateAxis = 60
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZ:rotateAxis", "xformOp:scale"]
+    }
+    
+    def Xform "XYZ"
+    {
+            float3 xformOp:rotateXYZ:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "YZX"
+    {
+            float3 xformOp:rotateYZX:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateYZX:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "ZXY"
+    {
+            float3 xformOp:rotateZXY:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZXY:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "XZY"
+    {
+            float3 xformOp:rotateXZY:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXZY:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "YXZ"
+    {
+            float3 xformOp:rotateYXZ:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateYXZ:rotateAxis", "xformOp:scale"]
+    }
+
+    def Xform "ZYX"
+    {
+            float3 xformOp:rotateZYX:rotateAxis = (60, 120, 180)
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            double3 xformOp:translate = (1.0, 2.0, 3.0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX:rotateAxis", "xformOp:scale"]
+    }
+}

--- a/third_party/maya/lib/usdMaya/testenv/testUsdImportXforms.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdImportXforms.py
@@ -191,6 +191,48 @@ class testUsdImportXforms(unittest.TestCase):
                         print "full failed xform:"
                         pprint.pprint(attrVals)
                         raise
+                    
+    def testImportXformsRotateAxis(self):
+        """
+        Tests that importing xforms that have a rotateAxis with rotate order other than just XYZ
+        still imports correctly
+        """
+        usdFile = os.path.abspath('UsdImportXformsTestRotateAxis.usda')
+        cmds.usdImport(file=usdFile, shadingMode='none')
+        
+        expectedRotates = {
+            'X': (60, 0, 0),
+            'Y': (0, 60, 0),
+            'Z': (0, 0, 60),
+            'XYZ': (-120, 60, 0),
+            'YZX': (-106.1021138, 25.6589063, 56.3099325),
+            'ZXY': (120, -60, 0),
+            'XZY': (-120, -60, 0),
+            'YXZ': (106.1021138, 25.6589063, -56.3099325),
+            'ZYX': (-106.1021138, -25.6589063, -56.3099325),
+        }
+        expectedScale = (.5, .5, .5)
+        expectedTranslation = (1.0, 2.0, 3.0)
+        
+        for rotOrderName, expectedRotation in expectedRotates.iteritems():
+            mayaTransform = self._GetMayaTransform(rotOrderName)
+            transformationMatrix = mayaTransform.transformation()
+    
+            actualTranslation = list(
+                transformationMatrix.translation(OM.MSpace.kTransform))
+            self.assertTrue(
+                Gf.IsClose(expectedTranslation, actualTranslation, self.EPSILON))
+    
+            expectedRotation = [Gf.DegreesToRadians(x) for x in expectedRotation]
+            actualRotation = transformationMatrix.rotationOrientation().asEulerRotation()
+            actualRotation = list(actualRotation)
+            #print rotOrderName, actualRotation
+            self.assertTrue(
+                Gf.IsClose(expectedRotation, actualRotation, self.EPSILON))
+    
+            actualScale = list(transformationMatrix.scale(OM.MSpace.kTransform))
+            self.assertTrue(
+                Gf.IsClose(expectedScale, actualScale, self.EPSILON))
 
 
     def testPivot(self):

--- a/third_party/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
@@ -1,0 +1,1161 @@
+#!/pxrpythonsubst
+#
+# Copyright 2017 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+from pxr import Gf, Usd
+
+# XXX: The try/except here is temporary until we change the Pixar-internal
+# package name to match the external package name.
+try:
+    from pxr import UsdMaya
+except ImportError:
+    from pixar import UsdMaya
+
+from maya import cmds
+from maya.api import OpenMaya as OM
+from maya import standalone
+
+import os
+import unittest
+import pprint
+import itertools
+from collections import OrderedDict
+
+class testUsdMayaXformStack(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        standalone.initialize('usd')
+        cmds.loadPlugin('pxrUsd')
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+    
+    # Named so this runs first, so we can be reasonably sure
+    # that UsdGeom hasn't been imported yet - see below
+    # tests:
+    #   PxrUsdMayaXformOpClassification::GetOpType
+    def test00GetOpType(self):
+        translateOp = UsdMaya.XformStack.CommonStack().GetOps()[0]
+        # could import UsdGeom, and compare objects
+        # directly, but had a bug where if you didn't
+        # import UsdGeom, the wrappers for
+        # XformOp::Type weren't created yet... so test
+        # for this
+        self.assertEqual(
+            str(translateOp.GetOpType()),
+            'UsdGeom.XformOp.TypeTranslate')
+        # ok, we've tested the XformOp::Type wrapper,
+        # may as well make sure the actual objects
+        # line up
+        from pxr import UsdGeom
+        self.assertEqual(
+            translateOp.GetOpType(),
+            UsdGeom.XformOp.TypeTranslate)
+
+    # tests:
+    #   PxrUsdMayaXformOpClassification::GetName
+    #   PxrUsdMayaXformOpClassification::GetOpType
+    #   PxrUsdMayaXformOpClassification::IsInvertedTwin
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::GetOps    
+    def testMayaStack(self):
+        from pxr import UsdGeom
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(
+            [(x.GetName(), x.IsInvertedTwin(), x.GetOpType()) for x in mayaStack.GetOps()],
+            [
+                ('translate',             False, UsdGeom.XformOp.TypeTranslate),
+                ('rotatePivotTranslate',  False, UsdGeom.XformOp.TypeTranslate),
+                ('rotatePivot',           False, UsdGeom.XformOp.TypeTranslate),
+                ('rotate',                False, UsdGeom.XformOp.TypeRotateXYZ),
+                ('rotateAxis',            False, UsdGeom.XformOp.TypeRotateXYZ),
+                ('rotatePivot',           True,  UsdGeom.XformOp.TypeTranslate),
+                ('scalePivotTranslate',   False, UsdGeom.XformOp.TypeTranslate),
+                ('scalePivot',            False, UsdGeom.XformOp.TypeTranslate),
+                ('shear',                 False, UsdGeom.XformOp.TypeTransform),
+                ('scale',                 False, UsdGeom.XformOp.TypeScale),
+                ('scalePivot',            True,  UsdGeom.XformOp.TypeTranslate),
+            ]
+        )
+            
+    # tests:
+    #   PxrUsdMayaXformOpClassification::GetName
+    #   PxrUsdMayaXformOpClassification::GetOpType
+    #   PxrUsdMayaXformOpClassification::IsInvertedTwin
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformStack::GetOps
+    def testCommonStack(self):
+        from pxr import UsdGeom
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(
+            [(x.GetName(), x.IsInvertedTwin(), x.GetOpType()) for x in commonStack.GetOps()],
+            [
+                ('translate', False, UsdGeom.XformOp.TypeTranslate),
+                ('pivot',     False, UsdGeom.XformOp.TypeTranslate),
+                ('rotate',    False, UsdGeom.XformOp.TypeRotateXYZ),
+                ('scale',     False, UsdGeom.XformOp.TypeScale),
+                ('pivot',     True,  UsdGeom.XformOp.TypeTranslate),
+            ]
+        )
+        
+    # tests:
+    #   PxrUsdMayaXformOpClassification::GetName
+    #   PxrUsdMayaXformOpClassification::GetOpType
+    #   PxrUsdMayaXformOpClassification::IsInvertedTwin
+    #   PxrUsdMayaXformStack::MatrixStack
+    #   PxrUsdMayaXformStack::GetOps
+    def testMatrixStack(self):
+        from pxr import UsdGeom
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        self.assertEqual(
+            [(x.GetName(), x.IsInvertedTwin(), x.GetOpType()) for x in matrixStack.GetOps()],
+            [('transform', False, UsdGeom.XformOp.TypeTransform)]
+        )
+
+    # tests:
+    #   PxrUsdMayaXformOpClassification::IsCompatibleType
+    #   PxrUsdMayaXformStack::CommonStack        
+    #   PxrUsdMayaXformStack::FindOp
+    def testIsCompatibleType(self):
+        from pxr import UsdGeom
+        commonStack = UsdMaya.XformStack.CommonStack()
+        
+        translateOp = commonStack.FindOp('translate') 
+        for opType in UsdGeom.XformOp.Type.allValues:
+            if opType == UsdGeom.XformOp.TypeTranslate:
+                self.assertTrue(translateOp.IsCompatibleType(opType),
+                                "{} should be compatible with {}".format(
+                                    translateOp.GetName(),
+                                    opType))
+            else:
+                self.assertFalse(translateOp.IsCompatibleType(opType),
+                                "{} should not be compatible with {}".format(
+                                    translateOp.GetName(),
+                                    opType))
+                
+        rotateOp = commonStack.FindOp('rotate')
+        for opType in UsdGeom.XformOp.Type.allValues:
+            if str(opType).startswith('UsdGeom.XformOp.TypeRotate'):
+                self.assertTrue(rotateOp.IsCompatibleType(opType),
+                                "{} should be compatible with {}".format(
+                                    rotateOp.GetName(),
+                                    opType))
+            else:
+                self.assertFalse(rotateOp.IsCompatibleType(opType),
+                                "{} should not be compatible with {}".format(
+                                    rotateOp.GetName(),
+                                    opType))
+    
+    # tests:
+    #   PxrUsdMayaXformOpClassification::operator==
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformStack::MayaStack
+    def testOpClassEqual(self):
+        mayaTranslate = UsdMaya.XformStack.MayaStack().GetOps()[0]
+        commonTranslate = UsdMaya.XformStack.CommonStack().GetOps()[0]
+        self.assertIsNot(mayaTranslate, commonTranslate)
+        self.assertEqual(mayaTranslate, commonTranslate)
+
+    # tests:
+    #   PxrUsdMayaXformOpClassification::CompatibleAttrNames
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::FindOp
+    def testCompatibleAttrNames(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        
+        translateOp = mayaStack.FindOp('translate')
+        self.assertItemsEqual(
+            translateOp.CompatibleAttrNames(),
+            [
+                'xformOp:translate:translate',
+                'xformOp:translate',  
+            ]
+        )
+        
+        rotateOp = mayaStack.FindOp('rotate')
+        self.assertItemsEqual(
+            rotateOp.CompatibleAttrNames(),
+            [
+                'xformOp:rotateX',
+                'xformOp:rotateX:rotate',
+                'xformOp:rotateX:rotateX',
+                'xformOp:rotateY',
+                'xformOp:rotateY:rotate',
+                'xformOp:rotateY:rotateY',
+                'xformOp:rotateZ',
+                'xformOp:rotateZ:rotate',
+                'xformOp:rotateZ:rotateZ',
+                'xformOp:rotateXYZ',
+                'xformOp:rotateXYZ:rotate',
+                'xformOp:rotateXYZ:rotateXYZ',
+                'xformOp:rotateXZY',
+                'xformOp:rotateXZY:rotate',
+                'xformOp:rotateXZY:rotateXZY',
+                'xformOp:rotateYXZ',
+                'xformOp:rotateYXZ:rotate',
+                'xformOp:rotateYXZ:rotateYXZ',
+                'xformOp:rotateYZX',
+                'xformOp:rotateYZX:rotate',
+                'xformOp:rotateYZX:rotateYZX',
+                'xformOp:rotateZXY',
+                'xformOp:rotateZXY:rotate',
+                'xformOp:rotateZXY:rotateZXY',
+                'xformOp:rotateZYX',
+                'xformOp:rotateZYX:rotate',
+                'xformOp:rotateZYX:rotateZYX',
+            ]
+        )
+        
+        shearOp = mayaStack.FindOp('shear')
+        self.assertItemsEqual(
+            shearOp.CompatibleAttrNames(),
+            [
+                'xformOp:transform:shear',
+            ]
+        )
+        
+        rotatePivotOp = mayaStack.FindOp('rotatePivot', isInvertedTwin=True)
+        self.assertItemsEqual(
+            rotatePivotOp.CompatibleAttrNames(),
+            [
+                'xformOp:translate:rotatePivot',
+            ]
+        )
+        
+    def testNoInit(self):
+        try:
+            UsdMaya.XformOpClassification()
+        except Exception as e:
+            self.assertTrue('cannot be instantiated from Python' in str(e))
+
+        try:
+            UsdMaya.XformStack()
+        except Exception as e:
+            self.assertTrue('cannot be instantiated from Python' in str(e))
+
+    # tests:
+    #   PxrUsdMayaXformStack::GetInversionTwins
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformStack::MatrixStack
+    def testGetInversionTwins(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(mayaStack.GetInversionTwins(),
+                         [(2, 5), (7, 10)])
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(commonStack.GetInversionTwins(),
+                         [(1, 4)])
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        self.assertEqual(matrixStack.GetInversionTwins(),
+                         [])
+    
+    # tests:
+    #   PxrUsdMayaXformStack::GetNameMatters
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformStack::MatrixStack
+    def testGetNameMatters(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertTrue(mayaStack.GetNameMatters())
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertTrue(commonStack.GetNameMatters())
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        self.assertFalse(matrixStack.GetNameMatters())
+        
+    # tests:
+    #   PxrUsdMayaXformStack::GetSize
+    #   PxrUsdMayaXformStack::(__len__)
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformStack::MatrixStack
+    def testGetSize(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(len(mayaStack), 11)
+        self.assertEqual(mayaStack.GetSize(), 11)
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(len(commonStack), 5)
+        self.assertEqual(commonStack.GetSize(), 5)
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        self.assertEqual(len(matrixStack), 1)
+        self.assertEqual(matrixStack.GetSize(), 1)
+        
+    #   PxrUsdMayaXformStack::operator[]
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformOpClassification::GetName
+    def testIndexing(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(mayaStack[0].GetName(), 'translate')
+        self.assertEqual(mayaStack[1].GetName(), 'rotatePivotTranslate')
+        self.assertEqual(mayaStack[2].GetName(), 'rotatePivot')
+        self.assertEqual(mayaStack[3].GetName(), 'rotate')
+        self.assertEqual(mayaStack[4].GetName(), 'rotateAxis')
+        self.assertEqual(mayaStack[5].GetName(), 'rotatePivot')
+        self.assertEqual(mayaStack[6].GetName(), 'scalePivotTranslate')
+        self.assertEqual(mayaStack[7].GetName(), 'scalePivot')
+        self.assertEqual(mayaStack[8].GetName(), 'shear')
+        self.assertEqual(mayaStack[9].GetName(), 'scale')
+        self.assertEqual(mayaStack[10].GetName(), 'scalePivot')
+
+        self.assertEqual(mayaStack[-11].GetName(), 'translate')
+        self.assertEqual(mayaStack[-10].GetName(), 'rotatePivotTranslate')
+        self.assertEqual(mayaStack[-9].GetName(), 'rotatePivot')
+        self.assertEqual(mayaStack[-8].GetName(), 'rotate')
+        self.assertEqual(mayaStack[-7].GetName(), 'rotateAxis')
+        self.assertEqual(mayaStack[-6].GetName(), 'rotatePivot')
+        self.assertEqual(mayaStack[-5].GetName(), 'scalePivotTranslate')
+        self.assertEqual(mayaStack[-4].GetName(), 'scalePivot')
+        self.assertEqual(mayaStack[-3].GetName(), 'shear')
+        self.assertEqual(mayaStack[-2].GetName(), 'scale')
+        self.assertEqual(mayaStack[-1].GetName(), 'scalePivot')
+        
+        def getStackItem(i):
+            return mayaStack[i]
+        
+        self.assertRaises(IndexError, getStackItem, 11)
+        self.assertRaises(IndexError, getStackItem, 12)
+        self.assertRaises(IndexError, getStackItem, 300)
+        self.assertRaises(IndexError, getStackItem, -12)
+        self.assertRaises(IndexError, getStackItem, -13)
+        self.assertRaises(IndexError, getStackItem, -1000)
+
+    #   PxrUsdMayaXformStack::FindOpIndex
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    def testFindOpIndex(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(mayaStack.FindOpIndex('translate'), 0)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivotTranslate'), 1)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivot'), 2)
+        self.assertEqual(mayaStack.FindOpIndex('rotate'), 3)
+        self.assertEqual(mayaStack.FindOpIndex('rotateAxis'), 4)
+        #assertEqual(mayaStack.FindOpIndex('rotatePivot'), 5)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivotTranslate'), 6)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivot'), 7)
+        self.assertEqual(mayaStack.FindOpIndex('shear'), 8)
+        self.assertEqual(mayaStack.FindOpIndex('scale'), 9)
+        #assertEqual(mayaStack.FindOpIndex('scalePivot'), 10)
+
+        self.assertEqual(mayaStack.FindOpIndex('translate', isInvertedTwin=False), 0)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivotTranslate', isInvertedTwin=False), 1)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivot', isInvertedTwin=False), 2)
+        self.assertEqual(mayaStack.FindOpIndex('rotate', isInvertedTwin=False), 3)
+        self.assertEqual(mayaStack.FindOpIndex('rotateAxis', isInvertedTwin=False), 4)
+        #assertEqual(mayaStack.FindOpIndex('rotatePivot', isInvertedTwin=False), 5)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivotTranslate', isInvertedTwin=False), 6)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivot', isInvertedTwin=False), 7)
+        self.assertEqual(mayaStack.FindOpIndex('shear', isInvertedTwin=False), 8)
+        self.assertEqual(mayaStack.FindOpIndex('scale', isInvertedTwin=False), 9)
+        #assertEqual(mayaStack.FindOpIndex('scalePivot', isInvertedTwin=False), 10)
+
+        self.assertEqual(mayaStack.FindOpIndex('translate', False), 0)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivotTranslate', False), 1)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivot', False), 2)
+        self.assertEqual(mayaStack.FindOpIndex('rotate', False), 3)
+        self.assertEqual(mayaStack.FindOpIndex('rotateAxis', False), 4)
+        #assertEqual(mayaStack.FindOpIndex('rotatePivot', False), 5)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivotTranslate', False), 6)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivot', False), 7)
+        self.assertEqual(mayaStack.FindOpIndex('shear', False), 8)
+        self.assertEqual(mayaStack.FindOpIndex('scale', False), 9)
+        #assertEqual(mayaStack.FindOpIndex('scalePivot', False), 10)
+
+        self.assertIs(mayaStack.FindOpIndex('translate', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOpIndex('rotatePivotTranslate', isInvertedTwin=True), None)
+        #self.assertIs(mayaStack.FindOpIndex('rotatePivot', isInvertedTwin=True), 2)
+        self.assertIs(mayaStack.FindOpIndex('rotate', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOpIndex('rotateAxis', isInvertedTwin=True), None)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivot', isInvertedTwin=True), 5)
+        self.assertIs(mayaStack.FindOpIndex('scalePivotTranslate', isInvertedTwin=True), None)
+        #self.assertIs(mayaStack.FindOpIndex('scalePivot', isInvertedTwin=True), 7)
+        self.assertIs(mayaStack.FindOpIndex('shear', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOpIndex('scale', isInvertedTwin=True), None)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivot', isInvertedTwin=True), 10)
+
+        self.assertIs(mayaStack.FindOpIndex('translate', True), None)
+        self.assertIs(mayaStack.FindOpIndex('rotatePivotTranslate', True), None)
+        #self.assertIs(mayaStack.FindOpIndex('rotatePivot', True), 2)
+        self.assertIs(mayaStack.FindOpIndex('rotate', True), None)
+        self.assertIs(mayaStack.FindOpIndex('rotateAxis', True), None)
+        self.assertEqual(mayaStack.FindOpIndex('rotatePivot', True), 5)
+        self.assertIs(mayaStack.FindOpIndex('scalePivotTranslate', True), None)
+        #self.assertIs(mayaStack.FindOpIndex('scalePivot', True), 7)
+        self.assertIs(mayaStack.FindOpIndex('shear', True), None)
+        self.assertIs(mayaStack.FindOpIndex('scale', True), None)
+        self.assertEqual(mayaStack.FindOpIndex('scalePivot', True), 10)
+        
+        self.assertIs(mayaStack.FindOpIndex('pivot'), None)
+        self.assertIs(mayaStack.FindOpIndex('pivot', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOpIndex('pivot', True), None)
+        self.assertIs(mayaStack.FindOpIndex('pivot', isInvertedTwin=False), None)
+        self.assertIs(mayaStack.FindOpIndex('pivot', False), None)
+        
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(commonStack.FindOpIndex('pivot'), 1)
+        self.assertEqual(commonStack.FindOpIndex('pivot', isInvertedTwin=True), 4)
+        self.assertEqual(commonStack.FindOpIndex('pivot', True), 4)
+        self.assertEqual(commonStack.FindOpIndex('pivot', isInvertedTwin=False), 1)
+        self.assertEqual(commonStack.FindOpIndex('pivot', False), 1)
+        self.assertEqual(commonStack.FindOpIndex('rotate'), 2)
+        self.assertIs(commonStack.FindOpIndex('rotate', isInvertedTwin=True), None)
+        self.assertIs(commonStack.FindOpIndex('rotate', True), None)
+        self.assertEqual(commonStack.FindOpIndex('rotate', isInvertedTwin=False), 2)
+        self.assertEqual(commonStack.FindOpIndex('rotate', False), 2)
+        self.assertIs(commonStack.FindOpIndex('scalePivot'), None)
+        self.assertIs(commonStack.FindOpIndex('scalePivot', isInvertedTwin=True), None)
+        self.assertIs(commonStack.FindOpIndex('scalePivot', True), None)
+        self.assertIs(commonStack.FindOpIndex('scalePivot', isInvertedTwin=False), None)
+        self.assertIs(commonStack.FindOpIndex('scalePivot', False), None)
+        
+    #   PxrUsdMayaXformStack::FindOpIndex
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformOpClassification::GetName
+    #   PxrUsdMayaXformOpClassification::IsInvertedTwin
+    def testFindOp(self):
+        def getNameInverted(op):
+            return (op.GetName(), op.IsInvertedTwin())
+        
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(getNameInverted(mayaStack.FindOp('translate')),
+                    ('translate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivotTranslate')),
+                    ('rotatePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot')),
+                    ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotate')),
+                    ('rotate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotateAxis')),
+                    ('rotateAxis', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot')),
+        #            ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivotTranslate')),
+                    ('scalePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivot')),
+                    ('scalePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('shear')),
+                    ('shear', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scale')),
+                    ('scale', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('scalePivot')),
+        #            ('scalePivot', False))
+
+        self.assertEqual(getNameInverted(mayaStack.FindOp('translate', isInvertedTwin=False)),
+                    ('translate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivotTranslate', isInvertedTwin=False)),
+                    ('rotatePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', isInvertedTwin=False)),
+                    ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotate', isInvertedTwin=False)),
+                    ('rotate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotateAxis', isInvertedTwin=False)),
+                    ('rotateAxis', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', isInvertedTwin=False)),
+        #            ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivotTranslate', isInvertedTwin=False)),
+                    ('scalePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', isInvertedTwin=False)),
+                    ('scalePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('shear', isInvertedTwin=False)),
+                    ('shear', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scale', isInvertedTwin=False)),
+                    ('scale', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', isInvertedTwin=False)),
+        #            ('scalePivot', False))
+
+        self.assertEqual(getNameInverted(mayaStack.FindOp('translate', False)),
+                    ('translate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivotTranslate', False)),
+                    ('rotatePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', False)),
+                    ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotate', False)),
+                    ('rotate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotateAxis', False)),
+                    ('rotateAxis', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', False)),
+        #            ('rotatePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivotTranslate', False)),
+                    ('scalePivotTranslate', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', False)),
+                    ('scalePivot', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('shear', False)),
+                    ('shear', False))
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scale', False)),
+                    ('scale', False))
+        #assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', False)),
+        #            ('scalePivot', False))
+
+        self.assertIs(mayaStack.FindOp('translate', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('rotatePivotTranslate', isInvertedTwin=True), None)
+        #self.assertIs(mayaStack.FindOp('rotatePivot', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('rotate', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('rotateAxis', isInvertedTwin=True), None)
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', isInvertedTwin=True)),
+                    ('rotatePivot', True))
+        self.assertIs(mayaStack.FindOp('scalePivotTranslate', isInvertedTwin=True), None)
+        #self.assertIs(mayaStack.FindOp('scalePivot', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('shear', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('scale', isInvertedTwin=True), None)
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', isInvertedTwin=True)),
+                    ('scalePivot', True))
+
+        self.assertIs(mayaStack.FindOp('translate', True), None)
+        self.assertIs(mayaStack.FindOp('rotatePivotTranslate', True), None)
+        #self.assertIs(mayaStack.FindOp('rotatePivot', True), None)
+        self.assertIs(mayaStack.FindOp('rotate', True), None)
+        self.assertIs(mayaStack.FindOp('rotateAxis', True), None)
+        self.assertEqual(getNameInverted(mayaStack.FindOp('rotatePivot', True)),
+                    ('rotatePivot', True))
+        self.assertIs(mayaStack.FindOp('scalePivotTranslate', True), None)
+        #self.assertIs(mayaStack.FindOp('scalePivot', True), None)
+        self.assertIs(mayaStack.FindOp('shear', True), None)
+        self.assertIs(mayaStack.FindOp('scale', True), None)
+        self.assertEqual(getNameInverted(mayaStack.FindOp('scalePivot', True)),
+                    ('scalePivot', True))
+        
+        self.assertIs(mayaStack.FindOp('pivot'), None)
+        self.assertIs(mayaStack.FindOp('pivot', isInvertedTwin=True), None)
+        self.assertIs(mayaStack.FindOp('pivot', True), None)
+        self.assertIs(mayaStack.FindOp('pivot', isInvertedTwin=False), None)
+        self.assertIs(mayaStack.FindOp('pivot', False), None)
+        
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(getNameInverted(commonStack.FindOp('pivot')),
+                    ('pivot', False))
+        self.assertEqual(getNameInverted(commonStack.FindOp('pivot', isInvertedTwin=True)),
+                    ('pivot', True))
+        self.assertEqual(getNameInverted(commonStack.FindOp('pivot', True)),
+                    ('pivot', True))
+        self.assertEqual(getNameInverted(commonStack.FindOp('pivot', isInvertedTwin=False)),
+                    ('pivot', False))
+        self.assertEqual(getNameInverted(commonStack.FindOp('pivot', False)),
+                    ('pivot', False))
+        self.assertEqual(getNameInverted(commonStack.FindOp('rotate')),
+                    ('rotate', False))
+        self.assertIs(commonStack.FindOp('rotate', isInvertedTwin=True), None)
+        self.assertIs(commonStack.FindOp('rotate', True), None)
+        self.assertEqual(getNameInverted(commonStack.FindOp('rotate', isInvertedTwin=False)),
+                    ('rotate', False))
+        self.assertEqual(getNameInverted(commonStack.FindOp('rotate', False)),
+                    ('rotate', False))
+        self.assertIs(commonStack.FindOp('scalePivot'), None)
+        self.assertIs(commonStack.FindOp('scalePivot', isInvertedTwin=True), None)
+        self.assertIs(commonStack.FindOp('scalePivot', True), None)
+        self.assertIs(commonStack.FindOp('scalePivot', isInvertedTwin=False), None)
+        self.assertIs(commonStack.FindOp('scalePivot', False), None)
+
+
+    #   PxrUsdMayaXformStack::FindOpIndexPair
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    def testFindOpIndexPair(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        self.assertEqual(mayaStack.FindOpIndexPair('translate'), (0, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('rotatePivotTranslate'), (1, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('rotatePivot'), (2, 5))
+        self.assertEqual(mayaStack.FindOpIndexPair('rotate'), (3, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('rotateAxis'), (4, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('scalePivotTranslate'), (6, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('scalePivot'), (7, 10))
+        self.assertEqual(mayaStack.FindOpIndexPair('shear'), (8, None))
+        self.assertEqual(mayaStack.FindOpIndexPair('scale'), (9, None))
+
+        self.assertEqual(mayaStack.FindOpIndexPair('pivot'), (None, None))
+        
+        commonStack = UsdMaya.XformStack.CommonStack()
+        self.assertEqual(commonStack.FindOpIndexPair('pivot'), (1, 4))
+        self.assertEqual(commonStack.FindOpIndexPair('rotate'), (2, None))
+        self.assertEqual(commonStack.FindOpIndexPair('scalePivot'), (None, None))
+
+    #   PxrUsdMayaXformStack::FindOpPair
+    #   PxrUsdMayaXformStack::MayaStack
+    #   PxrUsdMayaXformStack::CommonStack
+    #   PxrUsdMayaXformOpClassification::GetName
+    #   PxrUsdMayaXformOpClassification::IsInvertedTwin
+    def testFindOpPair(self):
+        def assertOp(op, expected):
+            if expected is None:
+                self.assertIs(op, None)
+            else:
+                self.assertEqual(op.GetName(), expected[0])
+                self.assertEqual(op.IsInvertedTwin(), expected[1])
+        
+        def assertFindOpPair(stack, name, expected0, expected1):
+            result = stack.FindOpPair(name)
+            self.assertEqual(len(result), 2)
+            assertOp(result[0], expected0)
+            assertOp(result[1], expected1)
+        
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        assertFindOpPair(mayaStack, 'translate',
+                         ('translate', False), None)
+        assertFindOpPair(mayaStack, 'rotatePivotTranslate',
+                         ('rotatePivotTranslate', False), None)
+        assertFindOpPair(mayaStack, 'rotatePivot',
+                         ('rotatePivot', False), ('rotatePivot', True))
+        assertFindOpPair(mayaStack, 'rotate',
+                         ('rotate', False), None)
+        assertFindOpPair(mayaStack, 'rotateAxis',
+                         ('rotateAxis', False), None)
+        assertFindOpPair(mayaStack, 'scalePivotTranslate',
+                         ('scalePivotTranslate', False), None)
+        assertFindOpPair(mayaStack, 'scalePivot',
+                         ('scalePivot', False), ('scalePivot', True))
+        assertFindOpPair(mayaStack, 'shear',
+                         ('shear', False), None)
+        assertFindOpPair(mayaStack, 'scale',
+                         ('scale', False), None)
+
+        assertFindOpPair(mayaStack, 'pivot', None, None)
+        
+        commonStack = UsdMaya.XformStack.CommonStack()
+        assertFindOpPair(commonStack, 'pivot',
+                         ('pivot', False), ('pivot', True))
+        assertFindOpPair(commonStack, 'rotate',
+                         ('rotate', False), None)
+        assertFindOpPair(commonStack, 'scalePivot', None, None)
+        
+    def makeMayaStackAttrs(self):
+        from pxr import UsdGeom
+        
+        self.stack = UsdMaya.XformStack.MayaStack()
+        self.stage = Usd.Stage.CreateInMemory()
+        self.prim = self.stage.DefinePrim('/myPrim', 'Xform')
+        self.xform = UsdGeom.Xform(self.prim)
+        self.ops = OrderedDict()
+        
+        self.ops['translate'] = self.xform.AddTranslateOp(opSuffix='translate')
+        self.ops['rotatePivotTranslate'] = self.xform.AddTranslateOp(opSuffix='rotatePivotTranslate')
+        self.ops['rotatePivot'] = self.xform.AddTranslateOp(opSuffix='rotatePivot')
+        self.ops['rotate'] = self.xform.AddRotateXYZOp(opSuffix='rotate')
+        self.ops['rotateAxis'] = self.xform.AddRotateXYZOp(opSuffix='rotateAxis')
+        self.ops['rotatePivotINV'] = self.xform.AddTranslateOp(opSuffix='rotatePivot', isInverseOp=True )
+        self.ops['scalePivotTranslate'] = self.xform.AddTranslateOp(opSuffix='scalePivotTranslate')
+        self.ops['scalePivot'] = self.xform.AddTranslateOp(opSuffix='scalePivot')
+        self.ops['shear'] = self.xform.AddTransformOp(opSuffix='shear')
+        # don't set the opSuffix for scale, just to test an op named "xformOp:scale"
+        # instead of "xformOp:scale:scale" (the second form has already been tested with
+        # "xformOp:translate:translate")
+        self.ops['scale'] = self.xform.AddScaleOp()
+        self.ops['scalePivotINV'] = self.xform.AddTranslateOp(opSuffix='scalePivot', isInverseOp=True)
+        
+    def makeCommonStackAttrs(self):
+        from pxr import UsdGeom
+        
+        self.stack = UsdMaya.XformStack.CommonStack()
+        self.stage = Usd.Stage.CreateInMemory()
+        self.prim = self.stage.DefinePrim('/myPrim', 'Xform')
+        self.xform = UsdGeom.Xform(self.prim)
+        self.ops = OrderedDict()
+
+        self.ops['translate'] = self.xform.AddTranslateOp(opSuffix='translate')
+        self.ops['pivot'] = self.xform.AddTranslateOp(opSuffix='pivot')
+        self.ops['rotate'] = self.xform.AddRotateXYZOp(opSuffix='rotate')
+        # don't set the opSuffix for scale, just to test an op named "xformOp:scale"
+        # instead of "xformOp:scale:scale" (the second form has already been tested with
+        # "xformOp:translate:translate")
+        self.ops['scale'] = self.xform.AddScaleOp()
+        self.ops['pivotINV'] = self.xform.AddTranslateOp(opSuffix='pivot', isInverseOp=True)
+        
+    def makeMatrixStackAttrs(self):
+        from pxr import UsdGeom
+        
+        self.stack = UsdMaya.XformStack.MatrixStack()
+        self.stage = Usd.Stage.CreateInMemory()
+        self.prim = self.stage.DefinePrim('/myPrim', 'Xform')
+        self.xform = UsdGeom.Xform(self.prim)
+        self.ops = {}
+
+        self.ops['transform'] = self.xform.AddTransformOp(opSuffix='transform')
+        
+    def makeXformOpsAndExpectedClassifications(self, stack, opNames, expectEmpty=False):
+        orderedOps = []
+        expected = []
+        for opName in opNames:
+            orderedOps.append(self.ops[opName])
+            if opName.endswith('INV'):
+                opName = opName[:-3]
+                inverted = True
+            else:
+                inverted = False
+            if not expectEmpty:
+                foundOp = stack.FindOp(opName, isInvertedTwin=inverted)
+                self.assertIsNotNone(foundOp, "could not find {} op in stack".format(opName))
+                expected.append(foundOp)
+        return orderedOps, expected
+        
+    def doSubstackTest(self, stack, opNames, expectEmpty=False, desc=None):
+        orderedOps, expected = self.makeXformOpsAndExpectedClassifications(
+            stack, opNames, expectEmpty=expectEmpty)
+        result = stack.MatchingSubstack(orderedOps)
+        self.assertEqual(result, expected, desc)
+        
+    def testMatchingSubstack_maya_full(self):
+        self.makeMayaStackAttrs()
+        self.doSubstackTest(self.stack, self.ops.keys())
+        
+    def testMatchingSubstack_common_full(self):
+        self.makeCommonStackAttrs()
+        self.doSubstackTest(self.stack, self.ops.keys())
+        
+    def testMatchingSubstack_matrix_full(self):
+        self.makeMatrixStackAttrs()
+        self.doSubstackTest(self.stack, self.ops.keys())
+
+    def testMatchingSubstack_maya_empty(self):
+        self.makeMayaStackAttrs()
+        self.doSubstackTest(self.stack, [], expectEmpty=True)
+
+    def testMatchingSubstack_common_empty(self):
+        self.makeCommonStackAttrs()
+        self.doSubstackTest(self.stack, [], expectEmpty=True)
+        
+    def testMatchingSubstack_matrix_empty(self):
+        self.makeMatrixStackAttrs()
+        self.doSubstackTest(self.stack, [], expectEmpty=True)
+        
+    def doMissing1SubstackTests(self, stack, allOpNames):
+        self.longMessage = True
+        pairedIndices = set()
+        for invertPair in stack.GetInversionTwins():
+            pairedIndices.update(invertPair)
+        for i in xrange(len(allOpNames)):
+            missingOp = allOpNames[i]
+            opsMinus1 = allOpNames[:i] + allOpNames[i + 1:]
+            # if the one we're taking out is a member of the inversion twins,
+            # then we should get back a non-match
+            expectEmpty = i in pairedIndices
+            self.doSubstackTest(stack, opsMinus1,
+                                expectEmpty=expectEmpty,
+                                desc="without {}".format(missingOp))
+
+    def testMatchingSubstack_maya_missing1(self):
+        self.makeMayaStackAttrs()
+        self.doMissing1SubstackTests(self.stack, self.ops.keys())
+
+    def testMatchingSubstack_common_missing1(self):
+        self.makeCommonStackAttrs()
+        self.doMissing1SubstackTests(self.stack, self.ops.keys())
+
+    def doOnly1SubstackTests(self, stack, allOpNames):
+        self.longMessage = True
+        pairedIndices = set()
+        for invertPair in stack.GetInversionTwins():
+            pairedIndices.update(invertPair)
+        for i in xrange(len(allOpNames)):
+            onlyOp = allOpNames[i]
+            # if the one we're taking is a member of the inversion twins,
+            # then we should get back a non-match
+            expectEmpty = i in pairedIndices
+            self.doSubstackTest(stack, [onlyOp],
+                                expectEmpty=expectEmpty,
+                                desc="only op: {}".format(onlyOp))
+
+    def testMatchingSubstack_maya_only1(self):
+        self.makeMayaStackAttrs()
+        self.doOnly1SubstackTests(self.stack, self.ops.keys())
+
+    def testMatchingSubstack_common_only1(self):
+        self.makeCommonStackAttrs()
+        self.doOnly1SubstackTests(self.stack, self.ops.keys())
+
+    def doTwinSubstackTests(self, stack, allOpNames):
+        twins = stack.GetInversionTwins()
+        # iterate through all combinations of pairs... practically, for
+        # maya, this means we try:
+        #   [firstPair]
+        #   [secondPair]
+        #   [firstPair, secondPair]
+        for numPairs in xrange(1, len(twins) + 1):
+            for pairSet in itertools.combinations(twins, numPairs):
+                usedIndices = set()
+                for pair in pairSet:
+                    usedIndices.update(pair)
+                usedIndices = sorted(usedIndices)
+                opNames = [allOpNames[i] for i in usedIndices]
+                self.doSubstackTest(stack, opNames,
+                                    desc="paired ops: {}".format(opNames))
+
+    def testMatchingSubstack_maya_twins(self):
+        self.makeMayaStackAttrs()
+        self.doTwinSubstackTests(self.stack, self.ops.keys())
+
+    def testMatchingSubstack_common_twins(self):
+        self.makeCommonStackAttrs()
+        self.doTwinSubstackTests(self.stack, self.ops.keys())
+        
+    def testMatchingSubstack_maya_half(self):
+        self.makeMayaStackAttrs()
+        self.doSubstackTest(self.stack, [
+            'rotatePivotTranslate',
+            'rotatePivot',
+            'rotate',
+            'rotatePivotINV',
+            'shear',
+            'scale',
+        ])
+
+    def testMatchingSubstack_common_half(self):
+        self.makeCommonStackAttrs()
+        self.doSubstackTest(self.stack, [
+            'translate',
+            'rotate',
+            'scale',
+        ])
+        
+    def testMatchingSubstack_wrongOrder(self):
+        self.makeMayaStackAttrs()
+        self.doSubstackTest(
+            self.stack, ['translate', 'rotate'])
+        self.doSubstackTest(
+            self.stack, ['rotate', 'translate'], expectEmpty=True)
+        
+        self.doSubstackTest(self.stack, [
+            'rotatePivotTranslate',
+            'rotatePivot',
+            'rotate',
+            'rotatePivotINV',
+            'scale',
+            'shear',
+        ], expectEmpty=True)
+        
+    def testMatchingSubstack_nameDoesntMatter(self):
+        self.makeMayaStackAttrs()
+        # For the matrix stack, name doesn't matter, so ANY
+        # opStack consisting of just a single Transform should match...
+        # ...so, ie, just the "shear" transform from the maya stack!
+        orderedOps = [self.ops['shear']]
+        
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        expectedOps = [matrixStack[0]]
+        
+        # check names doesn't match
+        self.assertNotIn(orderedOps[0].GetName(), expectedOps[0].CompatibleAttrNames())
+        result = matrixStack.MatchingSubstack(orderedOps)
+        
+        # ...but we should get back a result anyway!
+        self.assertEqual(result, expectedOps)
+        
+    def testMatchingSubstack_rotOrder(self):
+        from maya.OpenMaya import MEulerRotation
+        
+        self.makeMayaStackAttrs()
+        self.ops['rotateX'] = self.xform.AddRotateXOp(opSuffix='rotate')
+        self.ops['rotateY'] = self.xform.AddRotateYOp(opSuffix='rotate')
+        self.ops['rotateZ'] = self.xform.AddRotateZOp(opSuffix='rotate')
+        self.ops['rotateXYZ'] = self.ops['rotate']
+        self.ops['rotateYZX'] = self.xform.AddRotateYZXOp(opSuffix='rotate')
+        self.ops['rotateZXY'] = self.xform.AddRotateZXYOp(opSuffix='rotate')
+        self.ops['rotateXZY'] = self.xform.AddRotateXZYOp(opSuffix='rotate')
+        self.ops['rotateYXZ'] = self.xform.AddRotateYXZOp(opSuffix='rotate')
+        self.ops['rotateZYX'] = self.xform.AddRotateZYXOp(opSuffix='rotate')
+        
+        allRotates = [
+            'rotateX',
+            'rotateY',
+            'rotateZ',
+            'rotateXYZ',
+            'rotateYZX',
+            'rotateZXY',
+            'rotateXZY',
+            'rotateYXZ',
+            'rotateZYX',
+        ]
+        
+        expectedList = [self.stack.FindOp('translate'), self.stack.FindOp('rotate')]
+        for rotateOpName in allRotates:
+            orderedOps = [self.ops['translate'], self.ops[rotateOpName]]
+            resultList = self.stack.MatchingSubstack(orderedOps)
+            self.assertEqual(resultList, expectedList)
+            
+        # test a failed match
+        orderedOps = [self.ops[rotateOpName], self.ops['translate']]
+        resultList = self.stack.MatchingSubstack(orderedOps)
+        self.assertEqual(resultList, [])
+        
+    def testMatchingSubstack_rotOrder_rotAxis(self):
+        from maya.OpenMaya import MEulerRotation
+        
+        self.makeMayaStackAttrs()
+        self.ops['rotateAxisX'] = self.xform.AddRotateXOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisY'] = self.xform.AddRotateYOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisZ'] = self.xform.AddRotateZOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisXYZ'] = self.ops['rotateAxis']
+        self.ops['rotateAxisYZX'] = self.xform.AddRotateYZXOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisZXY'] = self.xform.AddRotateZXYOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisXZY'] = self.xform.AddRotateXZYOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisYXZ'] = self.xform.AddRotateYXZOp(opSuffix='rotateAxis')
+        self.ops['rotateAxisZYX'] = self.xform.AddRotateZYXOp(opSuffix='rotateAxis')
+        
+        allRotates = {
+            'rotateAxisX',
+            'rotateAxisY',
+            'rotateAxisZ',
+            'rotateAxisXYZ',
+            'rotateAxisYZX',
+            'rotateAxisZXY',
+            'rotateAxisXZY',
+            'rotateAxisYXZ',
+            'rotateAxisZYX',
+        }
+        
+        expectedList = [self.stack.FindOp('translate'), self.stack.FindOp('rotateAxis')]
+        for rotateOpName in allRotates:
+            orderedOps = [self.ops['translate'], self.ops[rotateOpName]]
+            resultList = self.stack.MatchingSubstack(orderedOps)
+            self.assertEqual(resultList, expectedList)
+            
+        # test a failed match
+        orderedOps = [self.ops[rotateOpName], self.ops['translate']]
+        resultList = self.stack.MatchingSubstack(orderedOps)
+        self.assertEqual(resultList, [])
+        
+    def doFirstMatchingTest(self, stacks, opNames, matchingStack, expectEmpty=False):
+        orderedOps, expected = self.makeXformOpsAndExpectedClassifications(
+            matchingStack, opNames, expectEmpty=expectEmpty)
+        result = UsdMaya.XformStack.FirstMatchingSubstack(stacks, orderedOps)
+        self.assertEqual(result, expected)
+        
+    def testFirstMatchingSubstack(self):
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        commonStack = UsdMaya.XformStack.CommonStack()
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        
+        # Should match maya only:
+        self.makeMayaStackAttrs()
+        mayaOnly = ['translate', 'rotate', 'shear']
+        self.doFirstMatchingTest(
+            [mayaStack, commonStack, matrixStack],
+            mayaOnly, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack, mayaStack, commonStack],
+            mayaOnly, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack, mayaStack],
+            mayaOnly, mayaStack)
+        self.doFirstMatchingTest(
+            [mayaStack],
+            mayaOnly, mayaStack)
+        self.doFirstMatchingTest(
+            [commonStack],
+            mayaOnly, mayaStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack],
+            mayaOnly, mayaStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack],
+            mayaOnly, mayaStack)
+        self.doFirstMatchingTest(
+            [commonStack, matrixStack],
+            mayaOnly, mayaStack, expectEmpty=True)
+        
+        # Should match common only:
+        self.makeCommonStackAttrs()
+        commonOnly = ['pivot', 'pivotINV']
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack, matrixStack],
+            commonOnly, commonStack)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack, mayaStack],
+            commonOnly, commonStack)
+        self.doFirstMatchingTest(
+            [matrixStack, mayaStack, commonStack],
+            commonOnly, commonStack)
+        self.doFirstMatchingTest(
+            [mayaStack],
+            commonOnly, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack],
+            commonOnly, commonStack)
+        self.doFirstMatchingTest(
+            [matrixStack],
+            commonOnly, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack],
+            commonOnly, commonStack)
+        self.doFirstMatchingTest(
+            [mayaStack, matrixStack],
+            commonOnly, commonStack, expectEmpty=True)
+
+        # Should match matrix only:
+        self.makeMatrixStackAttrs()
+        matrixOnly = ['transform']
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack, matrixStack],
+            matrixOnly, matrixStack)
+        self.doFirstMatchingTest(
+            [commonStack, matrixStack, mayaStack],
+            matrixOnly, matrixStack)
+        self.doFirstMatchingTest(
+            [matrixStack, mayaStack, commonStack],
+            matrixOnly, matrixStack)
+        self.doFirstMatchingTest(
+            [mayaStack],
+            matrixOnly, matrixStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack],
+            matrixOnly, matrixStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack],
+            matrixOnly, matrixStack)
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack],
+            matrixOnly, matrixStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [mayaStack, matrixStack],
+            matrixOnly, matrixStack)
+
+        # Should match either maya or common:
+        mayaOrCommon = ['translate', 'rotate', 'scale']
+        self.makeCommonStackAttrs()
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack, matrixStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack, mayaStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack, mayaStack, commonStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [mayaStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [commonStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack],
+            mayaOrCommon, mayaStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [mayaStack, matrixStack],
+            mayaOrCommon, mayaStack)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack],
+            mayaOrCommon, mayaStack)
+
+        # Should match nothing:
+        noMatch = ['translate', 'pivot', 'rotate']
+        self.makeCommonStackAttrs()
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack, matrixStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack, mayaStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack, mayaStack, commonStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [mayaStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [commonStack, mayaStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [mayaStack, matrixStack],
+            noMatch, commonStack, expectEmpty=True)
+        self.doFirstMatchingTest(
+            [matrixStack, commonStack],
+            noMatch, commonStack, expectEmpty=True)
+
+    def testFirstMatchingSubstack_rotOrder(self):
+        from maya.OpenMaya import MEulerRotation
+        
+        self.longMessage = True
+        
+        mayaStack = UsdMaya.XformStack.MayaStack()
+        commonStack = UsdMaya.XformStack.CommonStack()
+        matrixStack = UsdMaya.XformStack.MatrixStack()
+        
+        self.makeMayaStackAttrs()
+        self.ops['rotateX'] = self.xform.AddRotateXOp(opSuffix='rotate')
+        self.ops['rotateY'] = self.xform.AddRotateYOp(opSuffix='rotate')
+        self.ops['rotateZ'] = self.xform.AddRotateZOp(opSuffix='rotate')
+        self.ops['rotateXYZ'] = self.ops['rotate']
+        self.ops['rotateYZX'] = self.xform.AddRotateYZXOp(opSuffix='rotate')
+        self.ops['rotateZXY'] = self.xform.AddRotateZXYOp(opSuffix='rotate')
+        self.ops['rotateXZY'] = self.xform.AddRotateXZYOp(opSuffix='rotate')
+        self.ops['rotateYXZ'] = self.xform.AddRotateYXZOp(opSuffix='rotate')
+        self.ops['rotateZYX'] = self.xform.AddRotateZYXOp(opSuffix='rotate')
+        
+        allRotates = {
+            'rotateX': MEulerRotation.kXYZ,
+            'rotateY': MEulerRotation.kXYZ,
+            'rotateZ': MEulerRotation.kXYZ,
+            'rotateXYZ': MEulerRotation.kXYZ,
+            'rotateYZX': MEulerRotation.kYZX,
+            'rotateZXY': MEulerRotation.kZXY,
+            'rotateXZY': MEulerRotation.kXZY,
+            'rotateYXZ': MEulerRotation.kYXZ,
+            'rotateZYX': MEulerRotation.kZYX,
+        }
+        
+        expectedList = [mayaStack.FindOp('translate'), mayaStack.FindOp('rotate')]
+        for rotateOpName, expectedRotateOrder in allRotates.iteritems():
+            orderedOps = [self.ops['translate'], self.ops[rotateOpName]]
+            for stackList in (
+                    [],
+                    [mayaStack],
+                    [commonStack],
+                    [matrixStack],
+                    [mayaStack, commonStack],
+                    [commonStack, mayaStack],
+                    [matrixStack, mayaStack],
+                    [commonStack, matrixStack],
+                    [matrixStack, mayaStack, commonStack],
+                    [commonStack, matrixStack, mayaStack],
+                    [mayaStack, commonStack, matrixStack]):
+                def stackName(x):
+                    if x == mayaStack:
+                        return 'mayaStack'
+                    elif x == commonStack:
+                        return 'commonStack'
+                    elif x == matrixStack:
+                        return 'matrixStack'
+                    else:
+                        raise ValueError(x)
+                stackNames = [stackName(x) for x in stackList]
+                errMessage = '\nstackNames: ' + str(stackNames)
+                
+                expectNone = not (mayaStack in stackList or commonStack in stackList)
+                resultList = UsdMaya.XformStack.FirstMatchingSubstack(
+                    stackList, orderedOps)
+                if expectNone:
+                    self.assertEqual(resultList, [], str(stackNames))
+                else:
+                    self.assertEqual(resultList, expectedList, str(stackNames))
+                
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/third_party/maya/lib/usdMaya/translatorXformable.cpp
+++ b/third_party/maya/lib/usdMaya/translatorXformable.cpp
@@ -26,6 +26,7 @@
 
 #include "usdMaya/translatorPrim.h"
 #include "usdMaya/translatorUtil.h"
+#include "usdMaya/xformStack.h"
 
 #include "pxr/base/tf/token.h"
 #include "pxr/usd/usdGeom/xformable.h"
@@ -37,6 +38,7 @@
 #include <maya/MDagModifier.h>
 #include <maya/MFnAnimCurve.h>
 #include <maya/MFnTransform.h>
+#include <maya/MEulerRotation.h>
 #include <maya/MGlobal.h>
 #include <maya/MPlug.h>
 #include <maya/MTransformationMatrix.h>
@@ -48,126 +50,6 @@
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
-
-// For speed, store a set of known full-attribute-names; this
-// allows straight token comparison, without string parsing,
-// or string-to-token conversion; even doing Property::BaseName
-// will actually do string-to-token conversion...
-TF_DEFINE_PRIVATE_TOKENS(_FULL_OP_NAMES,
-    // These are from maya
-    ((translate, "xformOp:translate"))
-    ((rotatePivotTranslate, "xformOp:translate:rotatePivotTranslate"))
-    ((rotatePivot, "xformOp:translate:rotatePivot"))
-    ((rotateX, "xformOp:rotateX"))
-    ((rotateY, "xformOp:rotateY"))
-    ((rotateZ, "xformOp:rotateZ"))
-    ((rotateXYZ, "xformOp:rotateXYZ"))
-    ((rotateXZY, "xformOp:rotateXZY"))
-    ((rotateYXZ, "xformOp:rotateYXZ"))
-    ((rotateYZX, "xformOp:rotateYZX"))
-    ((rotateZXY, "xformOp:rotateZXY"))
-    ((rotateZYX, "xformOp:rotateZYX"))
-    ((rotateAxisX, "xformOp:rotateX:rotateAxis"))
-    ((rotateAxisY, "xformOp:rotateY:rotateAxis"))
-    ((rotateAxisZ, "xformOp:rotateZ:rotateAxis"))
-    ((rotateAxisXYZ, "xformOp:rotateXYZ:rotateAxis"))
-    ((rotateAxisXZY, "xformOp:rotateXZY:rotateAxis"))
-    ((rotateAxisYXZ, "xformOp:rotateYXZ:rotateAxis"))
-    ((rotateAxisYZX, "xformOp:rotateYZX:rotateAxis"))
-    ((rotateAxisZXY, "xformOp:rotateZXY:rotateAxis"))
-    ((rotateAxisZYX, "xformOp:rotateZYX:rotateAxis"))
-    ((scalePivotTranslate, "xformOp:translate:scalePivotTranslate"))
-    ((scalePivot, "xformOp:translate:scalePivot"))
-    ((shear, "xformOp:transform:shear"))
-    ((scale, "xformOp:scale"))
-
-    // These are from commonAPI (and not in maya)
-    ((pivot, "xformOp:translate:pivot"))
-    );
-
-TF_DEFINE_PRIVATE_TOKENS(_MAYA_OPS,
-    (translate)
-    (rotatePivotTranslate)
-    (rotatePivot)
-    (rotate)
-    (rotateAxis)
-    (rotatePivotINV)
-    (scalePivotTranslate)
-    (scalePivot)
-    (shear)
-    (scale)
-    (scalePivotINV)
-    );
-    
-static const std::vector<std::pair<int, int> > _MAYA_OPS_PIVOTPAIRS = boost::assign::list_of
-    ( std::make_pair(2, 5) )
-    ( std::make_pair(7, 10) );
-
-typedef std::unordered_map<TfToken, TfToken, TfToken::HashFunctor> TokenLookup;
-
-static const TokenLookup _MAYA_FULL_OP_NAME_LOOKUP = boost::assign::map_list_of
-    (_FULL_OP_NAMES->translate, _MAYA_OPS->translate)
-    (_FULL_OP_NAMES->rotatePivotTranslate, _MAYA_OPS->rotatePivotTranslate)
-    (_FULL_OP_NAMES->rotatePivot, _MAYA_OPS->rotatePivot)
-    (_FULL_OP_NAMES->rotateX, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateY, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZ, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateXYZ, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateXZY, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateYXZ, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateYZX, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZXY, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZYX, _MAYA_OPS->rotate)
-    (_FULL_OP_NAMES->rotateAxisX, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisY, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisZ, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisXYZ, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisXZY, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisYXZ, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisYZX, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisZXY, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->rotateAxisZYX, _MAYA_OPS->rotateAxis)
-    (_FULL_OP_NAMES->scalePivotTranslate, _MAYA_OPS->scalePivotTranslate)
-    (_FULL_OP_NAMES->scalePivot, _MAYA_OPS->scalePivot)
-    (_FULL_OP_NAMES->shear, _MAYA_OPS->shear)
-    (_FULL_OP_NAMES->scale, _MAYA_OPS->scale);
-
-static const TokenLookup _MAYA_INVERTED_FULL_OP_NAME_LOOKUP = boost::assign::map_list_of
-    (_FULL_OP_NAMES->rotatePivot, _MAYA_OPS->rotatePivotINV)
-    (_FULL_OP_NAMES->scalePivot, _MAYA_OPS->scalePivotINV);
-
-TF_DEFINE_PRIVATE_TOKENS(_COMMON_OPS,
-    ((translate, _MAYA_OPS->translate))
-    (pivot)
-    ((rotate, _MAYA_OPS->rotate))
-    ((scale, _MAYA_OPS->scale))
-    (pivotINV)
-    );
-
-TF_DEFINE_PRIVATE_TOKENS(_MISC_OPS,
-    (pivotTranslate)
-    );
-
-static const std::vector<std::pair<int, int> > _COMMON_OPS_PIVOTPAIRS = boost::assign::list_of
-    ( std::make_pair(1, 4) );
-
-static const TokenLookup _COMMON_FULL_OP_NAME_LOOKUP = boost::assign::map_list_of
-    (_FULL_OP_NAMES->translate, _COMMON_OPS->translate)
-    (_FULL_OP_NAMES->pivot, _COMMON_OPS->pivot)
-    (_FULL_OP_NAMES->rotateX, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateY, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZ, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateXYZ, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateXZY, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateYXZ, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateYZX, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZXY, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->rotateZYX, _COMMON_OPS->rotate)
-    (_FULL_OP_NAMES->scale, _COMMON_OPS->scale);
-
-static const TokenLookup _COMMON_INVERTED_FULL_OP_NAME_LOOKUP = boost::assign::map_list_of
-    (_FULL_OP_NAMES->pivot, _COMMON_OPS->pivotINV);
-
 
 // This function retrieves a value for a given xformOp and given time sample. It
 // knows how to deal with different type of ops and angle conversion
@@ -316,157 +198,6 @@ static void _setMayaAttribute(
     }
 }
 
-static TfToken
-_GetOpName(
-        const UsdGeomXformOp& xformOp,
-        const TokenLookup& fastNormalLookup,
-        const TokenLookup& fastInvertedLookup)
-{
-    // First check the fast-lookup maps
-    if (xformOp.IsInverseOp()) {
-        TokenLookup::const_iterator found = fastInvertedLookup.find(xformOp.GetName());
-        if (found != fastInvertedLookup.end()) return found->second;
-    }
-    else {
-        TokenLookup::const_iterator found = fastNormalLookup.find(xformOp.GetName());
-        if (found != fastNormalLookup.end()) return found->second;
-    }
-
-    // Wasn't an already-known name... try using the suffix
-    static const TfToken emptyToken;
-    std::vector<std::string> opSplitName = xformOp.SplitName();
-
-    if (opSplitName.size() == 3) {
-        // if we have some specialized name, SplitName will give us something
-        // like: ['xformOp:translate:rotatePivot']
-        std::string opName = opSplitName[2];
-
-        // If the xformop has !invert!, add INV at the end of its name
-        if (xformOp.IsInverseOp()) {
-            opName += "INV";
-        }
-
-        return TfToken(opName);
-    }
-
-    // if we don't have a name, convert it to a standard name based on type
-    switch(xformOp.GetOpType()) {
-        case UsdGeomXformOp::TypeTranslate: 
-            return _COMMON_OPS->translate;
-        break;
-
-        case UsdGeomXformOp::TypeScale: 
-            return _COMMON_OPS->scale;
-        break;
-
-        case UsdGeomXformOp::TypeRotateX:
-        case UsdGeomXformOp::TypeRotateY:
-        case UsdGeomXformOp::TypeRotateZ:
-        case UsdGeomXformOp::TypeRotateXYZ:
-        case UsdGeomXformOp::TypeRotateXZY:
-        case UsdGeomXformOp::TypeRotateYXZ:
-        case UsdGeomXformOp::TypeRotateYZX:
-        case UsdGeomXformOp::TypeRotateZXY:
-        case UsdGeomXformOp::TypeRotateZYX:
-            return _COMMON_OPS->rotate;
-        break;
-
-        case UsdGeomXformOp::TypeTransform: break;
-        case UsdGeomXformOp::TypeOrient: break;
-        case UsdGeomXformOp::TypeInvalid: break;
-        default: break;
-    }
-
-    // shouldn't be getting here.
-    return emptyToken;
-}
-
-// For each xformop, we want to find the corresponding opName.  There are 2
-// requirements:
-//  - the matches for each xformop must have increasing indexes in opNames.
-//  - pivotPairs must either both be matched or neither matched.
-//
-// this returns a vector of opNames.  The size of this vector will be 0 if no
-// complete match is found, or xformops.size() if a complete match is found.
-static std::vector<TfToken>
-_MatchXformOpNames(
-        const std::vector<UsdGeomXformOp>& xformops, 
-        const std::vector<TfToken>& opNames,
-        const std::vector<std::pair<int, int> >& pivotPairs,
-        const TokenLookup& fastNormalLookup,
-        const TokenLookup& fastInvertedLookup,
-        MTransformationMatrix::RotationOrder* MrotOrder)
-{
-
-    static const std::vector<TfToken> _NO_MATCH;
-    std::vector<TfToken> ret;
-
-    // nextOpName keeps track of where we will start looking for matches.  It
-    // will only move forward.
-    std::vector<TfToken>::const_iterator nextOpName = opNames.begin();
-
-    std::vector<bool> opNamesFound(opNames.size(), false);
-
-    TF_FOR_ALL(iter, xformops) {
-        const UsdGeomXformOp& xformOp = *iter;
-        const TfToken opName = _GetOpName(xformOp,
-                fastNormalLookup, fastInvertedLookup);
-
-        // walk through opNames until we find one that matches
-        std::vector<TfToken>::const_iterator findOp = std::find(
-                nextOpName,
-                opNames.end(),
-                opName);
-        if (findOp == opNames.end()) {
-            return _NO_MATCH;
-        }
-
-        // we found it
-
-        // if we're a rotate, set the maya rotation order (if it's relevant to
-        // this op)
-        if (opName == _COMMON_OPS->rotate) {
-            switch(xformOp.GetOpType()) {
-                case UsdGeomXformOp::TypeRotateXYZ:
-                    *MrotOrder = MTransformationMatrix::kXYZ;
-                break;
-                case UsdGeomXformOp::TypeRotateXZY:
-                    *MrotOrder = MTransformationMatrix::kXZY;
-                break;
-                case UsdGeomXformOp::TypeRotateYXZ:
-                    *MrotOrder = MTransformationMatrix::kYXZ;
-                break;
-                case UsdGeomXformOp::TypeRotateYZX:
-                    *MrotOrder = MTransformationMatrix::kYZX;
-                break;
-                case UsdGeomXformOp::TypeRotateZXY:
-                    *MrotOrder = MTransformationMatrix::kZXY;
-                break;
-                case UsdGeomXformOp::TypeRotateZYX:
-                    *MrotOrder = MTransformationMatrix::kZYX;
-                break;
-
-                default: break;
-            }
-        }
-
-        // move the nextOpName pointer along.
-        ret.push_back(*findOp);
-        int nextOpNameIndex = findOp - opNames.begin();
-        opNamesFound[nextOpNameIndex] = true; 
-        nextOpName = findOp + 1;
-    }
-
-    // check pivot pairs
-    TF_FOR_ALL(pairIter, pivotPairs) {
-        if (opNamesFound[pairIter->first] != opNamesFound[pairIter->second]) {
-            return _NO_MATCH;
-        }
-    }
-
-    return ret;
-}
-
 // For each xformop, we gather it's data either time sampled or not and we push
 // it to the corresponding Maya xform
 static bool _pushUSDXformOpToMayaXform(
@@ -515,18 +246,55 @@ static bool _pushUSDXformOpToMayaXform(
         }
     }
     if (xValue.size()) {
-        if (opName==_MAYA_OPS->shear) {
+        if (opName==PxrUsdMayaXformStackTokens->shear) {
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString(opName.GetText()), "XY", "XZ", "YZ", context);
         } 
-        else if (opName==_COMMON_OPS->pivot) {
+        else if (opName==PxrUsdMayaXformStackTokens->pivot) {
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString("rotatePivot"), "X", "Y", "Z", context);
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString("scalePivot"), "X", "Y", "Z", context);
         }
-        else if (opName==_MISC_OPS->pivotTranslate) {
+        else if (opName==PxrUsdMayaXformStackTokens->pivotTranslate) {
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString("rotatePivotTranslate"), "X", "Y", "Z", context);
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString("scalePivotTranslate"), "X", "Y", "Z", context);
-        } 
+        }
         else {
+            if (opName==PxrUsdMayaXformStackTokens->rotate) {
+                MFnTransform trans;
+                if(trans.setObject(MdagNode.object()))
+                {
+                    auto MrotOrder =
+                            PxrUsdMayaXformStack::RotateOrderFromOpType<MTransformationMatrix::RotationOrder>(
+                                    xformop.GetOpType());
+                    MPlug plg = MdagNode.findPlug("rotateOrder");
+                    if ( !plg.isNull() ) {
+                        trans.setRotationOrder(MrotOrder, /*no need to reorder*/ false);
+                    }
+                }
+            }
+            else if(opName==PxrUsdMayaXformStackTokens->rotateAxis)
+            {
+                // Rotate axis only accepts input in XYZ form
+                // (though it's actually stored as a quaternion),
+                // so we need to convert other rotation orders to XYZ
+                const auto opType = xformop.GetOpType();
+                if (opType != UsdGeomXformOp::TypeRotateXYZ
+                        && opType != UsdGeomXformOp::TypeRotateX
+                        && opType != UsdGeomXformOp::TypeRotateY
+                        && opType != UsdGeomXformOp::TypeRotateZ)
+                {
+                    for (size_t i = 0u; i < xValue.size(); ++i)
+                    {
+                        auto MrotOrder =
+                                PxrUsdMayaXformStack::RotateOrderFromOpType<MEulerRotation::RotationOrder>(
+                                        xformop.GetOpType());
+                        MEulerRotation eulerRot(xValue[i], yValue[i], zValue[i], MrotOrder);
+                        eulerRot.reorderIt(MEulerRotation::kXYZ);
+                        xValue[i] = eulerRot.x;
+                        yValue[i] = eulerRot.y;
+                        zValue[i] = eulerRot.z;
+                    }
+                }
+            }
             _setMayaAttribute(MdagNode, xValue, yValue, zValue, timeArray, MString(opName.GetText()), "X", "Y", "Z", context);
         }
         return true;
@@ -651,48 +419,31 @@ PxrUsdMayaTranslatorXformable::Read(
     std::vector<UsdGeomXformOp> xformops = xformSchema.GetOrderedXformOps(
         &resetsXformStack);
             
-    MTransformationMatrix::RotationOrder MrotOrder = MTransformationMatrix::kXYZ;
-
-    // This string array define the Xformops that are conformant to Maya and
-    // CommonAPI.
-    //
     // When we find ops, we match the ops by suffix ("" will define the basic
     // translate, rotate, scale) and by order. If we find an op with a
     // different name or out of order that will miss the match, we will rely on
     // matrix decomposition
 
-    std::vector<TfToken> opNames;
-    if (opNames.empty()) {
-        // Check if the xforms are the generic Maya xform operators 
-        opNames = _MatchXformOpNames(xformops,
-                _MAYA_OPS->allTokens, _MAYA_OPS_PIVOTPAIRS,
-                _MAYA_FULL_OP_NAME_LOOKUP, _MAYA_INVERTED_FULL_OP_NAME_LOOKUP,
-                &MrotOrder);
-    }
-
-    if (opNames.empty()) {
-        // Check if the xforms are the CommonAPI
-        opNames = _MatchXformOpNames(xformops,
-                _COMMON_OPS->allTokens, _COMMON_OPS_PIVOTPAIRS,
-                _COMMON_FULL_OP_NAME_LOOKUP, _COMMON_INVERTED_FULL_OP_NAME_LOOKUP,
-                &MrotOrder);
-    }
+    PxrUsdMayaXformStack::OpClassList stackOps = \
+            PxrUsdMayaXformStack::FirstMatchingSubstack(
+                    {
+                        &PxrUsdMayaXformStack::MayaStack(),
+                        &PxrUsdMayaXformStack::CommonStack()
+                    },
+                    xformops);
 
     MFnDagNode MdagNode(mayaNode);
-    if (!opNames.empty()) {
-        // make sure opNames.size() == xformops.size()
-        for (unsigned int i=0; i < opNames.size(); i++) {
+    if (!stackOps.empty()) {
+        // make sure stackIndices.size() == xformops.size()
+        for (unsigned int i=0; i < stackOps.size(); i++) {
             const UsdGeomXformOp& xformop(xformops[i]);
-            const TfToken& opName(opNames[i]);
+            const PxrUsdMayaXformOpClassification& opDef(stackOps[i]);
+            // If we got a valid stack, we have both the members of the inverted twins..
+            // ...so we can go ahead and skip the inverted twin
+            if (opDef.IsInvertedTwin()) continue;
 
-            if (opName==_COMMON_OPS->rotate) {
-                MPlug plg = MdagNode.findPlug("rotateOrder");
-                if ( !plg.isNull() ) {
-                    MFnTransform trans; 
-                    trans.setObject(mayaNode);
-                    trans.setRotationOrder(MrotOrder, /*no need to reorder*/ false);
-                }
-            }
+            const TfToken& opName(opDef.GetName());
+
             _pushUSDXformOpToMayaXform(xformop, opName, MdagNode, args, context);
         }
     } else {

--- a/third_party/maya/lib/usdMaya/wrapXformStack.cpp
+++ b/third_party/maya/lib/usdMaya/wrapXformStack.cpp
@@ -1,0 +1,264 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/pxr.h"
+#include "usdMaya/xformStack.h"
+
+#include "pxr/base/tf/pyContainerConversions.h"
+#include "pxr/base/tf/pyEnum.h"
+#include "pxr/base/tf/pyResultConversions.h"
+#include "pxr/base/tf/stringUtils.h"
+
+#include <maya/MEulerRotation.h>
+#include <maya/MTransformationMatrix.h>
+
+#include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
+#include <boost/python/import.hpp>
+#include <boost/python/raw_function.hpp>
+
+using namespace std;
+using boost::python::object;
+using boost::python::class_;
+using boost::python::no_init;
+using boost::python::self;
+using boost::python::extract;
+using boost::python::return_value_policy;
+using boost::python::return_by_value;
+using boost::python::copy_const_reference;
+using boost::python::reference_existing_object;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+    // We wrap this class, instead of PxrUsdMayaXformOpClassification directly, mostly
+    // just so we can handle the .IsNull() -> None conversion
+    class Usd_PyXformOpClassification {
+    public:
+        Usd_PyXformOpClassification(const PxrUsdMayaXformOpClassification& opClass)
+            : _opClass(opClass)
+        {
+        }
+
+        bool operator == (const Usd_PyXformOpClassification& other)
+        {
+            return _opClass == other._opClass;
+        }
+
+        TfToken const &GetName() const
+        {
+            return _opClass.GetName();
+        }
+
+        // In order to return wrapped UsdGeomXformOp::Type objects, we need to import
+        // the UsdGeom module
+        static void
+        ImportUsdGeomOnce()
+        {
+            static std::once_flag once;
+            std::call_once(once, [](){
+                boost::python::import("pxr.UsdGeom");
+            });
+        }
+
+        UsdGeomXformOp::Type GetOpType() const
+        {
+            ImportUsdGeomOnce();
+            return _opClass.GetOpType();
+        }
+
+        bool IsInvertedTwin() const
+        {
+            return _opClass.IsInvertedTwin();
+        }
+
+        bool IsCompatibleType(UsdGeomXformOp::Type otherType) const
+        {
+            return _opClass.IsCompatibleType(otherType);
+        }
+
+        std::vector<TfToken> CompatibleAttrNames() const
+        {
+            return _opClass.CompatibleAttrNames();
+        }
+
+        // to-python conversion of const PxrUsdMayaXformOpClassification.
+        static PyObject*
+        convert(const PxrUsdMayaXformOpClassification& opClass) {
+            TfPyLock lock;
+            if (opClass.IsNull())
+            {
+                return boost::python::incref(Py_None);
+            }
+            else
+            {
+                object obj((Usd_PyXformOpClassification(opClass)));
+                // Incref because ~object does a decref
+                return boost::python::incref(obj.ptr());
+            }
+        }
+
+    private:
+        PxrUsdMayaXformOpClassification _opClass;
+    };
+
+    class Usd_PyXformStack
+    {
+    public:
+        static inline object
+        convert_index(size_t index)
+        {
+            if (index == PxrUsdMayaXformStack::NO_INDEX)
+            {
+                return object(); // return None (handles the incref)
+            }
+            return object(index);
+        }
+
+        // Don't want to make this into a generic conversion rule, via
+        //    to_python_converter<PxrUsdMayaXformStack::IndexPair, Usd_PyXformStack>(),
+        // because that would make this apply to ANY pair of unsigned ints, which
+        // could be dangerous
+        static object
+        convert_index_pair(const PxrUsdMayaXformStack::IndexPair& indexPair)
+        {
+            return boost::python::make_tuple(
+                    convert_index(indexPair.first),
+                    convert_index(indexPair.second));
+        }
+
+        static PyObject*
+        convert(const PxrUsdMayaXformStack::OpClassPair& opPair)
+        {
+            boost::python::tuple result = boost::python::make_tuple(
+                    opPair.first, opPair.second);
+            // Incref because ~object does a decref
+            return boost::python::incref(result.ptr());
+        }
+
+        static const PxrUsdMayaXformOpClassification&
+        getitem(const PxrUsdMayaXformStack& stack, long index)
+        {
+            auto raise_index_error = [] () {
+                PyErr_SetString(PyExc_IndexError, "index out of range");
+                boost::python::throw_error_already_set();
+            };
+
+            if (index < 0)
+            {
+                if (static_cast<size_t>(-index) > stack.GetSize()) raise_index_error();
+                return stack[stack.GetSize() + index];
+            }
+            else
+            {
+                if (static_cast<size_t>(index) >= stack.GetSize()) raise_index_error();
+                return stack[index];
+            }
+        }
+
+        static object
+        GetInversionTwins(const PxrUsdMayaXformStack& stack)
+        {
+            boost::python::list result;
+            for(const auto& idxPair : stack.GetInversionTwins())
+            {
+                result.append(convert_index_pair(idxPair));
+            }
+            return result;
+        }
+
+        static object
+        FindOpIndex(
+                const PxrUsdMayaXformStack& stack,
+                const TfToken& opName,
+                bool isInvertedTwin=false)
+        {
+            return convert_index(stack.FindOpIndex(opName, isInvertedTwin));
+        }
+
+        static object
+        FindOpIndexPair(
+                const PxrUsdMayaXformStack& stack,
+                const TfToken& opName)
+        {
+            return convert_index_pair(stack.FindOpIndexPair(opName));
+        }
+    };
+}
+
+
+
+void wrapXformStack()
+{
+    class_<Usd_PyXformOpClassification>("XformOpClassification", no_init)
+        .def(self == self)
+        .def("GetName", &Usd_PyXformOpClassification::GetName,
+                return_value_policy<return_by_value>())
+        .def("GetOpType", &Usd_PyXformOpClassification::GetOpType)
+        .def("IsInvertedTwin", &Usd_PyXformOpClassification::IsInvertedTwin)
+        .def("IsCompatibleType", &Usd_PyXformOpClassification::IsCompatibleType)
+        .def("CompatibleAttrNames", &Usd_PyXformOpClassification::CompatibleAttrNames)
+        ;
+
+    boost::python::to_python_converter<PxrUsdMayaXformOpClassification,
+            Usd_PyXformOpClassification>();
+
+    class_<PxrUsdMayaXformStack, boost::noncopyable>("XformStack", no_init)
+        .def("GetOps", &PxrUsdMayaXformStack::GetOps,
+                return_value_policy<TfPySequenceToList>())
+        .def("GetInversionTwins", &Usd_PyXformStack::GetInversionTwins)
+        .def("GetNameMatters", &PxrUsdMayaXformStack::GetNameMatters)
+        .def("__getitem__", &Usd_PyXformStack::getitem,
+                return_value_policy<return_by_value>())
+        .def("__len__", &PxrUsdMayaXformStack::GetSize)
+        .def("GetSize", &PxrUsdMayaXformStack::GetSize)
+        .def("FindOpIndex", &Usd_PyXformStack::FindOpIndex,
+                (boost::python::arg("opName"), boost::python::arg("isInvertedTwin")=false))
+        .def("FindOp", &PxrUsdMayaXformStack::FindOp,
+                (boost::python::arg("opName"), boost::python::arg("isInvertedTwin")=false),
+                return_value_policy<copy_const_reference>())
+        .def("FindOpIndexPair", &Usd_PyXformStack::FindOpIndexPair)
+        .def("FindOpPair", &PxrUsdMayaXformStack::FindOpPair)
+        .def("MatchingSubstack", &PxrUsdMayaXformStack::MatchingSubstack)
+        .def("MayaStack", &PxrUsdMayaXformStack::MayaStack,
+                return_value_policy<return_by_value>())
+        .staticmethod("MayaStack")
+        .def("CommonStack", &PxrUsdMayaXformStack::CommonStack,
+                return_value_policy<return_by_value>())
+        .staticmethod("CommonStack")
+        .def("MatrixStack", &PxrUsdMayaXformStack::MatrixStack,
+                return_value_policy<return_by_value>())
+        .staticmethod("MatrixStack")
+        .def("FirstMatchingSubstack", &PxrUsdMayaXformStack::FirstMatchingSubstack)
+        .staticmethod("FirstMatchingSubstack")
+    ;
+
+    boost::python::to_python_converter<PxrUsdMayaXformStack::OpClassPair,
+            Usd_PyXformStack>();
+
+    boost::python::to_python_converter<std::vector<PxrUsdMayaXformStack::OpClass >,
+        TfPySequenceToPython<std::vector<PxrUsdMayaXformStack::OpClass > > >();
+
+    TfPyContainerConversions::from_python_sequence<std::vector<PxrUsdMayaXformStack const *>,
+        TfPyContainerConversions::variable_capacity_policy >();
+}

--- a/third_party/maya/lib/usdMaya/xformStack.cpp
+++ b/third_party/maya/lib/usdMaya/xformStack.cpp
@@ -1,0 +1,715 @@
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "usdMaya/xformStack.h"
+
+#include "pxr/base/tf/declarePtrs.h"
+#include "pxr/base/tf/stringUtils.h"
+
+#include <exception>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PUBLIC_TOKENS(PxrUsdMayaXformStackTokens,
+        PXRUSDMAYA_XFORM_STACK_TOKENS);
+
+typedef PxrUsdMayaXformStack::OpClassList OpClassList;
+typedef PxrUsdMayaXformStack::OpClass OpClass;
+typedef PxrUsdMayaXformStack::OpClassPair OpClassPair;
+
+typedef PxrUsdMayaXformStack::IndexPair IndexPair;
+typedef PxrUsdMayaXformStack::TokenIndexPairMap TokenIndexPairMap;
+typedef PxrUsdMayaXformStack::IndexMap IndexMap;
+
+namespace {
+    const UsdGeomXformOp::Type RotateOpTypes[] = {
+        UsdGeomXformOp::TypeRotateX,
+        UsdGeomXformOp::TypeRotateY,
+        UsdGeomXformOp::TypeRotateZ,
+        UsdGeomXformOp::TypeRotateXYZ,
+        UsdGeomXformOp::TypeRotateXZY,
+        UsdGeomXformOp::TypeRotateYXZ,
+        UsdGeomXformOp::TypeRotateYZX,
+        UsdGeomXformOp::TypeRotateZXY,
+        UsdGeomXformOp::TypeRotateZYX
+    };
+
+    bool _isThreeAxisRotate(UsdGeomXformOp::Type opType)
+    {
+        return (opType == UsdGeomXformOp::TypeRotateXYZ
+                || opType == UsdGeomXformOp::TypeRotateXZY
+                || opType == UsdGeomXformOp::TypeRotateYXZ
+                || opType == UsdGeomXformOp::TypeRotateYZX
+                || opType == UsdGeomXformOp::TypeRotateZXY
+                || opType == UsdGeomXformOp::TypeRotateZYX);
+    }
+
+    bool _isOneOrThreeAxisRotate(UsdGeomXformOp::Type opType)
+    {
+        return (opType == UsdGeomXformOp::TypeRotateXYZ
+                || opType == UsdGeomXformOp::TypeRotateXZY
+                || opType == UsdGeomXformOp::TypeRotateYXZ
+                || opType == UsdGeomXformOp::TypeRotateYZX
+                || opType == UsdGeomXformOp::TypeRotateZXY
+                || opType == UsdGeomXformOp::TypeRotateZYX
+                || opType == UsdGeomXformOp::TypeRotateX
+                || opType == UsdGeomXformOp::TypeRotateY
+                || opType == UsdGeomXformOp::TypeRotateZ);
+    }
+
+    IndexMap _buildInversionMap(
+            const std::vector<IndexPair>& inversionTwins)
+    {
+        IndexMap result;
+        for (const auto& twinPair : inversionTwins)
+        {
+            result[twinPair.first] = twinPair.second;
+            result[twinPair.second] = twinPair.first;
+        }
+        return result;
+    }
+
+    // Given a single index into ops, return the pair of
+    // indices, which is:
+    //     { opIndex, NO_INDEX }     if opIndex has no inversion twin
+    //     { opIndex, opIndexTwin }  if opIndex has an inversion twin, and opIndex < opIndexTwin
+    //     { opIndexTwin, opIndex }  if opIndex has an inversion twin, and opIndex > opIndexTwin
+    IndexPair
+    _makeInversionIndexPair(
+            size_t opIndex,
+            const IndexMap& inversionMap)
+    {
+        auto foundTwin = inversionMap.find(opIndex);
+        if (foundTwin == inversionMap.end())
+        {
+            return std::make_pair(opIndex, PxrUsdMayaXformStack::NO_INDEX);
+        }
+        else
+        {
+            const size_t twinOpIndex = foundTwin->second;
+            if (twinOpIndex >= opIndex)
+            {
+                return std::make_pair(opIndex, twinOpIndex);
+            }
+            else
+            {
+                return std::make_pair(twinOpIndex, opIndex);
+            }
+        }
+    }
+
+    TokenIndexPairMap _buildAttrNamesToIdxs(
+            const OpClassList& ops,
+            const IndexMap& inversionMap)
+    {
+        TokenIndexPairMap result;
+        for (size_t i = 0; i < ops.size(); ++i)
+        {
+            const PxrUsdMayaXformOpClassification& op = ops[i];
+            // Inverted twin pairs will always have same name, so can skip one
+            if (op.IsInvertedTwin()) continue;
+
+            for (auto attrName : op.CompatibleAttrNames())
+            {
+                auto indexPair = _makeInversionIndexPair(i, inversionMap);
+                // Insert, and check if it already existed
+                TF_VERIFY(result.insert({attrName, indexPair}).second,
+                        "AttrName %s already found in attrName lookup map",
+                        attrName.GetText());
+            }
+        }
+        return result;
+    }
+
+    TokenIndexPairMap _buildOpNamesToIdxs(
+            const OpClassList& ops,
+            const IndexMap& inversionMap)
+    {
+        TokenIndexPairMap result;
+        for (size_t i = 0; i < ops.size(); ++i)
+        {
+            const PxrUsdMayaXformOpClassification& op = ops[i];
+            // Inverted twin pairs will always have same name, so can skip one
+            if (op.IsInvertedTwin()) continue;
+
+            auto indexPair = _makeInversionIndexPair(i, inversionMap);
+            // Insert, and check if it already existed
+            TF_VERIFY(result.insert({op.GetName(), indexPair}).second,
+                    "Op classification name %s already found in op lookup map",
+                    op.GetName().GetText());
+        }
+        return result;
+    }
+
+}
+
+class _PxrUsdMayaXformOpClassificationData : public TfRefBase
+{
+public:
+    typedef TfRefPtr<_PxrUsdMayaXformOpClassificationData> RefPtr;
+
+    RefPtr static Create(const TfToken &name,
+            UsdGeomXformOp::Type opType,
+            bool isInvertedTwin)
+    {
+        return RefPtr(new _PxrUsdMayaXformOpClassificationData(
+                name, opType, isInvertedTwin));
+    }
+
+    bool operator ==(const _PxrUsdMayaXformOpClassificationData& other) const
+    {
+        return (m_name == other.m_name
+                && m_opType == other.m_opType
+                && m_isInvertedTwin == other.m_isInvertedTwin);
+    }
+
+    const TfToken m_name;
+    const UsdGeomXformOp::Type m_opType;
+    const bool m_isInvertedTwin;
+
+private:
+    _PxrUsdMayaXformOpClassificationData(const TfToken &name,
+            UsdGeomXformOp::Type opType,
+            bool isInvertedTwin) :
+                    m_name(name),
+                    m_opType(opType),
+                    m_isInvertedTwin(isInvertedTwin)
+    {
+    }
+};
+
+PxrUsdMayaXformOpClassification::PxrUsdMayaXformOpClassification() :
+                _sharedData(nullptr)
+{
+}
+
+PxrUsdMayaXformOpClassification::PxrUsdMayaXformOpClassification(
+        const TfToken &name,
+        UsdGeomXformOp::Type opType,
+        bool isInvertedTwin) :
+                _sharedData(_PxrUsdMayaXformOpClassificationData::Create(
+                        name, opType, isInvertedTwin))
+{
+}
+
+PxrUsdMayaXformOpClassification const &
+PxrUsdMayaXformOpClassification::NullInstance()
+{
+    static PxrUsdMayaXformOpClassification theNull;
+    return theNull;
+}
+
+bool
+PxrUsdMayaXformOpClassification::IsNull() const
+{
+    return !_sharedData;
+}
+
+TfToken const &
+PxrUsdMayaXformOpClassification::GetName() const
+{
+    return _sharedData->m_name;
+}
+
+UsdGeomXformOp::Type
+PxrUsdMayaXformOpClassification::GetOpType() const
+{
+    return _sharedData->m_opType;
+}
+
+bool
+PxrUsdMayaXformOpClassification::IsInvertedTwin() const
+{
+    return _sharedData->m_isInvertedTwin;
+}
+
+std::vector<TfToken>
+PxrUsdMayaXformOpClassification::CompatibleAttrNames() const
+{
+    // Note that we make tokens immortal because PxrUsdMayaXformOpClassification
+    // is currently not publically creatable, and is only used to make
+    // some global constants (ie, MayaStack and CommonStack)
+    std::vector<TfToken> result;
+    std::string attrName;
+    if (_isThreeAxisRotate(GetOpType()))
+    {
+        // Special handling for rotates, to deal with rotateX/rotateZXY/etc
+        if (GetName() == PxrUsdMayaXformStackTokens->rotate)
+        {
+            result.reserve(std::extent<decltype(RotateOpTypes)>::value * 3);
+            // Special handling for rotate, to deal with rotateX/rotateZXY/etc
+            for (UsdGeomXformOp::Type rotateType : RotateOpTypes)
+            {
+                // Add, ie, xformOp::rotateX
+                result.emplace_back(TfToken(
+                        UsdGeomXformOp::GetOpName(rotateType).GetString(),
+                        TfToken::Immortal));
+                // Add, ie, xformOp::rotateX::rotate
+                result.emplace_back(TfToken(
+                        UsdGeomXformOp::GetOpName(rotateType,
+                                PxrUsdMayaXformStackTokens->rotate).GetString(),
+                        TfToken::Immortal));
+                // Add, ie, xformOp::rotateX::rotateX
+                result.emplace_back(TfToken(
+                        UsdGeomXformOp::GetOpName(rotateType,
+                                UsdGeomXformOp::GetOpTypeToken(rotateType)).GetString(),
+                        TfToken::Immortal));
+            }
+        }
+        else
+        {
+            result.reserve(std::extent<decltype(RotateOpTypes)>::value);
+            for (UsdGeomXformOp::Type rotateType : RotateOpTypes)
+            {
+                // Add, ie, xformOp::rotateX::rotateAxis
+                result.emplace_back(TfToken(
+                        UsdGeomXformOp::GetOpName(rotateType,
+                                GetName()).GetString(),
+                        TfToken::Immortal));
+            }
+        }
+    }
+    else
+    {
+        // Add, ie, xformOp::translate::someName
+        result.emplace_back(TfToken(
+                UsdGeomXformOp::GetOpName(GetOpType(), GetName()).GetString(),
+                TfToken::Immortal));
+        if (GetName() == UsdGeomXformOp::GetOpTypeToken(GetOpType()))
+        {
+            // Add, ie, xformOp::translate
+            result.emplace_back(TfToken(
+                    UsdGeomXformOp::GetOpName(GetOpType()).GetString(),
+                    TfToken::Immortal));
+        }
+    }
+    return result;
+}
+
+bool
+PxrUsdMayaXformOpClassification::IsCompatibleType(UsdGeomXformOp::Type otherType) const
+{
+    if (GetOpType() == otherType) return true;
+    if (_isThreeAxisRotate(GetOpType() ))
+    {
+        return _isOneOrThreeAxisRotate(otherType);
+    }
+    return false;
+}
+
+bool PxrUsdMayaXformOpClassification::operator ==(const PxrUsdMayaXformOpClassification& other) const
+{
+    return *_sharedData == *other._sharedData;
+}
+
+// Lame that we need this... I had thought that constexpr would essentially be treated like
+// a compile-time #define, with better type safety! Instead, it seems it still creates a full-fledged
+// linker symbol...
+constexpr size_t PxrUsdMayaXformStack::NO_INDEX;
+
+class _PxrUsdMayaXformStackData : public TfRefBase
+{
+public:
+    typedef TfRefPtr<_PxrUsdMayaXformStackData> RefPtr;
+
+    RefPtr static Create(const OpClassList& ops,
+            const std::vector<IndexPair>& inversionTwins,
+            bool nameMatters)
+    {
+        return RefPtr(new _PxrUsdMayaXformStackData(
+                ops, inversionTwins, nameMatters));
+    }
+
+    _PxrUsdMayaXformStackData(
+            const OpClassList& ops,
+            const std::vector<IndexPair>& inversionTwins,
+            bool nameMatters) :
+                    m_ops(ops),
+                    m_inversionTwins(inversionTwins),
+                    m_inversionMap(_buildInversionMap(inversionTwins)),
+                    m_attrNamesToIdxs(
+                            _buildAttrNamesToIdxs(m_ops, m_inversionMap)),
+                    m_opNamesToIdxs(
+                            _buildOpNamesToIdxs(m_ops, m_inversionMap)),
+                    m_nameMatters(nameMatters)
+    {
+        // Verify that all inversion twins are of same type, and exactly one is marked
+        // as the inverted twin
+        for (auto& pair : m_inversionTwins)
+        {
+            const PxrUsdMayaXformOpClassification& first = m_ops[pair.first];
+            const PxrUsdMayaXformOpClassification& second = m_ops[pair.second];
+            TF_VERIFY(first.GetName() == second.GetName(),
+                    "Inversion twins %lu (%s) and %lu (%s) did not have same name",
+                    pair.first, first.GetName().GetText(),
+                    pair.second, second.GetName().GetText());
+            TF_VERIFY(first.GetOpType() == second.GetOpType(),
+                    "Inversion twins %lu and %lu (%s) were not same op type",
+                    pair.first, pair.second, first.GetName().GetText());
+            TF_VERIFY(first.IsInvertedTwin() != second.IsInvertedTwin(),
+                    "Inversion twins %lu and %lu (%s) were both marked as %s inverted twin",
+                    pair.first, pair.second, first.GetName().GetText(),
+                    first.IsInvertedTwin() ? "the" : "not the");
+        }
+    }
+
+    inline const OpClass&
+    GetOpClassFromIndex(
+            const size_t i) const
+    {
+        return i == PxrUsdMayaXformStack::NO_INDEX ? OpClass::NullInstance() : m_ops[i];
+    }
+
+    inline OpClassPair
+    MakeOpClassPairFromIndexPair(
+            const IndexPair& indexPair) const
+    {
+        return std::make_pair(
+                GetOpClassFromIndex(indexPair.first),
+                GetOpClassFromIndex(indexPair.second));
+    }
+
+    const OpClassList m_ops;
+    std::vector<IndexPair> m_inversionTwins;
+    IndexMap m_inversionMap;
+
+    // We store lookups from raw attribute name - use full attribute
+    // name because it's the only "piece" we know we have a pre-generated
+    // TfToken for - even Property::GetBaseName() generates a new TfToken
+    // "on the fly".
+    // The lookup maps to a PAIR of indices into the ops list;
+    // we return a pair because, due to inversion twins, it's possible
+    // for there to be two (but there should be only two!) ops with
+    // the same name - ie, if they're inversion twins. Thus, each pair
+    // of indices will either be:
+    //     { opIndex, NO_INDEX }     if opIndex has no inversion twin
+    //     { opIndex, opIndexTwin }  if opIndex has an inversion twin, and opIndex < opIndexTwin
+    //     { opIndexTwin, opIndex }  if opIndex has an inversion twin, and opIndex > opIndexTwin
+    TokenIndexPairMap m_attrNamesToIdxs;
+
+    // Also have a lookup by op name, for use by FindOp
+    TokenIndexPairMap m_opNamesToIdxs;
+
+    bool m_nameMatters = true;
+};
+
+PxrUsdMayaXformStack::PxrUsdMayaXformStack(
+        const OpClassList& ops,
+        const std::vector<IndexPair>& inversionTwins,
+        bool nameMatters) :
+        _sharedData(_PxrUsdMayaXformStackData::Create(
+                        ops, inversionTwins, nameMatters))
+{
+}
+
+OpClassList const &
+PxrUsdMayaXformStack::GetOps() const {
+    return _sharedData->m_ops;
+}
+
+std::vector<IndexPair> const &
+PxrUsdMayaXformStack::GetInversionTwins() const {
+    return _sharedData->m_inversionTwins;
+}
+
+bool
+PxrUsdMayaXformStack::GetNameMatters() const {
+    return _sharedData->m_nameMatters;
+}
+
+PxrUsdMayaXformOpClassification const &
+PxrUsdMayaXformStack::operator[] (const size_t index) const {
+    return _sharedData->m_ops[index];
+}
+
+size_t
+PxrUsdMayaXformStack::GetSize() const {
+    return _sharedData->m_ops.size();
+}
+
+size_t
+PxrUsdMayaXformStack::FindOpIndex(const TfToken& opName, bool isInvertedTwin) const
+{
+    const IndexPair& foundIdxPair = FindOpIndexPair(opName);
+
+    if(foundIdxPair.first == NO_INDEX) return NO_INDEX;
+
+    // we (potentially) found a pair of opPtrs... use the one that
+    // matches isInvertedTwin
+    const PxrUsdMayaXformOpClassification& firstOp = GetOps()[foundIdxPair.first];
+    if (firstOp.IsInvertedTwin())
+    {
+        if (isInvertedTwin) return foundIdxPair.first;
+        else return foundIdxPair.second;
+    }
+    else
+    {
+        if (isInvertedTwin) return foundIdxPair.second;
+        else return foundIdxPair.first;
+    }
+}
+
+const OpClass&
+PxrUsdMayaXformStack::FindOp(const TfToken& opName, bool isInvertedTwin) const
+{
+    return _sharedData->GetOpClassFromIndex(FindOpIndex(opName, isInvertedTwin));
+}
+
+const IndexPair&
+PxrUsdMayaXformStack::FindOpIndexPair(const TfToken& opName) const
+{
+    static IndexPair _NO_MATCH = std::make_pair(NO_INDEX, NO_INDEX);
+    TokenIndexPairMap::const_iterator foundTokenIdxPair =
+            _sharedData->m_opNamesToIdxs.find(opName);
+    if (foundTokenIdxPair == _sharedData->m_opNamesToIdxs.end())
+    {
+        // Couldn't find the xformop in our stack, abort
+        return _NO_MATCH;
+    }
+    return foundTokenIdxPair->second;
+}
+
+const OpClassPair
+PxrUsdMayaXformStack::FindOpPair(const TfToken& opName) const
+{
+    return _sharedData->MakeOpClassPairFromIndexPair(FindOpIndexPair(opName));
+}
+
+OpClassList
+PxrUsdMayaXformStack::MatchingSubstack(
+        const std::vector<UsdGeomXformOp>& xformops) const
+{
+    static const OpClassList _NO_MATCH;
+
+    if (xformops.empty()) return _NO_MATCH;
+
+    OpClassList ret;
+
+    // nextOp keeps track of where we will start looking for matches.  It
+    // will only move forward.
+    size_t nextOpIndex = 0;
+
+    std::vector<bool> opNamesFound(GetOps().size(), false);
+
+    TF_FOR_ALL(iter, xformops) {
+        const UsdGeomXformOp& xformOp = *iter;
+        size_t foundOpIdx = NO_INDEX;
+
+        if(GetNameMatters()) {
+            // First try the fast attrName lookup...
+            TokenIndexPairMap::const_iterator foundTokenIdxPair =
+                    _sharedData->m_attrNamesToIdxs.find(xformOp.GetName());
+            if (foundTokenIdxPair == _sharedData->m_attrNamesToIdxs.end())
+            {
+                // Couldn't find the xformop in our stack, abort
+                return _NO_MATCH;
+            }
+
+            // we found a pair of opPtrs... make sure one is
+            // not less than nextOp...
+            const IndexPair& foundIdxPair = foundTokenIdxPair->second;
+
+            if (foundIdxPair.first >= nextOpIndex)
+            {
+                foundOpIdx = foundIdxPair.first;
+            }
+            else if (foundIdxPair.second >= nextOpIndex && foundIdxPair.second != NO_INDEX)
+            {
+                foundOpIdx = foundIdxPair.second;
+            }
+            else
+            {
+                // The result we found is before an earlier-found op,
+                // so it doesn't match our stack... abort.
+                return _NO_MATCH;
+            }
+
+            assert(foundOpIdx != NO_INDEX);
+
+            // Now check that the op type matches...
+            if (!GetOps()[foundOpIdx].IsCompatibleType(xformOp.GetOpType()))
+            {
+                return _NO_MATCH;
+            }
+        }
+        else {
+            // If name does not matter, we just iterate through the remaining ops, until
+            // we find one with a matching type...
+            for(size_t i = nextOpIndex; i < GetSize(); ++i)
+            {
+                if (GetOps()[i].IsCompatibleType(xformOp.GetOpType()))
+                {
+                    foundOpIdx = i;
+                    break;
+                }
+            }
+            if (foundOpIdx == NO_INDEX) return _NO_MATCH;
+        }
+
+
+        // Ok, we found a match...
+        const PxrUsdMayaXformOpClassification& foundOp = GetOps()[foundOpIdx];
+
+        // move the nextOp pointer along.
+        ret.push_back(foundOp);
+        opNamesFound[foundOpIdx] = true;
+        nextOpIndex = foundOpIdx + 1;
+    }
+
+    // check pivot pairs
+    TF_FOR_ALL(pairIter, GetInversionTwins()) {
+        if (opNamesFound[pairIter->first] != opNamesFound[pairIter->second]) {
+            return _NO_MATCH;
+        }
+    }
+
+    return ret;
+}
+
+OpClassList
+PxrUsdMayaXformStack::FirstMatchingSubstack(
+        const std::vector<PxrUsdMayaXformStack const *>& stacks,
+        const std::vector<UsdGeomXformOp>& xformops)
+{
+    if (xformops.empty() || stacks.empty()) return OpClassList();
+
+    for (auto& stackPtr : stacks)
+    {
+        std::vector<PxrUsdMayaXformStack::OpClass> stackOps = \
+                stackPtr->MatchingSubstack(xformops);
+        if (!stackOps.empty())
+        {
+            return stackOps;
+        }
+    }
+
+    return OpClassList();
+}
+
+const PxrUsdMayaXformStack&
+PxrUsdMayaXformStack::MayaStack()
+{
+    static PxrUsdMayaXformStack mayaStack(
+            // ops
+            {
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->translate,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotatePivotTranslate,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotatePivot,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotate,
+                        UsdGeomXformOp::TypeRotateXYZ),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotateAxis,
+                        UsdGeomXformOp::TypeRotateXYZ),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotatePivot,
+                        UsdGeomXformOp::TypeTranslate,
+                        true /* isInvertedTwin */),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->scalePivotTranslate,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->scalePivot,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->shear,
+                        UsdGeomXformOp::TypeTransform),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->scale,
+                        UsdGeomXformOp::TypeScale),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->scalePivot,
+                        UsdGeomXformOp::TypeTranslate,
+                        true /* isInvertedTwin */)
+            },
+
+            // inversionTwins
+            {
+                {2, 5},
+                {7, 10},
+            });
+
+    return mayaStack;
+}
+
+const PxrUsdMayaXformStack&
+PxrUsdMayaXformStack::CommonStack()
+{
+    static PxrUsdMayaXformStack commonStack(
+            // ops
+            {
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->translate,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->pivot,
+                        UsdGeomXformOp::TypeTranslate),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->rotate,
+                        UsdGeomXformOp::TypeRotateXYZ),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->scale,
+                        UsdGeomXformOp::TypeScale),
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->pivot,
+                        UsdGeomXformOp::TypeTranslate,
+                        true /* isInvertedTwin */)
+            },
+
+            // inversionTwins
+            {
+                {1, 4},
+            });
+
+    return commonStack;
+}
+
+const PxrUsdMayaXformStack&
+PxrUsdMayaXformStack::MatrixStack()
+{
+    static PxrUsdMayaXformStack matrixStack(
+            // ops
+            {
+                PxrUsdMayaXformOpClassification(
+                        PxrUsdMayaXformStackTokens->transform,
+                        UsdGeomXformOp::TypeTransform)
+            },
+
+            // inversionTwins
+            {
+            },
+
+            // nameMatters
+            false
+    );
+
+    return matrixStack;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/xformStack.h
+++ b/third_party/maya/lib/usdMaya/xformStack.h
@@ -1,0 +1,317 @@
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#ifndef PXRUSDMAYA_XFORM_STACK_H
+#define PXRUSDMAYA_XFORM_STACK_H
+
+#include "pxr/pxr.h"
+#include "usdMaya/api.h"
+#include "pxr/base/tf/refPtr.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/usdGeom/xformOp.h"
+
+#include <maya/MTransformationMatrix.h>
+
+#include <limits>
+#include <vector>
+#include <unordered_map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Note: pivotTranslate is currently not used in MayaXformStack,
+// CommonXformStack, or MatrixStack, so it should never occur
+// at present, but there was some support for reading it, thus
+// why it's here
+
+/// \hideinitializer
+#define PXRUSDMAYA_XFORM_STACK_TOKENS \
+    (translate) \
+    (rotatePivotTranslate) \
+    (rotatePivot) \
+    (rotate) \
+    (rotateAxis) \
+    (scalePivotTranslate) \
+    (scalePivot) \
+    (shear) \
+    (scale) \
+    (pivot) \
+    (pivotTranslate) \
+    (transform)
+
+TF_DECLARE_PUBLIC_TOKENS(PxrUsdMayaXformStackTokens,
+        PXRUSDMAYA_API,
+        PXRUSDMAYA_XFORM_STACK_TOKENS);
+
+class _PxrUsdMayaXformOpClassificationData;
+class _PxrUsdMayaXformStackData;
+
+/// \class PxrUsdMayaXformOpClassification
+/// \brief Defines a named "class" of xform operation
+///
+/// Similar to UsdGeomXformOp, but without a specific attribute;
+/// UsdGeomXformOps can be thought of as "instances" of a
+/// PxrUsdMayaXformOpDefinition "type"
+class PxrUsdMayaXformOpClassification
+{
+public:
+    PxrUsdMayaXformOpClassification(const TfToken &name,
+                                       UsdGeomXformOp::Type opType,
+                                       bool isInvertedTwin=false);
+
+    PxrUsdMayaXformOpClassification();
+
+    static PxrUsdMayaXformOpClassification const & NullInstance();
+
+    PXRUSDMAYA_API
+    TfToken const &GetName() const;
+
+    PXRUSDMAYA_API
+    UsdGeomXformOp::Type GetOpType() const;
+
+    PXRUSDMAYA_API
+    bool IsInvertedTwin() const;;
+
+    /// Return True if the given op type is compatible with this
+    /// OpClassification (ie, is the same, or is, say rotateX, when
+    /// this op type is rotateXYZ)
+    PXRUSDMAYA_API
+    bool IsCompatibleType(UsdGeomXformOp::Type otherType) const;
+
+    PXRUSDMAYA_API
+    bool operator ==(const PxrUsdMayaXformOpClassification& other) const;
+
+    PXRUSDMAYA_API
+    bool IsNull() const;
+
+    PXRUSDMAYA_API
+    std::vector<TfToken> CompatibleAttrNames() const;
+
+private:
+    // Because this is an immutable type, we keep a pointer to shared
+    // data; this allows us to only have overhead associated with
+    // a RefPtr, while having easy-python-wrapping (without overhead
+    // of WeakPtr)
+    typedef TfRefPtr<_PxrUsdMayaXformOpClassificationData> DataRefPtr;
+
+    DataRefPtr _sharedData;
+};
+
+/// \class PxrUsdMayaXformStack
+/// \brief Defines a standard list of xform operations.
+///
+/// Used to define the set and order of transforms that programs like
+/// Maya use and understand.
+class PxrUsdMayaXformStack
+{
+public:
+    typedef PxrUsdMayaXformOpClassification OpClass;
+    typedef std::vector<OpClass> OpClassList;
+    typedef std::pair<const OpClass, const OpClass> OpClassPair;
+
+    // Internally, we use indices, because position sometimes matters...
+    // should be safe, since _ops is const.
+    static constexpr size_t NO_INDEX = std::numeric_limits<size_t>::max();
+    typedef std::pair<size_t, size_t> IndexPair;
+    typedef std::unordered_map<TfToken, IndexPair, TfToken::HashFunctor>
+            TokenIndexPairMap;
+    typedef std::unordered_map<size_t, size_t> IndexMap;
+
+
+    // Templated because we want it to work with both MEulerRotation::RotationOrder
+    // and MTransformationMatrix::RotationOrder
+    template<typename RotationOrder>
+    static RotationOrder RotateOrderFromOpType(
+            UsdGeomXformOp::Type opType,
+            RotationOrder defaultRotOrder=RotationOrder::kXYZ)
+    {
+        switch(opType) {
+            case UsdGeomXformOp::TypeRotateXYZ:
+                return  RotationOrder::kXYZ;
+            break;
+            case UsdGeomXformOp::TypeRotateXZY:
+                return  RotationOrder::kXZY;
+            break;
+            case UsdGeomXformOp::TypeRotateYXZ:
+                return  RotationOrder::kYXZ;
+            break;
+            case UsdGeomXformOp::TypeRotateYZX:
+                return  RotationOrder::kYZX;
+            break;
+            case UsdGeomXformOp::TypeRotateZXY:
+                return  RotationOrder::kZXY;
+            break;
+            case UsdGeomXformOp::TypeRotateZYX:
+                return  RotationOrder::kZYX;
+            break;
+            default:
+                return defaultRotOrder;
+            break;
+        }
+    }
+
+    PxrUsdMayaXformStack(
+            const OpClassList& ops,
+            const std::vector<IndexPair>& inversionTwins,
+            bool nameMatters=true);
+
+    // Don't want to accidentally make a copy, since the only instances are supposed
+    // to be static!
+    explicit PxrUsdMayaXformStack(const PxrUsdMayaXformStack& other) = default;
+    explicit PxrUsdMayaXformStack(PxrUsdMayaXformStack&& other) = default;
+
+    PXRUSDMAYA_API
+    OpClassList const & GetOps() const;
+
+    PXRUSDMAYA_API
+    const std::vector<IndexPair>& GetInversionTwins() const;
+
+    PXRUSDMAYA_API
+    bool GetNameMatters() const;
+
+    PXRUSDMAYA_API
+    PxrUsdMayaXformOpClassification const & operator[] (const size_t index) const;
+
+    PXRUSDMAYA_API
+    size_t GetSize() const;
+
+
+    /// \brief  Finds the index of the Op Classification with the given name in this stack
+    /// \param  opName the name of the operator classification we  wish to find
+    /// \param  isInvertedTwin the returned op classification object must match
+    ///         this param for it's IsInvertedTwin() - if an op is found that matches
+    ///         the name, but has the wrong invertedTwin status, NO_INDEX is returned
+    /// return  Index to the op classification object with the given name (and
+    ///         inverted twin state); will be NO_INDEX if no match could be found.
+    PXRUSDMAYA_API
+    size_t FindOpIndex(const TfToken& opName, bool isInvertedTwin=false) const;
+
+    /// \brief  Finds the Op Classification with the given name in this stack
+    /// \param  opName the name of the operator classification we  wish to find
+    /// \param  isInvertedTwin the returned op classification object must match
+    ///         this param for it's IsInvertedTwin() - if an op is found that matches
+    ///         the name, but has the wrong invertedTwin status, OpClass::NullInstance
+    ///         is returned
+    /// return  Reference to the op classification object with the given name (and
+    ///         inverted twin state); will be a reference to OpClass::NullInstance
+    ///         if no match could be found.
+    PXRUSDMAYA_API
+    const OpClass& FindOp(const TfToken& opName, bool isInvertedTwin=false) const;
+
+    /// \brief  Finds the indices of Op Classification(s) with the given name in this stack
+    /// \param  opName the name of the operator classification we  wish to find
+    /// return  A pair of indices to op classification objects with the given name;
+    ///         if the objects are part of an inverted twin pair, then both are
+    ///         returned (in the order they appear in this stack). If found, but
+    ///         not as part of an inverted twin pair, the first result will point
+    ///         to the found classification, and the second will be NO_INDEX.  If
+    ///         no matches are found, both will be NO_INDEX.
+    PXRUSDMAYA_API
+    const IndexPair& FindOpIndexPair(const TfToken& opName) const;
+
+    /// \brief  Finds the Op Classification(s) with the given name in this stack
+    /// \param  opName the name of the operator classification we  wish to find
+    /// return  A pair classification objects with the given name; if the objects
+    ///         are part of an inverted twin pair, then both are returned (in the
+    ///         order they appear in this stack). If found, but not as part of an
+    ///         inverted twin pair, the first result will point to the found
+    ///         classification, and the second will be OpClass::NullInstance.  If
+    ///         no matches are found, both results will be OpClass::NullInstance.
+    PXRUSDMAYA_API
+    const OpClassPair FindOpPair(const TfToken& opName) const;
+
+    /// \brief Returns a list of matching XformOpDefinitions for this stack
+    ///
+    /// For each xformop, we want to find the corresponding op within this
+    /// stack that it matches.  There are 3 requirements:
+    ///  - to be considered a match, the name and type must match an op in this stack
+    ///  - the matches for each xformop must have increasing indexes in the stack
+    ///  - inversionTwins must either both be matched or neither matched.
+    ///
+    /// This returns a vector of the matching XformOpDefinitions in this stack. The
+    /// size of this vector will be 0 if no complete match is found, or xformops.size()
+    /// if a complete match is found.
+    PXRUSDMAYA_API
+    OpClassList
+    MatchingSubstack(
+            const std::vector<UsdGeomXformOp>& xformops) const;
+
+    /// \brief The standard Maya xform stack
+    ///
+    /// Consists of these xform operators:
+    ///    translate
+    ///    rotatePivotTranslate
+    ///    rotatePivot
+    ///    rotate
+    ///    rotateAxis
+    ///    rotatePivot^-1 (inverted twin)
+    ///    scalePivotTranslate
+    ///    scalePivot
+    ///    shear
+    ///    scale
+    ///    scalePivot^-1 (inverted twin)
+    PXRUSDMAYA_API
+    static const PxrUsdMayaXformStack& MayaStack();
+
+
+    /// \brief The Common API xform stack
+    ///
+    /// Consists of these xform operators:
+    ///    translate
+    ///    pivot
+    ///    rotate
+    ///    scale
+    ///    pivot^-1 (inverted twin)
+    PXRUSDMAYA_API
+    static const PxrUsdMayaXformStack& CommonStack();
+
+    /// \brief xform "stack" consisting of only a single matrix xform
+    ///
+    /// This stack will match any list of xform ops that consist of a single
+    /// matrix "transform" op, regardless of name.
+    /// Consists of these xform operators:
+    ///    transform
+    PXRUSDMAYA_API
+    static const PxrUsdMayaXformStack& MatrixStack();
+
+    /// \brief Runs MatchingSubstack against the given list of stacks
+    ///
+    /// Returns the first non-empty result it finds; if all stacks
+    /// return an empty vector, an empty vector is returned.
+    static OpClassList
+    FirstMatchingSubstack(
+            const std::vector<PxrUsdMayaXformStack const *>& stacks,
+            const std::vector<UsdGeomXformOp>& xformops);
+
+private:
+    // Because this is an immutable type, we keep a pointer to shared
+    // data; this allows us to only have overhead associated with
+    // a RefPtr, while having easy-python-wrapping (without overhead
+    // of WeakPtr)
+    typedef TfRefPtr<_PxrUsdMayaXformStackData> DataRefPtr;
+
+    DataRefPtr _sharedData;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXRUSDMAYA_XFORM_STACK_H


### PR DESCRIPTION
### Description of Change(s)
This factors out the code for defining standardized transform stacks into a new class, xformStack.  This class is also responsible for checking compatibility with existing usd xform stacks.  This code is also exposed through the API for use externally.

There's actually nothing in the code which is specific to maya, so in theory it could be promoted to somewhere in the usd core, but it may be premature if it's not used anywhere else yet... and, of course, I'm sure that would warrant a higher level of scrutiny.

Speaking of scrutiny - I'm planning to add some unit tests, but wanted to give a chance for comment now!