### PR TITLE
provide a way to override the usd imaging scene delegate

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/delegate.h
+++ b/pxr/usdImaging/lib/usdImaging/delegate.h
@@ -434,6 +434,11 @@ public:
     USDIMAGING_API
     bool IsInInvisedPaths(const SdfPath &usdPath) const;
 
+protected:
+  
+    USDIMAGING_API
+    UsdStageRefPtr GetStage() { return _stage; }
+    
 private:
     // Internal friend class.
     class _Worker;

--- a/pxr/usdImaging/lib/usdImagingGL/hdEngine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/hdEngine.cpp
@@ -60,7 +60,8 @@ UsdImagingGLHdEngine::UsdImagingGLHdEngine(
         const SdfPath& rootPath,
         const SdfPathVector& excludedPrimPaths,
         const SdfPathVector& invisedPrimPaths,
-        const SdfPath& delegateID)
+        const SdfPath& delegateID,
+        UsdImagingDelegateCreatorFunc delegateCreatorFunc)
     : UsdImagingGLEngine()
     , _renderIndex(nullptr)
     , _selTracker(new HdxSelectionTracker)
@@ -77,6 +78,7 @@ UsdImagingGLHdEngine::UsdImagingGLHdEngine(
     , _invisedPrimPaths(invisedPrimPaths)
     , _isPopulated(false)
     , _renderTags()
+    , _delegateCreatorFunc(delegateCreatorFunc)
 {
     // _renderIndex, _taskController, and _delegate are initialized
     // by the plugin system.
@@ -983,7 +985,7 @@ UsdImagingGLHdEngine::SetRendererPlugin(TfToken const &id)
     _renderIndex = HdRenderIndex::New(renderDelegate);
 
     // Create the new delegate & task controller.
-    _delegate = new UsdImagingDelegate(_renderIndex, _delegateID);
+    _delegate = _delegateCreatorFunc(_renderIndex, _delegateID);
     _isPopulated = false;
 
     _taskController = new HdxTaskController(_renderIndex,
@@ -1036,6 +1038,13 @@ VtDictionary
 UsdImagingGLHdEngine::GetResourceAllocation() const
 {
     return _renderIndex->GetResourceRegistry()->GetResourceAllocation();
+}
+
+
+UsdImagingDelegate* 
+UsdImagingGLHdEngine::defaultUsdImagingDelegateCreator(HdRenderIndex* const renderIndex, const SdfPath& delegateId)
+{
+    return new UsdImagingDelegate(renderIndex, delegateId);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
@@ -56,9 +56,15 @@ typedef std::vector<UsdImagingGLHdEngineSharedPtr>
                                         UsdImagingGLHdEngineSharedPtrVector;
 typedef std::vector<UsdPrim> UsdPrimVector;
 
+typedef UsdImagingDelegate* (*UsdImagingDelegateCreatorFunc)(HdRenderIndex*, const SdfPath&);
+
 class UsdImagingGLHdEngine : public UsdImagingGLEngine
 {
 public:
+ 
+    USDIMAGINGGL_API
+    static UsdImagingDelegate* defaultUsdImagingDelegateCreator(HdRenderIndex* renderIndex, const SdfPath& delegateId);
+  
     // Important! Call UsdImagingGLHdEngine::IsDefaultPluginAvailable() before
     // construction; if no plugins are available, the class will only
     // get halfway constructed.
@@ -66,7 +72,8 @@ public:
     UsdImagingGLHdEngine(const SdfPath& rootPath,
                        const SdfPathVector& excludedPaths,
                        const SdfPathVector& invisedPaths=SdfPathVector(),
-                       const SdfPath& delegateID = SdfPath::AbsoluteRootPath());
+                       const SdfPath& delegateID = SdfPath::AbsoluteRootPath(),
+                       UsdImagingDelegateCreatorFunc delegateCreatorFunc = defaultUsdImagingDelegateCreator);
 
     USDIMAGINGGL_API
     static bool IsDefaultPluginAvailable();
@@ -248,6 +255,7 @@ private:
     bool _isPopulated;
 
     TfTokenVector _renderTags;
+    UsdImagingDelegateCreatorFunc _delegateCreatorFunc;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
This change provides a way for clients of UsdImaging to use a derived UsdImagingDelegate. We need to make this change to allow the AL_USDMayaPlugin to provide its own scene delegate to allow us to transparently map OpenGL handles from Maya/VP2 _(e.g. file textures, image planes, results from previous render passes, etc, etc)_ through to the GLSL shaders used within UsdHydra. We have a prototype of this up an running, and would like to start rolling this out to the public branch of AL_USDMaya. 

In effect, it allows us to set up some additional data within our USD files, e.g.

```
    def Shader "imagePlaneTest"
    {
        uniform token info:id = "HwUvTexture_1"
        color3f outputs:colour
        custom string mayakind = "imagePlane"
        custom string mayanode = "imagePlaneShape1"
        float2 imgp_offset = (0, 0)
        float2 imgp_scale = (0.5, 0.5)
        float imgp_rotate = 0
    }
   
    def Shader "fileTextureTest"
    {
        rel connectedSourceFor:uv = </material/uvcoords.outputs:result>
        uniform token info:id = "HwUvTexture_1"
        color3f outputs:colour
        float2 uv
        custom string mayakind = "fileTexture"
        custom string mayanode = "file1"
    }
```

Which are intercepted by our custom UsdImagingDelegate, and provides some customised TextureResource classes to map the maya VP2 data into UsdImaging, e.g. 

```c++
GLuint MayaFileTextureResource::GetTexelsTextureId()
{
  MHWRender::MRenderer* const renderer = MHWRender::MRenderer::theRenderer();
  MHWRender::MTextureManager* const textureMgr = renderer ? renderer->getTextureManager() : nullptr;
  const MHWRender::MTexture* texture = 0;

  if (textureMgr)
  {
    const MHWRender::MTexture* const texture = textureMgr->acquireTexture(m_fileTexture, true);
    if(texture)
    {
      const void* const handle = texture->resourceHandle();
      if(handle)
      {
        return *((const GLuint*)handle);
      }
    }
  }
  return 0;
}
```

### Fixes Issue(s)
- Provides a way for users of UsdImaging to override the behaviour of the imaging delegate used internally within UsdImaging. 

