### PR TITLE
Auto deleter for pointers stolen from a UT_String needs to be a callback deleter

### DIFF
--- a/third_party/houdini/lib/gusd/GU_USD.cpp
+++ b/third_party/houdini/lib/gusd/GU_USD.cpp
@@ -114,7 +114,7 @@ GusdGU_USD::ComputeRangeIndexMap(const GA_Range& r,
 
     exint i = 0;
     for(GA_Iterator it(r); !it.atEnd(); ++it, ++i)
-        indexMap(*it) = i;
+        indexMap(*it) = GA_Offset(i);
     return true;
 }
 

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -184,7 +184,11 @@ void _AppendTypes(const TfType& type, UT_Array<PRM_Name>& names,
     _MakePrefixedName(label, typeName.c_str(), depth, "|   ");
     
     names.append(PRM_Name(typeName.c_str(), deleter.appendCallback(
+#if HDK_API_VERSION >= 16050000
 	hboost::function<void (char *)>(free), label.steal())));
+#else
+	boost::function<void (char *)>(free), label.steal())));
+#endif
     
     for(const auto& derived : type.GetDirectlyDerivedTypes())
         _AppendTypes(derived, names, deleter, depth+1);
@@ -215,7 +219,11 @@ void _AppendKinds(const GusdUSD_Utils::KindNode* kind,
     _MakePrefixedName(label, name.c_str(), depth, "|   ");
 
     names.append(PRM_Name(name.c_str(), deleter.appendCallback(
+#if HDK_API_VERSION >= 16050000
 	hboost::function<void (char *)>(free), label.steal())));
+#else
+	boost::function<void (char *)>(free), label.steal())));
+#endif
     
     for(const auto& derived : kind->children)
         _AppendKinds(derived.get(), names, deleter, depth+1);

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -183,7 +183,8 @@ void _AppendTypes(const TfType& type, UT_Array<PRM_Name>& names,
     UT_String label;
     _MakePrefixedName(label, typeName.c_str(), depth, "|   ");
     
-    names.append(PRM_Name(typeName.c_str(), deleter.append(label.steal())));
+    names.append(PRM_Name(typeName.c_str(), deleter.appendCallback(
+	hboost::function<void (char *)>(free), label.steal())));
     
     for(const auto& derived : type.GetDirectlyDerivedTypes())
         _AppendTypes(derived, names, deleter, depth+1);
@@ -213,7 +214,8 @@ void _AppendKinds(const GusdUSD_Utils::KindNode* kind,
     UT_String label;
     _MakePrefixedName(label, name.c_str(), depth, "|   ");
 
-    names.append(PRM_Name(name.c_str(), deleter.append(label.steal())));
+    names.append(PRM_Name(name.c_str(), deleter.appendCallback(
+	hboost::function<void (char *)>(free), label.steal())));
     
     for(const auto& derived : kind->children)
         _AppendKinds(derived.get(), names, deleter, depth+1);

--- a/third_party/houdini/lib/gusd/refiner.cpp
+++ b/third_party/houdini/lib/gusd/refiner.cpp
@@ -152,7 +152,7 @@ GusdRefiner::refineDetail(
         if( overTransformsAttr ) {
             GA_ROHandleI h( overTransformsAttr );
             if( overTransformsAttr->getOwner() == GA_ATTRIB_DETAIL ) {
-                overlayTransforms = h.get( 0 );
+                overlayTransforms = h.get( GA_Offset(0) );
             }
             else {
                 // assume all prims in the range have the same usdovertransforms


### PR DESCRIPTION
This misuse of PRM_AutoDeleter was caught by running through an address sanitizer which pointer out the use of malloc to allocate and delete to free the stolen string.

The GA_Offset casting is from a build of Houdini where GA_Offset is a class, not a simple typedef to int. Often this catches bad code. The code in GU_Usd.cpp actually looks a bit suspicious, but I can't find any evidence it is actually called, so perhaps this function should be deleted?
