### PR TITLE
Fix a number of minor warnings in the Houdini plugin code.

### DIFF
--- a/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
@@ -481,7 +481,7 @@ GusdGT_PackedUSD(
         const SdfPath& srcPrimPath,
         exint instanceIndex,
         UsdTimeCode frame,
-        GusdPurposeSet purpose,
+        GusdPurposeSet,
         GT_AttributeListHandle pointAttributes,
         GT_AttributeListHandle vertexAttributes,
         GT_AttributeListHandle uniformAttributes,
@@ -493,7 +493,6 @@ GusdGT_PackedUSD(
     , m_srcPrimPath(srcPrimPath)
     , m_instanceIndex(instanceIndex)
     , m_frame(frame)
-    , m_purpose(purpose)
     , m_pointAttributes(pointAttributes)
     , m_vertexAttributes(vertexAttributes)
     , m_uniformAttributes(uniformAttributes)

--- a/third_party/houdini/lib/gusd/GT_PackedUSD.h
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.h
@@ -64,7 +64,7 @@ public:
         const SdfPath& srcPrimPath,
         exint index,
         UsdTimeCode frame,
-        GusdPurposeSet purpose,
+        GusdPurposeSet purpose,	// Unused
         GT_AttributeListHandle pointAttributes,
         GT_AttributeListHandle vertexAttributes,
         GT_AttributeListHandle uniformAttributes,
@@ -119,7 +119,6 @@ private:
     SdfPath         m_srcPrimPath;
     exint           m_instanceIndex;
     UsdTimeCode     m_frame;
-    GusdPurposeSet  m_purpose;
     UT_BoundingBox  m_box;
 
     GT_AttributeListHandle  m_pointAttributes;

--- a/third_party/houdini/lib/gusd/GT_PrimCache.h
+++ b/third_party/houdini/lib/gusd/GT_PrimCache.h
@@ -21,7 +21,7 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef __GUSD_GT_PRIMCACHE_H_
+#ifndef __GUSD_GT_PRIMCACHE_H__
 #define __GUSD_GT_PRIMCACHE_H__
 
 

--- a/third_party/houdini/lib/gusd/UT_CappedCache.h
+++ b/third_party/houdini/lib/gusd/UT_CappedCache.h
@@ -151,7 +151,7 @@ GusdUT_CappedCache::FindOrCreate(const UT_CappedKey& key,
         // Make sure another thread didn't beat us to it.
         a->second = findItem(key);
         if(!a->second) {
-            if(a->second = creator(args...)) {
+            if((a->second = creator(args...))) {
                 addItem(key, a->second);
             } else {
                 _constructMap.erase(a);

--- a/third_party/houdini/lib/gusd/UT_StaticInit.h
+++ b/third_party/houdini/lib/gusd/UT_StaticInit.h
@@ -54,9 +54,9 @@ struct GusdUT_StaticValHolder
 {
 public:
     typedef GusdUT_StaticValHolder<Fn> This;
-    using T = typename std::result_of<const Fn& ()>::type;
+    using T = typename std::result_of<Fn& ()>::type;
 
-    GusdUT_StaticValHolder(const Fn& fn)
+    GusdUT_StaticValHolder(Fn& fn)
         : _val(NULL), _fn(fn), _lock() {}
 
     GusdUT_StaticValHolder(This&& o) noexcept
@@ -85,7 +85,7 @@ public:
         }
 
 private:
-    const Fn&   _fn;
+    Fn&         _fn;
     UT_Lock     _lock;
     T*          _val;
 };

--- a/third_party/houdini/lib/gusd/UT_Version.h
+++ b/third_party/houdini/lib/gusd/UT_Version.h
@@ -26,7 +26,7 @@
    \brief Helpers for dealing with versioning in the HDK.
 */
 #ifndef _GUSD_UT_VERSION_H_
-#define _GUSD_UT_UT_VERSION_H_
+#define _GUSD_UT_VERSION_H_
 
 #include <pxr/pxr.h>
 
@@ -108,4 +108,4 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-#endif /* _GUSD_UT_UT_VERSION_H_ */
+#endif /* _GUSD_UT_VERSION_H_ */

--- a/third_party/houdini/lib/gusd/primWrapper.cpp
+++ b/third_party/houdini/lib/gusd/primWrapper.cpp
@@ -280,7 +280,8 @@ GusdPrimWrapper::GusdPrimWrapper()
 GusdPrimWrapper::GusdPrimWrapper( 
         const UsdTimeCode &time, 
         const GusdPurposeSet &purposes )
-    : m_time( time )
+    : GT_Primitive()
+    , m_time( time )
     , m_purposes( purposes )
     , m_visible( true )
     , m_lastXformSet( UsdTimeCode::Default() )
@@ -289,7 +290,8 @@ GusdPrimWrapper::GusdPrimWrapper(
 }
 
 GusdPrimWrapper::GusdPrimWrapper( const GusdPrimWrapper &in )
-    : m_time( in.m_time )
+    : GT_Primitive(in)
+    , m_time( in.m_time )
     , m_purposes( in.m_purposes )
     , m_visible( in.m_visible )
     , m_lastXformSet( in.m_lastXformSet )

--- a/third_party/houdini/lib/gusd/shaderWrapper.cpp
+++ b/third_party/houdini/lib/gusd/shaderWrapper.cpp
@@ -241,7 +241,7 @@ _vopGraphToUsdTraversal(const VOP_Node* vopNode,
                 parmDeps[parm] = shadeInput;
 
                 if(!isConnected) {
-                    double val;   
+                    fpreal val;
                     parm->getValue(0, val, 0, SYSgetSTID());
                     shadeInput.Set((float)val);
                 }

--- a/third_party/houdini/lib/gusd/stageCache.cpp
+++ b/third_party/houdini/lib/gusd/stageCache.cpp
@@ -974,8 +974,8 @@ GusdStageCacheReader::GetPrim(const UT_StringRef& path,
     if(path && primPath.IsAbsolutePath() &&
        primPath.IsAbsoluteRootOrPrimPath()) {
 
-        if(pair.second = _cache._impl->FindOrOpenMaskedStage(
-               path, opts, edit, primPath, err)) {
+        if((pair.second = _cache._impl->FindOrOpenMaskedStage(
+               path, opts, edit, primPath, err))) {
 
             pair.first =
                 GusdUSD_Utils::GetPrimFromStage(pair.second, primPath, err);

--- a/third_party/houdini/lib/gusd/stageCache.h
+++ b/third_party/houdini/lib/gusd/stageCache.h
@@ -92,7 +92,7 @@ public:
 
 
 public://TEMP
-    struct _Impl;
+    class _Impl;
     _Impl* const    _impl;
 
     friend class GusdStageCacheReader;

--- a/third_party/houdini/plugin/OP_gusd/OBJ_usdcamera.h
+++ b/third_party/houdini/plugin/OP_gusd/OBJ_usdcamera.h
@@ -92,7 +92,7 @@ public:
                                     OP_Operator* op);
 
     /** Overridden to modify defaults of scripted properties. */
-    virtual bool            runCreateScript();
+    virtual bool            runCreateScript() override;
 
     /** Evaluate the float value of a variable.
         This is where we hook in most of our USD queries. */
@@ -111,14 +111,14 @@ protected:
     virtual ~GusdOBJ_usdcamera() {}
 
     virtual int             applyInputIndependentTransform(OP_Context& ctx,
-                                                           UT_DMatrix4& mx);
+				UT_DMatrix4& mx) override;
 
-    virtual bool            updateParmsFlags();
+    virtual bool            updateParmsFlags() override;
 
-    virtual void            loadStart();
-    virtual void            loadFinished();
+    virtual void            loadStart() override;
+    virtual void            loadFinished() override;
 
-    virtual OP_ERROR        cookMyObj(OP_Context& ctx);
+    virtual OP_ERROR        cookMyObj(OP_Context& ctx) override;
 
 private:
     OP_ERROR                _Cook(OP_Context& ctx);

--- a/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.h
+++ b/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.h
@@ -59,7 +59,7 @@ public:
 
     virtual ~GusdROP_usdoutput();
 
-    virtual bool updateParmsFlags();
+    virtual bool updateParmsFlags() override;
     
     virtual int startRender(int frameCount,
                             fpreal tstart,


### PR DESCRIPTION
Some typos in include guards.
Adding override keyword consistently on virtual overrides.
Placing assignments in if() expressions inside parentheses.
Removing unuse m_purposeSet member data.
Pre-declare a class as a class, not as a struct.

These warnings were all reported by clang.
