### PR TITLE
[maya] fix for exporting orientation attribute for doubleSided meshes

### DIFF
--- a/third_party/maya/lib/usdMaya/translatorGprim.cpp
+++ b/third_party/maya/lib/usdMaya/translatorGprim.cpp
@@ -59,18 +59,20 @@ PxrUsdMayaTranslatorGprim::Write(
 {
     MFnDependencyNode depFn(mayaNode);
 
-    bool opposite = false;
-    // Gprim properties always authored on the shape
-    if (PxrUsdMayaUtil::getPlugValue(depFn, "opposite", &opposite)){
-        TfToken orientation = (opposite ? UsdGeomTokens->leftHanded :
-                                          UsdGeomTokens->rightHanded);
-        gprim.CreateOrientationAttr(VtValue(orientation), true);
-    }
-
     bool doubleSided = false;
     if (PxrUsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)){
         gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
     }
+
+    bool opposite = false;
+    // Gprim properties always authored on the shape
+    if (PxrUsdMayaUtil::getPlugValue(depFn, "opposite", &opposite)){
+        // If mesh is double sided in maya, opposite is disregarded
+        TfToken orientation = (opposite && !doubleSided ? UsdGeomTokens->leftHanded :
+                                                          UsdGeomTokens->rightHanded);
+        gprim.CreateOrientationAttr(VtValue(orientation), true);
+    }
+
 }
 
 


### PR DESCRIPTION
### Description of Change(s)
If a mesh is "doubleSided", do not export an "opposite" attribute. The "opposite" attribute is disabled and disregarded in maya, so it should not be set in usd. (Before "opposite" was getting exported regardless of "doubleSided".)

### Fixes Issue(s)
This is a fix for getting different sidedness across DCCs.

When a mesh is doubleSided, maya ignores the "opposite" sidedness, and treats the mesh the same as if it were unchecked. However, once you've exported the mesh to USD it would pick up on the disabled checkboxes state and will give you a different result. Other DCC's that consume the USD file will then have a different picture of the mesh than existed in maya. 