### PR TITLE
disable testUsdExportRenderLayerMode on maya-2018

### DIFF
--- a/third_party/maya/lib/usdMaya/testenv/testUsdExportRenderLayerMode.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdExportRenderLayerMode.py
@@ -34,8 +34,10 @@ from pxr import Vt
 from maya import cmds
 from maya import standalone
 from maya import OpenMayaRender as OMR
+from maya import OpenMaya as OM
 
-
+@unittest.skipIf(OM.MGlobal.apiVersion() >= 20180000,
+                 "Maya 2018 doesn't support old-style render layers")
 class testUsdExportRenderLayerMode(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
### Description of Change(s)
disable testUsdExportRenderLayerMode on maya-2018

### Fixes Issue(s)
- These tests will always fail on Maya 2018, since old-style render layers are disabled

