### PR TITLE
[maya] add stripNamespaces flag to usdExport

### DIFF
--- a/third_party/maya/lib/usdMaya/JobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/JobArgs.cpp
@@ -262,6 +262,9 @@ JobExportArgs::JobExportArgs(
                 PxrUsdExportJobArgsTokens->mergeTransformAndShape)),
         normalizeNurbs(
             _Boolean(userArgs, PxrUsdExportJobArgsTokens->normalizeNurbs)),
+        stripNamespaces(
+            _Boolean(userArgs,
+                PxrUsdExportJobArgsTokens->stripNamespaces)),
         parentScope(
             _AbsolutePath(userArgs, PxrUsdExportJobArgsTokens->parentScope)),
         renderLayerMode(
@@ -279,7 +282,6 @@ JobExportArgs::JobExportArgs(
                 PxrUsdExportJobArgsTokens->shadingMode,
                 PxrUsdMayaShadingModeTokens->none,
                 PxrUsdMayaShadingModeRegistry::ListExporters())),
-
         chaserNames(
             _Vector<std::string>(userArgs, PxrUsdExportJobArgsTokens->chaser)),
         allChaserArgs(
@@ -404,6 +406,7 @@ const VtDictionary& JobExportArgs::GetDefaultDictionary()
                 PxrUsdExportJobArgsTokens->defaultLayer.GetString();
         d[PxrUsdExportJobArgsTokens->shadingMode] =
                 PxrUsdMayaShadingModeTokens->displayColor.GetString();
+        d[PxrUsdExportJobArgsTokens->stripNamespaces] = false;
 
         // plugInfo.json site defaults.
         // The defaults dict should be correctly-typed, so enable

--- a/third_party/maya/lib/usdMaya/JobArgs.h
+++ b/third_party/maya/lib/usdMaya/JobArgs.h
@@ -79,6 +79,7 @@ TF_DECLARE_PUBLIC_TOKENS(PxrUsdMayaTranslatorTokens,
     (renderableOnly) \
     (renderLayerMode) \
     (shadingMode) \
+    (stripNamespaces) \
     /* renderLayerMode values */ \
     (defaultLayer) \
     (currentLayer) \
@@ -125,6 +126,7 @@ struct JobExportArgs
     const SdfPath materialCollectionsPath;
     const bool mergeTransformAndShape;
     const bool normalizeNurbs;
+    const bool stripNamespaces;
     const SdfPath parentScope;
     const TfToken renderLayerMode;
     const TfToken rootKind;

--- a/third_party/maya/lib/usdMaya/MayaInstancerWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaInstancerWriter.cpp
@@ -133,7 +133,7 @@ MayaInstancerWriter::_ExportPrototype(
     // The USD path of the prototype root if it were exported at its current
     // Maya location.
     const SdfPath prototypeComputedUsdPath =
-            PxrUsdMayaUtil::MDagPathToUsdPath(prototypeDagPath, false);
+            PxrUsdMayaUtil::MDagPathToUsdPath(prototypeDagPath, false, getArgs().stripNamespaces);
 
     MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid);
     itDag.reset(prototypeDagPath);
@@ -149,7 +149,7 @@ MayaInstancerWriter::_ExportPrototype(
         // The USD path of this prototype descendant prim if it were exported
         // at its current Maya location.
         const SdfPath curComputedUsdPath =
-                PxrUsdMayaUtil::MDagPathToUsdPath(curDagPath, false);
+                PxrUsdMayaUtil::MDagPathToUsdPath(curDagPath, false, getArgs().stripNamespaces);
 
         // Compute the current prim's relative path w/r/t the prototype root,
         // and use this to re-anchor it under the USD stage location where

--- a/third_party/maya/lib/usdMaya/MayaMeshWriter_Skin.cpp
+++ b/third_party/maya/lib/usdMaya/MayaMeshWriter_Skin.cpp
@@ -381,7 +381,7 @@ MayaMeshWriter::writeSkinningData(UsdGeomMesh& primSchema)
     // Get joint name tokens how MayaSkeletonWriter would generate them.
     // We don't need to check that they actually exist.
     VtTokenArray jointNames = MayaSkeletonWriter::GetJointNames(
-            jointDagPaths, rootJoint);
+            jointDagPaths, rootJoint, getArgs().stripNamespaces);
 
     // The data in the skinCluster is essentially already in the same format 
     // as UsdSkel expects, but we're going to compress it by only outputting

--- a/third_party/maya/lib/usdMaya/MayaSkeletonWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaSkeletonWriter.h
@@ -65,13 +65,14 @@ public:
     /// hierarchy with the given root joint.
     static VtTokenArray GetJointNames(
             const std::vector<MDagPath>& joints,
-            const MDagPath& rootJoint);
+            const MDagPath& rootJoint,
+            bool stripNamespaces);
     /// Gets the expected path where a UsdSkelSkeleton prim will be exported
     /// for the given root joint.
-    static SdfPath GetSkeletonPath(const MDagPath& rootJoint);
+    static SdfPath GetSkeletonPath(const MDagPath& rootJoint, bool stripNamespaces);
     /// Gets the expected path where a UsdSkelPackedJointAnimation prim will be
     /// exported for the given root joint.
-    static SdfPath GetAnimationPath(const MDagPath& rootJoint);
+    static SdfPath GetAnimationPath(const MDagPath& rootJoint, bool stripNamespaces);
 
 private:
     std::vector<MDagPath> _animatedJoints;

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
@@ -46,6 +46,9 @@ struct PxrUsdMayaExportParams {
     /// per-gprim bindings.
     bool exportCollectionBasedBindings=false;
 
+    /// Stripping namespaces.
+    bool stripNamespaces=false;
+
     /// Modified root path. 
     SdfPath overrideRootPath;
 

--- a/third_party/maya/lib/usdMaya/skelBindingsWriter.cpp
+++ b/third_party/maya/lib/usdMaya/skelBindingsWriter.cpp
@@ -72,7 +72,8 @@ static void
 _WriteSkelBindings(
     const SdfPath& bindingSite,
     const UsdStagePtr& stage,
-    const MDagPath& skeletonDagPath)
+    const MDagPath& skeletonDagPath,
+    bool stripNamespaces)
 {
     if (!skeletonDagPath.isValid()) {
         TF_CODING_ERROR("Skeleton '%s' is not valid",
@@ -84,7 +85,7 @@ _WriteSkelBindings(
     const UsdSkelBindingAPI bindingAPI = PxrUsdMayaTranslatorUtil
             ::GetAPISchemaForAuthoring<UsdSkelBindingAPI>(bindingPrim);
 
-    SdfPath skeletonPath = MayaSkeletonWriter::GetSkeletonPath(skeletonDagPath);
+    SdfPath skeletonPath = MayaSkeletonWriter::GetSkeletonPath(skeletonDagPath, stripNamespaces);
     if (stage->GetPrimAtPath(skeletonPath)) {
         if (UsdRelationship existingRel = bindingAPI.GetSkeletonRel()) {
             _CheckRelHasOneTarget(existingRel, skeletonPath);
@@ -93,7 +94,7 @@ _WriteSkelBindings(
             bindingAPI.CreateSkeletonRel().AddTarget(skeletonPath);
         }
     }
-    SdfPath animPath = MayaSkeletonWriter::GetAnimationPath(skeletonDagPath);
+    SdfPath animPath = MayaSkeletonWriter::GetAnimationPath(skeletonDagPath, stripNamespaces);
     if (stage->GetPrimAtPath(animPath)) {
         if (UsdRelationship existingRel = bindingAPI.GetAnimationSourceRel()) {
             _CheckRelHasOneTarget(existingRel, animPath);
@@ -140,7 +141,9 @@ _GetRootBoundPaths(
 }
 
 bool
-PxrUsdMaya_SkelBindingsWriter::WriteSkelBindings(const UsdStagePtr& stage) const
+PxrUsdMaya_SkelBindingsWriter::WriteSkelBindings(
+    const UsdStagePtr& stage,
+    bool stripNamespaces) const
 {
     for (const auto& skelRootPathAndData : _skelRootMap) {
         const SdfPath& skelRootPath = skelRootPathAndData.first;
@@ -158,7 +161,8 @@ PxrUsdMaya_SkelBindingsWriter::WriteSkelBindings(const UsdStagePtr& stage) const
             _WriteSkelBindings(
                     skelRootPath,
                     stage,
-                    *skelRootData.skeletonDagPaths.begin());
+                    *skelRootData.skeletonDagPaths.begin(),
+                    stripNamespaces);
             continue;
         }
 
@@ -211,7 +215,7 @@ PxrUsdMaya_SkelBindingsWriter::WriteSkelBindings(const UsdStagePtr& stage) const
                     /*minIncludeExcludeCollectionSize*/ 1u, // always compute
                     pathsToIgnore);
             for (const SdfPath& path : pathsToInclude) {
-                _WriteSkelBindings(path, stage, skeletonDagPath);
+                _WriteSkelBindings(path, stage, skeletonDagPath, stripNamespaces);
             }
         }
     }

--- a/third_party/maya/lib/usdMaya/skelBindingsWriter.h
+++ b/third_party/maya/lib/usdMaya/skelBindingsWriter.h
@@ -66,7 +66,7 @@ public:
 
     /// Writes the final minimal set of skel bindings into the stage. See the
     /// class description for more information on how this works.
-    bool WriteSkelBindings(const UsdStagePtr& stage) const;
+    bool WriteSkelBindings(const UsdStagePtr& stage, bool stripNamespaces) const;
 
 private:
     struct SkelRootData {

--- a/third_party/maya/lib/usdMaya/usdExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdExport.cpp
@@ -93,6 +93,9 @@ MSyntax usdExport::createSyntax()
     syntax.addFlag("-cls",
                    PxrUsdExportJobArgsTokens->exportColorSets.GetText(),
                    MSyntax::kBoolean);
+    syntax.addFlag("-sn",
+                   PxrUsdExportJobArgsTokens->stripNamespaces.GetText(),
+                   MSyntax::kBoolean);
     syntax.addFlag("-dms",
                    PxrUsdExportJobArgsTokens->defaultMeshScheme.GetText(),
                    MSyntax::kString);

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -141,6 +141,8 @@ global proc int usdTranslatorExport (string $parent,
 
         checkBox -l "Export Visibility" exportVisibilityCheckBox;
 
+        checkBox -l "Strip Namespaces" stripNamespacesCheckBox;
+
         checkBox -l "Renderable Only" renderableOnlyCheckBox;
          
         checkBox -l "Export all cameras" defaultCamerasCheckBox;
@@ -214,6 +216,8 @@ global proc int usdTranslatorExport (string $parent,
                     usdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "exportSkinClustersPopup");
                 } else if ($optionBreakDown[0] == "exportVisibility") {
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
+                } else if ($optionBreakDown[0] == "stripNamespaces") {
+                    usdTranslatorExport_SetCheckbox($optionBreakDown[1], "stripNamespacesCheckBox");
                 } else if ($optionBreakDown[0] == "animation") {
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "startTime") {
@@ -253,6 +257,7 @@ global proc int usdTranslatorExport (string $parent,
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "exportSkin", "exportSkinClustersPopup");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
+        $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromIntField($currentOptions, "startTime", "startTimeField");
         $currentOptions = usdTranslatorExport_AppendFromIntField($currentOptions, "endTime", "endTimeField");

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -247,6 +247,19 @@ bool usdWriteJob::beginJob(const std::string &iFileName, bool append)
 
                 // Write out data (non-animated/default values).
                 if (const auto& usdPrim = primWriter->getPrim()) {
+                    if (mJobCtx.mArgs.stripNamespaces) {
+                        auto foundPair = mUsdPathToDagPathMap.find(usdPrim.GetPath());
+                        if (foundPair != mUsdPathToDagPathMap.end()){
+                            std::string error = TfStringPrintf("Multiple dag nodes map to the same prim path after "
+                                                               "stripping namespaces: %s - %s",
+                                                               foundPair->second.fullPathName().asChar(),
+                                                               primWriter->getDagPath().fullPathName().asChar());
+                            MGlobal::displayError(MString(error.c_str()));
+                            return false;
+                        }
+                        mUsdPathToDagPathMap[usdPrim.GetPath()] = primWriter->getDagPath();
+                    }
+
                     primWriter->write(UsdTimeCode::Default());
 
                     MDagPath dag = primWriter->getDagPath();
@@ -278,6 +291,7 @@ bool usdWriteJob::beginJob(const std::string &iFileName, bool append)
     exportParams.mergeTransformAndShape = mJobCtx.mArgs.mergeTransformAndShape;
     exportParams.exportCollectionBasedBindings =
             mJobCtx.mArgs.exportCollectionBasedBindings;
+    exportParams.stripNamespaces = mJobCtx.mArgs.stripNamespaces;
     exportParams.overrideRootPath = mJobCtx.mArgs.usdModelRootOverridePath;
     exportParams.bindableRoots = mJobCtx.mArgs.dagPaths;
     exportParams.parentScope = mJobCtx.mArgs.parentScope;
@@ -302,7 +316,8 @@ bool usdWriteJob::beginJob(const std::string &iFileName, bool append)
         return false;
     }
 
-    if (!mJobCtx.getSkelBindingsWriter().WriteSkelBindings(mJobCtx.mStage)) {
+    if (!mJobCtx.getSkelBindingsWriter().WriteSkelBindings(mJobCtx.mStage,
+        mJobCtx.mArgs.stripNamespaces)) {
         return false;
     }
 

--- a/third_party/maya/lib/usdMaya/usdWriteJob.h
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.h
@@ -35,6 +35,8 @@
 
 #include "usdMaya/usdWriteJobCtx.h"
 
+#include "pxr/base/tf/hashmap.h"
+
 #include <maya/MObjectHandle.h>
 
 #include <string>
@@ -78,6 +80,9 @@ class usdWriteJob
     MObjectArray mRenderLayerObjs;
 
     PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type mDagPathToUsdPathMap;
+
+    // Currently only used if stripNamespaces is on, to ensure we don't have clashes
+    TfHashMap<SdfPath, MDagPath, SdfPath::Hash> mUsdPathToDagPathMap;
 
     PxrUsdMayaChaserRefPtrVector mChasers;
 

--- a/third_party/maya/lib/usdMaya/usdWriteJobCtx.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJobCtx.cpp
@@ -161,11 +161,17 @@ SdfPath usdWriteJobCtx::getUsdPathFromDagPath(const MDagPath& dagPath, bool inst
             std::stringstream ss;
             ss << mInstancesPrim.GetPath().GetString();
             MObject node = dagPath.node();
-            ss << "/" << dagPath.fullPathName().asChar() + 1;
+            ss << "/";
+            if (mArgs.stripNamespaces){
+                ss << PxrUsdMayaUtil::stripNamespaces(dagPath.fullPathName()).asChar() + 1;
+            } else{
+                ss << dagPath.fullPathName().asChar() + 1;
+            }
             if (!node.hasFn(MFn::kTransform)) {
                 ss << "/Shape";
             }
             auto pathName = ss.str();
+            pathName = TfStringReplace(pathName, "_", "__");  // avoid any issue with |: / _ name clashes
             std::replace(pathName.begin(), pathName.end(), '|', '_');
             std::replace(pathName.begin(), pathName.end(), ':', '_');
             path = SdfPath(pathName);
@@ -173,7 +179,7 @@ SdfPath usdWriteJobCtx::getUsdPathFromDagPath(const MDagPath& dagPath, bool inst
             return SdfPath();
         }
     } else {
-        path = PxrUsdMayaUtil::MDagPathToUsdPath(dagPath, false);
+        path = PxrUsdMayaUtil::MDagPathToUsdPath(dagPath, false, mArgs.stripNamespaces);
         if (!mParentScopePath.IsEmpty())
         {
             // Since path is from MDagPathToUsdPath, it will always be

--- a/third_party/maya/lib/usdMaya/util.h
+++ b/third_party/maya/lib/usdMaya/util.h
@@ -54,6 +54,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <regex>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -235,10 +236,10 @@ bool isIntermediate(const MObject & object);
 PXRUSDMAYA_API
 bool isRenderable(const MObject & object);
 
-// strip iDepth namespaces from the node name, go from taco:foo:bar to bar
-// for iDepth > 1
+// strip iDepth namespaces from the node name or string path, go from
+// taco:foo:bar to bar for iDepth > 1. If iDepth is -1, strips all namespaces.
 PXRUSDMAYA_API
-MString stripNamespaces(const MString & iNodeName, unsigned int iDepth);
+MString stripNamespaces(const MString & iNodeName, int iDepth = -1);
 
 PXRUSDMAYA_API
 std::string SanitizeName(const std::string& name);
@@ -380,7 +381,7 @@ MPlug FindChildPlugByName(const MPlug& plug, const MString& name);
 /// Elements of the path will be sanitized such that it is a valid SdfPath.
 /// This means it will replace ':' with '_'.
 PXRUSDMAYA_API
-PXR_NS::SdfPath MDagPathToUsdPath(const MDagPath& dagPath, bool mergeTransformAndShape);
+PXR_NS::SdfPath MDagPathToUsdPath(const MDagPath& dagPath, bool mergeTransformAndShape, bool stripNamespaces);
 
 /// Convenience function to retrieve custom data
 PXRUSDMAYA_API


### PR DESCRIPTION
This PR adds the option to strip maya namespaces from resulting prim names in the usdExport maya command.

### Description of Change(s)
If you have a node in maya named: `|root_node|one:two:nodename`
the default name for the exported prim is: `/root_node/one_two_nodename` (unchanged)
But if this new flag is provided the prim name will be: `/root_node/nodename`

If any dag nodes would result in the same prim path after stripping namespaces, an error will be raised.

### Fixes Issue(s)
issue #126:
- Often in maya, artists use references with different namespaces. Without this flag, there is no way to get exports to have the same hierarchy when exported. This causes problems later on for things like material assignment.
- This also allows exporting an identical hierarchy from a maya scene (rig file) and a referenced version of that file (animation file with referenced rig) so that geometry will be accessible at the same prim path.

### Limitations
This is a scaled back version of some initial designs that nonetheless satisfies our current needs, but here are some of the missing pieces that could be added later. 
1.) ability to strip a specific number of namespaces rather than all or none
2.) storing namespaces as prim metadata to allow reconstituting maya namespace for roundtripping

### Justification
We have found maya namespaces to be redundant when using USD. They are an opposite approach to the same problem: where maya inserts extra pieces to names in every level of a hierarchy to keep node names unique, USD solves it by renaming a single top node of a reference and using full paths. Mayas namespace solution makes it more complicated and less flexible to use matching expressions in modern applications like katana. 

The way that USD uses the name of the referencing prim rather than the referenced prim enables us to keep uniqueness without maya namespaces. If we remove all of them, then we have fewer problems because we have the most similar hierarchies across levels of maya referencing. The main need for a solution without limitation 1 is when identical maya references are parented to the same node. For now we are able to avoid that easily by ensuring that references always have a unique parent node. However, it would be easy to add another argument for the number of namespaces to strip.

Although round tripping is always a good goal for an exchange format, we don't yet have a use case that demands it. It is also not yet supported as is because the names will be different (`:` vs `_`) when reimporting an exported .usd file. If the need arises, roundtripping could be added on top of this current PR by modifying the usdExport and usdImport commands to use metadata for maya namespaces.

