### PR TITLE
[Usd] Change visibility of pcp child nodes iterator.

### DIFF
--- a/pxr/usd/lib/pcp/node.h
+++ b/pxr/usd/lib/pcp/node.h
@@ -326,14 +326,17 @@ class PcpNodeRef_ChildrenIterator
 {
 public:
     /// Constructs an invalid iterator.
+    PCP_API
     PcpNodeRef_ChildrenIterator();
 
     /// Constructs an iterator pointing to \p node. Passing a NULL value
     /// for \p node constructs an end iterator.
+    PCP_API
     PcpNodeRef_ChildrenIterator(const PcpNodeRef& node, bool end = false);
 
 private:
     friend class boost::iterator_core_access;
+    PCP_API
     void increment();
     bool equal(const PcpNodeRef_ChildrenIterator& other) const
     {


### PR DESCRIPTION
### Description of Change(s)
Change the visibility of pcp child nodes iterator.
We came across this while building [AL_USDMaya](https://github.com/AnimalLogic/AL_USDMaya/blob/develop/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.cpp#L731) on Windows where symbols are hidden by default.
The same symbols from the reverse iterator should also probably be exposed.

### Fixes Issue(s)
- Unable to build and use the iterator on Windows

