### PR TITLE
[usdMaya] Improving primvar export from maya.

### DIFF
--- a/pxr/usd/lib/usdGeom/primvar.cpp
+++ b/pxr/usd/lib/usdGeom/primvar.cpp
@@ -217,6 +217,12 @@ UsdGeomPrimvar::GetIndicesAttr() const
     return _GetIndicesAttr(/*create*/ false);
 }
 
+UsdAttribute
+UsdGeomPrimvar::CreateIndicesAttr() const
+{
+    return _GetIndicesAttr(/*create*/ true);
+}
+
 bool 
 UsdGeomPrimvar::SetIndices(const VtIntArray &indices, 
                            UsdTimeCode time) const

--- a/pxr/usd/lib/usdGeom/primvar.h
+++ b/pxr/usd/lib/usdGeom/primvar.h
@@ -528,6 +528,11 @@ public:
     /// an invalid attribute otherwise.
     USDGEOM_API
     UsdAttribute GetIndicesAttr() const;
+
+    /// Returns the existing indices attribute if the primvar is indexed
+    /// or creates a new one.
+    USDGEOM_API
+    UsdAttribute CreateIndicesAttr() const;
     
     /// Set the index that represents unauthored values in the indices array.
     /// 

--- a/pxr/usd/lib/usdGeom/wrapPrimvar.cpp
+++ b/pxr/usd/lib/usdGeom/wrapPrimvar.cpp
@@ -152,6 +152,7 @@ void wrapUsdGeomPrimvar()
         .def("GetIndices", _GetIndices, 
             (arg("time")=UsdTimeCode::Default()))
         .def("GetIndicesAttr", &Primvar::GetIndicesAttr)
+        .def("CreateIndicesAttr", &Primvar::GetIndicesAttr)
         .def("IsIndexed", &Primvar::IsIndexed)
 
         .def("GetUnauthoredValuesIndex", &Primvar::GetUnauthoredValuesIndex)

--- a/third_party/maya/lib/usdMaya/MayaMeshWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaMeshWriter.cpp
@@ -27,6 +27,7 @@
 #include "usdMaya/adaptor.h"
 #include "usdMaya/meshUtil.h"
 #include "usdMaya/primWriterRegistry.h"
+#include "usdMaya/writeUtil.h"
 
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/usd/usdGeom/mesh.h"
@@ -92,6 +93,20 @@ void _exportReferenceMesh(UsdGeomMesh& primSchema, MObject obj) {
     primVar.GetAttr().Set(VtValue(points));
 }
 
+template <typename T>
+void _prependValue(UsdAttribute& attr, const UsdTimeCode& usdTime, const T& value) {
+    VtArray<T> arr;
+    if (attr.Get(&arr, usdTime)) {
+        const auto arrSize = arr.size();
+        arr.resize(arrSize + 1);
+        for (auto i = decltype(arrSize){arrSize}; i > 0; --i) {
+            arr[i] = arr[i - 1];
+        }
+        arr[0] = value;
+        attr.Set(arr, usdTime);
+    }
+}
+
 }
 
 const GfVec2f MayaMeshWriter::_DefaultUV = GfVec2f(0.f);
@@ -101,6 +116,11 @@ const float MayaMeshWriter::_ShaderDefaultAlpha = 0.0;
 
 const GfVec3f MayaMeshWriter::_ColorSetDefaultRGB = GfVec3f(1.0);
 const float MayaMeshWriter::_ColorSetDefaultAlpha = 1.0;
+const GfVec4f MayaMeshWriter::_ColorSetDefaultRGBA = GfVec4f(
+    MayaMeshWriter::_ColorSetDefaultRGB[0],
+    MayaMeshWriter::_ColorSetDefaultRGB[1],
+    MayaMeshWriter::_ColorSetDefaultRGB[2],
+    MayaMeshWriter::_ColorSetDefaultAlpha);
 
 
 MayaMeshWriter::MayaMeshWriter(
@@ -119,6 +139,82 @@ MayaMeshWriter::MayaMeshWriter(
     TF_AXIOM(primSchema);
     mUsdPrim = primSchema.GetPrim();
     TF_AXIOM(mUsdPrim);
+}
+
+void MayaMeshWriter::_prependDefaultValue(UsdAttribute& attr, const UsdTimeCode& usdTime) {
+    const auto typeName = attr.GetTypeName();
+    if (typeName == SdfValueTypeNames->FloatArray) {
+        _prependValue(attr, usdTime, attr.GetName() == UsdGeomTokens->primvarsDisplayOpacity ?
+                                     MayaMeshWriter::_ShaderDefaultAlpha :
+                                     MayaMeshWriter::_ColorSetDefaultAlpha);
+    } else if (typeName == (PxrUsdMayaWriteUtil::WriteUVAsFloat2() ?
+                            SdfValueTypeNames->Float2Array : SdfValueTypeNames->TexCoord2fArray)) {
+        _prependValue(attr, usdTime, MayaMeshWriter::_DefaultUV);
+    } else if (typeName == SdfValueTypeNames->Color3fArray) {
+        _prependValue(attr, usdTime, attr.GetName() == UsdGeomTokens->primvarsDisplayColor ?
+                                     MayaMeshWriter::_ShaderDefaultRGB :
+                                     MayaMeshWriter::_ColorSetDefaultRGB);
+    } else if (typeName == SdfValueTypeNames->Color4fArray) {
+        _prependValue(attr, usdTime, MayaMeshWriter::_ColorSetDefaultRGBA);
+    }
+};
+
+// virtual
+void MayaMeshWriter::postExport()
+{
+    auto shiftPrimvar = [](const UsdGeomPrimvar& primvar) {
+        if (!primvar) {
+            return;
+        }
+        auto shiftIndices = [](UsdAttribute& attr, const UsdTimeCode& usdTime) {
+            VtArray<int> indices;
+            if (attr.Get(&indices, usdTime)) {
+                for (auto& id: indices) {
+                    id += 1;
+                }
+                attr.Set(indices, usdTime);
+            }
+        };
+
+        const auto unauthoredValueIndex = primvar.GetUnauthoredValuesIndex();
+        if (unauthoredValueIndex == -1) {
+            return;
+        }
+
+        // Either 0 or -1.
+        TF_AXIOM(unauthoredValueIndex == 0);
+
+        // At least one of the samples contain an unassigned value,
+        // we have to increase the indices by one, so unassigned values get to be 0
+        // and the rest shifts by one.
+        if (primvar.IsIndexed()) {
+            auto indicesAttr = primvar.GetIndicesAttr();
+            shiftIndices(indicesAttr, UsdTimeCode::Default());
+
+            std::vector<double> timeSamples;
+            if (indicesAttr.GetTimeSamples(&timeSamples)) {
+                for (auto timeSample: timeSamples) {
+                    shiftIndices(indicesAttr, timeSample);
+                }
+            }
+        }
+
+        // Also we have to prepend the default value to all the time samples.
+        auto attr = primvar.GetAttr();
+        _prependDefaultValue(attr, UsdTimeCode::Default());
+        std::vector<double> timeSamples;
+        if (attr.GetTimeSamples(&timeSamples)) {
+            for (auto timeSample: timeSamples) {
+                _prependDefaultValue(attr, timeSample);
+            }
+        }
+    };
+
+    UsdGeomMesh primSchema(mUsdPrim);
+
+    for (auto& primvar: primSchema.GetPrimvars()) {
+        shiftPrimvar(primvar);
+    }
 }
 
 //virtual 
@@ -221,8 +317,8 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
             curFaceVertexIndex++;
         }
     }
-    _SetAttribute(primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts);
-    _SetAttribute(primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices);
+    _SetAttribute(primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts, usdTime);
+    _SetAttribute(primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices, usdTime);
 
     // Read subdiv scheme tagging. If not set, we default to defaultMeshScheme
     // flag (this is specified by the job args but defaults to catmullClark).
@@ -297,10 +393,8 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
         }
 
         int unassignedValueIndex = -1;
-        PxrUsdMayaUtil::AddUnassignedUVIfNeeded(&uvValues,
-                                                &assignmentIndices,
-                                                &unassignedValueIndex,
-                                                _DefaultUV);
+        PxrUsdMayaUtil::SetUnassignedValueIndex(&assignmentIndices,
+                                                &unassignedValueIndex);
 
         // XXX:bug 118447
         // We should be able to configure the UV map name that triggers this
@@ -313,6 +407,7 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
 
         _createUVPrimVar(primSchema,
                          setName,
+                         usdTime,
                          uvValues,
                          interpolation,
                          assignmentIndices,
@@ -398,18 +493,15 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
             continue;
         }
 
-        PxrUsdMayaUtil::AddUnassignedColorAndAlphaIfNeeded(
-            &RGBData,
-            &AlphaData,
+        PxrUsdMayaUtil::SetUnassignedValueIndex(
             &assignmentIndices,
-            &unassignedValueIndex,
-            _ColorSetDefaultRGB,
-            _ColorSetDefaultAlpha);
+            &unassignedValueIndex);
 
         if (isDisplayColor) {
             // We tag the resulting displayColor/displayOpacity primvar as
             // authored to make sure we reconstruct the color set on import.
             _addDisplayPrimvars(primSchema,
+                                usdTime,
                                 colorSetRep,
                                 RGBData,
                                 AlphaData,
@@ -435,6 +527,7 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
             if (colorSetRep == MFnMesh::kAlpha) {
                 _createAlphaPrimVar(primSchema,
                                     colorSetNameToken,
+                                    usdTime,
                                     AlphaData,
                                     interpolation,
                                     assignmentIndices,
@@ -443,6 +536,7 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
             } else if (colorSetRep == MFnMesh::kRGB) {
                 _createRGBPrimVar(primSchema,
                                   colorSetNameToken,
+                                  usdTime,
                                   RGBData,
                                   interpolation,
                                   assignmentIndices,
@@ -451,6 +545,7 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
             } else if (colorSetRep == MFnMesh::kRGBA) {
                 _createRGBAPrimVar(primSchema,
                                    colorSetNameToken,
+                                   usdTime,
                                    RGBData,
                                    AlphaData,
                                    interpolation,
@@ -469,19 +564,16 @@ bool MayaMeshWriter::writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &pri
         // results in Gprims rendering the same way in usdview as they do in
         // Maya (i.e. unassigned components are invisible).
         int unassignedValueIndex = -1;
-        PxrUsdMayaUtil::AddUnassignedColorAndAlphaIfNeeded(
-                &shadersRGBData,
-                &shadersAlphaData,
+        PxrUsdMayaUtil::SetUnassignedValueIndex(
                 &shadersAssignmentIndices,
-                &unassignedValueIndex,
-                _ShaderDefaultRGB,
-                _ShaderDefaultAlpha);
+                &unassignedValueIndex);
 
         // Since these colors come from the shaders and not a colorset, we are
         // not adding the clamp attribute as custom data. We also don't need to
         // reconstruct a color set from them on import since they originated
         // from the bound shader(s), so the authored flag is set to false.
         _addDisplayPrimvars(primSchema,
+                            usdTime,
                             MFnMesh::kRGBA,
                             shadersRGBData,
                             shadersAlphaData,

--- a/third_party/maya/lib/usdMaya/MayaMeshWriter.h
+++ b/third_party/maya/lib/usdMaya/MayaMeshWriter.h
@@ -52,6 +52,8 @@ class MayaMeshWriter : public MayaTransformWriter
     virtual void write(const UsdTimeCode &usdTime) override;
     virtual bool exportsGprims() const override;
 
+    virtual void postExport() override;
+
   protected:
     bool writeMeshAttrs(const UsdTimeCode &usdTime, UsdGeomMesh &primSchema);
 
@@ -93,6 +95,7 @@ class MayaMeshWriter : public MayaTransformWriter
 
     bool _createAlphaPrimVar(UsdGeomGprim &primSchema,
                              const TfToken& name,
+                             const UsdTimeCode& usdTime,
                              const VtArray<float>& data,
                              const TfToken& interpolation,
                              const VtArray<int>& assignmentIndices,
@@ -101,6 +104,7 @@ class MayaMeshWriter : public MayaTransformWriter
 
     bool _createRGBPrimVar(UsdGeomGprim &primSchema,
                            const TfToken& name,
+                           const UsdTimeCode& usdTime,
                            const VtArray<GfVec3f>& data,
                            const TfToken& interpolation,
                            const VtArray<int>& assignmentIndices,
@@ -109,6 +113,7 @@ class MayaMeshWriter : public MayaTransformWriter
 
     bool _createRGBAPrimVar(UsdGeomGprim &primSchema,
                             const TfToken& name,
+                            const UsdTimeCode& usdTime,
                             const VtArray<GfVec3f>& rgbData,
                             const VtArray<float>& alphaData,
                             const TfToken& interpolation,
@@ -118,6 +123,7 @@ class MayaMeshWriter : public MayaTransformWriter
 
     bool _createUVPrimVar(UsdGeomGprim &primSchema,
                           const TfToken& name,
+                          const UsdTimeCode& usdTime,
                           const VtArray<GfVec2f>& data,
                           const TfToken& interpolation,
                           const VtArray<int>& assignmentIndices,
@@ -128,6 +134,7 @@ class MayaMeshWriter : public MayaTransformWriter
     /// authored opinions for them.
     bool _addDisplayPrimvars(
         UsdGeomGprim &primSchema,
+        const UsdTimeCode& usdTime,
         const MFnMesh::MColorRepresentation colorRep,
         const VtArray<GfVec3f>& RGBData,
         const VtArray<float>& AlphaData,
@@ -136,6 +143,10 @@ class MayaMeshWriter : public MayaTransformWriter
         const int unassignedValueIndex,
         const bool clamped,
         const bool authored);
+
+    /// Prepends a default value to an attribute containing primvars.
+    static void _prependDefaultValue(UsdAttribute& attr,
+                                     const UsdTimeCode& usdTime);
 
     /// Default value to use when collecting UVs from a UV set and a component
     /// has no authored value.
@@ -150,6 +161,7 @@ class MayaMeshWriter : public MayaTransformWriter
     /// component has no authored value.
     static const GfVec3f _ColorSetDefaultRGB;
     static const float _ColorSetDefaultAlpha;
+    static const GfVec4f _ColorSetDefaultRGBA;
 
     /// Input mesh before any skeletal deformations, cached between iterations.
     MObject _skelInputMesh;

--- a/third_party/maya/lib/usdMaya/testenv/testUsdExportColorSets.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdExportColorSets.py
@@ -347,7 +347,7 @@ class testUsdExportColorSets(unittest.TestCase):
             elif isRGB:
                 colorSetValue = self._ColorFromVec4f(colorSetValue)
 
-            colorSetValues.append(colorSetValue)
+            colorSetValues.insert(0, colorSetValue)
 
         return colorSetValues
 
@@ -369,11 +369,11 @@ class testUsdExportColorSets(unittest.TestCase):
         if isSparse:
             # Every other component is unassigned.
             if isFaceColor:
-                assignmentIndices = [0, 3, 1, 3, 2, 3]
+                assignmentIndices = [1, 0, 2, 0, 3, 0]
             elif isVertexColor:
-                assignmentIndices = [0, 4, 1, 4, 2, 4, 3, 4]
+                assignmentIndices = [1, 0, 2, 0, 3, 0, 4, 0]
             elif isFaceVertexColor:
-                assignmentIndices = [0, 12, 1, 12, 2, 12, 3, 12, 4, 12, 5, 12, 6, 12, 7, 12, 8, 12, 9, 12, 10, 12, 11, 12]
+                assignmentIndices = [1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0, 9, 0, 10, 0, 11, 0, 12, 0]
         else:
             # Every component has an assignment.
             if isFaceColor:
@@ -394,31 +394,10 @@ class testUsdExportColorSets(unittest.TestCase):
         Given a color set name, return the index that represents unauthored
         values when the color set is exported as a primvar.
         """
-        isSparse = self._IsColorSetSparse(colorSetName)
-
-        unassignedIndex = -1
-
-        if not isSparse:
-            return unassignedIndex
-
-        isFaceColor = colorSetName.startswith('FaceColor_')
-        isVertexColor = colorSetName.startswith('VertexColor_')
-        isFaceVertexColor = colorSetName.startswith('FaceVertexColor_')
-
-        # When we skip components, we'll only be assigning half of them.
-        # In the case of our cube, we have 6 faces, 8 vertices, and 24
-        # faceVertices, so the unassigned indices should be 3, 4, and
-        # 12, respectively.
-        if isFaceColor:
-            unassignedIndex = self._colorSetSourceMesh.numPolygons()
-        elif isVertexColor:
-            unassignedIndex = self._colorSetSourceMesh.numVertices()
-        elif isFaceVertexColor:
-            unassignedIndex = self._colorSetSourceMesh.numFaceVertices()
-
-        unassignedIndex /= 2
-
-        return unassignedIndex
+        if self._IsColorSetSparse(colorSetName):
+            return 0
+        else:
+            return -1
 
     def _GetExpectedColorSetInterpolation(self, colorSetName):
         isFaceColor = colorSetName.startswith('FaceColor_')

--- a/third_party/maya/lib/usdMaya/testenv/testUsdExportDisplayColor.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdExportDisplayColor.py
@@ -205,14 +205,14 @@ class testUsdExportDisplayColor(unittest.TestCase):
         cubeMesh = self._GetCubeMesh('OneFaceCube')
 
         expectedColors = Vt.Vec3fArray([
-            (0.0, 1.0, 0.0),
-            (0.5, 0.5, 0.5)])
+            (0.5, 0.5, 0.5),
+            (0.0, 1.0, 0.0)])
         expectedOpacities = Vt.FloatArray([
-            0.7,
-            0.0])
+            0.0,
+            0.7])
 
-        expectedIndices = Vt.IntArray([0, 1, 1, 1, 1, 1])
-        expectedUnauthoredValuesIndex = 1
+        expectedIndices = Vt.IntArray([1, 0, 0, 0, 0, 0])
+        expectedUnauthoredValuesIndex = 0
         self._AssertMeshDisplayColorAndOpacity(cubeMesh, expectedColors,
             expectedOpacities, UsdGeom.Tokens.uniform,
             expectedIndices, expectedUnauthoredValuesIndex)
@@ -239,13 +239,13 @@ class testUsdExportDisplayColor(unittest.TestCase):
         # opacity 0.
         oneFace = self._GetCubeMesh('ShadingGroupNoShaderOneFace')
         expectedColors = Vt.Vec3fArray([
-            (1, 0, 0),  
+            (0.5, 0.5, 0.5),
+            (1, 0, 0),
             (0, 0, 1), 
-            (0.21763764, 0.21763764, 0.21763764),  # initialShadingGroup
-            (0.5, 0.5, 0.5)])
-        expectedOpacities = Vt.FloatArray([1, 1, 1, 0])
-        expectedIndices = [3, 1, 2, 2, 0, 2]
-        expectedUnauthoredValuesIndex = 3
+            (0.21763764, 0.21763764, 0.21763764)])  # initialShadingGroup
+        expectedOpacities = Vt.FloatArray([0, 1, 1, 1])
+        expectedIndices = [0, 2, 3, 3, 1, 3]
+        expectedUnauthoredValuesIndex = 0
         self._AssertMeshDisplayColorAndOpacity(oneFace, expectedColors,
             expectedOpacities, UsdGeom.Tokens.uniform,
             expectedIndices, expectedUnauthoredValuesIndex)

--- a/third_party/maya/lib/usdMaya/testenv/testUsdExportUVSets.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdExportUVSets.py
@@ -173,6 +173,7 @@ class testUsdExportUVSets(unittest.TestCase):
         usdCubeMesh = self._GetCubeUsdMesh('OneMissingFaceCube')
 
         expectedValues = [
+            Gf.Vec2f(0.0, 0.0),
             Gf.Vec2f(0.375, 0),
             Gf.Vec2f(0.625, 0),
             Gf.Vec2f(0.625, 0.25),
@@ -186,18 +187,17 @@ class testUsdExportUVSets(unittest.TestCase):
             Gf.Vec2f(0.875, 0),
             Gf.Vec2f(0.875, 0.25),
             Gf.Vec2f(0.125, 0),
-            Gf.Vec2f(0.125, 0.25),
-            Gf.Vec2f(0.0, 0.0)
+            Gf.Vec2f(0.125, 0.25)
         ]
         expectedIndices = [
-            0, 1, 2, 3,
-            3, 2, 4, 5,
-            14, 14, 14, 14,
-            6, 7, 8, 9,
-            1, 10, 11, 2,
-            12, 0, 3, 13
+            1, 2, 3, 4,
+            4, 3, 5, 6,
+            0, 0, 0, 0,
+            7, 8, 9, 10,
+            2, 11, 12, 3,
+            13, 1, 4, 14
         ]
-        expectedUnauthoredValuesIndex = len(expectedValues) - 1
+        expectedUnauthoredValuesIndex = 0
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
@@ -216,21 +216,21 @@ class testUsdExportUVSets(unittest.TestCase):
         usdCubeMesh = self._GetCubeUsdMesh('OneAssignedFaceCube')
 
         expectedValues = [
+            Gf.Vec2f(0.0, 0.0),
             Gf.Vec2f(0.375, 0.5),
             Gf.Vec2f(0.625, 0.5),
             Gf.Vec2f(0.625, 0.75),
-            Gf.Vec2f(0.375, 0.75),
-            Gf.Vec2f(0.0, 0.0)
+            Gf.Vec2f(0.375, 0.75)
         ]
         expectedIndices = [
-            4, 4, 4, 4,
-            4, 4, 4, 4,
-            0, 1, 2, 3,
-            4, 4, 4, 4,
-            4, 4, 4, 4,
-            4, 4, 4, 4
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            1, 2, 3, 4,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0
         ]
-        expectedUnauthoredValuesIndex = len(expectedValues) - 1
+        expectedUnauthoredValuesIndex = 0
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 

--- a/third_party/maya/lib/usdMaya/util.cpp
+++ b/third_party/maya/lib/usdMaya/util.cpp
@@ -1019,83 +1019,21 @@ PxrUsdMayaUtil::CompressFaceVaryingPrimvarIndices(
 }
 
 bool
-PxrUsdMayaUtil::AddUnassignedUVIfNeeded(
-        VtArray<GfVec2f>* uvData,
-        VtArray<int>* assignmentIndices,
-        int* unassignedValueIndex,
-        const GfVec2f& defaultUV)
-{
-    if (!assignmentIndices || assignmentIndices->empty()) {
+PxrUsdMayaUtil::SetUnassignedValueIndex(
+    VtArray<int>* assignmentIndices,
+    int* unassignedValueIndex) {
+    if (assignmentIndices == nullptr || unassignedValueIndex == nullptr) {
         return false;
     }
 
     *unassignedValueIndex = -1;
-
-    for (size_t i = 0; i < assignmentIndices->size(); ++i) {
-        if ((*assignmentIndices)[i] >= 0) {
-            // This component has an assignment, so skip it.
-            continue;
+    for (auto& index: *assignmentIndices) {
+        if (index < 0) {
+            index = -1;
+            *unassignedValueIndex = 0;
         }
-
-        // We found an unassigned index. Add the unassigned value to uvData
-        // if we haven't already.
-        if (*unassignedValueIndex < 0) {
-            if (uvData) {
-                uvData->push_back(defaultUV);
-            }
-            *unassignedValueIndex = uvData->size() - 1;
-        }
-
-        // Assign the component the unassigned value index.
-        (*assignmentIndices)[i] = *unassignedValueIndex;
     }
-
-    return true;
-}
-
-bool
-PxrUsdMayaUtil::AddUnassignedColorAndAlphaIfNeeded(
-        VtArray<GfVec3f>* RGBData,
-        VtArray<float>* AlphaData,
-        VtArray<int>* assignmentIndices,
-        int* unassignedValueIndex,
-        const GfVec3f& defaultRGB,
-        const float defaultAlpha)
-{
-    if (!assignmentIndices || assignmentIndices->empty()) {
-        return false;
-    }
-
-    if (RGBData && AlphaData && (RGBData->size() != AlphaData->size())) {
-        TF_CODING_ERROR("Unequal sizes for color (%zu) and opacity (%zu)",
-                        RGBData->size(), AlphaData->size());
-    }
-
-    *unassignedValueIndex = -1;
-
-    for (size_t i=0; i < assignmentIndices->size(); ++i) {
-        if ((*assignmentIndices)[i] >= 0) {
-            // This component has an assignment, so skip it.
-            continue;
-        }
-
-        // We found an unassigned index. Add unassigned values to RGBData and
-        // AlphaData if we haven't already.
-        if (*unassignedValueIndex < 0) {
-            if (RGBData) {
-                RGBData->push_back(defaultRGB);
-            }
-            if (AlphaData) {
-                AlphaData->push_back(defaultAlpha);
-            }
-            *unassignedValueIndex = RGBData->size() - 1;
-        }
-
-        // Assign the component the unassigned value index.
-        (*assignmentIndices)[i] = *unassignedValueIndex;
-    }
-
-    return true;
+    return *unassignedValueIndex == 0;
 }
 
 bool

--- a/third_party/maya/lib/usdMaya/util.h
+++ b/third_party/maya/lib/usdMaya/util.h
@@ -294,32 +294,15 @@ void CompressFaceVaryingPrimvarIndices(
         PXR_NS::TfToken *interpolation,
         PXR_NS::VtArray<int>* assignmentIndices);
 
-/// If any components in \p assignmentIndices are unassigned (-1), the given
-/// default value will be added to uvData and all of those components will be
-/// assigned that index, which is returned in \p unassignedValueIndex.
-/// Returns true if unassigned values were added and indices were updated, or
-/// false otherwise.
+/// If any of the components in \p assignmentIndices are unassigned (<0), the
+/// \p unassignedValueIndex will be set to zero and all those indices will be
+/// set to -1. Otherwise \p unassignedValueIndices is set to -1.
+/// Returns true if there were any unassigned values and indices were updated,
+/// or false otherwise.
 PXRUSDMAYA_API
-bool AddUnassignedUVIfNeeded(
-        PXR_NS::VtArray<PXR_NS::GfVec2f>* uvData,
+bool SetUnassignedValueIndex(
         PXR_NS::VtArray<int>* assignmentIndices,
-        int* unassignedValueIndex,
-        const PXR_NS::GfVec2f& defaultUV);
-
-/// If any components in \p assignmentIndices are unassigned (-1), the given
-/// default values will be added to RGBData and AlphaData and all of those
-/// components will be assigned that index, which is returned in
-/// \p unassignedValueIndex.
-/// Returns true if unassigned values were added and indices were updated, or
-/// false otherwise.
-PXRUSDMAYA_API
-bool AddUnassignedColorAndAlphaIfNeeded(
-        PXR_NS::VtArray<PXR_NS::GfVec3f>* RGBData,
-        PXR_NS::VtArray<float>* AlphaData,
-        PXR_NS::VtArray<int>* assignmentIndices,
-        int* unassignedValueIndex,
-        const PXR_NS::GfVec3f& defaultRGB,
-        const float defaultAlpha);
+        int* unassignedValueIndex);
 
 /// Get whether \p plug is authored in the Maya scene.
 ///


### PR DESCRIPTION
### Description of Change(s)

The PR expands primvar export from Maya, adds support for changing topology and animated primvars, and optimises memory in a few cases.

It's important to note that this PR is not final yet, it's more of a place to start a discussion to improve solutions here.

Features of the patch.
- Primvar export now happens per frame. This can be useful in cases when colour sets and such contain animated data. Rigs, data imported from Alembic etc...
- Primvar export works with variable topology over time.
- Key deduplication happens during export, this can significantly increase memory usage in cases where there are lots of color sets and geometry data. We saw up to 10 times less memory usage.
- Exporting colour sets as motion vectors. Looking for the most common names, like v, velocity, velocityPP.

Things broken by the patch:
- Primvar unassigned value index.
- Tests disabled related to the new way of exporting primvars.

What's there to figure out?
1. What to do with unassigned value index. Currently, there is no way to setup the unassigned value index for primvars per frame, and that can cause issues with variable topology. We can either change the export code, and use the first value for unassigned values, meaning we always have to allocate it when exporting animation because we don't know beforehand if there'll be an unassigned value on one of the frames, or make the parameter vary over time. The second one seems to be the easiest way, but we decided not to make core changes in the initial version.
2. Expose accessing the indices value on the primvars. The accessor function is private at the moment, and not accessible in any way. IMHO it should behave like the value, i.e., the user can directly access it if needed. That also means removing the _ prefix from the accessor function.
3. Improve the handling of the memory optimizations (set attribute key), avoid passing around VtValues (use templated functions) and improve the comparisons. If we set up the keys using the new function, should we even care about cleaning up the keys afterwards?
4. Move the new set attribute key functions to the USD core? Either as part of the attribute or in a utility header. Implementing this memory optimisation in UsdAttribute itself is probably a way bigger change than we want to do as part of this PR so that I wouldn't care about that right now.
5. What to do with velocity export? We could improve it by allowing the user to set the parameter up via something on the mesh. How should we store that value? Looking for a specific user attribute name? Extension attributes? Extension attributes could have issues when loading a scene in a Maya session where the USD plugin is not available.

### Fixes Issue(s)
No reported issue.
-

