### PR TITLE
Pr/clang maya2018 fixes

### DIFF
--- a/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
+++ b/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
@@ -63,8 +63,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-class MDagPath;
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 

--- a/third_party/maya/lib/pxrUsdMayaGL/hdRenderer.h
+++ b/third_party/maya/lib/pxrUsdMayaGL/hdRenderer.h
@@ -38,8 +38,11 @@
 #include <maya/MDrawContext.h>
 #include <maya/MFrameContext.h>
 
+// Maya 2018 has "using" statements for nearly all MFn*/M* objects, and
+// having both "using" and a forward declaration raises a clang error.
+#if MAYA_API_VERSION < 20180000
 class M3dView;
-class MPxSurfaceShape;
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/third_party/maya/lib/usdMaya/editUtil.h
+++ b/third_party/maya/lib/usdMaya/editUtil.h
@@ -39,9 +39,6 @@
 #include <vector>
 #include <map>
 
-
-class MFnAssembly;
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \brief Utility class for handling edits on Assemblies in Maya.


### PR DESCRIPTION
### Description of Change(s)
Just some clang fixes for usdMaya and maya-2018

Note that I don't actually know if the entire project builds with clang + maya2018, these were just some errors I was getting from a clang-based static analysis tool... but I confirmed that they raised clang build errors for the specific compilation units in question (which are now fixed).
