### PR TITLE
[usdMaya] add PreExport / PostExport to PxrUsdMayaShadingModeExporter

### DIFF
--- a/third_party/maya/lib/usdMaya/shadingModeExporter.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeExporter.cpp
@@ -57,7 +57,7 @@ PxrUsdMayaShadingModeExporter::DoExport(
     const PxrUsdMayaUtil::ShapeSet& bindableRoots,
     bool mergeTransformAndShape,
     const SdfPath& overrideRootPath,
-    const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type&,
+    const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap,
     const SdfPath &materialCollectionsPath) 
 {
     MItDependencyNodes shadingEngineIter(MFn::kShadingEngine);
@@ -77,20 +77,24 @@ PxrUsdMayaShadingModeExporter::DoExport(
         }
     }
 
+    PxrUsdMayaShadingModeExportContext context(
+        MObject(),
+        stage,
+        mergeTransformAndShape,
+        bindableRoots,
+        overrideRootPath,
+        dagPathToUsdMap);
+
+    PreExport(context);
+
     MaterialAssignments matAssignments;
     for (; !shadingEngineIter.isDone(); shadingEngineIter.next()) {
         MObject shadingEngine(shadingEngineIter.thisNode());
-
-        PxrUsdMayaShadingModeExportContext c(
-            shadingEngine,
-            stage,
-            mergeTransformAndShape,
-            bindableRoots,
-            overrideRootPath);
+        context.SetShadingEngine(shadingEngine);
 
         UsdShadeMaterial mat;
         SdfPathSet boundPrimPaths;
-        Export(c, &mat, &boundPrimPaths);
+        Export(context, &mat, &boundPrimPaths);
 
         if (!boundPrimPaths.empty()) {
             matAssignments.push_back(std::make_pair(
@@ -98,11 +102,14 @@ PxrUsdMayaShadingModeExporter::DoExport(
         }
     }
 
+    context.SetShadingEngine(MObject());
+    PostExport(context);
+
     if (materialCollectionsPrim && !matAssignments.empty()) {
         std::vector<UsdCollectionAPI> collections = 
                 UsdUtilsCreateCollections(matAssignments, 
                         materialCollectionsPrim);
-    } 
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/shadingModeExporter.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporter.h
@@ -44,6 +44,7 @@ public:
     PXRUSDMAYA_API
     virtual ~PxrUsdMayaShadingModeExporter();
 
+
     PXRUSDMAYA_API
     void DoExport(const UsdStageRefPtr& stage,
                   const PxrUsdMayaUtil::ShapeSet& bindableRoots,
@@ -52,10 +53,26 @@ public:
                   const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap,
                   const SdfPath &materialCollectionsPath);
 
+    /// Called once, before any exports are started.
+    ///
+    /// Because it is called before the the per-shading-engine loop, the shadingEngine
+    /// in the passed PxrUsdMayaShadingModeExportContext will be a null MObject.
+    PXRUSDMAYA_API
+    virtual void PreExport(const PxrUsdMayaShadingModeExportContext& context) {};
+
+    /// Called inside of a loop, per-shading-engine
     PXRUSDMAYA_API
     virtual void Export(const PxrUsdMayaShadingModeExportContext& context,
                         UsdShadeMaterial * const mat, 
                         SdfPathSet * const boundPrimPaths)=0;
+
+    /// Called once, after Export is called for all shading engines.
+    ///
+    /// Because it is called after the the per-shading-engine loop, the shadingEngine
+    /// in the passed PxrUsdMayaShadingModeExportContext will be a null MObject.
+    PXRUSDMAYA_API
+    virtual void PostExport(const PxrUsdMayaShadingModeExportContext& context) {};
+
 };
 
 using PxrUsdMayaShadingModeExporterPtr = std::shared_ptr<PxrUsdMayaShadingModeExporter>;

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.cpp
@@ -52,11 +52,13 @@ PxrUsdMayaShadingModeExportContext::PxrUsdMayaShadingModeExportContext(
         const UsdStageRefPtr& stage,
         bool mergeTransformAndShape,
         const PxrUsdMayaUtil::ShapeSet& bindableRoots,
-        SdfPath overrideRootPath) :
+        SdfPath overrideRootPath,
+        const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap) :
     _shadingEngine(shadingEngine),
     _stage(stage),
     _mergeTransformAndShape(mergeTransformAndShape),
-    _overrideRootPath(overrideRootPath)
+    _overrideRootPath(overrideRootPath),
+    _dagPathToUsdMap(dagPathToUsdMap)
 {
     if (bindableRoots.empty()) {
         // if none specified, push back '/' which encompasses all

--- a/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
+++ b/third_party/maya/lib/usdMaya/shadingModeExporterContext.h
@@ -37,8 +37,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 class PxrUsdMayaShadingModeExportContext
 {
 public:
+    void SetShadingEngine(MObject shadingEngine) { _shadingEngine = shadingEngine; }
     MObject GetShadingEngine() const { return _shadingEngine; }
     const UsdStageRefPtr& GetUsdStage() const { return _stage; }
+    bool GetMergeTransformAndShape() const { return _mergeTransformAndShape; }
+    const SdfPath& GetOverrideRootPath() const { return _overrideRootPath; }
+    const SdfPathSet& GetBindableRoots() const { return _bindableRoots; }
+
+    const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& GetDagPathToUsdMap() const
+    { return _dagPathToUsdMap; }
 
     PXRUSDMAYA_API
     MObject GetSurfaceShader() const;
@@ -91,14 +98,15 @@ public:
             const UsdStageRefPtr& stage,
             bool mergeTransformAndShape,
             const PxrUsdMayaUtil::ShapeSet& bindableRoots,
-            SdfPath overrideRootPath);
+            SdfPath overrideRootPath,
+            const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& dagPathToUsdMap);
 private:
     MObject _shadingEngine;
     const UsdStageRefPtr& _stage;
     bool _mergeTransformAndShape;
     SdfPath _overrideRootPath;
-
     SdfPathSet _bindableRoots;
+    const PxrUsdMayaUtil::MDagPathMap<SdfPath>::Type& _dagPathToUsdMap;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
This adds two new virtual methods, PreExport and PostExport, which provide points at which sub-classes can customize the shader export process.

### Fixes Issue(s)
- A recent commit made DoExport no longer a virtual method; while this ensured a more unified export process, it also meant a loss of flexibility for shader exporters which need to do some sort of setup + tear down. This commit restores the ability for third-party subclasses to do such things.

