### PR TITLE
[usdview] add a "Save Flattened As" menu item

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -778,6 +778,9 @@ class AppController(QtCore.QObject):
             self._ui.actionSave_Overrides_As.triggered.connect(
                 self._saveOverridesAs)
 
+            self._ui.actionSave_Flattened_As.triggered.connect(
+                self._saveFlattenedAs)
+
             # Setup quit actions to ensure _cleanAndClose is only invoked once.
             self._ui.actionQuit.triggered.connect(QtWidgets.QApplication.instance().quit)
 
@@ -2479,6 +2482,25 @@ class AppController(QtCore.QObject):
                 targetLayer.Save()
             else:
                 self._stage.GetRootLayer().Export(saveName, 'Created by UsdView')
+
+    def _saveFlattenedAs(self):
+        recommendedFilename = self._parserData.usdFile.rsplit('.', 1)[0]
+        recommendedFilename += '_flattened.usd'
+        (saveName, _) = QtWidgets.QFileDialog.getSaveFileName(self._mainWindow,
+                                                     "Save file (*.usd)",
+                                                     "./" + recommendedFilename,
+                                                     'Usd Files (*.usd)'
+                                                        ';;Usd Ascii Files (*.usda)'
+                                                        ';;Usd Crate Files (*.usdc)'
+                                                        ';;Any Usd File (*.usd *.usda *.usdc)',
+                                                     'Any Usd File (*.usd *.usda *.usdc)')
+        if len(saveName) <= 0:
+            return
+
+        if (saveName.rsplit('.')[-1] not in ('usd', 'usda', 'usdc')):
+            saveName += '.usd'
+            
+        self._stage.Export(saveName)
 
     def _reopenStage(self):
         QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.BusyCursor)

--- a/pxr/usdImaging/lib/usdviewq/mainWindowUI.ui
+++ b/pxr/usdImaging/lib/usdviewq/mainWindowUI.ui
@@ -1117,6 +1117,7 @@
     <addaction name="separator"/>
     <addaction name="actionSave_Overrides_As"/>
     <addaction name="actionSave_Overrides_To_Scene"/>
+    <addaction name="actionSave_Flattened_As"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
@@ -1885,6 +1886,20 @@
   <action name="actionLoad_Overrides">
    <property name="text">
     <string>Load Overrides</string>
+   </property>
+  </action>
+  <action name="actionSave_Flattened_As">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Save Flattened As...</string>
+   </property>
+   <property name="iconText">
+    <string>Save Flattened As...</string>
+   </property>
+   <property name="toolTip">
+    <string>Save a flattened version of the current stage</string>
    </property>
   </action>
   <action name="showInterpreter">


### PR DESCRIPTION
### Description of Change(s)
Adds a new menu item to usdview, "Save Flattened As", which does as it says - saves a flattened version of the scene, as opposed to just a set of overrides.  This can be handy when doing debugging, or providing simplified versions of scenes to send to others, etc.  Particularly handy when used in combination with deactivating of prims, to get a "trimmed down" version of a scene.

### Fixes Issue(s)
- None

