### PR TITLE
Allow user to specify boost version

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -642,9 +642,14 @@ PTEX = Dependency("Ptex", InstallPtex, "include/PtexVersion.h")
 ############################################################
 # OpenImageIO
 
-OIIO_URL = "https://github.com/OpenImageIO/oiio/archive/Release-1.7.14.zip"
 
 def InstallOpenImageIO(context, force):
+    boost_version = int(context.boost.split(".")[1])
+    if boost_version >= 65:
+        OIIO_URL = "https://github.com/OpenImageIO/oiio/archive/Release-1.7.17.zip"
+    else:
+        OIIO_URL = "https://github.com/OpenImageIO/oiio/archive/Release-1.7.14.zip"
+
     with CurrentWorkingDirectory(DownloadURL(OIIO_URL, context, force)):
         extraArgs = ['-DOIIO_BUILD_TOOLS=OFF',
                      '-DOIIO_BUILD_TESTS=OFF',


### PR DESCRIPTION
### Description of Change(s) 

I'm using boost 1.65.1, and like the convenience of using the standard build script. This modification doesn't change the default behavior, but if boost version is specified on the command line, USD will build with the specified version.

Also handles toolset version for VS2015 and VS2017, because boost 1.65.1 insists on toolset 141 for VS2017.

OpenImageIO 1.7.17 is the minimum compatible with boost 1.65.1

### Fixes Issue(s) 

build script is hard coded to boost 1.61 and using the 140 toolset with VS2015 and VS2017


