### PR TITLE
mark the GfMatrix*.Get method const

### DIFF
--- a/pxr/base/lib/gf/matrix.template.cpp
+++ b/pxr/base/lib/gf/matrix.template.cpp
@@ -119,7 +119,7 @@ operator<<(std::ostream& out, const {{ MAT }}& m)
 }
 
 {{ SCL }} *
-{{ MAT }}::Get({{ SCL }} m[{{ DIM }}][{{ DIM }}])
+{{ MAT }}::Get({{ SCL }} m[{{ DIM }}][{{ DIM }}]) const
 {
     {{ MATRIX("m[%(i)s][%(j)s] = _mtx[%(i)s][%(j)s];", sep="\n    ",
               indent=4) }}

--- a/pxr/base/lib/gf/matrix.template.h
+++ b/pxr/base/lib/gf/matrix.template.h
@@ -182,7 +182,7 @@ public:
     /// Fills a {{ DIM }}x{{ DIM }} array of \c {{ SCL }} values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    {{ SCL }}* Get({{ SCL }} m[{{ DIM }}][{{ DIM }}]);
+    {{ SCL }}* Get({{ SCL }} m[{{ DIM }}][{{ DIM }}]) const;
 
     /// Returns vector components as an array of \c {{ SCL }} values.
     {{ SCL }}* GetArray()  {

--- a/pxr/base/lib/gf/matrix2d.cpp
+++ b/pxr/base/lib/gf/matrix2d.cpp
@@ -106,7 +106,7 @@ GfMatrix2d::SetDiagonal(const GfVec2d& v)
 }
 
 double *
-GfMatrix2d::Get(double m[2][2])
+GfMatrix2d::Get(double m[2][2]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix2d.h
+++ b/pxr/base/lib/gf/matrix2d.h
@@ -188,7 +188,7 @@ public:
     /// Fills a 2x2 array of \c double values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    double* Get(double m[2][2]);
+    double* Get(double m[2][2]) const;
 
     /// Returns vector components as an array of \c double values.
     double* GetArray()  {

--- a/pxr/base/lib/gf/matrix2f.cpp
+++ b/pxr/base/lib/gf/matrix2f.cpp
@@ -106,7 +106,7 @@ GfMatrix2f::SetDiagonal(const GfVec2f& v)
 }
 
 float *
-GfMatrix2f::Get(float m[2][2])
+GfMatrix2f::Get(float m[2][2]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix2f.h
+++ b/pxr/base/lib/gf/matrix2f.h
@@ -188,7 +188,7 @@ public:
     /// Fills a 2x2 array of \c float values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    float* Get(float m[2][2]);
+    float* Get(float m[2][2]) const;
 
     /// Returns vector components as an array of \c float values.
     float* GetArray()  {

--- a/pxr/base/lib/gf/matrix3d.cpp
+++ b/pxr/base/lib/gf/matrix3d.cpp
@@ -126,7 +126,7 @@ GfMatrix3d::SetDiagonal(const GfVec3d& v)
 }
 
 double *
-GfMatrix3d::Get(double m[3][3])
+GfMatrix3d::Get(double m[3][3]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix3d.h
+++ b/pxr/base/lib/gf/matrix3d.h
@@ -222,7 +222,7 @@ public:
     /// Fills a 3x3 array of \c double values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    double* Get(double m[3][3]);
+    double* Get(double m[3][3]) const;
 
     /// Returns vector components as an array of \c double values.
     double* GetArray()  {

--- a/pxr/base/lib/gf/matrix3f.cpp
+++ b/pxr/base/lib/gf/matrix3f.cpp
@@ -126,7 +126,7 @@ GfMatrix3f::SetDiagonal(const GfVec3f& v)
 }
 
 float *
-GfMatrix3f::Get(float m[3][3])
+GfMatrix3f::Get(float m[3][3]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix3f.h
+++ b/pxr/base/lib/gf/matrix3f.h
@@ -220,7 +220,7 @@ public:
     /// Fills a 3x3 array of \c float values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    float* Get(float m[3][3]);
+    float* Get(float m[3][3]) const;
 
     /// Returns vector components as an array of \c float values.
     float* GetArray()  {

--- a/pxr/base/lib/gf/matrix4d.cpp
+++ b/pxr/base/lib/gf/matrix4d.cpp
@@ -212,7 +212,7 @@ GfMatrix4d::SetDiagonal(const GfVec4d& v)
 }
 
 double *
-GfMatrix4d::Get(double m[4][4])
+GfMatrix4d::Get(double m[4][4]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix4d.h
+++ b/pxr/base/lib/gf/matrix4d.h
@@ -266,7 +266,7 @@ public:
     /// Fills a 4x4 array of \c double values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    double* Get(double m[4][4]);
+    double* Get(double m[4][4]) const;
 
     /// Returns vector components as an array of \c double values.
     double* GetArray()  {

--- a/pxr/base/lib/gf/matrix4f.cpp
+++ b/pxr/base/lib/gf/matrix4f.cpp
@@ -212,7 +212,7 @@ GfMatrix4f::SetDiagonal(const GfVec4f& v)
 }
 
 float *
-GfMatrix4f::Get(float m[4][4])
+GfMatrix4f::Get(float m[4][4]) const
 {
     m[0][0] = _mtx[0][0];
     m[0][1] = _mtx[0][1];

--- a/pxr/base/lib/gf/matrix4f.h
+++ b/pxr/base/lib/gf/matrix4f.h
@@ -266,7 +266,7 @@ public:
     /// Fills a 4x4 array of \c float values with the values in
     /// the matrix, specified in row-major order.
     GF_API
-    float* Get(float m[4][4]);
+    float* Get(float m[4][4]) const;
 
     /// Returns vector components as an array of \c float values.
     float* GetArray()  {


### PR DESCRIPTION
### Description of Change(s)
Pretty self explanatory. I wanted to use GfMatrid4d.Get from a const instance, but couldn't.

### Fixes Issue(s)
- None reported

