### PR TITLE
[usdGeom] allow UsdGeomXformable::GetLocalTransformation(resetsXformStack=nullptr)

### DIFF
--- a/pxr/usd/lib/usdGeom/xformable.cpp
+++ b/pxr/usd/lib/usdGeom/xformable.cpp
@@ -687,7 +687,7 @@ UsdGeomXformable::GetLocalTransformation(
         return false;
 
     if (opOrderVec.size() == 0) {
-        *resetsXformStack = false;
+        if (resetsXformStack) *resetsXformStack = false;
 
         // XXX: backwards compatibility
         if (TfGetEnvSetting(USD_READ_OLD_STYLE_TRANSFORM)) {


### PR DESCRIPTION
### Description of Change(s)
If there's no xform ops, you can get a crash if you use a nullptr for resetsXformStack.

### Fixes Issue(s)
- Crash if no xform ops, and you pass resetsXformStack=nullptr

