### PR TITLE
 [plug] fix for loading of same plugin twice 

### DIFF
--- a/pxr/base/lib/plug/plugin.cpp
+++ b/pxr/base/lib/plug/plugin.cpp
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/dl.h"
 #include "pxr/base/tf/fileUtils.h"
 #include "pxr/base/tf/hash.h"
-#include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/hashset.h"
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/pyLock.h"
@@ -59,7 +58,7 @@ using std::vector;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef TfHashMap< std::string, PlugPluginRefPtr, TfHash > _PluginMap;
+typedef PlugPlugin::PluginMap _PluginMap;
 typedef TfHashMap< std::string, PlugPluginPtr, TfHash > _WeakPluginMap;
 typedef TfHashMap< TfType, PlugPluginPtr, TfHash > _ClassMap;
 
@@ -75,12 +74,16 @@ static TfStaticData<_ClassMap> _classMap;
 static std::mutex _classMapMutex;
 
 pair<PlugPluginPtr, bool>
-PlugPlugin::_NewDynamicLibraryPlugin(const std::string & path,
-                                     const std::string & name,
-                                     const std::string & dsoPath,
-                                     const std::string & resourcePath,
-                                     const JsObject & plugInfo)
+PlugPlugin::_NewPlugin(const Plug_RegistrationMetadata &metadata,
+                       _Type pluginType,
+                       const char* pluginTypeName,
+                       const std::string& pluginCreationPath,
+                       PluginMap& allPluginsByName,
+                       PluginMap* allPluginsByCreationPath)
 {
+    const std::string& path = metadata.pluginPath;
+    const std::string& name = metadata.pluginName;
+
     {
         // Already registered?
         std::lock_guard<std::mutex> lock(_allPluginsMutex);
@@ -90,124 +93,66 @@ PlugPlugin::_NewDynamicLibraryPlugin(const std::string & path,
 
         // Already registered with the same name but a different path?  Give
         // priority to the path we've registered already and ignore this one.
-        it = _allPluginsByDynamicLibraryName->find(name);
-        if (it != _allPluginsByDynamicLibraryName->end())
+        it = allPluginsByName.find(name);
+        if (it != allPluginsByName.end())
             return std::make_pair(it->second, false);
     }
 
-    // Go ahead and create a plugin. 
-    TF_DEBUG(PLUG_REGISTRATION).Msg("Registering dso plugin '%s' at '%s'.\n",
-                                    name.c_str(), dsoPath.c_str());
+    // Go ahead and create a plugin.
+    TF_DEBUG(PLUG_REGISTRATION).Msg("Registering %s plugin '%s' at '%s'.\n",
+                                    pluginTypeName, name.c_str(),
+                                    pluginCreationPath.c_str());
     PlugPluginRefPtr plugin =
-        TfCreateRefPtr(new PlugPlugin(dsoPath, name, resourcePath,
-                                      plugInfo, LibraryType));
+            TfCreateRefPtr(new PlugPlugin(pluginCreationPath, name,
+                                          metadata.resourcePath,
+                                          metadata.plugInfo, pluginType));
 
     pair<PlugPluginPtr, bool> result;
     {
         std::lock_guard<std::mutex> lock(_allPluginsMutex);
         pair<_PluginMap::iterator, bool> iresult =
-            _allPlugins->insert(make_pair(path, plugin));
+                _allPlugins->insert(make_pair(path, plugin));
         result.first = iresult.first->second;
         result.second = iresult.second;
 
-        // If successfully inserted, add to _allPluginsByDynamicLibraryName too.
+        // If successfully inserted, add to allPluginsByName too.
         if (iresult.second) {
-            (*_allPluginsByDynamicLibraryName)[name]   = plugin;
-            (*_libraryPluginsByDsoPath)[dsoPath] = plugin;
+            allPluginsByName[name] = plugin;
+            // Wanted to have this just handled in _NewDynamicLibraryPlugin,
+            // after calling _NewPlugin, but that would have required
+            // re-accquiring the lock, which would potentially be slower
+            if (allPluginsByCreationPath != nullptr) {
+                (*allPluginsByCreationPath)[pluginCreationPath] = plugin;
+            }
         }
     }
 
     return result;
 }
 
+
+pair<PlugPluginPtr, bool>
+PlugPlugin::_NewDynamicLibraryPlugin(const Plug_RegistrationMetadata& metadata)
+{
+    return _NewPlugin(metadata, LibraryType, "dso", metadata.libraryPath,
+                      *_allPluginsByDynamicLibraryName,
+                      &(*_allPluginsByDynamicLibraryName));
+}
+
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 pair<PlugPluginPtr, bool>
-PlugPlugin::_NewPythonModulePlugin(const std::string & modulePath,
-                                   const std::string & moduleName,
-                                   const std::string & resourcePath,
-                                   const JsObject & plugInfo)
+PlugPlugin::_NewPythonModulePlugin(const Plug_RegistrationMetadata& metadata)
 {
-    {
-        // Already registered?
-        std::lock_guard<std::mutex> lock(_allPluginsMutex);
-
-        _PluginMap::const_iterator it = _allPlugins->find(modulePath);
-        if (it != _allPlugins->end())
-            return std::make_pair(it->second, false);
-
-        // Already registered with the same moduleName but a different path?
-        // Give priority to the path we've registered already and ignore this
-        // one.
-        it = _allPluginsByModuleName->find(moduleName);
-        if (it != _allPluginsByModuleName->end())
-            return std::make_pair(it->second, false);
-    }
-
-    // Go ahead and create a plugin.
-    TF_DEBUG(PLUG_REGISTRATION).Msg("Registering python plugin '%s' at '%s'.\n",
-                                    moduleName.c_str(), modulePath.c_str());
-    PlugPluginRefPtr plugin =
-        TfCreateRefPtr(new PlugPlugin(modulePath, moduleName, resourcePath,
-                                      plugInfo, PythonType));
-    pair<PlugPluginPtr, bool> result;
-    {
-        std::lock_guard<std::mutex> lock(_allPluginsMutex);
-        pair<_PluginMap::iterator, bool> iresult =
-            _allPlugins->insert(make_pair(modulePath, plugin));
-        result.first = iresult.first->second;
-        result.second = iresult.second;
-
-        // If successfully inserted, add to _allPluginsByModuleName too.
-        if (iresult.second)
-            (*_allPluginsByModuleName)[plugin->GetName()] = plugin;
-    }
-
-    return result;
+    return _NewPlugin(metadata, PythonType, "python", metadata.pluginPath,
+                      *_allPluginsByModuleName);
 }
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 std::pair<PlugPluginPtr, bool> 
-PlugPlugin::_NewResourcePlugin(const std::string & path,
-                               const std::string & name,
-                               const std::string & resourcePath,
-                               const JsObject & plugInfo)
+PlugPlugin::_NewResourcePlugin(const Plug_RegistrationMetadata& metadata)
 {
-    {
-        // Already registered?
-        std::lock_guard<std::mutex> lock(_allPluginsMutex);
-
-        _PluginMap::const_iterator it = _allPlugins->find(path);
-        if (it != _allPlugins->end())
-            return std::make_pair(it->second, false);
-
-        // Already registered with the same name but a different path?
-        // Give priority to the path we've registered already and ignore
-        // this one.
-        it = _allPluginsByResourceName->find(name);
-        if (it != _allPluginsByResourceName->end())
-            return std::make_pair(it->second, false);
-    }
-
-    // Go ahead and create a plugin.
-    TF_DEBUG(PLUG_REGISTRATION).Msg("Registering resource plugin '%s' at '%s'.\n",
-                                    name.c_str(), path.c_str());
-    PlugPluginRefPtr plugin =
-        TfCreateRefPtr(new PlugPlugin(path, name, resourcePath,
-                                      plugInfo, ResourceType));
-    pair<PlugPluginPtr, bool> result;
-    {
-        std::lock_guard<std::mutex> lock(_allPluginsMutex);
-        pair<_PluginMap::iterator, bool> iresult =
-            _allPlugins->insert(make_pair(path, plugin));
-        result.first = iresult.first->second;
-        result.second = iresult.second;
-
-        // If successfully inserted, add to _allPluginsByResourceName too.
-        if (iresult.second)
-            (*_allPluginsByResourceName)[plugin->GetName()] = plugin;
-    }
-
-    return result;
+    return _NewPlugin(metadata, ResourceType, "resource", metadata.pluginPath,
+                      *_allPluginsByResourceName);
 }
 
 PlugPlugin::PlugPlugin(const std::string & path,

--- a/pxr/base/lib/plug/plugin.h
+++ b/pxr/base/lib/plug/plugin.h
@@ -26,9 +26,11 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/plug/api.h"
+#include "pxr/base/plug/info.h"
 
 #include "pxr/base/js/types.h"
 #include "pxr/base/tf/declarePtrs.h"
+#include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/refPtr.h"
 #include "pxr/base/tf/weakPtr.h"
 
@@ -57,6 +59,8 @@ class TfType;
 ///
 class PlugPlugin : public TfRefBase, public TfWeakBase {
 public:
+    typedef TfHashMap< std::string, PlugPluginRefPtr, TfHash > PluginMap;
+
     PLUG_API virtual ~PlugPlugin();
 
     /// Loads the plugin.
@@ -115,7 +119,7 @@ public:
     PLUG_API std::string FindPluginResource(const std::string& path, bool verify = true) const;
 
 private:
-    enum _Type { 
+    enum _Type {
         LibraryType, 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED        
         PythonType, 
@@ -142,28 +146,27 @@ private:
     static PlugPluginPtrVector _GetAllPlugins();
 
     PLUG_LOCAL
+    static std::pair<PlugPluginPtr, bool>
+    _NewPlugin(const Plug_RegistrationMetadata &metadata,
+               _Type pluginType,
+               const char* pluginTypeName,
+               const std::string& pluginCreationPath,
+               PluginMap& allPluginsByName,
+               PluginMap* allPluginsByCreationPath=nullptr);
+
+    PLUG_LOCAL
     static std::pair<PlugPluginPtr, bool> 
-    _NewDynamicLibraryPlugin(const std::string & path,
-                             const std::string & name,
-                             const std::string & dsoPath,
-                             const std::string & resourcePath,
-                             const JsObject & plugInfo);
+    _NewDynamicLibraryPlugin(const Plug_RegistrationMetadata& metadata);
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
     PLUG_LOCAL
     static std::pair<PlugPluginPtr, bool> 
-    _NewPythonModulePlugin(const std::string & path,
-                           const std::string & name,
-                           const std::string & resourcePath,
-                           const JsObject & plugInfo);
+    _NewPythonModulePlugin(const Plug_RegistrationMetadata& metadata);
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
     PLUG_LOCAL
     static std::pair<PlugPluginPtr, bool> 
-    _NewResourcePlugin(const std::string & path,
-                       const std::string & name,
-                       const std::string & resourcePath,
-                       const JsObject & plugInfo);
+    _NewResourcePlugin(const Plug_RegistrationMetadata& metadata);
 
     PLUG_LOCAL
     bool _Load();

--- a/pxr/base/lib/plug/registry.cpp
+++ b/pxr/base/lib/plug/registry.cpp
@@ -88,33 +88,15 @@ PlugRegistry::_RegisterPlugin(
         break;
 
     case Plug_RegistrationMetadata::LibraryType:
-        newPlugin =
-            PlugPlugin::_NewDynamicLibraryPlugin(
-                metadata.pluginPath,
-                metadata.pluginName,
-                metadata.libraryPath,
-                metadata.resourcePath,
-                metadata.plugInfo);
+        newPlugin = PlugPlugin::_NewDynamicLibraryPlugin(metadata);
         break;
-
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
     case Plug_RegistrationMetadata::PythonType:
-        newPlugin =
-            PlugPlugin::_NewPythonModulePlugin(
-                metadata.pluginPath,
-                metadata.pluginName,
-                metadata.resourcePath,
-                metadata.plugInfo);
+        newPlugin = PlugPlugin::_NewPythonModulePlugin(metadata);
         break;
 #endif // PXR_PYTHON_SUPPORT_ENABLED
-
     case Plug_RegistrationMetadata::ResourceType:
-        newPlugin =
-            PlugPlugin::_NewResourcePlugin(
-                metadata.pluginPath,
-                metadata.pluginName,
-                metadata.resourcePath,
-                metadata.plugInfo);
+        newPlugin = PlugPlugin::_NewResourcePlugin(metadata);
         break;
     }
 


### PR DESCRIPTION
### Description of Change(s)

This modifies the way that plugin locking is done, to avoid a race condition where the same plugin is loaded twice, causing errors and/or crashes.

(Note: The first commit consolidates some code related to plugin creation - this was just so that I didn't have to repeat adding the same code three times.)

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/358

