### PR TITLE
[usdMaya] fix usdExport to account for camera shake attribute

### DIFF
--- a/third_party/maya/lib/usdMaya/MayaCameraWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaCameraWriter.cpp
@@ -105,10 +105,12 @@ bool MayaCameraWriter::writeCameraAttrs(const UsdTimeCode &usdTime, UsdGeomCamer
         const double verticalAperture = PxrUsdMayaUtil::ConvertInchesToMM(
             camFn.verticalFilmAperture());
 
+        // Film offset and shake (when enabled) have the same effect on film back
         const double horizontalApertureOffset = PxrUsdMayaUtil::ConvertInchesToMM(
-            camFn.horizontalFilmOffset());
+            (camFn.shakeEnabled() ?
+             camFn.horizontalFilmOffset() + camFn.horizontalShake() : camFn.horizontalFilmOffset()));
         const double verticalApertureOffset = PxrUsdMayaUtil::ConvertInchesToMM(
-            camFn.verticalFilmOffset());
+            (camFn.shakeEnabled() ? camFn.verticalFilmOffset() + camFn.verticalShake() : camFn.verticalFilmOffset()));
 
         primSchema.GetHorizontalApertureAttr().Set(
             float(horizontalAperture), usdTime);


### PR DESCRIPTION
### Description of Change(s)
Adds maya camera's shake offset to USD camera aperture offset if shake is enabled.

This documentation indicates that simply adding the values should be sufficient: https://help.autodesk.com/view/MAYAUL/2018/ENU/?guid=GUID-C3EBB008-7DBE-4B9D-B9AC-1DA974CEFE15

### Fixes Issue(s)
- Exported Maya cameras that use shakeEnabled, shakeHorizontal and shakeVertical will not line up with USD camera.

