### PR TITLE
Switch from boost::shared_ptr to std::shared_ptr.

### DIFF
--- a/extras/usd/examples/usdObj/pch.h
+++ b/extras/usd/examples/usdObj/pch.h
@@ -160,7 +160,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/decay.hpp>

--- a/extras/usd/examples/usdSchemaExamples/pch.h
+++ b/extras/usd/examples/usdSchemaExamples/pch.h
@@ -166,7 +166,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/base/lib/plug/pch.h
+++ b/pxr/base/lib/plug/pch.h
@@ -171,7 +171,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/is_abstract.hpp>
 #include <boost/type_traits/is_base_of.hpp>

--- a/pxr/base/lib/tf/copyOnWritePtr.h
+++ b/pxr/base/lib/tf/copyOnWritePtr.h
@@ -81,7 +81,6 @@
 
 #include <boost/mpl/if.hpp>
 #include <boost/operators.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -89,7 +88,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // General case -- use shared_ptr.
 template <typename Pointee>
 struct Tf_CowSharedPtrHelper {
-    typedef boost::shared_ptr<Pointee> PtrType;
+    typedef std::shared_ptr<Pointee> PtrType;
     static PtrType New(Pointee const *p = 0) {
         return p ? PtrType(new Pointee(*p)) : PtrType(new Pointee());
     }

--- a/pxr/base/lib/tf/pch.h
+++ b/pxr/base/lib/tf/pch.h
@@ -228,7 +228,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/base/lib/vt/pch.h
+++ b/pxr/base/lib/vt/pch.h
@@ -158,7 +158,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/decay.hpp>

--- a/pxr/base/lib/work/pch.h
+++ b/pxr/base/lib/work/pch.h
@@ -107,7 +107,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_class.hpp>
 #include <boost/type_traits/is_const.hpp>

--- a/pxr/imaging/lib/garch/pch.h
+++ b/pxr/imaging/lib/garch/pch.h
@@ -138,7 +138,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/is_abstract.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_class.hpp>

--- a/pxr/imaging/lib/glf/drawTarget.h
+++ b/pxr/imaging/lib/glf/drawTarget.h
@@ -42,13 +42,11 @@
 #include <set>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfDrawTarget);
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 
 /// \class GlfDrawTarget
 ///

--- a/pxr/imaging/lib/glf/glContext.h
+++ b/pxr/imaging/lib/glf/glContext.h
@@ -28,12 +28,11 @@
 #include "pxr/imaging/glf/api.h"
 #include "pxr/base/arch/threads.h"
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 
 /// \class GlfGLContext
 ///

--- a/pxr/imaging/lib/glf/glContextRegistry.cpp
+++ b/pxr/imaging/lib/glf/glContextRegistry.cpp
@@ -29,13 +29,12 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/instantiateSingleton.h"
 #include <boost/unordered_map.hpp>
-#include <boost/weak_ptr.hpp>
 #include <map>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::weak_ptr<class GlfGLContext> GlfGLContextWeakPtr;
+typedef std::weak_ptr<class GlfGLContext> GlfGLContextWeakPtr;
 
 static GlfGLContextSharedPtr _nullContext;
 

--- a/pxr/imaging/lib/glf/glContextRegistry.h
+++ b/pxr/imaging/lib/glf/glContextRegistry.h
@@ -33,14 +33,15 @@
 #include <boost/optional.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 struct GlfGLContextRegistry_Data;
 
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 
 /// \class GlfGLContextRegistry
 ///

--- a/pxr/imaging/lib/glf/glRawContext.h
+++ b/pxr/imaging/lib/glf/glRawContext.h
@@ -34,7 +34,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfGLRawContext> GlfGLRawContextSharedPtr;
+typedef std::shared_ptr<class GlfGLRawContext> GlfGLRawContextSharedPtr;
 
 class GlfGLRawContext : public GlfGLContext {
 public:

--- a/pxr/imaging/lib/glf/image.h
+++ b/pxr/imaging/lib/glf/image.h
@@ -36,14 +36,13 @@
 #include "pxr/base/vt/value.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfImage> GlfImageSharedPtr;
+typedef std::shared_ptr<class GlfImage> GlfImageSharedPtr;
 
 /// \class GlfImage
 ///

--- a/pxr/imaging/lib/glf/imageRegistry.h
+++ b/pxr/imaging/lib/glf/imageRegistry.h
@@ -30,14 +30,13 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfImage> GlfImageSharedPtr;
+typedef std::shared_ptr<class GlfImage> GlfImageSharedPtr;
 
 class GlfRankedTypeMap;
 

--- a/pxr/imaging/lib/glf/pch.h
+++ b/pxr/imaging/lib/glf/pch.h
@@ -185,7 +185,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/has_left_shift.hpp>
@@ -206,7 +205,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/imaging/lib/glf/testGLContext.cpp
+++ b/pxr/imaging/lib/glf/testGLContext.cpp
@@ -219,7 +219,7 @@ GlfTestGLContext::_IsSharing(GlfGLContextSharedPtr const & otherContext)const
 {
 #ifdef MENV30
     GlfTestGLContextSharedPtr otherGlfTestGLContext =
-        boost::dynamic_pointer_cast<GlfTestGLContext>(otherContext);
+        std::dynamic_pointer_cast<GlfTestGLContext>(otherContext);
     return (otherGlfTestGLContext &&
             Glf_TestGLContextPrivate::areSharing(_context, otherGlfTestGLContext->_context));
 #else

--- a/pxr/imaging/lib/glf/testGLContext.h
+++ b/pxr/imaging/lib/glf/testGLContext.h
@@ -30,13 +30,11 @@
 #include "pxr/imaging/glf/api.h"
 #include "pxr/imaging/glf/glContext.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class Glf_TestGLContextPrivate;
 
-typedef boost::shared_ptr<class GlfTestGLContext> GlfTestGLContextSharedPtr;
+typedef std::shared_ptr<class GlfTestGLContext> GlfTestGLContextSharedPtr;
 
 /// \class GlfTestGLContext
 ///

--- a/pxr/imaging/lib/glf/uvTextureData.h
+++ b/pxr/imaging/lib/glf/uvTextureData.h
@@ -28,15 +28,13 @@
 #include "pxr/imaging/glf/api.h"
 #include "pxr/imaging/glf/baseTextureData.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <memory>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfImage> GlfImageSharedPtr;
+typedef std::shared_ptr<class GlfImage> GlfImageSharedPtr;
 
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfUVTextureData);
 

--- a/pxr/imaging/lib/glf/uvTextureStorageData.h
+++ b/pxr/imaging/lib/glf/uvTextureStorageData.h
@@ -30,8 +30,6 @@
 
 #include "pxr/base/vt/value.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 

--- a/pxr/imaging/lib/hd/basisCurvesTopology.h
+++ b/pxr/imaging/lib/hd/basisCurvesTopology.h
@@ -35,12 +35,12 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdBasisCurvesTopology> HdBasisCurvesTopologySharedPtr;
+typedef std::shared_ptr<class HdBasisCurvesTopology> HdBasisCurvesTopologySharedPtr;
 
 
 /// \class HdBasisCurvesTopology

--- a/pxr/imaging/lib/hd/bufferArray.h
+++ b/pxr/imaging/lib/hd/bufferArray.h
@@ -33,10 +33,9 @@
 #include "pxr/base/vt/value.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/enable_shared_from_this.hpp>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -44,10 +43,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdBufferArrayRange;
 
-typedef boost::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
-typedef boost::shared_ptr<HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::weak_ptr<HdBufferArrayRange> HdBufferArrayRangePtr;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
+typedef std::shared_ptr<HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::weak_ptr<HdBufferArrayRange> HdBufferArrayRangePtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
 
 /// \class HdBufferArray
 ///
@@ -55,7 +54,7 @@ typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
 /// can be shared across multiple HdRprims, in the context of buffer
 /// aggregation.
 ///
-class HdBufferArray : public boost::enable_shared_from_this<HdBufferArray>,
+class HdBufferArray : public std::enable_shared_from_this<HdBufferArray>,
     boost::noncopyable {
 public:
     HD_API

--- a/pxr/imaging/lib/hd/bufferArrayRange.h
+++ b/pxr/imaging/lib/hd/bufferArrayRange.h
@@ -32,7 +32,8 @@
 #include "pxr/imaging/hd/bufferResource.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -40,8 +41,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdBufferArray;
 
 typedef std::vector<struct HdBufferSpec> HdBufferSpecVector;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 
 /// \class HdBufferArrayRange
 ///

--- a/pxr/imaging/lib/hd/bufferArrayRegistry.h
+++ b/pxr/imaging/lib/hd/bufferArrayRegistry.h
@@ -39,16 +39,16 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <tbb/concurrent_unordered_map.h>
 
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
+typedef std::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
 
 /// \class HdBufferArrayRegistry
 ///

--- a/pxr/imaging/lib/hd/bufferResource.h
+++ b/pxr/imaging/lib/hd/bufferResource.h
@@ -32,8 +32,8 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
 #include <cstddef>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -42,7 +42,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdBufferResource;
 
-typedef boost::shared_ptr<HdBufferResource> HdBufferResourceSharedPtr;
+typedef std::shared_ptr<HdBufferResource> HdBufferResourceSharedPtr;
 
 typedef std::vector<
     std::pair<TfToken, HdBufferResourceSharedPtr> > HdBufferResourceNamedList;

--- a/pxr/imaging/lib/hd/bufferSource.h
+++ b/pxr/imaging/lib/hd/bufferSource.h
@@ -32,19 +32,18 @@
 #include "pxr/base/tf/token.h"
 
 #include <atomic>
+#include <memory>
 #include <vector>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdBufferSource;
-typedef boost::shared_ptr<HdBufferSource> HdBufferSourceSharedPtr;
-typedef boost::shared_ptr<HdBufferSource const> HdBufferSourceConstSharedPtr;
+typedef std::shared_ptr<HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<HdBufferSource const> HdBufferSourceConstSharedPtr;
 typedef std::vector<HdBufferSourceSharedPtr> HdBufferSourceVector;
-typedef boost::weak_ptr<HdBufferSource> HdBufferSourceWeakPtr;
+typedef std::weak_ptr<HdBufferSource> HdBufferSourceWeakPtr;
 
 /// \class HdBufferSource
 ///

--- a/pxr/imaging/lib/hd/changeTracker.h
+++ b/pxr/imaging/lib/hd/changeTracker.h
@@ -33,10 +33,9 @@
 #include "pxr/base/tf/hashmap.h"
 
 #include <atomic>
+#include <memory>
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/weak_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/lib/hd/compExtCompInputSource.h
+++ b/pxr/imaging/lib/hd/compExtCompInputSource.h
@@ -34,7 +34,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdExtCompCpuComputation;
 
-typedef boost::shared_ptr<HdExtCompCpuComputation>
+typedef std::shared_ptr<HdExtCompCpuComputation>
                                                HdExtCompCpuComputationSharedPtr;
 
 ///

--- a/pxr/imaging/lib/hd/computation.h
+++ b/pxr/imaging/lib/hd/computation.h
@@ -29,14 +29,15 @@
 #include "pxr/imaging/hd/version.h"
 #include "pxr/imaging/hd/bufferSpec.h"
 #include "pxr/imaging/hd/perfLog.h"
-#include <boost/shared_ptr.hpp>
+
+#include <memory>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::shared_ptr<class HdComputation> HdComputationSharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdComputation> HdComputationSharedPtr;
 typedef std::vector<HdComputationSharedPtr> HdComputationVector;
 
 /// \class HdComputation

--- a/pxr/imaging/lib/hd/dirtyList.h
+++ b/pxr/imaging/lib/hd/dirtyList.h
@@ -30,14 +30,14 @@
 #include "pxr/imaging/hd/rprimCollection.h"
 #include "pxr/imaging/hd/types.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRenderIndex;
 
-typedef boost::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
-typedef boost::weak_ptr<class HdDirtyList> HdDirtyListPtr;
+typedef std::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
+typedef std::weak_ptr<class HdDirtyList> HdDirtyListPtr;
 
 /// \class HdDirtyList
 ///

--- a/pxr/imaging/lib/hd/engine.h
+++ b/pxr/imaging/lib/hd/engine.h
@@ -30,7 +30,7 @@
 
 #include "pxr/imaging/hd/task.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -38,8 +38,8 @@ class HdRenderIndex;
 class HdRenderDelegate;
 class HdResourceRegistry;
 
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
 
 /// \class HdEngine
 ///

--- a/pxr/imaging/lib/hd/extCompCpuComputation.h
+++ b/pxr/imaging/lib/hd/extCompCpuComputation.h
@@ -40,7 +40,7 @@ class HdExtComputation;
 class HdExtCompCpuComputation;
 
 typedef std::vector<VtValue> VtValueVector;
-typedef boost::shared_ptr<HdExtCompCpuComputation>
+typedef std::shared_ptr<HdExtCompCpuComputation>
                                 HdExtCompCpuComputationSharedPtr;
 
 ///

--- a/pxr/imaging/lib/hd/extCompInputSource.h
+++ b/pxr/imaging/lib/hd/extCompInputSource.h
@@ -64,7 +64,7 @@ private:
     Hd_ExtCompInputSource &operator = (const Hd_ExtCompInputSource &)  = delete;
 };
 
-typedef boost::shared_ptr<Hd_ExtCompInputSource> Hd_ExtCompInputSourceSharedPtr;
+typedef std::shared_ptr<Hd_ExtCompInputSource> Hd_ExtCompInputSourceSharedPtr;
 typedef std::vector<Hd_ExtCompInputSourceSharedPtr>
                                            Hd_ExtCompInputSourceSharedPtrVector;
 

--- a/pxr/imaging/lib/hd/extCompPrimvarBufferSource.h
+++ b/pxr/imaging/lib/hd/extCompPrimvarBufferSource.h
@@ -35,7 +35,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdExtCompCpuComputation;
 
-typedef boost::shared_ptr<HdExtCompCpuComputation>
+typedef std::shared_ptr<HdExtCompCpuComputation>
                                                HdExtCompCpuComputationSharedPtr;
 
 /// Hd Buffer Source that binds a PrimVar to a Ext Computation output.

--- a/pxr/imaging/lib/hd/instanceRegistry.h
+++ b/pxr/imaging/lib/hd/instanceRegistry.h
@@ -30,9 +30,9 @@
 #include "pxr/imaging/hd/perfLog.h"
 #include "pxr/imaging/hf/perfLog.h"
 
-#include <boost/shared_ptr.hpp>
 #include <tbb/concurrent_unordered_map.h>
 
+#include <memory>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -145,7 +145,7 @@ public:
 
 private:
     template <typename T>
-    static bool _IsUnique(boost::shared_ptr<T> const &value) {
+    static bool _IsUnique(std::shared_ptr<T> const &value) {
         return value.unique();
     }
 

--- a/pxr/imaging/lib/hd/meshTopology.h
+++ b/pxr/imaging/lib/hd/meshTopology.h
@@ -36,12 +36,12 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdMeshTopology> HdMeshTopologySharedPtr;
+typedef std::shared_ptr<class HdMeshTopology> HdMeshTopologySharedPtr;
 
 /// \class HdMeshTopology
 ///

--- a/pxr/imaging/lib/hd/pch.h
+++ b/pxr/imaging/lib/hd/pch.h
@@ -88,7 +88,6 @@
 #include <boost/any.hpp>
 #include <boost/call_traits.hpp>
 #include <boost/container/vector.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/functional/hash_fwd.hpp>
@@ -96,7 +95,6 @@
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator_adaptors.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/bool.hpp>
@@ -150,7 +148,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
@@ -169,7 +166,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/imaging/lib/hd/perfLog.h
+++ b/pxr/imaging/lib/hd/perfLog.h
@@ -36,16 +36,16 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include "pxr/base/tf/hashmap.h"
 
+#include <memory>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class SdfPath;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 // XXX: it would be nice to move this into Trace or use the existing Trace
 // counter mechanism, however we are restricted to TraceLite in the rocks.

--- a/pxr/imaging/lib/hd/renderDelegate.cpp
+++ b/pxr/imaging/lib/hd/renderDelegate.cpp
@@ -54,7 +54,7 @@ HdRenderDelegate::~HdRenderDelegate() = default;
 HdRenderPassStateSharedPtr
 HdRenderDelegate::CreateRenderPassState() const
 {
-    return boost::make_shared<HdRenderPassState>();
+    return std::make_shared<HdRenderPassState>();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/lib/hd/renderDelegate.h
+++ b/pxr/imaging/lib/hd/renderDelegate.h
@@ -29,7 +29,7 @@
 #include "pxr/imaging/hd/changeTracker.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -42,9 +42,9 @@ class HdSceneDelegate;
 class HdRenderPass;
 class HdInstancer;
 
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 ///
 /// The HdRenderParam is an opaque (to core Hydra) handle, to an object

--- a/pxr/imaging/lib/hd/renderIndex.cpp
+++ b/pxr/imaging/lib/hd/renderIndex.cpp
@@ -370,8 +370,8 @@ HdRenderIndex::_RemoveTaskSubtree(const SdfPath &root,
         ++nextIt;
 
         // Yuck!!!
-        const boost::shared_ptr<HdSceneTask> sceneTask =
-                                 boost::dynamic_pointer_cast<HdSceneTask>(task);
+        const std::shared_ptr<HdSceneTask> sceneTask =
+                                 std::dynamic_pointer_cast<HdSceneTask>(task);
 
         if (sceneTask) {
             if ((sceneTask->GetDelegate() == sceneDelegate) &&

--- a/pxr/imaging/lib/hd/renderIndex.h
+++ b/pxr/imaging/lib/hd/renderIndex.h
@@ -41,14 +41,13 @@
 #include "pxr/base/tf/hashmap.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 
 #include <tbb/enumerable_thread_specific.h>
 
+#include <memory>
 #include <vector>
 #include <unordered_map>
-#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -65,9 +64,9 @@ class VtValue;
 class HdInstancer;
 
 
-typedef boost::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
-typedef boost::shared_ptr<class HdTask> HdTaskSharedPtr;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
+typedef std::shared_ptr<class HdTask> HdTaskSharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 typedef std::vector<HdTaskSharedPtr> HdTaskSharedPtrVector;
 typedef std::unordered_map<TfToken,
                            VtValue,
@@ -467,7 +466,7 @@ HdRenderIndex::InsertTask(HdSceneDelegate* delegate, SdfPath const& id)
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
 
-    HdTaskSharedPtr task = boost::make_shared<T>(delegate, id);
+    HdTaskSharedPtr task = std::make_shared<T>(delegate, id);
     _TrackDelegateTask(delegate, id, task);
 }
 

--- a/pxr/imaging/lib/hd/renderPass.h
+++ b/pxr/imaging/lib/hd/renderPass.h
@@ -31,16 +31,16 @@
 #include "pxr/imaging/hd/rprimCollection.h"
 #include "pxr/imaging/hd/task.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdRenderIndex;
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdDirtyList> HdDirtyListSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
 
 /// \class HdRenderPass
 ///

--- a/pxr/imaging/lib/hd/renderPassState.h
+++ b/pxr/imaging/lib/hd/renderPassState.h
@@ -33,13 +33,13 @@
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/gf/vec4d.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 /// \class HdRenderPassState
 ///

--- a/pxr/imaging/lib/hd/resource.h
+++ b/pxr/imaging/lib/hd/resource.h
@@ -30,14 +30,14 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <cstddef>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdResource> HdResourceSharedPtr;
+typedef std::shared_ptr<class HdResource> HdResourceSharedPtr;
 
 /// \class HdResource
 ///

--- a/pxr/imaging/lib/hd/resourceRegistry.h
+++ b/pxr/imaging/lib/hd/resourceRegistry.h
@@ -45,8 +45,6 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
 #include <map>
 #include <memory>
 #include <atomic>
@@ -55,14 +53,14 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
-typedef boost::shared_ptr<class HdMeshTopology> HdMeshTopologySharedPtr;
-typedef boost::shared_ptr<class HdBasisCurvesTopology> 
+typedef std::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
+typedef std::shared_ptr<class HdMeshTopology> HdMeshTopologySharedPtr;
+typedef std::shared_ptr<class HdBasisCurvesTopology>
                                                  HdBasisCurvesTopologySharedPtr;
-typedef boost::weak_ptr<class HdBufferArrayRange> HdBufferArrayRangePtr;
-typedef boost::shared_ptr<class HdComputation> HdComputationSharedPtr;
-typedef boost::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::weak_ptr<class HdBufferArrayRange> HdBufferArrayRangePtr;
+typedef std::shared_ptr<class HdComputation> HdComputationSharedPtr;
+typedef std::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 /// \class HdResourceRegistry
 ///

--- a/pxr/imaging/lib/hd/rprim.h
+++ b/pxr/imaging/lib/hd/rprim.h
@@ -36,7 +36,7 @@
 #include "pxr/base/gf/range3d.h"
 #include "pxr/base/arch/inttypes.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -49,14 +49,14 @@ class HdRenderIndex;
 class HdRepr;
 class HdRenderParam;
 
-typedef boost::shared_ptr<HdRepr> HdReprSharedPtr;
-typedef boost::shared_ptr<HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<HdRepr> HdReprSharedPtr;
+typedef std::shared_ptr<HdBufferSource> HdBufferSourceSharedPtr;
 
 typedef std::vector<struct HdBufferSpec> HdBufferSpecVector;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
 typedef std::vector<HdBufferSourceSharedPtr> HdBufferSourceVector;
-typedef boost::shared_ptr<HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::shared_ptr<class HdComputation> HdComputationSharedPtr;
+typedef std::shared_ptr<HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdComputation> HdComputationSharedPtr;
 typedef std::vector<HdComputationSharedPtr> HdComputationVector;
 
 /// \class HdRprim

--- a/pxr/imaging/lib/hd/sceneDelegate.h
+++ b/pxr/imaging/lib/hd/sceneDelegate.h
@@ -44,7 +44,7 @@
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/tf/hash.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/lib/hd/smoothNormals.h
+++ b/pxr/imaging/lib/hd/smoothNormals.h
@@ -32,13 +32,13 @@
 
 #include "pxr/base/tf/token.h"
 
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 class Hd_VertexAdjacency;
 

--- a/pxr/imaging/lib/hd/sprim.h
+++ b/pxr/imaging/lib/hd/sprim.h
@@ -32,7 +32,7 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/lib/hd/strategyBase.h
+++ b/pxr/imaging/lib/hd/strategyBase.h
@@ -32,13 +32,13 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/dictionary.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 
 /// \class HdAggregationStrategy
 ///

--- a/pxr/imaging/lib/hd/task.h
+++ b/pxr/imaging/lib/hd/task.h
@@ -37,15 +37,14 @@
 
 #include <vector>
 #include <unordered_map>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdTask> HdTaskSharedPtr;
+typedef std::shared_ptr<class HdTask> HdTaskSharedPtr;
 typedef std::vector<HdTaskSharedPtr> HdTaskSharedPtrVector;
 
-typedef boost::shared_ptr<class HdSceneTask> HdSceneTaskSharedPtr;
+typedef std::shared_ptr<class HdSceneTask> HdSceneTaskSharedPtr;
 typedef std::vector<HdSceneTaskSharedPtr> HdSceneTaskSharedPtrVector;
 
 // We want to use token as a key not std::string, so use an unordered_map over VtDictionary

--- a/pxr/imaging/lib/hd/texture.h
+++ b/pxr/imaging/lib/hd/texture.h
@@ -36,14 +36,14 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
+typedef std::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
 
 ///
 /// Represents a Texture Buffer Prim.

--- a/pxr/imaging/lib/hd/textureResource.h
+++ b/pxr/imaging/lib/hd/textureResource.h
@@ -31,14 +31,14 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <cstdint>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
+typedef std::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
 
 class HdTextureResource {
 public:

--- a/pxr/imaging/lib/hd/topology.h
+++ b/pxr/imaging/lib/hd/topology.h
@@ -29,12 +29,13 @@
 #include "pxr/imaging/hd/version.h"
 #include "pxr/base/arch/inttypes.h"
 
-#include <boost/shared_ptr.hpp>
+#include <iostream>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdTopology> HdTopologySharedPtr;
+typedef std::shared_ptr<class HdTopology> HdTopologySharedPtr;
 
 class HdTopology {
 public:

--- a/pxr/imaging/lib/hd/unitTestHelper.cpp
+++ b/pxr/imaging/lib/hd/unitTestHelper.cpp
@@ -161,7 +161,7 @@ void
 Hd_TestDriver::Draw(HdRenderPassSharedPtr const &renderPass)
 {
     HdTaskSharedPtrVector tasks = {
-        boost::make_shared<Hd_DrawTask>(renderPass, _renderPassState)
+        std::make_shared<Hd_DrawTask>(renderPass, _renderPassState)
     };
     _engine.Execute(_sceneDelegate->GetRenderIndex(), tasks);
 }

--- a/pxr/imaging/lib/hd/unitTestNullRenderDelegate.cpp
+++ b/pxr/imaging/lib/hd/unitTestNullRenderDelegate.cpp
@@ -161,7 +161,7 @@ public:
         TfToken const &role,
         HdBufferSpecVector const &bufferSpecs) override
     {
-        return boost::make_shared<Hd_NullStrategy::_BufferArray>(
+        return std::make_shared<Hd_NullStrategy::_BufferArray>(
                 role, bufferSpecs);
     }
 
@@ -183,7 +183,7 @@ public:
         HdBufferArraySharedPtr const &bufferArray) const override
     {
         const auto ba =
-            boost::static_pointer_cast<_BufferArray>(bufferArray);
+            std::static_pointer_cast<_BufferArray>(bufferArray);
         return ba->GetBufferSpecs();
     }
 
@@ -240,7 +240,7 @@ protected:
         _GetRepr(HdSceneDelegate *sceneDelegate,
                  TfToken const &reprName,
                  HdDirtyBits *dirtyBits) override  {
-        static HdReprSharedPtr result = boost::make_shared<HdRepr>();
+        static HdReprSharedPtr result = std::make_shared<HdRepr>();
         return result;
     };
 

--- a/pxr/imaging/lib/hd/vertexAdjacency.h
+++ b/pxr/imaging/lib/hd/vertexAdjacency.h
@@ -36,15 +36,14 @@
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/vt/array.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
-typedef boost::shared_ptr<class Hd_AdjacencyBuilderComputation> Hd_AdjacencyBuilderComputationSharedPtr;
-typedef boost::weak_ptr<class Hd_AdjacencyBuilderComputation> Hd_AdjacencyBuilderComputationPtr;
+typedef std::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
+typedef std::shared_ptr<class Hd_AdjacencyBuilderComputation> Hd_AdjacencyBuilderComputationSharedPtr;
+typedef std::weak_ptr<class Hd_AdjacencyBuilderComputation> Hd_AdjacencyBuilderComputationPtr;
 
 class HdMeshTopology;
 
@@ -206,7 +205,7 @@ private:
 ///
 class Hd_AdjacencyBuilderForGPUComputation : public HdComputedBufferSource {
 public:
-    typedef boost::shared_ptr<class Hd_AdjacencyBuilderComputation>
+    typedef std::shared_ptr<class Hd_AdjacencyBuilderComputation>
         Hd_AdjacencyBuilderComputationSharedPtr;
 
     HD_API

--- a/pxr/imaging/lib/hd/vtBufferSource.h
+++ b/pxr/imaging/lib/hd/vtBufferSource.h
@@ -34,8 +34,8 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/vt/value.h"
 
+#include <memory>
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 #include <iosfwd>
 

--- a/pxr/imaging/lib/hdSt/basisCurves.cpp
+++ b/pxr/imaging/lib/hdSt/basisCurves.cpp
@@ -164,17 +164,17 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
         typedef HdBufferArrayRangeSharedPtr HdBarPtr;
         if (HdBarPtr const& bar = drawItem->GetConstantPrimVarRange()){
             HdStBufferArrayRangeGLSharedPtr bar_ =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
+                std::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
             hasAuthoredNormals |= bool(bar_->GetResource(HdTokens->normals));
         }
         if (HdBarPtr const& bar = drawItem->GetVertexPrimVarRange()) {
             HdStBufferArrayRangeGLSharedPtr bar_ =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
+                std::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
             hasAuthoredNormals |= bool(bar_->GetResource(HdTokens->normals));
         }
         if (HdBarPtr const& bar = drawItem->GetElementPrimVarRange()){
             HdStBufferArrayRangeGLSharedPtr bar_ =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
+                std::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
 
             hasAuthoredNormals |= bool(bar_->GetResource(HdTokens->normals));
         }
@@ -182,7 +182,7 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
         for (int i = 0; i < instanceNumLevels; ++i) {
             if (HdBarPtr const& bar = drawItem->GetInstancePrimVarRange(i)) {
                 HdStBufferArrayRangeGLSharedPtr bar_ =
-                    boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
+                    std::static_pointer_cast<HdStBufferArrayRangeGL> (bar);
 
                 hasAuthoredNormals |= bool(bar_->GetResource(HdTokens->normals));
             }
@@ -194,7 +194,7 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
                                         (_SupportsSmoothCurves(desc,
                                                                _refineLevel)));
     HdStResourceRegistrySharedPtr resourceRegistry =
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
             renderIndex.GetResourceRegistry());
 
     HdSt_GeometricShaderSharedPtr geomShader =
@@ -231,7 +231,7 @@ HdStBasisCurves::_InitRepr(TfToken const &reprName,
         _BasisCurvesReprConfig::DescArray descs = _GetReprDesc(reprName);
 
         // add new repr
-        _reprs.emplace_back(reprName, boost::make_shared<HdRepr>());
+        _reprs.emplace_back(reprName, std::make_shared<HdRepr>());
         HdReprSharedPtr &repr = _reprs.back().second;
 
         *dirtyBits |= HdChangeTracker::NewRepr;
@@ -383,7 +383,7 @@ HdStBasisCurves::_PopulateTopology(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     if (*dirtyBits & HdChangeTracker::DirtyRefineLevel) {
@@ -420,14 +420,14 @@ HdStBasisCurves::_PopulateTopology(HdSceneDelegate *sceneDelegate,
             // XXX: Registry is currently in core Hd, so doesn't have access
             // to the St version of the topology,
             HdBasisCurvesTopologySharedPtr baseTopology =
-                    boost::static_pointer_cast<HdBasisCurvesTopology>(topology);
+                    std::static_pointer_cast<HdBasisCurvesTopology>(topology);
 
             topologyInstance.SetValue(baseTopology);
         }
 
         // XXX: Registry is currently in core Hd, so doesn't have access
         // to the St version of the topology,
-        _topology = boost::static_pointer_cast<HdSt_BasisCurvesTopology>(
+        _topology = std::static_pointer_cast<HdSt_BasisCurvesTopology>(
                                                    topologyInstance.GetValue());
         TF_VERIFY(_topology);
 
@@ -495,7 +495,7 @@ HdStBasisCurves::_PopulateVertexPrimVars(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     // The "points" attribute is expected to be in this list.
@@ -615,7 +615,7 @@ HdStBasisCurves::_PopulateElementPrimVars(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     TfTokenVector primVarNames = GetPrimVarUniformNames(sceneDelegate);

--- a/pxr/imaging/lib/hdSt/basisCurves.h
+++ b/pxr/imaging/lib/hdSt/basisCurves.h
@@ -35,13 +35,11 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/vt/array.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStDrawItem;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
-typedef boost::shared_ptr<class HdSt_BasisCurvesTopology>
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdSt_BasisCurvesTopology>
                                               HdSt_BasisCurvesTopologySharedPtr;
 
 /// \class HdStBasisCurves

--- a/pxr/imaging/lib/hdSt/basisCurvesTopology.h
+++ b/pxr/imaging/lib/hdSt/basisCurvesTopology.h
@@ -30,9 +30,9 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdSt_BasisCurvesTopology>
+typedef std::shared_ptr<class HdSt_BasisCurvesTopology>
                                               HdSt_BasisCurvesTopologySharedPtr;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
 
 
 // HdSt_BasisCurvesTopology

--- a/pxr/imaging/lib/hdSt/bufferArrayRangeGL.h
+++ b/pxr/imaging/lib/hdSt/bufferArrayRangeGL.h
@@ -30,18 +30,16 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/imaging/hd/bufferArrayRange.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdBufferArrayGL;
 
-typedef boost::shared_ptr<class HdStBufferArrayRangeGL> HdStBufferArrayRangeGLSharedPtr;
+typedef std::shared_ptr<class HdStBufferArrayRangeGL> HdStBufferArrayRangeGLSharedPtr;
 
 class HdStBufferResourceGL;
 
-typedef boost::shared_ptr<class HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
+typedef std::shared_ptr<class HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
 typedef std::vector<
     std::pair<TfToken, HdStBufferResourceGLSharedPtr> > HdStBufferResourceGLNamedList;
 

--- a/pxr/imaging/lib/hdSt/bufferResourceGL.h
+++ b/pxr/imaging/lib/hdSt/bufferResourceGL.h
@@ -33,7 +33,6 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -43,7 +42,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStBufferResourceGL;
 
-typedef boost::shared_ptr<HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
+typedef std::shared_ptr<HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
 
 typedef std::vector<
     std::pair<TfToken, HdStBufferResourceGLSharedPtr> > HdStBufferResourceGLNamedList;

--- a/pxr/imaging/lib/hdSt/camera.h
+++ b/pxr/imaging/lib/hdSt/camera.h
@@ -35,8 +35,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/gf/matrix4d.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 

--- a/pxr/imaging/lib/hdSt/codeGen.h
+++ b/pxr/imaging/lib/hdSt/codeGen.h
@@ -30,8 +30,6 @@
 #include "pxr/imaging/hdSt/resourceBinder.h"
 #include "pxr/imaging/hdSt/glslProgram.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <map>
 #include <vector>
 #include <sstream>
@@ -39,8 +37,8 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
-typedef boost::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderPtr;
 typedef std::vector<HdStShaderCodeSharedPtr> HdStShaderCodeSharedPtrVector;
 
 /// \class HdSt_CodeGen

--- a/pxr/imaging/lib/hdSt/commandBuffer.h
+++ b/pxr/imaging/lib/hdSt/commandBuffer.h
@@ -33,8 +33,6 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/matrix4d.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -43,10 +41,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdStDrawItem;
 class HdStDrawItemInstance;
 
-typedef boost::shared_ptr<class HdStResourceRegistry>
+typedef std::shared_ptr<class HdStResourceRegistry>
     HdStResourceRegistrySharedPtr;
-typedef boost::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdSt_DrawBatch> HdSt_DrawBatchSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdSt_DrawBatch> HdSt_DrawBatchSharedPtr;
 typedef std::vector<HdSt_DrawBatchSharedPtr> HdSt_DrawBatchSharedPtrVector;
 
 /// \class HdStCommandBuffer

--- a/pxr/imaging/lib/hdSt/computeShader.h
+++ b/pxr/imaging/lib/hdSt/computeShader.h
@@ -37,13 +37,11 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdStComputeShader> HdStComputeShaderSharedPtr;
+typedef std::shared_ptr<class HdStComputeShader> HdStComputeShaderSharedPtr;
 
 /// \class HdStComputeShader
 ///

--- a/pxr/imaging/lib/hdSt/copyComputation.cpp
+++ b/pxr/imaging/lib/hdSt/copyComputation.cpp
@@ -53,9 +53,9 @@ HdStCopyComputationGPU::Execute(HdBufferArrayRangeSharedPtr const &range_,
     }
 
     HdStBufferArrayRangeGLSharedPtr srcRange =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (_src);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (_src);
     HdStBufferArrayRangeGLSharedPtr range =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (range_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (range_);
 
     HdStBufferResourceGLSharedPtr src = srcRange->GetResource(_name);
     HdStBufferResourceGLSharedPtr dst = range->GetResource(_name);
@@ -134,7 +134,7 @@ void
 HdStCopyComputationGPU::AddBufferSpecs(HdBufferSpecVector *specs) const
 {
     HdStBufferArrayRangeGLSharedPtr srcRange =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (_src);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (_src);
 
     specs->emplace_back(_name, srcRange->GetResource(_name)->GetTupleType());
 }

--- a/pxr/imaging/lib/hdSt/dispatchBuffer.h
+++ b/pxr/imaging/lib/hdSt/dispatchBuffer.h
@@ -32,12 +32,10 @@
 #include "pxr/imaging/hdSt/bufferArrayRangeGL.h"
 #include "pxr/imaging/hdSt/bufferResourceGL.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStDispatchBuffer> HdStDispatchBufferSharedPtr;
+typedef std::shared_ptr<class HdStDispatchBuffer> HdStDispatchBufferSharedPtr;
 
 /// \class HdStDispatchBuffer
 ///

--- a/pxr/imaging/lib/hdSt/drawBatch.cpp
+++ b/pxr/imaging/lib/hdSt/drawBatch.cpp
@@ -239,7 +239,7 @@ HdSt_DrawBatch::_GetDrawingProgram(HdStRenderPassStateSharedPtr const &state,
             // code is broken and needs to be fixed.  When we open up more
             // shaders for customization, we will need to check them as well.
             
-            typedef boost::shared_ptr<class GlfGLSLFX> GlfGLSLFXSharedPtr;
+            typedef std::shared_ptr<class GlfGLSLFX> GlfGLSLFXSharedPtr;
 
             GlfGLSLFXSharedPtr glslSurfaceFallback = 
                 GlfGLSLFXSharedPtr(

--- a/pxr/imaging/lib/hdSt/drawBatch.h
+++ b/pxr/imaging/lib/hdSt/drawBatch.h
@@ -32,7 +32,6 @@
 #include "pxr/imaging/hd/repr.h"
 #include "pxr/imaging/hdSt/shaderCode.h"
 
-#include <boost/shared_ptr.hpp>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -41,13 +40,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdStDrawItem;
 class HdStDrawItemInstance;
 
-typedef boost::shared_ptr<class HdSt_DrawBatch> HdSt_DrawBatchSharedPtr;
-typedef boost::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
-typedef boost::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
-typedef boost::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdSt_DrawBatch> HdSt_DrawBatchSharedPtr;
+typedef std::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
+typedef std::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
 typedef std::vector<HdSt_DrawBatchSharedPtr> HdSt_DrawBatchSharedPtrVector;
 typedef std::vector<class HdBindingRequest> HdBindingRequestVector;
-typedef boost::shared_ptr<class HdStResourceRegistry>
+typedef std::shared_ptr<class HdStResourceRegistry>
     HdStResourceRegistrySharedPtr;
 
 /// \class HdSt_DrawBatch

--- a/pxr/imaging/lib/hdSt/drawItem.h
+++ b/pxr/imaging/lib/hdSt/drawItem.h
@@ -32,8 +32,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdRenderIndex;
-typedef boost::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
 
 class HdStDrawItem : public HdDrawItem {
 public:

--- a/pxr/imaging/lib/hdSt/drawItemInstance.h
+++ b/pxr/imaging/lib/hdSt/drawItemInstance.h
@@ -27,11 +27,10 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hdSt/drawItem.h"
-#include "boost/shared_ptr.hpp"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdSt_DrawBatch> HdDrawBatchSharedPtr;
+typedef std::shared_ptr<class HdSt_DrawBatch> HdDrawBatchSharedPtr;
 
 /// \class HdStDrawItemInstance
 ///

--- a/pxr/imaging/lib/hdSt/drawTarget.h
+++ b/pxr/imaging/lib/hdSt/drawTarget.h
@@ -36,8 +36,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/tf/staticTokens.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -60,7 +58,7 @@ class HdStCamera;
 class HdStDrawTargetAttachmentDescArray;
 
 
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 
 typedef std::vector<class HdStDrawTarget const *> HdStDrawTargetPtrConstVector;
 

--- a/pxr/imaging/lib/hdSt/extCompGpuComputation.cpp
+++ b/pxr/imaging/lib/hdSt/extCompGpuComputation.cpp
@@ -84,7 +84,7 @@ HdStExtCompGpuComputation::Execute(
     }
 
     HdStBufferArrayRangeGLSharedPtr range =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(range_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(range_);
 
     TF_VERIFY(range);
     // XXX Currently these computations are always meant to be 1:1 to the
@@ -99,7 +99,7 @@ HdStExtCompGpuComputation::Execute(
     HdStBufferArrayRangeGLSharedPtr inputRange;
     HdStBufferResourceGLNamedList inputResources;
     if (_resource->GetInternalRange()) {
-        inputRange = boost::static_pointer_cast<HdStBufferArrayRangeGL>(
+        inputRange = std::static_pointer_cast<HdStBufferArrayRangeGL>(
                 _resource->GetInternalRange());
         inputResources = inputRange->GetResources();
     }
@@ -261,7 +261,7 @@ HdStExtCompGpuComputation::CreateComputation(
 
     // Downcast the resource registry
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::dynamic_pointer_cast<HdStResourceRegistry>(
+        std::dynamic_pointer_cast<HdStResourceRegistry>(
                               renderIndex.GetResourceRegistry());
     
     HdStExtCompGpuComputationResourceSharedPtr resource(
@@ -366,7 +366,7 @@ HdSt_GetExtComputationPrimVarsComputations(
                 
                 if (gpuComputation) {
                     HdComputationSharedPtr comp =
-                        boost::static_pointer_cast<HdComputation>(
+                        std::static_pointer_cast<HdComputation>(
                             gpuComputation);
                     computations->push_back(comp);
                     // There is a companion resource that requires allocation

--- a/pxr/imaging/lib/hdSt/extCompGpuComputation.h
+++ b/pxr/imaging/lib/hdSt/extCompGpuComputation.h
@@ -40,9 +40,9 @@ class HdSceneDelegate;
 class HdExtComputation;
 class HdStExtCompGpuComputation;
 class HdStGLSLProgram;
-typedef boost::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
+typedef std::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
 
-typedef boost::shared_ptr<HdStExtCompGpuComputation>
+typedef std::shared_ptr<HdStExtCompGpuComputation>
                                 HdStExtCompGpuComputationSharedPtr;
 
 /// \class HdStExtCompGpuComputation

--- a/pxr/imaging/lib/hdSt/extCompGpuComputationBufferSource.h
+++ b/pxr/imaging/lib/hdSt/extCompGpuComputationBufferSource.h
@@ -37,7 +37,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStExtCompGpuComputationBufferSource;
-typedef boost::shared_ptr<class HdStExtCompGpuComputationBufferSource>
+typedef std::shared_ptr<class HdStExtCompGpuComputationBufferSource>
     HdStExtCompGpuComputationBufferSourceSharedPtr;
 
 /// \class HdStExtCompGpuComputationBufferSource

--- a/pxr/imaging/lib/hdSt/extCompGpuComputationResource.cpp
+++ b/pxr/imaging/lib/hdSt/extCompGpuComputationResource.cpp
@@ -184,7 +184,7 @@ HdStExtCompGpuComputationResource::AllocateInternalRange(
             bufferSpecs.emplace_back(source->GetName(), tupleType);
         }
 
-        _internalRange = boost::static_pointer_cast<HdStBufferArrayRangeGL>(
+        _internalRange = std::static_pointer_cast<HdStBufferArrayRangeGL>(
             resourceRegistry->AllocateShaderStorageBufferArrayRange(
                 HdTokens->primVar, bufferSpecs));
     }

--- a/pxr/imaging/lib/hdSt/extCompGpuComputationResource.h
+++ b/pxr/imaging/lib/hdSt/extCompGpuComputationResource.h
@@ -35,9 +35,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStExtCompGpuComputationResource;
 class HdStGLSLProgram;
-typedef boost::shared_ptr<class HdStExtCompGpuComputationResource> 
+typedef std::shared_ptr<class HdStExtCompGpuComputationResource> 
     HdStExtCompGpuComputationResourceSharedPtr;
-typedef boost::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
+typedef std::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
 
 /// \class HdStExtCompGpuComputationResource
 ///

--- a/pxr/imaging/lib/hdSt/fallbackLightingShader.h
+++ b/pxr/imaging/lib/hdSt/fallbackLightingShader.h
@@ -35,7 +35,6 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <vector>
 

--- a/pxr/imaging/lib/hdSt/geometricShader.h
+++ b/pxr/imaging/lib/hdSt/geometricShader.h
@@ -38,7 +38,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
+typedef std::shared_ptr<class HdSt_GeometricShader> HdSt_GeometricShaderSharedPtr;
 
 /// \class HdSt_GeometricShader
 ///

--- a/pxr/imaging/lib/hdSt/glslProgram.h
+++ b/pxr/imaging/lib/hdSt/glslProgram.h
@@ -29,12 +29,10 @@
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hdSt/resourceGL.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStResourceRegistry;
-typedef boost::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
+typedef std::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
 
 /// \class HdStGLSLProgram
 ///

--- a/pxr/imaging/lib/hdSt/glslfxShader.h
+++ b/pxr/imaging/lib/hdSt/glslfxShader.h
@@ -35,13 +35,11 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStGLSLFXShader> HdStGLSLFXShaderSharedPtr;
-typedef boost::shared_ptr<class GlfGLSLFX> GlfGLSLFXSharedPtr;
+typedef std::shared_ptr<class HdStGLSLFXShader> HdStGLSLFXShaderSharedPtr;
+typedef std::shared_ptr<class GlfGLSLFX> GlfGLSLFXSharedPtr;
 
 // XXX: DOCS!
 class HdStGLSLFXShader : public HdStSurfaceShader {

--- a/pxr/imaging/lib/hdSt/immediateDrawBatch.cpp
+++ b/pxr/imaging/lib/hdSt/immediateDrawBatch.cpp
@@ -174,7 +174,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetTopologyRange();
 
         HdStBufferArrayRangeGLSharedPtr indexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
 
         if (indexBar && (!indexBar->IsAggregatedWith(indexBarCurrent))) {
             binder.UnbindBufferArray(indexBarCurrent);
@@ -189,7 +189,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetElementPrimVarRange();
 
         HdStBufferArrayRangeGLSharedPtr elementBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
 
         if (elementBar && (!elementBar->IsAggregatedWith(elementBarCurrent))) {
             binder.UnbindBufferArray(elementBarCurrent);
@@ -204,7 +204,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetVertexPrimVarRange();
 
         HdStBufferArrayRangeGLSharedPtr vertexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
 
         if (vertexBar && (!vertexBar->IsAggregatedWith(vertexBarCurrent))) {
             binder.UnbindBufferArray(vertexBarCurrent);
@@ -219,7 +219,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetConstantPrimVarRange();
 
         HdStBufferArrayRangeGLSharedPtr constantBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
 
         if (constantBar && (!constantBar->IsAggregatedWith(constantBarCurrent))) {
             binder.UnbindConstantBuffer(constantBarCurrent);
@@ -234,7 +234,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetFaceVaryingPrimVarRange();
 
         HdStBufferArrayRangeGLSharedPtr fvarBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
 
         if (fvarBar && (!fvarBar->IsAggregatedWith(fvarBarCurrent))) {
             binder.UnbindBufferArray(fvarBarCurrent);
@@ -252,7 +252,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
                 drawItem->GetInstancePrimVarRange(i);
 
             HdStBufferArrayRangeGLSharedPtr instanceBar =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceBar_);
+                std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceBar_);
 
             if (instanceBar) {
                 if (static_cast<size_t>(i) >= instanceBarCurrents.size()) {
@@ -274,7 +274,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
             drawItem->GetInstanceIndexRange();
 
         HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
 
         if (instanceIndexBar && 
             (!instanceIndexBar->IsAggregatedWith(instanceIndexBarCurrent))) {
@@ -291,7 +291,7 @@ HdSt_ImmediateDrawBatch::ExecuteDraw(
                 ? HdStBufferArrayRangeGLSharedPtr()
                 : program.GetSurfaceShader()->GetShaderData();
         HdStBufferArrayRangeGLSharedPtr shaderBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (shaderBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (shaderBar_);
 
         // shaderBar isn't needed when the material is overriden
         if (shaderBar && (!shaderBar->IsAggregatedWith(shaderBarCurrent))) {

--- a/pxr/imaging/lib/hdSt/indirectDrawBatch.cpp
+++ b/pxr/imaging/lib/hdSt/indirectDrawBatch.cpp
@@ -326,7 +326,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             indexBar_ = drawItem->GetTopologyRange();
         HdStBufferArrayRangeGLSharedPtr indexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
 
         //
         // element (per-face) buffer data
@@ -334,7 +334,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             elementBar_ = drawItem->GetElementPrimVarRange();
         HdStBufferArrayRangeGLSharedPtr elementBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
 
         //
         // vertex attrib buffer data
@@ -342,7 +342,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             vertexBar_ = drawItem->GetVertexPrimVarRange();
         HdStBufferArrayRangeGLSharedPtr vertexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
 
         //
         // constant buffer data
@@ -350,7 +350,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             constantBar_ = drawItem->GetConstantPrimVarRange();
         HdStBufferArrayRangeGLSharedPtr constantBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
 
         //
         // face varying buffer data
@@ -358,7 +358,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             fvarBar_ = drawItem->GetFaceVaryingPrimVarRange();
         HdStBufferArrayRangeGLSharedPtr fvarBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
 
         //
         // instance buffer data
@@ -369,7 +369,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
             HdBufferArrayRangeSharedPtr const &
                 ins_ = drawItem->GetInstancePrimVarRange(i);
             HdStBufferArrayRangeGLSharedPtr ins =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
+                std::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
 
             instanceBars[i] = ins;
         }
@@ -380,7 +380,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             instanceIndexBar_ = drawItem->GetInstanceIndexRange();
         HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
 
         //
         // shader parameter
@@ -388,7 +388,7 @@ HdSt_IndirectDrawBatch::_CompileBatch(
         HdBufferArrayRangeSharedPtr const &
             shaderBar_ = drawItem->GetMaterialShader()->GetShaderData();
         HdStBufferArrayRangeGLSharedPtr shaderBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(shaderBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(shaderBar_);
 
         // 3 for triangles, 4 for quads, n for patches
         GLuint numIndicesPerPrimitive
@@ -1049,31 +1049,31 @@ HdSt_IndirectDrawBatch::ExecuteDraw(
     // constant buffer bind
     HdBufferArrayRangeSharedPtr constantBar_ = batchItem->GetConstantPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr constantBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
     binder.BindConstantBuffer(constantBar);
 
     // index buffer bind
     HdBufferArrayRangeSharedPtr indexBar_ = batchItem->GetTopologyRange();
     HdStBufferArrayRangeGLSharedPtr indexBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(indexBar_);
     binder.BindBufferArray(indexBar);
 
     // element buffer bind
     HdBufferArrayRangeSharedPtr elementBar_ = batchItem->GetElementPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr elementBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
     binder.BindBufferArray(elementBar);
 
     // fvar buffer bind
     HdBufferArrayRangeSharedPtr fvarBar_ = batchItem->GetFaceVaryingPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr fvarBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
     binder.BindBufferArray(fvarBar);
 
     // vertex buffer bind
     HdBufferArrayRangeSharedPtr vertexBar_ = batchItem->GetVertexPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr vertexBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
     binder.BindBufferArray(vertexBar);
 
     // instance buffer bind
@@ -1083,7 +1083,7 @@ HdSt_IndirectDrawBatch::ExecuteDraw(
     // intance index indirection
     HdBufferArrayRangeSharedPtr instanceIndexBar_ = batchItem->GetInstanceIndexRange();
     HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
     if (instanceIndexBar) {
         // note that while instanceIndexBar is mandatory for instancing but
         // instanceBar can technically be empty (it doesn't make sense though)
@@ -1091,7 +1091,7 @@ HdSt_IndirectDrawBatch::ExecuteDraw(
         for (int i = 0; i < instancerNumLevels; ++i) {
             HdBufferArrayRangeSharedPtr ins_ = batchItem->GetInstancePrimVarRange(i);
             HdStBufferArrayRangeGLSharedPtr ins =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
+                std::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
             instanceBars[i] = ins;
             binder.BindInstanceBufferArray(instanceBars[i], i);
         }
@@ -1113,7 +1113,7 @@ HdSt_IndirectDrawBatch::ExecuteDraw(
     HdStBufferArrayRangeGLSharedPtr shaderBar;
     TF_FOR_ALL(shader, shaders) {
         HdBufferArrayRangeSharedPtr shaderBar_ = (*shader)->GetShaderData();
-        shaderBar = boost::static_pointer_cast<HdStBufferArrayRangeGL>(shaderBar_);
+        shaderBar = std::static_pointer_cast<HdStBufferArrayRangeGL>(shaderBar_);
         if (shaderBar) {
             binder.BindBuffer(HdTokens->materialParams, 
                               shaderBar->GetResource());
@@ -1207,21 +1207,21 @@ HdSt_IndirectDrawBatch::_GPUFrustumCulling(
     HdBufferArrayRangeSharedPtr constantBar_ =
         batchItem->GetConstantPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr constantBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
     int instancerNumLevels = batchItem->GetInstancePrimVarNumLevels();
     std::vector<HdStBufferArrayRangeGLSharedPtr> instanceBars(instancerNumLevels);
     for (int i = 0; i < instancerNumLevels; ++i) {
         HdBufferArrayRangeSharedPtr ins_ = batchItem->GetInstancePrimVarRange(i);
 
         HdStBufferArrayRangeGLSharedPtr ins =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(ins_);
 
         instanceBars[i] = ins;
     }
     HdBufferArrayRangeSharedPtr instanceIndexBar_ =
         batchItem->GetInstanceIndexRange();
     HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
 
     HdStBufferArrayRangeGLSharedPtr cullDispatchBar =
         _dispatchBufferCullInput->GetBufferArrayRange();
@@ -1357,7 +1357,7 @@ HdSt_IndirectDrawBatch::_GPUFrustumCullingXFB(
     HdBufferArrayRangeSharedPtr constantBar_ =
         batchItem->GetConstantPrimVarRange();
     HdStBufferArrayRangeGLSharedPtr constantBar =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
 
     HdStBufferArrayRangeGLSharedPtr cullDispatchBar =
         _dispatchBufferCullInput->GetBufferArrayRange();
@@ -1446,7 +1446,7 @@ HdSt_IndirectDrawBatch::DrawItemInstanceChanged(HdStDrawItemInstance const* inst
         HdBufferArrayRangeSharedPtr const &instanceIndexBar_ =
             instance->GetDrawItem()->GetInstanceIndexRange();
         HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
 
         int newInstanceCount = instanceIndexBar
                              ? instanceIndexBar->GetNumElements() : 1;

--- a/pxr/imaging/lib/hdSt/instancer.cpp
+++ b/pxr/imaging/lib/hdSt/instancer.cpp
@@ -106,7 +106,7 @@ HdStInstancer::GetInstancePrimVars()
         // be updated just once even if there're multiple prototypes.
         if (HdChangeTracker::IsAnyPrimVarDirty(dirtyBits, instancerId)) {
             HdStResourceRegistrySharedPtr const& resourceRegistry = 
-                boost::static_pointer_cast<HdStResourceRegistry>(
+                std::static_pointer_cast<HdStResourceRegistry>(
                 GetDelegate()->GetRenderIndex().GetResourceRegistry());
 
             TfTokenVector primVarNames;
@@ -262,7 +262,7 @@ HdStInstancer::GetInstanceIndices(SdfPath const &prototypeId)
     // dirtyBits within this function.
 
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         GetDelegate()->GetRenderIndex().GetResourceRegistry());
 
     // delegate provides sparse index array for prototypeId.

--- a/pxr/imaging/lib/hdSt/instancer.h
+++ b/pxr/imaging/lib/hdSt/instancer.h
@@ -39,7 +39,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdDrawItem;
 struct HdRprimSharedData;
 
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 
 /// \class HdStInstancer
 ///

--- a/pxr/imaging/lib/hdSt/interleavedMemoryManager.cpp
+++ b/pxr/imaging/lib/hdSt/interleavedMemoryManager.cpp
@@ -50,7 +50,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 HdBufferArrayRangeSharedPtr
 HdStInterleavedMemoryManager::CreateBufferArrayRange()
 {
-    return (boost::make_shared<_StripedInterleavedBufferRange>());
+    return (std::make_shared<_StripedInterleavedBufferRange>());
 }
 
 /// Returns the buffer specs from a given buffer array
@@ -59,7 +59,7 @@ HdStInterleavedMemoryManager::GetBufferSpecs(
     HdBufferArraySharedPtr const &bufferArray) const
 {
     _StripedInterleavedBufferSharedPtr bufferArray_ =
-        boost::static_pointer_cast<_StripedInterleavedBuffer> (bufferArray);
+        std::static_pointer_cast<_StripedInterleavedBuffer> (bufferArray);
     return bufferArray_->GetBufferSpecs();
 }
 
@@ -73,7 +73,7 @@ HdStInterleavedMemoryManager::GetResourceAllocation(
     size_t gpuMemoryUsed = 0;
 
     _StripedInterleavedBufferSharedPtr bufferArray_ =
-        boost::static_pointer_cast<_StripedInterleavedBuffer> (bufferArray);
+        std::static_pointer_cast<_StripedInterleavedBuffer> (bufferArray);
 
     TF_FOR_ALL(resIt, bufferArray_->GetResources()) {
         HdStBufferResourceGLSharedPtr const & resource = resIt->second;
@@ -110,7 +110,7 @@ HdStInterleavedUBOMemoryManager::CreateBufferArray(
 {
     HdStRenderContextCaps &caps = HdStRenderContextCaps::GetInstance();
 
-    return boost::make_shared<
+    return std::make_shared<
         HdStInterleavedMemoryManager::_StripedInterleavedBuffer>(
             role, bufferSpecs,
             caps.uniformBufferOffsetAlignment,
@@ -148,7 +148,7 @@ HdStInterleavedSSBOMemoryManager::CreateBufferArray(
 {
     HdStRenderContextCaps &caps = HdStRenderContextCaps::GetInstance();
 
-    return boost::make_shared<
+    return std::make_shared<
         HdStInterleavedMemoryManager::_StripedInterleavedBuffer>(
             role, bufferSpecs,
             /*bufferOffsetAlignment=*/0,
@@ -418,7 +418,7 @@ HdStInterleavedMemoryManager::_StripedInterleavedBuffer::Reallocate(
     GLuint oldId = GetResources().begin()->second->GetId();
 
     _StripedInterleavedBufferSharedPtr curRangeOwner_ =
-        boost::static_pointer_cast<_StripedInterleavedBuffer> (curRangeOwner);
+        std::static_pointer_cast<_StripedInterleavedBuffer> (curRangeOwner);
 
     GLuint curId = curRangeOwner_->GetResources().begin()->second->GetId();
 

--- a/pxr/imaging/lib/hdSt/interleavedMemoryManager.h
+++ b/pxr/imaging/lib/hdSt/interleavedMemoryManager.h
@@ -37,7 +37,6 @@
 #include "pxr/base/tf/mallocTag.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
 #include <list>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -163,11 +162,11 @@ protected:
         int _numElements;
     };
 
-    typedef boost::shared_ptr<_StripedInterleavedBuffer>
+    typedef std::shared_ptr<_StripedInterleavedBuffer>
         _StripedInterleavedBufferSharedPtr;
-    typedef boost::shared_ptr<_StripedInterleavedBufferRange>
+    typedef std::shared_ptr<_StripedInterleavedBufferRange>
         _StripedInterleavedBufferRangeSharedPtr;
-    typedef boost::weak_ptr<_StripedInterleavedBufferRange>
+    typedef std::weak_ptr<_StripedInterleavedBufferRange>
         _StripedInterleavedBufferRangePtr;
 
     /// striped buffer
@@ -260,7 +259,7 @@ protected:
         HdStBufferResourceGLNamedList _resourceList;
 
         _StripedInterleavedBufferRangeSharedPtr _GetRangeSharedPtr(size_t idx) const {
-            return boost::static_pointer_cast<_StripedInterleavedBufferRange>(GetRange(idx).lock());
+            return std::static_pointer_cast<_StripedInterleavedBufferRange>(GetRange(idx).lock());
         }
 
     };

--- a/pxr/imaging/lib/hdSt/light.h
+++ b/pxr/imaging/lib/hdSt/light.h
@@ -35,8 +35,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -54,7 +52,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DECLARE_PUBLIC_TOKENS(HdStLightTokens, HDST_API, HDST_LIGHT_TOKENS);
 
 class HdSceneDelegate;
-typedef boost::shared_ptr<class HdStLight> HdStLightSharedPtr;
+typedef std::shared_ptr<class HdStLight> HdStLightSharedPtr;
 typedef std::vector<class HdStLight const *> HdStLightPtrConstVector;
 
 /// \class HdStLight

--- a/pxr/imaging/lib/hdSt/lightingShader.h
+++ b/pxr/imaging/lib/hdSt/lightingShader.h
@@ -29,12 +29,10 @@
 #include "pxr/imaging/hdSt/shaderCode.h"
 #include "pxr/base/gf/matrix4d.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStLightingShader> HdStLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdStLightingShader> HdStLightingShaderSharedPtr;
 
 /// \class HdStLightingShader
 ///

--- a/pxr/imaging/lib/hdSt/material.cpp
+++ b/pxr/imaging/lib/hdSt/material.cpp
@@ -184,7 +184,7 @@ HdStMaterial::Sync(HdSceneDelegate *sceneDelegate,
                     }
 
                     texResource =
-                        boost::dynamic_pointer_cast<HdStTextureResource>
+                        std::dynamic_pointer_cast<HdStTextureResource>
                         (texInstance.GetValue());
                     if (!TF_VERIFY(texResource,
                             "Incorrect texture resource with path %s",
@@ -285,7 +285,7 @@ HdStMaterial::Reload()
 HdStShaderCodeSharedPtr
 HdStMaterial::GetShaderCode() const
 {
-    return boost::static_pointer_cast<HdStShaderCode>(_surfaceShader);
+    return std::static_pointer_cast<HdStShaderCode>(_surfaceShader);
 }
 
 void

--- a/pxr/imaging/lib/hdSt/material.h
+++ b/pxr/imaging/lib/hdSt/material.h
@@ -29,12 +29,10 @@
 #include "pxr/imaging/hd/material.h"
 #include "pxr/imaging/hf/perfLog.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
-typedef boost::shared_ptr<class HdStSurfaceShader> HdStSurfaceShaderSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStSurfaceShader> HdStSurfaceShaderSharedPtr;
 
 class HdStMaterial final: public HdMaterial {
 public:

--- a/pxr/imaging/lib/hdSt/mesh.cpp
+++ b/pxr/imaging/lib/hdSt/mesh.cpp
@@ -154,7 +154,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     // note: there's a potential optimization if _topology is already registered
@@ -215,7 +215,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
             if (topologyInstance.IsFirstInstance()) {
                 // if this is the first instance, set this topology to registry.
                 topologyInstance.SetValue(
-                        boost::static_pointer_cast<HdMeshTopology>(topology));
+                        std::static_pointer_cast<HdMeshTopology>(topology));
 
                 // if refined, we submit a subdivision preprocessing
                 // no matter what desc says
@@ -239,7 +239,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
                     resourceRegistry->AddSource(quadInfoBuilder);
                 }
             }
-            _topology = boost::static_pointer_cast<HdSt_MeshTopology>(
+            _topology = std::static_pointer_cast<HdSt_MeshTopology>(
                                                    topologyInstance.GetValue());
         }
         TF_VERIFY(_topology);
@@ -493,7 +493,7 @@ HdStMesh::_PopulateVertexPrimVars(HdSceneDelegate *sceneDelegate,
     HdRenderIndex &renderIndex = sceneDelegate->GetRenderIndex();
 
     HdStResourceRegistrySharedPtr const &resourceRegistry =
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         renderIndex.GetResourceRegistry());
 
     // The "points" attribute is expected to be in this list.
@@ -709,7 +709,7 @@ HdStMesh::_PopulateVertexPrimVars(HdSceneDelegate *sceneDelegate,
                     drawItem->GetVertexPrimVarRange()) {
                     if (bar->IsValid()) {
                         HdStBufferArrayRangeGLSharedPtr bar_ =
-                            boost::static_pointer_cast<HdStBufferArrayRangeGL>
+                            std::static_pointer_cast<HdStBufferArrayRangeGL>
                                                                           (bar);
                         HdStBufferResourceGLSharedPtr pointsResource =
                                             bar_->GetResource(HdTokens->points);
@@ -910,7 +910,7 @@ HdStMesh::_PopulateFaceVaryingPrimVars(HdSceneDelegate *sceneDelegate,
     if (primVarNames.empty()) return;
 
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     HdBufferSourceVector sources;
@@ -995,7 +995,7 @@ HdStMesh::_PopulateElementPrimVars(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
 
@@ -1139,7 +1139,7 @@ HdStMesh::_UpdateDrawItem(HdSceneDelegate *sceneDelegate,
     SdfPath const& id = GetId();
 
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     /* VISIBILITY */
@@ -1307,7 +1307,7 @@ HdStMesh::_UpdateDrawItemGeometricShader(HdSceneDelegate *sceneDelegate,
                                  geomStyle);
 
     HdStResourceRegistrySharedPtr resourceRegistry =
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
             renderIndex.GetResourceRegistry());
 
     HdSt_GeometricShaderSharedPtr geomShader =
@@ -1377,7 +1377,7 @@ HdStMesh::_InitRepr(TfToken const &reprName, HdDirtyBits *dirtyBits)
     bool isNew = it == _reprs.end();
     if (isNew) {
         // add new repr
-        _reprs.emplace_back(reprName, boost::make_shared<HdRepr>());
+        _reprs.emplace_back(reprName, std::make_shared<HdRepr>());
         HdReprSharedPtr &repr = _reprs.back().second;
 
         // set dirty bit to say we need to sync a new repr (buffer array

--- a/pxr/imaging/lib/hdSt/mesh.h
+++ b/pxr/imaging/lib/hdSt/mesh.h
@@ -35,8 +35,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/vt/array.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -44,12 +42,12 @@ class HdStDrawItem;
 class HdSceneDelegate;
 class HdStMaterial;
 
-typedef boost::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
-typedef boost::shared_ptr<class HdSt_MeshTopology> HdSt_MeshTopologySharedPtr;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
-typedef boost::shared_ptr<class HdStResourceRegistry>
+typedef std::shared_ptr<class Hd_VertexAdjacency> Hd_VertexAdjacencySharedPtr;
+typedef std::shared_ptr<class HdSt_MeshTopology> HdSt_MeshTopologySharedPtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdStResourceRegistry>
     HdStResourceRegistrySharedPtr;
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
 
 /// A subdivision surface or poly-mesh object.
 ///

--- a/pxr/imaging/lib/hdSt/meshTopology.h
+++ b/pxr/imaging/lib/hdSt/meshTopology.h
@@ -29,9 +29,6 @@
 #include "pxr/imaging/hd/meshTopology.h"
 #include "pxr/imaging/hd/types.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -40,15 +37,15 @@ class HdSt_Subdivision;
 struct HdQuadInfo;
 class SdfPath;
 
-typedef boost::weak_ptr<class HdBufferSource> HdBufferSourceWeakPtr;
-typedef boost::weak_ptr<class HdSt_AdjacencyBuilderComputation> HdSt_AdjacencyBuilderComputationPtr;
-typedef boost::weak_ptr<class HdSt_QuadInfoBuilderComputation> HdSt_QuadInfoBuilderComputationPtr;
-typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::shared_ptr<class HdComputation> HdComputationSharedPtr;
-typedef boost::shared_ptr<class HdSt_AdjacencyBuilderComputation> HdSt_AdjacencyBuilderComputationSharedPtr;
-typedef boost::shared_ptr<class HdSt_QuadInfoBuilderComputation> HdSt_QuadInfoBuilderComputationSharedPtr;
-typedef boost::shared_ptr<class HdSt_MeshTopology> HdSt_MeshTopologySharedPtr;
+typedef std::weak_ptr<class HdBufferSource> HdBufferSourceWeakPtr;
+typedef std::weak_ptr<class HdSt_AdjacencyBuilderComputation> HdSt_AdjacencyBuilderComputationPtr;
+typedef std::weak_ptr<class HdSt_QuadInfoBuilderComputation> HdSt_QuadInfoBuilderComputationPtr;
+typedef std::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdComputation> HdComputationSharedPtr;
+typedef std::shared_ptr<class HdSt_AdjacencyBuilderComputation> HdSt_AdjacencyBuilderComputationSharedPtr;
+typedef std::shared_ptr<class HdSt_QuadInfoBuilderComputation> HdSt_QuadInfoBuilderComputationSharedPtr;
+typedef std::shared_ptr<class HdSt_MeshTopology> HdSt_MeshTopologySharedPtr;
 
 /// \class HdSt_MeshTopology
 ///

--- a/pxr/imaging/lib/hdSt/pch.h
+++ b/pxr/imaging/lib/hdSt/pch.h
@@ -86,7 +86,6 @@
 #include <boost/any.hpp>
 #include <boost/call_traits.hpp>
 #include <boost/container/vector.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/functional/hash_fwd.hpp>
@@ -94,7 +93,6 @@
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/iterator_adaptors.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/mpl/bool.hpp>
@@ -144,7 +142,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits/decay.hpp>
@@ -162,7 +159,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <opensubdiv/far/patchTable.h>
 #include <opensubdiv/far/patchTableFactory.h>
 #include <opensubdiv/far/stencilTable.h>

--- a/pxr/imaging/lib/hdSt/persistentBuffer.h
+++ b/pxr/imaging/lib/hdSt/persistentBuffer.h
@@ -28,12 +28,10 @@
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hdSt/resourceGL.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStPersistentBuffer> HdStPersistentBufferSharedPtr;
+typedef std::shared_ptr<class HdStPersistentBuffer> HdStPersistentBufferSharedPtr;
 
 /// \class HdStPersistentBuffer
 ///

--- a/pxr/imaging/lib/hdSt/points.cpp
+++ b/pxr/imaging/lib/hdSt/points.cpp
@@ -110,7 +110,7 @@ HdStPoints::_UpdateDrawItem(HdSceneDelegate *sceneDelegate,
 
     HdSt_PointsShaderKey shaderKey;
     HdStResourceRegistrySharedPtr resourceRegistry =
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
             sceneDelegate->GetRenderIndex().GetResourceRegistry());
     drawItem->SetGeometricShader(
         HdSt_GeometricShader::Create(shaderKey, resourceRegistry));
@@ -171,7 +171,7 @@ HdStPoints::_PopulateVertexPrimVars(HdSceneDelegate *sceneDelegate,
 
     SdfPath const& id = GetId();
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::static_pointer_cast<HdStResourceRegistry>(
+        std::static_pointer_cast<HdStResourceRegistry>(
         sceneDelegate->GetRenderIndex().GetResourceRegistry());
 
     // The "points" attribute is expected to be in this list.
@@ -277,7 +277,7 @@ HdStPoints::_InitRepr(TfToken const &reprName,
     _PointsReprConfig::DescArray const &descs = _GetReprDesc(reprName);
 
     if (_reprs.empty()) {
-        _reprs.emplace_back(reprName, boost::make_shared<HdRepr>());
+        _reprs.emplace_back(reprName, std::make_shared<HdRepr>());
 
         HdReprSharedPtr &repr = _reprs.back().second;
 

--- a/pxr/imaging/lib/hdSt/points.h
+++ b/pxr/imaging/lib/hdSt/points.h
@@ -35,8 +35,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/vt/array.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class HdStPoints

--- a/pxr/imaging/lib/hdSt/quadrangulate.cpp
+++ b/pxr/imaging/lib/hdSt/quadrangulate.cpp
@@ -437,20 +437,20 @@ HdSt_QuadrangulateComputationGPU::Execute(
     GLuint program = computeProgram->GetProgram().GetId();
 
     HdStBufferArrayRangeGLSharedPtr range_ =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (range);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (range);
 
     // buffer resources for GPU computation
     HdBufferResourceSharedPtr primVar_ = range_->GetResource(_name);
     HdStBufferResourceGLSharedPtr primVar =
-        boost::static_pointer_cast<HdStBufferResourceGL> (primVar_);
+        std::static_pointer_cast<HdStBufferResourceGL> (primVar_);
 
     HdStBufferArrayRangeGLSharedPtr quadrangulateTableRange_ =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (quadrangulateTableRange);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (quadrangulateTableRange);
 
     HdBufferResourceSharedPtr quadrangulateTable_ =
         quadrangulateTableRange_->GetResource();
     HdStBufferResourceGLSharedPtr quadrangulateTable =
-        boost::static_pointer_cast<HdStBufferResourceGL> (quadrangulateTable_);
+        std::static_pointer_cast<HdStBufferResourceGL> (quadrangulateTable_);
 
     // prepare uniform buffer for GPU computation
     struct Uniform {

--- a/pxr/imaging/lib/hdSt/quadrangulate.h
+++ b/pxr/imaging/lib/hdSt/quadrangulate.h
@@ -35,12 +35,10 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdSt_QuadInfoBuilderComputation>
+typedef std::shared_ptr<class HdSt_QuadInfoBuilderComputation>
                                        HdSt_QuadInfoBuilderComputationSharedPtr;
 
 class HdSt_MeshTopology;

--- a/pxr/imaging/lib/hdSt/renderDelegate.cpp
+++ b/pxr/imaging/lib/hdSt/renderDelegate.cpp
@@ -132,7 +132,7 @@ HdStRenderDelegate::CreateRenderPass(HdRenderIndex *index,
 HdRenderPassStateSharedPtr
 HdStRenderDelegate::CreateRenderPassState() const
 {
-    return boost::make_shared<HdStRenderPassState>();
+    return std::make_shared<HdStRenderPassState>();
 }
 
 HdInstancer *

--- a/pxr/imaging/lib/hdSt/renderDelegate.h
+++ b/pxr/imaging/lib/hdSt/renderDelegate.h
@@ -31,7 +31,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdStResourceRegistry>
+typedef std::shared_ptr<class HdStResourceRegistry>
     HdStResourceRegistrySharedPtr;
 
 ///

--- a/pxr/imaging/lib/hdSt/renderPass.cpp
+++ b/pxr/imaging/lib/hdSt/renderPass.cpp
@@ -59,7 +59,7 @@ HdSt_RenderPass::_Execute(HdRenderPassStateSharedPtr const &renderPassState,
 
     // Downcast render pass state
     HdStRenderPassStateSharedPtr stRenderPassState =
-        boost::dynamic_pointer_cast<HdStRenderPassState>(
+        std::dynamic_pointer_cast<HdStRenderPassState>(
         renderPassState);
     TF_VERIFY(stRenderPassState);
 
@@ -68,7 +68,7 @@ HdSt_RenderPass::_Execute(HdRenderPassStateSharedPtr const &renderPassState,
 
     // Downcast the resource registry
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
-        boost::dynamic_pointer_cast<HdStResourceRegistry>(
+        std::dynamic_pointer_cast<HdStResourceRegistry>(
         GetRenderIndex()->GetResourceRegistry());
     TF_VERIFY(resourceRegistry);
 

--- a/pxr/imaging/lib/hdSt/renderPass.h
+++ b/pxr/imaging/lib/hdSt/renderPass.h
@@ -29,12 +29,11 @@
 #include "pxr/imaging/hdSt/commandBuffer.h"
 #include "pxr/imaging/hd/renderPass.h"
 
-#include <boost/shared_ptr.hpp>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdSt_RenderPass> HdSt_RenderPassSharedPtr;
+typedef std::shared_ptr<class HdSt_RenderPass> HdSt_RenderPassSharedPtr;
 
 /// \class HdSt_RenderPass
 ///

--- a/pxr/imaging/lib/hdSt/renderPassShader.h
+++ b/pxr/imaging/lib/hdSt/renderPassShader.h
@@ -35,12 +35,10 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
 
 /// \class HdStRenderPassShader
 ///

--- a/pxr/imaging/lib/hdSt/renderPassState.cpp
+++ b/pxr/imaging/lib/hdSt/renderPassState.cpp
@@ -137,7 +137,7 @@ HdStRenderPassState::Sync(HdResourceRegistrySharedPtr const &resourceRegistry)
             HdTokens->drawingShader, bufferSpecs);
 
         HdStBufferArrayRangeGLSharedPtr _renderPassStateBar_ =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (_renderPassStateBar);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (_renderPassStateBar);
 
         // add buffer binding request
         _renderPassShader->AddBufferBinding(
@@ -220,7 +220,7 @@ HdStRenderPassState::SetRenderPassShader(HdStRenderPassShaderSharedPtr const &re
     if (_renderPassStateBar) {
 
         HdStBufferArrayRangeGLSharedPtr _renderPassStateBar_ =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (_renderPassStateBar);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (_renderPassStateBar);
 
         _renderPassShader->AddBufferBinding(
             HdBindingRequest(HdBinding::UBO, _tokens->renderPassState,

--- a/pxr/imaging/lib/hdSt/renderPassState.h
+++ b/pxr/imaging/lib/hdSt/renderPassState.h
@@ -30,14 +30,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
-typedef boost::shared_ptr<class HdStLightingShader> HdStLightingShaderSharedPtr;
-typedef boost::shared_ptr<class HdStRenderPassShader>
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStLightingShader> HdStLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassShader>
                 HdStRenderPassShaderSharedPtr;
-typedef boost::shared_ptr<class HdSt_FallbackLightingShader>
+typedef std::shared_ptr<class HdSt_FallbackLightingShader>
                 HdSt_FallbackLightingShaderSharedPtr;
 typedef std::vector<HdStShaderCodeSharedPtr> HdStShaderCodeSharedPtrVector;
 

--- a/pxr/imaging/lib/hdSt/resourceBinder.cpp
+++ b/pxr/imaging/lib/hdSt/resourceBinder.cpp
@@ -193,7 +193,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetConstantPrimVarRange()) {
 
         HdStBufferArrayRangeGLSharedPtr constantBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(constantBar_);
 
         MetaData::StructBlock sblock(HdTokens->constantPrimVars);
         TF_FOR_ALL (it, constantBar->GetResources()) {
@@ -226,7 +226,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
             drawItem->GetInstancePrimVarRange(i)) {
 
             HdStBufferArrayRangeGLSharedPtr instanceBar =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceBar_);
+                std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceBar_);
 
             TF_FOR_ALL (it, instanceBar->GetResources()) {
                 // non-interleaved, always create new binding.
@@ -252,7 +252,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetVertexPrimVarRange()) {
 
         HdStBufferArrayRangeGLSharedPtr vertexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(vertexBar_);
 
         TF_FOR_ALL (it, vertexBar->GetResources()) {
             HdBinding vertexPrimVarBinding =
@@ -272,7 +272,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetTopologyRange()) {
 
         HdStBufferArrayRangeGLSharedPtr topologyBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(topologyBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(topologyBar_);
 
         TF_FOR_ALL (it, topologyBar->GetResources()) {
             if (it->first == HdTokens->indices) {
@@ -301,7 +301,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetElementPrimVarRange()) {
 
         HdStBufferArrayRangeGLSharedPtr elementBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(elementBar_);
 
         TF_FOR_ALL (it, elementBar->GetResources()) {
             HdBinding elementPrimVarBinding =
@@ -321,7 +321,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetFaceVaryingPrimVarRange()) {
 
         HdStBufferArrayRangeGLSharedPtr fvarBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(fvarBar_);
 
         TF_FOR_ALL (it, fvarBar->GetResources()) {
             HdBinding fvarPrimVarBinding =
@@ -381,7 +381,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         drawItem->GetInstanceIndexRange()) {
 
         HdStBufferArrayRangeGLSharedPtr instanceIndexBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL>(instanceIndexBar_);
 
         HdStBufferResourceGLSharedPtr instanceIndices
             = instanceIndexBar->GetResource(HdTokens->instanceIndices);
@@ -431,7 +431,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
         // uniform block
         HdBufferArrayRangeSharedPtr const &shaderBar_ = (*shader)->GetShaderData();
         HdStBufferArrayRangeGLSharedPtr shaderBar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (shaderBar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (shaderBar_);
         if (shaderBar) {
             HdBinding shaderParamBinding =
                 locator.GetBinding(structBufferBindingType, HdTokens->materialParams);
@@ -532,7 +532,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
 
             HdBufferArrayRangeSharedPtr bar_ = it->GetBar();
             HdStBufferArrayRangeGLSharedPtr bar =
-                boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+                std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
 
             for (auto const& nameRes : bar->GetResources()) {
                 HdTupleType valueType = nameRes.second->GetTupleType();
@@ -555,7 +555,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
 
                 HdBufferArrayRangeSharedPtr bar_ = it->GetBar();
                 HdStBufferArrayRangeGLSharedPtr bar =
-                    boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+                    std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
 
                 for (auto const& nameRes : bar->GetResources()) {
                     HdBinding binding = locator.GetBinding(it->GetBindingType(), nameRes.first);
@@ -929,19 +929,19 @@ HdSt_ResourceBinder::Bind(HdBindingRequest const& req) const
     } else if (req.IsResource()) {
         HdBufferResourceSharedPtr res_ = req.GetResource();
         HdStBufferResourceGLSharedPtr res =
-            boost::static_pointer_cast<HdStBufferResourceGL> (res_);
+            std::static_pointer_cast<HdStBufferResourceGL> (res_);
 
         BindBuffer(req.GetName(), res, req.GetOffset());
     } else if (req.IsInterleavedBufferArray()) {
         // note: interleaved buffer needs only 1 binding
         HdBufferArrayRangeSharedPtr bar_ = req.GetBar();
         HdStBufferArrayRangeGLSharedPtr bar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
         BindBuffer(req.GetName(), bar->GetResource(), req.GetOffset());
     } else if (req.IsBufferArray()) {
         HdBufferArrayRangeSharedPtr bar_ = req.GetBar();
         HdStBufferArrayRangeGLSharedPtr bar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
         BindBufferArray(bar);
     }
 }
@@ -954,20 +954,20 @@ HdSt_ResourceBinder::Unbind(HdBindingRequest const& req) const
     } else if (req.IsResource()) {
         HdBufferResourceSharedPtr res_ = req.GetResource();
         HdStBufferResourceGLSharedPtr res =
-            boost::static_pointer_cast<HdStBufferResourceGL> (res_);
+            std::static_pointer_cast<HdStBufferResourceGL> (res_);
 
         UnbindBuffer(req.GetName(), res);
     } else if (req.IsInterleavedBufferArray()) {
         // note: interleaved buffer needs only 1 binding
         HdBufferArrayRangeSharedPtr bar_ = req.GetBar();
         HdStBufferArrayRangeGLSharedPtr bar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
 
         UnbindBuffer(req.GetName(), bar->GetResource());
     } else if (req.IsBufferArray()) {
         HdBufferArrayRangeSharedPtr bar_ = req.GetBar();
         HdStBufferArrayRangeGLSharedPtr bar =
-            boost::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
+            std::static_pointer_cast<HdStBufferArrayRangeGL> (bar_);
 
         UnbindBufferArray(bar);
     }

--- a/pxr/imaging/lib/hdSt/resourceBinder.h
+++ b/pxr/imaging/lib/hdSt/resourceBinder.h
@@ -41,10 +41,10 @@ class HdStDrawItem;
 class HdStShaderCode;
 class HdStResourceGL;
 
-typedef boost::shared_ptr<class HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
-typedef boost::shared_ptr<class HdStBufferArrayRangeGL> HdStBufferArrayRangeGLSharedPtr;
+typedef std::shared_ptr<class HdStBufferResourceGL> HdStBufferResourceGLSharedPtr;
+typedef std::shared_ptr<class HdStBufferArrayRangeGL> HdStBufferArrayRangeGLSharedPtr;
 
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
 typedef std::vector<HdStShaderCodeSharedPtr> HdStShaderCodeSharedPtrVector;
 typedef std::vector<class HdBindingRequest> HdBindingRequestVector;
 

--- a/pxr/imaging/lib/hdSt/resourceGL.h
+++ b/pxr/imaging/lib/hdSt/resourceGL.h
@@ -31,14 +31,12 @@
 #include "pxr/imaging/hd/resource.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <cstddef>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStResourceGL> HdStResourceGLSharedPtr;
+typedef std::shared_ptr<class HdStResourceGL> HdStResourceGLSharedPtr;
 
 /// \class HdStResourceGL
 ///

--- a/pxr/imaging/lib/hdSt/resourceRegistry.h
+++ b/pxr/imaging/lib/hdSt/resourceRegistry.h
@@ -32,15 +32,15 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::shared_ptr<class HdStDispatchBuffer>
+typedef std::shared_ptr<class HdStDispatchBuffer>
     HdStDispatchBufferSharedPtr;
-typedef boost::shared_ptr<class HdStPersistentBuffer>
+typedef std::shared_ptr<class HdStPersistentBuffer>
     HdStPersistentBufferSharedPtr;
-typedef boost::shared_ptr<class HdStResourceRegistry>
+typedef std::shared_ptr<class HdStResourceRegistry>
     HdStResourceRegistrySharedPtr;
-typedef boost::shared_ptr<class HdSt_GeometricShader>
+typedef std::shared_ptr<class HdSt_GeometricShader>
     HdSt_GeometricShaderSharedPtr;
-typedef boost::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
+typedef std::shared_ptr<class HdStGLSLProgram> HdStGLSLProgramSharedPtr;
 
 /// \class HdStResourceRegistry
 ///

--- a/pxr/imaging/lib/hdSt/shaderCode.h
+++ b/pxr/imaging/lib/hdSt/shaderCode.h
@@ -32,8 +32,6 @@
 #include "pxr/imaging/hdSt/resourceBinder.h"  // XXX: including a private class
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <string>
 #include <vector>
 
@@ -42,7 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 typedef std::vector<class HdBindingRequest> HdBindingRequestVector;
 
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
 typedef std::vector<HdStShaderCodeSharedPtr> HdStShaderCodeSharedPtrVector;
 
 

--- a/pxr/imaging/lib/hdSt/smoothNormals.cpp
+++ b/pxr/imaging/lib/hdSt/smoothNormals.cpp
@@ -87,7 +87,7 @@ HdSt_SmoothNormalsComputationGPU::Execute(
     TF_VERIFY(adjacencyRange_);
 
     HdStBufferArrayRangeGLSharedPtr adjacencyRange =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (adjacencyRange_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (adjacencyRange_);
 
     // select shader by datatype
     TfToken shaderToken;
@@ -118,7 +118,7 @@ HdSt_SmoothNormalsComputationGPU::Execute(
     GLuint program = computeProgram->GetProgram().GetId();
 
     HdStBufferArrayRangeGLSharedPtr range =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (range_);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (range_);
 
     // buffer resources for GPU computation
     HdStBufferResourceGLSharedPtr points = range->GetResource(_srcName);

--- a/pxr/imaging/lib/hdSt/smoothNormals.h
+++ b/pxr/imaging/lib/hdSt/smoothNormals.h
@@ -32,12 +32,11 @@
 #include "pxr/base/tf/token.h"
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 class Hd_VertexAdjacency;
 

--- a/pxr/imaging/lib/hdSt/subdivision.h
+++ b/pxr/imaging/lib/hdSt/subdivision.h
@@ -204,7 +204,7 @@ public:
     public:
         VertexBuffer(HdBufferResourceSharedPtr const &resource) { 
             _resource =
-                boost::static_pointer_cast<HdStBufferResourceGL> (resource);
+                std::static_pointer_cast<HdStBufferResourceGL> (resource);
         }
 
         // bit confusing, osd expects 'GetNumElements()' returns the num components,

--- a/pxr/imaging/lib/hdSt/subdivision3.cpp
+++ b/pxr/imaging/lib/hdSt/subdivision3.cpp
@@ -317,7 +317,7 @@ HdSt_Osd3Subdivision::RefineGPU(HdBufferArrayRangeSharedPtr const &range,
     // filling coarse vertices has been done at resource registry.
 
     HdStBufferArrayRangeGLSharedPtr range_ =
-        boost::static_pointer_cast<HdStBufferArrayRangeGL> (range);
+        std::static_pointer_cast<HdStBufferArrayRangeGL> (range);
 
     // vertex buffer wrapper for OpenSubdiv API
     HdSt_OsdRefineComputationGPU::VertexBuffer vertexBuffer(

--- a/pxr/imaging/lib/hdSt/surfaceShader.h
+++ b/pxr/imaging/lib/hdSt/surfaceShader.h
@@ -37,8 +37,6 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -46,9 +44,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
-typedef boost::shared_ptr<class HdStSurfaceShader> HdStSurfaceShaderSharedPtr;
-typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdStSurfaceShader> HdStSurfaceShaderSharedPtr;
+typedef std::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 
 /// \class HdStSurfaceShader
 ///

--- a/pxr/imaging/lib/hdSt/texture.h
+++ b/pxr/imaging/lib/hdSt/texture.h
@@ -36,14 +36,12 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
+typedef std::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
 
 ///
 /// Represents a Texture Buffer Prim.

--- a/pxr/imaging/lib/hdSt/textureResource.h
+++ b/pxr/imaging/lib/hdSt/textureResource.h
@@ -37,15 +37,14 @@
 #include "pxr/base/gf/vec4f.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <cstdint>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStTextureResource> HdStTextureResourceSharedPtr;
-typedef boost::shared_ptr<class HdStSimpleTextureResource> HdStSimpleTextureResourceSharedPtr;
+typedef std::shared_ptr<class HdStTextureResource> HdStTextureResourceSharedPtr;
+typedef std::shared_ptr<class HdStSimpleTextureResource> HdStSimpleTextureResourceSharedPtr;
 
 /// HdStTextureResource is an interface to a GL-backed texture.
 class HdStTextureResource : public HdTextureResource, boost::noncopyable {

--- a/pxr/imaging/lib/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/lib/hdSt/unitTestHelper.cpp
@@ -101,7 +101,7 @@ HdSt_TestDriver::HdSt_TestDriver()
  , _geomPass()
  , _geomAndGuidePass()
  , _renderPassState(
-    boost::dynamic_pointer_cast<HdStRenderPassState>(
+    std::dynamic_pointer_cast<HdStRenderPassState>(
         _renderDelegate.CreateRenderPassState()))
 {
     TfToken reprName = HdTokens->hull;
@@ -121,7 +121,7 @@ HdSt_TestDriver::HdSt_TestDriver(TfToken const &reprName)
  , _geomPass()
  , _geomAndGuidePass()
  , _renderPassState(
-    boost::dynamic_pointer_cast<HdStRenderPassState>(
+    std::dynamic_pointer_cast<HdStRenderPassState>(
         _renderDelegate.CreateRenderPassState()))
 {
     _Init(reprName);
@@ -168,7 +168,7 @@ void
 HdSt_TestDriver::Draw(HdRenderPassSharedPtr const &renderPass)
 {
     HdTaskSharedPtrVector tasks = {
-        boost::make_shared<HdSt_DrawTask>(renderPass, _renderPassState)
+        std::make_shared<HdSt_DrawTask>(renderPass, _renderPassState)
     };
     _engine.Execute(_sceneDelegate->GetRenderIndex(), tasks);
 

--- a/pxr/imaging/lib/hdSt/unitTestHelper.h
+++ b/pxr/imaging/lib/hdSt/unitTestHelper.h
@@ -103,7 +103,7 @@ private:
 ///
 /// A custom lighting shader for unit tests.
 ///
-typedef boost::shared_ptr<class HdSt_TestLightingShader> HdSt_TestLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdSt_TestLightingShader> HdSt_TestLightingShaderSharedPtr;
 
 class HdSt_TestLightingShader : public HdStLightingShader {
 public:

--- a/pxr/imaging/lib/hdSt/vboMemoryManager.cpp
+++ b/pxr/imaging/lib/hdSt/vboMemoryManager.cpp
@@ -56,7 +56,7 @@ HdStVBOMemoryManager::CreateBufferArray(
     TfToken const &role,
     HdBufferSpecVector const &bufferSpecs)
 {
-    return boost::make_shared<HdStVBOMemoryManager::_StripedBufferArray>(
+    return std::make_shared<HdStVBOMemoryManager::_StripedBufferArray>(
         role, bufferSpecs, _isImmutable);
 }
 
@@ -64,7 +64,7 @@ HdStVBOMemoryManager::CreateBufferArray(
 HdBufferArrayRangeSharedPtr
 HdStVBOMemoryManager::CreateBufferArrayRange()
 {
-    return boost::make_shared<_StripedBufferArrayRange>();
+    return std::make_shared<_StripedBufferArrayRange>();
 }
 
 
@@ -93,7 +93,7 @@ HdStVBOMemoryManager::GetBufferSpecs(
     HdBufferArraySharedPtr const &bufferArray) const
 {
     _StripedBufferArraySharedPtr bufferArray_ =
-        boost::static_pointer_cast<_StripedBufferArray> (bufferArray);
+        std::static_pointer_cast<_StripedBufferArray> (bufferArray);
     return bufferArray_->GetBufferSpecs();
 }
 
@@ -108,7 +108,7 @@ HdStVBOMemoryManager::GetResourceAllocation(
     size_t gpuMemoryUsed = 0;
 
     _StripedBufferArraySharedPtr bufferArray_ =
-        boost::static_pointer_cast<_StripedBufferArray> (bufferArray);
+        std::static_pointer_cast<_StripedBufferArray> (bufferArray);
 
     TF_FOR_ALL(resIt, bufferArray_->GetResources()) {
         HdStBufferResourceGLSharedPtr const & resource = resIt->second;
@@ -278,7 +278,7 @@ HdStVBOMemoryManager::_StripedBufferArray::Reallocate(
     HD_PERF_COUNTER_INCR(HdPerfTokens->vboRelocated);
 
     _StripedBufferArraySharedPtr curRangeOwner_ =
-        boost::static_pointer_cast<_StripedBufferArray> (curRangeOwner);
+        std::static_pointer_cast<_StripedBufferArray> (curRangeOwner);
 
     if (!TF_VERIFY(GetResources().size() ==
                       curRangeOwner_->GetResources().size())) {
@@ -367,7 +367,7 @@ HdStVBOMemoryManager::_StripedBufferArray::Reallocate(
                 HdStGLBufferRelocator relocator(curId, newId);
                 TF_FOR_ALL (it, ranges) {
                     _StripedBufferArrayRangeSharedPtr range =
-                        boost::static_pointer_cast<_StripedBufferArrayRange>(*it);
+                        std::static_pointer_cast<_StripedBufferArrayRange>(*it);
                     if (!range) {
                         TF_CODING_ERROR("_StripedBufferArrayRange "
                                         "expired unexpectedly.");
@@ -422,7 +422,7 @@ HdStVBOMemoryManager::_StripedBufferArray::Reallocate(
     // update ranges
     for (size_t idx = 0; idx < ranges.size(); ++idx) {
         _StripedBufferArrayRangeSharedPtr range =
-            boost::static_pointer_cast<_StripedBufferArrayRange>(ranges[idx]);
+            std::static_pointer_cast<_StripedBufferArrayRange>(ranges[idx]);
         if (!range) {
             TF_CODING_ERROR("_StripedBufferArrayRange expired unexpectedly.");
             continue;

--- a/pxr/imaging/lib/hdSt/vboMemoryManager.h
+++ b/pxr/imaging/lib/hdSt/vboMemoryManager.h
@@ -36,7 +36,6 @@
 #include "pxr/base/tf/mallocTag.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
 #include <list>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -217,11 +216,11 @@ protected:
         int _capacity;
     };
 
-    typedef boost::shared_ptr<_StripedBufferArray>
+    typedef std::shared_ptr<_StripedBufferArray>
         _StripedBufferArraySharedPtr;
-    typedef boost::shared_ptr<_StripedBufferArrayRange>
+    typedef std::shared_ptr<_StripedBufferArrayRange>
         _StripedBufferArrayRangeSharedPtr;
-    typedef boost::weak_ptr<_StripedBufferArrayRange>
+    typedef std::weak_ptr<_StripedBufferArrayRange>
         _StripedBufferArrayRangePtr;
 
     /// striped buffer array
@@ -313,7 +312,7 @@ protected:
 
         // Helpper routine to cast the range shared pointer.
         _StripedBufferArrayRangeSharedPtr _GetRangeSharedPtr(size_t idx) const {
-            return boost::static_pointer_cast<_StripedBufferArrayRange>(GetRange(idx).lock());
+            return std::static_pointer_cast<_StripedBufferArrayRange>(GetRange(idx).lock());
         }
     };
 };

--- a/pxr/imaging/lib/hdSt/vboSimpleMemoryManager.cpp
+++ b/pxr/imaging/lib/hdSt/vboSimpleMemoryManager.cpp
@@ -43,8 +43,6 @@
 #include <atomic>
 
 #include <boost/functional/hash.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -60,14 +58,14 @@ HdStVBOSimpleMemoryManager::CreateBufferArray(
     TfToken const &role,
     HdBufferSpecVector const &bufferSpecs)
 {
-    return boost::make_shared<HdStVBOSimpleMemoryManager::_SimpleBufferArray>(
+    return std::make_shared<HdStVBOSimpleMemoryManager::_SimpleBufferArray>(
         role, bufferSpecs);
 }
 
 HdBufferArrayRangeSharedPtr
 HdStVBOSimpleMemoryManager::CreateBufferArrayRange()
 {
-    return boost::make_shared<HdStVBOSimpleMemoryManager::_SimpleBufferArrayRange>();
+    return std::make_shared<HdStVBOSimpleMemoryManager::_SimpleBufferArrayRange>();
 }
 
 HdAggregationStrategy::AggregationId
@@ -88,7 +86,7 @@ HdStVBOSimpleMemoryManager::GetBufferSpecs(
     HdBufferArraySharedPtr const &bufferArray) const
 {
     _SimpleBufferArraySharedPtr bufferArray_ =
-        boost::static_pointer_cast<_SimpleBufferArray> (bufferArray);
+        std::static_pointer_cast<_SimpleBufferArray> (bufferArray);
     return bufferArray_->GetBufferSpecs();
 }
 
@@ -102,7 +100,7 @@ HdStVBOSimpleMemoryManager::GetResourceAllocation(
     size_t gpuMemoryUsed = 0;
 
     _SimpleBufferArraySharedPtr bufferArray_ =
-        boost::static_pointer_cast<_SimpleBufferArray> (bufferArray);
+        std::static_pointer_cast<_SimpleBufferArray> (bufferArray);
 
     TF_FOR_ALL(resIt, bufferArray_->GetResources()) {
         HdStBufferResourceGLSharedPtr const & resource = resIt->second;

--- a/pxr/imaging/lib/hdSt/vboSimpleMemoryManager.h
+++ b/pxr/imaging/lib/hdSt/vboSimpleMemoryManager.h
@@ -188,11 +188,11 @@ protected:
         int _numElements;
     };
 
-    typedef boost::shared_ptr<_SimpleBufferArray>
+    typedef std::shared_ptr<_SimpleBufferArray>
         _SimpleBufferArraySharedPtr;
-    typedef boost::shared_ptr<_SimpleBufferArrayRange>
+    typedef std::shared_ptr<_SimpleBufferArrayRange>
         _SimpleBufferArrayRangeSharedPtr;
-    typedef boost::weak_ptr<_SimpleBufferArrayRange>
+    typedef std::weak_ptr<_SimpleBufferArrayRange>
         _SimpleBufferArrayRangePtr;
 
     /// \class _SimpleBufferArray
@@ -280,7 +280,7 @@ protected:
 
         _SimpleBufferArrayRangeSharedPtr _GetRangeSharedPtr() const {
             return GetRangeCount() > 0
-                ? boost::static_pointer_cast<_SimpleBufferArrayRange>(GetRange(0).lock())
+                ? std::static_pointer_cast<_SimpleBufferArrayRange>(GetRange(0).lock())
                 : _SimpleBufferArrayRangeSharedPtr();
         }
     };

--- a/pxr/imaging/lib/hdx/drawTargetRenderPass.h
+++ b/pxr/imaging/lib/hdx/drawTargetRenderPass.h
@@ -36,7 +36,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 
 class HdStDrawTargetRenderPassState;
 

--- a/pxr/imaging/lib/hdx/drawTargetTask.h
+++ b/pxr/imaging/lib/hdx/drawTargetTask.h
@@ -40,7 +40,7 @@ class HdStDrawTarget;
 
 
 typedef std::unique_ptr<HdxDrawTargetRenderPass> HdxDrawTargetRenderPassUniquePtr;
-typedef boost::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
 
 // Not strictly necessary here.
 // But without it, would require users of the class to include it anyway

--- a/pxr/imaging/lib/hdx/intersector.cpp
+++ b/pxr/imaging/lib/hdx/intersector.cpp
@@ -63,13 +63,13 @@ HdxIntersector::_Init(GfVec2i const& size)
         _index->GetRenderDelegate()->CreateRenderPass(&*_index, col);
 
     // initialize renderPassState with ID render shader
-    _pickableRenderPassState = boost::make_shared<HdStRenderPassState>(
-        boost::make_shared<HdStRenderPassShader>(HdxPackageRenderPassIdShader()));
+    _pickableRenderPassState = std::make_shared<HdStRenderPassState>(
+        std::make_shared<HdStRenderPassShader>(HdxPackageRenderPassIdShader()));
 
     // Turn off color writes for the unpickables (we only want to condition the
     // depth buffer)
-    _unpickableRenderPassState = boost::make_shared<HdStRenderPassState>(
-        boost::make_shared<HdStRenderPassShader>(HdxPackageRenderPassIdShader()));
+    _unpickableRenderPassState = std::make_shared<HdStRenderPassState>(
+        std::make_shared<HdStRenderPassShader>(HdxPackageRenderPassIdShader()));
     _unpickableRenderPassState->SetColorMaskUseDefault(false);
     _unpickableRenderPassState->SetColorMask(HdRenderPassState::ColorMaskNone);
 
@@ -334,7 +334,7 @@ HdxIntersector::Query(HdxIntersector::Params const& params,
                 pickablesCol.CreateInverseCollection();
             _unpickableRenderPass->SetRprimCollection(unpickablesCol);
 
-            tasks.push_back(boost::make_shared<HdxIntersector_DrawTask>(
+            tasks.push_back(std::make_shared<HdxIntersector_DrawTask>(
                     _unpickableRenderPass,
                     _unpickableRenderPassState,
                     params.renderTags));
@@ -345,7 +345,7 @@ HdxIntersector::Query(HdxIntersector::Params const& params,
         //
         // XXX: make intersector a Task
         _pickableRenderPass->SetRprimCollection(pickablesCol);
-        tasks.push_back(boost::make_shared<HdxIntersector_DrawTask>(
+        tasks.push_back(std::make_shared<HdxIntersector_DrawTask>(
                 _pickableRenderPass,
                 _pickableRenderPassState,
                 params.renderTags));

--- a/pxr/imaging/lib/hdx/intersector.h
+++ b/pxr/imaging/lib/hdx/intersector.h
@@ -35,8 +35,6 @@
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <functional>
 #include <memory>
 #include <vector>
@@ -50,8 +48,8 @@ class HdEngine;
 class HdRenderIndex;
 class HdRprimCollection;
 
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
-typedef boost::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassState> HdStRenderPassStateSharedPtr;
 
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfDrawTarget);
 

--- a/pxr/imaging/lib/hdx/pch.h
+++ b/pxr/imaging/lib/hdx/pch.h
@@ -143,7 +143,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits/decay.hpp>
@@ -161,7 +160,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/imaging/lib/hdx/renderSetupTask.h
+++ b/pxr/imaging/lib/hdx/renderSetupTask.h
@@ -34,15 +34,13 @@
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/gf/vec4d.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdxRenderSetupTask> HdxRenderSetupTaskSharedPtr;
-typedef boost::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdxRenderSetupTask> HdxRenderSetupTaskSharedPtr;
+typedef std::shared_ptr<class HdStShaderCode> HdStShaderCodeSharedPtr;
 struct HdxRenderTaskParams;
 class HdStRenderPassState;
 

--- a/pxr/imaging/lib/hdx/renderTask.h
+++ b/pxr/imaging/lib/hdx/renderTask.h
@@ -31,16 +31,14 @@
 #include "pxr/imaging/hdx/renderSetupTask.h"  // for short-term compatibility.
 #include "pxr/imaging/hdSt/renderPassState.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
-typedef boost::shared_ptr<class HdxRenderSetupTask> HdxRenderSetupTaskSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdxRenderSetupTask> HdxRenderSetupTaskSharedPtr;
 typedef std::vector<HdRenderPassSharedPtr> HdRenderPassSharedPtrVector;
 
 /// \class HdxRenderTask

--- a/pxr/imaging/lib/hdx/selectionTask.h
+++ b/pxr/imaging/lib/hdx/selectionTask.h
@@ -32,8 +32,6 @@
 
 #include "pxr/base/gf/vec4f.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -48,7 +46,7 @@ struct HdxSelectionTaskParams
     GfVec4f maskColor;
 };
 
-typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
+typedef std::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 
 /// \class HdxSelectionTask
 ///

--- a/pxr/imaging/lib/hdx/selectionTracker.h
+++ b/pxr/imaging/lib/hdx/selectionTracker.h
@@ -40,9 +40,9 @@ class TfToken;
 class SdfPath;
 class VtValue;
 
-typedef boost::shared_ptr<class HdxSelection> HdxSelectionSharedPtr;
-typedef boost::shared_ptr<class HdxSelectionTracker> HdxSelectionTrackerSharedPtr;
-typedef boost::weak_ptr<class HdxSelectionTracker> HdxSelectionTrackerWeakPtr;
+typedef std::shared_ptr<class HdxSelection> HdxSelectionSharedPtr;
+typedef std::shared_ptr<class HdxSelectionTracker> HdxSelectionTrackerSharedPtr;
+typedef std::weak_ptr<class HdxSelectionTracker> HdxSelectionTrackerWeakPtr;
 
 
 enum HdxSelectionHighlightMode {

--- a/pxr/imaging/lib/hdx/shadowTask.cpp
+++ b/pxr/imaging/lib/hdx/shadowTask.cpp
@@ -205,7 +205,7 @@ HdxShadowTask::_Sync(HdTaskContext* ctx)
 
             // Creates a pass with the right geometry that will be
             // use during Execute phase to draw the maps
-            HdRenderPassSharedPtr p = boost::make_shared<HdSt_RenderPass>
+            HdRenderPassSharedPtr p = std::make_shared<HdSt_RenderPass>
                 (&delegate->GetRenderIndex(), col);
 
             HdStRenderPassShaderSharedPtr renderPassShadowShader

--- a/pxr/imaging/lib/hdx/shadowTask.h
+++ b/pxr/imaging/lib/hdx/shadowTask.h
@@ -36,8 +36,6 @@
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/base/tf/declarePtrs.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -45,9 +43,9 @@ class HdRenderIndex;
 class HdSceneDelegate;
 class GlfSimpleLight;
 
-typedef boost::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
-typedef boost::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdStRenderPassShader> HdStRenderPassShaderSharedPtr;
+typedef std::shared_ptr<class HdRenderPassState> HdRenderPassStateSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
 typedef std::vector<HdRenderPassStateSharedPtr> HdRenderPassStateSharedPtrVector;
 typedef std::vector<HdRenderPassSharedPtr> HdRenderPassSharedPtrVector;
 

--- a/pxr/imaging/lib/hdx/simpleLightBypassTask.cpp
+++ b/pxr/imaging/lib/hdx/simpleLightBypassTask.cpp
@@ -102,7 +102,7 @@ HdxSimpleLightBypassTask::_Sync(HdTaskContext* ctx)
     // Done at end, because the lighting context can be changed above.
     // Also we want the context in the shader as it's only a partial copy
     // of the context we own.
-    (*ctx)[HdxTokens->lightingShader]  = boost::dynamic_pointer_cast<HdStLightingShader>(_lightingShader);
+    (*ctx)[HdxTokens->lightingShader]  = std::dynamic_pointer_cast<HdStLightingShader>(_lightingShader);
     (*ctx)[HdxTokens->lightingContext] = _lightingShader->GetLightingContext();
 
 }

--- a/pxr/imaging/lib/hdx/simpleLightBypassTask.h
+++ b/pxr/imaging/lib/hdx/simpleLightBypassTask.h
@@ -30,8 +30,6 @@
 #include "pxr/imaging/hd/task.h"
 #include "pxr/imaging/glf/simpleLightingContext.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -48,7 +46,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdRenderIndex;
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
 
 
 class HdxSimpleLightBypassTask : public HdSceneTask {

--- a/pxr/imaging/lib/hdx/simpleLightTask.cpp
+++ b/pxr/imaging/lib/hdx/simpleLightTask.cpp
@@ -108,7 +108,7 @@ HdxSimpleLightTask::_Sync(HdTaskContext* ctx)
     // so later on other tasks can use this information 
     // draw shadows or other purposes
     (*ctx)[HdxTokens->lightingShader] =
-        boost::dynamic_pointer_cast<HdStLightingShader>(_lightingShader);
+        std::dynamic_pointer_cast<HdStLightingShader>(_lightingShader);
 
     _TaskDirtyState dirtyState;
     _GetTaskDirtyState(HdTokens->geometry, &dirtyState);

--- a/pxr/imaging/lib/hdx/simpleLightTask.h
+++ b/pxr/imaging/lib/hdx/simpleLightTask.h
@@ -39,17 +39,15 @@
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/tf/declarePtrs.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class HdRenderIndex;
 class HdSceneDelegate;
 
-typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
-typedef boost::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
-typedef boost::shared_ptr<class HdxShadowMatrixComputation> HdxShadowMatrixComputationSharedPtr;
+typedef std::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdxShadowMatrixComputation> HdxShadowMatrixComputationSharedPtr;
 
 TF_DECLARE_REF_PTRS(GlfSimpleShadowArray);
 

--- a/pxr/imaging/lib/hdx/simpleLightingShader.h
+++ b/pxr/imaging/lib/hdx/simpleLightingShader.h
@@ -41,14 +41,13 @@
 #include "pxr/base/tf/token.h"
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
+typedef std::shared_ptr<class HdxSimpleLightingShader> HdxSimpleLightingShaderSharedPtr;
 
 /// \class HdxSimpleLightingShader
 ///

--- a/pxr/imaging/lib/hdx/testenv/testHdxCameraAndLight.cpp
+++ b/pxr/imaging/lib/hdx/testenv/testHdxCameraAndLight.cpp
@@ -96,7 +96,7 @@ static void CameraAndLightTest()
         new HdSt_RenderPass(index.get(), collection));
     HdEngine engine;
 
-    HdTaskSharedPtr drawTask = boost::make_shared<Hd_TestTask>(renderPass,
+    HdTaskSharedPtr drawTask = std::make_shared<Hd_TestTask>(renderPass,
                                                                renderPassState);
     HdTaskSharedPtrVector tasks = { drawTask };
 

--- a/pxr/imaging/lib/pxOsd/meshTopology.h
+++ b/pxr/imaging/lib/pxOsd/meshTopology.h
@@ -35,13 +35,10 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class PxOsdMeshTopology> PxOsdMeshTopologySharedPtr;
+typedef std::shared_ptr<class PxOsdMeshTopology> PxOsdMeshTopologySharedPtr;
 
 /// \class PxOsdMeshTopology
 ///

--- a/pxr/imaging/lib/pxOsd/pch.h
+++ b/pxr/imaging/lib/pxOsd/pch.h
@@ -127,7 +127,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits/decay.hpp>
 #include <boost/type_traits/has_left_shift.hpp>
@@ -142,7 +141,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <opensubdiv/far/topologyRefiner.h>
 #include <opensubdiv/far/topologyRefinerFactory.h>
 #include <tbb/atomic.h>

--- a/pxr/imaging/lib/pxOsd/refinerFactory.h
+++ b/pxr/imaging/lib/pxOsd/refinerFactory.h
@@ -37,7 +37,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class OpenSubdiv::Far::TopologyRefiner> PxOsdTopologyRefinerSharedPtr;
+typedef std::shared_ptr<class OpenSubdiv::Far::TopologyRefiner> PxOsdTopologyRefinerSharedPtr;
 
 class PxOsdRefinerFactory {
 

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -141,7 +141,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits/decay.hpp>
@@ -159,7 +158,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
-#include <boost/weak_ptr.hpp>
 #include <embree2/rtcore.h>
 #include <embree2/rtcore_geometry.h>
 #include <embree2/rtcore_ray.h>

--- a/pxr/imaging/plugin/hdStream/pch.h
+++ b/pxr/imaging/plugin/hdStream/pch.h
@@ -106,7 +106,6 @@
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/tuple/to_seq.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_const.hpp>
 #include <boost/type_traits/is_convertible.hpp>
@@ -114,5 +113,4 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>

--- a/pxr/usd/lib/pcp/cache.cpp
+++ b/pxr/usd/lib/pcp/cache.cpp
@@ -67,7 +67,7 @@ using std::make_pair;
 using std::pair;
 using std::vector;
 
-using boost::dynamic_pointer_cast;
+using std::dynamic_pointer_cast;
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/usd/lib/pcp/namespaceEdits.cpp
+++ b/pxr/usd/lib/pcp/namespaceEdits.cpp
@@ -39,7 +39,7 @@ using std::make_pair;
 using std::pair;
 using std::vector;
 
-using boost::dynamic_pointer_cast;
+using std::dynamic_pointer_cast;
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/usd/lib/pcp/pch.h
+++ b/pxr/usd/lib/pcp/pch.h
@@ -186,7 +186,6 @@
 #endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/pcp/testenv/testPcpIterator.cpp
+++ b/pxr/usd/lib/pcp/testenv/testPcpIterator.cpp
@@ -223,17 +223,17 @@ _TestRandomAccessOperations(IteratorType first, IteratorType last)
     }
 }
 
-static boost::shared_ptr<PcpCache>
+static std::shared_ptr<PcpCache>
 _CreateCacheForRootLayer(const std::string& rootLayerPath)
 {
     SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(rootLayerPath);
     if (!rootLayer) {
-        return boost::shared_ptr<PcpCache>();
+        return std::shared_ptr<PcpCache>();
     }
 
     const PcpLayerStackIdentifier layerStackID(
         rootLayer, SdfLayerRefPtr(), ArResolverContext());
-    return boost::shared_ptr<PcpCache>(new PcpCache(layerStackID));
+    return std::shared_ptr<PcpCache>(new PcpCache(layerStackID));
 }
 
 int 
@@ -256,7 +256,7 @@ main(int argc, char** argv)
         const std::string layerPath(argv[1]);
         const SdfPath primPath(argv[2]);
 
-        boost::shared_ptr<PcpCache> cache = _CreateCacheForRootLayer(layerPath);
+        std::shared_ptr<PcpCache> cache = _CreateCacheForRootLayer(layerPath);
         if (!cache) {
             std::cerr << "Failed to load root layer " << layerPath << std::endl;
             return EXIT_FAILURE;
@@ -267,7 +267,7 @@ main(int argc, char** argv)
     }
 
     // Otherwise, run the normal test suite.
-    boost::shared_ptr<PcpCache> cache = _CreateCacheForRootLayer("root.sdf");
+    std::shared_ptr<PcpCache> cache = _CreateCacheForRootLayer("root.sdf");
     TF_AXIOM(cache);
 
     SdfPathSet includePayload;

--- a/pxr/usd/lib/pcp/testenv/testPcpPathTranslation_HardToReach.cpp
+++ b/pxr/usd/lib/pcp/testenv/testPcpPathTranslation_HardToReach.cpp
@@ -39,22 +39,21 @@
 #include <iostream>
 #include <string>
 #include <boost/assign/list_of.hpp>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-static boost::shared_ptr<PcpCache>
+static std::shared_ptr<PcpCache>
 _CreateCacheForRootLayer(const std::string& rootLayerPath)
 {
     SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(rootLayerPath);
 
     if (!rootLayer) {
-        return boost::shared_ptr<PcpCache>();
+        return std::shared_ptr<PcpCache>();
     }
 
     const PcpLayerStackIdentifier layerStackID(
         rootLayer, SdfLayerRefPtr(), ArResolverContext());
-    return boost::shared_ptr<PcpCache>(new PcpCache(layerStackID));
+    return std::shared_ptr<PcpCache>(new PcpCache(layerStackID));
 }
 
 static void
@@ -109,7 +108,7 @@ TestReverseTranslation_1()
     std::cout << "========== TestReverseTranslation_1..."  << std::endl;
 
     const std::string rootLayer = "TestReverseTranslation_1/1.sdf";
-    boost::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
+    std::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
     if (!pcpCache) {
         TF_FATAL_ERROR("Unable to open @%s@", rootLayer.c_str());
     }
@@ -216,7 +215,7 @@ TestReverseTranslation_2()
               << std::endl;
 
     const std::string rootLayer = "TestReverseTranslation_1/1.sdf";
-    boost::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
+    std::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
     if (!pcpCache) {
         TF_FATAL_ERROR("Unable to open @%s@", rootLayer.c_str());
     }
@@ -274,7 +273,7 @@ TestReverseTranslation_3()
     std::cout << "========== TestReverseTranslation_3..." << std::endl;
 
     const std::string rootLayer = "TestReverseTranslation_3/root.sdf";
-    boost::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
+    std::shared_ptr<PcpCache> pcpCache = _CreateCacheForRootLayer(rootLayer);
     if (!pcpCache) {
         TF_FATAL_ERROR("Unable to open @%s@", rootLayer.c_str());
     }

--- a/pxr/usd/lib/sdf/fileFormatRegistry.h
+++ b/pxr/usd/lib/sdf/fileFormatRegistry.h
@@ -34,7 +34,6 @@
 #include "pxr/base/tf/type.h"
 #include "pxr/base/tf/weakBase.h"
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <atomic>
 #include <mutex>
 #include <vector>
@@ -105,7 +104,7 @@ private:
         mutable SdfFileFormatRefPtr _format;
     };
 
-    typedef boost::shared_ptr<_Info> _InfoSharedPtr;
+    typedef std::shared_ptr<_Info> _InfoSharedPtr;
     typedef std::vector<_InfoSharedPtr> _InfoSharedPtrVector;
 
     // 1-to-1 mapping from file format Id -> file format info

--- a/pxr/usd/lib/sdf/layer.cpp
+++ b/pxr/usd/lib/sdf/layer.cpp
@@ -1700,7 +1700,7 @@ SdfLayer::ApplyRootPrimOrder( vector<TfToken>* vec ) const
 SdfSubLayerProxy
 SdfLayer::GetSubLayerPaths() const
 {
-    boost::shared_ptr<Sdf_ListEditor<SdfSubLayerTypePolicy> > editor(
+    std::shared_ptr<Sdf_ListEditor<SdfSubLayerTypePolicy> > editor(
         new Sdf_SubLayerListEditor(SdfCreateNonConstHandle(this)));
     
     return SdfSubLayerProxy(editor, SdfListOpTypeOrdered);

--- a/pxr/usd/lib/sdf/listEditorProxy.h
+++ b/pxr/usd/lib/sdf/listEditorProxy.h
@@ -34,7 +34,6 @@
 #include "pxr/base/vt/value.h"  // for Vt_DefaultValueFactory
 
 #include <boost/mpl/logical.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/optional.hpp>
 
@@ -78,7 +77,7 @@ public:
 
     /// Creates a new proxy object backed by the supplied list editor.
     explicit SdfListEditorProxy(
-        const boost::shared_ptr<Sdf_ListEditor<TypePolicy> >& listEditor)
+        const std::shared_ptr<Sdf_ListEditor<TypePolicy> >& listEditor)
         : _listEditor(listEditor)
     {
     }
@@ -381,7 +380,7 @@ public:
     }
 
 #if !defined(doxygen)
-    typedef boost::shared_ptr<Sdf_ListEditor<TypePolicy> >
+    typedef std::shared_ptr<Sdf_ListEditor<TypePolicy> >
         This::*UnspecifiedBoolType;
 #endif
 
@@ -473,7 +472,7 @@ private:
     }
 
 private:
-    boost::shared_ptr<Sdf_ListEditor<TypePolicy> > _listEditor;
+    std::shared_ptr<Sdf_ListEditor<TypePolicy> > _listEditor;
 
     friend class Sdf_ListEditorProxyAccess;
     template <class T> friend class SdfPyWrapListEditorProxy;

--- a/pxr/usd/lib/sdf/listProxy.h
+++ b/pxr/usd/lib/sdf/listProxy.h
@@ -211,7 +211,7 @@ public:
 
     /// Create a new proxy wrapping the list operation vector specified by
     /// \p op in the underlying \p listEditor.
-    SdfListProxy(const boost::shared_ptr<Sdf_ListEditor<TypePolicy> >& editor,
+    SdfListProxy(const std::shared_ptr<Sdf_ListEditor<TypePolicy> >& editor,
                 SdfListOpType op) :
         _listEditor(editor),
         _op(op)
@@ -425,7 +425,7 @@ public:
     }
 
 #if !defined(doxygen)
-    typedef boost::shared_ptr<Sdf_ListEditor<TypePolicy> >
+    typedef std::shared_ptr<Sdf_ListEditor<TypePolicy> >
         This::*UnspecifiedBoolType;
 #endif
 
@@ -604,7 +604,7 @@ private:
     }
 
 private:
-    boost::shared_ptr<Sdf_ListEditor<TypePolicy> > _listEditor;
+    std::shared_ptr<Sdf_ListEditor<TypePolicy> > _listEditor;
     SdfListOpType _op;
 
     template <class> friend class SdfPyWrapListProxy;

--- a/pxr/usd/lib/sdf/mapEditProxy.h
+++ b/pxr/usd/lib/sdf/mapEditProxy.h
@@ -635,7 +635,7 @@ public:
     }
 
 #if !defined(doxygen)
-    typedef boost::shared_ptr<Sdf_MapEditor<Type> > This::*UnspecifiedBoolType;
+    typedef std::shared_ptr<Sdf_MapEditor<Type> > This::*UnspecifiedBoolType;
 #endif
 
     /// Returns \c true in a boolean context if the value is valid,
@@ -926,7 +926,7 @@ private:
 private:
     template <class ProxyT> friend class SdfPyWrapMapEditProxy;
 
-    boost::shared_ptr<Sdf_MapEditor<T> > _editor;
+    std::shared_ptr<Sdf_MapEditor<T> > _editor;
 };
 
 // Cannot get from a VtValue except as the correct type.

--- a/pxr/usd/lib/sdf/mapEditor.cpp
+++ b/pxr/usd/lib/sdf/mapEditor.cpp
@@ -181,10 +181,10 @@ private:
 //
 
 template <class T>
-boost::shared_ptr<Sdf_MapEditor<T> > 
+std::shared_ptr<Sdf_MapEditor<T> > 
 Sdf_CreateMapEditor(const SdfSpecHandle& owner, const TfToken& field)
 {
-    return boost::shared_ptr<Sdf_MapEditor<T> >(
+    return std::shared_ptr<Sdf_MapEditor<T> >(
         new Sdf_LsdMapEditor<T>(owner, field));
 }
 
@@ -195,7 +195,7 @@ Sdf_CreateMapEditor(const SdfSpecHandle& owner, const TfToken& field)
 #define SDF_INSTANTIATE_MAP_EDITOR(MapType)                          \
     template class Sdf_MapEditor<MapType>;                           \
     template class Sdf_LsdMapEditor<MapType>;                        \
-    template boost::shared_ptr<Sdf_MapEditor<MapType> >              \
+    template std::shared_ptr<Sdf_MapEditor<MapType> >              \
         Sdf_CreateMapEditor(const SdfSpecHandle&, const TfToken&);   \
 
 #include "pxr/base/vt/dictionary.h"

--- a/pxr/usd/lib/sdf/mapEditor.h
+++ b/pxr/usd/lib/sdf/mapEditor.h
@@ -29,7 +29,6 @@
 #include "pxr/usd/sdf/spec.h"
 
 #include <boost/noncopyable.hpp>
-#include <boost/shared_ptr.hpp>
 #include <string>
 #include <utility>
 
@@ -89,7 +88,7 @@ protected:
 };
 
 template <class T>
-boost::shared_ptr<Sdf_MapEditor<T> > 
+std::shared_ptr<Sdf_MapEditor<T> > 
 Sdf_CreateMapEditor(const SdfSpecHandle& owner, const TfToken& field);
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/lib/sdf/pch.h
+++ b/pxr/usd/lib/sdf/pch.h
@@ -218,7 +218,6 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/regex.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/sdf/primSpec.cpp
+++ b/pxr/usd/lib/sdf/primSpec.cpp
@@ -291,10 +291,10 @@ SdfPrimSpec::RemoveNameChild(const SdfPrimSpecHandle& child)
             GetLayer(), GetPath(), child->GetNameToken());
 }
 
-boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
 SdfPrimSpec::_GetNameChildrenOrderEditor() const
 {
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor( 
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor( 
             new Sdf_VectorListEditor<SdfNameTokenKeyPolicy>( 
                 SdfCreateHandle(this),
                 SdfFieldKeys->PrimOrder, SdfListOpTypeOrdered));
@@ -412,10 +412,10 @@ SdfPrimSpec::GetRelationships() const
         GetLayer(), GetPath(), SdfChildrenKeys->PropertyChildren);
 }
 
-boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
 SdfPrimSpec::_GetPropertyOrderEditor() const
 {
-    return boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >( 
+    return std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >( 
             new Sdf_VectorListEditor<SdfNameTokenKeyPolicy>( 
                 SdfCreateHandle(this),
                 SdfFieldKeys->PropertyOrder, SdfListOpTypeOrdered));
@@ -678,7 +678,7 @@ SdfPrimSpec::ClearReferenceList()
 SdfVariantSetNamesProxy
 SdfPrimSpec::GetVariantSetNameList() const
 {
-    boost::shared_ptr<Sdf_ListEditor<SdfNameKeyPolicy> > editor( 
+    std::shared_ptr<Sdf_ListEditor<SdfNameKeyPolicy> > editor( 
             new Sdf_ListOpListEditor<SdfNameKeyPolicy>( 
                 SdfCreateHandle(this), SdfFieldKeys->VariantSetNames));
     return SdfVariantSetNamesProxy(editor);

--- a/pxr/usd/lib/sdf/primSpec.h
+++ b/pxr/usd/lib/sdf/primSpec.h
@@ -744,11 +744,11 @@ private:
     bool _ValidateEdit(const TfToken& key) const;
 
     // Returns a list editor object for name children order list edits.
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
     _GetNameChildrenOrderEditor() const;
 
     // Returns a list editor object for property order list edits.
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
     _GetPropertyOrderEditor() const;
 
 private:

--- a/pxr/usd/lib/sdf/proxyTypes.cpp
+++ b/pxr/usd/lib/sdf/proxyTypes.cpp
@@ -32,8 +32,6 @@
 
 #include "pxr/base/tf/registryManager.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_REGISTRY_FUNCTION(TfType)
@@ -59,19 +57,19 @@ template <>
 struct Sdf_ListEditorProxyTraits<SdfPathEditorProxy> {
     typedef SdfPathEditorProxy::TypePolicy TypePolicy;
 
-    static boost::shared_ptr<Sdf_ListEditor<TypePolicy> > GetListEditor(
+    static std::shared_ptr<Sdf_ListEditor<TypePolicy> > GetListEditor(
         const SdfSpecHandle& o, const TfToken& n)
     {
         if (n == SdfFieldKeys->TargetPaths) {
-            return boost::shared_ptr<Sdf_ListEditor<TypePolicy> >(
+            return std::shared_ptr<Sdf_ListEditor<TypePolicy> >(
                 new Sdf_RelationshipTargetListEditor(o, TypePolicy(o)));
         }
         else if (n == SdfFieldKeys->ConnectionPaths) {
-            return boost::shared_ptr<Sdf_ListEditor<TypePolicy> >(
+            return std::shared_ptr<Sdf_ListEditor<TypePolicy> >(
                 new Sdf_AttributeConnectionListEditor(o, TypePolicy(o)));
         }
 
-        return boost::shared_ptr<Sdf_ListEditor<TypePolicy> >(
+        return std::shared_ptr<Sdf_ListEditor<TypePolicy> >(
             new Sdf_ListOpListEditor<TypePolicy>(o, n, TypePolicy(o)));
     }
 };
@@ -80,10 +78,10 @@ template <>
 struct Sdf_ListEditorProxyTraits<SdfReferenceEditorProxy> {
     typedef SdfReferenceEditorProxy::TypePolicy TypePolicy;
 
-    static boost::shared_ptr<Sdf_ListEditor<TypePolicy> > GetListEditor(
+    static std::shared_ptr<Sdf_ListEditor<TypePolicy> > GetListEditor(
         const SdfSpecHandle& o, const TfToken& n)
     {
-        return boost::shared_ptr<Sdf_ListEditor<TypePolicy> >(
+        return std::shared_ptr<Sdf_ListEditor<TypePolicy> >(
             new Sdf_ListOpListEditor<SdfReferenceTypePolicy>(o, n));
     }
 };

--- a/pxr/usd/lib/sdf/relationshipSpec.cpp
+++ b/pxr/usd/lib/sdf/relationshipSpec.cpp
@@ -457,10 +457,10 @@ SdfRelationshipSpec::GetTargetPathForAttribute(
 // Relational Attribute Ordering
 //
 
-boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
 SdfRelationshipSpec::_GetTargetAttributeOrderEditor(const SdfPath& path) const
 {
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor;
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor;
     SdfSpecHandle relTargetSpec = _GetTargetSpec(path);
     if (relTargetSpec) {
         editor.reset(new Sdf_VectorListEditor<SdfNameTokenKeyPolicy>(
@@ -563,7 +563,7 @@ SdfRelationshipSpec::ApplyAttributeOrderForTargetPath(
     const SdfPath& path,
     std::vector<TfToken>* vec) const
 {
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor = 
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> > editor = 
         _GetTargetAttributeOrderEditor(path);
     if (editor) {
         editor->ApplyEdits(vec);

--- a/pxr/usd/lib/sdf/relationshipSpec.h
+++ b/pxr/usd/lib/sdf/relationshipSpec.h
@@ -247,7 +247,7 @@ private:
 
     SdfSpecHandle _FindOrCreateTargetSpec(const SdfPath& path);
 
-    boost::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
+    std::shared_ptr<Sdf_ListEditor<SdfNameTokenKeyPolicy> >
     _GetTargetAttributeOrderEditor(const SdfPath& path) const;
 
     SdfSpecHandle _FindOrCreateChildSpecForMarker(const SdfPath& key);

--- a/pxr/usd/lib/sdf/types.h
+++ b/pxr/usd/lib/sdf/types.h
@@ -79,7 +79,6 @@
 #include <boost/preprocessor/seq/size.hpp>
 #include <boost/preprocessor/stringize.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
-#include <boost/shared_ptr.hpp>
 #include <iosfwd>
 #include <list>
 #include <map>

--- a/pxr/usd/lib/usd/pch.h
+++ b/pxr/usd/lib/usd/pch.h
@@ -209,7 +209,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdGeom/pch.h
+++ b/pxr/usd/lib/usdGeom/pch.h
@@ -176,7 +176,6 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdHydra/pch.h
+++ b/pxr/usd/lib/usdHydra/pch.h
@@ -166,7 +166,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdLux/pch.h
+++ b/pxr/usd/lib/usdLux/pch.h
@@ -173,7 +173,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdRi/pch.h
+++ b/pxr/usd/lib/usdRi/pch.h
@@ -170,7 +170,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdShade/pch.h
+++ b/pxr/usd/lib/usdShade/pch.h
@@ -172,7 +172,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdSkel/pch.h
+++ b/pxr/usd/lib/usdSkel/pch.h
@@ -167,7 +167,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdUI/pch.h
+++ b/pxr/usd/lib/usdUI/pch.h
@@ -166,7 +166,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/lib/usdUtils/pch.h
+++ b/pxr/usd/lib/usdUtils/pch.h
@@ -198,7 +198,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/pxr/usd/plugin/usdAbc/alembicData.h
+++ b/pxr/usd/plugin/usdAbc/alembicData.h
@@ -27,7 +27,6 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/data.h"
 #include "pxr/base/tf/declarePtrs.h"
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -113,7 +112,7 @@ protected:
     virtual void _VisitSpecs(SdfAbstractDataSpecVisitor* visitor) const;
 
 private:
-    boost::shared_ptr<class UsdAbc_AlembicDataReader> _reader;
+    std::shared_ptr<class UsdAbc_AlembicDataReader> _reader;
 };
 
 

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -42,7 +42,6 @@
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/shared_array.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/type_traits/remove_reference.hpp>
@@ -352,7 +351,7 @@ public:
 #endif
 
     typedef std::vector<uint32_t> IndexArray;
-    typedef boost::shared_ptr<IndexArray> IndexArrayPtr;
+    typedef std::shared_ptr<IndexArray> IndexArrayPtr;
 
     class Error {
     public:
@@ -409,7 +408,7 @@ public:
 
     /// A sample using raw data from a shared pointer to a T.
     template <class T>
-    _SampleForAlembic(const boost::shared_ptr<T>& value) :
+    _SampleForAlembic(const std::shared_ptr<T>& value) :
         _numSamples(1),
         _value(_HolderValue(new _ScalarHolder<T>(value)))
     {
@@ -532,7 +531,7 @@ private:
         virtual const void* Get() const { return _ptr; }
 
     private:
-        boost::shared_ptr<VtValue> _value;
+        std::shared_ptr<VtValue> _value;
         const void* _ptr;
     };
 
@@ -540,12 +539,12 @@ private:
     template <class T>
     class _ScalarHolder : public _Holder {
     public:
-        _ScalarHolder(const boost::shared_ptr<T>& ptr) : _ptr(ptr) { }
+        _ScalarHolder(const std::shared_ptr<T>& ptr) : _ptr(ptr) { }
         virtual ~_ScalarHolder() { }
         virtual const void* Get() const { return _ptr.get(); }
 
     private:
-        boost::shared_ptr<T> _ptr;
+        std::shared_ptr<T> _ptr;
     };
 
     // Hold a shared_array.
@@ -569,7 +568,7 @@ private:
         bool IsError(std::string* msg) const { return _holder->Error(msg); }
 
     private:
-        boost::shared_ptr<_Holder> _holder;
+        std::shared_ptr<_Holder> _holder;
     };
 
     template <class T>
@@ -605,7 +604,7 @@ template <class UsdType, class AlembicType>
 struct _SampleForAlembicConstructConverter {
     _SampleForAlembic operator()(const VtValue& value) const
     {
-        return _SampleForAlembic(boost::shared_ptr<AlembicType>(
+        return _SampleForAlembic(std::shared_ptr<AlembicType>(
             new AlembicType(value.UncheckedGet<UsdType>())));
     }
 };

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -164,8 +164,8 @@ private:
     SdfPath _path;
     TfToken _name;
     const SdfAbstractData* _data;
-    boost::shared_ptr<VtValue> _value;
-    boost::shared_ptr<SdfTimeSampleMap> _local;
+    std::shared_ptr<VtValue> _value;
+    std::shared_ptr<SdfTimeSampleMap> _local;
     const SdfTimeSampleMap* _samples;
     bool _timeSampled;
     SdfValueTypeName _typeName;

--- a/pxr/usd/plugin/usdAbc/pch.h
+++ b/pxr/usd/plugin/usdAbc/pch.h
@@ -201,7 +201,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/decay.hpp>

--- a/pxr/usdImaging/lib/usdImaging/adapterRegistry.h
+++ b/pxr/usdImaging/lib/usdImaging/adapterRegistry.h
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -38,7 +37,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class TfType;
 class UsdImagingPrimAdapter;
-typedef boost::shared_ptr<UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
+typedef std::shared_ptr<UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
 
 #define USD_IMAGING_ADAPTER_KEY_TOKENS          \
     ((instanceAdapterKey, "__instanceAdapter")) \

--- a/pxr/usdImaging/lib/usdImaging/delegate.h
+++ b/pxr/usdImaging/lib/usdImaging/delegate.h
@@ -69,7 +69,7 @@ class UsdImagingIndexProxy;
 class UsdImagingInstancerContext;
 
 typedef boost::container::flat_map<SdfPath, bool> PickabilityMap;
-typedef boost::shared_ptr<UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
+typedef std::shared_ptr<UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
 
 /// \class UsdImagingDelegate
 ///
@@ -527,7 +527,7 @@ private:
     // ---------------------------------------------------------------------- //
 
     // Usd Prim Type to Adapter lookup table.
-    typedef boost::shared_ptr<UsdImagingPrimAdapter> _AdapterSharedPtr;
+    typedef std::shared_ptr<UsdImagingPrimAdapter> _AdapterSharedPtr;
     typedef TfHashMap<TfToken, 
                          _AdapterSharedPtr, TfToken::HashFunctor> _AdapterMap;
     _AdapterMap _adapterMap;

--- a/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
@@ -1209,7 +1209,7 @@ UsdImagingInstanceAdapter::_GetProtoRprim(SdfPath const& instancerPath,
 UsdImagingPrimAdapterSharedPtr
 UsdImagingInstanceAdapter::_GetSharedFromThis()
 {
-    boost::shared_ptr<class UsdImagingPrimAdapter> a = shared_from_this();
+    std::shared_ptr<class UsdImagingPrimAdapter> a = shared_from_this();
     return a;
 }
 

--- a/pxr/usdImaging/lib/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/instanceAdapter.h
@@ -30,8 +30,6 @@
 #include "pxr/base/tf/hashmap.h"
 
 #include <boost/unordered_map.hpp> 
-#include <boost/shared_ptr.hpp> 
-#include <boost/enable_shared_from_this.hpp> 
 
 #include <mutex>
 
@@ -296,7 +294,7 @@ private:
         // draw call (though this is a detail of the renderer implementation).
         VtIntArray indices;
     };
-    typedef boost::shared_ptr<_ProtoGroup> _ProtoGroupPtr;
+    typedef std::shared_ptr<_ProtoGroup> _ProtoGroupPtr;
 
     // A proto rprim represents a single rprim under a prototype root declared
     // on the instancer. For example, a character may be targeted by the

--- a/pxr/usdImaging/lib/usdImaging/instancerContext.h
+++ b/pxr/usdImaging/lib/usdImaging/instancerContext.h
@@ -28,12 +28,10 @@
 #include "pxr/usdImaging/usdImaging/api.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<class UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
+typedef std::shared_ptr<class UsdImagingPrimAdapter> UsdImagingPrimAdapterSharedPtr;
 
 /// \class UsdImagingInstancerContext
 ///

--- a/pxr/usdImaging/lib/usdImaging/pch.h
+++ b/pxr/usdImaging/lib/usdImaging/pch.h
@@ -88,7 +88,6 @@
 #include <boost/compressed_pair.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/vector.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/functional/hash_fwd.hpp>
@@ -161,7 +160,6 @@
 #include <boost/range/iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
@@ -186,7 +184,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
 #include <boost/variant.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.h
@@ -31,7 +31,6 @@
 
 #include <mutex>
 #include <boost/unordered_map.hpp> 
-#include <boost/shared_ptr.hpp> 
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -273,7 +272,7 @@ private:
         // gprim and not actually a prototype from Hydra's perspective.
         SdfPath protoRootPath;
     };
-    typedef boost::shared_ptr<_Prototype> _PrototypeSharedPtr;
+    typedef std::shared_ptr<_Prototype> _PrototypeSharedPtr;
 
     // A proto rprim represents a single rprim under a prototype root declared
     // on the instancer. For example, a character may be targeted by the

--- a/pxr/usdImaging/lib/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/primAdapter.h
@@ -39,9 +39,6 @@
 
 #include "pxr/base/tf/type.h"
 
-#include <boost/enable_shared_from_this.hpp> 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class UsdPrim;
@@ -51,7 +48,7 @@ class UsdImagingDelegate;
 class UsdImagingIndexProxy;
 class UsdImagingInstancerContext;
 
-typedef boost::shared_ptr<class UsdImagingPrimAdapter> 
+typedef std::shared_ptr<class UsdImagingPrimAdapter> 
                                                 UsdImagingPrimAdapterSharedPtr;
 
 /// \class UsdImagingPrimAdapter
@@ -59,7 +56,7 @@ typedef boost::shared_ptr<class UsdImagingPrimAdapter>
 /// Base class for all PrimAdapters.
 ///
 class UsdImagingPrimAdapter 
-            : public boost::enable_shared_from_this<UsdImagingPrimAdapter> {
+            : public std::enable_shared_from_this<UsdImagingPrimAdapter> {
 public:
     
     // ---------------------------------------------------------------------- //

--- a/pxr/usdImaging/lib/usdImaging/unitTestHelper.cpp
+++ b/pxr/usdImaging/lib/usdImaging/unitTestHelper.cpp
@@ -147,7 +147,7 @@ void
 UsdImaging_TestDriver::Draw()
 {
     HdTaskSharedPtrVector tasks = {
-        boost::make_shared<UsdImaging_DrawTask>(_geometryPass, _renderPassState)
+        std::make_shared<UsdImaging_DrawTask>(_geometryPass, _renderPassState)
     };
     _engine.Execute(_delegate->GetRenderIndex(), tasks);
 }

--- a/pxr/usdImaging/lib/usdImaging/unitTestHelper.h
+++ b/pxr/usdImaging/lib/usdImaging/unitTestHelper.h
@@ -36,12 +36,11 @@
 #include "pxr/imaging/hdSt/renderDelegate.h"
 
 #include <string>
-#include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-typedef boost::shared_ptr<HdRenderPass> HdRenderPassSharedPtr;
+typedef std::shared_ptr<HdRenderPass> HdRenderPassSharedPtr;
 
 /// \class UsdImaging_TestDriver
 ///

--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -53,7 +53,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class UsdPrim;
 
-typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
+typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfDrawTarget);
 TF_DECLARE_WEAK_PTRS(GlfSimpleLightingContext);
 

--- a/pxr/usdImaging/lib/usdImagingGL/gl.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/gl.cpp
@@ -151,7 +151,7 @@ UsdImagingGL::PrepareBatch(
     hdEngines.reserve(renderers.size());
     TF_FOR_ALL(it, renderers) {
         hdEngines.push_back(
-            boost::dynamic_pointer_cast<UsdImagingGLHdEngine>(
+            std::dynamic_pointer_cast<UsdImagingGLHdEngine>(
                 (*it)->_engine));
     }
 

--- a/pxr/usdImaging/lib/usdImagingGL/gl.h
+++ b/pxr/usdImaging/lib/usdImagingGL/gl.h
@@ -31,8 +31,6 @@
 #include "pxr/usdImaging/usdImagingGL/api.h"
 #include "pxr/usdImaging/usdImagingGL/engine.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -41,8 +39,8 @@ class SdfPath;
 typedef std::vector<SdfPath> SdfPathVector;
 typedef std::vector<UsdPrim> UsdPrimVector;
 
-typedef boost::shared_ptr<class UsdImagingGLEngine> UsdImagingGLEngineSharedPtr;
-typedef boost::shared_ptr<class UsdImagingGL> UsdImagingGLSharedPtr;
+typedef std::shared_ptr<class UsdImagingGLEngine> UsdImagingGLEngineSharedPtr;
+typedef std::shared_ptr<class UsdImagingGL> UsdImagingGLSharedPtr;
 typedef std::vector<UsdImagingGLSharedPtr> UsdImagingGLSharedPtrVector;
 
 /// \class UsdImagingGL

--- a/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
@@ -42,15 +42,13 @@
 
 #include "pxr/base/tf/declarePtrs.h"
 
-#include <boost/shared_ptr.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfSimpleLightingContext);
 
 class HdRenderIndex;
-typedef boost::shared_ptr<class UsdImagingGLHdEngine> 
+typedef std::shared_ptr<class UsdImagingGLHdEngine> 
                                         UsdImagingGLHdEngineSharedPtr;
 typedef std::vector<UsdImagingGLHdEngineSharedPtr> 
                                         UsdImagingGLHdEngineSharedPtrVector;

--- a/pxr/usdImaging/lib/usdImagingGL/pch.h
+++ b/pxr/usdImaging/lib/usdImagingGL/pch.h
@@ -91,7 +91,6 @@
 #include <boost/compressed_pair.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/container/vector.hpp>
-#include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/functional/hash_fwd.hpp>
@@ -177,7 +176,6 @@
 #include <boost/range/iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
@@ -203,7 +201,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/value_init.hpp>
 #include <boost/variant.hpp>
-#include <boost/weak_ptr.hpp>
 #include <tbb/atomic.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usdImaging/lib/usdImagingGL/testenv/testUsdImagingGLBasicDrawing.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/testenv/testUsdImagingGLBasicDrawing.cpp
@@ -52,15 +52,13 @@
 #include "pxr/usdImaging/usdImagingGL/hdEngine.h"
 #include "pxr/usdImaging/usdImagingGL/refEngine.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-typedef boost::shared_ptr<class UsdImagingGLEngine> UsdImagingGLEngineSharedPtr;
+typedef std::shared_ptr<class UsdImagingGLEngine> UsdImagingGLEngineSharedPtr;
 
 class My_TestGLDrawing : public UsdImagingGL_UnitTestGLDrawing {
 public:

--- a/pxr/usdImaging/lib/usdviewq/pch.h
+++ b/pxr/usdImaging/lib/usdviewq/pch.h
@@ -163,7 +163,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <boost/type_traits.hpp>
 #include <boost/type_traits/add_reference.hpp>

--- a/third_party/katana/lib/usdKatana/cache.h
+++ b/third_party/katana/lib/usdKatana/cache.h
@@ -29,8 +29,6 @@
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/base/tf/singleton.h"
 
-#include <boost/shared_ptr.hpp>
-
 #include <map>
 #include <string>
 
@@ -42,7 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // Forward declare pointers.
 SDF_DECLARE_HANDLES(SdfLayer);
 typedef TfRefPtr<class UsdStage> UsdStageRefPtr;
-typedef boost::shared_ptr<class UsdImagingGL> UsdImagingGLSharedPtr;
+typedef std::shared_ptr<class UsdImagingGL> UsdImagingGLSharedPtr;
 class SdfPath;
 class UsdPrim;
 

--- a/third_party/katana/plugin/vmp_usd/usdVMP.h
+++ b/third_party/katana/plugin/vmp_usd/usdVMP.h
@@ -31,8 +31,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 
-#include <boost/shared_ptr.hpp>
-
 #include "pxr/pxr.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/hash.h"
@@ -55,7 +53,7 @@ FnLogSetup("USDVMP")
 namespace FnKat = Foundry::Katana;
 
 
-typedef boost::shared_ptr<PXR_NS::UsdImagingGL> UsdImagingGLSharedPtr;
+typedef std::shared_ptr<PXR_NS::UsdImagingGL> UsdImagingGLSharedPtr;
 
 //--------------------------------------------------------------------------------
 // USDVMP

--- a/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
+++ b/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
@@ -69,8 +69,7 @@ TF_DEBUG_CODES(
     PXRUSDMAYAGL_QUEUE_INFO
 );
 
-
-typedef boost::shared_ptr<class HdxIntersector> HdxIntersectorSharedPtr;
+typedef std::shared_ptr<class HdxIntersector> HdxIntersectorSharedPtr;
 
 
 /// \brief This is an helper object that shapes can hold to get consistent usd

--- a/third_party/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/third_party/maya/lib/usdMaya/referenceAssembly.cpp
@@ -301,16 +301,16 @@ UsdMayaReferenceAssembly::UsdMayaReferenceAssembly(
     //           if adding a new Representation
     //
     _representations[std::string(UsdMayaRepresentationCollapsed::_assemblyType.asChar())] = 
-        boost::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationCollapsed(this, UsdMayaRepresentationCollapsed::_assemblyType) );
+        std::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationCollapsed(this, UsdMayaRepresentationCollapsed::_assemblyType) );
 
     _representations[std::string(UsdMayaRepresentationPlayback::_assemblyType.asChar())] = 
-        boost::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationPlayback(this, UsdMayaRepresentationPlayback::_assemblyType) );
+        std::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationPlayback(this, UsdMayaRepresentationPlayback::_assemblyType) );
 
     _representations[std::string(UsdMayaRepresentationExpanded::_assemblyType.asChar())] = 
-        boost::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationExpanded(this, UsdMayaRepresentationExpanded::_assemblyType) );
+        std::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationExpanded(this, UsdMayaRepresentationExpanded::_assemblyType) );
 
     _representations[std::string(UsdMayaRepresentationFull::_assemblyType.asChar())] = 
-        boost::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationFull(this, UsdMayaRepresentationFull::_assemblyType) );
+        std::shared_ptr<MPxRepresentation>( new UsdMayaRepresentationFull(this, UsdMayaRepresentationFull::_assemblyType) );
 }
 
 
@@ -346,7 +346,7 @@ MString UsdMayaReferenceAssembly::getActive() const
 MStringArray UsdMayaReferenceAssembly::getRepresentations(MStatus* status) const
 {
     MStringArray repTypes;
-    std::map<std::string, boost::shared_ptr<MPxRepresentation> >::const_iterator it;
+    std::map<std::string, std::shared_ptr<MPxRepresentation> >::const_iterator it;
     for (it=_representations.begin(); it != _representations.end(); ++it) {
         repTypes.append(MString(it->first.c_str()));
     }
@@ -356,7 +356,7 @@ MStringArray UsdMayaReferenceAssembly::getRepresentations(MStatus* status) const
 MString UsdMayaReferenceAssembly::getRepType(const MString& rep) const
 {
     std::string tmpRep(rep.asChar());
-    std::map<std::string, boost::shared_ptr<MPxRepresentation> >::const_iterator repIt;
+    std::map<std::string, std::shared_ptr<MPxRepresentation> >::const_iterator repIt;
     repIt = _representations.find(tmpRep);
     if (repIt != _representations.end()) {
         return repIt->second->getType();
@@ -374,7 +374,7 @@ MString UsdMayaReferenceAssembly::getRepLabel(const MString& rep) const
 MStringArray UsdMayaReferenceAssembly::repTypes() const 
 {
     MStringArray repTypes;
-    std::map<std::string, boost::shared_ptr<MPxRepresentation> >::const_iterator it;
+    std::map<std::string, std::shared_ptr<MPxRepresentation> >::const_iterator it;
     for (it=_representations.begin(); it != _representations.end(); ++it) {
         repTypes.append(MString(it->first.c_str()));
     }
@@ -412,7 +412,7 @@ bool UsdMayaReferenceAssembly::activateRep(const MString& repMStr)
     }
     std::string rep(std::string(repMStr.asChar()));
 
-    std::map<std::string, boost::shared_ptr<MPxRepresentation> >::const_iterator repIt;
+    std::map<std::string, std::shared_ptr<MPxRepresentation> >::const_iterator repIt;
     repIt = _representations.find(rep);
     if (repIt == _representations.end()) {
         return false;

--- a/third_party/maya/lib/usdMaya/referenceAssembly.h
+++ b/third_party/maya/lib/usdMaya/referenceAssembly.h
@@ -43,8 +43,6 @@
 #include <maya/MString.h>
 #include <maya/MTypeId.h>
 
-#include <boost/shared_ptr.hpp>
-
 #include <map>
 #include <string>
 #include <vector>
@@ -268,9 +266,9 @@ public:
     // was edited directly (in which case _updatingRepNamespace == false).
     bool _updatingRepNamespace;
 
-    std::map<std::string, boost::shared_ptr<MPxRepresentation> > _representations;
+    std::map<std::string, std::shared_ptr<MPxRepresentation> > _representations;
     bool _activateRepOnFileLoad; 
-    boost::shared_ptr<MPxRepresentation> _activeRep;
+    std::shared_ptr<MPxRepresentation> _activeRep;
     bool _inSetInternalValue;
     bool _hasEdits;
 };


### PR DESCRIPTION
This converts from using `boost::shared_ptr` and friends
(like `weak_ptr`) over to using the `std` equivalents.

Fixes issue #170.
