### PR TITLE
[UsdImaging] Remove unnecessary boost::noncopyable

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/pch.h
+++ b/pxr/usdImaging/lib/usdImaging/pch.h
@@ -112,7 +112,6 @@
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/transform_view.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>

--- a/pxr/usdImaging/lib/usdImaging/valueCache.h
+++ b/pxr/usdImaging/lib/usdImaging/valueCache.h
@@ -38,8 +38,6 @@
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
-
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_queue.h>
 
@@ -51,8 +49,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// A heterogeneous value container without type erasure.
 ///
-class UsdImagingValueCache : boost::noncopyable {
+class UsdImagingValueCache {
 public:
+    UsdImagingValueCache(const UsdImagingValueCache&) = delete;
+    UsdImagingValueCache& operator=(const UsdImagingValueCache&) = delete;
+
     typedef PxOsdSubdivTags SubdivTags;
 
     struct PrimvarInfo {

--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -45,7 +45,6 @@
 #include "pxr/base/gf/vec4i.h"
 #include "pxr/base/vt/dictionary.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/unordered_map.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -61,8 +60,15 @@ TF_DECLARE_WEAK_PTRS(GlfSimpleLightingContext);
 ///
 /// Interface class for render engines.
 ///
-class UsdImagingGLEngine : private boost::noncopyable {
+class UsdImagingGLEngine {
 public:
+    USDIMAGINGGL_API
+    UsdImagingGLEngine() = default;
+
+    // Disallow copies
+    UsdImagingGLEngine(const UsdImagingGLEngine&) = delete;
+    UsdImagingGLEngine& operator=(const UsdImagingGLEngine&) = delete;
+
     USDIMAGINGGL_API
     virtual ~UsdImagingGLEngine();
 

--- a/pxr/usdImaging/lib/usdviewq/pch.h
+++ b/pxr/usdImaging/lib/usdviewq/pch.h
@@ -110,7 +110,6 @@
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/transform_view.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>


### PR DESCRIPTION
### Description of Change(s)
Remove use of boost noncopyable.

### Fixes Issue(s)
Reduces dependency on boost.

