### PR TITLE
[Imaging] Remove unnecessary boost::noncopyable

### DIFF
--- a/pxr/imaging/lib/cameraUtil/pch.h
+++ b/pxr/imaging/lib/cameraUtil/pch.h
@@ -81,7 +81,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor/arithmetic/add.hpp>

--- a/pxr/imaging/lib/glf/baseTextureData.h
+++ b/pxr/imaging/lib/glf/baseTextureData.h
@@ -33,20 +33,24 @@
 #include "pxr/base/tf/refPtr.h"
 #include "pxr/base/tf/weakPtr.h"
 
-#include <boost/noncopyable.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 TF_DECLARE_WEAK_AND_REF_PTRS(GlfBaseTextureData);
 
 class GlfBaseTextureData : public TfRefBase,
-                           public TfWeakBase,
-                           boost::noncopyable
+                           public TfWeakBase
 {
 public:
     GLF_API
     virtual ~GlfBaseTextureData();
+
+    GLF_API
+    GlfBaseTextureData() = default;
+
+    // Disallow copies
+    GlfBaseTextureData(const GlfBaseTextureData&) = delete;
+    GlfBaseTextureData& operator=(const GlfBaseTextureData&) = delete;
 
     struct WrapInfo {
         WrapInfo() :

--- a/pxr/imaging/lib/glf/contextCaps.h
+++ b/pxr/imaging/lib/glf/contextCaps.h
@@ -28,8 +28,6 @@
 #include "pxr/imaging/glf/api.h"
 #include "pxr/base/tf/singleton.h"
 
-#include <boost/noncopyable.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -51,11 +49,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///     subscribe to when the caps changes, so they can
 ///     update and invalidate.
 ///
-class GlfContextCaps : boost::noncopyable {
+class GlfContextCaps {
 public:
 
     GLF_API
     static GlfContextCaps &GetInstance();
+
+    // Disallow copies
+    GlfContextCaps(const GlfContextCaps&) = delete;
+    GlfContextCaps& operator=(const GlfContextCaps&) = delete;
 
     // GL version
     int glVersion;                    // 400 (4.0), 410 (4.1), ...

--- a/pxr/imaging/lib/glf/glContext.h
+++ b/pxr/imaging/lib/glf/glContext.h
@@ -27,7 +27,6 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/glf/api.h"
 #include "pxr/base/arch/threads.h"
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -49,10 +48,14 @@ typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 /// This mechanism depends on the application code registering callbacks to
 /// provide access to its GL contexts.
 ///
-class GlfGLContext : public boost::noncopyable {
+class GlfGLContext {
 public:
     GLF_API
     virtual ~GlfGLContext();
+
+    // Disallow copies
+    GlfGLContext(const GlfGLContext&) = delete;
+    GlfGLContext& operator=(const GlfGLContext&) = delete;
 
     /// Returns an instance for the current GL context.
     GLF_API
@@ -162,12 +165,16 @@ protected:
 /// The underlying calls to make GL contexts current can be moderately
 /// expensive.  So, this mechanism should be used carefully.
 ///
-class GlfGLContextScopeHolder : boost::noncopyable {
+class GlfGLContextScopeHolder {
 public:
     /// Make the given context current and restore the current context
     /// when this object is destroyed.
     GLF_API
     explicit GlfGLContextScopeHolder(const GlfGLContextSharedPtr& newContext);
+
+    // Disallow copies
+    GlfGLContextScopeHolder(const GlfGLContextScopeHolder&) = delete;
+    GlfGLContextScopeHolder& operator=(const GlfGLContextScopeHolder&) = delete;
 
     GLF_API
     ~GlfGLContextScopeHolder();
@@ -249,10 +256,16 @@ private:
 /// If you subclass GlfGLContext you should subclass this type and
 /// instantiate an instance on the heap.  It will be cleaned up
 /// automatically.
-class GlfGLContextRegistrationInterface : boost::noncopyable {
+class GlfGLContextRegistrationInterface {
 public:
     GLF_API
     virtual ~GlfGLContextRegistrationInterface();
+
+    // Disallow copies
+    GlfGLContextRegistrationInterface(
+        const GlfGLContextRegistrationInterface&) = delete;
+    GlfGLContextRegistrationInterface& operator=(
+        const GlfGLContextRegistrationInterface&) = delete;
 
     /// If this GLContext system supports a shared context this should
     /// return it.  This will be called at most once.

--- a/pxr/imaging/lib/glf/glContextRegistry.h
+++ b/pxr/imaging/lib/glf/glContextRegistry.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/glf/glContext.h"
 #include "pxr/base/tf/singleton.h"
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -46,8 +45,12 @@ typedef boost::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 ///
 /// Registry of GlfGLContexts.
 ///
-class GlfGLContextRegistry : boost::noncopyable {
+class GlfGLContextRegistry {
 public:
+    // Disallow copies
+    GlfGLContextRegistry(const GlfGLContextRegistry&) = delete;
+    GlfGLContextRegistry& operator=(const GlfGLContextRegistry&) = delete;
+
     static GlfGLContextRegistry& GetInstance()
     {
         return TfSingleton<GlfGLContextRegistry>::GetInstance();

--- a/pxr/imaging/lib/glf/image.h
+++ b/pxr/imaging/lib/glf/image.h
@@ -35,7 +35,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <string>
@@ -51,18 +50,23 @@ typedef boost::shared_ptr<class GlfImage> GlfImageSharedPtr;
 ///
 /// The class allows basic access to texture image file data.
 ///
-class GlfImage : public boost::noncopyable {
-
+class GlfImage {
 public:
+    GLF_API
+    GlfImage() = default;
+
+    // Disallow copies
+    GlfImage(const GlfImage&) = delete;
+    GlfImage& operator=(const GlfImage&) = delete;
 
     /// Specifies whether to treat the image origin as the upper-left corner
     /// or the lower left
     enum ImageOriginLocation
     {
-        OriginUpperLeft, 
+        OriginUpperLeft,
         OriginLowerLeft
-    }; 
-   
+    };
+
     /// \class StorageSpec
     ///
     /// Describes the memory layout and storage of a texture image

--- a/pxr/imaging/lib/glf/simpleShadowArray.h
+++ b/pxr/imaging/lib/glf/simpleShadowArray.h
@@ -36,20 +36,22 @@
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/imaging/garch/gl.h"
 
-#include <boost/noncopyable.hpp>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
 class GlfSimpleShadowArray : public TfRefBase,
-                             public TfWeakBase,
-                             boost::noncopyable {
+                             public TfWeakBase {
 public:
     GLF_API
     GlfSimpleShadowArray(GfVec2i const & size, size_t numLayers);
     GLF_API
     virtual ~GlfSimpleShadowArray();
+
+    // Disallow copies
+    GlfSimpleShadowArray(const GlfSimpleShadowArray&) = delete;
+    GlfSimpleShadowArray& operator=(const GlfSimpleShadowArray&) = delete;
 
     GLF_API
     GfVec2i GetSize() const;

--- a/pxr/imaging/lib/glf/texture.h
+++ b/pxr/imaging/lib/glf/texture.h
@@ -40,7 +40,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/noncopyable.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -60,7 +59,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(GlfTexture);
 /// A texture is typically defined by reading texture image data from an image
 /// file but a texture might also represent an attachment of a draw target.
 ///
-class GlfTexture : public TfRefBase, public TfWeakBase, boost::noncopyable {
+class GlfTexture : public TfRefBase, public TfWeakBase {
 public:
     /// \class Binding
     ///
@@ -89,6 +88,10 @@ public:
 
     GLF_API
     virtual ~GlfTexture() = 0;
+
+    // Disallow copies
+    GlfTexture(const GlfTexture&) = delete;
+    GlfTexture& operator=(const GlfTexture&) = delete;
 
     /// Returns the bindings to use this texture for the shader resource
     /// named \a identifier. If \a samplerId is specified, the bindings

--- a/pxr/imaging/lib/glf/textureRegistry.h
+++ b/pxr/imaging/lib/glf/textureRegistry.h
@@ -36,7 +36,6 @@
 #include "pxr/base/tf/weakPtr.h"
 #include "pxr/base/vt/dictionary.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <map>
 
@@ -51,8 +50,12 @@ class GlfTextureFactoryBase;
 
 /// \class GlfTextureRegistry
 ///
-class GlfTextureRegistry : boost::noncopyable {
+class GlfTextureRegistry {
 public:
+    // Disallow copies
+    GlfTextureRegistry(const GlfTextureRegistry&) = delete;
+    GlfTextureRegistry& operator=(const GlfTextureRegistry&) = delete;
+
     GLF_API
     static GlfTextureRegistry & GetInstance();
 

--- a/pxr/imaging/lib/hd/bufferArray.h
+++ b/pxr/imaging/lib/hd/bufferArray.h
@@ -32,7 +32,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
@@ -55,8 +54,7 @@ typedef boost::shared_ptr<class HdBufferSource> HdBufferSourceSharedPtr;
 /// can be shared across multiple HdRprims, in the context of buffer
 /// aggregation.
 ///
-class HdBufferArray : public boost::enable_shared_from_this<HdBufferArray>,
-    boost::noncopyable {
+class HdBufferArray : public boost::enable_shared_from_this<HdBufferArray> {
 public:
     HD_API
     HdBufferArray(TfToken const &role,
@@ -65,6 +63,10 @@ public:
 
     HD_API
     virtual ~HdBufferArray();
+
+    // Disallow copies
+    HdBufferArray(const HdBufferArray&) = delete;
+    HdBufferArray& operator=(const HdBufferArray&) = delete;
 
     /// Returns the role of the GPU data in this bufferArray.
     TfToken const& GetRole() const {return _role;}

--- a/pxr/imaging/lib/hd/bufferArrayRange.h
+++ b/pxr/imaging/lib/hd/bufferArrayRange.h
@@ -31,7 +31,6 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/imaging/hd/bufferResource.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -51,7 +50,7 @@ typedef boost::shared_ptr<class HdBufferArrayRange> HdBufferArrayRangeSharedPtr;
 /// inherited of this interface so that client (drawItem) can be agnostic about
 /// the implementation detail of aggregation.
 ///
-class HdBufferArrayRange : boost::noncopyable {
+class HdBufferArrayRange {
 public:
     /// Destructor (do nothing).
     /// The specialized range class may want to do something for garbage
@@ -60,6 +59,13 @@ public:
     /// since the destructor gets called frequently on various contexts.
     HD_API
     virtual ~HdBufferArrayRange();
+
+    /// Default constructor
+    HdBufferArrayRange() = default;
+
+    /// Disallow copies
+    HdBufferArrayRange(const HdBufferArrayRange&) = delete;
+    HdBufferArrayRange& operator=(const HdBufferArrayRange&) = delete;
 
     /// Returns true if this range is valid
     virtual bool IsValid() const = 0;

--- a/pxr/imaging/lib/hd/bufferArrayRegistry.h
+++ b/pxr/imaging/lib/hd/bufferArrayRegistry.h
@@ -38,7 +38,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <tbb/concurrent_unordered_map.h>
 
@@ -54,13 +53,16 @@ typedef boost::shared_ptr<class HdBufferArray> HdBufferArraySharedPtr;
 ///
 /// Manages the pool of buffer arrays.
 ///
-class HdBufferArrayRegistry : public boost::noncopyable {
+class HdBufferArrayRegistry {
 public:
     HF_MALLOC_TAG_NEW("new HdBufferArrayRegistry");
 
     HD_API
     HdBufferArrayRegistry();
     ~HdBufferArrayRegistry()   = default;
+
+    HdBufferArrayRegistry(const HdBufferArrayRegistry&) = delete;
+    HdBufferArrayRegistry& operator=(const HdBufferArrayRegistry&) = delete;
 
     /// Allocate new buffer array range using strategy
     /// Thread-Safe

--- a/pxr/imaging/lib/hd/bufferSource.h
+++ b/pxr/imaging/lib/hd/bufferSource.h
@@ -33,7 +33,6 @@
 
 #include <atomic>
 #include <vector>
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 
@@ -57,9 +56,13 @@ typedef boost::weak_ptr<HdBufferSource> HdBufferSourceWeakPtr;
 /// The public interface provided is intended to be convenient for OpenGL API
 /// calls.
 ///
-class HdBufferSource : public boost::noncopyable {
+class HdBufferSource {
 public:
     HdBufferSource() : _state(UNRESOLVED) { }
+
+    // Disallow copies
+    HdBufferSource(const HdBufferSource&) = delete;
+    HdBufferSource& operator=(const HdBufferSource&) = delete;
 
     HD_API
     virtual ~HdBufferSource();

--- a/pxr/imaging/lib/hd/changeTracker.h
+++ b/pxr/imaging/lib/hd/changeTracker.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/hashmap.h"
 
 #include <atomic>
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/weak_ptr.hpp>
@@ -54,7 +53,7 @@ class HdRenderIndex;
 /// with the change is required, at which point the resource is updated and the
 /// flag is cleared.
 ///
-class HdChangeTracker : public boost::noncopyable {
+class HdChangeTracker {
 public:
 
     enum RprimDirtyBits : HdDirtyBits {
@@ -101,8 +100,13 @@ public:
 
     HD_API
     HdChangeTracker();
+
     HD_API
     virtual ~HdChangeTracker();
+
+    // Disallow copies
+    HdChangeTracker(const HdChangeTracker&) = delete;
+    HdChangeTracker& operator=(const HdChangeTracker&) = delete;
 
     // ---------------------------------------------------------------------- //
     /// \name Rprim Object Tracking

--- a/pxr/imaging/lib/hd/pch.h
+++ b/pxr/imaging/lib/hd/pch.h
@@ -112,7 +112,6 @@
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/vector/vector40.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>

--- a/pxr/imaging/lib/hd/perfLog.h
+++ b/pxr/imaging/lib/hd/perfLog.h
@@ -35,7 +35,6 @@
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include "pxr/base/tf/hashmap.h"
 
@@ -94,8 +93,12 @@ typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 ///
 /// Performance counter monitoring.
 ///
-class HdPerfLog : public boost::noncopyable {
+class HdPerfLog {
 public:
+    // Disallow copies
+    HdPerfLog(const HdPerfLog&) = delete;
+    HdPerfLog& operator=(const HdPerfLog&) = delete;
+
     HD_API
     static HdPerfLog& GetInstance() {
         return TfSingleton<HdPerfLog>::GetInstance();

--- a/pxr/imaging/lib/hd/renderIndex.h
+++ b/pxr/imaging/lib/hd/renderIndex.h
@@ -42,7 +42,6 @@
 #include "pxr/base/gf/vec4i.h"
 #include "pxr/base/tf/hashmap.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr.hpp>
 
@@ -116,7 +115,7 @@ typedef std::unordered_map<TfToken,
 /// If two viewers use different HdRenderDelegate's, then it may unfortunately 
 /// require populating two HdRenderIndex's.
 ///
-class HdRenderIndex final : public boost::noncopyable {
+class HdRenderIndex final {
 public:
     typedef std::vector<HdDrawItem const*> HdDrawItemPtrVector;
     typedef std::unordered_map<TfToken, HdDrawItemPtrVector,
@@ -136,6 +135,10 @@ public:
 
     HD_API
     ~HdRenderIndex();
+
+    // Disallow copies
+    HdRenderIndex(const HdRenderIndex&) = delete;
+    HdRenderIndex& operator=(const HdRenderIndex&) = delete;
 
     /// Clear all r (render), s (state) and b (buffer) prims.
     HD_API

--- a/pxr/imaging/lib/hd/renderPass.h
+++ b/pxr/imaging/lib/hd/renderPass.h
@@ -68,8 +68,11 @@ typedef boost::shared_ptr<class HdRenderPass> HdRenderPassSharedPtr;
 /// Rendering backends are expected to specialize this abstract class, and
 /// return the specialized object via HdRenderDelegate::CreateRenderPass
 ///
-class HdRenderPass : boost::noncopyable {
+class HdRenderPass {
 public:
+    HdRenderPass(const HdRenderPass&) = delete;
+    HdRenderPass& operator=(const HdRenderPass&) = delete;
+    
     HD_API
     HdRenderPass(HdRenderIndex *index, HdRprimCollection const& collection);
     HD_API

--- a/pxr/imaging/lib/hd/resource.h
+++ b/pxr/imaging/lib/hd/resource.h
@@ -29,7 +29,6 @@
 #include "pxr/imaging/hd/version.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <cstddef>
@@ -43,13 +42,18 @@ typedef boost::shared_ptr<class HdResource> HdResourceSharedPtr;
 ///
 /// Base class for all GPU resource objects.
 ///
-class HdResource : boost::noncopyable 
+class HdResource
 {
 public:
     HD_API
     HdResource(TfToken const & role);
+
     HD_API
     virtual ~HdResource();
+
+    // Disallow copies
+    HdResource(const HdResource&) = delete;
+    HdResource& operator=(const HdResource&) = delete;
 
     /// Returns the role of the GPU data in this resource.
     TfToken const & GetRole() const {return _role;}

--- a/pxr/imaging/lib/hd/resourceRegistry.h
+++ b/pxr/imaging/lib/hd/resourceRegistry.h
@@ -44,7 +44,6 @@
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <map>
@@ -68,12 +67,16 @@ typedef boost::shared_ptr<class HdResourceRegistry> HdResourceRegistrySharedPtr;
 ///
 /// A central registry of all GPU resources.
 ///
-class HdResourceRegistry : public boost::noncopyable  {
+class HdResourceRegistry {
 public:
     HF_MALLOC_TAG_NEW("new HdResourceRegistry");
 
     HD_API
     HdResourceRegistry();
+
+    // Disallow copies
+    HdResourceRegistry(const HdResourceRegistry&) = delete;
+    HdResourceRegistry& operator=(const HdResourceRegistry&) = delete;
 
     HD_API
     virtual ~HdResourceRegistry();

--- a/pxr/imaging/lib/hdSt/pch.h
+++ b/pxr/imaging/lib/hdSt/pch.h
@@ -105,7 +105,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/pointer_cast.hpp>

--- a/pxr/imaging/lib/hdSt/textureResource.h
+++ b/pxr/imaging/lib/hdSt/textureResource.h
@@ -37,7 +37,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/gf/vec4f.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <cstdint>
@@ -49,10 +48,17 @@ typedef boost::shared_ptr<class HdStTextureResource> HdStTextureResourceSharedPt
 typedef boost::shared_ptr<class HdStSimpleTextureResource> HdStSimpleTextureResourceSharedPtr;
 
 /// HdStTextureResource is an interface to a GL-backed texture.
-class HdStTextureResource : public HdTextureResource, boost::noncopyable {
+class HdStTextureResource : public HdTextureResource {
 public:
     HDST_API
     virtual ~HdStTextureResource();
+
+    HDST_API
+    HdStTextureResource() = default; 
+
+    // Disallow copies
+    HdStTextureResource(const HdStTextureResource&) = delete;
+    HdStTextureResource& operator=(const HdStTextureResource&) = delete;
 
     // Access to underlying GL storage.
     HDST_API virtual GLuint GetTexelsTextureId() = 0;

--- a/pxr/imaging/lib/hdx/drawTargetRenderPass.h
+++ b/pxr/imaging/lib/hdx/drawTargetRenderPass.h
@@ -48,7 +48,7 @@ class HdStDrawTargetRenderPassState;
 /// to major changes.  It is likely this functionality will be absorbed into
 /// the base class.
 ///
-class HdxDrawTargetRenderPass : boost::noncopyable {
+class HdxDrawTargetRenderPass {
 public:
     HDX_API
     HdxDrawTargetRenderPass(HdRenderIndex *index);

--- a/pxr/imaging/lib/hdx/pch.h
+++ b/pxr/imaging/lib/hdx/pch.h
@@ -105,7 +105,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>

--- a/pxr/imaging/lib/hf/pch.h
+++ b/pxr/imaging/lib/hf/pch.h
@@ -75,7 +75,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor/arithmetic/add.hpp>

--- a/pxr/imaging/lib/pxOsd/pch.h
+++ b/pxr/imaging/lib/pxOsd/pch.h
@@ -90,7 +90,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -103,7 +103,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor.hpp>

--- a/pxr/imaging/plugin/hdStream/pch.h
+++ b/pxr/imaging/plugin/hdStream/pch.h
@@ -78,7 +78,6 @@
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/remove.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/preprocessor/arithmetic/add.hpp>


### PR DESCRIPTION
Same rationale as #373 

