### PR TITLE
cmake: Fix building with ninja.

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -100,13 +100,13 @@ function(pxr_python_bin BIN_NAME)
     endif()
 
     # Add the target.
-    add_custom_target(${BIN_NAME}
+    add_custom_target(${BIN_NAME}_script
         DEPENDS ${outputs} ${pb_DEPENDENCIES}
     )
-    add_dependencies(python ${BIN_NAME})
+    add_dependencies(python ${BIN_NAME}_script)
 
     _get_folder("" folder)
-    set_target_properties(${BIN_NAME}
+    set_target_properties(${BIN_NAME}_script
         PROPERTIES
             FOLDER "${folder}"
     )


### PR DESCRIPTION
Ninja and cmake get unhappy when there is a custom command output
and a custom target with the same name resulting in a cyclic
dependency between them. This isn't an issue with cmake's support
for Makefiles.
