### PR TITLE
Fix warnings about missing parentheses.

### DIFF
--- a/pxr/usd/lib/sdf/primSpec.cpp
+++ b/pxr/usd/lib/sdf/primSpec.cpp
@@ -817,7 +817,7 @@ _FindOrCreateVariantSpec(const SdfPrimSpecHandle &primSpec,
 
     // Create a new variant set spec and add it to the variant set list.
     if (!varSetSpec) {
-        if (varSetSpec = SdfVariantSetSpec::New(primSpec, varSel.first))
+        if ((varSetSpec = SdfVariantSetSpec::New(primSpec, varSel.first)))
             primSpec->GetVariantSetNameList().Add(varSel.first);
     }
 

--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -1315,7 +1315,7 @@ UsdStage::_CreatePropertySpecForEditing(const UsdProperty &prop)
         for (Usd_Resolver r(&prim.GetPrimIndex()); r.IsValid(); r.NextLayer()) {
             if (SdfPropertySpecHandle propSpec = r.GetLayer()->
                 GetPropertyAtPath(r.GetLocalPath().AppendProperty(propName))) {
-                if (specToCopy = TfDynamic_cast<TypedSpecHandle>(propSpec))
+                if ((specToCopy = TfDynamic_cast<TypedSpecHandle>(propSpec)))
                     break;
                 // Type mismatch.
                 TF_RUNTIME_ERROR("Spec type mismatch.  Failed to create %s for "
@@ -1798,7 +1798,7 @@ UsdStage::_IsValidForLoad(const SdfPath& path) const
         // Lets see if any ancestor exists, if so it's safe to attempt to load.
         SdfPath parentPath = path;
         while (parentPath != SdfPath::AbsoluteRootPath()) {
-            if (curPrim = GetPrimAtPath(parentPath)) {
+            if ((curPrim = GetPrimAtPath(parentPath))) {
                 break;
             }
             parentPath = parentPath.GetParentPath();

--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -167,7 +167,7 @@ UsdImagingDelegate::_IsDrawModeApplied(UsdPrim const& prim)
     UsdAttribute attr;
     if (model.GetKind(&kind) && KindRegistry::IsA(kind, KindTokens->component))
         applyDrawMode = true;
-    else if (attr = model.GetModelApplyDrawModeAttr())
+    else if ((attr = model.GetModelApplyDrawModeAttr()))
         attr.Get(&applyDrawMode);
 
     if (!applyDrawMode)


### PR DESCRIPTION
This happens when the result of a comparison is used as the
condition within an if statement in clang (and gcc?).
