### PR TITLE
Fix format security warnings under clang.

### DIFF
--- a/pxr/imaging/lib/glf/drawTarget.cpp
+++ b/pxr/imaging/lib/glf/drawTarget.cpp
@@ -170,8 +170,8 @@ GlfDrawTarget::AddAttachment( std::string const & name,
 
 
         TF_VERIFY( attachment->GetGlTextureName() > 0 ,
-                   std::string("Attachment \""+name+"\" was not added "
-                       "and cannot be bound in MatDisplayMaterial").c_str());
+                   "Attachment \"%s\" was not added "
+                       "and cannot be bound in MatDisplayMaterial", name.c_str());
 
         _BindAttachment( attachment );
 

--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -5768,11 +5768,11 @@ public:
         else {
             if (!TF_VERIFY(layer->GetBracketingTimeSamplesForPath(
                         specId, localTime, &lower, &upper),
-                TfStringPrintf("No bracketing time samples for "
+                        "No bracketing time samples for "
                                "%s on <%s> for time %g between %g and %g",
                                layer->GetIdentifier().c_str(),
                                specId.GetFullSpecPath().GetText(),
-                               localTime, lower, upper).c_str())) {
+                               localTime, lower, upper)) {
                 return false;
             }
         }


### PR DESCRIPTION
This wants to get a literal string for the format argument and
then to do the substitution itself.
