### PR TITLE
Fix mismatched tags warnings.

### DIFF
--- a/pxr/base/lib/tf/scopeDescription.cpp
+++ b/pxr/base/lib/tf/scopeDescription.cpp
@@ -87,7 +87,7 @@ struct _StackRegistry
     // Lock class used by clients that read stacks.
     friend class StackLock;
     class StackLock {
-        friend class _StackRegistry;
+        friend struct _StackRegistry;
         StackLock(StackLock const &) = delete;
         StackLock &operator=(StackLock const &) = delete;
         inline StackLock(_Stack *stack, _StackRegistry *reg)

--- a/pxr/usdImaging/lib/usdImaging/materialAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/materialAdapter.h
@@ -31,7 +31,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HdMaterialNetworkMap;
+struct HdMaterialNetworkMap;
 
 
 /// \class UsdImagingMaterialAdapter


### PR DESCRIPTION
These happen under clang.
