### PR TITLE
Fixing infinite recursion when instances and materials are outside the instancer's scope

### DIFF
--- a/third_party/katana/lib/usdKatana/readPointInstancer.cpp
+++ b/third_party/katana/lib/usdKatana/readPointInstancer.cpp
@@ -411,7 +411,8 @@ PxrUsdKatanaReadPointInstancer(
     // Validate instancer data.
     //
 
-    const std::string instancerPath = instancer.GetPath().GetString();
+    const auto instancerSdfPath = instancer.GetPath();
+    const std::string instancerPath = instancerSdfPath.GetString();
 
     UsdStageWeakPtr stage = instancer.GetPrim().GetStage();
 
@@ -637,7 +638,7 @@ PxrUsdKatanaReadPointInstancer(
                     {
                         const SdfPath &commonPrefix =
                                 protoPath.GetCommonPrefix(materialPath);
-                        if (commonPrefix.GetString() == "/")
+                        if (commonPrefix.GetString() == "/" || instancerSdfPath.HasPrefix(commonPrefix))
                         {
                             // XXX Unhandled case.
                             // The prim and its material are not under the same

--- a/third_party/katana/lib/usdKatana/utils.h
+++ b/third_party/katana/lib/usdKatana/utils.h
@@ -108,10 +108,12 @@ struct PxrUsdKatanaUtils {
     /// katana location, given a scenegraph generator configuration.
     static std::string ConvertUsdPathToKatLocation(
             const SdfPath &path,
-            const PxrUsdKatanaUsdInPrivateData& data);
+            const PxrUsdKatanaUsdInPrivateData& data,
+            bool allowOutsideIsolation = false);
     static std::string ConvertUsdPathToKatLocation(
             const SdfPath &path,
-            const PxrUsdKatanaUsdInArgsRefPtr &usdInArgs);
+            const PxrUsdKatanaUsdInArgsRefPtr &usdInArgs,
+            bool allowOutsideIsolation = false);
 
     /// USD Looks can have Katana child-parent relationships, which means that
     /// we'll have to do some extra processing to find the correct path that


### PR DESCRIPTION
### Description of Change(s)
The following changes cases when infinite recursion happens in pxrUsdIn when sources are outside the scope of the pointInstancer. The change also deals with corner-case material assignments, when the materials are outside the primitive's scope. For that, we just expect the material to be built by something else (it'll be in all our cases), we don't do any additional checks.


### Fixes Issue(s)
- #286

