### PR TITLE
[usdview] fix for upAxis=y not being set properly on startup

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1286,6 +1286,7 @@ class AppController(QtCore.QObject):
                 self._stageView = StageView(parent=self._mainWindow,
                     dataModel=self._dataModel,
                     printTiming=self._printTiming)
+                self._stageView._stageReplaced()
 
                 self._stageView.fpsHUDInfo = self._fpsHUDInfo
                 self._stageView.fpsHUDKeys = self._fpsHUDKeys


### PR DESCRIPTION
### Description of Change(s)

The latest dev refactored stageView, eliminating StageView.SetStage() in favor of StageView._stageReplaced().  However, when a new StageView is constructed, _stageReplaced is never called on it (while SetStage formerly was), so the view is not properly initialized (including setting of upAxis).

This change just adds in a call to _stageReplaced() where a call to SetStage formerly existed.  However, I'm not sure if this is the right way to fix this - I feel that, given the new naming, the intent may have been to include this setup within the constructor... but I was a bit more hesitant to make that change, since it departed a bit more from old behavior.

Also, not that the old version included other calls to SetStage:

https://github.com/PixarAnimationStudios/USD/blob/022f7ef54ff8ce15120f34e61e078c1daf471153/pxr/usdImaging/lib/usdviewq/appController.py#L1173

https://github.com/PixarAnimationStudios/USD/blob/022f7ef54ff8ce15120f34e61e078c1daf471153/pxr/usdImaging/lib/usdviewq/appController.py#L1332

...which I haven't replicated here (again, not sure if it was appropriate).

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/385

