### PR TITLE
[Hd] Fix for import modules better than PySide and PySide2

### DIFF
--- a/third_party/houdini/lib/gusd/treemodel.py
+++ b/third_party/houdini/lib/gusd/treemodel.py
@@ -23,13 +23,9 @@
 #
 import hou
 
-if hou.applicationVersion()[0] >= 16:
-    from PySide2.QtGui import *
-    from PySide2.QtCore import *
-    from PySide2.QtWidgets import *
-else:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
+from hutil.Qt.QtGui import *
+from hutil.Qt.QtCore import *
+from hutil.Qt.QtWidgets import *
 
 from pxr import Usd, Sdf, UsdGeom
 

--- a/third_party/houdini/lib/gusd/treeview.py
+++ b/third_party/houdini/lib/gusd/treeview.py
@@ -23,13 +23,9 @@
 #
 import hou
 
-if hou.applicationVersion()[0] >= 16:
-    from PySide2.QtGui import *
-    from PySide2.QtCore import *
-    from PySide2.QtWidgets import *
-else:
-    from PySide.QtGui import *
-    from PySide.QtCore import *
+from hutil.Qt.QtGui import *
+from hutil.Qt.QtCore import *
+from hutil.Qt.QtWidgets import *
 
 import re
 from treemodel import *


### PR DESCRIPTION
### Description of Change(s)
Houdini include Qt.py in hutil modules.
So i think not good about Houdini version check.

### Fixes Issue(s)
- use Qt.py in hutil modules.

