### PR TITLE
[Pxr] Add UsdStage::GetObjectAtPath.

### DIFF
--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -1746,6 +1746,32 @@ UsdStage::GetPrimAtPath(const SdfPath &path) const
     return UsdPrim(primData, proxyPrimPath);
 }
 
+UsdObject
+UsdStage::GetObjectAtPath(const SdfPath &path) const
+{
+    // Maintain consistent behavior with GetPrimAtPath
+    if (!path.IsAbsolutePath()) {
+        return UsdObject();
+    }
+
+    const bool isPrimPath = path.IsPrimPath();
+    const bool isPropPath = !isPrimPath && path.IsPropertyPath();
+    if (!isPrimPath && !isPropPath) {
+        return UsdObject();
+    }
+
+    // A valid prim must be found to return either a prim or prop
+    if (isPrimPath) {
+        return GetPrimAtPath(path);
+    } else if (isPropPath) {
+        if (auto prim = GetPrimAtPath(path.GetPrimPath())) {
+            return prim.GetProperty(path.GetNameToken());
+        }
+    }
+
+    return UsdObject();
+}
+
 Usd_PrimDataConstPtr
 UsdStage::_GetPrimDataAtPath(const SdfPath &path) const
 {

--- a/pxr/usd/lib/usd/stage.h
+++ b/pxr/usd/lib/usd/stage.h
@@ -728,6 +728,32 @@ public:
     USD_API
     UsdPrim GetPrimAtPath(const SdfPath &path) const;
 
+    /// Return the UsdObject at \p path, or an invalid UsdObject if none exists.
+    ///
+    /// If \p path indicates a prim beneath an instance, returns an instance
+    /// proxy prim if a prim exists at the corresponding path in that instance's 
+    /// master. If \p path indicates a property beneath a child of an instance, 
+    /// returns a property whose parent prim is an instance proxy prim.
+    ///
+    /// Example:
+    ///
+    /// \code
+    ///if (UsdObject obj = stage->GetObjectAtPath(path)) {
+    ///    if (UsdPrim prim = obj.As<UsdPrim>()) {
+    ///        // Do things with prim
+    ///    }
+    ///    else if (UsdProperty prop = obj.As<UsdProperty>()) {
+    ///        // Do things with property. We can also cast to
+    ///        // UsdRelationship or UsdAttribute using this same pattern.
+    ///    }
+    ///}
+    ///else {
+    ///    // No object at specified path
+    ///}
+    /// \endcode
+    USD_API
+    UsdObject GetObjectAtPath(const SdfPath &path) const;
+
 private:
     // Return the primData object at \p path.
     Usd_PrimDataConstPtr _GetPrimDataAtPath(const SdfPath &path) const;

--- a/pxr/usd/lib/usd/testenv/testUsdPrims.py
+++ b/pxr/usd/lib/usd/testenv/testUsdPrims.py
@@ -61,6 +61,33 @@ class TestUsdPrim(unittest.TestCase):
             assert a == b
             assert hash(a) == hash(b)
 
+            # check for prims/props that exist
+            p = s.GetObjectAtPath(u'/foo')
+            assert p
+            assert type(p) is Usd.Prim
+
+            a = s.GetObjectAtPath(u'/foo.attr')
+            assert a
+            assert type(a) is Usd.Attribute
+
+            r = s.GetObjectAtPath(u'/foo.relationship')
+            assert r 
+            assert type(r) is Usd.Relationship
+
+            # check for prims/props that dont exist
+            p = s.GetObjectAtPath(u'/nonexistent')
+            assert not p
+            assert type(p) is Usd.Prim
+
+            a = s.GetObjectAtPath(u'/foo.nonexistentattr')
+            assert not a
+            assert type(a) is Usd.Property
+
+            r = s.GetObjectAtPath(u'/foo.nonexistentrelationship')
+            assert not r 
+            assert type(r) is Usd.Property
+
+
     def test_OverrideMetadata(self):
         for fmt in allFormats:
             weak = Sdf.Layer.CreateAnonymous('OverrideMetadataTest.'+fmt)

--- a/pxr/usd/lib/usd/wrapStage.cpp
+++ b/pxr/usd/lib/usd/wrapStage.cpp
@@ -435,6 +435,7 @@ void wrapUsdStage()
         .def("HasDefaultPrim", &UsdStage::HasDefaultPrim)
 
         .def("GetPrimAtPath", &UsdStage::GetPrimAtPath, arg("path"))
+        .def("GetObjectAtPath", &UsdStage::GetObjectAtPath, arg("path"))
         .def("Traverse", (UsdPrimRange (UsdStage::*)())
              &UsdStage::Traverse)
         .def("Traverse",


### PR DESCRIPTION
### Description of Change(s)

This allows a convenient way to get items in a stage from paths,
whether they are property paths or prim paths.

### Fixes Issue(s)

This was requested on the interest forum a while back, don't have the link handy.

