### PR TITLE
[UsdUtils] Remove TF_FOR_ALL usage.

### DIFF
--- a/pxr/usd/lib/usdUtils/pipeline.cpp
+++ b/pxr/usd/lib/usdUtils/pipeline.cpp
@@ -87,8 +87,7 @@ UsdUtilsGetModelNameFromRootLayer(
     }
 
     // Otherwise, fallback to getting the first non-class child in the layer.
-    TF_FOR_ALL(rootChildrenIter, rootLayer->GetRootPrims()) {
-        const SdfPrimSpecHandle& rootPrim = *rootChildrenIter;
+    for (const auto& rootPrim : rootLayer->GetRootPrims()) {
         if (rootPrim->GetSpecifier() != SdfSpecifierClass) {
             return rootPrim->GetNameToken();
         }
@@ -100,8 +99,7 @@ UsdUtilsGetModelNameFromRootLayer(
 TF_MAKE_STATIC_DATA(std::set<UsdUtilsRegisteredVariantSet>, _regVarSets)
 {
     PlugPluginPtrVector plugs = PlugRegistry::GetInstance().GetAllPlugins();
-    TF_FOR_ALL(plugIter, plugs) {
-        PlugPluginPtr plug = *plugIter;
+    for (const auto& plug : plugs) {
         JsObject metadata = plug->GetMetadata();
         JsValue pipelineUtilsDictValue;
         if (TfMapLookup(metadata, _tokens->UsdUtilsPipeline, &pipelineUtilsDictValue)) {

--- a/pxr/usd/lib/usdUtils/stageCache.cpp
+++ b/pxr/usd/lib/usdUtils/stageCache.cpp
@@ -71,8 +71,8 @@ UsdUtilsStageCache::GetSessionLayerForVariantSelections(
     std::sort(variantSelectionsSorted.begin(), variantSelectionsSorted.end());
 
     std::string sessionKey = modelName;
-    TF_FOR_ALL(itr, variantSelectionsSorted) {
-        sessionKey += ":" + itr->first + "=" + itr->second;
+    for (const auto& p : variantSelectionsSorted) {
+        sessionKey += ":" + p.first + "=" + p.second;
     }
 
     SdfLayerRefPtr ret;
@@ -89,10 +89,9 @@ UsdUtilsStageCache::GetSessionLayerForVariantSelections(
                     layer,
                     modelName,
                     SdfSpecifierOver);
-                TF_FOR_ALL(varSelItr, variantSelections) {
+                for (const auto& p : variantSelections) {
                     // Construct the variant opinion for the session layer.
-                    over->GetVariantSelections()[varSelItr->first] =
-                        varSelItr->second;
+                    over->GetVariantSelections()[p.first] = p.second;
                 }
             }
             sessionLayerMap[sessionKey] = layer;


### PR DESCRIPTION
### Description of Change(s)

Replaces uses of `TF_FOR_ALL` macro with standard for each construct introduced in C++11.

### Fixes Issue(s)
Towards #80 , many uses left.

