### PR TITLE
[UsdRi] Remove TF_FOR_ALL usage.

### DIFF
--- a/pxr/usd/lib/usdRi/statementsAPI.cpp
+++ b/pxr/usd/lib/usdRi/statementsAPI.cpp
@@ -263,8 +263,7 @@ UsdRiStatementsAPI::GetRiAttributes(
     std::vector<UsdProperty> validProps;
     std::vector<string> names;
     bool requestedNameSpace = (nameSpace != "");
-    TF_FOR_ALL(propItr, props){
-        UsdProperty prop = *propItr;
+    for (const auto& prop : props) {
         names = prop.SplitName();
         if (requestedNameSpace && names[2] != nameSpace) {
             // wrong namespace


### PR DESCRIPTION
### Description of Change(s)
Replaces uses of TF_FOR_ALL macro with standard for each construct introduced in C++11.

### Fixes Issue(s)
Towards #80 , many uses left.

