### PR TITLE
[UsdGeom] Remove TF_FOR_ALL usage.

### DIFF
--- a/pxr/usd/lib/usdGeom/basisCurves.cpp
+++ b/pxr/usd/lib/usdGeom/basisCurves.cpp
@@ -234,12 +234,12 @@ _ComputeVaryingDataSize(const UsdGeomBasisCurves &basisCurves,
     // Code is deliberately verbose to clarify each case.
     if (curvesType == UsdGeomTokens->linear) {
         if (isNonPeriodic) {
-            TF_FOR_ALL(itr, curveVertexCts) {
-                result += *itr;
+            for (const auto& curveVertexCt : curveVertexCts) {
+                result += curveVertexCt;
             }
         } else {
-            TF_FOR_ALL(itr, curveVertexCts) {
-                result += *itr + 1;
+            for (const auto& curveVertexCt : curveVertexCts) {
+                result += curveVertexCt + 1;
             }
         }
         return result;
@@ -251,12 +251,12 @@ _ComputeVaryingDataSize(const UsdGeomBasisCurves &basisCurves,
 
     if (curvesType == UsdGeomTokens->cubic) {
         if (isNonPeriodic) {
-            TF_FOR_ALL(itr, curveVertexCts) {
-                result += (*itr - 4)/vstep + 2;
+            for (const auto& curveVertexCt : curveVertexCts) {
+                result += (curveVertexCt - 4)/vstep + 2;
             }
         } else {
-            TF_FOR_ALL(itr, curveVertexCts) {
-                result += *itr/vstep;
+            for (const auto& curveVertexCt : curveVertexCts) {
+                result += curveVertexCt/vstep;
             }
         }
     }
@@ -271,8 +271,8 @@ _ComputeVertexDataSize(
 {
     // http://renderman.pixar.com/resources/current/rps/appnote.19.html
     size_t result = 0;
-    TF_FOR_ALL(itr, curveVertexCounts) {
-        result += *itr;
+    for (const auto& curveVertexCount : curveVertexCounts) {
+        result += curveVertexCount;
     }
        
     return result;

--- a/pxr/usd/lib/usdGeom/collectionAPI.cpp
+++ b/pxr/usd/lib/usdGeom/collectionAPI.cpp
@@ -209,8 +209,8 @@ UsdGeomCollectionAPI::AddTarget(
 
     targetFaceCounts.push_back(faceIndices.size()); 
     targetFaceIndices.reserve(targetFaceIndices.size() + faceIndices.size());
-    TF_FOR_ALL(it, faceIndices) {
-        targetFaceIndices.push_back(*it);
+    for (const auto& index : faceIndices) {
+        targetFaceIndices.push_back(index);
     }
     targets.push_back(target);
 
@@ -318,9 +318,7 @@ UsdGeomCollectionAPI::GetCollections(const UsdPrim &prim)
     vector<UsdGeomCollectionAPI> result;
     vector<UsdProperty> collectionProperties = prim.GetPropertiesInNamespace(
         UsdGeomTokens->collection);
-    TF_FOR_ALL(propIt, collectionProperties) {
-        const UsdProperty &prop = *propIt;
-
+    for (const auto& prop : collectionProperties) {
         if (!prop.Is<UsdRelationship>())
             continue;
 
@@ -410,13 +408,11 @@ UsdGeomCollectionAPI::Validate(std::string *reason) const
         allTimeSamples.insert(tfcTimes.begin(), tfcTimes.end());
 
     allTimes.reserve(allTimes.size() + allTimeSamples.size());
-    TF_FOR_ALL(timeSampleIt, allTimeSamples) {
-        allTimes.push_back(UsdTimeCode(*timeSampleIt));
+    for (const auto& timeSample : allTimeSamples) {
+        allTimes.push_back(UsdTimeCode(timeSample));
     }
 
-    TF_FOR_ALL(timeIt, allTimes) {
-        const UsdTimeCode &time = *timeIt;
-
+    for (const auto& time : allTimes) {
         VtIntArray faceCounts, faceIndices;
         if (!GetTargetFaceCounts(&faceCounts, time) ||
             !GetTargetFaceIndices(&faceIndices, time)) {
@@ -434,8 +430,9 @@ UsdGeomCollectionAPI::Validate(std::string *reason) const
         }
         
         size_t totalFaceCounts = 0;
-        TF_FOR_ALL(faceCountsIter, faceCounts) 
-            totalFaceCounts += *faceCountsIter;
+        for (const auto& faceCount : faceCounts) {
+            totalFaceCounts += faceCount;
+        }
 
         if (faceIndices.size() != totalFaceCounts) {
             *reason += TfStringPrintf("The sum of all 'targetFaceCounts'"

--- a/pxr/usd/lib/usdGeom/faceSetAPI.cpp
+++ b/pxr/usd/lib/usdGeom/faceSetAPI.cpp
@@ -84,9 +84,7 @@ UsdGeomFaceSetAPI::GetFaceSets(const UsdPrim &prim)
 
     vector<UsdProperty> faceSetProperties = prim.GetPropertiesInNamespace(
         UsdGeomTokens->faceSet);
-    TF_FOR_ALL(propIt, faceSetProperties) {
-        const UsdProperty &prop = *propIt;
-        
+    for (const auto& prop : faceSetProperties) {
         if (prop.GetBaseName() != _tokens->isPartition) 
             continue;
 
@@ -267,14 +265,12 @@ UsdGeomFaceSetAPI::Validate(string *reason) const
         allTimeSamples.insert(fcTimes.begin(), fcTimes.end());
 
     allTimes.reserve(allTimes.size() + allTimeSamples.size());
-    TF_FOR_ALL(it, allTimeSamples) {
-        allTimes.push_back(UsdTimeCode(*it));
+    for (const auto& time : allTimeSamples) {
+        allTimes.push_back(UsdTimeCode(time));
     }
 
     size_t prevNumFaceCounts = std::numeric_limits<size_t>::max();
-    TF_FOR_ALL(timeIt, allTimes) {
-        const UsdTimeCode &time = *timeIt;
-
+    for (const auto& time : allTimes) {
         VtIntArray faceIndices;
         if (GetFaceIndices(&faceIndices, time)) {
             if (isPartition && _ContainsDuplicates(faceIndices)) {
@@ -309,8 +305,8 @@ UsdGeomFaceSetAPI::Validate(string *reason) const
             prevNumFaceCounts = faceCounts.size();
 
             size_t sum = 0;
-            TF_FOR_ALL(faceCountsIt, faceCounts) {
-                sum += *faceCountsIt;
+            for (const auto& faceCount : faceCounts) {
+                sum += faceCount;
             }
             if (faceIndices.size() != sum) {
                 isValid = false;
@@ -434,8 +430,8 @@ UsdGeomFaceSetAPI::AppendFaceGroup(const VtIntArray &indices,
 
     faceCounts.push_back(indices.size());
     faceIndices.reserve(faceIndices.size() + indices.size());
-    TF_FOR_ALL(indicesIt, indices) {
-        faceIndices.push_back(*indicesIt);
+    for (const auto& index : indices) {
+        faceIndices.push_back(index);
     }
 
     bool success = true;

--- a/pxr/usd/lib/usdGeom/imageable.cpp
+++ b/pxr/usd/lib/usdGeom/imageable.cpp
@@ -210,11 +210,11 @@ UsdGeomImageable::_MakePrimvars(std::vector<UsdProperty> const &props) const
     std::vector<UsdGeomPrimvar> primvars;
     primvars.reserve(props.size());
     
-    TF_FOR_ALL(prop, props) {
+    for (const auto& prop : props) {
         // All prefixed properties except the ones that contain extra
         // namespaces (eg. the ":indices" attributes belonging to indexed
         // primvars) will be valid primvars.
-        if (UsdGeomPrimvar primvar = UsdGeomPrimvar(prop->As<UsdAttribute>()))
+        if (UsdGeomPrimvar primvar = UsdGeomPrimvar(prop.As<UsdAttribute>()))
             primvars.push_back(primvar);
     }
     return primvars;
@@ -347,9 +347,7 @@ _MakeVisible(const UsdPrim &prim, UsdTimeCode const &time, bool *hasInvisibleAnc
 
                 // Invis all siblings of prim.
                 UsdPrim::SiblingRange children = parent.GetAllChildren();
-                TF_FOR_ALL(childIt, children) {
-                    const UsdPrim &childPrim = *childIt;
-                    
+                for (const auto& childPrim : children) {
                     if (childPrim != prim) {
                         UsdGeomImageable imageableChild(childPrim);
                         if (imageableChild) {

--- a/pxr/usd/lib/usdGeom/metrics.cpp
+++ b/pxr/usd/lib/usdGeom/metrics.cpp
@@ -90,8 +90,7 @@ TF_MAKE_STATIC_DATA(TfToken, _fallbackUpAxis)
         .Get<TfToken>();
     
     PlugPluginPtrVector plugs = PlugRegistry::GetInstance().GetAllPlugins();
-    TF_FOR_ALL(plugIter, plugs) {
-        PlugPluginPtr plug = *plugIter;
+    for (const auto& plug : plugs) {
         JsObject metadata = plug->GetMetadata();
         JsValue metricsDictValue;
         if (TfMapLookup(metadata, _tokens->UsdGeomMetrics, &metricsDictValue)){

--- a/pxr/usd/lib/usdGeom/modelAPI.cpp
+++ b/pxr/usd/lib/usdGeom/modelAPI.cpp
@@ -482,8 +482,8 @@ UsdGeomModelAPI::GetConstraintTargets() const
     vector<UsdGeomConstraintTarget> constraintTargets;
 
     const vector<UsdAttribute> &attributes = GetPrim().GetAttributes();
-    TF_FOR_ALL(attrIt, attributes) {
-        UsdGeomConstraintTarget constraintTarget(*attrIt);
+    for (const auto& attr : attributes) {
+        UsdGeomConstraintTarget constraintTarget(attr);
 
         // Add it to the list, if it is a valid constraint target.
         if (constraintTarget) {

--- a/pxr/usd/lib/usdGeom/pointBased.cpp
+++ b/pxr/usd/lib/usdGeom/pointBased.cpp
@@ -215,8 +215,8 @@ UsdGeomPointBased::ComputeExtent(const VtVec3fArray& points,
 
     // Calculate bounds
     GfRange3d bbox;
-    TF_FOR_ALL(pointsItr, points) {
-        bbox.UnionWith(GfVec3f(*pointsItr));
+    for (const auto& point : points) {
+        bbox.UnionWith(GfVec3f(point));
     }
 
     (*extent)[0] = GfVec3f(bbox.GetMin());

--- a/pxr/usd/lib/usdGeom/pointInstancer.cpp
+++ b/pxr/usd/lib/usdGeom/pointInstancer.cpp
@@ -660,8 +660,7 @@ UsdGeomPointInstancer::ComputeInstanceTransformsAtTime(
             return false;
         }
 
-        TF_FOR_ALL(iter, protoIndices) {
-            const int protoIndex = *iter;
+        for (const auto& protoIndex : protoIndices) {
             if (protoIndex < 0 || static_cast<size_t>(protoIndex) >= protoPaths.size()) {
                 TF_WARN("%s -- invalid prototype index: %d. Should be in [0, %zu)",
                         GetPrim().GetPath().GetText(),
@@ -763,8 +762,7 @@ UsdGeomPointInstancer::ComputeExtentAtTime(
     }
 
     // verify that all the protoIndices are in bounds.
-    TF_FOR_ALL(iter, protoIndices) {
-        const int protoIndex = *iter;
+    for (const auto& protoIndex : protoIndices) {
         if (protoIndex < 0 || 
             static_cast<size_t>(protoIndex) >= protoPaths.size()) {
             TF_WARN("%s -- invalid prototype index: %d. Should be in [0, %zu)",

--- a/pxr/usd/lib/usdGeom/points.cpp
+++ b/pxr/usd/lib/usdGeom/points.cpp
@@ -193,11 +193,11 @@ UsdGeomPoints::ComputeExtent(const VtVec3fArray& points,
     // Calculate bounds
     GfRange3d bbox;
     TfIterator<const VtFloatArray> widthsItr(widths);
-    TF_FOR_ALL(pointsItr, points) {
+    for (const auto& point : points) {
         float halfWidth = *widthsItr/2;
         GfVec3f widthVec(halfWidth);
-        bbox.UnionWith(GfVec3f(*pointsItr) + widthVec);
-        bbox.UnionWith(GfVec3f(*pointsItr) - widthVec);
+        bbox.UnionWith(GfVec3f(point) + widthVec);
+        bbox.UnionWith(GfVec3f(point) - widthVec);
 
         widthsItr++;
     }

--- a/pxr/usd/lib/usdGeom/xformCache.cpp
+++ b/pxr/usd/lib/usdGeom/xformCache.cpp
@@ -184,8 +184,8 @@ UsdGeomXformCache::SetTime(UsdTimeCode time)
         return;
 
     // Mark all cached CTMs as invalid, but leave the queries behind.
-    TF_FOR_ALL(it, _ctmCache) {
-        it->second.ctmIsValid = false;
+    for (auto& p : _ctmCache) {
+        p.second.ctmIsValid = false;
     }
 
     _time = time;

--- a/pxr/usd/lib/usdGeom/xformCommonAPI.cpp
+++ b/pxr/usd/lib/usdGeom/xformCommonAPI.cpp
@@ -199,12 +199,15 @@ UsdGeomXformOp::Type
 _GetRotateOpType(const vector<UsdGeomXformOp>& ops,
                  bool includeSingleAxisTypes=false)
 {
-    TF_FOR_ALL(it, ops) {
-        if (_validRotateTypes->count(it->GetOpType()))
-            return it->GetOpType();
+    for (const auto& op : ops) {
+        if (_validRotateTypes->count(op.GetOpType())) {
+            return op.GetOpType();
+        }
+
         if (includeSingleAxisTypes &&
-                _validSingleAxisRotateTypes->count(it->GetOpType()))
-            return it->GetOpType();
+                _validSingleAxisRotateTypes->count(op.GetOpType())) {
+            return op.GetOpType();
+        }
     }
     return UsdGeomXformOp::TypeRotateXYZ;
 }
@@ -262,15 +265,15 @@ _GetCommonOpTypesForOpOrder(const vector<UsdGeomXformOp>& xformOps,
     bool hasScaleOp = false;
     size_t numInverseTranslateOps = 0;
 
-    TF_FOR_ALL(it, xformOps) {
-        if (_validRotateTypes->count(it->GetOpType()) ||
-                _validSingleAxisRotateTypes->count(it->GetOpType())) {
+    for (const auto& op : xformOps) {
+        if (_validRotateTypes->count(op.GetOpType()) ||
+                _validSingleAxisRotateTypes->count(op.GetOpType())) {
             hasRotateOp = true;
-            rotateOpType = it->GetOpType();
-        } else if (it->GetOpType() == UsdGeomXformOp::TypeScale) {
+            rotateOpType = op.GetOpType();
+        } else if (op.GetOpType() == UsdGeomXformOp::TypeScale) {
             hasScaleOp = true;
-        } else if (it->GetOpType() == UsdGeomXformOp::TypeTranslate &&
-                   it->IsInverseOp()) {
+        } else if (op.GetOpType() == UsdGeomXformOp::TypeTranslate &&
+                   op.IsInverseOp()) {
             ++numInverseTranslateOps;
         }
     }
@@ -580,9 +583,9 @@ static
 TfToken
 _GetRotateOpNameToken(const vector<UsdGeomXformOp> &ops)
 {
-    TF_FOR_ALL(it, ops) {
-        if (_validRotateTypes->count(it->GetOpType()))
-            return it->GetOpName();
+    for (const auto& op : ops) {
+        if (_validRotateTypes->count(op.GetOpType()))
+            return op.GetOpName();
     }
     return _tokens->xformOpRotateXYZ;
 }
@@ -611,8 +614,9 @@ UsdGeomXformCommonAPI::_ValidateAndComputeXformOpIndices(
     typedef std::map<TfToken, int> XformOpToIndexMap;
     XformOpToIndexMap xformOpToIndexMap;
     // Initialize all indices to _InvalidIndex.
-    TF_FOR_ALL(it, opNameTokens)
-        xformOpToIndexMap[*it] = _InvalidIndex;
+    for (const auto& token : opNameTokens) {
+        xformOpToIndexMap[token] = _InvalidIndex;
+    }
 
     for(size_t index = 0; index < _xformOps.size(); ++index) {
         const TfToken opName = _xformOps[index].GetOpName();
@@ -627,8 +631,8 @@ UsdGeomXformCommonAPI::_ValidateAndComputeXformOpIndices(
     
     // Verify that the xformOps that do exist are in a compatible order.
     int lastNonNegativeIndex = _InvalidIndex;
-    TF_FOR_ALL(opNameIt, opNameTokens) {
-        int opIndex = xformOpToIndexMap[*opNameIt];
+    for (const auto& token : opNameTokens) {
+        int opIndex = xformOpToIndexMap[token];
         if (opIndex != _InvalidIndex) {    
             TF_VERIFY(opIndex != lastNonNegativeIndex);
 

--- a/pxr/usd/lib/usdGeom/xformable.cpp
+++ b/pxr/usd/lib/usdGeom/xformable.cpp
@@ -405,14 +405,14 @@ UsdGeomXformable::SetXformOpOrder(
     if (resetXformStack)
         ops.push_back(UsdGeomXformOpTypes->resetXformStack);
 
-    TF_FOR_ALL(it, orderedXformOps) {
+    for (const auto& xformOp : orderedXformOps) {
         // Check to make sure that the xformOp being added to xformOpOrder 
         // belongs to this prim.
-        if (it->GetAttr().GetPrim() == GetPrim()) {
-            ops.push_back(it->GetOpName());
+        if (xformOp.GetAttr().GetPrim() == GetPrim()) {
+            ops.push_back(xformOp.GetOpName());
         } else {
             TF_CODING_ERROR("XformOp attribute <%s> does not belong to schema "
-                            "prim <%s>.",  it->GetAttr().GetPath().GetText(),
+                            "prim <%s>.",  xformOp.GetAttr().GetPath().GetText(),
                             GetPath().GetText()); 
             return false;
         }
@@ -515,8 +515,8 @@ UsdGeomXformable::XformQuery::XformQuery(const UsdGeomXformable &xformable):
         _xformOps = orderedXformOps;
 
         // Create attribute queries for all the xform ops.
-        TF_FOR_ALL(it, _xformOps) {
-            it->_CreateAttributeQuery();
+        for (const auto& xformOp : _xformOps) {
+            xformOp._CreateAttributeQuery();
         }
     }
 }
@@ -534,8 +534,8 @@ bool
 _TransformMightBeTimeVarying(vector<UsdGeomXformOp> const &xformOps)
 {
     // If any of the xform ops may vary, then the cumulative transform may vary.
-    TF_FOR_ALL(it, xformOps) {
-        if (it->MightBeTimeVarying())
+    for (const auto& xformOp : xformOps) {
+        if (xformOp.MightBeTimeVarying())
             return true;
     }
 
@@ -708,9 +708,10 @@ bool
 UsdGeomXformable::XformQuery::IsAttributeIncludedInLocalTransform(
     const TfToken &attrName) const
 {
-    TF_FOR_ALL(it, _xformOps) {
-        if (it->GetName() == attrName)
+    for (const auto& xformOp : _xformOps) {
+        if (xformOp.GetName() == attrName) {
             return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
### Description of Change(s)
Replaces uses of `TF_FOR_ALL` macro with standard for each construct introduced in C++11.

### Fixes Issue(s)
Towards #80 , many uses left.