### PR TITLE
[Plug] Remove TF_FOR_ALL usage.

### DIFF
--- a/pxr/base/lib/plug/testenv/testPlugPixver.cpp
+++ b/pxr/base/lib/plug/testenv/testPlugPixver.cpp
@@ -76,10 +76,10 @@ int main(int argc, char* argv[])
     // Print out the paths so we can compare runs when something fails
     cout << "==== paths ====" << endl;
     sort(paths.begin(), paths.end());
-    TF_FOR_ALL(it, paths) {
-        cout << *it << endl;
-        if (IsPathToCheck(*it)) {
-            filtered_paths.push_back(*it);
+    for (const auto& path : paths) {
+        cout << path << endl;
+        if (IsPathToCheck(path)) {
+            filtered_paths.push_back(path);
         }
     }
     cout << endl;

--- a/pxr/base/lib/plug/wrapPlugin.cpp
+++ b/pxr/base/lib/plug/wrapPlugin.cpp
@@ -28,7 +28,6 @@
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyPtrHelpers.h"
 #include "pxr/base/tf/pyResultConversions.h"
-#include "pxr/base/tf/iterator.h"
 
 #include <boost/python.hpp>
 #include <string>
@@ -45,9 +44,9 @@ static dict
 _ConvertDict( const JsObject & dictionary )
 {
     dict result;
-    TF_FOR_ALL(i, dictionary) {
-        const string & key = i->first;
-        const JsValue & val = i->second;
+    for (const auto& p : dictionary) {
+        const string & key  = p.first;
+        const JsValue & val = p.second;
 
         result[key] = JsConvertToContainerType<object, dict>(val);
     }


### PR DESCRIPTION
### Description of Change(s)
Replaces uses of TF_FOR_ALL macro with standard for each construct introduced in C++11.

### Fixes Issue(s)
Towards #80 , many uses left.
