### PR TITLE
[Usd] Add more informative error message in sg.

### DIFF
--- a/pxr/usd/lib/usd/usdGenSchema.py
+++ b/pxr/usd/lib/usd/usdGenSchema.py
@@ -259,7 +259,7 @@ class ClassInfo(object):
                        + '<' + str(sdfPrim.path) + '>')
         errorSuffix = ('See '
                        'https://graphics.pixar.com/usd/docs/api/'
-                       '_usd__page__generating_schemas.html#Usd_IsAVsAPISchemas '
+                       '_usd__page__generating_schemas.html '
                        'for more information.\n')
         errorMsg = lambda s: errorPrefix + '\n' + s + '\n' + errorSuffix
 

--- a/pxr/usd/lib/usd/usdGenSchema.py
+++ b/pxr/usd/lib/usd/usdGenSchema.py
@@ -254,19 +254,36 @@ def _IsTyped(p):
 
 class ClassInfo(object):
     def __init__(self, usdPrim, sdfPrim):
+        # Error handling
+        errorPrefix = ('Invalid schema definition at ' 
+                       + '<' + str(sdfPrim.path) + '>')
+        errorSuffix = ('See '
+                       'https://graphics.pixar.com/usd/docs/api/'
+                       '_usd__page__generating_schemas.html#Usd_IsAVsAPISchemas '
+                       'for more information.\n')
+        errorMsg = lambda s: errorPrefix + '\n' + s + '\n' + errorSuffix
+
         # First validate proper class naming...
         if (sdfPrim.typeName != sdfPrim.path.name and
             sdfPrim.typeName != ''):
-            raise Exception("Code generation requires that every instantiable "
-                            "class's name must match its declared type "
-                            "('%s' and '%s' do not match.)" % 
-                            (sdfPrim.typeName, sdfPrim.path.name))
+            raise Exception(errorMsg("Code generation requires that every instantiable "
+                                     "class's name must match its declared type "
+                                     "('%s' and '%s' do not match.)" % 
+                                     (sdfPrim.typeName, sdfPrim.path.name)))
         
         # NOTE: usdPrim should ONLY be used for querying information regarding
         # the class's parent in order to avoid duplicating class members during
         # code generation.
         inherits = usdPrim.GetMetadata('inheritPaths') 
         inheritsList = _ListOpToList(inherits)
+
+        # We do not allow multiple inheritance 
+        numInherits = len(inheritsList)
+        if numInherits > 1:
+            raise Exception(errorMsg(('Schemas can only inherit from one other schema '
+                                      'at most. This schema inherits from %d (%s).' 
+                                      % (numInherits, 
+                                         ', '.join(map(str, inheritsList))))))
 
         # Allow user to specify custom naming through customData metadata.
         self.customData = dict(sdfPrim.customData)
@@ -321,14 +338,6 @@ class ClassInfo(object):
         self.isApi = not self.isTyped and not self.isConcrete
         self.isMultipleApply = self.customData.get('isMultipleApply', False)
         self.isPrivateApply = self.customData.get('isPrivateApply', False)
-
-        errorPrefix = ('Invalid schema definition at ' 
-                       + '<' + str(sdfPrim.path) + '>')
-        errorSuffix = ('       See '
-                       'https://graphics.pixar.com/usd/docs/api/'
-                       '_usd__page__generating_schemas.html#Usd_IsAVsAPISchemas '
-                       'for more information.\n')
-        errorMsg = lambda s: errorPrefix + s + '\n' + errorSuffix
 
         if self.isConcrete and not self.isTyped:
             raise Exception(errorMsg('Schema classes must either inherit '


### PR DESCRIPTION
This is part of a continuing effort to make schemaGen friendlier to use.

### Description of Change(s)

UsdGenSchema disallows schemas from inheriting from multiple
parents. Currently this error manifests as:

```
ERROR: 'NoneType' object has no attribute 'typeName'
```

Needless to say, this isn't particularly helpful. This commit
changes the error to manifest as follows(given an example schema
defined at /MyC):

```
ERROR: Invalid schema definition at </MyC>
Schemas can only inherit from one other schema at most. This schema inherits from 2 (/MyBase, /Xformable).
See https://graphics.pixar.com/usd/docs/api/_usd__page__generating_schemas.html for more information.
```

