### PR TITLE
[houdini] Add basic support for writing GT_TYPE_TEXTURE attrs in 16.5+

### DIFF
--- a/third_party/houdini/lib/gusd/GT_Utils.cpp
+++ b/third_party/houdini/lib/gusd/GT_Utils.cpp
@@ -134,6 +134,12 @@ struct GtDataToUsdTypename
             = SdfValueTypeNames->Float3;
         m_typeLookup[KeyType(GT_STORE_REAL32, GT_TYPE_NONE, 3, true)]
             = SdfValueTypeNames->Float3Array;
+#if (GUSD_VER_CMP_2(>=,16,5))
+        m_typeLookup[KeyType(GT_STORE_REAL32, GT_TYPE_TEXTURE, 3, false)]
+            = SdfValueTypeNames->Float3;
+        m_typeLookup[KeyType(GT_STORE_REAL32, GT_TYPE_TEXTURE, 3, true)]
+            = SdfValueTypeNames->Float3Array;
+#endif
         // VectorFloat
         m_typeLookup[KeyType(GT_STORE_REAL32, GT_TYPE_VECTOR, 3, false)]
             = SdfValueTypeNames->Vector3f;


### PR DESCRIPTION
### Description of Change(s)

Houdini 16.5 introduced a new `GT_TYPE_TEXTURE` storage type, which it uses for newly-created `uv` attributes. This change adds basic support for writing float attributes tagged with this type as `Float3/Float3Array` primvars.