### PR TITLE
[usdHoudini] Creating a shading mode registry for houdini

### DIFF
--- a/third_party/houdini/lib/gusd/CMakeLists.txt
+++ b/third_party/houdini/lib/gusd/CMakeLists.txt
@@ -41,6 +41,7 @@ pxr_shared_library(${PXR_PACKAGE}
         purpose
         refiner
         scopeWrapper
+        shadingModeRegistry
         shaderWrapper
         stageCache
         stageEdit
@@ -86,6 +87,7 @@ pxr_shared_library(${PXR_PACKAGE}
 
     CPPFILES
         plugin.cpp
+        ribShadingExporter.cpp
 
     PRIVATE_CLASSES
         GEO_IOTranslator
@@ -95,6 +97,7 @@ pxr_shared_library(${PXR_PACKAGE}
         packedUsdWrapper
         pointsWrapper
         instancerWrapper
+        debugCodes
 
     PYMODULE_FILES
         __init__.py

--- a/third_party/houdini/lib/gusd/ribShadingExporter.cpp
+++ b/third_party/houdini/lib/gusd/ribShadingExporter.cpp
@@ -1,0 +1,60 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "shadingModeRegistry.h"
+#include "shaderWrapper.h"
+
+#include <OP/OP_Node.h>
+#include <UT/UT_String.h>
+#include <VOP/VOP_Node.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION_WITH_TAG(GusdShadingModeRegistry, rib) {
+    GusdShadingModeRegistry::getInstance().registerExporter(
+        "rib", "RIB", [](OP_Node* opNode,
+                         const UsdStagePtr& stage,
+                         const SdfPath& looksPath,
+                         const GusdShadingModeRegistry::HouMaterialMap& houMaterialMap,
+                         const std::string& shaderOutDir) {
+            for (const auto& assignment: houMaterialMap) {
+                VOP_Node* materialVop = opNode->findVOPNode(assignment.first.c_str());
+                if (materialVop == nullptr ||
+                    strcmp(materialVop->getRenderMask(), "RIB") != 0) {
+                    continue;
+                }
+
+                UT_String vopPath(materialVop->getFullPath());
+                vopPath.forceAlphaNumeric();
+                SdfPath path = looksPath.AppendPath(SdfPath(vopPath.toStdString()));
+
+                GusdShaderWrapper shader(materialVop, stage, path.GetString(), shaderOutDir);
+                for (const auto& primPath: assignment.second) {
+                    UsdPrim prim = stage->GetPrimAtPath(primPath);
+                    shader.bind(prim);
+                }
+            }
+        });
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/houdini/lib/gusd/shadingModeRegistry.cpp
+++ b/third_party/houdini/lib/gusd/shadingModeRegistry.cpp
@@ -1,0 +1,175 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "shadingModeRegistry.h"
+#include "debugCodes.h"
+
+#include "pxr/base/plug/plugin.h"
+#include "pxr/base/plug/registry.h"
+
+#include "pxr/base/tf/debug.h"
+#include "pxr/base/tf/instantiateSingleton.h"
+#include "pxr/base/tf/scriptModuleLoader.h"
+#include "pxr/base/tf/staticTokens.h"
+#include "pxr/base/tf/stl.h"
+#include "pxr/base/tf/token.h"
+
+#include <OP/OP_Node.h>
+#include <OP/OP_OperatorTable.h>
+
+#include <map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(_tokens,
+    (houdiniPlugin)
+    (UsdHoudini)
+    (ShadingModePlugin)
+);
+
+namespace {
+
+template <typename T> bool inline
+getData(const JsValue& any, T& val)
+{
+    if (!any.Is<T>()) {
+        TF_CODING_ERROR("Bad plugInfo.json");
+        return false;
+    }
+
+    val = any.Get<T>();
+    return true;
+}
+
+bool inline
+readNestedDict(
+        const JsObject& data,
+        const std::vector<TfToken>& keys,
+        JsObject& dict)
+{
+    JsObject currDict = data;
+    for (const auto& currKey: keys) {
+        JsValue any;
+        if (!TfMapLookup(currDict, currKey, &any)) {
+            return false;
+        }
+
+        if (!any.IsObject()) {
+            TF_CODING_ERROR("Bad plugInfo data.");
+            return false;
+        }
+        currDict = any.GetJsObject();
+    }
+    dict = currDict;
+    return true;
+}
+
+bool inline
+hasPlugin(
+    const PlugPluginPtr& plug,
+    const std::vector<TfToken>& scope,
+    const TfToken& pluginType)
+{
+    JsObject metadata = plug->GetMetadata();
+    JsObject houdiniMetadata;
+    if (!readNestedDict(metadata, scope, houdiniMetadata)) {
+        return false;
+    }
+
+    JsValue any;
+    if (TfMapLookup(houdiniMetadata, pluginType, &any)) {
+        bool hasPlugin = false;
+        return getData(any, hasPlugin) & hasPlugin;
+    }
+
+    return false;
+}
+
+void inline
+loadAllPlugins(std::once_flag& once_flag, const std::vector<TfToken>& scope, const TfToken& pluginType, OP_OperatorTable* table) {
+    std::call_once(once_flag, [&scope, &table, &pluginType](){
+        for (const auto& plug: PlugRegistry::GetInstance().GetAllPlugins()) {
+            if (hasPlugin(plug, scope, pluginType)) {
+                TF_DEBUG(PXRUSDHOUDINI_REGISTRY).Msg(
+                    "Found UsdHoudini plugin %s: Loading from: %s",
+                    plug->GetName().c_str(),
+                    plug->GetPath().c_str());
+                if (!table->loadDSO(plug->GetPath().c_str())) {
+                    TF_CODING_ERROR("Failed to load usdHoudini plugin.");
+                }
+            }
+        }
+    });
+}
+
+}
+
+using _ExporterRegistryElem = std::tuple<GusdShadingModeRegistry::ExporterFn, TfToken>;
+using _ExporterRegistry = std::map<TfToken, _ExporterRegistryElem>;
+static _ExporterRegistry _exporterRegistry;
+
+bool
+GusdShadingModeRegistry::registerExporter(
+    const std::string& name,
+    const std::string& label,
+    GusdShadingModeRegistry::ExporterFn creator) {
+    auto insertStatus = _exporterRegistry.insert(
+        {TfToken(name), _ExporterRegistryElem{creator, TfToken(label)}}
+    );
+    return insertStatus.second;
+}
+
+GusdShadingModeRegistry::ExporterFn
+GusdShadingModeRegistry::_getExporter(const TfToken& name) {
+    TfRegistryManager::GetInstance().SubscribeTo<GusdShadingModeRegistry>();
+    const auto it = _exporterRegistry.find(name);
+    return it == _exporterRegistry.end() ? nullptr : std::get<0>(it->second);
+}
+
+GusdShadingModeRegistry::ExporterList
+GusdShadingModeRegistry::_listExporters() {
+    TfRegistryManager::GetInstance().SubscribeTo<GusdShadingModeRegistry>();
+    GusdShadingModeRegistry::ExporterList ret;
+    ret.reserve(_exporterRegistry.size());
+    for (const auto& it: _exporterRegistry) {
+        ret.emplace_back(it.first, std::get<1>(it.second));
+    }
+    return ret;
+}
+
+void
+GusdShadingModeRegistry::loadPlugins(OP_OperatorTable* table) {
+    static std::once_flag _shadingModesLoaded;
+    static std::vector<TfToken> scope = {_tokens->UsdHoudini};
+    loadAllPlugins(_shadingModesLoaded, scope, _tokens->ShadingModePlugin, table);
+}
+
+TF_INSTANTIATE_SINGLETON(GusdShadingModeRegistry);
+
+GusdShadingModeRegistry&
+GusdShadingModeRegistry::getInstance() {
+    return TfSingleton<GusdShadingModeRegistry>::GetInstance();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/houdini/lib/gusd/shadingModeRegistry.h
+++ b/third_party/houdini/lib/gusd/shadingModeRegistry.h
@@ -1,0 +1,114 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef __GUSD_SHADEROUTPUTREGISTRY_H__
+#define __GUSD_SHADEROUTPUTREGISTRY_H__
+
+#include <pxr/pxr.h>
+
+#include <pxr/base/tf/declarePtrs.h>
+#include <pxr/base/tf/registryManager.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/tf/singleton.h>
+#include <pxr/base/tf/weakPtr.h>
+
+#include "gusd/api.h"
+
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <UT/UT_Map.h>
+
+#include <vector>
+#include <tuple>
+#include <functional>
+
+class OP_Node;
+class OP_OperatorTable;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DECLARE_WEAK_PTRS(GusdShaderOutputRegistry);
+
+/// Class for registering and querying shader exporters.
+/// To make sure the plugins will be loaded before creating
+/// the user interface for USD Output, the plugin registry
+/// loads registered plugins.
+/// Add the following snippet to plugInfo.json to tell the registry which
+/// plugin to load.
+/// "Info" : {
+///     "UsdHoudini" : {
+///         "ShadingModePlugin" : true
+///     }
+/// },
+/// Plugin loads happen via Houdini, so the library needs to be a valid
+/// Houdini plugin. Example:
+/// #include <SYS/SYS_Version.h>
+/// #include <UT/UT_DSOVersion.h>
+/// #include <OP/OP_OperatorTable.h>
+/// 
+/// extern "C" {
+///     void newDriverOperator(OP_OperatorTable* operators) { }
+/// }
+class GusdShadingModeRegistry : public TfWeakBase
+{
+private:
+    GusdShadingModeRegistry() = default;
+public:
+    using HouMaterialMap = UT_Map<std::string, std::vector<SdfPath>>;
+    using ExporterFn = std::function<
+        void(OP_Node*, const UsdStagePtr&, const SdfPath&,
+             const HouMaterialMap&, const std::string&)>;
+    using ExporterList = std::vector<std::tuple<TfToken, TfToken>>;
+
+    static ExporterFn
+    getExporter(const TfToken& name) {
+        return getInstance()._getExporter(name);
+    }
+
+    static ExporterList
+    listExporters() {
+        return getInstance()._listExporters();
+    }
+
+    GUSD_API
+    static GusdShadingModeRegistry& getInstance();
+
+    GUSD_API
+    bool registerExporter(
+        const std::string& name,
+        const std::string& label,
+        ExporterFn fn);
+
+    GUSD_API
+    static void loadPlugins(OP_OperatorTable* table);
+private:
+    friend class TfSingleton<GusdShadingModeRegistry>;
+
+    ExporterFn _getExporter(const TfToken& name);
+    ExporterList _listExporters();
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // __GUSD_SHADEROUTPUTREGISTRY_H__

--- a/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.h
+++ b/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.h
@@ -36,6 +36,7 @@
 #include <UT/UT_Map.h>
 
 #include "gusd/GT_Utils.h"
+#include "gusd/shadingModeRegistry.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -45,7 +46,6 @@ class GusdROP_usdoutput : public ROP_Node
 
     typedef std::pair<std::string, std::string> UsdRefShader;
     typedef UT_Map<UsdRefShader, std::vector<SdfPath> > UsdRefShaderMap;
-    typedef UT_Map<std::string, std::vector<SdfPath> >  HouMaterialMap;
 
     enum Granularity { ONE_FILE, PER_FRAME };
 
@@ -76,7 +76,7 @@ private:
     ROP_RENDER_CODE closeStage(fpreal tend);
 
     ROP_RENDER_CODE bindAndWriteShaders(UsdRefShaderMap& usdRefShaderMap,
-                                        HouMaterialMap& houMaterialMap);
+                                        GusdShadingModeRegistry::HouMaterialMap& houMaterialMap);
     void resetState();
 
     ROP_RENDER_CODE abort(const std::string& errorMessage);


### PR DESCRIPTION
### Description of Change(s)
The PR is our initial take on a usdMaya-like shading mode registry for Houdini. To have the most flexibility for implementing all kinds of shader exporters, we decided to inject custom code into GusdROP_usdoutput::bindAndWriteShaders , via a simple function pointer. For simplicity, I avoided the class-based approach of usdMaya, because usdoutput's shader binding already happens in bulk.

We haven't tested this change with USD-Arnold Houdini related plugins, so currently, this PR is only opened for feedback, until we can confirm the current approach covers our needs.

### Fixes Issue(s)
No reported issues.

