### PR TITLE
[Usd] Add better static assert.

### DIFF
--- a/pxr/usd/lib/usd/attribute.h
+++ b/pxr/usd/lib/usd/attribute.h
@@ -385,6 +385,7 @@ public:
     /// retrieve resolved asset paths from SdfAssetPath-valued attributes.
     template <typename T>
     bool Get(T* value, UsdTimeCode time = UsdTimeCode::Default()) const {
+        static_assert(!std::is_const<T>::value, "");
         static_assert(SdfValueTypeTraits<T>::IsValueType, "");
         return _Get(value, time);
     }


### PR DESCRIPTION
### Description of Change(s)

This static assert makes it clearer that get cannot be called
with a const T*. Before this, the static assert below would fail, but
the output error is much less clear.

