### PR TITLE
[usdHoudini]: Fix usage of nonexistent VtArray::GetSize() method

### DIFF
--- a/third_party/houdini/lib/gusd/GT_VtArray.h
+++ b/third_party/houdini/lib/gusd/GT_VtArray.h
@@ -233,7 +233,7 @@ void
 GusdGT_VtArray<T>::swap(ArrayType& o)
 {
     _array.swap(o);
-    _size = _array.GetSize();
+    _size = _array.size();
     _UpdateDataPointer(false);
 }
 

--- a/third_party/houdini/lib/gusd/UT_VtArray.h
+++ b/third_party/houdini/lib/gusd/UT_VtArray.h
@@ -54,7 +54,7 @@ public:
     typedef typename ArrayType::const_reverse_iterator  const_reverse_iterator;
 
     GusdUT_VtArrayRO(const ArrayType& array)
-        : _array(array), _size(array.GetSize()), _data(array.cdata())
+        : _array(array), _size(array.size()), _data(array.cdata())
         { UT_ASSERT(_size == 0 || _data != NULL); }
 
     const T&                operator()(exint i) const
@@ -107,14 +107,14 @@ public:
     const T&                operator()(exint i) const
                             {
                                 UT_ASSERT_P(i >= 0 && i < _size);
-                                UT_ASSERT_P(_size == _array.GetSize());
+                                UT_ASSERT_P(_size == _array.size());
                                 return _data[i];
                             }
 
     T&                      operator()(exint i)
                             {
                                 UT_ASSERT_P(i >= 0 && i < _size);
-                                UT_ASSERT_P(_size == _array.GetSize());
+                                UT_ASSERT_P(_size == _array.size());
                                 return _data[i];
                             }
     
@@ -160,7 +160,7 @@ public:
     void                    update()
                             {
                                 _data = _array.data();
-                                _size = _array.GetSize();
+                                _size = _array.size();
                                 UT_ASSSERT(_size == 0 || _data != NULL);
                             }
 


### PR DESCRIPTION
### Description of Change(s)

Fixes references to a nonexistent `VtArray::GetSize()` method by `GusdGT_VtArray`, `GusdUT_VtArrayRO`, and `GusdUT_VtArrayRW`. I'm guessing this was an old method, and that these instances may have been missed during a refactor.