### PR TITLE
[usdHoudini] Translate st primvar to/from Houdini uv attribute

### DIFF
--- a/third_party/houdini/lib/gusd/GT_VtArray.h
+++ b/third_party/houdini/lib/gusd/GT_VtArray.h
@@ -233,7 +233,7 @@ void
 GusdGT_VtArray<T>::swap(ArrayType& o)
 {
     _array.swap(o);
-    _size = _array.GetSize();
+    _size = _array.size();
     _UpdateDataPointer(false);
 }
 

--- a/third_party/houdini/lib/gusd/UT_VtArray.h
+++ b/third_party/houdini/lib/gusd/UT_VtArray.h
@@ -54,7 +54,7 @@ public:
     typedef typename ArrayType::const_reverse_iterator  const_reverse_iterator;
 
     GusdUT_VtArrayRO(const ArrayType& array)
-        : _array(array), _size(array.GetSize()), _data(array.cdata())
+        : _array(array), _size(array.size()), _data(array.cdata())
         { UT_ASSERT(_size == 0 || _data != NULL); }
 
     const T&                operator()(exint i) const
@@ -107,14 +107,14 @@ public:
     const T&                operator()(exint i) const
                             {
                                 UT_ASSERT_P(i >= 0 && i < _size);
-                                UT_ASSERT_P(_size == _array.GetSize());
+                                UT_ASSERT_P(_size == _array.size());
                                 return _data[i];
                             }
 
     T&                      operator()(exint i)
                             {
                                 UT_ASSERT_P(i >= 0 && i < _size);
-                                UT_ASSERT_P(_size == _array.GetSize());
+                                UT_ASSERT_P(_size == _array.size());
                                 return _data[i];
                             }
     
@@ -160,7 +160,7 @@ public:
     void                    update()
                             {
                                 _data = _array.data();
-                                _size = _array.GetSize();
+                                _size = _array.size();
                                 UT_ASSSERT(_size == 0 || _data != NULL);
                             }
 

--- a/third_party/houdini/lib/gusd/tokens.h
+++ b/third_party/houdini/lib/gusd/tokens.h
@@ -36,7 +36,9 @@ PXR_NAMESPACE_OPEN_SCOPE
     (Alpha)                                     \
     (Cd)                                        \
     (displayColor)                              \
-    (displayOpacity)
+    (displayOpacity)                            \
+    (st)                                        \
+    (uv)
 
 TF_DECLARE_PUBLIC_TOKENS(GusdTokens, GUSD_TOKENS);
 


### PR DESCRIPTION
### Description of Change(s)

Adds basic translation between USD's `st` primvar and Houdini's `uv` attribute during import (unpacking) and export. This allows USD UV data to be preserved through (or manipulated by) Houdini, and for UVs generated in Houdini to be exported to USD's canonical primvar, without manual attribute wrangling.

#### Import

The unpacking logic will currently prefer a `uv` primvar if both `st` and `uv` are found and are selected for import. Otherwise, if `st` is found and is a `Float2Array` type, it will be "promoted" to a `Float3Array` in transit and applied to Houdini's `uv` attribute.

If `st` is *not* a `Float2Array`, it will still be remapped to Houdini's `uv` attribute, but no type conversion will be done and a warning will be issued. This is considered an edge case, and the current behavior may be considered undesirable, so it can be augmented or removed if necessary.

#### Export

The export logic is similar to import, although a bit more selective. If a `uv` attribute is being written from Houdini, and it is a float attribute scoped to either points or vertices with a tuple size >= 2, it will be translated to a `Float2Array` and written to the `st` primvar. It may be preferable for this check to be further limited to only consider an attribute with a tuple size of exactly 3.

#### Future

Eventually, we should be able to replace the uses of the `Float2Array` type name with a forthcoming `textureCoordinate2f ` (or similar) type, in order to make the behaviors even more explicit. Also, when reading `st` data to `uv` in Houdini 16.5+ (and possibly when reading `uv` as-is), I think we will want to mark it as `GT_TYPE_TEXTURE` (new in 16.5), in order to align with Houdini's own behavior for application-generated UV data.

### Fixes Issue(s)

Addresses #362, as well as fixing some references to a nonexistent `VtArray::GetSize()` method by other `Gusd` classes, which was temporarily open as #414.