### PR TITLE
Fix simple lighting shader to compile under OSX

### DIFF
--- a/pxr/imaging/lib/glf/shaders/simpleLighting.glslfx
+++ b/pxr/imaging/lib/glf/shaders/simpleLighting.glslfx
@@ -374,13 +374,13 @@ simpleLighting(vec4 color, vec4 Peye, vec3 Neye, vec4 Ctint,
 
     // Get the roughness and metallic values
 
-#if HD_HAS_displayRoughness
+#if defined(HD_HAS_displayRoughness)
     float roughness = max(0.0, min(1.0, float(HdGet_displayRoughness())));
 #else
     float roughness = 0.0;
 #endif
 
-#if HD_HAS_displayMetallic
+#if defined(HD_HAS_displayMetallic)
     float metallic  = max(0.0, min(1.0, float(HdGet_displayMetallic())));
 #else
     float metallic = 0.0;
@@ -391,7 +391,7 @@ simpleLighting(vec4 color, vec4 Peye, vec3 Neye, vec4 Ctint,
 
     LightingInterfaceProperties props;
 
-#if HD_HAS_displayRoughness
+#if defined(HD_HAS_displayRoughness)
     float specularExp = (1.0 - roughness) * 120.0 + 8.0;
     props.shininess = specularExp;
     matSpecular.rgb = mix(vec3(1.0), matDiffuse.rgb, metallic);


### PR DESCRIPTION
The OSX GLSL compiler doesn't like preprocessor directives like:
#if foo
when the macro "foo" has not been defined. This was showing up in the simple lighting shader when checking a couple of "HD_HAS_xxx" conditions, causing the shader to fail to compile. These check should be of the form:
#if defined(foo)
as all other checks for "HD_HAS_xxx" conditions are in other shaders.