### PR TITLE
Guard against empty tokenization in ApplyCollection

### DIFF
--- a/pxr/usd/lib/usd/collectionAPI.cpp
+++ b/pxr/usd/lib/usd/collectionAPI.cpp
@@ -144,6 +144,12 @@ UsdCollectionAPI::ApplyCollection(
     // Ensure that the collection name is valid.
     TfTokenVector tokens = SdfPath::TokenizeIdentifierAsTokens(name);
 
+    if ( tokens.empty() )
+    {
+        TF_CODING_ERROR("Invalid collection name '%s'.", name.GetText());
+        return UsdCollectionAPI();
+    }
+
     TfToken baseName = *tokens.rbegin();
     if (IsSchemaPropertyBaseName(baseName)) {
         TF_CODING_ERROR("Invalid collection name '%s'. The base-name '%s' is a "

--- a/pxr/usd/lib/usd/testenv/testUsdCollectionAPI.py
+++ b/pxr/usd/lib/usd/testenv/testUsdCollectionAPI.py
@@ -52,6 +52,7 @@ class TestUsdCollectionAPI(unittest.TestCase):
         # Test an explicitOnly collection.
         explicitColl = Usd.CollectionAPI.ApplyCollection(testPrim, 
                 "test:Explicit:Collection", Usd.Tokens.explicitOnly)
+
         self.assertTrue(explicitColl.HasNoIncludedPaths())
         self.assertEqual(['CollectionAPI:test:Explicit:Collection'],
                          testPrim.GetAppliedSchemas())
@@ -323,6 +324,11 @@ class TestUsdCollectionAPI(unittest.TestCase):
                 excludeInstanceGeomMquery, stage, 
                 predicate=Usd.TraverseInstanceProxies())
         self.assertEqual(len(allIncObjects), 2)
+        
+    def test_invalidCollectionName(self):
+        with self.assertRaises(Exception):
+            explicitColl2 = Usd.CollectionAPI.ApplyCollection(testPrim,
+                "a:b(c)", Usd.Tokens.explicitOnly)
 
     def test_invalidCollections(self):
         invalidCollectionNames = ["invalidExpansionRule", 


### PR DESCRIPTION
### Description of Change(s)

Ensure ApplyCollection doesn't access an empty vector when called with an invalid name.

