### PR TITLE
Fixing IsRelativePath call in AnchorRelativePath

### DIFF
--- a/pxr/usd/lib/ar/defaultResolver.cpp
+++ b/pxr/usd/lib/ar/defaultResolver.cpp
@@ -108,7 +108,7 @@ ArDefaultResolver::AnchorRelativePath(
     const std::string& path)
 {
     if (TfIsRelativePath(anchorPath) ||
-        !ArDefaultResolver::IsRelativePath(path)) {
+        !IsRelativePath(path)) {
         return path;
     }
 


### PR DESCRIPTION
### Description of Change(s)
The change updates ArDefaultResolver::AnchorRelativePath so it'll call the virtual IsRelativePath function, instead of explicitly calling ArDefaultResolver::IsRelativePath. This helps developers who want to replace ArDefaultResolver.
