### PR TITLE
Pick up the first camera when there is no main camera specified

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -2211,7 +2211,12 @@ class AppController(QtCore.QObject):
                     if camera.GetName() == self._startingPrimCameraName:
                         setCamera(camera)
                         break
-
+                    
+            # If no main camera was specified, we pick up the first one:
+            if not self._startingPrimCamera and self._allSceneCameras:
+                setCamera(self._allSceneCameras[0])
+                
+        
         # Now that we have the current camera and all cameras, build the menu
         self._ui.menuCamera.clear()
         if len(self._allSceneCameras) == 0:


### PR DESCRIPTION
### Description of Change(s)
Just by default to pick up the first camera from the camera list if there is any.

There may be multiple cameras in a production shot, but we can choose to just have one camera prim recognized by usdView, means picking up the first camera here will be a great help.

Ideally, if usdView could support command plugin that implements a postStageLoad callback, which will give client code a chance to set up something so it works better in usdView.

### Fixes Issue(s)
- The free camera gets used instead of the shot camera we want to use when a shot is loaded in usdView manually.