### PR TITLE
add support for Boost_USE_STATIC_LIBS on Windows. Fixes #407

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -82,8 +82,11 @@ _add_define("NOMINMAX")
 _add_define("YY_NO_UNISTD_H")
 
 # Forces all libraries that have separate source to be linked as
-# DLL's rather than static libraries on Microsoft Windows.
-_add_define("BOOST_ALL_DYN_LINK")
+# DLL's rather than static libraries on Microsoft Windows, unless
+# explicitely told otherwise.
+if (NOT ${Boost_USE_STATIC_LIBS})
+    _add_define("BOOST_ALL_DYN_LINK")
+endif()
 
 # Need half::_toFloat and half::_eLut.
 _add_define("OPENEXR_DLL")


### PR DESCRIPTION
### Description of Change(s)

This commit allows the user to specify the `Boost_USE_STATIC_LIBS` option to disable auto-linking on Windows (`msvcdefaults.cmake` was always forcing linking the dynamic boost libs (dlls) on Windows)

If the option is not set in CMake, the usual behavior does not change.

### Fixes Issue(s)

- #407 

