### PR TITLE
Fix GetDisplayName() for Anonymous Layers.

### DIFF
--- a/pxr/usd/lib/sdf/assetPathResolver.cpp
+++ b/pxr/usd/lib/sdf/assetPathResolver.cpp
@@ -212,6 +212,10 @@ Sdf_GetAnonLayerDisplayName(
     // We want to find the second occurence of ':', traversing from the left,
     // in our identifier which is of the form anon:0x4rfs23:displayName
     auto fst = std::find(identifier.begin(), identifier.end(), ':');
+    if (fst == identifier.end()) {
+        return std::string();
+    }
+
     auto snd = std::find(fst + 1, identifier.end(), ':');
     if (snd == identifier.end()) {
         return std::string();

--- a/pxr/usd/lib/sdf/assetPathResolver.cpp
+++ b/pxr/usd/lib/sdf/assetPathResolver.cpp
@@ -209,9 +209,15 @@ string
 Sdf_GetAnonLayerDisplayName(
     const string& identifier)
 {
-    if (std::count(identifier.begin(), identifier.end(), ':') == 2)
-        return identifier.substr(identifier.rfind(':') + 1);
-    return std::string();
+    // We want to find the second occurence of ':', traversing from the left,
+    // in our identifier which is of the form anon:0x4rfs23:displayName
+    auto fst = std::find(identifier.begin(), identifier.end(), ':');
+    auto snd = std::find(fst + 1, identifier.end(), ':');
+    if (snd == identifier.end()) {
+        return std::string();
+    }
+
+    return identifier.substr(std::distance(identifier.begin(), snd) + 1);
 }
 
 string

--- a/pxr/usd/lib/sdf/testenv/testSdfLayer.py
+++ b/pxr/usd/lib/sdf/testenv/testSdfLayer.py
@@ -61,6 +61,19 @@ class TestSdfLayer(unittest.TestCase):
         with self.assertRaises(Tf.ErrorException):
             l = Sdf.Layer.OpenAsAnonymous('foo.invalid')
 
+    def test_AnonymousIdentifiersDisplayName(self):
+        # Ensure anonymous identifiers work as expected
+
+        ident = 'anonIdent.sdf'
+        l = Sdf.Layer.CreateAnonymous(ident)
+        self.assertEqual(l.GetDisplayName(), ident)
+
+        identWithColons = 'anonIdent:afterColon.sdf'
+        l = Sdf.Layer.CreateAnonymous(identWithColons)
+        self.assertEqual(l.GetDisplayName(), identWithColons)
+
+        l = Sdf.Layer.CreateAnonymous()
+        self.assertEqual(l.GetDisplayName(), '')
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/lib/usd/testenv/testUsdStage.py
+++ b/pxr/usd/lib/usd/testenv/testUsdStage.py
@@ -28,6 +28,22 @@ from pxr import Sdf,Usd,Tf
 allFormats = ['usd' + c for c in 'ac']
 
 class TestUsdStage(unittest.TestCase):
+    def test_AnonymousIdentifiersDisplayName(self):
+        # Ensure anonymous identifiers work as expected
+
+        for fmt in allFormats:
+            ident = 'anonIdent.' + fmt
+            s = Usd.Stage.CreateInMemory(ident)
+            assert s.GetRootLayer().GetDisplayName() == ident
+
+            identWithColons = 'anonIdent:afterColon.' + fmt
+            s = Usd.Stage.CreateInMemory(identWithColons)
+            assert s.GetRootLayer().GetDisplayName() == identWithColons
+
+            # This name is provided by default in stage
+            s = Usd.Stage.CreateInMemory()
+            assert s.GetRootLayer().GetDisplayName() == 'tmp.usda'
+
     def test_UsedLayers(self):
         for fmt in allFormats:
             sMain = Usd.Stage.CreateInMemory('testUsedLayers.'+fmt)

--- a/pxr/usd/lib/usd/testenv/testUsdStage.py
+++ b/pxr/usd/lib/usd/testenv/testUsdStage.py
@@ -28,22 +28,6 @@ from pxr import Sdf,Usd,Tf
 allFormats = ['usd' + c for c in 'ac']
 
 class TestUsdStage(unittest.TestCase):
-    def test_AnonymousIdentifiersDisplayName(self):
-        # Ensure anonymous identifiers work as expected
-
-        for fmt in allFormats:
-            ident = 'anonIdent.' + fmt
-            s = Usd.Stage.CreateInMemory(ident)
-            assert s.GetRootLayer().GetDisplayName() == ident
-
-            identWithColons = 'anonIdent:afterColon.' + fmt
-            s = Usd.Stage.CreateInMemory(identWithColons)
-            assert s.GetRootLayer().GetDisplayName() == identWithColons
-
-            # This name is provided by default in stage
-            s = Usd.Stage.CreateInMemory()
-            assert s.GetRootLayer().GetDisplayName() == 'tmp.usda'
-
     def test_UsedLayers(self):
         for fmt in allFormats:
             sMain = Usd.Stage.CreateInMemory('testUsedLayers.'+fmt)


### PR DESCRIPTION
### Description of Change(s)

It was broken when the provided identifier had a colon in it,
which is legal in a posix file path.

e.g.

```python
from pxr import Usd
s = Usd.Stage.CreateInMemory('foo:foo.usda')
s.GetRootLayer().GetDisplayName()
```

Should return `foo:foo.usda`, but currently returns an empty string

### Fixes Issue(s)
- None

