### PR TITLE
[maya] remove duplicate usdTranslatorExport_AppendFromTextField mel func

### DIFF
--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -78,12 +78,6 @@ global proc string usdTranslatorExport_AppendMultiFloatFromTextField(string $cur
     return $currentOptions;
 }
 
-global proc string usdTranslatorExport_AppendFromTextField(string $currentOptions, string $arg, string $widget) {
-    string $rawValue = `textFieldGrp -q -text $widget`;
-    $currentOptions = $currentOptions + ";" + $arg + "=" + $rawValue;
-    return $currentOptions;
-}
-
 global proc int usdTranslatorExport (string $parent,
                                      string $action,
                                      string $initialSettings,


### PR DESCRIPTION
### Description of Change(s)

So, in our pr/export_parent_scope pull request (https://github.com/PixarAnimationStudios/USD/pull/223), we accidentally introduced a duplicate MEL function. Looks like we both implemented it, and then when we did a rebase, we didn't pick up the duplicated code. Apologies!
