### PR TITLE
[usdAlembic] Preferring st over uv attribute if present for UV writes.

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -62,11 +62,12 @@ pxr_plugin(usdAbc
 )
 
 pxr_test_scripts(
-    testenv/testUsdAbcAlembicData.py       
-    testenv/testUsdAbcBugs.py              
-    testenv/testUsdAbcCamera.py  
-    testenv/testUsdAbcConversionSubdiv.py 
-    testenv/testUsdAbcInstancing.py 
+    testenv/testUsdAbcAlembicData.py
+    testenv/testUsdAbcBugs.py
+    testenv/testUsdAbcCamera.py
+    testenv/testUsdAbcConversionSubdiv.py
+    testenv/testUsdAbcInstancing.py
+    testenv/testUsdAbcUvWrite.py
 )
 
 pxr_install_test_dir(
@@ -107,6 +108,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdAbcInstancingPinst
     DEST testUsdAbcInstancingPinst
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdAbcUvWrite
+    DEST testUsdAbcUvWrite
 )
 
 pxr_register_test(testUsdAbcAlembicData
@@ -172,4 +178,10 @@ pxr_register_test(testUsdAbcInstancingNinst
     ENV
         USD_ABC_TESTSUFFIX=ninst
         USD_ABC_DISABLE_INSTANCING=1
+)
+
+pxr_register_test(testUsdAbcUvWrite
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcUvWrite"
+    EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -103,7 +103,10 @@ TF_DECLARE_PUBLIC_TOKENS(UsdAbcPrimTypeNames, USD_ABC_PRIM_TYPE_NAMES);
     (userProperties) \
     /* end */
 #define USD_ABC_POINTBASED_NAMES \
-    ((uv, "primvars:uv"))
+    ((uv, "primvars:uv")) \
+    ((uvIndices, "primvars:uv:indices")) \
+    ((st, "primvars:st")) \
+    ((stIndices, "primvars:st:indices")) \
     /* end */
 #define USD_ABC_PROPERTY_NAMES \
     USD_ABC_GPRIM_NAMES \

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcUvWrite.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcUvWrite.py
@@ -1,0 +1,73 @@
+#!/pxrpythonsubst
+#
+# Copyright 2018 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+from pxr import Usd, UsdAbc, UsdGeom
+import tempfile, unittest
+
+class TestUsdAbcUvWrite(unittest.TestCase):
+    def test_Write(self):
+        with tempfile.NamedTemporaryFile(suffix='.abc') as tempAbcFile:
+            tempAbcFile.close()
+            testFile = 'testUsdAbcUvWrite.usda'
+
+            planeStPath = '/pPlaneSt'
+            planeUvPath = '/pPlaneUv'
+            planeStUvPath = '/pPlaneStUv'
+
+            UsdAbc._WriteAlembic(testFile, tempAbcFile.name)
+
+            stage = Usd.Stage.Open(testFile)
+            self.assertTrue(stage)
+            roundStage = Usd.Stage.Open(tempAbcFile.name)
+            self.assertTrue(roundStage)
+
+            planeSt = UsdGeom.Mesh.Get(stage, planeStPath)
+            planeUv = UsdGeom.Mesh.Get(stage, planeUvPath)
+            planeStUv = UsdGeom.Mesh.Get(stage, planeStUvPath)
+
+            self.assertTrue(planeSt)
+            self.assertTrue(planeUv)
+            self.assertTrue(planeStUv)
+
+            rplaneSt = UsdGeom.Mesh.Get(roundStage, planeStPath)
+            rplaneUv = UsdGeom.Mesh.Get(roundStage, planeUvPath)
+            rplaneStUv = UsdGeom.Mesh.Get(roundStage, planeStUvPath)
+
+            self.assertTrue(rplaneSt)
+            self.assertTrue(rplaneUv)
+            self.assertTrue(rplaneStUv)
+
+            self.assertEqual(planeSt.GetPrimvar('st').Get(), rplaneSt.GetPrimvar('uv').Get(0))
+            self.assertEqual(planeSt.GetPrimvar('st').GetIndices(), rplaneSt.GetPrimvar('uv').GetIndices(0))
+
+            self.assertEqual(planeUv.GetPrimvar('uv').Get(), rplaneUv.GetPrimvar('uv').Get(0))
+            self.assertEqual(planeUv.GetPrimvar('uv').GetIndices(), rplaneUv.GetPrimvar('uv').GetIndices(0))
+
+            self.assertEqual(planeStUv.GetPrimvar('st').Get(), rplaneStUv.GetPrimvar('uv').Get(0))
+            self.assertEqual(planeStUv.GetPrimvar('st').GetIndices(), rplaneStUv.GetPrimvar('uv').GetIndices(0))
+
+            del stage
+            del roundStage
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcUvWrite/testUsdAbcUvWrite.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcUvWrite/testUsdAbcUvWrite.usda
@@ -1,0 +1,53 @@
+#usda 1.0
+(
+    defaultPrim = "pPlane1"
+    endTimeCode = 1
+    startTimeCode = 1
+    upAxis = "Y"
+)
+
+def Mesh "pPlaneSt" (
+    kind = "component"
+)
+{
+    float3[] extent = [(-0.5, 0.0, -0.5), (0.5, 0.0, 0.5)]
+    int[] faceVertexCounts = [4]
+    int[] faceVertexIndices = [0, 1, 3, 2]
+    point3f[] points = [(-0.5, 0.0, 0.5), (0.5, 0.0, 0.5), (-0.5, 0.0, -0.5), (0.5, 0.0, -0.5)]
+    float2[] primvars:st = [(0, 0), (1, 0), (1, 1), (0, 1)] (
+        interpolation = "vertex"
+    )
+    int[] primvars:st:indices = [3, 2, 1, 0]
+}
+
+def Mesh "pPlaneUv" (
+    kind = "component"
+)
+{
+    float3[] extent = [(-0.5, 0.0, -0.5), (0.5, 0.0, 0.5)]
+    int[] faceVertexCounts = [4]
+    int[] faceVertexIndices = [0, 1, 3, 2]
+    point3f[] points = [(-0.5, 0.0, 0.5), (0.5, 0.0, 0.5), (-0.5, 0.0, -0.5), (0.5, 0.0, -0.5)]
+    float2[] primvars:uv = [(0, 0), (2, 0), (2, 2), (0, 2)] (
+        interpolation = "vertex"
+    )
+    int[] primvars:uv:indices = [0, 1, 2, 3]
+}
+
+def Mesh "pPlaneStUv" (
+    kind = "component"
+)
+{
+    float3[] extent = [(-0.5, 0.0, -0.5), (0.5, 0.0, 0.5)]
+    int[] faceVertexCounts = [4]
+    int[] faceVertexIndices = [0, 1, 3, 2]
+    point3f[] points = [(-0.5, 0.0, 0.5), (0.5, 0.0, 0.5), (-0.5, 0.0, -0.5), (0.5, 0.0, -0.5)]
+    float2[] primvars:st = [(0, 0), (1, 0), (1, 1), (0, 1)] (
+        interpolation = "vertex"
+    )
+    int[] primvars:st:indices = [3, 2, 1, 0]
+    float2[] primvars:uv = [(0, 0), (2, 0), (2, 2), (0, 2)] (
+        interpolation = "vertex"
+    )
+    int[] primvars:uv:indices = [0, 1, 2, 3]
+}


### PR DESCRIPTION
### Description of Change(s)
The following change modifies the behaviour of the alembicWriter plugin so that it prefers the "st" attribute over the "uv" attribute. When exporting USD from any 3rd party application, the plugins write uvs to the "st" attribute not to "uv".

### Fixes Issue(s)
No issues reported.
