### PR TITLE
[usdHoudini] Fixing treeview for USD Import and not installing the gusd python files twice

### DIFF
--- a/third_party/houdini/lib/gusd/CMakeLists.txt
+++ b/third_party/houdini/lib/gusd/CMakeLists.txt
@@ -115,12 +115,3 @@ install(
     DESTINATION
         ${PXR_INSTALL_SUBDIR}/config/Icons
 )
-
-install( 
-    FILES
-        __init__.py
-        treeview.py
-        treemodel.py       
-    DESTINATION
-        ${PXR_INSTALL_SUBDIR}/scripts/python/gusd
-)

--- a/third_party/houdini/plugin/OP_gusd/UsdImport.pypanel
+++ b/third_party/houdini/plugin/OP_gusd/UsdImport.pypanel
@@ -9,7 +9,7 @@
     <script><![CDATA[
 import hou
 import sys
-from gusd import TreeView
+from pxr.Gusd.treeview import TreeView
 
 def createInterface():
 


### PR DESCRIPTION
### Description of Change(s)
The PR improves on a recent change that introduced a gusd py module to the build and started installing the gusd python files in the standard location. There are two main differences, changing how UsdImport.pypanel imports the treeview module, so there won't be an error message using the new module, secondly stop installing the same python files into third_party/Houdini/scripts/python/gusd. Installing the same files twice could confuse users, and error messages, as these scripts try to load the _gusd module, even if it's not present.

### Fixes Issue(s)
No reported issues.

