### PR TITLE
[usdImaging] Enabling tx support in imaging.

### DIFF
--- a/pxr/imaging/lib/glf/plugInfo.json
+++ b/pxr/imaging/lib/glf/plugInfo.json
@@ -6,7 +6,7 @@
                 "Types": {                                                                  
                     "Glf_OIIOImage" : {
                         "bases": ["GlfImage"],
-                        "imageTypes": ["bmp", "exr", "jpg", "png", "tif", "zfile"],
+                        "imageTypes": ["bmp", "exr", "jpg", "png", "tif", "zfile", "tx"],
                         "precedence": 0
                     },
                     "GlfPtexTexture" : {


### PR DESCRIPTION
### Description of Change(s)
The PR add tx to the list of supported textures to fix issue #97 . The conclusion there was to manually maintain the supported texture format lists because listing all the supported formats from OIIO would lead loading the incorrect texture formats using Glf_OIIOImage. (like ptex)

### Fixes Issue(s)
- #97 

