### PR TITLE
[usd] Add dumpcrate utility to build scripts.

### DIFF
--- a/pxr/usd/bin/CMakeLists.txt
+++ b/pxr/usd/bin/CMakeLists.txt
@@ -2,6 +2,7 @@ set(DIRS
     usdcat
     usdcheck
     usddiff
+    usddumpcrate
     usdedit
     usdstitch
     usdstitchclips

--- a/pxr/usd/bin/usddumpcrate/CMakeLists.txt
+++ b/pxr/usd/bin/usddumpcrate/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(PXR_PREFIX pxr/usd)
+set(PXR_PACKAGE usd)
+
+pxr_python_bin(usddumpcrate
+    LIBRARIES
+      sdf
+      usd
+)


### PR DESCRIPTION
### Description of Change(s)

usddumpcrate wasn't being built by cmake, this change fixes that.

### Fixes Issue(s)
- No filed issues I know of.

