### PR TITLE
[Sdf] Clean up warning, remove unused capture.

### DIFF
--- a/pxr/usd/bin/sdfdump/sdfdump.cpp
+++ b/pxr/usd/bin/sdfdump/sdfdump.cpp
@@ -352,7 +352,7 @@ Validate(SdfLayerHandle const &layer, ReportParams const &p,
                       layer->GetIdentifier().c_str());
     vector<SdfPath> paths;
     layer->Traverse(SdfPath::AbsoluteRootPath(),
-                    [&paths, &p, layer](SdfPath const &path) {
+                    [&paths, layer](SdfPath const &path) {
                         TF_DESCRIBE_SCOPE(
                             "Collecting path <%s> in @%s@",
                             path.GetText(), layer->GetIdentifier().c_str());


### PR DESCRIPTION
### Description of Change(s)

Cleans up a little warning, emitted by newer compilers(clang in this case)

### Fixes Issue(s)
- None filed.

