### PR TITLE
Export more methods from the light adapter class so it can be subclassed

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/lightAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/lightAdapter.h
@@ -79,19 +79,23 @@ public:
 
     /// Returns a bit mask of attributes to be udpated, or
     /// HdChangeTracker::AllDirty if the entire prim must be resynchronized.
+    USDIMAGING_API
     virtual HdDirtyBits ProcessPropertyChange(UsdPrim const& prim,
                                               SdfPath const& cachePath,
                                               TfToken const& propertyName);
 
+    USDIMAGING_API
     virtual void MarkDirty(UsdPrim const& prim,
                            SdfPath const& cachePath,
                            HdDirtyBits dirty,
                            UsdImagingIndexProxy* index);
 
+    USDIMAGING_API
     virtual void MarkTransformDirty(UsdPrim const& prim,
                                     SdfPath const& cachePath,
                                     UsdImagingIndexProxy* index);
 
+    USDIMAGING_API
     virtual void MarkVisibilityDirty(UsdPrim const& prim,
                                      SdfPath const& cachePath,
                                      UsdImagingIndexProxy* index);


### PR DESCRIPTION
Export more methods from the light adapter class so it can be subclassed in other libraries.