### PR TITLE
[Ar] Replace boost noncopyable.

### DIFF
--- a/pxr/usd/lib/ar/resolver.h
+++ b/pxr/usd/lib/ar/resolver.h
@@ -28,7 +28,6 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/ar/api.h"
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <string>
 #include <vector>
@@ -52,11 +51,14 @@ class VtValue;
 /// Clients may use #ArGetResolver to access the configured asset resolver.
 ///
 class ArResolver 
-    : public boost::noncopyable
 {
 public:
     AR_API
     virtual ~ArResolver();
+
+    // Disallow copies
+    ArResolver(const ArResolver&) = delete;
+    ArResolver& operator=(const ArResolver&) = delete;
 
     // --------------------------------------------------------------------- //
     /// \anchor ArResolver_resolution

--- a/pxr/usd/lib/ar/resolverScopedCache.h
+++ b/pxr/usd/lib/ar/resolverScopedCache.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/ar/api.h"
 #include "pxr/base/vt/value.h"
-#include <boost/noncopyable.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -45,9 +44,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// \see \ref ArResolver_scopedCache "Scoped Resolution Cache"
 class ArResolverScopedCache
-    : public boost::noncopyable
 {
 public:
+
+    // Disallow copies
+    ArResolverScopedCache(const ArResolverScopedCache&) = delete;
+    ArResolverScopedCache& operator=(const ArResolverScopedCache&) = delete;
+
     /// Begin an asset resolver cache scope. 
     ///
     /// Calls ArResolver::BeginCacheScope on the configured asset resolver


### PR DESCRIPTION
### Description of Change(s)

Further reduce dependence on boost in hopes of a brighter future
of magnificent compile times. Standard C++ now provides proper facilities
for making objects non-copyable(`=delete`), and generally provides better error messages
than boost::noncopyable, so we use this.

### Fixes Issue(s)
- None filed, just more cleanup.

