### PR TITLE
[Pcp] Replace boost noncopyable

### DIFF
--- a/pxr/usd/lib/pcp/dependencies.h
+++ b/pxr/usd/lib/pcp/dependencies.h
@@ -37,7 +37,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/usd/sdf/site.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <iosfwd>
@@ -55,11 +54,15 @@ TF_DECLARE_WEAK_PTRS(PcpLayerStack);
 /// Tracks the dependencies of PcpPrimIndex entries in a PcpCache.
 /// This is an internal class only meant for use by PcpCache.
 ///
-class Pcp_Dependencies : boost::noncopyable {
+class Pcp_Dependencies {
 public:
     /// Construct with no dependencies.
     Pcp_Dependencies();
     ~Pcp_Dependencies();
+
+    // Pcp_Dependencies needs to be noncopyable
+    Pcp_Dependencies(const Pcp_Dependencies&) = delete;
+    Pcp_Dependencies& operator=(const Pcp_Dependencies&) = delete;
 
     /// \name Registration
     /// @{

--- a/pxr/usd/lib/pcp/layerStack.h
+++ b/pxr/usd/lib/pcp/layerStack.h
@@ -34,7 +34,6 @@
 #include "pxr/usd/sdf/layerTree.h"
 #include "pxr/base/tf/declarePtrs.h"
 
-#include <boost/noncopyable.hpp>
 #include <iosfwd>
 #include <memory>
 #include <string>
@@ -62,11 +61,18 @@ class PcpLifeboat;
 ///
 /// PcpLayerStacks are constructed and managed by a Pcp_LayerStackRegistry.
 ///
-class PcpLayerStack : public TfRefBase, public TfWeakBase, boost::noncopyable {
+class PcpLayerStack : public TfRefBase, public TfWeakBase {
 public:
     // See Pcp_LayerStackRegistry for creating layer stacks.
     PCP_API
     virtual ~PcpLayerStack();
+
+    // PcpLayerStack needs to be noncopyable
+    PCP_API
+    PcpLayerStack(const PcpLayerStack&) = delete;
+
+    PCP_API
+    PcpLayerStack& operator=(const PcpLayerStack&) = delete;
 
     /// Returns the identifier for this layer stack.
     PCP_API

--- a/pxr/usd/lib/pcp/mapExpression.h
+++ b/pxr/usd/lib/pcp/mapExpression.h
@@ -196,8 +196,13 @@ private: // data
         _OpAddRootIdentity
     };
 
-    class _Node : public boost::noncopyable {
+    class _Node {
     public:
+        // _Node needs to be noncopyable
+        _Node(const _Node&) = delete;  
+
+        _Node& operator=(const _Node&) = delete;
+
         // The Key holds all the state needed to uniquely identify
         // this (sub-)expression.
         struct Key {

--- a/pxr/usd/lib/pcp/payloadDecorator.h
+++ b/pxr/usd/lib/pcp/payloadDecorator.h
@@ -29,8 +29,6 @@
 #include "pxr/usd/sdf/layer.h"
 #include "pxr/base/tf/declarePtrs.h"
 
-#include <boost/noncopyable.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class PcpPayloadContext;
@@ -61,9 +59,16 @@ TF_DECLARE_REF_PTRS(PcpPayloadDecorator);
 /// are stronger than the payload.
 ///
 class PcpPayloadDecorator :
-    public TfRefBase, public TfWeakBase, boost::noncopyable
+    public TfRefBase, public TfWeakBase
 {
 public:
+    // PcpPayloadDecorator needs to be noncopyable
+    PCP_API
+    PcpPayloadDecorator(const PcpPayloadDecorator&) = delete;
+
+    PCP_API
+    PcpPayloadDecorator& operator=(const PcpPayloadDecorator&) = delete;
+
     /// Decorate the SdfLayer arguments \p args with additional arguments
     /// that will be used when opening the layer specified in the payload 
     /// \p payload when composing the index at \p primIndexPath.


### PR DESCRIPTION
### Description of Change(s)
(Message taken from previous PR) 

Further reduce dependence on boost in hopes of a brighter future
of magnificent compile times. Standard C++ now provides proper facilities
for making objects non-copyable(`=delete`), and generally provides better error messages
than boost::noncopyable, so we use this.

### Fixes Issue(s)
- None filed, more cleanup.

