### PR TITLE
[Trace] Replace boost noncopyable.

### DIFF
--- a/pxr/base/lib/trace/trace.h
+++ b/pxr/base/lib/trace/trace.h
@@ -32,7 +32,6 @@
 #include "pxr/base/trace/api.h"
 #include "pxr/base/trace/collector.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/preprocessor/cat.hpp>
 
 #include <atomic>
@@ -236,7 +235,7 @@ private:
 /// The TRACE_FUNCTION() macro may be even more convenient in some
 /// circumstances.
 ///
-struct TraceAuto : public boost::noncopyable {
+struct TraceAuto {
     /// Constructor taking function name, pretty function name and a scope name.
     ///
     TraceAuto(const char *funcName, const char *prettyFuncName,
@@ -247,6 +246,10 @@ struct TraceAuto : public boost::noncopyable {
         _collector->BeginEvent(_key);
         std::atomic_thread_fence(std::memory_order_seq_cst);
     }
+
+    // TraceAuto cannot be copied.
+    TraceAuto(const TraceAuto&) = delete;
+    TraceAuto& operator=(const TraceAuto&) = delete;
 
     /// Constructor taking a TfToken key.
     ///


### PR DESCRIPTION
### Description of Change(s)
(Message taken from previous PR)

Further reduce dependence on boost in hopes of a brighter future
of magnificent compile times. Standard C++ now provides proper facilities
for making objects non-copyable(=delete), and generally provides better error messages
than boost::noncopyable, so we use this.

### Fixes Issue(s)
- None filed, cleanup.

