### PR TITLE
[HD] Setting up a default fallbackValue for shader parameters when connected.

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.cpp
@@ -686,7 +686,7 @@ UsdImagingGLHydraMaterialAdapter::_WalkShaderNetwork(
 
                 // Extract the fallback value for this input
                 VtValue fallbackValue;
-                shaderInput.Get(&fallbackValue);
+                const auto hasFallbackValue = shaderInput.Get(&fallbackValue);
 
                 SdfPath connection;
                 UsdShadeConnectableAPI source;
@@ -695,6 +695,12 @@ UsdImagingGLHydraMaterialAdapter::_WalkShaderNetwork(
                 if (UsdShadeConnectableAPI::GetConnectedSource(
                     shaderInput, &source, &outputName, &sourceType)) {
                     connection = source.GetPath();
+                    if (!hasFallbackValue) {
+                        // We need to have a valid fallback value based on the
+                        // input's type, otherwise codeGen won't know the correct function signature
+                        // and will generate faulty shader code.
+                        fallbackValue = shaderInput.GetTypeName().GetDefaultValue();
+                    }
                 }
 
                 // Finally, initialize data for this potential input to the 


### PR DESCRIPTION
### Description of Change(s)
In cases when shader parameters are connected to textures, but no fallbackValue is set, CodeGen fails to generate the right function signature (missing the return type) causing a compilation error. The change uses the type of the input value and sets the fallbackValue to that type's default Value when a fallback value is not authored on the shader.

### Fixes Issue(s)
Nothing reported.

