### PR TITLE
[Pcp] Remove use of std::auto_ptr.

### DIFF
--- a/pxr/usd/lib/pcp/wrapCache.cpp
+++ b/pxr/usd/lib/pcp/wrapCache.cpp
@@ -45,14 +45,14 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-static std::auto_ptr<PcpCache>
+static std::shared_ptr<PcpCache>
 _New(const PcpLayerStackIdentifier& identifier,
      const std::string& targetSchema,
      bool usd,
      const PcpPayloadDecoratorRefPtr& payloadDecorator)
 {
-    return std::auto_ptr<PcpCache>(
-        new PcpCache(identifier, targetSchema, usd, payloadDecorator));
+    return std::make_shared<PcpCache>(identifier, targetSchema, 
+                                      usd, payloadDecorator);
 }
 
 static boost::python::tuple
@@ -235,7 +235,7 @@ _Reload( PcpCache & cache )
 void 
 wrapCache()
 {
-    class_<PcpCache, std::auto_ptr<PcpCache>, boost::noncopyable> 
+    class_<PcpCache, std::shared_ptr<PcpCache>, boost::noncopyable> 
         ("Cache", no_init)
 
         .def("__init__", 


### PR DESCRIPTION
### Description of Change(s)
This is deprecated in C++11, and removed in C++17, so we shouldn't rely
on it (source: https://en.cppreference.com/w/cpp/memory/auto_ptr).

Note that this uses shared_ptr, we could use unique_ptr if we relied on
a newer version of boost, as far as I know.


### Fixes Issue(s)
- Future proofing.

