### PR TITLE
switch libtiff to http download

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -567,7 +567,7 @@ JPEG = Dependency("JPEG", InstallJPEG, "include/jpeglib.h")
 ############################################################
 # TIFF
 
-TIFF_URL = "ftp://download.osgeo.org/libtiff/tiff-4.0.7.zip"
+TIFF_URL = "http://download.osgeo.org/libtiff/tiff-4.0.7.zip"
 
 def InstallTIFF(context, force):
     with CurrentWorkingDirectory(DownloadURL(TIFF_URL, context, force)):


### PR DESCRIPTION
### Description of Change(s)

Switch libtiff to download via http

### Fixes Issue(s)

- Some firewalls do not support FTP anymore
- libtiff was the only dependency that was being pulled via ftp, so it reduces the number of protocols required for the build.


