### PR TITLE
[usdMaya] fix for VP2 selection when MAYA_VP2_USE_VP1_SELECTION is off

### DIFF
--- a/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
+++ b/third_party/maya/lib/pxrUsdMayaGL/batchRenderer.h
@@ -49,6 +49,7 @@
 #include <maya/MDrawContext.h>
 #include <maya/MDrawRequest.h>
 #include <maya/MObjectHandle.h>
+#include <maya/MMessage.h>
 #include <maya/MSelectionContext.h>
 #include <maya/MTypes.h>
 #include <maya/MUserData.h>
@@ -217,6 +218,11 @@ public:
             const GfMatrix4d& projectionMatrix,
             GfVec3d* hitPoint);
 
+    /// Returns whether soft selection for proxy shapes is currently enabled.
+    PXRUSDMAYAGL_API
+    inline bool GetObjectSoftSelectEnabled()
+    { return _objectSoftSelectEnabled; }
+
 private:
 
     friend class TfSingleton<UsdMayaGLBatchRenderer>;
@@ -279,6 +285,12 @@ private:
             MHWRender::MDrawContext& context,
             void* clientData);
 
+    /// Record changes to soft select options
+    ///
+    /// This callback is just so we don't have to query the soft selection
+    /// options through mel every time we have a selection event.
+    static void _OnSoftSelectOptionsChangedCallback(void* clientData);
+
     /// Perform post-render state cleanup.
     ///
     /// For Viewport 2.0, this method gets invoked by
@@ -336,6 +348,8 @@ private:
     MUint64 _lastSelectionFrameStamp;
     bool _legacyRenderPending;
     bool _legacySelectionPending;
+    bool _objectSoftSelectEnabled;
+    MCallbackId _softSelectOptionsCallbackId;
 
     /// Type definition for a set of pointers to shape adapters.
     typedef std::unordered_set<PxrMayaHdShapeAdapter*> _ShapeAdapterSet;

--- a/third_party/maya/lib/pxrUsdMayaGL/proxyShapeDelegate.cpp
+++ b/third_party/maya/lib/pxrUsdMayaGL/proxyShapeDelegate.cpp
@@ -136,10 +136,23 @@ UsdMayaGL_ClosestPointOnProxyShape(
     return didIsect;
 }
 
+/// Delegate for returning whether object soft-select mode is currently on
+/// Technically, we could make ProxyShape track this itself, but then that would
+/// be making two callbacks to track the same thing... so we use BatchRenderer
+/// implementation
+bool
+UsdMayaGL_ObjectSoftSelectEnabled()
+{
+    return UsdMayaGLBatchRenderer::GetInstance().GetObjectSoftSelectEnabled();
+}
+
+
 TF_REGISTRY_FUNCTION(UsdMayaProxyShape)
 {
     UsdMayaProxyShape::SetClosestPointDelegate(
             UsdMayaGL_ClosestPointOnProxyShape);
+    UsdMayaProxyShape::SetObjectSoftSelectEnabledDelegate(
+            UsdMayaGL_ObjectSoftSelectEnabled);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/third_party/maya/lib/pxrUsdMayaGL/shapeAdapter.cpp
@@ -315,10 +315,13 @@ PxrMayaHdShapeAdapter::_GetWireframeColor(
 
     // Dormant objects may be included in a soft selection.
     if (displayStatus == MHWRender::kDormant) {
-        const UsdMayaGLSoftSelectHelper& softSelectHelper =
-            UsdMayaGLBatchRenderer::GetInstance().GetSoftSelectHelper();
-        useWireframeColor = softSelectHelper.GetFalloffColor(shapeDagPath,
-                                                             mayaWireColor);
+        auto& batchRenderer = UsdMayaGLBatchRenderer::GetInstance();
+        if (batchRenderer.GetObjectSoftSelectEnabled()) {
+            const UsdMayaGLSoftSelectHelper& softSelectHelper =
+                UsdMayaGLBatchRenderer::GetInstance().GetSoftSelectHelper();
+            useWireframeColor = softSelectHelper.GetFalloffColor(shapeDagPath,
+                                                                 mayaWireColor);
+        }
     }
 
     // If the object isn't included in a soft selection, just ask Maya for the

--- a/third_party/maya/lib/usdMaya/proxyShape.cpp
+++ b/third_party/maya/lib/usdMaya/proxyShape.cpp
@@ -104,6 +104,9 @@ TF_DEFINE_ENV_SETTING(PIXMAYA_ENABLE_BOUNDING_BOX_MODE, false,
 UsdMayaProxyShape::ClosestPointDelegate
 UsdMayaProxyShape::_sharedClosestPointDelegate = nullptr;
 
+UsdMayaProxyShape::ObjectSoftSelectEnabledDelgate
+UsdMayaProxyShape::_sharedObjectSoftSelectEnabledDelgate = nullptr;
+
 bool
 UsdMayaIsBoundingBoxModeEnabled()
 {
@@ -370,6 +373,26 @@ void
 UsdMayaProxyShape::SetClosestPointDelegate(ClosestPointDelegate delegate)
 {
     _sharedClosestPointDelegate = delegate;
+}
+
+/* static */
+void
+UsdMayaProxyShape::SetObjectSoftSelectEnabledDelegate(
+        ObjectSoftSelectEnabledDelgate delegate)
+{
+    _sharedObjectSoftSelectEnabledDelgate = delegate;
+}
+
+/* static */
+bool
+UsdMayaProxyShape::GetObjectSoftSelectEnabled()
+{
+    // If the delegate isn't set, we just assume soft select isn't currently
+    // enabled - this will mean that the object is selectable in VP2, by default
+    if (!_sharedObjectSoftSelectEnabledDelgate) {
+        return false;
+    }
+    return _sharedObjectSoftSelectEnabledDelgate();
 }
 
 /* virtual */
@@ -962,13 +985,29 @@ UsdMayaProxyShape::~UsdMayaProxyShape()
 MSelectionMask
 UsdMayaProxyShape::getShapeSelectionMask() const
 {
-    if (_CanBeSoftSelected()) {
-        // to support soft selection (mode=Object), we need to add kSelectMeshes
-        // to our selection mask.
-        MSelectionMask::SelectionType selType = MSelectionMask::kSelectMeshes;
-        return MSelectionMask(selType);
+    // The intent of this function is to control whether this object is
+    // selectable at all in VP2
+
+    // However, due to a bug / quirk, it could be used to specifically control
+    // whether the object was SOFT-selectable if you were using
+    // MAYA_VP2_USE_VP1_SELECTON; in this mode, this setting is NOT querierd
+    // when doing "normal" selection, but IS queried when doing soft
+    // selection.
+
+    // Unfortunately, it is queried for both "normal" selection AND soft
+    // selection if you are using "true" VP2 selection.  So in order to
+    // control soft selection, in both modes, we keep track of whether
+    // we currently have object soft-select enabled, and then return an empty
+    // selection mask if it is, but this object is set to be non-soft-selectable
+
+    const static MSelectionMask emptyMask;
+    const static MSelectionMask normalMask(MSelectionMask::kSelectMeshes);
+
+    if (GetObjectSoftSelectEnabled() && !_CanBeSoftSelected()) {
+        // Disable selection, to disable soft-selection
+        return emptyMask;
     }
-    return MPxSurfaceShape::getShapeSelectionMask();
+    return normalMask;
 }
 
 bool

--- a/third_party/maya/lib/usdMaya/proxyShape.h
+++ b/third_party/maya/lib/usdMaya/proxyShape.h
@@ -127,6 +127,10 @@ class UsdMayaProxyShape : public MPxSurfaceShape,
         typedef std::function<bool(const UsdMayaProxyShape&, const GfRay&,
                 GfVec3d*)> ClosestPointDelegate;
 
+        /// Delegate function for returning whether object soft select mode is
+        /// currently on
+        typedef std::function<bool(void)> ObjectSoftSelectEnabledDelgate;
+
         PXRUSDMAYA_API
         static void* creator(const PluginStaticData& psData);
 
@@ -138,6 +142,13 @@ class UsdMayaProxyShape : public MPxSurfaceShape,
 
         PXRUSDMAYA_API
         static void SetClosestPointDelegate(ClosestPointDelegate delegate);
+
+        PXRUSDMAYA_API
+        static void SetObjectSoftSelectEnabledDelegate(
+                ObjectSoftSelectEnabledDelgate delegate);
+
+        PXRUSDMAYA_API
+        static bool GetObjectSoftSelectEnabled();
 
         // Virtual function overrides
         PXRUSDMAYA_API
@@ -252,6 +263,8 @@ class UsdMayaProxyShape : public MPxSurfaceShape,
         bool _useFastPlayback;
 
         static ClosestPointDelegate _sharedClosestPointDelegate;
+        static ObjectSoftSelectEnabledDelgate
+            _sharedObjectSoftSelectEnabledDelgate;
 };
 
 


### PR DESCRIPTION
### Description of Change(s)

Currently, if using "pure" VP2 selection (ie, MAYA_VP2_USE_VP1_SELECTION is not
set), then if the "softSelectable" attribute is off, the object cannot be
selected by clicking on it in the viewport.

This is because proxyShape attempts to control soft-selection via
MPxSurfaceShape::getShapeSelectionMask().  Unfortunately, the intent of this
function is to control which selection filters the shape responds to, for any
selection (ie, normal + soft selection), and it is only a quirk / bug of
MAYA_VP2_USE_VP1_SELECTION mode that this setting is queried for soft selection,
but not normal selection.

To make the softSelectable attr work in both pure VP2 and
MAYA_VP2_USE_VP1_SELECTION modes, we now check if object-mode soft-selection is
currently on, and if the object is set to be not selectable; if so, we return
an empty mask, disabling selection.

### Fixes Issue(s)
- Selection when using "pure" VP2 mode (no MAYA_VP2_USE_VP1_SELECTION), and softSelectable attribute is off

