### PR TITLE
[usdMaya] added optional euler filter for import

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -185,6 +185,7 @@ pxr_test_scripts(
         testenv/testUsdImportAsAssemblies.py
         testenv/testUsdImportCamera.py
         testenv/testUsdImportColorSets.py
+        testenv/testUsdImportEulerFilter.py
         testenv/testUsdImportFrameRange.py
         testenv/testUsdImportMesh.py
         testenv/testUsdImportNestedAssemblyAnimation.py
@@ -604,6 +605,20 @@ pxr_register_test(testUsdImportColorSets
         MAYA_DISABLE_CIP=1
         MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
 )
+
+pxr_install_test_dir(
+        SRC testenv/UsdImportEulerFilterTest
+        DEST testUsdImportEulerFilter
+)
+pxr_register_test(testUsdImportEulerFilter
+        CUSTOM_PYTHON "${MAYA_BASE_DIR}/bin/mayapy"
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImportEulerFilter"
+        TESTENV testUsdImportEulerFilter
+        ENV
+        MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
+        MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
+        MAYA_DISABLE_CIP=1
+        )
 
 pxr_install_test_dir(
     SRC testenv/UsdImportFrameRangeTest

--- a/third_party/maya/lib/usdMaya/JobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/JobArgs.cpp
@@ -42,8 +42,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DEFINE_PUBLIC_TOKENS(PxrUsdMayaTranslatorTokens,
         PXRUSDMAYA_TRANSLATOR_TOKENS);
 
-TF_DEFINE_PUBLIC_TOKENS(PxUsdExportJobArgsTokens, 
-        PXRUSDMAYA_JOBARGS_TOKENS);
+TF_DEFINE_PUBLIC_TOKENS(PxrUsdExportJobArgsTokens,
+        PXRUSDMAYA_EXPORT_JOBARGS_TOKENS);
 
 TF_DEFINE_PRIVATE_TOKENS(
     _defaultIncludeMetadataKeys, 
@@ -51,6 +51,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     (instanceable)
     (kind)
 );
+
+TF_DEFINE_PUBLIC_TOKENS(PxrUsdImportJobArgsTokens,
+        PXRUSDMAYA_IMPORT_JOBARGS_TOKENS);
 
 JobExportArgs::JobExportArgs()
     :
@@ -72,7 +75,7 @@ JobExportArgs::JobExportArgs()
         normalizeNurbs(false),
         exportNurbsExplicitUV(true),
         exportColorSets(true),
-        renderLayerMode(PxUsdExportJobArgsTokens->defaultLayer),
+        renderLayerMode(PxrUsdExportJobArgsTokens->defaultLayer),
         defaultMeshScheme(UsdGeomTokens->catmullClark),
         exportVisibility(true),
         parentScope(SdfPath())
@@ -153,7 +156,8 @@ JobImportArgs::JobImportArgs()
         includeMetadataKeys(
                 _defaultIncludeMetadataKeys->allTokens.begin(),
                 _defaultIncludeMetadataKeys->allTokens.end()),
-        includeAPINames(/*empty*/)
+        includeAPINames(/*empty*/),
+        eulerFilterMode(PxrUsdImportJobArgsTokens->Auto)
 {
 }
 
@@ -163,7 +167,8 @@ operator <<(std::ostream& out, const JobImportArgs& importArgs)
     out << "shadingMode: " << importArgs.shadingMode << std::endl
         << "assemblyRep: " << importArgs.assemblyRep << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
-        << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl;
+        << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl
+        << "eulerFilterMode: " << importArgs.eulerFilterMode << std::endl;
 
     return out;
 }

--- a/third_party/maya/lib/usdMaya/JobArgs.h
+++ b/third_party/maya/lib/usdMaya/JobArgs.h
@@ -55,7 +55,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DECLARE_PUBLIC_TOKENS(PxrUsdMayaTranslatorTokens,
         PXRUSDMAYA_TRANSLATOR_TOKENS);
 
-#define PXRUSDMAYA_JOBARGS_TOKENS \
+#define PXRUSDMAYA_EXPORT_JOBARGS_TOKENS \
+    (Uniform) \
     (defaultLayer) \
     (currentLayer) \
     (modelingVariant) \
@@ -63,8 +64,16 @@ TF_DECLARE_PUBLIC_TOKENS(PxrUsdMayaTranslatorTokens,
     ((auto_, "auto")) \
     ((explicit_, "explicit"))
 
-TF_DECLARE_PUBLIC_TOKENS(PxUsdExportJobArgsTokens, 
-        PXRUSDMAYA_JOBARGS_TOKENS);
+TF_DECLARE_PUBLIC_TOKENS(PxrUsdExportJobArgsTokens,
+        PXRUSDMAYA_EXPORT_JOBARGS_TOKENS);
+
+#define PXRUSDMAYA_IMPORT_JOBARGS_TOKENS \
+    (Auto) \
+    (On) \
+    (Off)
+
+TF_DECLARE_PUBLIC_TOKENS(PxrUsdImportJobArgsTokens,
+        PXRUSDMAYA_IMPORT_JOBARGS_TOKENS);
 
 struct JobExportArgs
 {
@@ -157,6 +166,7 @@ struct JobImportArgs
     bool importWithProxyShapes;
     TfToken::Set includeMetadataKeys;
     TfToken::Set includeAPINames;
+    TfToken eulerFilterMode;
 };
 
 PXRUSDMAYA_API

--- a/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.cpp
+++ b/third_party/maya/lib/usdMaya/MayaNurbsSurfaceWriter.cpp
@@ -237,7 +237,7 @@ bool MayaNurbsSurfaceWriter::writeNurbsSurfaceAttrs(
     bool setWeights = false;
 
     // Create st vec2f vertex primvar
-    // NOTE: We currently support PxUsdExportJobArgsTokens->Uniform
+    // NOTE: We currently support PxrUsdExportJobArgsTokens->Uniform
     // So no need to do a check in its value yet
     VtArray<GfVec2f> stValues;
     if (getArgs().exportNurbsExplicitUV) {

--- a/third_party/maya/lib/usdMaya/primReaderArgs.cpp
+++ b/third_party/maya/lib/usdMaya/primReaderArgs.cpp
@@ -32,13 +32,15 @@ PxrUsdMayaPrimReaderArgs::PxrUsdMayaPrimReaderArgs(
         const TfToken& shadingMode,
         const GfInterval& timeInterval,
         const TfToken::Set& includeMetadataKeys,
-        const TfToken::Set& includeAPINames)
+        const TfToken::Set& includeAPINames,
+        const TfToken& eulerFilterMode)
     : 
         _prim(prim),
         _shadingMode(shadingMode),
         _timeInterval(timeInterval),
         _includeMetadataKeys(includeMetadataKeys),
-        _includeAPINames(includeAPINames)
+        _includeAPINames(includeAPINames),
+        _eulerFilterMode(eulerFilterMode)
 {
 }
 const UsdPrim&
@@ -56,6 +58,11 @@ GfInterval
 PxrUsdMayaPrimReaderArgs::GetTimeInterval() const
 {
     return _timeInterval;
+}
+const TfToken&
+PxrUsdMayaPrimReaderArgs::GetEulerFilterMode() const
+{
+    return _eulerFilterMode;
 }
 
 const TfToken::Set&

--- a/third_party/maya/lib/usdMaya/primReaderArgs.h
+++ b/third_party/maya/lib/usdMaya/primReaderArgs.h
@@ -49,7 +49,8 @@ public:
             const TfToken& shadingMode,
             const GfInterval& timeInterval,
             const TfToken::Set& includeMetadataKeys,
-            const TfToken::Set& includeAPINames);
+            const TfToken::Set& includeAPINames,
+            const TfToken& eulerFilterMode);
 
     /// \brief return the usd prim that should be read.
     PXRUSDMAYA_API
@@ -69,6 +70,9 @@ public:
     PXRUSDMAYA_API
     const TfToken::Set& GetIncludeAPINames() const;
 
+    PXRUSDMAYA_API
+    const TfToken& GetEulerFilterMode() const;
+
     bool ShouldImportUnboundShaders() const {
         // currently this is disabled.
         return false;
@@ -80,6 +84,7 @@ private:
     const GfInterval _timeInterval;
     const TfToken::Set& _includeMetadataKeys;
     const TfToken::Set& _includeAPINames;
+    const TfToken& _eulerFilterMode;
 };
 
 

--- a/third_party/maya/lib/usdMaya/testenv/UsdImportEulerFilterTest/UsdImportEulerFilterTest.usda
+++ b/third_party/maya/lib/usdMaya/testenv/UsdImportEulerFilterTest/UsdImportEulerFilterTest.usda
@@ -1,0 +1,102 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    endTimeCode = 2
+    startTimeCode = 0
+    upAxis = "Y"
+)
+
+def Xform "World" (
+    kind = "component"
+)
+{
+    def Xform "EulerFlips"
+    {
+        float3 xformOp:rotateXYZ.timeSamples = {
+            0: (0, 80, 0),
+            1: (0, 90, 0),
+            2: (0, 100, 0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        float3 xformOp:rotateXYZ:rotateOffset = (0, 0, 0)
+        float3 xformOp:scale = (1, 1, 1)
+        float3 xformOp:scale:scaleOffset = (1, 1, 1)
+        matrix4d xformOp:transform:shear = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+        double3 xformOp:translate = (0, 0, 0)
+        float3 xformOp:translate:rotatePivot = (0, 0, 0)
+        float3 xformOp:translate:rotatePivotOffset = (0, 0, 0)
+        float3 xformOp:translate:scalePivot = (0, 0, 0)
+        float3 xformOp:translate:scalePivotOffset = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:rotatePivotOffset", "xformOp:translate:rotatePivot", "xformOp:rotateXYZ:rotateOffset", "xformOp:rotateXYZ", "!invert!xformOp:translate:rotatePivot", "xformOp:translate:scalePivotOffset", "xformOp:translate:scalePivot", "xformOp:transform:shear", "xformOp:scale:scaleOffset", "xformOp:scale", "!invert!xformOp:translate:scalePivot"]
+    }
+
+    def Xform "NoEulerFlips"
+    {
+        float3 xformOp:rotateXYZ.timeSamples = {
+            0: (0, 10, 0),
+            1: (0, 20, 0),
+            2: (0, 30, 0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        float3 xformOp:rotateXYZ:rotateOffset = (0, 0, 0)
+        float3 xformOp:scale = (1, 1, 1)
+        float3 xformOp:scale:scaleOffset = (1, 1, 1)
+        matrix4d xformOp:transform:shear = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+        double3 xformOp:translate = (0, 0, 0)
+        float3 xformOp:translate:rotatePivot = (0, 0, 0)
+        float3 xformOp:translate:rotatePivotOffset = (0, 0, 0)
+        float3 xformOp:translate:scalePivot = (0, 0, 0)
+        float3 xformOp:translate:scalePivotOffset = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:rotatePivotOffset", "xformOp:translate:rotatePivot", "xformOp:rotateXYZ:rotateOffset", "xformOp:rotateXYZ", "!invert!xformOp:translate:rotatePivot", "xformOp:translate:scalePivotOffset", "xformOp:translate:scalePivot", "xformOp:transform:shear", "xformOp:scale:scaleOffset", "xformOp:scale", "!invert!xformOp:translate:scalePivot"]
+    }
+
+    def Xform "SimpleXformEulerFlips"
+    {
+        float3 xformOp:rotateXYZ.timeSamples = {
+            0: (0, 80, 0),
+            1: (0, 90, 0),
+            2: (0, 100, 0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+
+    def Xform "SimpleZXYXformEulerFlips"
+    {
+        float3 xformOp:rotateZXY.timeSamples = {
+            0: (90, 80, 0),
+            1: (90, 90, 0),
+            2: (90, 100, 0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZXY", "xformOp:scale"]
+    }
+
+    def Xform "SimpleXformBuiltInEulerFlips"
+    {
+        float3 xformOp:rotateXYZ.timeSamples = {
+            0: (0, 80, 0),
+            1: (0, 90, 0),
+            2: (180.0, 80.0, 180.0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+
+        def Xform "SimpleZXYXformBuiltInEulerFlips"
+    {
+        float3 xformOp:rotateZXY.timeSamples = {
+            0: (0, 80, 0),
+            1: (0, 90, 0),
+            2: (180.0, 80.0, 180.0),
+        }
+        float3 xformOp:scale = (1.0, 1.0, 1.0)
+        double3 xformOp:translate = (0.0, 0.0, 0.0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZXY", "xformOp:scale"]
+    }
+}

--- a/third_party/maya/lib/usdMaya/testenv/testUsdImportEulerFilter.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdImportEulerFilter.py
@@ -1,0 +1,462 @@
+#!/pxrpythonsubst
+#
+# Copyright 2016 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+from pxr import Gf
+
+from maya import cmds
+from maya.api import OpenMaya as OM
+from maya.api import OpenMayaAnim as OMA
+from maya import standalone
+
+import os
+import unittest
+
+
+class testUsdImportEulerFilter(unittest.TestCase):
+
+    EPSILON = 1e-6
+
+    @classmethod
+    def setUpClass(cls):
+        standalone.initialize('usd')
+        cmds.loadPlugin('pxrUsd')
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(cls):
+        # Create a new file so each test case starts with a fresh state.
+        cmds.file(new=1, f=1)
+
+    def _GetNode(self, nodeName):
+        if not cmds.objExists(nodeName):
+            return None
+
+        selectionList = OM.MSelectionList()
+        selectionList.add(nodeName)
+        return selectionList.getDependNode(0)
+
+    def _GetMayaTransform(self, transformName):
+        node = self._GetNode(transformName)
+        if node:
+            return OM.MFnTransform(node)
+        return None
+
+    def _TestRotations(self, xformName, expectedRotations):
+        for timeCode in range(3):
+            mayaTime = OM.MTime(timeCode)
+            OMA.MAnimControl.setCurrentTime(mayaTime)
+
+            mayaTransform = self._GetMayaTransform(xformName)
+            transformationMatrix = mayaTransform.transformation()
+            actualRotation = [Gf.RadiansToDegrees(r) for r in transformationMatrix.rotation()]
+            expectedRotation = expectedRotations[timeCode]
+            self.assertTrue(
+                Gf.IsClose(
+                    expectedRotation,
+                    actualRotation,
+                    self.EPSILON),
+                "Expected '{0}' but got '{1}' for xform {2} at t={3}".format(
+                    expectedRotation,
+                    actualRotation,
+                    xformName,
+                    timeCode))
+
+    def testImportXformNoEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation not suffering from Euler flips results in the correct
+        rotations when using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [0.0, 10.0, 0.0],
+            1: [0.0, 20.0, 0.0],
+            2: [0.0, 30.0, 0.0]}
+
+        xformName = "NoEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportXformNoEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation not suffering from Euler flips results in the correct
+        rotations when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [0.0, 10.0, 0.0],
+            1: [0.0, 20.0, 0.0],
+            2: [0.0, 30.0, 0.0]}
+
+        xformName = "NoEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportXformNoEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation not suffering from Euler flips results in the correct
+        rotations when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [0.0, 10.0, 0.0],
+            1: [0.0, 20.0, 0.0],
+            2: [0.0, 30.0, 0.0]}
+
+        xformName = "NoEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportXformEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation suffering from Euler flips results in the correct (flipped)
+        rotations when not using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [180.0, 80.0, 180.0]}
+
+        xformName = "EulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportXformEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "EulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportXformEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has custom XformOps with a
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "EulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "SimpleXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "SimpleXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "SimpleXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a ZXY
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [90.0, 80.0, 0.0],
+            1: [90.0, 90.0, 0.0],
+            2: [90.0, 100.0, 0.0]}
+
+        xformName = "SimpleZXYXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a ZXY
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [90.0, 80.0, 0.0],
+            1: [90.0, 90.0, 0.0],
+            2: [90.0, 100.0, 0.0]}
+
+        xformName = "SimpleZXYXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a ZXY
+        rotation suffering from Euler flips results in the correct rotations
+        when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [90.0, 80.0, 0.0],
+            1: [90.0, 90.0, 0.0],
+            2: [90.0, 100.0, 0.0]}
+
+        xformName = "SimpleZXYXformEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformBuiltInEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin euler flip results in the correct rotations
+        when using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [180.0, 80.0, 180.0]}
+
+        xformName = "SimpleXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformBuiltInEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin euler flip results in the correct rotations
+        when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "SimpleXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleXformBuiltInEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin euler flip results in the correct rotations
+        when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [180.0, 80.0, 180.0]}
+
+        xformName = "SimpleXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformBuiltInEulerFlipsFilterOff(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin ZXY euler flip results in the correct rotations
+        when using the Euler filter mode Off.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="Off")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [180.0, 80.0, 180.0]}
+
+        xformName = "SimpleZXYXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformBuiltInEulerFlipsFilterOn(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin ZXY euler flip results in the correct rotations
+        when using the Euler filter mode On.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True,
+            eulerFilterMode="On")
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [0.0, 100.0, 0.0]}
+
+        xformName = "SimpleZXYXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+    def testImportSimpleZXYXformBuiltInEulerFlipsFilterAuto(self):
+        """
+        Tests that importing a USD Xform that has simple XformOps with a
+        builtin ZXY euler flip results in the correct rotations
+        when using the Euler filter mode Auto.
+        """
+        usdFile = os.path.abspath('UsdImportEulerFilterTest.usda')
+        cmds.usdImport(
+            file=usdFile,
+            shadingMode='none',
+            readAnimData=True)
+
+        expectedRotations = {
+            0: [0.0, 80.0, 0.0],
+            1: [0.0, 90.0, 0.0],
+            2: [180.0, 80.0, 180.0]}
+
+        xformName = "SimpleZXYXformBuiltInEulerFlips"
+        self._TestRotations(xformName, expectedRotations)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/third_party/maya/lib/usdMaya/translatorCamera.cpp
+++ b/third_party/maya/lib/usdMaya/translatorCamera.cpp
@@ -395,7 +395,8 @@ PxrUsdMayaTranslatorCamera::ReadToCamera(
             defaultJobArgs.shadingMode,
             defaultJobArgs.timeInterval,
             defaultJobArgs.includeMetadataKeys,
-            defaultJobArgs.includeAPINames);
+            defaultJobArgs.includeAPINames,
+            defaultJobArgs.eulerFilterMode);
 
     return _ReadToCamera(usdCamera, cameraObject, args, NULL);
 }

--- a/third_party/maya/lib/usdMaya/usdExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdExport.cpp
@@ -229,14 +229,14 @@ try
         argData.getFlagArgument("exportSkin", 0, stringVal);
 
         const TfToken tok(stringVal.asChar());
-        if (tok == PxUsdExportJobArgsTokens->none) {
+        if (tok == PxrUsdExportJobArgsTokens->none) {
             jobArgs.exportSkin = false;
         }
-        else if (tok == PxUsdExportJobArgsTokens->auto_) {
+        else if (tok == PxrUsdExportJobArgsTokens->auto_) {
             jobArgs.exportSkin = true;
             jobArgs.autoSkelRoots = true;
         }
-        else if (tok == PxUsdExportJobArgsTokens->explicit_) {
+        else if (tok == PxrUsdExportJobArgsTokens->explicit_) {
             jobArgs.exportSkin = true;
             jobArgs.autoSkelRoots = false;
         }
@@ -338,9 +338,9 @@ try
         const TfToken renderLayerMode(stringVal.asChar());
 
         if (!renderLayerMode.IsEmpty()) {
-            if (renderLayerMode != PxUsdExportJobArgsTokens->defaultLayer &&
-                   renderLayerMode != PxUsdExportJobArgsTokens->currentLayer &&
-                   renderLayerMode != PxUsdExportJobArgsTokens->modelingVariant)
+            if (renderLayerMode != PxrUsdExportJobArgsTokens->defaultLayer &&
+                   renderLayerMode != PxrUsdExportJobArgsTokens->currentLayer &&
+                   renderLayerMode != PxrUsdExportJobArgsTokens->modelingVariant)
             {
                 MGlobal::displayError(TfStringPrintf(
                         "Invalid renderLayerMode '%s'. "

--- a/third_party/maya/lib/usdMaya/usdImport.cpp
+++ b/third_party/maya/lib/usdMaya/usdImport.cpp
@@ -75,6 +75,7 @@ MSyntax usdImport::createSyntax()
     syntax.addFlag("-fr" , "-frameRange"        , MSyntax::kDouble, MSyntax::kDouble);
     syntax.addFlag("-md" , "-metadata"          , MSyntax::kString);
     syntax.addFlag("-api" , "-apiSchema"        , MSyntax::kString);
+    syntax.addFlag("-ef", "-eulerFilterMode"    , MSyntax::kString);
     syntax.makeFlagMultiUse("variant");
     syntax.makeFlagMultiUse("metadata");
     syntax.makeFlagMultiUse("apiSchema");
@@ -238,6 +239,16 @@ MStatus usdImport::doIt(const MArgList & args)
     }
     if (!includeAPINames.empty()) {
         jobArgs.includeAPINames = includeAPINames;
+    }
+    
+    if (argData.isFlagSet("eulerFilterMode"))
+    {
+        MString stringVal;
+        argData.getFlagArgument("eulerFilterMode", 0, stringVal);
+        std::string eulerFilterMode = stringVal.asChar();
+        if (!eulerFilterMode.empty()) {
+            jobArgs.eulerFilterMode = TfToken(eulerFilterMode);
+        }
     }
 
     // Create the command

--- a/third_party/maya/lib/usdMaya/usdReadJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdReadJob.cpp
@@ -266,7 +266,8 @@ bool usdReadJob::_DoImport(UsdPrimRange& rootRange,
                                               mArgs.shadingMode,
                                               mArgs.timeInterval,
                                               mArgs.includeMetadataKeys,
-                                              mArgs.includeAPINames);
+                                              mArgs.includeAPINames,
+                                              mArgs.eulerFilterMode);
                 PxrUsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
 
                 // If we are NOT importing on behalf of an assembly, then we'll

--- a/third_party/maya/lib/usdMaya/usdReadJob_ImportWithProxies.cpp
+++ b/third_party/maya/lib/usdMaya/usdReadJob_ImportWithProxies.cpp
@@ -190,7 +190,8 @@ usdReadJob::_ProcessProxyPrims(
                                       mArgs.shadingMode,
                                       mArgs.timeInterval,
                                       mArgs.includeMetadataKeys,
-                                      mArgs.includeAPINames);
+                                      mArgs.includeAPINames,
+                                      mArgs.eulerFilterMode);
         PxrUsdMayaPrimReaderContext ctx(&mNewNodeRegistry);
 
         if (!_CreateParentTransformNodes(proxyPrim, args, &ctx)) {
@@ -247,7 +248,8 @@ usdReadJob::_ProcessSubAssemblyPrims(const std::vector<UsdPrim>& subAssemblyPrim
                                       mArgs.shadingMode,
                                       mArgs.timeInterval,
                                       mArgs.includeMetadataKeys,
-                                      mArgs.includeAPINames);
+                                      mArgs.includeAPINames,
+                                      mArgs.eulerFilterMode);
         PxrUsdMayaPrimReaderContext ctx(&mNewNodeRegistry);
 
         // We use the file path of the file currently being imported and
@@ -285,7 +287,8 @@ usdReadJob::_ProcessCameraPrims(const std::vector<UsdPrim>& cameraPrims)
                                       mArgs.shadingMode,
                                       mArgs.timeInterval,
                                       mArgs.includeMetadataKeys,
-                                      mArgs.includeAPINames);
+                                      mArgs.includeAPINames,
+                                      mArgs.eulerFilterMode);
         PxrUsdMayaPrimReaderContext ctx(&mNewNodeRegistry);
 
         if (!_CreateParentTransformNodes(cameraPrim, args, &ctx)) {

--- a/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorExport.cpp
@@ -126,9 +126,9 @@ usdTranslatorExport::writer(const MFileObject &file,
             }
             if (theOption[0] == MString("renderLayerMode")) {
                 const TfToken mode(theOption[1].asChar());
-                if (mode != PxUsdExportJobArgsTokens->defaultLayer &&
-                        mode != PxUsdExportJobArgsTokens->currentLayer &&
-                        mode != PxUsdExportJobArgsTokens->modelingVariant) {
+                if (mode != PxrUsdExportJobArgsTokens->defaultLayer &&
+                        mode != PxrUsdExportJobArgsTokens->currentLayer &&
+                        mode != PxrUsdExportJobArgsTokens->modelingVariant) {
                     TF_WARN("renderLayerMode '%s' not recognized",
                             mode.GetText());
                 } else {
@@ -158,14 +158,14 @@ usdTranslatorExport::writer(const MFileObject &file,
             }
             if (theOption[0] == MString("exportSkin")) {
                 const TfToken tok(theOption[1].asChar());
-                if (tok == PxUsdExportJobArgsTokens->none) {
+                if (tok == PxrUsdExportJobArgsTokens->none) {
                     jobArgs.exportSkin = false;
                 }
-                else if (tok == PxUsdExportJobArgsTokens->auto_) {
+                else if (tok == PxrUsdExportJobArgsTokens->auto_) {
                     jobArgs.exportSkin = true;
                     jobArgs.autoSkelRoots = true;
                 }
-                else if (tok == PxUsdExportJobArgsTokens->explicit_) {
+                else if (tok == PxrUsdExportJobArgsTokens->explicit_) {
                     jobArgs.exportSkin = true;
                     jobArgs.autoSkelRoots = false;
                 }

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.cpp
@@ -109,6 +109,8 @@ MStatus usdTranslatorImport::reader(const MFileObject & file,
                 customFrameRange.SetMin(theOption[1].asDouble());
             } else if (theOption[0] == MString("endTime")) {
                 customFrameRange.SetMax(theOption[1].asDouble());
+            } else if (theOption[0] == MString("eulerFilterMode")) {
+                jobArgs.eulerFilterMode = TfToken(theOption[1].asChar());
             }
         }
     }

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.h
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.h
@@ -46,7 +46,8 @@ const char* const usdTranslatorImportDefaults =
         "shadingMode=displayColor;"
         "readAnimData=1;"
         "useCustomFrameRange=0;"
-        "assemblyRep=Collapsed";
+        "assemblyRep=Collapsed;"
+        "eulerFilterMode=Auto";
 
 
 class usdTranslatorImport : public MPxFileTranslator

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
@@ -102,6 +102,11 @@ global proc int usdTranslatorImport (string $parent,
             menuItem -l $niceName -ann $modeName;
         }
 
+        optionMenuGrp -l "Euler Filter Mode:" eulerFilterModePopup;
+            menuItem -l "Auto";
+            menuItem -l "On";
+            menuItem -l "Off";
+
         checkBox -l "Read Animation Data" -cc ("usdTranslatorImport_AnimationCB") readAnimDataCheckBox;
 
         checkBox -l "Custom Frame Range" -cc ("usdTranslatorImport_AnimationCB") customFrameRangeCheckBox;
@@ -137,6 +142,8 @@ global proc int usdTranslatorImport (string $parent,
                     intFieldGrp -e -v1 $endTime endTimeField;
                 } else if ($optionBreakDown[0] == "useCustomFrameRange") {
                     usdTranslatorImport_SetCheckbox($optionBreakDown[1], "customFrameRangeCheckBox");
+                } else if ($optionBreakDown[0] == "eulerFilterMode") {
+                    optionMenuGrp -e -value $optionBreakDown[1] eulerFilterModePopup;
                 }
             }
         }
@@ -151,6 +158,7 @@ global proc int usdTranslatorImport (string $parent,
         $currentOptions = usdTranslatorImport_AppendFromIntField($currentOptions, "startTime", "startTimeField");
         $currentOptions = usdTranslatorImport_AppendFromIntField($currentOptions, "endTime", "endTimeField");
         $currentOptions = usdTranslatorImport_AppendFromCheckbox($currentOptions, "useCustomFrameRange", "customFrameRangeCheckBox");
+        $currentOptions = usdTranslatorImport_AppendFromPopup($currentOptions, "eulerFilterMode", "eulerFilterModePopup");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;

--- a/third_party/maya/lib/usdMaya/usdWriteJob.cpp
+++ b/third_party/maya/lib/usdMaya/usdWriteJob.cpp
@@ -117,7 +117,7 @@ bool usdWriteJob::beginJob(const std::string &iFileName, bool append)
 
     MGlobal::displayInfo("usdWriteJob::beginJob: Create stage file "+MString(mFileName.c_str()));
 
-    if (mJobCtx.mArgs.renderLayerMode == PxUsdExportJobArgsTokens->modelingVariant) {
+    if (mJobCtx.mArgs.renderLayerMode == PxrUsdExportJobArgsTokens->modelingVariant) {
         // Handle usdModelRootOverridePath for USD Variants
         MFnRenderLayer::listAllRenderLayers(mRenderLayerObjs);
         if (mRenderLayerObjs.length() > 1) {
@@ -154,7 +154,7 @@ bool usdWriteJob::beginJob(const std::string &iFileName, bool append)
 
     // Switch to the default render layer unless the renderLayerMode is
     // 'currentLayer', or the default layer is already the current layer.
-    if (mJobCtx.mArgs.renderLayerMode != PxUsdExportJobArgsTokens->currentLayer &&
+    if (mJobCtx.mArgs.renderLayerMode != PxrUsdExportJobArgsTokens->currentLayer &&
             MFnRenderLayer::currentLayer() != MFnRenderLayer::defaultRenderLayer()) {
         // Set the RenderLayer to the default render layer
         MFnRenderLayer defaultLayer(MFnRenderLayer::defaultRenderLayer());


### PR DESCRIPTION
### Description of Change(s)

Added Euler filter to Maya import to fix potential Euler flips for animated rotations.
The filter is using Maya's `MEulerRotation::setToClosestSolution()`.
Added _eulerFilterMode_ option to specify the filter mode (_Auto_ (Default), _On_, _Off_).

This helps with #410 but obviously only on the Maya side.

This PR is replacing PR https://github.com/PixarAnimationStudios/USD/pull/450
