### PR TITLE
[usdedit] Use stronger env var in tests.

### DIFF
--- a/pxr/usd/bin/usdedit/CMakeLists.txt
+++ b/pxr/usd/bin/usdedit/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
         COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit write_protected.usda"
         EXPECTED_RETURN_CODE 1 
         ENV
-            EDITOR="${HEADBIN}"
+          USD_EDITOR="${HEADBIN}"
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
     )
@@ -54,7 +54,7 @@ else()
         COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit -n write_protected.usda"
         EXPECTED_RETURN_CODE 0
         ENV
-            EDITOR="${HEADBIN}"
+          USD_EDITOR="${HEADBIN}"
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
     )
@@ -70,7 +70,7 @@ else()
         COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit -f write_protected.usda"
         EXPECTED_RETURN_CODE 0
         ENV
-            EDITOR="${HEADBIN}"
+          USD_EDITOR="${HEADBIN}"
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
     )
@@ -88,7 +88,7 @@ else()
         EXPECTED_RETURN_CODE 0
         DIFF_COMPARE ascii_output.txt
         ENV
-            EDITOR="sed -i 's/hello/goodbye/g'"
+          USD_EDITOR="sed -i 's/hello/goodbye/g'"
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
     )
@@ -106,7 +106,7 @@ else()
         EXPECTED_RETURN_CODE 0
         DIFF_COMPARE crate_output.txt
         ENV
-            EDITOR="sed -i 's/hello/goodbye/g'"
+          USD_EDITOR="sed -i 's/hello/goodbye/g'"
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
     )


### PR DESCRIPTION
### Description of Change(s)
Set the stronger env var in the usdedit tests. Afair, `USD_EDITOR` was provided after the tests were first created, hence the impedance mismatch. 

### Fixes Issue(s)
- #505 

