### PR TITLE
Removing the whitespace on the standards compliant flags - MSVC

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -26,9 +26,7 @@
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /EHsc")
 
 # Standards compliant.
-set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast
-                                      /Zc:strictStrings
-                                      /Zc:inline")
+set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings /Zc:inline")
 
 # Turn on all but informational warnings.
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /W3")


### PR DESCRIPTION
### Description of Change(s)
Removing the whitespace on the standards compliant flags to fix build runs which use NMake Makesfiles or NMake Makefiles JOM on Windows

### Fixes Issue(s)
`pxr\base\lib\arch\CMakeFiles\arch.dir\flags.make(5) : fatal error U1033: syntax error : '/Zc' unexpected`

Cheers