### PR TITLE
Adding hydra support for USD volume schema

### DIFF
--- a/pxr/imaging/lib/hd/CMakeLists.txt
+++ b/pxr/imaging/lib/hd/CMakeLists.txt
@@ -44,6 +44,7 @@ pxr_library(hd
         extCompPrimvarBufferSource
         extComputation
         extComputationContext
+	field
         geomSubset
         instancer
         instanceRegistry
@@ -88,6 +89,7 @@ pxr_library(hd
         unitTestNullRenderDelegate
         unitTestNullRenderPass
         vertexAdjacency
+	volume
         vtBufferSource
 
     PUBLIC_HEADERS

--- a/pxr/imaging/lib/hd/field.cpp
+++ b/pxr/imaging/lib/hd/field.cpp
@@ -1,0 +1,44 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hd/field.h"
+#include "pxr/imaging/hd/perfLog.h"
+#include "pxr/imaging/hd/sceneDelegate.h"
+
+#include "pxr/base/gf/matrix4d.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_DEFINE_PUBLIC_TOKENS(HdFieldTokens, HD_FIELD_TOKENS);
+
+HdField::HdField(SdfPath const &id)
+ : HdBprim(id)
+{
+}
+
+HdField::~HdField()
+{
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/lib/hd/field.cpp
+++ b/pxr/imaging/lib/hd/field.cpp
@@ -29,9 +29,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-TF_DEFINE_PUBLIC_TOKENS(HdFieldTokens, HD_FIELD_TOKENS);
-
 HdField::HdField(SdfPath const &id)
  : HdBprim(id)
 {

--- a/pxr/imaging/lib/hd/field.h
+++ b/pxr/imaging/lib/hd/field.h
@@ -1,0 +1,74 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef HD_FIELD_H
+#define HD_FIELD_H
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/hd/api.h"
+#include "pxr/imaging/hd/version.h"
+#include "pxr/imaging/hd/bprim.h"
+
+#include "pxr/base/tf/staticTokens.h"
+
+#include <boost/shared_ptr.hpp>
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+#define HD_FIELD_TOKENS                        \
+    (transform)
+
+TF_DECLARE_PUBLIC_TOKENS(HdFieldTokens, HD_API, HD_FIELD_TOKENS);
+
+class HdSceneDelegate;
+typedef boost::shared_ptr<class HdField> HdFieldSharedPtr;
+typedef std::vector<class HdField const *> HdFieldPtrConstVector;
+
+/// \class HdField
+///
+/// Hydra schema for a USD field primitive. Acts like a texture, combined
+/// with other fields to make up a renderable volume.
+///
+class HdField : public HdBprim {
+public:
+    HD_API
+    HdField(SdfPath const & id);
+    HD_API
+    virtual ~HdField();
+
+    // Change tracking for HdField
+    enum DirtyBits : HdDirtyBits {
+        Clean                 = 0,
+        DirtyTransform        = 1 << 0,
+        DirtyParams           = 1 << 1,
+        AllDirty              = (DirtyTransform
+                                 |DirtyParams)
+    };
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // HD_FIELD_H

--- a/pxr/imaging/lib/hd/field.h
+++ b/pxr/imaging/lib/hd/field.h
@@ -37,12 +37,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-#define HD_FIELD_TOKENS                        \
-    (transform)
-
-TF_DECLARE_PUBLIC_TOKENS(HdFieldTokens, HD_API, HD_FIELD_TOKENS);
-
 class HdSceneDelegate;
 typedef boost::shared_ptr<class HdField> HdFieldSharedPtr;
 typedef std::vector<class HdField const *> HdFieldPtrConstVector;

--- a/pxr/imaging/lib/hd/sceneDelegate.cpp
+++ b/pxr/imaging/lib/hd/sceneDelegate.cpp
@@ -344,6 +344,17 @@ HdSceneDelegate::GetClipPlanes(SdfPath const& cameraId)
 }
 
 // -----------------------------------------------------------------------//
+/// \name Volume Aspects
+// -----------------------------------------------------------------------//
+
+/*virtual*/
+HdVolumeFieldDescriptorVector
+HdSceneDelegate::GetVolumeFieldDescriptors(SdfPath const &volumeId)
+{
+    return HdVolumeFieldDescriptorVector();
+}
+
+// -----------------------------------------------------------------------//
 /// \name ExtComputation Aspects
 // -----------------------------------------------------------------------//
 

--- a/pxr/imaging/lib/hd/sceneDelegate.h
+++ b/pxr/imaging/lib/hd/sceneDelegate.h
@@ -240,6 +240,27 @@ struct HdExtComputationOutputDescriptor {
 typedef std::vector<HdExtComputationOutputDescriptor>
         HdExtComputationOutputDescriptorVector;
 
+/// \struct HdVolumeFieldDescriptor
+///
+/// Description of a single field related to a volume primitive.
+///
+struct HdVolumeFieldDescriptor {
+    TfToken fieldName;
+    TfToken fieldPrimType;
+    SdfPath fieldId;
+
+    HdVolumeFieldDescriptor() {}
+    HdVolumeFieldDescriptor(
+        TfToken const & fieldName_,
+        TfToken const & fieldPrimType_,
+        SdfPath const & fieldId_)
+    : fieldName(fieldName_), fieldPrimType(fieldPrimType_), fieldId(fieldId_)
+    { }
+};
+
+typedef std::vector<HdVolumeFieldDescriptor>
+	HdVolumeFieldDescriptorVector;
+
 /// \class HdSceneDelegate
 ///
 /// Adapter class providing data exchange with the client scene graph.
@@ -529,6 +550,14 @@ public:
     /// orientation.
     HD_API
     virtual std::vector<GfVec4d> GetClipPlanes(SdfPath const& cameraId);
+
+    // -----------------------------------------------------------------------//
+    /// \name Volume Aspects
+    // -----------------------------------------------------------------------//
+
+    HD_API
+    virtual HdVolumeFieldDescriptorVector
+    GetVolumeFieldDescriptors(SdfPath const &volumeId);
 
     // -----------------------------------------------------------------------//
     /// \name ExtComputation Aspects

--- a/pxr/imaging/lib/hd/tokens.h
+++ b/pxr/imaging/lib/hd/tokens.h
@@ -200,6 +200,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (mesh)                                      \
     (basisCurves)                               \
     (points)                                    \
+    (volume)                                    \
                                                 \
     /* Sprims */                                \
     (camera)                                    \
@@ -217,6 +218,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (extComputation)                            \
                                                 \
     /* Bprims */                                \
+    (openvdbAsset)				\
+    (field3dAsset)				\
     (texture)
 
 #define HD_PRIMVAR_ROLE_TOKENS                  \

--- a/pxr/imaging/lib/hd/volume.cpp
+++ b/pxr/imaging/lib/hd/volume.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hd/volume.h"
+#include "pxr/imaging/hd/perfLog.h"
+#include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/imaging/hd/rprimCollection.h"
+
+#include "pxr/base/gf/matrix4d.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_DEFINE_PUBLIC_TOKENS(HdVolumeTokens, HD_VOLUME_TOKENS);
+
+HdVolume::HdVolume(SdfPath const &id,
+                   SdfPath const& instancerId)
+ : HdRprim(id, instancerId)
+{
+}
+
+HdVolume::~HdVolume()
+{
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/lib/hd/volume.cpp
+++ b/pxr/imaging/lib/hd/volume.cpp
@@ -30,9 +30,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-TF_DEFINE_PUBLIC_TOKENS(HdVolumeTokens, HD_VOLUME_TOKENS);
-
 HdVolume::HdVolume(SdfPath const &id,
                    SdfPath const& instancerId)
  : HdRprim(id, instancerId)

--- a/pxr/imaging/lib/hd/volume.h
+++ b/pxr/imaging/lib/hd/volume.h
@@ -1,0 +1,75 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef HD_VOLUME_H
+#define HD_VOLUME_H
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/hd/api.h"
+#include "pxr/imaging/hd/version.h"
+#include "pxr/imaging/hd/rprim.h"
+
+#include "pxr/base/tf/staticTokens.h"
+
+#include <boost/shared_ptr.hpp>
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+#define HD_VOLUME_TOKENS                        \
+    (fields)                                    \
+    (transform)
+
+TF_DECLARE_PUBLIC_TOKENS(HdVolumeTokens, HD_API, HD_VOLUME_TOKENS);
+
+class HdSceneDelegate;
+typedef boost::shared_ptr<class HdVolume> HdVolumeSharedPtr;
+typedef std::vector<class HdVolume const *> HdVolumePtrConstVector;
+
+/// \class HdVolume
+///
+/// Hd schema for a renderable volume primitive.
+///
+class HdVolume : public HdRprim {
+public:
+    HD_API
+    HdVolume(SdfPath const & id,
+             SdfPath const& instancerId = SdfPath());
+    HD_API
+    virtual ~HdVolume();
+
+    // Change tracking for HdVolume
+    enum DirtyBits : HdDirtyBits {
+        Clean                 = 0,
+        DirtyTransform        = 1 << 0,
+        DirtyFields           = 1 << 1,
+        AllDirty              = (DirtyTransform
+                                 |DirtyFields)
+    };
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif  // HD_VOLUME_H

--- a/pxr/imaging/lib/hd/volume.h
+++ b/pxr/imaging/lib/hd/volume.h
@@ -37,13 +37,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-#define HD_VOLUME_TOKENS                        \
-    (fields)                                    \
-    (transform)
-
-TF_DECLARE_PUBLIC_TOKENS(HdVolumeTokens, HD_API, HD_VOLUME_TOKENS);
-
 class HdSceneDelegate;
 typedef boost::shared_ptr<class HdVolume> HdVolumeSharedPtr;
 typedef std::vector<class HdVolume const *> HdVolumePtrConstVector;
@@ -59,15 +52,6 @@ public:
              SdfPath const& instancerId = SdfPath());
     HD_API
     virtual ~HdVolume();
-
-    // Change tracking for HdVolume
-    enum DirtyBits : HdDirtyBits {
-        Clean                 = 0,
-        DirtyTransform        = 1 << 0,
-        DirtyFields           = 1 << 1,
-        AllDirty              = (DirtyTransform
-                                 |DirtyFields)
-    };
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
@@ -18,6 +18,7 @@ pxr_library(usdImaging
         usdLux
         usdRi
         usdShade
+        usdVol
         ar
         ${Boost_PYTHON_LIBRARY}
         ${PYTHON_LIBRARY}
@@ -43,18 +44,22 @@ pxr_library(usdImaging
         cubeAdapter
         cylinderAdapter
         domeLightAdapter
+        fieldAdapter
+	field3dAssetAdapter
         gprimAdapter
         instanceAdapter
         lightAdapter
         materialAdapter
         meshAdapter
         nurbsPatchAdapter
+	openvdbAssetAdapter
         pointsAdapter
         pointInstancerAdapter
         primAdapter
         rectLightAdapter
         sphereAdapter
         sphereLightAdapter
+        volumeAdapter
 
     PUBLIC_HEADERS
         api.h

--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -2692,6 +2692,21 @@ UsdImagingDelegate::GetLightParamValue(SdfPath const &id,
     return value;
 }
 
+HdVolumeFieldDescriptorVector
+UsdImagingDelegate::GetVolumeFieldDescriptors(SdfPath const &volumeId)
+{
+    // PERFORMANCE: We should schedule this to be updated during Sync, rather
+    // than pulling values on demand.
+    SdfPath usdPath = GetPathForUsd(volumeId);
+    _PrimInfo *primInfo = GetPrimInfo(usdPath);
+    if (TF_VERIFY(primInfo)) {
+        return primInfo->adapter
+            ->GetVolumeFieldDescriptors(primInfo->usdPrim, usdPath, _time);
+    }
+
+    return HdVolumeFieldDescriptorVector();
+}
+
 VtValue
 UsdImagingDelegate::GetMaterialResource(SdfPath const &materialId)
 {

--- a/pxr/usdImaging/lib/usdImaging/delegate.h
+++ b/pxr/usdImaging/lib/usdImaging/delegate.h
@@ -342,6 +342,11 @@ public:
     virtual VtValue GetLightParamValue(SdfPath const &id, 
                                        TfToken const &paramName) override;
 
+    // Volume Support
+    USDIMAGING_API
+    virtual HdVolumeFieldDescriptorVector
+    GetVolumeFieldDescriptors(SdfPath const &volumeId) override;
+
     // Material Support
     USDIMAGING_API 
     virtual VtValue GetMaterialResource(SdfPath const &materialId) override;

--- a/pxr/usdImaging/lib/usdImaging/field3dAssetAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/field3dAssetAdapter.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usdImaging/usdImaging/field3dAssetAdapter.h"
+#include "pxr/usdImaging/usdImaging/delegate.h"
+#include "pxr/usdImaging/usdImaging/indexProxy.h"
+#include "pxr/usdImaging/usdImaging/tokens.h"
+
+#include "pxr/imaging/hd/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    typedef UsdImagingField3DAssetAdapter Adapter;
+    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
+    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
+}
+
+UsdImagingField3DAssetAdapter::~UsdImagingField3DAssetAdapter() 
+{
+}
+
+TfToken
+UsdImagingField3DAssetAdapter::GetPrimTypeToken() const
+{
+    return HdPrimTypeTokens->field3dAsset;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImaging/field3dAssetAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/field3dAssetAdapter.h
@@ -1,0 +1,60 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef USDIMAGING_FIELD3D_ASSET_ADAPTER_H
+#define USDIMAGING_FIELD3D_ASSET_ADAPTER_H
+
+/// \file usdImaging/field3dAssetAdapter.h
+
+#include "pxr/pxr.h"
+#include "pxr/usdImaging/usdImaging/api.h"
+#include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+class UsdPrim;
+
+/// \class UsdImagingField3DAssetAdapter
+///
+/// Adapter class for fields of type Field3DAsset
+///
+class UsdImagingField3DAssetAdapter : public UsdImagingFieldAdapter {
+public:
+    typedef UsdImagingFieldAdapter BaseAdapter;
+
+    UsdImagingField3DAssetAdapter()
+        : UsdImagingFieldAdapter()
+    {}
+
+    USDIMAGING_API
+    virtual ~UsdImagingField3DAssetAdapter();
+
+    USDIMAGING_API
+    virtual TfToken GetPrimTypeToken() const;
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USDIMAGING_FIELD3D_ASSET_ADAPTER_H

--- a/pxr/usdImaging/lib/usdImaging/fieldAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/fieldAdapter.cpp
@@ -1,0 +1,144 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+#include "pxr/usdImaging/usdImaging/delegate.h"
+#include "pxr/usdImaging/usdImaging/indexProxy.h"
+#include "pxr/usdImaging/usdImaging/tokens.h"
+
+#include "pxr/imaging/hd/tokens.h"
+
+#include "pxr/imaging/hd/field.h"
+
+#include "pxr/base/tf/envSetting.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    typedef UsdImagingFieldAdapter Adapter;
+    TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
+    // No factory here, UsdImagingFieldAdapter is abstract.
+}
+
+UsdImagingFieldAdapter::~UsdImagingFieldAdapter() 
+{
+}
+
+bool
+UsdImagingFieldAdapter::IsSupported(UsdImagingIndexProxy const* index) const
+{
+    return index->IsBprimTypeSupported(GetPrimTypeToken());
+}
+
+SdfPath
+UsdImagingFieldAdapter::Populate(UsdPrim const& prim, 
+                            UsdImagingIndexProxy* index,
+                            UsdImagingInstancerContext const* instancerContext)
+{
+    index->InsertBprim(GetPrimTypeToken(), prim.GetPath(), prim);
+    HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+
+    return prim.GetPath();
+}
+
+void
+UsdImagingFieldAdapter::_RemovePrim(SdfPath const& cachePath,
+                                         UsdImagingIndexProxy* index)
+{
+    index->RemoveBprim(GetPrimTypeToken(), cachePath);
+}
+
+
+void 
+UsdImagingFieldAdapter::TrackVariability(UsdPrim const& prim,
+                                        SdfPath const& cachePath,
+                                        HdDirtyBits* timeVaryingBits,
+                                        UsdImagingInstancerContext const* 
+                                            instancerContext) const
+{
+    // Discover time-varying transforms.
+    _IsTransformVarying(prim,
+        HdField::DirtyBits::DirtyTransform,
+        UsdImagingTokens->usdVaryingXform,
+        timeVaryingBits);
+
+    // If any of the field attributes is time varying 
+    // we will assume all field params are time-varying.
+    const std::vector<UsdAttribute> &attrs = prim.GetAttributes();
+    TF_FOR_ALL(attrIter, attrs) {
+        const UsdAttribute& attr = *attrIter;
+        if (attr.GetNumTimeSamples()>1){
+            *timeVaryingBits |= HdField::DirtyBits::DirtyParams;
+        }
+    }
+}
+
+// Thread safe.
+//  * Populate dirty bits for the given \p time.
+void 
+UsdImagingFieldAdapter::UpdateForTime(UsdPrim const& prim,
+                               SdfPath const& cachePath, 
+                               UsdTimeCode time,
+                               HdDirtyBits requestedBits,
+                               UsdImagingInstancerContext const* 
+                                   instancerContext) const
+{
+}
+
+HdDirtyBits
+UsdImagingFieldAdapter::ProcessPropertyChange(UsdPrim const& prim,
+                                      SdfPath const& cachePath, 
+                                      TfToken const& propertyName)
+{
+    return HdChangeTracker::AllDirty;
+}
+
+void
+UsdImagingFieldAdapter::MarkDirty(UsdPrim const& prim,
+                                  SdfPath const& cachePath,
+                                  HdDirtyBits dirty,
+                                  UsdImagingIndexProxy* index)
+{
+    index->MarkBprimDirty(cachePath, dirty);
+}
+
+void
+UsdImagingFieldAdapter::MarkTransformDirty(UsdPrim const& prim,
+                                           SdfPath const& cachePath,
+                                           UsdImagingIndexProxy* index)
+{
+    static const HdDirtyBits transformDirty = HdField::DirtyTransform;
+    index->MarkBprimDirty(cachePath, transformDirty);
+}
+
+void
+UsdImagingFieldAdapter::MarkVisibilityDirty(UsdPrim const& prim,
+                                            SdfPath const& cachePath,
+                                            UsdImagingIndexProxy* index)
+{
+    // TBD
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImaging/fieldAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/fieldAdapter.h
@@ -1,0 +1,124 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef USDIMAGING_FIELD_ADAPTER_H
+#define USDIMAGING_FIELD_ADAPTER_H
+
+/// \file usdImaging/lightAdapter.h
+
+#include "pxr/pxr.h"
+#include "pxr/usdImaging/usdImaging/api.h"
+#include "pxr/usdImaging/usdImaging/primAdapter.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+class UsdPrim;
+
+/// \class UsdImagingFieldAdapter
+///
+/// Base class for all USD fields.
+///
+class UsdImagingFieldAdapter : public UsdImagingPrimAdapter {
+public:
+    typedef UsdImagingPrimAdapter BaseAdapter;
+
+
+    UsdImagingFieldAdapter()
+        : UsdImagingPrimAdapter()
+    {}
+
+    USDIMAGING_API
+    virtual ~UsdImagingFieldAdapter();
+
+    USDIMAGING_API
+    virtual SdfPath Populate(UsdPrim const& prim,
+                     UsdImagingIndexProxy* index,
+                     UsdImagingInstancerContext const* instancerContext = NULL);
+
+    USDIMAGING_API
+    virtual bool IsSupported(UsdImagingIndexProxy const* index) const;
+    
+    // ---------------------------------------------------------------------- //
+    /// \name Parallel Setup and Resolve
+    // ---------------------------------------------------------------------- //
+
+    /// Thread Safe.
+    USDIMAGING_API
+    virtual void TrackVariability(UsdPrim const& prim,
+                                  SdfPath const& cachePath,
+                                  HdDirtyBits* timeVaryingBits,
+                                  UsdImagingInstancerContext const* 
+                                      instancerContext = NULL) const;
+
+
+    /// Thread Safe.
+    USDIMAGING_API
+    virtual void UpdateForTime(UsdPrim const& prim,
+                               SdfPath const& cachePath, 
+                               UsdTimeCode time,
+                               HdDirtyBits requestedBits,
+                               UsdImagingInstancerContext const* 
+                                   instancerContext = NULL) const;
+
+    // ---------------------------------------------------------------------- //
+    /// \name Change Processing 
+    // ---------------------------------------------------------------------- //
+
+    /// Returns a bit mask of attributes to be udpated, or
+    /// HdChangeTracker::AllDirty if the entire prim must be resynchronized.
+    USDIMAGING_API
+    virtual HdDirtyBits ProcessPropertyChange(UsdPrim const& prim,
+                                              SdfPath const& cachePath,
+                                              TfToken const& propertyName);
+
+    USDIMAGING_API
+    virtual void MarkDirty(UsdPrim const& prim,
+                           SdfPath const& cachePath,
+                           HdDirtyBits dirty,
+                           UsdImagingIndexProxy* index);
+
+    USDIMAGING_API
+    virtual void MarkTransformDirty(UsdPrim const& prim,
+                                    SdfPath const& cachePath,
+                                    UsdImagingIndexProxy* index);
+
+    USDIMAGING_API
+    virtual void MarkVisibilityDirty(UsdPrim const& prim,
+                                     SdfPath const& cachePath,
+                                     UsdImagingIndexProxy* index);
+
+    /// Returns the token specifying the Hydra primitive type that is created
+    /// by this adapter.
+    virtual TfToken GetPrimTypeToken() const = 0;
+
+protected:
+    USDIMAGING_API
+    virtual void _RemovePrim(SdfPath const& cachePath,
+                             UsdImagingIndexProxy* index);
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USDIMAGING_FIELD_ADAPTER_H

--- a/pxr/usdImaging/lib/usdImaging/openvdbAssetAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/openvdbAssetAdapter.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usdImaging/usdImaging/openvdbAssetAdapter.h"
+#include "pxr/usdImaging/usdImaging/delegate.h"
+#include "pxr/usdImaging/usdImaging/indexProxy.h"
+#include "pxr/usdImaging/usdImaging/tokens.h"
+
+#include "pxr/imaging/hd/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    typedef UsdImagingOpenVDBAssetAdapter Adapter;
+    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
+    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
+}
+
+UsdImagingOpenVDBAssetAdapter::~UsdImagingOpenVDBAssetAdapter() 
+{
+}
+
+TfToken
+UsdImagingOpenVDBAssetAdapter::GetPrimTypeToken() const
+{
+    return HdPrimTypeTokens->openvdbAsset;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImaging/openvdbAssetAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/openvdbAssetAdapter.h
@@ -1,0 +1,60 @@
+//
+// Copyright 2017 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef USDIMAGING_OPENVDB_ASSET_ADAPTER_H
+#define USDIMAGING_OPENVDB_ASSET_ADAPTER_H
+
+/// \file usdImaging/openvdbAssetAdapter.h
+
+#include "pxr/pxr.h"
+#include "pxr/usdImaging/usdImaging/api.h"
+#include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+class UsdPrim;
+
+/// \class UsdImagingOpenVDBAssetAdapter
+///
+/// Adapter class for fields of type OpenVDBAsset
+///
+class UsdImagingOpenVDBAssetAdapter : public UsdImagingFieldAdapter {
+public:
+    typedef UsdImagingFieldAdapter BaseAdapter;
+
+    UsdImagingOpenVDBAssetAdapter()
+        : UsdImagingFieldAdapter()
+    {}
+
+    USDIMAGING_API
+    virtual ~UsdImagingOpenVDBAssetAdapter();
+
+    USDIMAGING_API
+    virtual TfToken GetPrimTypeToken() const;
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USDIMAGING_OPENVDB_ASSET_ADAPTER_H

--- a/pxr/usdImaging/lib/usdImaging/plugInfo.json
+++ b/pxr/usdImaging/lib/usdImaging/plugInfo.json
@@ -104,6 +104,13 @@
                         "isInternal": true,
                         "primTypeName": "Sphere"
                     },
+                    "UsdImagingVolumeAdapter": {
+                        "bases": [
+                            "UsdImagingGprimAdapter"
+                        ],
+                        "isInternal": true,
+                        "primTypeName": "Volume"
+                    },
                     "UsdImagingDomeLightAdapter": {
                         "bases": [
                             "UsdImagingLightAdapter"
@@ -145,6 +152,20 @@
                         ],
                         "isInternal": true,
                         "primTypeName": "DistantLight"
+                    },
+                    "UsdImagingOpenVDBAssetAdapter": {
+                        "bases": [
+                            "UsdImagingFieldAdapter"
+                        ],
+                        "isInternal": true,
+                        "primTypeName": "OpenVDBAsset"
+                    },
+                    "UsdImagingField3DAssetAdapter": {
+                        "bases": [
+                            "UsdImagingFieldAdapter"
+                        ],
+                        "isInternal": true,
+                        "primTypeName": "Field3DAsset"
                     }
                 }
             },

--- a/pxr/usdImaging/lib/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/primAdapter.cpp
@@ -344,6 +344,14 @@ UsdImagingPrimAdapter::GetTextureResource(UsdPrim const& usdPrim,
     return nullptr;
 }
 
+HdVolumeFieldDescriptorVector
+UsdImagingPrimAdapter::GetVolumeFieldDescriptors(UsdPrim const& usdPrim,
+	                                         SdfPath const &id,
+                                                 UsdTimeCode time) const
+{
+    return HdVolumeFieldDescriptorVector();
+}
+
 void
 UsdImagingPrimAdapter::SetDelegate(UsdImagingDelegate* delegate)
 {

--- a/pxr/usdImaging/lib/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/primAdapter.h
@@ -323,6 +323,15 @@ public:
                        UsdTimeCode time) const;
 
     // ---------------------------------------------------------------------- //
+    /// \name Volume field information
+    // ---------------------------------------------------------------------- //
+
+    USDIMAGING_API
+    virtual HdVolumeFieldDescriptorVector
+    GetVolumeFieldDescriptors(UsdPrim const& usdPrim, SdfPath const &id,
+                              UsdTimeCode time) const;
+
+    // ---------------------------------------------------------------------- //
     /// \name Utilities 
     // ---------------------------------------------------------------------- //
 

--- a/pxr/usdImaging/lib/usdImaging/volumeAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/volumeAdapter.cpp
@@ -1,0 +1,170 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/usdImaging/usdImaging/volumeAdapter.h"
+#include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+#include "pxr/usdImaging/usdImaging/delegate.h"
+#include "pxr/usdImaging/usdImaging/indexProxy.h"
+#include "pxr/usdImaging/usdImaging/tokens.h"
+
+#include "pxr/imaging/hd/perfLog.h"
+#include "pxr/imaging/hd/tokens.h"
+#include "pxr/imaging/hd/volume.h"
+
+#include "pxr/usd/usdGeom/xformCache.h"
+#include "pxr/usd/usdVol/tokens.h"
+#include "pxr/usd/usdVol/volume.h"
+#include "pxr/usd/usdVol/fieldBase.h"
+
+#include "pxr/base/tf/type.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    typedef UsdImagingVolumeAdapter Adapter;
+    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
+    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
+}
+
+UsdImagingVolumeAdapter::~UsdImagingVolumeAdapter() 
+{
+}
+
+bool
+UsdImagingVolumeAdapter::IsSupported(UsdImagingIndexProxy const* index) const
+{
+    return index->IsRprimTypeSupported(HdPrimTypeTokens->volume);
+}
+
+bool
+UsdImagingVolumeAdapter::_GatherVolumeData(UsdPrim const& prim, 
+			    SdfPathVector *fieldProperties,
+			    SdfPathVector *fields) const
+{
+    // Gather all relationships in the "field" namespace to figure out which
+    // field primitives make up this volume.
+    for (auto &&rel : prim.GetRelationships())
+    {
+	if (rel.GetNamespace() == UsdVolTokens->field)
+	{
+	    SdfPathVector targets;
+
+	    if (rel.GetTargets(&targets) && targets.size() > 0)
+	    {
+		fieldProperties->push_back(rel.GetPath());
+		fields->push_back(*targets.begin());
+	    }
+	}
+    }
+
+    return (fields->size() > 0);
+}
+
+SdfPath
+UsdImagingVolumeAdapter::Populate(UsdPrim const& prim, 
+                            UsdImagingIndexProxy* index,
+                            UsdImagingInstancerContext const* instancerContext)
+{
+    return  _AddRprim(HdPrimTypeTokens->volume,
+	prim, index, GetMaterialId(prim), instancerContext);
+}
+
+void 
+UsdImagingVolumeAdapter::TrackVariability(UsdPrim const& prim,
+                                          SdfPath const& cachePath,
+                                          HdDirtyBits* timeVaryingBits,
+                                          UsdImagingInstancerContext const* 
+                                              instancerContext) const
+{
+    // Just call the base class to test for a time-varying transform.
+    BaseAdapter::TrackVariability(
+	prim, cachePath, timeVaryingBits, instancerContext);
+
+    // Relationships can't be time varying, so we don't need to worry
+    // about the mapping from field names to field prim paths being
+    // time varying.
+}
+
+// Thread safe.
+//  * Populate dirty bits for the given \p time.
+void 
+UsdImagingVolumeAdapter::UpdateForTime(UsdPrim const& prim,
+                               SdfPath const& cachePath, 
+                               UsdTimeCode time,
+                               HdDirtyBits requestedBits,
+                               UsdImagingInstancerContext const* 
+                                   instancerContext) const
+{
+    // Call the base class to update the transform.
+    BaseAdapter::UpdateForTime(
+	prim, cachePath, time, requestedBits, instancerContext);
+}
+
+HdVolumeFieldDescriptorVector
+UsdImagingVolumeAdapter::GetVolumeFieldDescriptors(UsdPrim const& usdPrim,
+                                                    SdfPath const &id,
+                                                    UsdTimeCode time) const
+{
+    HdVolumeFieldDescriptorVector descriptors;
+    SdfPathVector fieldProperties;
+    SdfPathVector fields;
+
+    // Build bprims for all our fields.
+    if (_GatherVolumeData(usdPrim, &fieldProperties, &fields))
+    {
+	for (int i = 0, n = fields.size(); i < n; i++)
+	{
+	    UsdPrim		 fieldUsdPrim(_GetPrim(fields[i]));
+	    UsdVolFieldBase	 fieldPrim(fieldUsdPrim);
+
+	    if (fieldPrim)
+	    {
+		TfToken			 fieldName;
+		TfToken			 fieldPrimType;
+		auto			 adapter =_GetPrimAdapter(fieldUsdPrim);
+		UsdImagingFieldAdapter	*fieldAdapter;
+
+		fieldAdapter = dynamic_cast<UsdImagingFieldAdapter *>(
+		    adapter.get());
+		if (TF_VERIFY(fieldAdapter))
+		{
+		    fieldName = SdfPath::StripNamespace(
+			fieldProperties[i].GetNameToken());
+		    fieldPrimType = fieldAdapter->GetPrimTypeToken();
+		    descriptors.push_back(
+			HdVolumeFieldDescriptor(fieldName,
+						fieldPrimType,
+						fieldUsdPrim.GetPath()));
+		}
+	    }
+	}
+    }
+
+    return descriptors;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+

--- a/pxr/usdImaging/lib/usdImaging/volumeAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/volumeAdapter.h
@@ -1,0 +1,86 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef USDIMAGING_VOLUME_ADAPTER_H
+#define USDIMAGING_VOLUME_ADAPTER_H
+
+/// \file usdImaging/volumeAdapter.h
+
+#include "pxr/pxr.h"
+#include "pxr/usdImaging/usdImaging/api.h"
+#include "pxr/usdImaging/usdImaging/primAdapter.h"
+#include "pxr/usdImaging/usdImaging/gprimAdapter.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class UsdImagingVolumeAdapter
+///
+/// Delegate support for UsdVolVolume.
+///
+class UsdImagingVolumeAdapter : public UsdImagingGprimAdapter {
+public:
+    typedef UsdImagingGprimAdapter BaseAdapter;
+
+    UsdImagingVolumeAdapter()
+        : UsdImagingGprimAdapter()
+    {}
+    virtual ~UsdImagingVolumeAdapter();
+
+    virtual SdfPath Populate(UsdPrim const& prim,
+                     UsdImagingIndexProxy* index,
+                     UsdImagingInstancerContext const*
+			instancerContext = NULL) override;
+
+    virtual bool IsSupported(UsdImagingIndexProxy const* index) const override;
+
+    // ---------------------------------------------------------------------- //
+    /// \name Parallel Setup and Resolve
+    // ---------------------------------------------------------------------- //
+    /// Thread Safe.
+    virtual void TrackVariability(UsdPrim const& prim,
+                                  SdfPath const& cachePath,
+                                  HdDirtyBits* timeVaryingBits,
+                                  UsdImagingInstancerContext const*
+                                      instancerContext = NULL) const override;
+
+    /// Thread Safe.
+    virtual void UpdateForTime(UsdPrim const& prim,
+                               SdfPath const& cachePath,
+                               UsdTimeCode time,
+                               HdDirtyBits requestedBits,
+                               UsdImagingInstancerContext const*
+                                   instancerContext = NULL) const override;
+
+    virtual HdVolumeFieldDescriptorVector
+    GetVolumeFieldDescriptors(UsdPrim const& usdPrim, SdfPath const &id,
+                              UsdTimeCode time) const override;
+
+private:
+    bool _GatherVolumeData(UsdPrim const& prim, 
+			   SdfPathVector *fieldProperties,
+			   SdfPathVector *fields) const;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USDIMAGING_VOLUME_ADAPTER_H


### PR DESCRIPTION
Note that this pull request won't build without PR #514, but I was asked to submit it in advance of that one being accepted.

This PR provides usdImaging adapters for volume and field prims, Hd base classes for field bprims and volume rprims, and new scene delegate and prim adapter virtuals for fetching field information from a volume primitive.