### PR TITLE
[usd] Block Authoring Prims on Inactive Ancestor.

### DIFF
--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -3187,11 +3187,12 @@ UsdStage::_DefinePrim(const SdfPath &path, const TfToken &typeName)
     }
 
     // Disallow authoring a prim under an inactive ancestor
+    // Note that GetPrimAtPath() is safe here due to the way _DefinePrim
+    // recurses up to the toplevel prim at 3167.
     if (!GetPrimAtPath(parentPath).IsActive()) {
-        TF_RUNTIME_ERROR("Failed to create UsdPrim <%s>. "
-                         "Cannot author a UsdPrim under an inactive ancestor <%s>.", 
-                         path.GetText(),
-                         parentPath.GetText());
+        TF_WARN("Failed to create UsdPrim <%s>. "
+                "Cannot author a UsdPrim under an inactive ancestor <%s>.", 
+                path.GetText(), parentPath.GetText());
         return UsdPrim();
     }
     

--- a/pxr/usd/lib/usd/testenv/testUsdPrims.py
+++ b/pxr/usd/lib/usd/testenv/testUsdPrims.py
@@ -439,6 +439,36 @@ class TestUsdPrim(unittest.TestCase):
             p3 = s.DefinePrim(p3Path)
             self.assertTrue(p3)
 
+            print 'Test defining under inactive ...'
+            s = Usd.Stage.CreateInMemory('OverrideOverInactive.'+fmt)
+
+            p1Path = '/f'
+            p1 = s.OverridePrim(p1Path)
+
+            p1.SetActive(False)
+            p2Path = '/f/g'
+            p2 = s.OverridePrim(p2Path)
+            self.assertFalse(p2)
+            
+            p1.SetActive(True)
+            p2 = s.OverridePrim('/f/g')
+            self.assertTrue(p2)
+
+            p1.SetActive(False)
+            p3Path = '/f/g/h'
+            p3 = s.OverridePrim(p3Path)
+            self.assertFalse(p3)
+
+            p1.SetActive(True)
+            p2 = s.GetPrimAtPath(p2Path)
+            p2.SetActive(False)
+            p3 = s.OverridePrim(p3Path)
+            self.assertFalse(p3)    
+
+            p2.SetActive(True)
+            p3 = s.OverridePrim(p3Path)
+            self.assertTrue(p3)
+
     def test_ChangeTypeName(self):
         for fmt in allFormats:
             s = Usd.Stage.CreateInMemory('ChangeTypeName.'+fmt)

--- a/pxr/usd/lib/usd/testenv/testUsdPrims.py
+++ b/pxr/usd/lib/usd/testenv/testUsdPrims.py
@@ -411,11 +411,33 @@ class TestUsdPrim(unittest.TestCase):
     def test_DefineOverInactive(self):
         for fmt in allFormats:
             s = Usd.Stage.CreateInMemory('DefineOverInactive.'+fmt)
-            p1 = s.DefinePrim('/f')
-            p1.SetActive(False)
 
-            with self.assertRaises(Tf.ErrorException):
-                g = s.DefinePrim('/f/g')
+            p1Path = '/f'
+            p1 = s.DefinePrim(p1Path)
+
+            p1.SetActive(False)
+            p2Path = '/f/g'
+            p2 = s.DefinePrim(p2Path)
+            self.assertFalse(p2)
+            
+            p1.SetActive(True)
+            p2 = s.DefinePrim('/f/g')
+            self.assertTrue(p2)
+
+            p1.SetActive(False)
+            p3Path = '/f/g/h'
+            p3 = s.DefinePrim(p3Path)
+            self.assertFalse(p3)
+
+            p1.SetActive(True)
+            p2 = s.GetPrimAtPath(p2Path)
+            p2.SetActive(False)
+            p3 = s.DefinePrim(p3Path)
+            self.assertFalse(p3)    
+
+            p2.SetActive(True)
+            p3 = s.DefinePrim(p3Path)
+            self.assertTrue(p3)
 
     def test_ChangeTypeName(self):
         for fmt in allFormats:

--- a/pxr/usd/lib/usd/testenv/testUsdPrims.py
+++ b/pxr/usd/lib/usd/testenv/testUsdPrims.py
@@ -408,6 +408,14 @@ class TestUsdPrim(unittest.TestCase):
         assert not stage.GetPrimAtPath(
             deactivatedScope.GetPath().AppendChild('child'))
 
+    def test_DefineOverInactive(self):
+        for fmt in allFormats:
+            s = Usd.Stage.CreateInMemory('DefineOverInactive.'+fmt)
+            p1 = s.DefinePrim('/f')
+            p1.SetActive(False)
+
+            with self.assertRaises(Tf.ErrorException):
+                g = s.DefinePrim('/f/g')
 
     def test_ChangeTypeName(self):
         for fmt in allFormats:


### PR DESCRIPTION
### Description of Change(s)

Currently, authoring a prim via DefinePrim with a pre-existing non-active ancestor would throw a TfRuntimeError, _but_ would still complete the authoring. To reproduce run:

```
from pxr import Tf, Usd
s = Usd.Stage.CreateInMemory()
p = s.DefinePrim('/p')
p.SetActive(False)
try:
    g = s.DefinePrim('/p/g')
except Tf.ErrorException as e:
    print 'oops: ', str(e)
print '-------'
print s.GetRootLayer().ExportToString()
```

and get

```
oops:
        Error in 'pxrInternal_v0_8__pxrReserved__::UsdStage::_DefinePrim' at line 3076 in file pxr/usd/lib/usd/stage.cpp : 'Failed to define UsdPrim </p/g>'
-------

def "p" (
   active = false
)
{
   def "g"
   {
   }
}
```

With this change the behavior now results in a more reasonable error message, and the authoring does not take place.

```
oops:
	Error in 'pxrInternal_v0_8__pxrReserved__::UsdStage::_DefinePrim' at line 3172 in file pxr/usd/lib/usd/stage.cpp : 'Failed to create UsdPrim </p/g>. Cannot author a UsdPrim under an inactive ancestor </p>.'
-------

def "p" (
    active = false
)
{
}
```


### Fixes Issue(s)
- None filed, ran into in the wild

