### PR TITLE
Alembic plugin: Optionally disable parent-xform-as-mesh behavior

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -90,6 +90,11 @@ TF_DEFINE_ENV_SETTING(
     "Switch to true to enable writing Alembic uv sets as primvars:st with type "
     "texCoord2fArray to USD");
 
+
+TF_DEFINE_ENV_SETTING(
+    USD_ABC_XFORM_PRIM_COLLAPSE, true,
+    "Collapse Xforms containing a single geometry into a single geom Prim in USD");
+
 namespace {
 
 using namespace ::Alembic::AbcGeom;
@@ -3479,6 +3484,10 @@ _ReadPrim(
         // huge if statement or deep if nesting, we'll use do/while and
         // break to do it.
         do {
+            if (!TfGetEnvSetting(USD_ABC_XFORM_PRIM_COLLAPSE)) {
+                // Transform collapse is specified as unwanted behavior
+                break;
+            }
             // Parent has to be a transform.
             IObject parent = object.getParent();
             if (!IXform::matches(parent.getHeader())) {


### PR DESCRIPTION
### Description of Change(s)

When reading an Alembic file, the generated USD Prim hierarchy is currently affected by the structure of the Alembic file itself. In cases where the Alembic hierarchy consists of an Xform with a single geometry or camera, like so:

```
/Xform xformNameA
    /Subd geomNameB
```

The generated USD Prim hierarchy looks like this:

```
/Mesh xformNameA
```

However, if the Alembic hierarchy has an Xform with two or more geometries or cameras:

```
/Xform xformNameA
    /Subd geomNameB
    /Subd geomNameC
```

The USD Prim hierarchy maintains the same structure as the Alembic hierarchy:

```
/Xform xformNameA
    /Mesh geomNameB
    /Mesh geomNameC
```

This is problematic in a pipeline that expects assets to maintain a consistent Prim hierarchy regardless of their contents.

This change adds a control, USD_ABC_XFORM_PRIM_COLLAPSE, set to true to maintain existing behavior, that when set to false will maintain the Xform -> Prim hierarchy in all cases.