### PR TITLE
[sdf] Add functions for finding registered formats.

### DIFF
--- a/pxr/usd/lib/sdf/CMakeLists.txt
+++ b/pxr/usd/lib/sdf/CMakeLists.txt
@@ -189,6 +189,7 @@ pxr_test_scripts(
     testenv/testSdfBatchNamespaceEdit.py
     testenv/testSdfCopyUtils.py
     testenv/testSdfCustomLayerData.py
+    testenv/testSdfFileFormat.py
     testenv/testSdfLayer.py
     testenv/testSdfLayerMuting.py
     testenv/testSdfListOp.py
@@ -306,6 +307,11 @@ pxr_register_test(testSdfCustomLayerData
 
 pxr_register_test(testSdfHardToReach
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfHardToReach"
+)
+
+pxr_register_test(testSdfFileFormat
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfFileFormat"
 )
 
 pxr_register_test(testSdfLayer

--- a/pxr/usd/lib/sdf/fileFormat.cpp
+++ b/pxr/usd/lib/sdf/fileFormat.cpp
@@ -251,6 +251,7 @@ SdfFileFormat::WriteToString(
     return false;
 }
 
+/* static */
 std::string
 SdfFileFormat::GetFileExtension(
     const std::string& s)
@@ -270,6 +271,14 @@ SdfFileFormat::GetFileExtension(
     return extension.empty() ? s : extension;
 }
 
+/* static */
+std::set<std::string>
+SdfFileFormat::FindAllFileFormatExtensions()
+{
+    return _FileFormatRegistry->FindAllFileFormatExtensions();
+}
+
+/* static */
 SdfFileFormatConstPtr
 SdfFileFormat::FindById(
     const TfToken& formatId)
@@ -277,6 +286,7 @@ SdfFileFormat::FindById(
     return _FileFormatRegistry->FindById(formatId);
 }
 
+/* static */
 SdfFileFormatConstPtr
 SdfFileFormat::FindByExtension(
     const std::string& extension,

--- a/pxr/usd/lib/sdf/fileFormat.h
+++ b/pxr/usd/lib/sdf/fileFormat.h
@@ -241,6 +241,10 @@ public:
     /// leading dot character.
     SDF_API static std::string GetFileExtension(const std::string& s);
 
+    /// Returns a set containing the extension(s) corresponding to 
+    /// all registered file formats.
+    SDF_API static std::set<std::string> FindAllFileFormatExtensions();
+
     /// Returns the file format instance with the specified \p formatId
     /// identifier. If a format with a matching identifier is not found, this
     /// returns a null file format pointer.

--- a/pxr/usd/lib/sdf/fileFormatRegistry.cpp
+++ b/pxr/usd/lib/sdf/fileFormatRegistry.cpp
@@ -139,6 +139,19 @@ Sdf_FileFormatRegistry::FindByExtension(
     return formatInfo ? _GetFileFormat(formatInfo) : TfNullPtr;
 }
 
+std::set<std::string>
+Sdf_FileFormatRegistry::FindAllFileFormatExtensions()
+{
+    _RegisterFormatPlugins();
+
+    std::set<std::string> result; 
+    for (const auto& p : _extensionIndex) {
+        result.insert(p.first);
+    }
+
+    return result;
+}
+
 TfToken
 Sdf_FileFormatRegistry::GetPrimaryFormatForExtension(
     const std::string& ext)

--- a/pxr/usd/lib/sdf/fileFormatRegistry.h
+++ b/pxr/usd/lib/sdf/fileFormatRegistry.h
@@ -66,6 +66,10 @@ public:
         const std::string& s,
         const std::string& target = std::string());
 
+    /// Returns a set containing the extension(s) corresponding to 
+    /// all registered file formats.
+    std::set<std::string> FindAllFileFormatExtensions();
+
     /// Returns the id of the file format plugin that is registered as
     /// the primary format for the given file extension.
     TfToken GetPrimaryFormatForExtension(const std::string& ext);

--- a/pxr/usd/lib/sdf/testenv/testSdfFileFormat.py
+++ b/pxr/usd/lib/sdf/testenv/testSdfFileFormat.py
@@ -1,0 +1,53 @@
+#!/pxrpythonsubst
+#
+# Copyright 2018 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Sdf, Tf
+import unittest
+
+class TestSdfFileFormat(unittest.TestCase):
+    def test_StaticMethods(self):
+        print 'Testing static methods on SdfFileFormat...'
+
+        # FindById
+        # Note that the id and extension are the same in our case
+        sdfFileFormat = Sdf.FileFormat.FindById('sdf')
+        self.assertTrue(sdfFileFormat)
+        self.assertEqual(sdfFileFormat.GetFileExtensions(), ['sdf'])
+
+        # FindByExtension
+        sdfFileFormat = Sdf.FileFormat.FindByExtension('sdf')
+        self.assertTrue(sdfFileFormat)
+        self.assertEqual(sdfFileFormat.GetFileExtensions(), ['sdf'])
+
+        # GetFileExtension
+        self.assertEqual(Sdf.FileFormat.GetFileExtension('foo.sdf'), 'sdf')
+        self.assertEqual(Sdf.FileFormat.GetFileExtension('/something/bar/foo.sdf'), 'sdf')
+        self.assertEqual(Sdf.FileFormat.GetFileExtension('./bar/baz/foo.sdf'), 'sdf')
+         
+        # FindAllFileFormatExtensions
+        exts = Sdf.FileFormat.FindAllFileFormatExtensions()
+        self.assertTrue('sdf' in exts)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/lib/sdf/wrapFileFormat.cpp
+++ b/pxr/usd/lib/sdf/wrapFileFormat.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/tf/pyCall.h"
 #include "pxr/base/tf/pyPtrHelpers.h"
 #include "pxr/base/tf/pyStaticTokens.h"
+#include "pxr/base/tf/pyResultConversions.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/scope.hpp>
@@ -130,6 +131,10 @@ void wrapFileFormat()
 
         .def("GetFileExtension", &This::GetFileExtension)
         .staticmethod("GetFileExtension")
+
+        .def("FindAllFileFormatExtensions", &This::FindAllFileFormatExtensions,
+             return_value_policy<TfPySequenceToList>())
+        .staticmethod("FindAllFileFormatExtensions")
 
         .def("FindById", &This::FindById)
         .staticmethod("FindById")


### PR DESCRIPTION
### Description of Change(s)

This provides FindAllFileFormats(), returning a set of TfTypes corresponding to the registered formats, and FindAllFileFormatExtensions(), returning the set of all extensions for the registered types.

This has been useful in populating GUIs and will probably have other use cases I haven't imagined yet.


### Fixes Issue(s)
- None filed, just fulfilling my dreams

