### PR TITLE
Katana plugin asset resolver fixes

### DIFF
--- a/third_party/katana/lib/usdKatana/attrMap.cpp
+++ b/third_party/katana/lib/usdKatana/attrMap.cpp
@@ -52,10 +52,7 @@ PxrUsdKatanaAttrMap::Set(
     if (attr.IsValid() && attr.HasAuthoredValueOpinion()
         && attr.Get(&val, _usdTimeCode)) {
         FnKat::Attribute kat_attr =
-            PxrUsdKatanaUtils::ConvertVtValueToKatAttr( val,
-                                    /* asShaderParam */ true,
-                                    /* pathAsModel */ false,
-                                    /* resolvePath */ false);
+            PxrUsdKatanaUtils::ConvertVtValueToKatAttr(val);
         _groupBuilder.set(path, kat_attr);
     }
     return *this;

--- a/third_party/katana/lib/usdKatana/readBlindData.cpp
+++ b/third_party/katana/lib/usdKatana/readBlindData.cpp
@@ -70,9 +70,7 @@ PxrUsdKatanaReadBlindData(
                 // generated "as is", we *do not* want the prmanStatement style
                 // "type"/"value" declaration to be created.
                 attrs.set(attrName, 
-                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
-                        vtValue, 
-                        /* asShaderParam */ true));
+                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue));
             }
             else if (blindAttr.HasAuthoredValueOpinion())
             {

--- a/third_party/katana/lib/usdKatana/readLightFilter.cpp
+++ b/third_party/katana/lib/usdKatana/readLightFilter.cpp
@@ -71,10 +71,7 @@ struct _UsdBuilder {
         if (attr.IsValid() && attr.HasAuthoredValueOpinion()
             && attr.Get(&val, _time)) {
             FnKat::Attribute kat_attr =
-                PxrUsdKatanaUtils::ConvertVtValueToKatAttr( val,
-                                        /* asShaderParam */ true,
-                                        /* pathAsModel */ false,
-                                        /* resolvePath */ false);
+                PxrUsdKatanaUtils::ConvertVtValueToKatAttr(val);
             _builder.set(kat_name.c_str(), kat_attr);
         }
         return *this;

--- a/third_party/katana/lib/usdKatana/readMaterial.cpp
+++ b/third_party/katana/lib/usdKatana/readMaterial.cpp
@@ -203,7 +203,7 @@ _GatherShadingParameters(
         if (flatten || 
             !PxrUsdKatana_IsAttrValFromBaseMaterial(attr)) {
             paramsBuilder.set(inputId,
-                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue, true));
+                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue));
         }
     }
     
@@ -228,8 +228,7 @@ _GatherShadingParameters(
                 }
                 
                 paramsBuilder.set(attr.GetName().GetString(),
-                        PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
-                                vtValue, true));
+                        PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue));
             }
         }
     }
@@ -765,7 +764,7 @@ _UnrollInterfaceFromPrim(const UsdPrim& prim,
         if (interfaceInput.GetAttr().Get(&attrVal) && !attrVal.IsEmpty()) {
             materialBuilder.set(
                     TfStringPrintf("parameters.%s", renamedParam.c_str()),
-                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(attrVal, true));
+                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(attrVal));
         }
 
         if (interfaceInputConsumers.count(interfaceInput) == 0) {

--- a/third_party/katana/lib/usdKatana/readPrim.cpp
+++ b/third_party/katana/lib/usdKatana/readPrim.cpp
@@ -197,35 +197,29 @@ _GatherRibAttributes(
             attrName = nameSpace +
                 riStatements.GetRiAttributeName(prop).GetString();
 
+            // XXX asShaderParam really means:
+            // "For arrays, as a single attr vs a type/value pair group"
+            // The type/value pair group is meaningful for attrs who don't
+            // have a formal type definition -- like a "user" RiAttribute.
+            //
+            // However, other array values (such as two-element shadingrate)
+            // are not expecting the type/value pair form and will not
+            // generate rib correctly. As such, we'll handle the "user"
+            // attribute as a special case.
+            const bool asShaderParam = (nameSpace != "user.");
+
             VtValue vtValue;
             UsdAttribute usdAttr = prim.GetAttribute(prop.GetName());
             if (usdAttr) {
                 if (!usdAttr.Get(&vtValue, currentTime)) 
                     continue;
-
-                // XXX asShaderParam really means:
-                // "For arrays, as a single attr vs a type/value pair group"
-                // The type/value pair group is meaningful for attrs who don't
-                // have a formal type definition -- like a "user" RiAttribute.
-                // 
-                // However, other array values (such as two-element shadingrate)
-                // are not expecting the type/value pair form and will not
-                // generate rib correctly. As such, we'll handle the "user"
-                // attribute as a special case.
-                bool asShaderParam = true;
-                
-                if (nameSpace == "user.")
-                {
-                    asShaderParam = false;
-                }
-
                 attrsBuilder.set(attrName, PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue,
                     asShaderParam) );
             }
             else {
                 UsdRelationship usdRel = prim.GetRelationship(prop.GetName());
                 attrsBuilder.set(attrName, PxrUsdKatanaUtils::ConvertRelTargetsToKatAttr(usdRel,
-                    /* asShaderParam */ false) );
+                    asShaderParam) );
             }
             hasAttrs = true;
         }

--- a/third_party/katana/lib/usdKatana/readPrim.cpp
+++ b/third_party/katana/lib/usdKatana/readPrim.cpp
@@ -648,7 +648,7 @@ _AddExtraAttributesOrNamespaces(
                 }
                 
                 FnKat::Attribute attr = 
-                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue, true);
+                    PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue);
                 
                 if (!attr.isValid())
                 {
@@ -666,8 +666,7 @@ _AddExtraAttributesOrNamespaces(
                 UsdRelationship & usdRelationship = (*I);
                 
                 FnKat::StringAttribute attr = 
-                    PxrUsdKatanaUtils::ConvertRelTargetsToKatAttr(
-                        usdRelationship, true);
+                    PxrUsdKatanaUtils::ConvertRelTargetsToKatAttr(usdRelationship);
                 if (!attr.isValid())
                 {
                     continue;
@@ -739,7 +738,7 @@ _AddCustomProperties(
         }
         
         FnKat::Attribute attr =
-            PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue, true);
+            PxrUsdKatanaUtils::ConvertVtValueToKatAttr(vtValue);
 
         if (!attr.isValid())
         {

--- a/third_party/katana/lib/usdKatana/utils.cpp
+++ b/third_party/katana/lib/usdKatana/utils.cpp
@@ -267,8 +267,8 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
         std::vector<int> vec(rawVal.begin(), rawVal.end());
         FnKat::IntBuilder builder(/* tupleSize = */ 1);
         builder.set(vec);
-        typeAttr = FnKat::StringAttribute(TfStringPrintf("int [%zu]",
-                                                         rawVal.size()));
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("int [%zu]", rawVal.size()));
         valueAttr = builder.build();
     }
 
@@ -277,8 +277,8 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
         std::vector<float> vec(rawVal.begin(), rawVal.end());
         FnKat::FloatBuilder builder(/* tupleSize = */ 1);
         builder.set(vec);
-        typeAttr = FnKat::StringAttribute(TfStringPrintf("float [%zu]",
-                                                         rawVal.size()));
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("float [%zu]", rawVal.size()));
         valueAttr = builder.build();
     }
     else if (val.IsHolding<VtArray<double> >()) {
@@ -286,8 +286,8 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
         std::vector<double> vec(rawVal.begin(), rawVal.end());
         FnKat::DoubleBuilder builder(/* tupleSize = */ 1);
         builder.set(vec);
-        typeAttr = FnKat::StringAttribute(TfStringPrintf("double [%zu]",
-                                                         rawVal.size()));
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("double [%zu]", rawVal.size()));
         valueAttr = builder.build();
     }
 
@@ -308,8 +308,8 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
          FnKat::FloatBuilder builder(/* tupleSize = */ 16);
          builder.set(vec);
          valueAttr = builder.build();
-         typeAttr = FnKat::StringAttribute(TfStringPrintf("matrix [%zu]",
-                                                         rawVal.size()));
+         typeAttr = FnKat::StringAttribute(
+             TfStringPrintf("matrix [%zu]", rawVal.size()));
     }
 
     // GfVec2f
@@ -485,18 +485,16 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
 
     // VtArray<SdfAssetPath>
     else if (val.IsHolding<VtArray<SdfAssetPath> >()) {
+        // This will replicate the previous behavior:
+        // if (asShaderParam) return valueAttr; asShaderParam = false;
         const VtArray<SdfAssetPath> &rawVal = val.UncheckedGet<VtArray<SdfAssetPath> >();
         FnKat::StringBuilder builder;
         TF_FOR_ALL(strItr, rawVal) {
             builder.push_back(_ResolveAssetPath(*strItr));
         }
-        FnKat::GroupBuilder attrBuilder;
-        attrBuilder.set("type",
-                        FnKat::StringAttribute(
-                            TfStringPrintf("string [%zu]",assetArray.size())));
-        attrBuilder.set("value", stringBuilder.build());
-        // NOTE: needs typeAttr set?
-        valueAttr = attrBuilder.build();
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("string [%zu]", rawVal.size()));
+        valueAttr = builder.build();
     }
      
     // If being used as a shader param, the type will be provided elsewhere,

--- a/third_party/katana/lib/usdKatana/utils.cpp
+++ b/third_party/katana/lib/usdKatana/utils.cpp
@@ -201,7 +201,7 @@ _ConvertArrayToVector(const VtVec4dArray &a, std::vector<double> *r)
 FnKat::Attribute
 PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
         const VtValue & val, 
-        bool asShaderParam, bool pathsAsModel, bool resolvePaths)
+        bool asShaderParam)
 {
     if (val.IsHolding<bool>()) {
         return FnKat::IntAttribute(int(val.UncheckedGet<bool>()));
@@ -225,9 +225,7 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
     }
     if (val.IsHolding<SdfAssetPath>()) {
         const SdfAssetPath& assetPath(val.UncheckedGet<SdfAssetPath>());
-        return FnKat::StringAttribute(
-            resolvePaths ?  _ResolveAssetPath(assetPath)
-            : assetPath.GetAssetPath());
+        return FnKat::StringAttribute(_ResolveAssetPath(assetPath));
     }
     if (val.IsHolding<TfToken>()) {
         const TfToken &myVal = val.UncheckedGet<TfToken>();
@@ -487,14 +485,10 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
 
     // VtArray<SdfAssetPath>
     else if (val.IsHolding<VtArray<SdfAssetPath> >()) {
-        FnKat::StringBuilder stringBuilder;
-        const VtArray<SdfAssetPath> &assetArray = 
-            val.UncheckedGet<VtArray<SdfAssetPath> >();
-        TF_FOR_ALL(strItr, assetArray) {
-            stringBuilder.push_back(
-                resolvePaths ?
-                _ResolveAssetPath(*strItr)
-                : strItr->GetAssetPath());
+        const VtArray<SdfAssetPath> &rawVal = val.UncheckedGet<VtArray<SdfAssetPath> >();
+        FnKat::StringBuilder builder;
+        TF_FOR_ALL(strItr, rawVal) {
+            builder.push_back(_ResolveAssetPath(*strItr));
         }
         FnKat::GroupBuilder attrBuilder;
         attrBuilder.set("type",

--- a/third_party/katana/lib/usdKatana/utils.cpp
+++ b/third_party/katana/lib/usdKatana/utils.cpp
@@ -272,6 +272,30 @@ PxrUsdKatanaUtils::ConvertVtValueToKatAttr(
         valueAttr = builder.build();
     }
 
+    else if (val.IsHolding<VtArray<unsigned> >()) {
+        // Lossy translation of array<unsigned> to array<int>
+        // No warning is printed as they obscure more important warnings
+        const VtArray<unsigned> rawVal = val.Get<VtArray<unsigned> >();
+        std::vector<int> vec(rawVal.begin(), rawVal.end());
+        FnKat::IntBuilder builder(/* tupleSize = */ 1);
+        builder.set(vec);
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("unsigned [%zu]", rawVal.size()));
+        valueAttr = builder.build();
+    }
+
+    else if (val.IsHolding<VtArray<long> >()) {
+        // Lossy translation of array<long> to array<int>
+        // No warning is printed as they obscure more important warnings
+        const VtArray<long> rawVal = val.Get<VtArray<long> >();
+        std::vector<int> vec(rawVal.begin(), rawVal.end());
+        FnKat::IntBuilder builder(/* tupleSize = */ 1);
+        builder.set(vec);
+        typeAttr = FnKat::StringAttribute(
+            TfStringPrintf("long [%zu]", rawVal.size()));
+        valueAttr = builder.build();
+    }
+
     else if (val.IsHolding<VtArray<float> >()) {
         const VtArray<float> rawVal = val.UncheckedGet<VtArray<float> >();
         std::vector<float> vec(rawVal.begin(), rawVal.end());
@@ -998,6 +1022,34 @@ PxrUsdKatanaUtils::ConvertVtValueToKatCustomGeomAttr(
         builder.set(vec);
         *valueAttr = builder.build();
         *inputTypeAttr = FnKat::StringAttribute("int");
+        if (elementSize > 1) {
+            *elementSizeAttr = FnKat::IntAttribute(elementSize);
+        }
+        return;
+    }
+    if (val.IsHolding<VtArray<unsigned> >()) {
+        // Lossy translation of array<unsigned> to array<int>
+        // No warning is printed as they obscure more important warnings
+        const VtArray<unsigned> rawVal = val.Get<VtArray<unsigned> >();
+        std::vector<int> vec(rawVal.begin(), rawVal.end());
+        FnKat::IntBuilder builder(/* tupleSize = */ 1);
+        builder.set(vec);
+        *valueAttr = builder.build();
+        *inputTypeAttr = FnKat::StringAttribute("unsigned");
+        if (elementSize > 1) {
+            *elementSizeAttr = FnKat::IntAttribute(elementSize);
+        }
+        return;
+    }
+    if (val.IsHolding<VtArray<long> >()) {
+        // Lossy translation of array<long> to array<int>
+        // No warning is printed as they obscure more important warnings
+        const VtArray<long> rawVal = val.Get<VtArray<long> >();
+        std::vector<int> vec(rawVal.begin(), rawVal.end());
+        FnKat::IntBuilder builder(/* tupleSize = */ 1);
+        builder.set(vec);
+        *valueAttr = builder.build();
+        *inputTypeAttr = FnKat::StringAttribute("long");
         if (elementSize > 1) {
             *elementSizeAttr = FnKat::IntAttribute(elementSize);
         }

--- a/third_party/katana/lib/usdKatana/utils.h
+++ b/third_party/katana/lib/usdKatana/utils.h
@@ -60,20 +60,19 @@ struct PxrUsdKatanaUtils {
     static void ConvertArrayToVector(const VtVec3fArray &a, std::vector<float> *r);
 
     /// Convert a VtValue to a Katana attribute.
-    /// If asShaderParam is true, it will use the special encoding
-    /// Katana uses for shading arguments.
-    /// The pathsAsModel argument is used when trying to resolve asset paths.
+    /// If asShaderParam is false, convert arrays to type + array pairs
+    /// pathsAsModel is not used
+    /// resolvePaths is whether you get asset id or resolved path as strings for assets
     static FnKat::Attribute ConvertVtValueToKatAttr( const VtValue & val,
-                                                     bool asShaderParam,
+                                                     bool asShaderParam = true,
                                                      bool pathsAsModel = false,
                                                      bool resolvePaths = true);
 
     /// Extract the targets of a relationship to a Katana attribute.
-    /// If asShaderParam is true, it will use the special encoding
-    /// Katana uses for shading arguments.
+    /// If asShaderParam is false, convert arrays to type + array pairs
     static FnKat::Attribute ConvertRelTargetsToKatAttr(
             const UsdRelationship &rel, 
-            bool asShaderParam);
+            bool asShaderParam = true);
 
     /// Convert a VtValue to a Katana custom geometry attribute (primvar).
     /// Katana uses a different encoding here from other attributes, which

--- a/third_party/katana/lib/usdKatana/utils.h
+++ b/third_party/katana/lib/usdKatana/utils.h
@@ -61,12 +61,8 @@ struct PxrUsdKatanaUtils {
 
     /// Convert a VtValue to a Katana attribute.
     /// If asShaderParam is false, convert arrays to type + array pairs
-    /// pathsAsModel is not used
-    /// resolvePaths is whether you get asset id or resolved path as strings for assets
     static FnKat::Attribute ConvertVtValueToKatAttr( const VtValue & val,
-                                                     bool asShaderParam = true,
-                                                     bool pathsAsModel = false,
-                                                     bool resolvePaths = true);
+                                                     bool asShaderParam = true);
 
     /// Extract the targets of a relationship to a Katana attribute.
     /// If asShaderParam is false, convert arrays to type + array pairs


### PR DESCRIPTION
### Description of Change(s)

In the Katana USD plugin this replaces direct calls to the Resolver with use of the pre-resolved path in an SdfAssetPath. This primarily fixes filenames of relative assets from usd files that are not in the current directory.

First patch does the minimal change to fix the bug. Subsequent patches remove any attempt to use the resolver, and then remove redundant or unnecessary flags from the attribute converter function, these are not needed now that the resolver has already been run correctly by Sdf Layer, and correct the behavior in some (obscure?) cases such as arrays of assets.
