### PR TITLE
[Imaging] Improving shadow support in HdxTaskController

### DIFF
--- a/pxr/imaging/lib/hdx/taskController.h
+++ b/pxr/imaging/lib/hdx/taskController.h
@@ -30,10 +30,13 @@
 #include "pxr/imaging/hdx/intersector.h"
 #include "pxr/imaging/hdx/selectionTracker.h"
 #include "pxr/imaging/hdx/renderSetupTask.h"
+#include "pxr/imaging/hdx/shadowTask.h"
 
 #include "pxr/imaging/hd/renderIndex.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 #include "pxr/imaging/hd/task.h"
+
+#include "pxr/imaging/cameraUtil/conformWindow.h"
 
 #include "pxr/imaging/glf/simpleLightingContext.h"
 #include "pxr/usd/sdf/path.h"
@@ -112,6 +115,11 @@ public:
     HDX_API
     void SetRenderParams(HdxRenderTaskParams const& params);
 
+    /// Set the shadow params. Note: params.camera will
+    /// be overwritten, since they come from SetCameraState.
+    HDX_API
+    void SetShadowParams(HdxShadowTaskParams const& params);
+
     /// -------------------------------------------------------
     /// Lighting API
 
@@ -136,6 +144,10 @@ public:
     /// Set the camera clip planes.
     HDX_API
     void SetCameraClipPlanes(std::vector<GfVec4d> const& clipPlanes);
+
+    /// Set the camera window policy.
+    HDX_API
+    void SetCameraWindowPolicy(CameraUtilConformWindowPolicy windowPolicy);
 
     /// -------------------------------------------------------
     /// Picking API
@@ -167,6 +179,13 @@ public:
     void SetSelectionColor(GfVec4f const& color);
 
     /// -------------------------------------------------------
+    /// Shadow API
+
+    /// Turns the shadow task on or off.
+    HDX_API
+    void SetEnableShadows(bool enable);
+
+    /// -------------------------------------------------------
     /// Progressive Image Generation
     
     /// Return whether the image has converged.
@@ -192,6 +211,7 @@ private:
     void _CreateRenderTasks();
     void _CreateSelectionTask();
     void _CreateLightingTask();
+    void _CreateShadowTask();
 
     // A private scene delegate member variable backs the tasks this
     // controller generates. To keep _Delegate simple, the containing class
@@ -240,6 +260,7 @@ private:
     SdfPath _idRenderTaskId;
     SdfPath _selectionTaskId;
     SdfPath _simpleLightTaskId;
+    SdfPath _shadowTaskId;
 
     // Generated cameras
     SdfPath _cameraId;


### PR DESCRIPTION
### Description of Change(s)
The change adds shadow task generation to HdxTaskController and sets up the camera Window Policy so shadows can be rendered via the HdStream backend.

This is useful for people, who want to build their own renderer using the base classes and not rely on feeding the render index from an USD scene.