### PR TITLE
Allow this library to build against Houdini 17

### DIFF
--- a/third_party/houdini/lib/gusd/GEO_IOTranslator.cpp
+++ b/third_party/houdini/lib/gusd/GEO_IOTranslator.cpp
@@ -71,7 +71,8 @@ checkExtension(const char* name)
     UT_String nameStr(name);
     if(nameStr.fileExtension()
      &&  (!strcmp(nameStr.fileExtension(), ".usd")
-       || !strcmp(nameStr.fileExtension(), ".usda"))) {
+       || !strcmp(nameStr.fileExtension(), ".usda")
+       || !strcmp(nameStr.fileExtension(), ".usdc"))) {
         return true;
     }
     return false;
@@ -110,11 +111,13 @@ fileLoad(GEO_Detail* gdp, UT_IStream& is, bool ate_magic)
     // all the top level prims.
     auto defPrim = stage->GetDefaultPrim();
     if(  defPrim ) {
-        GusdGU_PackedUSD::Build( *detail, fileName, defPrim.GetPath(), f );
+        GusdGU_PackedUSD::Build(*detail, fileName, defPrim.GetPath(), f, NULL,
+	    GusdPurposeSet(GUSD_PURPOSE_DEFAULT | GUSD_PURPOSE_PROXY));
     }
     else {
         for( const auto &child : stage->GetPseudoRoot().GetChildren() ) {
-            GusdGU_PackedUSD::Build( *detail, fileName, child.GetPath(), f );
+            GusdGU_PackedUSD::Build(*detail, fileName, child.GetPath(), f, NULL,
+		GusdPurposeSet(GUSD_PURPOSE_DEFAULT | GUSD_PURPOSE_PROXY));
         }
     }
 

--- a/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
@@ -36,6 +36,7 @@
 #include <GT/GT_GEODetailList.h>
 #include <GT/GT_GEOPrimPacked.h>
 #include <GT/GT_GEOPrimCollectBoxes.h>
+#include <GT/GT_Names.h>
 #include <GT/GT_PrimCollect.h>
 #include <GT/GT_PrimInstance.h>
 #include <GT/GT_PrimPointMesh.h>
@@ -45,6 +46,7 @@
 #include <GT/GT_RefineCollect.h>
 #include <GT/GT_RefineParms.h>
 #include <GU/GU_PrimPacked.h>
+#include <GA/GA_Names.h>
 #include <UT/UT_Options.h>
 
 #include <pxr/usd/usdGeom/xformCache.h>
@@ -91,8 +93,8 @@ struct _ViewportAttrFilter : public GT_GEOAttributeFilter
     virtual bool isValid(const GA_Attribute& attrib) const
     {
         // TODO Verify atts have correct type and dimension.
-        return attrib.getName() == "__primitive_id"
-            || attrib.getName() == "Cd";
+        return attrib.getName() == GT_Names::primitive_id
+            || attrib.getName() == GA_Names::Cd;
     }
 };
 
@@ -148,14 +150,15 @@ public:
     appendAttrs( GT_AttributeListHandle dest, int i ) const
     {
         if( dest && m_uniformAttrs ) {
-            if( auto colorArray = m_uniformAttrs->get( "Cd", 0 )) {
+            if( auto colorArray = m_uniformAttrs->get( GA_Names::Cd, 0 )) {
                 dest = dest->addAttribute( 
-                    "Cd", 
+                    GA_Names::Cd, 
                     new GT_DASubArray( colorArray, i, 1), true );
             }
-            if( auto idArray = m_uniformAttrs->get( "__primitive_id", 0 )) {
+            auto idArray = m_uniformAttrs->get( GT_Names::primitive_id, 0 );
+            if( idArray ) {
                 dest = dest->addAttribute( 
-                    "__primitive_id",
+                    GT_Names::primitive_id,
                     new GT_DASubArray( idArray, i, 1), true );
             }
         }
@@ -334,7 +337,7 @@ public:
                     filter, primOffsetList, vtxOffsetList);
 
         GT_PrimInstance* gtInst;
-        if( uniformAttrs->hasName( "Cd" )) {
+        if( uniformAttrs->hasName( GA_Names::Cd )) {
             gtInst = new GT_PrimInstanceWithColor( 
                                 geo, 
                                 xformArray, 

--- a/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
@@ -36,7 +36,6 @@
 #include <GT/GT_GEODetailList.h>
 #include <GT/GT_GEOPrimPacked.h>
 #include <GT/GT_GEOPrimCollectBoxes.h>
-#include <GT/GT_Names.h>
 #include <GT/GT_PrimCollect.h>
 #include <GT/GT_PrimInstance.h>
 #include <GT/GT_PrimPointMesh.h>
@@ -93,7 +92,7 @@ struct _ViewportAttrFilter : public GT_GEOAttributeFilter
     virtual bool isValid(const GA_Attribute& attrib) const
     {
         // TODO Verify atts have correct type and dimension.
-        return attrib.getName() == GT_Names::primitive_id
+        return attrib.getName() == "__primitive_id"
             || attrib.getName() == GA_Names::Cd;
     }
 };
@@ -155,10 +154,10 @@ public:
                     GA_Names::Cd, 
                     new GT_DASubArray( colorArray, i, 1), true );
             }
-            auto idArray = m_uniformAttrs->get( GT_Names::primitive_id, 0 );
+            auto idArray = m_uniformAttrs->get( "__primitive_id", 0 );
             if( idArray ) {
                 dest = dest->addAttribute( 
-                    GT_Names::primitive_id,
+                    "__primitive_id",
                     new GT_DASubArray( idArray, i, 1), true );
             }
         }

--- a/third_party/houdini/lib/gusd/GT_PackedUSD.h
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.h
@@ -24,6 +24,7 @@
 #ifndef __GUSD_GT_PACKEDUSD_H__
 #define __GUSD_GT_PACKEDUSD_H__
 
+#include "gusd/api.h"
 #include "gusd/purpose.h"
 
 #include <pxr/pxr.h>
@@ -81,6 +82,7 @@ public:
 
     virtual GT_PrimitiveHandle doSoftCopy() const override;
 
+    GUSD_API
     static int getStaticPrimitiveType();
 
     virtual int getPrimitiveType() const override;

--- a/third_party/houdini/lib/gusd/GT_PointInstancer.h
+++ b/third_party/houdini/lib/gusd/GT_PointInstancer.h
@@ -24,6 +24,8 @@
 #ifndef __GUSD_GT_POINTINSTANCER_H__
 #define __GUSD_GT_POINTINSTANCER_H__
 
+#include "gusd/api.h"
+
 #include <pxr/pxr.h>
 
 #include <GT/GT_PrimPointMesh.h>
@@ -34,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// that it is treated differently by the GusdRefiner and has
 /// a different GusdPrimWrapper.
 
-class GusdGT_PointInstancer : public GT_PrimPointMesh
+class GUSD_API GusdGT_PointInstancer : public GT_PrimPointMesh
 {
 public:
     GusdGT_PointInstancer() {}

--- a/third_party/houdini/lib/gusd/GT_PrimCache.cpp
+++ b/third_party/houdini/lib/gusd/GT_PrimCache.cpp
@@ -41,9 +41,11 @@
 #include <GT/GT_RefineParms.h>
 #include <GT/GT_CatPolygonMesh.h>
 #include <SYS/SYS_Hash.h>
+#include <SYS/SYS_Version.h>
 #include <UT/UT_HDKVersion.h>
 
-#if HDK_API_VERSION >= 16050446
+// 0x100501BE corresponds to 16.5.446.
+#if SYS_VERSION_FULL_INT >= 0x100501BE
 #include <GT/GT_PackedAlembic.h>
 #endif
 
@@ -127,7 +129,7 @@ namespace {
         GT_PrimitiveHandle prim;
     };
 
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
     static inline void intrusive_ptr_add_ref(const CacheEntry *o) { const_cast<CacheEntry *>(o)->incref(); }
     static inline void intrusive_ptr_release(const CacheEntry *o) { const_cast<CacheEntry *>(o)->decref(); }
 #endif
@@ -438,7 +440,7 @@ CreateEntryFn::operator()(
             return new CacheEntry( refiner.getPrimCollect()->getPrim( 0 ) );
         }
         else {
-#if HDK_API_VERSION >= 16050446
+#if SYS_VERSION_FULL_INT >= 0x100501BE
             auto meshHndl = refiner.coalescedMeshes[0].result();
             // XXX In houdini 16.5 we'll crash if we don't wrap the output
             // of GT_CatPolygonMesh in a GT_PackedAlembicMesh, similar to 
@@ -455,7 +457,7 @@ CreateEntryFn::operator()(
     for( size_t i = 0; i < refiner.coalescedMeshes.size(); ++i ) {
         auto& catMesh = refiner.coalescedMeshes[i];
         GT_PrimitiveHandle meshPrim = catMesh.result();
-#if HDK_API_VERSION >= 16050446
+#if SYS_VERSION_FULL_INT >= 0x100501BE
         collect->appendPrimitive(
                 new GT_PackedAlembicMesh( meshPrim, refiner.coalescedIds[i] ) );
 #else

--- a/third_party/houdini/lib/gusd/GT_Utils.cpp
+++ b/third_party/houdini/lib/gusd/GT_Utils.cpp
@@ -30,6 +30,7 @@
 #include <GT/GT_PrimInstance.h>
 #include <GT/GT_Util.h>
 #include <GA/GA_ATIGroupBool.h>
+#include <SYS/SYS_Version.h>
 
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/gf/vec3h.h>
@@ -1324,9 +1325,14 @@ setCustomAttributesFromGTPrim(
     const GT_AttributeMapHandle attrMapHandle = gtAttrs->getMap();
     for(AttrMapIterator mapIt=attrMapHandle->begin(); !mapIt.atEnd(); ++mapIt) {
 
+#if SYS_VERSION_FULL_INT < 0x11000000
         string name = mapIt.name();
+#else
+        string name = mapIt->first.toStdString();
+#endif
+
 #if (GUSD_VER_CMP_1(>=,15))
-        const int attrIndex = attrMapHandle->get(mapIt.name());
+        const int attrIndex = attrMapHandle->get(name);
 #else
         const int attrIndex = attrMapHandle->getMapIndex(mapIt.thing());
 #endif

--- a/third_party/houdini/lib/gusd/GT_Utils.h
+++ b/third_party/houdini/lib/gusd/GT_Utils.h
@@ -163,6 +163,10 @@ public:
 
 
 template <>
+struct GusdGT_Utils::StorageByType<bool>
+{ static const GT_Storage value = GT_STORE_UINT8; };
+
+template <>
 struct GusdGT_Utils::StorageByType<uint8>
 { static const GT_Storage value = GT_STORE_UINT8; };
 

--- a/third_party/houdini/lib/gusd/GT_VtArray.h
+++ b/third_party/houdini/lib/gusd/GT_VtArray.h
@@ -28,6 +28,7 @@
 #include <GT/GT_DataArray.h>
 #include <GT/GT_DANumeric.h>
 #include <SYS/SYS_Compiler.h>
+#include <SYS/SYS_Version.h>
 #include <SYS/SYS_Math.h>
 
 #include <pxr/pxr.h>
@@ -172,6 +173,8 @@ protected:                                                              \
                                         tsize, nrepeats, stride); }
 
     _DECL_GETTERS(U8,  uint8);
+    _DECL_GETTERS(I8,  int8);
+    _DECL_GETTERS(I16, int16);
     _DECL_GETTERS(I32, int32);
     _DECL_GETTERS(I64, int64);
     _DECL_GETTERS(F16, fpreal16);
@@ -267,7 +270,7 @@ GusdGT_VtArray<T>::getArrayT(GT_DataArrayHandle& buf) const
     if(SYS_IsSame<PODType,PODT>::value)
         return reinterpret_cast<const PODT*>(_data);
 
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
     typedef GT_DANumeric<PODT,
         GusdGT_Utils::StorageByType<PODT>::value> _GTArrayType;
 #else

--- a/third_party/houdini/lib/gusd/GT_VtArray.h
+++ b/third_party/houdini/lib/gusd/GT_VtArray.h
@@ -172,9 +172,11 @@ protected:                                                              \
                         { extendedFillT(dst, start, length,             \
                                         tsize, nrepeats, stride); }
 
-    _DECL_GETTERS(U8,  uint8);
+#if SYS_VERSION_FULL_INT >= 0x10050000
     _DECL_GETTERS(I8,  int8);
     _DECL_GETTERS(I16, int16);
+#endif
+    _DECL_GETTERS(U8,  uint8);
     _DECL_GETTERS(I32, int32);
     _DECL_GETTERS(I64, int64);
     _DECL_GETTERS(F16, fpreal16);

--- a/third_party/houdini/lib/gusd/GU_PackedUSD.h
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.h
@@ -28,6 +28,7 @@
 
 #include <GU/GU_PackedImpl.h>
 #include <GT/GT_Handles.h>
+#include <SYS/SYS_Version.h>
 #include <UT/UT_Error.h>
 
 #include <pxr/pxr.h>
@@ -94,12 +95,13 @@ public:
     virtual ~GusdGU_PackedUSD();
 
     static void install(GA_PrimitiveFactory &factory);
+    GUSD_API
     static GA_PrimitiveTypeId typeId();
 
     const UT_StringHolder& fileName() const { return m_fileName; }
     UT_StringHolder intrinsicFileName() const { return m_fileName; }
     void setFileName( const UT_StringHolder& fileName );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     UT_StringHolder intrinsicFileName(const GU_PrimPacked *prim) const
     { return intrinsicFileName(); }
     void setFileName(GU_PrimPacked *prim, const UT_StringHolder& fileName)
@@ -109,7 +111,7 @@ public:
     const UT_StringHolder& altFileName() const { return m_altFileName; }
     UT_StringHolder intrinsicAltFileName() const { return m_altFileName; }
     void setAltFileName( const UT_StringHolder& fileName );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     UT_StringHolder intrinsicAltFileName(const GU_PrimPacked *prim) const
     { return intrinsicAltFileName(); }
     void setAltFileName(GU_PrimPacked *prim, const UT_StringHolder& fileName)
@@ -120,7 +122,7 @@ public:
     UT_StringHolder intrinsicPrimPath() const { return m_primPath.GetText(); }
     void setPrimPath( const UT_StringHolder& p );
     void setPrimPath( const SdfPath& primPath  );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     UT_StringHolder intrinsicPrimPath(const GU_PrimPacked *prim) const
     { return intrinsicPrimPath(); }
     void setPrimPath(GU_PrimPacked *prim, const UT_StringHolder& p)
@@ -133,7 +135,7 @@ public:
     UT_StringHolder intrinsicSrcPrimPath() const { return m_srcPrimPath.GetText(); }
     void setSrcPrimPath( const UT_StringHolder& p );
     void setSrcPrimPath( const SdfPath& primPath  );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     UT_StringHolder intrinsicSrcPrimPath(const GU_PrimPacked *prim) const
     { return intrinsicSrcPrimPath(); }
     void setSrcPrimPath(GU_PrimPacked *prim, const UT_StringHolder& p)
@@ -144,7 +146,7 @@ public:
     // index in the source point instancer.
     exint index() const { return m_index; }
     void setIndex( exint i );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     exint index(const GU_PrimPacked *prim) const
     { return index(); }
     void setIndex(GU_PrimPacked *prim, exint i)
@@ -156,14 +158,14 @@ public:
     
     // return the USD prim type
     UT_StringHolder intrinsicType() const;
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     UT_StringHolder intrinsicType(const GU_PrimPacked *prim) const
     { return intrinsicType(); }
 #endif
 
     GA_Size usdLocalToWorldTransformSize() const { return 16; }
     void usdLocalToWorldTransform(fpreal64* val, exint size) const;
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     GA_Size usdLocalToWorldTransformSize(const GU_PrimPacked *prim) const
     { return 16; }
     void usdLocalToWorldTransform(const GU_PrimPacked *prim,
@@ -175,7 +177,7 @@ public:
     fpreal intrinsicFrame() const { return GusdUSD_Utils::GetNumericTime(m_frame); }
     void setFrame( UsdTimeCode frame );
     void setFrame( fpreal frame );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     fpreal intrinsicFrame(const GU_PrimPacked *prim) const
     { return intrinsicFrame(); }
     void setFrame(GU_PrimPacked *prim, fpreal frame)
@@ -188,7 +190,7 @@ public:
     exint getNumPurposes() const;
     void getIntrinsicPurposes( UT_StringArray& purposes ) const;
     void setIntrinsicPurposes( const UT_StringArray& purposes );
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
     exint getNumPurposes(const GU_PrimPacked *prim) const
     { return getNumPurposes(); }
     void getIntrinsicPurposes(const GU_PrimPacked *prim,
@@ -205,7 +207,7 @@ public:
 
     virtual bool     isValid() const override;
     virtual bool     save(UT_Options &options, const GA_SaveMap &map) const override;
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
     virtual bool     load(const UT_Options &options, const GA_LoadMap &map) override;
     virtual void     update(const UT_Options &options) override;
 #else
@@ -227,8 +229,15 @@ public:
 
     virtual bool     getLocalTransform(UT_Matrix4D &m) const override;
 
+#if SYS_VERSION_FULL_INT < 0x11000000
     virtual bool     unpack(GU_Detail &destgdp) const override;
     virtual bool     unpackUsingPolygons(GU_Detail &destgdp) const override;
+#else
+    virtual bool     unpack(GU_Detail &destgdp,
+			    const UT_Matrix4D *transform) const override;
+    virtual bool     unpackUsingPolygons(GU_Detail &destgdp,
+			    const GU_PrimPacked *prim) const override;
+#endif
 
     bool visibleGT() const;   
     GT_PrimitiveHandle fullGT() const;
@@ -250,8 +259,16 @@ public:
     /// of \p sev.
     UsdPrim getUsdPrim(UT_ErrorSeverity sev=UT_ERROR_ABORT) const;
 
-    bool unpackGeometry( GU_Detail &destgdp,
-                         const char* primvarPattern ) const;
+#if SYS_VERSION_FULL_INT >= 0x11000000
+    bool unpackGeometry(
+        GU_Detail &destgdp,
+        const char* primvarPattern,
+        const UT_Matrix4D *transform) const;
+#else
+    bool unpackGeometry(
+        GU_Detail &destgdp,
+        const char* primvarPattern) const;
+#endif
 
     const UT_Matrix4D& getUsdTransform() const;
     

--- a/third_party/houdini/lib/gusd/GU_USD.cpp
+++ b/third_party/houdini/lib/gusd/GU_USD.cpp
@@ -45,6 +45,7 @@
 #include <GU/GU_PrimPacked.h>
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_ParallelUtil.h>
+#include <SYS/SYS_Version.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -903,10 +904,20 @@ GusdGU_USD::AppendExpandedPackedPrims(
 
                 GA_Size gdCurrent = gd.getNumPrimitives();
 
+#if SYS_VERSION_FULL_INT >= 0x11000000
+                UT_Matrix4D transform;
+                pp->getFullTransform4(transform);
+
+                // Unpack this prim.
+                if (!prim->unpackGeometry(gd, primvarPattern.c_str(), &transform)) {
+                    return false;
+                }
+#else
                 // Unpack this prim.
                 if (!prim->unpackGeometry(gd, primvarPattern.c_str())) {
                     return false;
                 }
+#endif
 
                 const GA_Offset offset =
                     indexToOffset(primIndexPairs(i).second);
@@ -1342,7 +1353,7 @@ GusdGU_USD::GetPackedPrimViewportLODAndPurposes(
         if (const GusdGU_PackedUSD* prim =
             dynamic_cast<const GusdGU_PackedUSD*>(pp->implementation())) {
 
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
             viewportLOD(i) = prim->intrinsicViewportLOD();
 #else
             viewportLOD(i) = prim->intrinsicViewportLOD(pp);

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -25,6 +25,7 @@
 
 #include <OP/OP_Node.h>
 #include <PRM/PRM_AutoDeleter.h>
+#include <PRM/PRM_Conditional.h>
 #include <PRM/PRM_Parm.h>
 #include <PRM/PRM_SpareData.h>
 #include <UT/UT_Singleton.h>
@@ -184,8 +185,8 @@ void _AppendTypes(const TfType& type, UT_Array<PRM_Name>& names,
     _MakePrefixedName(label, typeName.c_str(), depth, "|   ");
     
     names.append(PRM_Name(typeName.c_str(), deleter.appendCallback(
-#if HDK_API_VERSION >= 16050000
-	hboost::function<void (char *)>(free), label.steal())));
+#if SYS_VERSION_FULL_INT >= 0x10050000
+	boost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));
 #endif
@@ -219,8 +220,8 @@ void _AppendKinds(const GusdUSD_Utils::KindNode* kind,
     _MakePrefixedName(label, name.c_str(), depth, "|   ");
 
     names.append(PRM_Name(name.c_str(), deleter.appendCallback(
-#if HDK_API_VERSION >= 16050000
-	hboost::function<void (char *)>(free), label.steal())));
+#if SYS_VERSION_FULL_INT >= 0x10050000
+	boost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));
 #endif

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -183,9 +183,11 @@ void _AppendTypes(const TfType& type, UT_Array<PRM_Name>& names,
     // Add spacing at front, by depth, to indicate hierarchy.
     UT_String label;
     _MakePrefixedName(label, typeName.c_str(), depth, "|   ");
-    
+
+    // Only 16.5 (not 16.0 and not 17.0) needs to use hboost::function here.
+    // In 16.0 hboost doesn't exist yet. In 17.0 the argument is templated.
     names.append(PRM_Name(typeName.c_str(), deleter.appendCallback(
-#if SYS_VERSION_FULL_INT >= 0x10050000
+#if SYS_VERSION_FULL_INT >= 0x10050000 && SYS_VERSION_FULL_INT < 0x11000000
 	hboost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));
@@ -219,8 +221,10 @@ void _AppendKinds(const GusdUSD_Utils::KindNode* kind,
     UT_String label;
     _MakePrefixedName(label, name.c_str(), depth, "|   ");
 
+    // Only 16.5 (not 16.0 and not 17.0) needs to use hboost::function here.
+    // In 16.0 hboost doesn't exist yet. In 17.0 the argument is templated.
     names.append(PRM_Name(name.c_str(), deleter.appendCallback(
-#if SYS_VERSION_FULL_INT >= 0x10050000
+#if SYS_VERSION_FULL_INT >= 0x10050000 && SYS_VERSION_FULL_INT < 0x11000000
 	hboost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -249,7 +249,7 @@ PRM_Name* _GetPurposeNames()
 {
     static UT_Array<PRM_Name> names;
     for(const auto& p : UsdGeomImageable::GetOrderedPurposeTokens())
-        names.append(PRM_Name(p.GetString().c_str()));
+        names.append(PRM_Name(p.GetString().c_str(), p.GetString().c_str()));
     names.append(PRM_Name());
     return &names(0);
 }

--- a/third_party/houdini/lib/gusd/PRM_Shared.cpp
+++ b/third_party/houdini/lib/gusd/PRM_Shared.cpp
@@ -186,7 +186,7 @@ void _AppendTypes(const TfType& type, UT_Array<PRM_Name>& names,
     
     names.append(PRM_Name(typeName.c_str(), deleter.appendCallback(
 #if SYS_VERSION_FULL_INT >= 0x10050000
-	boost::function<void (char *)>(free), label.steal())));
+	hboost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));
 #endif
@@ -221,7 +221,7 @@ void _AppendKinds(const GusdUSD_Utils::KindNode* kind,
 
     names.append(PRM_Name(name.c_str(), deleter.appendCallback(
 #if SYS_VERSION_FULL_INT >= 0x10050000
-	boost::function<void (char *)>(free), label.steal())));
+	hboost::function<void (char *)>(free), label.steal())));
 #else
 	boost::function<void (char *)>(free), label.steal())));
 #endif

--- a/third_party/houdini/lib/gusd/USD_CustomTraverse.cpp
+++ b/third_party/houdini/lib/gusd/USD_CustomTraverse.cpp
@@ -530,12 +530,18 @@ const PRM_Template* _CreateTemplates()
     return templates;
 }
 
-GusdUSD_TraverseType _type(new GusdUSD_CustomTraverse,
+} /* namespace */
+
+void
+GusdUSD_CustomTraverse::Initialize()
+{
+    // Simply creating this object will register it with our traversal
+    // table.
+    static GusdUSD_TraverseType _type(new GusdUSD_CustomTraverse,
                            "std:custom", "Custom Traversal", _CreateTemplates(),
                            "Configurable traversal, allowing complex "
                            "discovery patterns.");
-
-} /*namespace*/
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/third_party/houdini/lib/gusd/USD_CustomTraverse.h
+++ b/third_party/houdini/lib/gusd/USD_CustomTraverse.h
@@ -103,6 +103,8 @@ public:
                               UT_Array<PrimIndexPair>& prims,
                               bool skipRoot=true,
                               const GusdUSD_Traverse::Opts* opts=nullptr) const;
+
+    static void	    Initialize();
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/houdini/lib/gusd/USD_XformCache.cpp
+++ b/third_party/houdini/lib/gusd/USD_XformCache.cpp
@@ -30,6 +30,7 @@
 #include <UT/UT_Interrupt.h>
 #include <UT/UT_Matrix4.h>
 #include <UT/UT_ParallelUtil.h>
+#include <SYS/SYS_Version.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -57,14 +58,14 @@ struct _CappedXformItem : public UT_CappedItem
 
 typedef UT_IntrusivePtr<const _CappedXformItem> _CappedXformItemHandle;
 
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
 static inline void intrusive_ptr_add_ref(const _CappedXformItem *o) { const_cast<_CappedXformItem *>(o)->incref(); }
 static inline void intrusive_ptr_release(const _CappedXformItem *o) { const_cast<_CappedXformItem *>(o)->decref(); }
 #endif
 
 } /*namespace*/
 
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
 static inline void intrusive_ptr_add_ref(const GusdUSD_XformCache::XformInfo *o) { const_cast<GusdUSD_XformCache::XformInfo *>(o)->incref(); }
 static inline void intrusive_ptr_release(const GusdUSD_XformCache::XformInfo *o) { const_cast<GusdUSD_XformCache::XformInfo *>(o)->decref(); }
 #endif

--- a/third_party/houdini/lib/gusd/UT_Gf.h
+++ b/third_party/houdini/lib/gusd/UT_Gf.h
@@ -36,10 +36,12 @@
 #include "pxr/base/gf/quaternion.h"
 #include "pxr/base/gf/quatd.h"
 #include "pxr/base/gf/quatf.h"
+#include "pxr/base/gf/quath.h"
 #include "pxr/base/gf/vec4d.h"
 #include "pxr/base/gf/vec4f.h"
 
 #include <UT/UT_VectorTypes.h>
+#include <SYS/SYS_Version.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -178,6 +180,10 @@ public:
     static inline void                  Convert(const GfQuatf& from,
                                                 UT_QuaternionT<T>& to);
 
+    template <class T>
+    static inline void                  Convert(const GfQuath& from,
+                                                UT_QuaternionT<T>& to);
+
     template <class T>             
     static inline void                  Convert(const GfVec4d& from,
                                                 UT_QuaternionT<T>& to);
@@ -197,6 +203,10 @@ public:
     template <class T>
     static inline void                  Convert(const UT_QuaternionT<T>& from,
                                                 GfQuatf& to);
+
+    template <class T>
+    static inline void                  Convert(const UT_QuaternionT<T>& from,
+                                                GfQuath& to);
 
     template <class T>
     static inline void                  Convert(const UT_QuaternionT<T>& from,
@@ -264,18 +274,25 @@ private:
         /**/
 
 /** Declare POD tuples for Gf types.*/
+GUSDUT_DECLARE_POD_TUPLE(class GfVec2h, fpreal16, 2);
+GUSDUT_DECLARE_POD_TUPLE(class GfVec3h, fpreal16, 3);
+GUSDUT_DECLARE_POD_TUPLE(class GfVec4h, fpreal16, 4);
+
 GUSDUT_DECLARE_POD_TUPLE(class GfVec2f, fpreal32, 2);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec3f, fpreal32, 3);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec4f, fpreal32, 4);
+
 GUSDUT_DECLARE_POD_TUPLE(class GfVec2d, fpreal64, 2);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec3d, fpreal64, 3);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec4d, fpreal64, 4);
+
 GUSDUT_DECLARE_POD_TUPLE(class GfVec2i, int32, 2);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec3i, int32, 3);
 GUSDUT_DECLARE_POD_TUPLE(class GfVec4i, int32, 4);
 
 GUSDUT_DECLARE_POD_TUPLE(class GfQuaternion, fpreal64, 4);
 
+GUSDUT_DECLARE_POD_TUPLE(class GfQuath, fpreal16, 4);
 GUSDUT_DECLARE_POD_TUPLE(class GfQuatf, fpreal32, 4);
 GUSDUT_DECLARE_POD_TUPLE(class GfQuatd, fpreal64, 4);
 
@@ -299,6 +316,10 @@ GUSDUT_DECLARE_POD_TUPLE(class GfSize3, std::size_t, 3);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
+GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec2h);
+GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec3h);
+GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec4h);
+
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec2f);
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec3f);
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec4f);
@@ -313,6 +334,7 @@ GUSDUT_DECLARE_IS_POD(PXR_NS::GfVec4i);
 
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfQuaternion);
 
+GUSDUT_DECLARE_IS_POD(PXR_NS::GfQuath);
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfQuatf);
 GUSDUT_DECLARE_IS_POD(PXR_NS::GfQuatd);
 
@@ -343,9 +365,15 @@ _GUSDUT_DECLARE_UNCASTABLE(class GfQuatf);
 _GUSDUT_DECLARE_UNCASTABLE(class GfQuatd);
 _GUSDUT_DECLARE_UNCASTABLE(UT_QuaternionF);
 _GUSDUT_DECLARE_UNCASTABLE(UT_QuaternionD);
-// _GUSDUT_DECLARE_UNCASTABLE(UT_QuaternionR);
+#if SYS_VERSION_FULL_INT >= 0x11000000
+_GUSDUT_DECLARE_UNCASTABLE(UT_QuaternionH);
+#endif
 
 /** Declare equivalent between Gf and UT.*/
+_GUSDUT_DECLARE_EQUIVALENCE(class GfVec2h, UT_Vector2H);
+_GUSDUT_DECLARE_EQUIVALENCE(class GfVec3h, UT_Vector3H);
+_GUSDUT_DECLARE_EQUIVALENCE(class GfVec4h, UT_Vector4H);
+
 _GUSDUT_DECLARE_EQUIVALENCE(class GfVec2d, UT_Vector2D);
 _GUSDUT_DECLARE_EQUIVALENCE(class GfVec3d, UT_Vector3D);
 _GUSDUT_DECLARE_EQUIVALENCE(class GfVec4d, UT_Vector4D);
@@ -515,6 +543,14 @@ GusdUT_Gf::Convert(const GfQuatf& from, UT_QuaternionT<T>& to)
 
 template <class T>
 void
+GusdUT_Gf::Convert(const GfQuath& from, UT_QuaternionT<T>& to)
+{
+    return _ConvertQuat(from, to);
+}
+
+
+template <class T>
+void
 GusdUT_Gf::Convert(const GfVec4d& from, UT_QuaternionT<T>& to)
 {
     to = UT_QuaternionT<T>(from[1],from[2],from[3],from[0]);
@@ -533,7 +569,7 @@ template <class T>
 void
 GusdUT_Gf::Convert(const UT_QuaternionT<T>& from, GfQuaternion& to)
 {
-    to.SetReal(from.z());
+    to.SetReal(from.w());
     to.SetImaginary(GfVec3d(from.x(), from.y(), from.z()));
 }
 
@@ -542,7 +578,7 @@ template <class T>
 void
 GusdUT_Gf::Convert(const UT_QuaternionT<T>& from, GfQuatd& to)
 {
-    to.SetReal(from.z());
+    to.SetReal(from.w());
     to.SetImaginary(GfVec3d(from.x(), from.y(), from.z()));
 }
 
@@ -551,8 +587,18 @@ template <class T>
 void
 GusdUT_Gf::Convert(const UT_QuaternionT<T>& from, GfQuatf& to)
 {
-    to.SetReal(from.z());
+    to.SetReal(from.w());
     to.SetImaginary(GfVec3f(from.x(), from.y(), from.z()));
+}
+
+
+template <class T>
+void
+GusdUT_Gf::Convert(const UT_QuaternionT<T>& from, GfQuath& to)
+{
+    to.SetReal(GfHalf(from.w()));
+    to.SetImaginary(
+	GfVec3h(GfHalf(from.x()), GfHalf(from.y()), GfHalf(from.z())));
 }
 
 
@@ -560,7 +606,6 @@ template <class T>
 void
 GusdUT_Gf::Convert(const UT_QuaternionT<T>& from, GfVec4d& to)
 {
- 
     to = GfVec4d(from.w(), from.x(), from.y(), from.z());
 }
 

--- a/third_party/houdini/lib/gusd/UT_TypeTraits.h
+++ b/third_party/houdini/lib/gusd/UT_TypeTraits.h
@@ -31,6 +31,7 @@
 #include <pxr/pxr.h>
 #include <SYS/SYS_Types.h>
 #include <SYS/SYS_TypeTraits.h>
+#include <SYS/SYS_Version.h>
 #include <UT/UT_VectorTypes.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -84,9 +85,11 @@ public:
                 typename GusdUT_TypeTraits::PODTuple<B>::ValueType>::value)
 
 
-/* Declare traits on core types.    
-   TODO: Do we care about fpreal16 and fpreal?
-   Wait until somebody needs them...*/
+/* Declare traits on core types. */   
+GUSDUT_DECLARE_POD_TUPLE(UT_Vector2H, fpreal16, 2);
+GUSDUT_DECLARE_POD_TUPLE(UT_Vector3H, fpreal16, 3);
+GUSDUT_DECLARE_POD_TUPLE(UT_Vector4H, fpreal16, 4);
+
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector2F, fpreal32, 2);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector3F, fpreal32, 3);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector4F, fpreal32, 4);
@@ -94,6 +97,7 @@ GUSDUT_DECLARE_POD_TUPLE(UT_Vector4F, fpreal32, 4);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector2D, fpreal64, 2);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector3D, fpreal64, 3);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector4D, fpreal64, 4);
+
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector2I, int64, 2);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector3I, int64, 3);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector4I, int64, 4);
@@ -102,6 +106,9 @@ GUSDUT_DECLARE_POD_TUPLE(UT_Vector2i, int32, 2);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector3i, int32, 3);
 GUSDUT_DECLARE_POD_TUPLE(UT_Vector4i, int32, 4);
  
+#if SYS_VERSION_FULL_INT >= 0x11000000
+GUSDUT_DECLARE_POD_TUPLE(UT_QuaternionH, fpreal16, 4);
+#endif
 GUSDUT_DECLARE_POD_TUPLE(UT_QuaternionF, fpreal32, 4);
 GUSDUT_DECLARE_POD_TUPLE(UT_QuaternionD, fpreal64, 4);
 
@@ -114,6 +121,7 @@ GUSDUT_DECLARE_POD_TUPLE(UT_Matrix3D, fpreal64, 9);
 GUSDUT_DECLARE_POD_TUPLE(UT_Matrix4D, fpreal64, 16);
 
 /* Declare PODs as POD tuples of tupleSize=1.*/
+GUSDUT_DECLARE_POD_TUPLE(bool,      bool, 1);
 GUSDUT_DECLARE_POD_TUPLE(uint8,     uint8, 1);
 GUSDUT_DECLARE_POD_TUPLE(uint16,    uint16, 1);
 GUSDUT_DECLARE_POD_TUPLE(uint32,    uint32, 1);

--- a/third_party/houdini/lib/gusd/defaultArray.h
+++ b/third_party/houdini/lib/gusd/defaultArray.h
@@ -37,7 +37,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Simple array wrapper, providing an array that may either hold a
 /// single constant value, or an array of values.
 template <typename T>
-class GUSD_API GusdDefaultArray
+class GusdDefaultArray
 {
 public:
     using value_type = T;

--- a/third_party/houdini/lib/gusd/instancerWrapper.cpp
+++ b/third_party/houdini/lib/gusd/instancerWrapper.cpp
@@ -49,6 +49,7 @@
 #include <UT/UT_Matrix4.h>
 #include <UT/UT_Quaternion.h>
 #include <UT/UT_StringArray.h>
+#include <SYS/SYS_Version.h>
 
 #include "pxr/usd/usdGeom/xformCache.h"
 #include "pxr/usd/sdf/cleanupEnabler.h"
@@ -703,7 +704,7 @@ writePrototypes(const GusdContext& ctxt, const UsdStagePtr& stage,
                 // Use the context's usdinstancepath as default if no attributes
                 std::tuple<string, bool> usdInstancePath(ctxt.usdInstancePath, generateProtoNames);
                 if (instancePathAttr.isValid()) {
-#if HDK_API_VERSION < 16050000
+#if SYS_VERSION_FULL_INT < 0x10050000
                     string instancePathAttrVal = instancePathAttr.get(offsetIt.getOffset());
 #else
                     string instancePathAttrVal = instancePathAttr.get(offsetIt.getOffset()).toStdString();
@@ -1527,7 +1528,7 @@ GusdInstancerWrapper::unpack(
     }
 
 
-    GA_Offset start = -1;
+    GA_Offset start = GA_INVALID_OFFSET;
 
     for( size_t i = 0; i < indices.size(); ++i )
     {

--- a/third_party/houdini/lib/gusd/meshWrapper.cpp
+++ b/third_party/houdini/lib/gusd/meshWrapper.cpp
@@ -1024,7 +1024,7 @@ updateFromGTPrim(const GT_PrimitiveHandle& sourcePrim,
 
             for( auto it = primAttrs->begin(); !it.atEnd(); ++it ) {
 
-                if(!filter.matches( it.getName() )) 
+                if(!filter.matches( it.getName().toStdString() )) 
                     continue;
 
                 GT_DataArrayHandle data = it.getData();

--- a/third_party/houdini/lib/gusd/meshWrapper.cpp
+++ b/third_party/houdini/lib/gusd/meshWrapper.cpp
@@ -44,6 +44,7 @@
 #include <GT/GT_DASubArray.h>
 #include <GT/GT_GEOPrimPacked.h>
 #include <GT/GT_DAConstant.h>
+#include <SYS/SYS_Version.h>
 #include <numeric>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -1023,9 +1024,13 @@ updateFromGTPrim(const GT_PrimitiveHandle& sourcePrim,
             // identical, write the value as constant.
 
             for( auto it = primAttrs->begin(); !it.atEnd(); ++it ) {
-
+#if SYS_VERSION_FULL_INT < 0x11000000
+                if(!filter.matches( it.getName() )) 
+                    continue;
+#else
                 if(!filter.matches( it.getName().toStdString() )) 
                     continue;
+#endif
 
                 GT_DataArrayHandle data = it.getData();
                 TfToken interpolation = UsdGeomTokens->uniform;

--- a/third_party/houdini/lib/gusd/plugin.cpp
+++ b/third_party/houdini/lib/gusd/plugin.cpp
@@ -31,7 +31,7 @@
 #include "GT_PackedUSD.h"
 #include "GT_Utils.h"
 #include "GU_PackedUSD.h"
-#include "gusd/GT_PointInstancer.h"
+#include "GT_PointInstancer.h"
 #include "curvesWrapper.h"
 #include "NURBSCurvesWrapper.h"
 
@@ -41,6 +41,7 @@
 #include "scopeWrapper.h"
 #include "xformWrapper.h"
 #include "instancerWrapper.h"
+#include "USD_CustomTraverse.h"
 #include "USD_Traverse.h"
 
 #include "pxr/usd/usdGeom/curves.h"
@@ -108,6 +109,7 @@ GusdInit()
             TfToken("PointInstancer"), &GusdInstancerWrapper::defineForRead);
 
     GusdUSD_TraverseTable::GetInstance().SetDefault("std:components");
+    GusdUSD_CustomTraverse::Initialize();
     libInitialized = true;
 }
 
@@ -131,6 +133,10 @@ GusdNewGeometryIO()
     geoextension = UTgetGeoExtensions();
     if (!geoextension->findExtension("usd"))
        geoextension->addExtension("usd");
+    if (!geoextension->findExtension("usda"))
+       geoextension->addExtension("usda");
+    if (!geoextension->findExtension("usdc"))
+       geoextension->addExtension("usdc");
    geomIOInitialized = true;
 }
 

--- a/third_party/houdini/lib/gusd/refiner.cpp
+++ b/third_party/houdini/lib/gusd/refiner.cpp
@@ -40,6 +40,8 @@
 #include <GT/GT_PrimFragments.h>
 #include <GT/GT_PrimPackedDetail.h>
 
+#include <SYS/SYS_Types.h>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;
@@ -532,7 +534,7 @@ GusdRefinerCollector::add(
 
     // If addNumericSuffix is true, use the name directly unless there
     // is a conflict. Otherwise add a numeric suffix to keep names unique.
-    int64_t count = 0;
+    int64 count = 0;
     auto it = m_names.find( path );
     if( it == m_names.end() ) {
         // Name has not been used before
@@ -561,7 +563,7 @@ GusdRefinerCollector::add(
     }
 
     // Add a numeric suffix to get a unique name
-    SdfPath newPath( TfStringPrintf( "%s_%ld", path.GetText(), count ));
+    SdfPath newPath( TfStringPrintf("%s_%" SYS_PRId64, path.GetText(), count));
 
     m_gprims.push_back(GprimArrayEntry(newPath,prim,xform,purpose,writeCtrlFlags));
     return newPath;

--- a/third_party/houdini/lib/gusd/writeCtrlFlags.h
+++ b/third_party/houdini/lib/gusd/writeCtrlFlags.h
@@ -25,6 +25,7 @@
 #ifndef __GUSD_WRITECTRLFLAGS_H__
 #define __GUSD_WRITECTRLFLAGS_H__
 
+#include "gusd/api.h"
 #include <pxr/pxr.h>
 
 #include <GT/GT_Primitive.h>
@@ -61,6 +62,7 @@ struct GusdWriteCtrlFlags {
     {}
 
     // Update flags with values read from prims attributes.
+    GUSD_API
     void update( const GT_PrimitiveHandle &prim );
 
     static bool getBoolAttr( 

--- a/third_party/houdini/plugin/OP_gusd/SOP_usdimport.cpp
+++ b/third_party/houdini/plugin/OP_gusd/SOP_usdimport.cpp
@@ -42,6 +42,7 @@
 #include <OP/OP_OperatorTable.h>
 #include <PI/PI_EditScriptedParms.h>
 #include <PRM/PRM_AutoDeleter.h>
+#include <PRM/PRM_Conditional.h>
 #include <UT/UT_WorkArgs.h>
 #include <UT/UT_UniquePtr.h>
 #include <PY/PY_Python.h>

--- a/third_party/houdini/plugin/OP_gusd/SOP_usdunpack.cpp
+++ b/third_party/houdini/plugin/OP_gusd/SOP_usdunpack.cpp
@@ -39,6 +39,7 @@
 #include <OP/OP_OperatorTable.h>
 #include <PI/PI_EditScriptedParms.h>
 #include <PRM/PRM_AutoDeleter.h>
+#include <PRM/PRM_Conditional.h>
 #include <UT/UT_WorkArgs.h>
 #include <UT/UT_UniquePtr.h>
 #include <PY/PY_Python.h>


### PR DESCRIPTION
Trying to bring this library in line with the needs of Houdini 17:
* Several changes to packed primitive function signatures
* Support float16 UT_Quaternions and vectors
* Exporting a few symbols and classes needed by H17 plugins. Removing
  export claim from GusdDefaultArray which is a header-only template class
  and so shouldn't claim to export any symbols
* GEO_IOTranslator accepts usd, usda, or usdc extensions
* GEO_IOTranslator loads proxy and default prims, rather than just proxy
* USD_CustomTraverse intialization invoked by an explicit function call
  (which is called from gustInitialize)
* USD_XformCache env var initialization fix, most likely peculiar to the
  way that H17 causes this library to be loaded
* Convert uses of HDK_API_VERSION to SYS_VERSION_FULL_INT. This latter
  variable is a more reliable reflection of the Houdini build version,
  and so should be used in preference to HDK_API_VERSION
* Use GA and GT constants for Houdini geometry attribute names where
  applicable. Use GT_Offset constants instead of assuming GT_Offset==int
* In printf functions, use SYS_PRI constants for reliable cross-platform
  printing of 64 bit values
* More error checking when converting Houdini attributes to/from USD
  attributes, and when calculating prim xforms