### PR TITLE
[UsdView] Adding resource path containing shader resources to the default search path.

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1064,6 +1064,16 @@ class AppController(QtCore.QObject):
 
     def _openStage(self, usdFilePath, populationMaskPaths):
 
+        # We are iterating through the plugin registry to add anything
+        # containing shaders to the default search path.
+        resourcePaths = set()
+        from pxr import Plug
+        pr = Plug.Registry()
+        for t in pr.GetAllPlugins():
+            if t.metadata.get('ShaderResources') is not None:
+                resourcePaths.add(t.resourcePath)
+        Ar.DefaultResolver.SetDefaultSearchPath(sorted(list(resourcePaths)))
+
         def _GetFormattedError(reasons=[]):
             err = ("Error: Unable to open stage '{0}'\n".format(usdFilePath))
             if reasons:


### PR DESCRIPTION
### Description of Change(s)
The PR loads all the resource paths containing shaders in usdview. This way users are able to attach default shaders (or any kind of shader resources from a plugin) without specifying the full path.

### Fixes Issue(s)
No issues reported.

