### PR TITLE
renderSetupTask: stencilEnable is not initialized

### DIFF
--- a/pxr/imaging/lib/hdx/renderSetupTask.h
+++ b/pxr/imaging/lib/hdx/renderSetupTask.h
@@ -133,6 +133,7 @@ struct HdxRenderTaskParams : public HdTaskParams
         , stencilFailOp(HdStencilOpKeep)
         , stencilZFailOp(HdStencilOpKeep)
         , stencilZPassOp(HdStencilOpKeep)
+        , stencilEnable(false)
         , cullStyle(HdCullStyleBackUnlessDoubleSided)
         , geomStyle(HdGeomStylePolygons)
         , complexity(HdComplexityLow)


### PR DESCRIPTION
This value was subsequently used uninitialized, after being passed onto the
renderPassState, in SyncParams

### Description of Change(s)

Ran into this when I was doing memory profiling to try to track down (what turned out to be) an unrelated crash.

Note that, since nothing ever seems to alter HdxRenderTaskParams.stencilEnable, it's possible that the "correct" thing to do may be to remove this parameter from the struct entirely... however, that's not a call I wanted to make.  For now, this at least prevents usage of uninitialized memory.

### Fixes Issue(s)
- stencilEnabled was being set to an essentially random value (which usually evaluated to true)

