### PR TITLE
[usdImaging] valueCache - avoid storing iterators to prevent crash

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/valueCache.h
+++ b/pxr/usdImaging/lib/usdImaging/valueCache.h
@@ -65,6 +65,9 @@ public:
         SdfPath _path;
         TfToken _attribute;
     public:
+        Key()
+        {}
+
         Key(SdfPath const& path, TfToken const& attr)
             : _path(path)
             , _attribute(attr)
@@ -184,7 +187,7 @@ private:
         typedef tbb::concurrent_unordered_map<Key, Element, Key::Hash> _MapType;
         typedef typename _MapType::iterator                            _MapIt;
         typedef typename _MapType::const_iterator                      _MapConstIt;
-        typedef tbb::concurrent_queue<_MapIt>                          _QueueType;
+        typedef tbb::concurrent_queue<Key>                             _QueueType;
 
         _MapType   _map;
         _QueueType _deferredDeleteQueue;
@@ -233,7 +236,7 @@ private:
 
         // If we're going to erase the old value, swap to avoid a copy.
         std::swap(it->second, *value);
-        cache->_deferredDeleteQueue.push(it);
+        cache->_deferredDeleteQueue.push(it->first);
         return true;
     }
 
@@ -278,10 +281,10 @@ private:
     void _GarbageCollect(_TypedCache<T> &cache) {
         typedef _TypedCache<T> Cache_t;
 
-        typename Cache_t::_MapIt it;
+        Key key;
 
-        while (cache._deferredDeleteQueue.try_pop(it)) {
-            cache._map.unsafe_erase(it);
+        while (cache._deferredDeleteQueue.try_pop(key)) {
+            cache._map.unsafe_erase(key);
         }
     }
 


### PR DESCRIPTION
### Description of Change(s)
We were having a crash with our custom sceneDelegate, and tracked the problem down to UsdImagingValueCache using iterators that had since become invalid.

My change here simply alters things so that we store the map key, instead of an iterator, which should always be safe; however, it will be slower when iterating over the items to cleanup in _GarbageCollect, as we need to re-do the lookup for each item.  My hope is that speed is less important during this phase (thus the reason why deletion is delayed?), and this won't be a problem.

If you believe this will create performance issues, we can discuss alternative solutions, but I wanted to at least get this discussion started.

### Fixes Issue(s)
- Crash when doing things that cause items to be added to the render index

