### PR TITLE
Expose the normals attribute through hydra on meshes

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/gprimAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/gprimAdapter.cpp
@@ -52,25 +52,6 @@ TF_REGISTRY_FUNCTION(TfType)
     // No factory here, GprimAdapter is abstract.
 }
 
-static HdInterpolation
-_UsdToHdInterpolation(TfToken const& usdInterp)
-{
-    if (usdInterp == UsdGeomTokens->uniform) {
-        return HdInterpolationUniform;
-    } else if (usdInterp == UsdGeomTokens->vertex) {
-        return HdInterpolationVertex;
-    } else if (usdInterp == UsdGeomTokens->varying) {
-        return HdInterpolationVarying;
-    } else if (usdInterp == UsdGeomTokens->faceVarying) {
-        return HdInterpolationFaceVarying;
-    } else if (usdInterp == UsdGeomTokens->constant) {
-        return HdInterpolationConstant;
-    }
-    TF_CODING_ERROR("Unknown USD interpolation %s; treating as constant",
-                    usdInterp.GetText());
-    return HdInterpolationConstant;
-}
-
 static TfToken
 _UsdToHdRole(TfToken const& usdRole)
 {
@@ -122,6 +103,26 @@ UsdImagingGprimAdapter::_ResolveCachePath(SdfPath const& primPath,
         }
     }
     return cachePath;
+}
+
+/* static */
+HdInterpolation
+UsdImagingGprimAdapter::_UsdToHdInterpolation(TfToken const& usdInterp)
+{
+    if (usdInterp == UsdGeomTokens->uniform) {
+        return HdInterpolationUniform;
+    } else if (usdInterp == UsdGeomTokens->vertex) {
+        return HdInterpolationVertex;
+    } else if (usdInterp == UsdGeomTokens->varying) {
+        return HdInterpolationVarying;
+    } else if (usdInterp == UsdGeomTokens->faceVarying) {
+        return HdInterpolationFaceVarying;
+    } else if (usdInterp == UsdGeomTokens->constant) {
+        return HdInterpolationConstant;
+    }
+    TF_CODING_ERROR("Unknown USD interpolation %s; treating as constant",
+                    usdInterp.GetText());
+    return HdInterpolationConstant;
 }
 
 /* static */

--- a/pxr/usdImaging/lib/usdImaging/gprimAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/gprimAdapter.h
@@ -135,6 +135,12 @@ public:
     static SdfPath _ResolveCachePath(SdfPath const& cachePath,
             UsdImagingInstancerContext const* instancerContext);
 
+    // Helper function to convert an interpolation metadat token into an
+    // HdInterpolation value.
+    USDIMAGING_API
+    static HdInterpolation
+    _UsdToHdInterpolation(TfToken const& usdInterp);
+
 protected:
 
     USDIMAGING_API


### PR DESCRIPTION
Expose the normals attribute through hydra on meshes using almost the same code used for exposing this attribute on basis curves. The only difference is retrieving the interpolation metadata from the normals attribute for meshes, which isn't necessary on basis curves.

If there is a normals primvar on the mesh, I have been told that this primvar should take precedence over the normals attribute from the UsdGeomPointBased schema. This commit (like the basis curves adapter) does not do this, but it is necessary code in any case, and does handle the simple situation where a mesh uses the schema attribute, and the render delegate expects to have access to it.