### PR TITLE
Add maya 2018 and 2019 in findmaya.cmake for Win

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -83,6 +83,8 @@ elseif(WIN32)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
+            "C:/Program Files/Autodesk/Maya2019"
+            "C:/Program Files/Autodesk/Maya2018"
             "C:/Program Files/Autodesk/Maya2017"
             "C:/Program Files/Autodesk/Maya2016.5"
             "C:/Program Files/Autodesk/Maya2015.5-x64"


### PR DESCRIPTION
### Description of Change(s)
Add the version of Maya to be able to compile correctly
### Fixes Issue(s)
- not being able to compile with Maya 2018 and 2019

