### PR TITLE
[build_usd] print tracebacks on error if verbosity >= 3

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -65,6 +65,9 @@ def PrintCommandOutput(output):
         sys.stdout.write(output)
 
 def PrintError(error):
+    if verbosity >= 3 and sys.exc_info()[1] is not None:
+        import traceback
+        traceback.print_exc()
     print "ERROR:", error
 
 # Helpers for determining platform


### PR DESCRIPTION
### Description of Change(s)
Mostly handy if debugging build_usd.py itself - but could be handy in other circumstances. And it makes sense not to swallow the traceback if verbosity is this high.

### Fixes Issue(s)
- Tracebacks swallowed even on high verbosity

