### PR TITLE
[hd] Properly set up both the shadow projection and view matrices

### DIFF
--- a/pxr/imaging/lib/hdx/simpleLightTask.cpp
+++ b/pxr/imaging/lib/hdx/simpleLightTask.cpp
@@ -296,7 +296,8 @@ HdxSimpleLightTask::_Sync(HdTaskContext* ctx)
             // Complete the shadow setup for this light
             int shadowId = _glfSimpleLights[lightId].GetShadowIndex();
 
-            _shadows->SetViewMatrix(shadowId, GfMatrix4d(1));
+            _shadows->SetViewMatrix(shadowId,
+                    _glfSimpleLights[lightId].GetTransform());
             _shadows->SetProjectionMatrix(shadowId,
                 _glfSimpleLights[lightId].GetShadowMatrix());
         }


### PR DESCRIPTION
### Description of Change(s)
For some fancy shadowing updates we're working on, we need access to both the view + projection parts of the shadow / light projection.  The data structures are actually set up to support this, but at the point where they're populated, it essentially just sets the projection, and sets the view matrix to identity.  This makes the HdxSimpleLightTask properly set the light's view / transform matrix as well.

Of course, in order for this to work properly, the SimpleLight has to be properly set up, so that IT transform + shadow matrices are set up properly / separately.  Currently, nothing in the main code base actually sets the the shadow matrix - but it's possible you folks might have third party code which is, and it may need to be adapted. ie, if you are  passing in a shadow matrix which is actually the combined view + transform matrix, AND setting the light transform to non-identity, this will need to be corrected.


### Fixes Issue(s)
- None (but provides new capabilities for shadows)

