### PR TITLE
Tweaks to make build_usd.py work with ninja

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -232,8 +232,10 @@ def RunCMake(context, force, extraArgs = None):
                     generator=(generator or ""),
                     extraArgs=(" ".join(extraArgs) if extraArgs else "")))
         Run("cmake --build . --config Release --target install -- {multiproc}"
-            .format(multiproc=("/M:{procs}" if Windows() else "-j{procs}")
-                               .format(procs=context.numJobs)))
+            .format(multiproc=("/M:{procs}"
+                               if generator and "Visual Studio" in generator
+                               else "-j{procs}")
+                              .format(procs=context.numJobs)))
 
 def PatchFile(filename, patches):
     """Applies patches to the specified file. patches is a list of tuples

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -218,16 +218,22 @@ def RunCMake(context, force, extraArgs = None):
     if MacOS():
         osx_rpath = "-DCMAKE_MACOSX_RPATH=ON"
 
+    # Note: we use -DCMAKE_BUILD_TYPE=Release for single-configuration
+    #       generators (Ninja, make), and --config Relase for multi-configuration
+    #       generators (Visual Studio); technically we don't need BOTH at the same
+    #       time, but specifying both is simpler than branching
     with CurrentWorkingDirectory(buildDir):
         Run('cmake '
             '-DCMAKE_INSTALL_PREFIX="{instDir}" '
             '-DCMAKE_PREFIX_PATH="{depsInstDir}" '
+            '-DCMAKE_BUILD_TYPE=Release '
             '{osx_rpath} '
             '{generator} '
             '{extraArgs} '
             '"{srcDir}"'
             .format(instDir=instDir,
                     depsInstDir=context.instDir,
+                    cmakeBuildType=cmakeBuildType,
                     srcDir=srcDir,
                     osx_rpath=(osx_rpath or ""),
                     generator=(generator or ""),
@@ -236,7 +242,8 @@ def RunCMake(context, force, extraArgs = None):
             .format(multiproc=("/M:{procs}"
                                if generator and "Visual Studio" in generator
                                else "-j{procs}")
-                              .format(procs=context.numJobs)))
+                              .format(procs=context.numJobs),
+                    buildConfig=buildConfig))
 
 def PatchFile(filename, patches, multiLineMatches=False):
     """Applies patches to the specified file. patches is a list of tuples


### PR DESCRIPTION
### Description of Change(s)

Initially aimed to make it work on windows, but subsequently tested / got it working on all 3 platforms: windows, linux (ubuntu), and MacOS 

### Fixes Issue(s)
- build_usd.py fails with --generator=Ninja

