### PR TITLE
[Build] Only build boost bits required for OIIO when building OIIO.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -494,7 +494,6 @@ def InstallBoost(context, force, buildArgs):
             'threading=multi', 
             'variant=release',
             '--with-atomic',
-            '--with-date_time',
             '--with-filesystem',
             '--with-program_options',
             '--with-system',
@@ -503,6 +502,7 @@ def InstallBoost(context, force, buildArgs):
 
         if context.buildOIIO:
             b2_settings.append("--with-regex")
+            b2_settings.append("--with-date_time")
 
         if context.buildPython:
             b2_settings.append("--with-python")

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -497,10 +497,12 @@ def InstallBoost(context, force, buildArgs):
             '--with-date_time',
             '--with-filesystem',
             '--with-program_options',
-            '--with-regex',
             '--with-system',
             '--with-thread'
         ]
+
+        if context.buildOIIO:
+            b2_settings.append("--with-regex")
 
         if context.buildPython:
             b2_settings.append("--with-python")


### PR DESCRIPTION
### Description of Change(s)
This dependency was removed, so we don't need to build a shared
library or install its headers in the build script anymore.

### Fixes Issue(s)
- None filed.

