### PR TITLE
[Build] Make examples+tutorials optional.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -935,6 +935,16 @@ def InstallUSD(context, force, buildArgs):
             extraArgs.append('-DPXR_BUILD_TESTS=ON')
         else:
             extraArgs.append('-DPXR_BUILD_TESTS=OFF')
+
+        if context.buildExamples:
+            extraArgs.append('-DPXR_BUILD_EXAMPLES=ON')
+        else:
+            extraArgs.append('-DPXR_BUILD_EXAMPLES=OFF')
+
+        if context.buildTutorials:
+            extraArgs.append('-DPXR_BUILD_TUTORIALS=ON')
+        else:
+            extraArgs.append('-DPXR_BUILD_TUTORIALS=OFF')
             
         if context.buildImaging:
             extraArgs.append('-DPXR_BUILD_IMAGING=ON')
@@ -1122,6 +1132,16 @@ subgroup.add_argument("--tests", dest="build_tests", action="store_true",
 subgroup.add_argument("--no-tests", dest="build_tests", action="store_false",
                       help="Do not build unit tests (default)")
 subgroup = group.add_mutually_exclusive_group()
+subgroup.add_argument("--examples", dest="build_examples", action="store_true",
+                      default=False, help="Build examples")
+subgroup.add_argument("--no-examples", dest="build_examples", action="store_false",
+                      help="Do not build examples (default)")
+subgroup = group.add_mutually_exclusive_group()
+subgroup.add_argument("--tutorials", dest="build_tutorials", action="store_true",
+                      default=False, help="Build tutorials")
+subgroup.add_argument("--no-tutorials", dest="build_tutorials", action="store_false",
+                      help="Do not build tutorials (default)")
+subgroup = group.add_mutually_exclusive_group()
 subgroup.add_argument("--docs", dest="build_docs", action="store_true",
                       default=False, help="Build documentation")
 subgroup.add_argument("--no-docs", dest="build_docs", action="store_false",
@@ -1299,6 +1319,8 @@ class InstallContext:
         self.buildTests = args.build_tests
         self.buildDocs = args.build_docs
         self.buildPython = args.build_python
+        self.buildExamples = args.build_examples
+        self.buildTutorials = args.build_tutorials
 
         # - Imaging
         self.buildImaging = (args.build_imaging == IMAGING or
@@ -1520,6 +1542,8 @@ Building with settings:
     Python support              {buildPython}
     Documentation               {buildDocs}
     Tests                       {buildTests}
+    Examples                    {buildExamples}
+    Tutorials                   {buildTutorials}
     Alembic Plugin              {buildAlembic}
       HDF5 support:             {enableHDF5}
     MaterialX Plugin            {buildMaterialX}
@@ -1566,6 +1590,8 @@ summaryMsg = summaryMsg.format(
     buildPython=("On" if context.buildPython else "Off"),
     buildDocs=("On" if context.buildDocs else "Off"),
     buildTests=("On" if context.buildTests else "Off"),
+    buildExamples=("On" if context.buildExamples else "Off"),
+    buildTutorials=("On" if context.buildTutorials else "Off"),
     buildAlembic=("On" if context.buildAlembic else "Off"),
     buildMaterialX=("On" if context.buildMaterialX else "Off"),
     enableHDF5=("On" if context.enableHDF5 else "Off"),

--- a/extras/usd/CMakeLists.txt
+++ b/extras/usd/CMakeLists.txt
@@ -1,3 +1,6 @@
-add_subdirectory(examples)
-add_subdirectory(tutorials)
-
+if (PXR_BUILD_TUTORIALS)
+    add_subdirectory(tutorials)
+endif()
+if (PXR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()


### PR DESCRIPTION
### Description of Change(s)

This makes the examples set (usdObj, etc) optional to build. This is desirable for applications embedding a USD build which want a minimal set of components.

### Fixes Issue(s)
- None filed.

