### PR TITLE
[USD] Adding UDIM support to HdSt

### DIFF
--- a/pxr/imaging/lib/glf/CMakeLists.txt
+++ b/pxr/imaging/lib/glf/CMakeLists.txt
@@ -81,6 +81,7 @@ pxr_library(glf
         texture
         textureHandle
         textureRegistry
+        udimTexture
         uniformBlock
         utils
         uvTexture

--- a/pxr/imaging/lib/glf/contextCaps.cpp
+++ b/pxr/imaging/lib/glf/contextCaps.cpp
@@ -62,11 +62,13 @@ GlfContextCaps::GlfContextCaps()
     : glVersion(0)
     , coreProfile(false)
 
+    , maxArrayTextureLayers(0)
     , maxUniformBlockSize(0)
     , maxShaderStorageBlockSize(0)
     , maxTextureBufferSize(0)
     , uniformBufferOffsetAlignment(0)
 
+    , arrayTexturesEnabled(false)
     , shaderStorageBufferEnabled(false)
     , bufferStorageEnabled(false)
     , directStateAccessEnabled(false)
@@ -110,6 +112,7 @@ GlfContextCaps::_LoadCaps()
 
     // note that this function is called without GL context, in some unit tests.
 
+    arrayTexturesEnabled         = false;
     shaderStorageBufferEnabled   = false;
     bufferStorageEnabled         = false;
     directStateAccessEnabled     = false;
@@ -119,6 +122,7 @@ GlfContextCaps::_LoadCaps()
     explicitUniformLocation      = false;
     shadingLanguage420pack       = false;
     shaderDrawParametersEnabled  = false;
+    maxArrayTextureLayers        = 256;          // GL spec minimum
     maxUniformBlockSize          = 16*1024;      // GL spec minimum
     maxShaderStorageBlockSize    = 16*1024*1024; // GL spec minimum
     maxTextureBufferSize         = 64*1024;      // GL spec minimum
@@ -155,6 +159,11 @@ GlfContextCaps::_LoadCaps()
         }
     } else {
         glslVersion = 0;
+    }
+
+    if (glVersion >= 300) {
+        glGetIntegerv(GL_MAX_ARRAY_TEXTURE_LAYERS, &maxArrayTextureLayers);
+        arrayTexturesEnabled = true;
     }
 
     // initialize by Core versions

--- a/pxr/imaging/lib/glf/contextCaps.h
+++ b/pxr/imaging/lib/glf/contextCaps.h
@@ -64,12 +64,14 @@ public:
     bool coreProfile;
 
     // Max constants
+    int maxArrayTextureLayers;
     int maxUniformBlockSize;
     int maxShaderStorageBlockSize;
     int maxTextureBufferSize;
     int uniformBufferOffsetAlignment;
 
     // GL extensions (ordered by version)
+    bool arrayTexturesEnabled;        // EXT_texture_array                (3.0)
     bool shaderStorageBufferEnabled;  // ARB_shader_storage_buffer_object (4.3)
     bool bufferStorageEnabled;        // ARB_buffer_storage               (4.4)
     bool directStateAccessEnabled;    // ARB_direct_state_access          (4.5)

--- a/pxr/imaging/lib/glf/image.cpp
+++ b/pxr/imaging/lib/glf/image.cpp
@@ -49,12 +49,13 @@ GlfImage::IsSupportedImageFile(std::string const & filename)
 /* static */
 GlfImageSharedPtr
 GlfImage::OpenForReading(std::string const & filename, int subimage,
-                         bool suppressErrors)
+                         int mip, bool suppressErrors)
 {
     GlfImageRegistry & registry = GlfImageRegistry::GetInstance();
 
     GlfImageSharedPtr image = registry._ConstructImage(filename);
-    if (!image || !image->_OpenForReading(filename, subimage, suppressErrors)) {
+    if (!image || !image->_OpenForReading(filename, subimage,
+                                          mip, suppressErrors)) {
         return GlfImageSharedPtr();
     }
 

--- a/pxr/imaging/lib/glf/image.h
+++ b/pxr/imaging/lib/glf/image.h
@@ -97,6 +97,7 @@ public:
     GLF_API
     static GlfImageSharedPtr OpenForReading(std::string const & filename,
                                             int subimage = 0,
+                                            int mip = 0,
                                             bool suppressErrors = false);
 
     /// Reads the image file into \a storage.
@@ -165,6 +166,7 @@ public:
 protected:
     virtual bool _OpenForReading(std::string const & filename,
                                  int subimage,
+                                 int mip,
                                  bool suppressErrors) = 0;
 
     virtual bool _OpenForWriting(std::string const & filename) = 0;

--- a/pxr/imaging/lib/glf/oiioImage.cpp
+++ b/pxr/imaging/lib/glf/oiioImage.cpp
@@ -81,12 +81,13 @@ public:
 
 protected:
     virtual bool _OpenForReading(std::string const & filename, int subimage,
-                                 bool suppressErrors);
+                                 int mip, bool suppressErrors);
     virtual bool _OpenForWriting(std::string const & filename);
 
 private:
     std::string _filename;
     int _subimage;
+    int _miplevel;
     ImageBuf _imagebuf;
 };
 
@@ -269,7 +270,7 @@ _SetAttribute(ImageSpec * spec,
 }
 
 Glf_OIIOImage::Glf_OIIOImage()
-    : _subimage(0)
+    : _subimage(0), _miplevel(0)
 {
 }
 
@@ -391,13 +392,15 @@ Glf_OIIOImage::GetNumMipLevels() const
 /* virtual */
 bool
 Glf_OIIOImage::_OpenForReading(std::string const & filename, int subimage,
-                               bool suppressErrors)
+                               int mip, bool suppressErrors)
 {
     _filename = filename;
     _subimage = subimage;
+    _miplevel = mip;
     _imagebuf.clear();
-    return _imagebuf.init_spec(_filename, subimage, /*mipmap*/0)
-           && (_imagebuf.nsubimages() > subimage);
+    return _imagebuf.init_spec(_filename, subimage, mip)
+           && (_imagebuf.nsubimages() > subimage)
+           && _imagebuf.nmiplevels() > mip;
 }
 
 /* virtual */
@@ -421,7 +424,7 @@ Glf_OIIOImage::ReadCropped(int const cropTop,
 
     //// seek subimage
     ImageSpec spec = imageInput->spec();
-    if (!imageInput->seek_subimage(_subimage, 0, spec)){
+    if (!imageInput->seek_subimage(_subimage, _miplevel, spec)){
         imageInput->close();
         TF_CODING_ERROR("Unable to seek subimage");
         return false;

--- a/pxr/imaging/lib/glf/stbImage.cpp
+++ b/pxr/imaging/lib/glf/stbImage.cpp
@@ -83,7 +83,7 @@ public:
 
 protected:
     virtual bool _OpenForReading(std::string const & filename, int subimage,
-                                 bool suppressErrors);
+                                 int mip, bool suppressErrors);
     virtual bool _OpenForWriting(std::string const & filename);
 
 private:
@@ -98,7 +98,6 @@ private:
                    StorageSpec const & storage);
         
     std::string _filename;
-    int _subimage;
     int _width;
     int _height;
     
@@ -186,7 +185,6 @@ Glf_StbImage::_GetInfoFromStorageSpec(GlfImage::StorageSpec const & storage)
 }
 
 Glf_StbImage::Glf_StbImage()
-    : _subimage(0)
 {
 }
 
@@ -363,11 +361,10 @@ Glf_StbImage::GetNumMipLevels() const
 /* virtual */
 bool
 Glf_StbImage::_OpenForReading(std::string const & filename, int subimage,
-                               bool suppressErrors)
+                              int mip, bool suppressErrors)
 {
     _filename = filename;
-    _subimage = subimage;
-   
+
     std::string fileExtension = _GetFilenameExtension();
     if (fileExtension == "hdr") {
         _outputType = GL_FLOAT;
@@ -375,7 +372,6 @@ Glf_StbImage::_OpenForReading(std::string const & filename, int subimage,
         _outputType = GL_UNSIGNED_BYTE;
     }
 
-    //read the header file to obtain width, height, and bpp info
     std::shared_ptr<ArAsset> asset = ArGetResolver().OpenAsset(_filename);
     if (!asset) { 
         return false;
@@ -388,7 +384,8 @@ Glf_StbImage::_OpenForReading(std::string const & filename, int subimage,
 
     return stbi_info_from_memory(
         reinterpret_cast<stbi_uc const*>(buffer.get()), asset->GetSize(), 
-        &_width, &_height, &_nchannels);
+        &_width, &_height, &_nchannels) &&
+            subimage == 0 && mip == 0;
 }
 
 /* virtual */

--- a/pxr/imaging/lib/glf/textureRegistry.cpp
+++ b/pxr/imaging/lib/glf/textureRegistry.cpp
@@ -147,6 +147,33 @@ GlfTextureRegistry::GetTextureHandle(GlfTextureRefPtr texture)
     return textureHandle;
 }
 
+GlfTextureHandleRefPtr
+GlfTextureRegistry::GetTextureHandle(
+    const TfToken& texture,
+    GlfImage::ImageOriginLocation originLocation,
+    const GlfTextureFactoryBase* textureFactory) {
+    if (!TF_VERIFY(textureFactory != nullptr)) {
+        return nullptr;
+    }
+
+    _TextureMetadata md(texture);
+
+    std::map<std::pair<TfToken, GlfImage::ImageOriginLocation>,
+        _TextureMetadata>::iterator it =
+        _textureRegistry.find(std::make_pair(texture, originLocation));
+
+    if (it != _textureRegistry.end() && it->second.IsMetadataEqual(md)) {
+        return it->second.GetHandle();
+    } else {
+        GlfTextureHandleRefPtr textureHandle =
+            GlfTextureHandle::New(
+                textureFactory->New(texture, originLocation));
+        md.SetHandle(textureHandle);
+        _textureRegistry[std::make_pair(texture, originLocation)] = md;
+        return textureHandle;
+    }
+}
+
 bool
 GlfTextureRegistry::HasTexture(const TfToken &texture,
                              GlfImage::ImageOriginLocation originLocation) const

--- a/pxr/imaging/lib/glf/textureRegistry.h
+++ b/pxr/imaging/lib/glf/textureRegistry.h
@@ -38,6 +38,7 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <functional>
 #include <map>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -64,8 +65,15 @@ public:
     GlfTextureHandleRefPtr GetTextureHandle(const TfTokenVector &textures,
                                   GlfImage::ImageOriginLocation originLocation = 
                                                      GlfImage::OriginUpperLeft);
+
     GLF_API
     GlfTextureHandleRefPtr GetTextureHandle(GlfTextureRefPtr texture);
+
+    GLF_API
+    GlfTextureHandleRefPtr GetTextureHandle(
+        const TfToken& texture,
+        GlfImage::ImageOriginLocation originLocation,
+        const GlfTextureFactoryBase* textureFactory);
 
     // garbage collection methods
     GLF_API

--- a/pxr/imaging/lib/glf/udimTexture.cpp
+++ b/pxr/imaging/lib/glf/udimTexture.cpp
@@ -1,0 +1,376 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+/// \file glf/udimTexture.cpp
+
+#include "pxr/imaging/glf/glew.h"
+
+#include "pxr/imaging/glf/udimTexture.h"
+
+#include "pxr/imaging/glf/contextCaps.h"
+#include "pxr/imaging/glf/diagnostic.h"
+#include "pxr/imaging/glf/glContext.h"
+
+#include "pxr/imaging/glf/image.h"
+
+#include "pxr/base/tf/stringUtils.h"
+
+#include "pxr/base/trace/trace.h"
+#include "pxr/base/work/loops.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+struct _TextureSize {
+    _TextureSize(unsigned int w, unsigned int h) : width(w), height(h) { }
+    unsigned int width, height;
+};
+
+struct _MipDesc {
+    _MipDesc(const _TextureSize& s, GlfImageSharedPtr&& i) :
+        size(s), image(std::move(i)) { }
+    _TextureSize size;
+    GlfImageSharedPtr image;
+};
+
+using _MipDescArray = std::vector<_MipDesc>;
+
+_MipDescArray _GetMipLevels(const TfToken& filePath)
+{
+    constexpr int maxMipReads = 32;
+    _MipDescArray ret {};
+    ret.reserve(maxMipReads);
+    unsigned int prevWidth = std::numeric_limits<unsigned int>::max();
+    unsigned int prevHeight = std::numeric_limits<unsigned int>::max();
+    for (unsigned int mip = 0; mip < maxMipReads; ++mip) {
+        GlfImageSharedPtr image = GlfImage::OpenForReading(filePath, 0, mip);
+        if (image == nullptr) {
+            break;
+        }
+        const unsigned int currHeight = std::max(1, image->GetWidth());
+        const unsigned int currWidth = std::max(1,image->GetHeight());
+        if (currWidth < prevWidth &&
+            currHeight < prevHeight) {
+            prevWidth = currWidth;
+            prevHeight = currHeight;
+            ret.push_back({{currWidth, currHeight}, std::move(image)});
+        }
+    }
+    return ret;
+};
+
+}
+
+bool GlfIsSupportedUdimTexture(std::string const& imageFilePath)
+{
+    return TfStringContains(imageFilePath, "<UDIM>");
+}
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    TfType::Define<GlfUdimTexture, TfType::Bases<GlfTexture>>();
+}
+
+GlfUdimTexture::GlfUdimTexture(
+    TfToken const& imageFilePath,
+    GlfImage::ImageOriginLocation originLocation,
+    std::vector<std::tuple<int, TfToken>>&& tiles)
+    : GlfTexture(originLocation), _tiles(std::move(tiles))
+{
+}
+
+GlfUdimTexture::~GlfUdimTexture()
+{
+    _FreeTextureObject();
+}
+
+GlfUdimTextureRefPtr
+GlfUdimTexture::New(
+    TfToken const& imageFilePath,
+    GlfImage::ImageOriginLocation originLocation,
+    std::vector<std::tuple<int, TfToken>>&& tiles)
+{
+    return TfCreateRefPtr(new GlfUdimTexture(
+        imageFilePath, originLocation, std::move(tiles)));
+}
+
+GlfTexture::BindingVector
+GlfUdimTexture::GetBindings(
+    TfToken const& identifier,
+    GLuint samplerId)
+{
+    _ReadImage();
+    BindingVector ret;
+    ret.push_back(Binding(
+        TfToken(identifier.GetString() + "_Images"), GlfTextureTokens->texels,
+            GL_TEXTURE_2D_ARRAY, _imageArray, samplerId));
+    ret.push_back(Binding(
+        TfToken(identifier.GetString() + "_Layout"), GlfTextureTokens->layout,
+            GL_TEXTURE_1D, _layout, 0));
+
+    return ret;
+}
+
+VtDictionary
+GlfUdimTexture::GetTextureInfo(bool forceLoad)
+{
+    VtDictionary ret;
+
+    if (forceLoad) {
+        _ReadImage();
+    }
+
+    if (_loaded) {
+        ret["memoryUsed"] = GetMemoryUsed();
+        ret["width"] = static_cast<int>(_width);
+        ret["height"] = static_cast<int>(_height);
+        ret["depth"] = static_cast<int>(_depth);
+        ret["format"] = static_cast<int>(_format);
+        if (!_tiles.empty()) {
+            ret["imageFilePath"] = std::get<1>(_tiles.front());
+        }
+        ret["referenceCount"] = GetRefCount().Get();
+    } else {
+        ret["memoryUsed"] = size_t{0};
+        ret["width"] = 0;
+        ret["height"] = 0;
+        ret["depth"] = 1;
+        ret["format"] = _format;
+    }
+    ret["referenceCount"] = GetRefCount().Get();
+    return ret;
+}
+
+void
+GlfUdimTexture::_FreeTextureObject()
+{
+    GlfSharedGLContextScopeHolder sharedGLContextScopeHolder;
+
+    if (glIsTexture(_imageArray)) {
+        glDeleteTextures(1, &_imageArray);
+        _imageArray = 0;
+    }
+
+    if (glIsTexture(_layout)) {
+        glDeleteTextures(1, &_layout);
+        _layout = 0;
+    }
+}
+
+void
+GlfUdimTexture::_ReadImage()
+{
+    TRACE_FUNCTION();
+
+    if (_loaded) {
+        return;
+    }
+    _loaded = true;
+    _FreeTextureObject();
+
+    if (_tiles.empty()) {
+        return;
+    }
+
+    const _MipDescArray firstImageMips = _GetMipLevels(std::get<1>(_tiles[0]));
+
+    if (firstImageMips.empty()) {
+        return;
+    }
+
+    _format = firstImageMips[0].image->GetFormat();
+    const GLenum type = firstImageMips[0].image->GetType();
+    unsigned int numChannels;
+    if (_format == GL_RED || _format == GL_LUMINANCE) {
+        numChannels = 1;
+    } else if (_format == GL_RG) {
+        numChannels = 2;
+    } else if (_format == GL_RGB) {
+        numChannels = 3;
+    } else if (_format == GL_RGBA) {
+        numChannels = 4;
+    } else {
+        return;
+    }
+
+    GLenum internalFormat = GL_RGBA8;
+    unsigned int sizePerElem = 1;
+    if (type == GL_FLOAT) {
+        constexpr GLenum internalFormats[] =
+            { GL_R32F, GL_RG32F, GL_RGB32F, GL_RGBA32F };
+        internalFormat = internalFormats[numChannels - 1];
+        sizePerElem = 4;
+    } else if (type == GL_UNSIGNED_SHORT) {
+        constexpr GLenum internalFormats[] =
+            { GL_R16, GL_RG16, GL_RGB16, GL_RGBA16 };
+        internalFormat = internalFormats[numChannels - 1];
+        sizePerElem = 2;
+    } else if (type == GL_HALF_FLOAT_ARB) {
+        constexpr GLenum internalFormats[] =
+            { GL_R16F, GL_RG16F, GL_RGB16F, GL_RGBA16F };
+        internalFormat = internalFormats[numChannels - 1];
+        sizePerElem = 2;
+    } else if (type == GL_UNSIGNED_BYTE) {
+        constexpr GLenum internalFormats[] =
+            { GL_R8, GL_RG8, GL_RGB8, GL_RGBA8 };
+        internalFormat = internalFormats[numChannels - 1];
+        sizePerElem = 1;
+    }
+
+    const unsigned int maxTileCount =
+        std::get<0>(_tiles.back()) + 1;
+    _depth = static_cast<unsigned int>(_tiles.size());
+    const unsigned int numBytesPerPixel = sizePerElem * numChannels;
+    const unsigned int numBytesPerPixelLayer = numBytesPerPixel * _depth;
+
+    unsigned int targetPixelCount =
+        static_cast<unsigned int>(GetMemoryRequested())
+        / (_depth * numBytesPerPixel);
+
+    std::vector<_TextureSize> mips {};
+    mips.reserve(firstImageMips.size());
+    if (firstImageMips.size() == 1) {
+        unsigned int width = firstImageMips[0].size.width;
+        unsigned int height = firstImageMips[0].size.height;
+        while (true) {
+            mips.emplace_back(width, height);
+            if (width == 1 && height == 1) {
+                break;
+            }
+            width = std::max(1u, width / 2u);
+            height = std::max(1u, height / 2u);
+        }
+        std::reverse(mips.begin(), mips.end());
+    } else {
+        for (auto it = firstImageMips.crbegin();
+             it != firstImageMips.crend(); ++it) {
+            mips.emplace_back(it->size);
+        }
+    }
+
+    unsigned int mipCount = 0;
+    {
+        for (auto const& mip: mips) {
+            const unsigned int currentPixelCount = mip.width * mip.height;
+            if (targetPixelCount <= currentPixelCount) {
+                break;
+            }
+            ++mipCount;
+            targetPixelCount -= currentPixelCount;
+        }
+    }
+    if (mipCount == 0) {
+        mips.clear();
+        mips.emplace_back(1, 1);
+    } else {
+        mips.resize(mipCount, {0, 0});
+        std::reverse(mips.begin(), mips.end());
+    }
+
+    _width = mips[0].width;
+    _height = mips[0].height;
+
+    std::vector<std::vector<uint8_t>> mipData;
+    mipData.resize(mipCount);
+
+    // Texture array queries will use a float as the array specifier.
+    std::vector<float> layoutData;
+    layoutData.resize(maxTileCount, 0.0f);
+
+    glGenTextures(1, &_imageArray);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, _imageArray);
+    glTexStorage3D(GL_TEXTURE_2D_ARRAY,
+        mipCount, internalFormat,
+        _width, _height, _depth);
+
+    size_t totalTextureMemory = 0;
+    for (unsigned int mip = 0; mip < mipCount; ++mip) {
+        _TextureSize const& mipSize = mips[mip];
+        const unsigned int currentMipMemory =
+            mipSize.width * mipSize.height * numBytesPerPixelLayer;
+        mipData[mip].resize(currentMipMemory, 0);
+        totalTextureMemory += currentMipMemory;
+    }
+
+    WorkParallelForN(_tiles.size(), [&](size_t begin, size_t end) {
+        for (size_t tileId = begin; tileId < end; ++tileId) {
+            std::tuple<int, TfToken> const& tile = _tiles[tileId];
+            layoutData[std::get<0>(tile)] = tileId + 1;
+            _MipDescArray images = _GetMipLevels(std::get<1>(tile));
+            if (images.empty()) { continue; }
+            for (unsigned int mip = 0; mip < mipCount; ++mip) {
+                _TextureSize const& mipSize = mips[mip];
+                const unsigned int numBytesPerLayer =
+                    mipSize.width * mipSize.height * numBytesPerPixel;
+                GlfImage::StorageSpec spec;
+                spec.width = mipSize.width;
+                spec.height = mipSize.height;
+                spec.format = _format;
+                spec.type = type;
+                spec.flipped = true;
+                spec.data = mipData[mip].data()
+                            + (tileId * numBytesPerLayer);
+                const auto it = std::find_if(images.rbegin(), images.rend(),
+                    [&mipSize](const _MipDesc& i)
+                    { return mipSize.width <= i.size.width &&
+                             mipSize.height <= i.size.height;});
+                (it == images.rend() ? images.front() : *it).image->Read(spec);
+            }
+        }
+    }, 1);
+
+    for (unsigned int mip = 0; mip < mipCount; ++mip) {
+        _TextureSize const& mipSize = mips[mip];
+        glTexSubImage3D(GL_TEXTURE_2D_ARRAY, mip, 0, 0, 0,
+                        mipSize.width, mipSize.height, _depth, _format, type,
+                        mipData[mip].data());
+    }
+
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+
+    glGenTextures(1, &_layout);
+    glBindTexture(GL_TEXTURE_1D, _layout);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexImage1D(GL_TEXTURE_1D, 0, GL_R32F, layoutData.size(), 0,
+        GL_RED, GL_FLOAT, layoutData.data());
+    glBindTexture(GL_TEXTURE_1D, 0);
+
+    GLF_POST_PENDING_GL_ERRORS();
+
+    _SetMemoryUsed(totalTextureMemory + _tiles.size() * sizeof(float));
+}
+
+void
+GlfUdimTexture::_OnMemoryRequestedDirty()
+{
+    _loaded = false;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/lib/glf/udimTexture.h
+++ b/pxr/imaging/lib/glf/udimTexture.h
@@ -1,0 +1,109 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef GLF_UDIMTEXTURE_H
+#define GLF_UDIMTEXTURE_H
+
+/// \file glf/udimTexture.h
+
+#include "pxr/pxr.h"
+#include "pxr/imaging/glf/api.h"
+
+#include "pxr/imaging/glf/texture.h"
+
+#include <string>
+#include <vector>
+#include <tuple>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// Returns true if the file given by \p imageFilePath represents a udim file,
+/// and false otherwise.
+///
+/// This function simply checks the existence of the <udim> tag in the
+/// file name and does not otherwise guarantee that
+/// the file is in any way valid for reading.
+///
+GLF_API bool GlfIsSupportedUdimTexture(std::string const& imageFilePath);
+
+class GlfUdimTexture;
+TF_DECLARE_WEAK_AND_REF_PTRS(GlfUdimTexture);
+
+class GlfUdimTexture : public GlfTexture {
+public:
+    GLF_API
+    virtual ~GlfUdimTexture();
+
+    GLF_API
+    static GlfUdimTextureRefPtr New(
+        TfToken const& imageFilePath,
+        GlfImage::ImageOriginLocation originLocation,
+        std::vector<std::tuple<int, TfToken>>&& tiles);
+
+    GLF_API
+    GlfTexture::BindingVector GetBindings(
+        TfToken const& identifier,
+        GLuint samplerId) override;
+
+    GLF_API
+    VtDictionary GetTextureInfo(bool forceLoad) override;
+
+    GLuint GetGlTextureName() {
+        _ReadImage();
+        return _imageArray;
+    }
+
+    GLuint GetGlLayoutName() {
+        _ReadImage();
+        return _layout;
+    }
+
+protected:
+    GLF_API
+    GlfUdimTexture(
+        TfToken const& imageFilePath,
+        GlfImage::ImageOriginLocation originLocation,
+        std::vector<std::tuple<int, TfToken>>&& tiles);
+
+    GLF_API
+    void _FreeTextureObject();
+
+    GLF_API
+    void _ReadImage();
+
+    GLF_API
+    void _OnMemoryRequestedDirty() override;
+private:
+    std::vector<std::tuple<int, TfToken>> _tiles;
+    unsigned int _width = 0;
+    unsigned int _height = 0;
+    unsigned int _depth = 0;
+    unsigned int _format = 0;
+    GLuint _imageArray = 0;
+    GLuint _layout = 0;
+    bool _loaded = false;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // GLF_UDIMTEXTURE_H

--- a/pxr/imaging/lib/glf/uvTextureData.cpp
+++ b/pxr/imaging/lib/glf/uvTextureData.cpp
@@ -101,7 +101,7 @@ GlfUVTextureData::_GetDegradedImageInputChain(double scaleX, double scaleY,
 {
     _DegradedImageInput chain(scaleX, scaleY);
     for (int level = startMip; level < lastMip; level++) {
-        GlfImageSharedPtr image = GlfImage::OpenForReading(_filePath, level);
+        GlfImageSharedPtr image = GlfImage::OpenForReading(_filePath, 0, level);
         chain.images.push_back(image);
     }
     return chain;
@@ -122,7 +122,7 @@ GlfUVTextureData::_GetNumMipLevelsValid(const GlfImageSharedPtr image) const
     // in that case 
     for (int mipCounter = 1; mipCounter < 32; mipCounter++) {
         GlfImageSharedPtr image = GlfImage::OpenForReading(_filePath,
-            mipCounter, /*suppressErrors=*/ true);
+            0 /*subimage*/, mipCounter, /*suppressErrors=*/ true);
         if (!image) {
             potentialMipLevels = mipCounter;
             break;
@@ -190,7 +190,7 @@ GlfUVTextureData::_ReadDegradedImageInput(bool generateMipmap,
     // If no targetMemory set, use degradeLevel to determine mipLevel
     if (targetMemory == 0) {
         GlfImageSharedPtr image =
-		GlfImage::OpenForReading(_filePath, degradeLevel);
+		GlfImage::OpenForReading(_filePath, 0, degradeLevel);
         if (!image) {
             return _DegradedImageInput(1.0, 1.0);
         }
@@ -215,7 +215,7 @@ GlfUVTextureData::_ReadDegradedImageInput(bool generateMipmap,
     for (int i = 1; i < numMipLevels; i++) {
         // Open the image and is requested to use the i-th
         // down-sampled image (mipLevel).
-        GlfImageSharedPtr image = GlfImage::OpenForReading(_filePath, i);
+        GlfImageSharedPtr image = GlfImage::OpenForReading(_filePath, 0, i);
 
         // If mipLevel could not be opened, return fullImage. We are
         // not supposed to hit this. GlfImage will return the last

--- a/pxr/imaging/lib/hd/binding.h
+++ b/pxr/imaging/lib/hd/binding.h
@@ -63,11 +63,15 @@ public:
                 TBO,                 //
 
                 // shader parameter bindings
-                FALLBACK,                     // fallback value
-                TEXTURE_2D,          // non-bindless uv texture
-                TEXTURE_PTEX_TEXEL,  // non-bindless ptex texels
-                TEXTURE_PTEX_LAYOUT, // non-bindless ptex layout
+                FALLBACK,             // fallback value
+                TEXTURE_2D,           // non-bindless uv texture
+                TEXTURE_UDIM_ARRAY,   // non-bindless udim texture array
+                TEXTURE_UDIM_LAYOUT,  // non-bindless udim layout
+                TEXTURE_PTEX_TEXEL,   // non-bindless ptex texels
+                TEXTURE_PTEX_LAYOUT,  // non-bindless ptex layout
                 BINDLESS_TEXTURE_2D,          // bindless uv texture
+                BINDLESS_TEXTURE_UDIM_ARRAY,  // bindless uv texture array
+                BINDLESS_TEXTURE_UDIM_LAYOUT, // bindless udim layout
                 BINDLESS_TEXTURE_PTEX_TEXEL,  // bindless ptex texels
                 BINDLESS_TEXTURE_PTEX_LAYOUT, // bindless ptex layout
                 PRIMVAR_REDIRECT     // primvar redirection

--- a/pxr/imaging/lib/hd/enums.h
+++ b/pxr/imaging/lib/hd/enums.h
@@ -278,6 +278,24 @@ enum HdInterpolation
 };
 
 ///
+/// \enum HdTextureType
+/// Enumerates Hydra's supported texture types.
+///
+/// Uv:   Sample the uv coordinates and accesses a single texture.
+///
+/// Ptex: Use the ptex connectivity information to sample a ptex texture.
+///
+/// Udim: Remap the uv coordinates into udim coordinates using a maximum
+///       tile width of 10 and sample all the udim tiles found in the
+///       file system.
+///
+enum class HdTextureType
+{
+    Uv,
+    Ptex,
+    Udim
+};
+
 /// \enum HdDepthPriority
 /// Sets the priorities for a depth based operation
 ///

--- a/pxr/imaging/lib/hd/materialParam.cpp
+++ b/pxr/imaging/lib/hd/materialParam.cpp
@@ -36,13 +36,13 @@ HdMaterialParam::HdMaterialParam(ParamType paramType,
                                  VtValue const& fallbackValue,
                                  SdfPath const& connection,
                                  TfTokenVector const& samplerCoords,
-                                 bool isPtex)
+                                 HdTextureType textureType)
     : _paramType(paramType)
     , _name(name)
     , _fallbackValue(fallbackValue)
     , _connection(connection)
     , _samplerCoords(samplerCoords)
-    , _isPtex(isPtex)
+    , _textureType(textureType)
 {
     /*NOTHING*/
 }
@@ -64,7 +64,7 @@ HdMaterialParam::ComputeHash(HdMaterialParamVector const &params)
         TF_FOR_ALL(coordIt, paramIt->GetSamplerCoordinates()) {
             boost::hash_combine(hash, coordIt->Hash());
         }
-        boost::hash_combine(hash, paramIt->IsPtex());
+        boost::hash_combine(hash, paramIt->GetTextureType());
     }
     return hash;
 }
@@ -80,12 +80,6 @@ HdMaterialParam::GetSamplerCoordinates() const
 {
     // NOTE: could discover from texture connection.
     return _samplerCoords;
-}
-
-bool
-HdMaterialParam::IsPtex() const
-{
-    return _isPtex;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/lib/hd/materialParam.h
+++ b/pxr/imaging/lib/hd/materialParam.h
@@ -26,6 +26,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/imaging/hd/api.h"
+#include "pxr/imaging/hd/enums.h"
 #include "pxr/imaging/hd/version.h"
 #include "pxr/imaging/hd/types.h"
 #include "pxr/usd/sdf/path.h"
@@ -63,7 +64,7 @@ public:
                     VtValue const& fallbackValue,
                     SdfPath const& connection=SdfPath(),
                     TfTokenVector const& samplerCoords=TfTokenVector(),
-                    bool isPtex = false);
+                    HdTextureType textureType = HdTextureType::Uv);
 
     HD_API
     ~HdMaterialParam();
@@ -94,9 +95,9 @@ public:
         return GetParamType() == ParamTypeFallback;
     }
 
-    // XXX: we don't want this, we need a better way of supplying this answer.
-    HD_API
-    bool IsPtex() const;
+    HdTextureType GetTextureType() const {
+        return _textureType;
+    }
 
     HD_API
     TfTokenVector const& GetSamplerCoordinates() const;
@@ -107,7 +108,7 @@ private:
     VtValue _fallbackValue;
     SdfPath _connection;
     TfTokenVector _samplerCoords;
-    bool _isPtex;
+    HdTextureType _textureType;
 };
 
 

--- a/pxr/imaging/lib/hd/texture.cpp
+++ b/pxr/imaging/lib/hd/texture.cpp
@@ -125,10 +125,10 @@ HdTexture::GetInitialDirtyBitsMask() const
     return AllDirty;
 }
 
-bool
-HdTexture::IsPtex() const
+HdTextureType
+HdTexture::GetTextureType() const
 {
-    return false;
+    return HdTextureType::Uv;
 }
 
 bool

--- a/pxr/imaging/lib/hd/texture.h
+++ b/pxr/imaging/lib/hd/texture.h
@@ -30,6 +30,7 @@
 #include "pxr/imaging/hd/bprim.h"
 #include "pxr/imaging/hd/textureResource.h"
 #include "pxr/imaging/hd/types.h"
+#include "pxr/imaging/hd/enums.h"
 
 #include "pxr/usd/sdf/path.h"
 
@@ -85,10 +86,10 @@ public:
     // ---------------------------------------------------------------------- //
     /// \name Texture API
     // ---------------------------------------------------------------------- //
-    
-    /// Returns true if the texture should be interpreted as a PTex texture.
+
+    /// Returns the type of the texture.
     HD_API
-    bool IsPtex() const;
+    virtual HdTextureType GetTextureType() const;
 
     /// Returns true if mipmaps should be generated when loading.
     HD_API

--- a/pxr/imaging/lib/hdSt/codeGen.cpp
+++ b/pxr/imaging/lib/hdSt/codeGen.cpp
@@ -251,6 +251,11 @@ _GetPackedTypeDefinitions()
            "int hd_int_get(ivec2 v)        { return v.x; }\n"
            "int hd_int_get(ivec3 v)        { return v.x; }\n"
            "int hd_int_get(ivec4 v)        { return v.x; }\n"
+        // udim helper function
+            "vec3 hd_sample_udim(vec2 v) {\n"
+            "vec2 vf = floor(v);\n"
+            "return vec3(v.x - vf.x, v.y - vf.y, clamp(vf.x, 0.0, 10.0) + 10.0 * vf.y);\n"
+            "}\n"
 
         // -------------------------------------------------------------------
         // Packed HdType implementation.
@@ -418,6 +423,10 @@ namespace {
         case HdBinding::BINDLESS_SSBO_RANGE:
         case HdBinding::TEXTURE_2D:
         case HdBinding::BINDLESS_TEXTURE_2D:
+        case HdBinding::TEXTURE_UDIM_ARRAY:
+        case HdBinding::BINDLESS_TEXTURE_UDIM_ARRAY:
+        case HdBinding::TEXTURE_UDIM_LAYOUT:
+        case HdBinding::BINDLESS_TEXTURE_UDIM_LAYOUT:
         case HdBinding::TEXTURE_PTEX_TEXEL:
         case HdBinding::TEXTURE_PTEX_LAYOUT:
             if (caps.explicitUniformLocation) {
@@ -1064,6 +1073,14 @@ static void _EmitDeclaration(std::stringstream &str,
     case HdBinding::TEXTURE_2D:
     case HdBinding::BINDLESS_TEXTURE_2D:
         str << "uniform sampler2D " << name << ";\n";
+        break;
+    case HdBinding::TEXTURE_UDIM_ARRAY:
+    case HdBinding::BINDLESS_TEXTURE_UDIM_ARRAY:
+        str << "uniform sampler2DArray " << name.GetText() << "_Images;\n";
+        break;
+    case HdBinding::TEXTURE_UDIM_LAYOUT:
+    case HdBinding::BINDLESS_TEXTURE_UDIM_LAYOUT:
+        str << "uniform sampler1D " << name.GetText() << "_Layout;\n";
         break;
     case HdBinding::TEXTURE_PTEX_TEXEL:
         str << "uniform sampler2DArray " << name << "_Data;\n";
@@ -2669,6 +2686,92 @@ HdSt_CodeGen::_GenerateShaderParameters()
                     << "vec2(0.0, 0.0)";
             }
             accessors << "); }\n";
+        } else if (bindingType == HdBinding::BINDLESS_TEXTURE_UDIM_ARRAY) {
+            // a function returning sampler2DArray is allowed in 430 or later
+            if (caps.glslVersion >= 430) {
+                accessors
+                    << "sampler2DArray\n"
+                    << "HdGetSampler_" << it->second.name << "() {\n"
+                    << "  int shaderCoord = GetDrawingCoord().shaderCoord; \n"
+                    << "  return sampler2DArray(shaderData[shaderCoord]."
+                    << it->second.name << ");\n"
+                    << "  }\n";
+            }
+            accessors
+                << it->second.dataType
+                << " HdGet_" << it->second.name << "()" << " {\n"
+                << "  int shaderCoord = GetDrawingCoord().shaderCoord;\n";
+
+            if (!it->second.inPrimvars.empty()) {
+                accessors
+                    << "#if defined(HD_HAS_"
+                    << it->second.inPrimvars[0] << ")\n"
+                    << "  vec3 c = hd_sample_udim(HdGet_"
+                    << it->second.inPrimvars[0] << "().xy);\n"
+                    << "  c.z = texelFetch(sampler1D(shaderData[shaderCoord]."
+                    << it->second.name << "_layout), int(c.z), 0).x - 1;\n"
+                    << "#else\n"
+                    << "  vec3 c = vec3(0.0, 0.0, 0.0);\n"
+                    << "#endif\n";
+            } else {
+                accessors
+                    << "  vec3 c = vec3(0.0, 0.0, 0.0);\n";
+            }
+            accessors
+                << "if (c.z < -0.5) { return vec4(0, 0, 0, 0)" << swizzle
+                << "; } else { \n"
+                << "  return texture(sampler2DArray(shaderData[shaderCoord]."
+                << it->second.name << "), c)" << swizzle << ";}\n}\n";
+        } else if (bindingType == HdBinding::TEXTURE_UDIM_ARRAY) {
+            declarations
+                << LayoutQualifier(it->first)
+                << "uniform sampler2DArray sampler2dArray_"
+                << it->second.name << ";\n";
+
+            if (caps.glslVersion >= 430) {
+                accessors
+                    << "sampler2DArray\n"
+                    << "HdGetSampler_" << it->second.name << "() {\n"
+                    << "  return sampler2dArray_" << it->second.name << ";"
+                    << "}\n";
+            }
+            // vec4 HdGet_name(vec2 coord) { vec3 c = hd_sample_udim(coord);
+            // c.z = texelFetch(sampler1d_name_layout, int(c.z), 0).x - 1;
+            // if (c.z < -0.5) { return vec4(0, 0, 0, 0).xyz; } else {
+            // return texture(sampler2dArray_name, hd_sample_udim(coord)).xyz;}}
+            accessors
+                << it->second.dataType
+                << " HdGet_" << it->second.name
+                << "(vec2 coord) { vec3 c = hd_sample_udim(coord);\n"
+                << "  c.z = texelFetch(sampler1d_" << it->second.name
+                << "_layout" << ", int(c.z), 0).x - 1;\n"
+                << "if (c.z < -0.5) { return vec4(0, 0, 0, 0)"
+                << swizzle << "; } else {\n"
+                << "  return texture(sampler2dArray_"
+                << it->second.name << ", c)" << swizzle << ";}}\n";
+            // vec4 HdGet_name() { return HdGet_name(HdGet_st().xy); }
+            accessors
+                << it->second.dataType
+                << " HdGet_" << it->second.name
+                << "() { return HdGet_" << it->second.name << "(";
+            if (!it->second.inPrimvars.empty()) {
+                accessors
+                    << "\n"
+                    << "#if defined(HD_HAS_"
+                    << it->second.inPrimvars[0] << ")\n"
+                    << "HdGet_" << it->second.inPrimvars[0] << "().xy\n"
+                    << "#else\n"
+                    << "vec2(0.0, 0.0)\n"
+                    << "#endif\n";
+            } else {
+                accessors
+                    << "vec2(0.0, 0.0)";
+            }
+            accessors << "); }\n";
+        } else if (bindingType == HdBinding::TEXTURE_UDIM_LAYOUT) {
+            declarations
+                << LayoutQualifier(it->first)
+                << "uniform sampler1D sampler1d_" << it->second.name << ";\n";
         } else if (bindingType == HdBinding::BINDLESS_TEXTURE_PTEX_TEXEL) {
             accessors
                 << _GetUnpackedType(it->second.dataType, false)

--- a/pxr/imaging/lib/hdSt/drawTargetTextureResource.cpp
+++ b/pxr/imaging/lib/hdSt/drawTargetTextureResource.cpp
@@ -79,10 +79,10 @@ HdSt_DrawTargetTextureResource::SetSampler(HdWrap wrapS,
                          _borderColor.GetArray());
 }
 
-bool
-HdSt_DrawTargetTextureResource::IsPtex() const
+HdTextureType
+HdSt_DrawTargetTextureResource::GetTextureType() const
 {
-    return false;
+    return HdTextureType::Uv;
 }
 
 GLuint

--- a/pxr/imaging/lib/hdSt/drawTargetTextureResource.h
+++ b/pxr/imaging/lib/hdSt/drawTargetTextureResource.h
@@ -43,7 +43,7 @@ public:
     //
     // HdTextureResource API
     //
-    virtual bool IsPtex() const override;
+    virtual HdTextureType GetTextureType() const override;
     virtual size_t GetMemoryUsed() override;
 
     //

--- a/pxr/imaging/lib/hdSt/material.cpp
+++ b/pxr/imaging/lib/hdSt/material.cpp
@@ -230,7 +230,8 @@ HdStMaterial::Sync(HdSceneDelegate *sceneDelegate,
                 HdStShaderCode::TextureDescriptor tex;
                 tex.name = param.GetName();
 
-                if (texResource->IsPtex()) {
+                const HdTextureType textureType = texResource->GetTextureType();
+                if (textureType == HdTextureType::Ptex) {
                     hasPtex = true;
                     tex.type =
                         HdStShaderCode::TextureDescriptor::TEXTURE_PTEX_TEXEL;
@@ -267,7 +268,42 @@ HdStMaterial::Sync(HdSceneDelegate *sceneDelegate,
                                                           tex.handle));
                         sources.push_back(source);
                     }
-                } else {
+                } else if (textureType == HdTextureType::Udim) {
+                    tex.type = HdStShaderCode::TextureDescriptor::TEXTURE_UDIM_ARRAY;
+                    tex.handle =
+                        bindless ? texResource->GetTexelsTextureHandle()
+                                 : texResource->GetTexelsTextureId();
+                    tex.sampler =  texResource->GetTexelsSamplerId();
+                    textures.push_back(tex);
+
+                    if (bindless) {
+                        HdBufferSourceSharedPtr source(
+                            new HdSt_BindlessSamplerBufferSource(
+                                tex.name,
+                                GL_SAMPLER_2D_ARRAY,
+                                tex.handle));
+                        sources.push_back(source);
+                    }
+
+                    tex.name =
+                        TfToken(param.GetName().GetString() + "_layout");
+                    tex.type =
+                        HdStShaderCode::TextureDescriptor::TEXTURE_UDIM_LAYOUT;
+                    tex.handle =
+                        bindless ? texResource->GetLayoutTextureHandle()
+                                 : texResource->GetLayoutTextureId();
+                    tex.sampler = 0;
+                    textures.push_back(tex);
+
+                    if (bindless) {
+                        HdBufferSourceSharedPtr source(
+                            new HdSt_BindlessSamplerBufferSource(
+                                tex.name,
+                                GL_SAMPLER_1D,
+                                tex.handle));
+                        sources.push_back(source);
+                    }
+                } else if (textureType == HdTextureType::Uv) {
                     tex.type = HdStShaderCode::TextureDescriptor::TEXTURE_2D;
                     tex.handle =
                                 bindless ? texResource->GetTexelsTextureHandle()
@@ -363,13 +399,17 @@ HdStMaterial::_GetTextureResource(
     //
     // XXX todo handle fallback Ptex textures
     if (!texResource) {
-        GlfUVTextureStorageRefPtr texPtr = 
+        // Fallback texture are only supported for UV textures.
+        if (param.GetTextureType() != HdTextureType::Uv) {
+            return {};
+        }
+        GlfUVTextureStorageRefPtr texPtr =
             GlfUVTextureStorage::New(1,1, param.GetFallbackValue());
         GlfTextureHandleRefPtr texture =
             GlfTextureRegistry::GetInstance().GetTextureHandle(texPtr);
         texResource.reset(
             new HdStSimpleTextureResource(texture,
-                                          false,
+                                          HdTextureType::Uv,
                                           HdWrapClamp,
                                           HdWrapClamp,
                                           HdMinFilterNearest,

--- a/pxr/imaging/lib/hdSt/resourceBinder.cpp
+++ b/pxr/imaging/lib/hdSt/resourceBinder.cpp
@@ -32,6 +32,7 @@
 #include "pxr/imaging/hdSt/shaderCode.h"
 #include "pxr/imaging/hdSt/drawItem.h"
 #include "pxr/imaging/hd/bufferSpec.h"
+#include "pxr/imaging/hd/enums.h"
 #include "pxr/imaging/hd/tokens.h"
 
 #include "pxr/base/tf/staticTokens.h"
@@ -552,7 +553,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
                     = MetaData::ShaderParameterAccessor(glName,
                                                         /*type=*/glType);
             } else if (it->IsTexture()) {
-                if (it->IsPtex()) {
+                if (it->GetTextureType() == HdTextureType::Ptex) {
                     // ptex texture
                     HdBinding texelBinding = bindless
                         ? HdBinding(HdBinding::BINDLESS_TEXTURE_PTEX_TEXEL, bindlessTextureLocation++)
@@ -577,7 +578,42 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
                     // XXX: same name ?
                     TfToken layoutName = TfToken(std::string(name.GetText()) + "_layout");
                     _bindingMap[layoutName] = layoutBinding; // used for non-bindless
-                } else {
+                } else if (it->GetTextureType() == HdTextureType::Udim) {
+                    // Texture Array for UDIM
+                    HdBinding textureBinding =
+                        bindless
+                        ? HdBinding(HdBinding::BINDLESS_TEXTURE_UDIM_ARRAY,
+                            bindlessTextureLocation++)
+                        : HdBinding(HdBinding::TEXTURE_UDIM_ARRAY,
+                            locator.uniformLocation++);
+                    metaDataOut->shaderParameterBinding[textureBinding] =
+                        MetaData::ShaderParameterAccessor(
+                            /*name=*/it->GetName(),
+                            /*type=*/glType,
+                            /*inPrimvars=*/it->GetSamplerCoordinates());
+                    // used for non-bindless
+                    _bindingMap[it->GetName()] = textureBinding;
+
+                    // Layout for UDIM
+                    TfToken layoutName =
+                        TfToken(std::string(it->GetName().GetText())
+                        + "_layout");
+                    HdBinding layoutBinding =
+                        bindless
+                        ? HdBinding(HdBinding::BINDLESS_TEXTURE_UDIM_LAYOUT,
+                            bindlessTextureLocation++)
+                        : HdBinding(HdBinding::TEXTURE_UDIM_LAYOUT,
+                            locator.uniformLocation++);
+
+                    metaDataOut->shaderParameterBinding[layoutBinding] =
+                        MetaData::ShaderParameterAccessor(
+                            /*name=*/layoutName,
+                            /*type=*/HdStGLConversions::GetGLSLTypename(
+                                HdType::HdTypeFloat));
+
+                    // used for non-bindless
+                    _bindingMap[layoutName] = layoutBinding;
+                } else if (it->GetTextureType() == HdTextureType::Uv) {
                     // 2d texture
                     HdBinding textureBinding = bindless
                         ? HdBinding(HdBinding::BINDLESS_TEXTURE_2D, bindlessTextureLocation++)

--- a/pxr/imaging/lib/hdSt/shaderCode.h
+++ b/pxr/imaging/lib/hdSt/shaderCode.h
@@ -81,7 +81,8 @@ public:
     struct TextureDescriptor {
         TfToken name;
         size_t handle; // GLuint64, for bindless textures
-        enum { TEXTURE_2D, TEXTURE_PTEX_TEXEL, TEXTURE_PTEX_LAYOUT };
+        enum { TEXTURE_2D, TEXTURE_UDIM_ARRAY, TEXTURE_UDIM_LAYOUT,
+               TEXTURE_PTEX_TEXEL, TEXTURE_PTEX_LAYOUT };
         int type;
         unsigned int sampler;
     };

--- a/pxr/imaging/lib/hdSt/surfaceShader.cpp
+++ b/pxr/imaging/lib/hdSt/surfaceShader.cpp
@@ -113,6 +113,19 @@ HdStSurfaceShader::BindResources(HdSt_ResourceBinder const &binder, int program)
             
             glProgramUniform1i(program, binding.GetLocation(), samplerUnit);
             samplerUnit++;
+        } else if (binding.GetType() == HdBinding::TEXTURE_UDIM_ARRAY) {
+            glActiveTexture(GL_TEXTURE0 + samplerUnit);
+            glBindTexture(GL_TEXTURE_2D_ARRAY, (GLuint)it->handle);
+            glBindSampler(samplerUnit, it->sampler);
+
+            glProgramUniform1i(program, binding.GetLocation(), samplerUnit);
+            samplerUnit++;
+        } else if (binding.GetType() == HdBinding::TEXTURE_UDIM_LAYOUT) {
+            glActiveTexture(GL_TEXTURE0 + samplerUnit);
+            glBindTexture(GL_TEXTURE_1D, (GLuint)it->handle);
+
+            glProgramUniform1i(program, binding.GetLocation(), samplerUnit);
+            samplerUnit++;
         } else if (binding.GetType() == HdBinding::TEXTURE_PTEX_TEXEL) {
             glActiveTexture(GL_TEXTURE0 + samplerUnit);
             glBindTexture(GL_TEXTURE_2D_ARRAY, (GLuint)it->handle);
@@ -144,6 +157,15 @@ HdStSurfaceShader::UnbindResources(HdSt_ResourceBinder const &binder, int progra
             glActiveTexture(GL_TEXTURE0 + samplerUnit);
             glBindTexture(GL_TEXTURE_2D, 0);
             glBindSampler(samplerUnit, 0);
+            samplerUnit++;
+        } else if (binding.GetType() == HdBinding::TEXTURE_UDIM_ARRAY) {
+            glActiveTexture(GL_TEXTURE0 + samplerUnit);
+            glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+            glBindSampler(samplerUnit, 0);
+            samplerUnit++;
+        } else if (binding.GetType() == HdBinding::TEXTURE_UDIM_LAYOUT) {
+            glActiveTexture(GL_TEXTURE0 + samplerUnit);
+            glBindTexture(GL_TEXTURE_1D, 0);
             samplerUnit++;
         } else if (binding.GetType() == HdBinding::TEXTURE_PTEX_TEXEL) {
             glActiveTexture(GL_TEXTURE0 + samplerUnit);

--- a/pxr/imaging/lib/hdSt/textureResource.h
+++ b/pxr/imaging/lib/hdSt/textureResource.h
@@ -74,7 +74,7 @@ public:
     /// this reference requires of the texture.  Set to 0 for unrestricted.
     HDST_API
     HdStSimpleTextureResource(GlfTextureHandleRefPtr const &textureHandle,
-                              bool isPtex,
+                              HdTextureType textureType,
                               HdWrap wrapS,
                               HdWrap wrapT,
                               HdMinFilter minFilter,
@@ -84,7 +84,7 @@ public:
     HDST_API
     virtual ~HdStSimpleTextureResource();
 
-    virtual bool IsPtex() const override;
+    virtual HdTextureType GetTextureType() const override;
     virtual size_t GetMemoryUsed() override;
 
     HDST_API virtual GLuint GetTexelsTextureId() override;
@@ -99,7 +99,7 @@ private:
     GfVec4f _borderColor;
     float _maxAnisotropy;
     GLuint _sampler;
-    bool _isPtex;
+    HdTextureType _textureType;
     size_t _memoryRequest;
 
     HdWrap _wrapS;

--- a/pxr/imaging/lib/hdSt/unitTestDelegate.cpp
+++ b/pxr/imaging/lib/hdSt/unitTestDelegate.cpp
@@ -79,18 +79,18 @@ HdSt_UnitTestDelegate::GetTextureResource(SdfPath const& textureId)
         GlfTextureRegistry::GetInstance().GetTextureHandle(_textures[textureId].texture);
 
     // Simple way to detect if the glf texture is ptex or not
-    bool isPtex = false;
+    HdTextureType textureType = HdTextureType::Uv;
 #ifdef PXR_PTEX_SUPPORT_ENABLED
     GlfPtexTextureRefPtr pTex = 
         TfDynamic_cast<GlfPtexTextureRefPtr>(_textures[textureId].texture);
     if (pTex) {
-        isPtex = true;
+        textureType = HdTextureType::Ptex;
     }
 #endif
 
     return HdTextureResourceSharedPtr(
         new HdStSimpleTextureResource(texture,
-                                      isPtex,
+                                      textureType,
                                       HdWrapUseMetadata,
                                       HdWrapUseMetadata,
                                       HdMinFilterNearestMipmapLinear,

--- a/pxr/imaging/lib/hdx/unitTestDelegate.cpp
+++ b/pxr/imaging/lib/hdx/unitTestDelegate.cpp
@@ -116,8 +116,8 @@ public:
     virtual ~DrawTargetTextureResource() {
     };
 
-    virtual bool IsPtex() const {
-        return false;
+    virtual HdTextureType GetTextureType() const override {
+        return HdTextureType::Uv;
     }
 
     virtual GLuint GetTexelsTextureId() {

--- a/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
@@ -60,6 +60,7 @@ pxr_library(usdImaging
         rectLightAdapter
         sphereAdapter
         sphereLightAdapter
+        textureUtils
         volumeAdapter
 
     PUBLIC_HEADERS

--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -2652,7 +2652,7 @@ UsdImagingDelegate::GetMaterialParams(SdfPath const &materialId)
                 paramIt->GetFallbackValue(),
                 GetPathForIndex(paramIt->GetConnection()),
                 paramIt->GetSamplerCoordinates(),
-                paramIt->IsPtex());
+                paramIt->GetTextureType());
         }
     }
 

--- a/pxr/usdImaging/lib/usdImaging/textureUtils.cpp
+++ b/pxr/usdImaging/lib/usdImaging/textureUtils.cpp
@@ -1,0 +1,98 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usdImaging/usdImaging/textureUtils.h"
+
+#include "pxr/base/tf/fileUtils.h"
+
+#include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/resolverScopedCache.h"
+
+#include "pxr/usd/sdf/layerUtils.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+std::vector<std::tuple<int, TfToken>>
+UsdImaging_GetUdimTiles(
+    std::string const& basePath,
+    int tileLimit,
+    SdfLayerHandle const& layerHandle) {
+    const std::string::size_type pos = basePath.find("<UDIM>");
+    if (pos == std::string::npos) {
+        return {};
+    }
+    std::string formatString = basePath;
+    formatString.replace(pos, 6, "%i");
+
+    ArResolverScopedCache resolverCache;
+    ArResolver& resolver = ArGetResolver();
+
+    constexpr int startTile = 1001;
+    const int endTile = startTile + tileLimit;
+    std::vector<std::tuple<int, TfToken>> ret;
+    ret.reserve(tileLimit);
+    for (int t = startTile; t <= endTile; ++t) {
+        const std::string path =
+            layerHandle
+            ? SdfComputeAssetPathRelativeToLayer(
+                layerHandle, TfStringPrintf(formatString.c_str(), t))
+            : TfStringPrintf(formatString.c_str(), t);
+        if (!resolver.Resolve(path).empty()) {
+            ret.emplace_back(t - startTile, TfToken(path));
+        }
+    }
+    ret.shrink_to_fit();
+    return ret;
+}
+
+bool
+UsdImaging_UdimTilesExist(
+    std::string const& basePath,
+    int tileLimit,
+    SdfLayerHandle const& layerHandle) {
+    const std::string::size_type pos = basePath.find("<UDIM>");
+    if (pos == std::string::npos) {
+        return false;
+    }
+    std::string formatString = basePath;
+    formatString.replace(pos, 6, "%i");
+
+    ArResolverScopedCache resolverCache;
+    ArResolver& resolver = ArGetResolver();
+
+    constexpr int startTile = 1001;
+    const int endTile = startTile + tileLimit;
+    for (int t = startTile; t <= endTile; ++t) {
+        const std::string path =
+            layerHandle
+            ? SdfComputeAssetPathRelativeToLayer(
+                layerHandle, TfStringPrintf(formatString.c_str(), t))
+            : TfStringPrintf(formatString.c_str(), t);
+        if (!resolver.Resolve(path).empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImaging/textureUtils.h
+++ b/pxr/usdImaging/lib/usdImaging/textureUtils.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2018 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,40 +21,36 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef HD_TEXTURE_RESOURCE_H
-#define HD_TEXTURE_RESOURCE_H
+#ifndef USDIMAGING_TEXTURE_UTILS_H
+#define USDIMAGING_TEXTURE_UTILS_H
 
 #include "pxr/pxr.h"
-#include "pxr/imaging/hd/api.h"
-#include "pxr/imaging/hd/enums.h"
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/shared_ptr.hpp>
+#include "pxr/usd/sdf/layer.h"
 
-#include <cstdint>
+#include "pxr/usdImaging/usdImaging/api.h"
+
+#include <tuple>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+USDIMAGING_API
+std::vector<std::tuple<int, TfToken>>
+UsdImaging_GetUdimTiles(
+    std::string const& basePath,
+    int tileLimit,
+    SdfLayerHandle const& layerHandle = SdfLayerHandle());
 
-typedef boost::shared_ptr<class HdTextureResource> HdTextureResourceSharedPtr;
-
-class HdTextureResource {
-public:
-    typedef size_t ID;
-
-    /// Returns the hash value of the texture for \a sourceFile
-    HD_API
-    static ID ComputeHash(TfToken const & sourceFile);
-
-    HD_API
-    virtual ~HdTextureResource();
-
-    virtual HdTextureType GetTextureType() const = 0;
-
-    virtual size_t GetMemoryUsed() = 0;
-};
+USDIMAGING_API
+bool
+UsdImaging_UdimTilesExist(
+    std::string const& basePath,
+    int tileLimit,
+    SdfLayerHandle const& layerHandle = SdfLayerHandle());
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-#endif //HD_TEXTURE_RESOURCE_H
+#endif // USDIMAGING_TEXTURE_UTILS_H

--- a/pxr/usdImaging/lib/usdImagingGL/drawModeAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/drawModeAdapter.cpp
@@ -396,7 +396,8 @@ UsdImagingGLDrawModeAdapter::UpdateForTime(UsdPrim const& prim,
                     params.push_back(HdMaterialParam(
                                 HdMaterialParam::ParamTypeTexture,
                                 textureNames[i], fallback,
-                                attr.GetPath(), samplerParams, false));
+                                attr.GetPath(), samplerParams,
+                                HdTextureType::Uv));
                 }
             }
             valueCache->GetMaterialParams(cachePath) = params;


### PR DESCRIPTION
### Description of Change(s)
The following PR adds UDIM support to HdSt. There are a few outstanding issues yet to be solved, but since this is a big change I think it's work starting to review early.

Issues.
- I don't really like the isUdim (and isPtex) flags all over the place. While it would be good to get rid of them, I think it should be done after this PR.
- Same goes for the dynamic casts to get the texture and layout ids. I think these should be moved to the base glf texture class, as it's OpenGL specific already. For now having a buffer/texture to store texels and one for layouts is a good overall approximation for multiple types of textures. Alternatively, we could request ids based on tokens and have a function to iterate through textures in the base glf texture class.
- I have to do some performance tests wrt loading large amounts of udim textures and make sure we only load the data when required.
- Texture origins are not yet handled properly.
- Probably I need to do more checks in codeGen regarding the OpenGL version / caps.


### Fixes Issue(s)
No reported issues.
