### PR TITLE
Adding python access to the IsSupported method on renderer plugins.

### DIFF
--- a/pxr/imaging/lib/hd/renderThread.h
+++ b/pxr/imaging/lib/hd/renderThread.h
@@ -29,6 +29,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <thread>
 

--- a/pxr/usdImaging/lib/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.cpp
@@ -700,6 +700,13 @@ UsdImagingGLEngine::GetRendererPluginDesc(TfToken const &id) const
 
 /* virtual */
 bool
+UsdImagingGLEngine::GetRendererPluginIsSupported(TfToken const &id) const
+{
+    return false;
+}
+
+/* virtual */
+bool
 UsdImagingGLEngine::SetRendererPlugin(TfToken const &id)
 {
     return false;

--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -371,6 +371,10 @@ public:
     USDIMAGINGGL_API
     virtual std::string GetRendererPluginDesc(TfToken const &id) const;
 
+    /// Checks if a renderer plugin is supported in this runtime environment.
+    USDIMAGINGGL_API
+    virtual bool GetRendererPluginIsSupported(TfToken const &id) const;
+
     /// Set the current render-graph delegate to \p id.
     /// the plugin will be loaded if it's not yet.
     USDIMAGINGGL_API

--- a/pxr/usdImaging/lib/usdImagingGL/gl.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/gl.cpp
@@ -298,6 +298,13 @@ UsdImagingGL::GetRendererPluginDesc(TfToken const &id) const
 
 /* virtual */
 bool
+UsdImagingGL::GetRendererPluginIsSupported(TfToken const &id) const
+{
+    return _engine->GetRendererPluginIsSupported(id);
+}
+
+/* virtual */
+bool
 UsdImagingGL::SetRendererPlugin(TfToken const &id)
 {
     return _engine->SetRendererPlugin(id);

--- a/pxr/usdImaging/lib/usdImagingGL/gl.h
+++ b/pxr/usdImaging/lib/usdImagingGL/gl.h
@@ -180,6 +180,9 @@ public:
     virtual std::string GetRendererPluginDesc(TfToken const &id) const;
 
     USDIMAGINGGL_API
+    virtual bool GetRendererPluginIsSupported(TfToken const &id) const;
+
+    USDIMAGINGGL_API
     virtual bool SetRendererPlugin(TfToken const &id);
 
     USDIMAGINGGL_API

--- a/pxr/usdImaging/lib/usdImagingGL/hdEngine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/hdEngine.cpp
@@ -895,6 +895,21 @@ UsdImagingGLHdEngine::GetRendererPluginDesc(TfToken const &id) const
     return pluginDescriptor.displayName;
 }
 
+/* virtual */
+bool
+UsdImagingGLHdEngine::GetRendererPluginIsSupported(TfToken const &id) const
+{
+    HdxRendererPlugin *plugin = nullptr;
+    bool supported = false;
+    plugin = HdxRendererPluginRegistry::GetInstance().GetRendererPlugin(id);
+    if (TF_VERIFY(plugin)) {
+        supported = plugin->IsSupported();
+        HdxRendererPluginRegistry::GetInstance().ReleasePlugin(plugin);
+    }
+
+    return supported;
+}
+
 /* static */
 bool
 UsdImagingGLHdEngine::IsDefaultPluginAvailable()

--- a/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/hdEngine.h
@@ -153,6 +153,9 @@ public:
     virtual std::string GetRendererPluginDesc(TfToken const &id) const;
 
     USDIMAGINGGL_API
+    virtual bool GetRendererPluginIsSupported(TfToken const &id) const;
+
+    USDIMAGINGGL_API
     virtual bool SetRendererPlugin(TfToken const &id);
 
     USDIMAGINGGL_API

--- a/pxr/usdImaging/lib/usdImagingGL/wrapGL.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/wrapGL.cpp
@@ -123,6 +123,8 @@ void wrapGL()
             .def("GetRendererPlugins", &UsdImagingGL::GetRendererPlugins,
                  return_value_policy< TfPySequenceToTuple >())
             .def("GetRendererPluginDesc", &UsdImagingGL::GetRendererPluginDesc)
+            .def("GetRendererPluginIsSupported",
+                 &UsdImagingGL::GetRendererPluginIsSupported)
             .def("SetRendererPlugin", &UsdImagingGL::SetRendererPlugin)
             .def("GetResourceAllocation", &UsdImagingGL::GetResourceAllocation)
         ;

--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1222,6 +1222,15 @@ class AppController(QtCore.QObject):
                     if action.text() == self._stageView.rendererPluginName:
                         action.setChecked(True)
                         break
+                # Then display an error message to let the user know something
+                # went wrong, and disable the menu item so it can't be selected
+                # again.
+                for action in self._ui.rendererPluginActionGroup.actions():
+                    if action.pluginType == plugin:
+                        self.statusMessage(
+                            'Renderer not supported: %s' % action.text())
+                        action.setText(action.text() + " (unsupported)")
+                        action.setDisabled(True)
 
     def _configureRendererPlugins(self):
         if self._stageView:

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -910,7 +910,13 @@ class StageView(QtOpenGL.QGLWidget):
 
     def GetRendererPlugins(self):
         if self._renderer:
-            return self._renderer.GetRendererPlugins()
+            plugins = self._renderer.GetRendererPlugins()
+            supported_plugins = []
+            for plugin in plugins:
+                if self._renderer.GetRendererPluginIsSupported(plugin):
+                    supported_plugins.append(plugin)
+
+            return supported_plugins
         else:
             return []
 

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -910,13 +910,7 @@ class StageView(QtOpenGL.QGLWidget):
 
     def GetRendererPlugins(self):
         if self._renderer:
-            plugins = self._renderer.GetRendererPlugins()
-            supported_plugins = []
-            for plugin in plugins:
-                if self._renderer.GetRendererPluginIsSupported(plugin):
-                    supported_plugins.append(plugin)
-
-            return supported_plugins
+            return self._renderer.GetRendererPlugins()
         else:
             return []
 


### PR DESCRIPTION
Use this method to decide which renderers to show in the usdview menu.

Unrelated, but I couldn't bring myself to make a separate pull request for it: also including <functional> in renderThread.h for definition of std::function.