### PR TITLE
[Cmake] Don't blindly overwrite CMAKE_MODULE_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     endif()
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/defaults
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+                      ${CMAKE_SOURCE_DIR}/cmake/defaults
                       ${CMAKE_SOURCE_DIR}/cmake/modules
                       ${CMAKE_SOURCE_DIR}/cmake/macros)
 


### PR DESCRIPTION
### Description of Change(s)
Make sure CMAKE_MODULE_PATH passed via command line has precedence over USD.

### Fixes Issue(s)
If there are non standard paths/ installs CMAKE_MODULE_PATH is a much easier route than specifying multiple locations, but USD is currently overwriting any CMAKE_MODULE_PATH passed to it.

