### PR TITLE
[usdview] Enable OpenGL 3 or 4 on OS X when possible.

### DIFF
--- a/pxr/imaging/lib/glf/contextCaps.cpp
+++ b/pxr/imaging/lib/glf/contextCaps.cpp
@@ -346,6 +346,25 @@ GlfContextCaps::_LoadCaps()
     }
 }
 
+GlfContextCaps::CoreVAO::CoreVAO()
+    : vao(GL_NONE)
+{
+    if (GlfContextCaps::GetInstance().coreProfile) {
+        glGenVertexArrays(1, &vao);
+        glBindVertexArray(vao);
+    }
+}
+
+GlfContextCaps::CoreVAO::~CoreVAO()
+{
+    if (vao != GL_NONE) {
+        glBindVertexArray(0);
+        // XXX: We should not delete the VAO on every draw call, but we
+        // currently must because it is GL Context state and we do not control
+        // the context.
+        glDeleteVertexArrays(1, &vao);
+    }
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/lib/glf/contextCaps.h
+++ b/pxr/imaging/lib/glf/contextCaps.h
@@ -72,8 +72,20 @@ public:
     GLF_API
     static const GlfContextCaps &GetInstance();
 
+    /// Core-Profile contexts must bind a VAO (Vertex Array Object) because
+    /// they do not have a default vertex array object. VAO objects are
+    /// container objects which are not shared between contexts, so this object
+    /// will create and bind a VAO here so that core rendering code does not have to
+    /// explicitly manage per-GL context state.
+    class CoreVAO {
+        unsigned vao;
+    public:
+        CoreVAO();
+        ~CoreVAO();
+    };
 
-
+    
+    
     // GL version
     int glVersion;                    // 400 (4.0), 410 (4.1), ...
 

--- a/pxr/imaging/lib/hdSt/codeGen.cpp
+++ b/pxr/imaging/lib/hdSt/codeGen.cpp
@@ -1644,7 +1644,7 @@ HdSt_CodeGen::_GenerateDrawingCoord()
            << "  dc.fvarCoord               = drawingCoord1.x; \n"
            << "  dc.shaderCoord             = drawingCoord1.z; \n"
            << "  dc.vertexCoord             = drawingCoord1.w; \n"
-           << "  dc.topologyVisibilityCoord = drawingCoord2.x; \n"
+           << "  dc.topologyVisibilityCoord = drawingCoord2; \n"
            << "  dc.instanceIndex           = GetInstanceIndex().indices;\n";
 
     if (_metaData.drawingCoordIBinding.binding.IsValid()) {

--- a/pxr/imaging/lib/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/lib/hdSt/shaders/basisCurves.glslfx
@@ -759,7 +759,7 @@ void main(void)
     color.rgb = HdGet_displayColor().rgb;
 #endif
 #ifdef HD_HAS_displayOpacity
-    color.a = HdGet_displayOpacity().r;
+    color.a = HdGet_displayOpacity();
 #endif
 
     vec3 Peye = inData.Peye.xyz / inData.Peye.w;
@@ -801,7 +801,7 @@ void main(void)
     color.rgb = HdGet_displayColor().rgb;
 #endif
 #ifdef HD_HAS_displayOpacity
-    color.a = HdGet_displayOpacity().r;
+    color.a = HdGet_displayOpacity();
 #endif
     color.rgb = ApplyColorOverrides(color).rgb;
 

--- a/pxr/imaging/lib/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/lib/hdSt/shaders/mesh.glslfx
@@ -541,7 +541,7 @@ void main(void)
     color.rgb = HdGet_displayColor().rgb;
 #endif
 #ifdef HD_HAS_displayOpacity
-    color.a = HdGet_displayOpacity().r;
+    color.a = HdGet_displayOpacity();
 #endif
 
     vec3 Peye = inData.Peye.xyz / inData.Peye.w;

--- a/pxr/imaging/lib/hdSt/shaders/points.glslfx
+++ b/pxr/imaging/lib/hdSt/shaders/points.glslfx
@@ -88,7 +88,7 @@ void main(void)
     color.rgb = HdGet_displayColor().rgb;
 #endif
 #ifdef HD_HAS_displayOpacity
-    color.a = HdGet_displayOpacity().r;
+    color.a = HdGet_displayOpacity();
 #endif
 
     vec4 patchCoord = vec4(0);

--- a/pxr/imaging/lib/hdSt/shaders/visibility.glslfx
+++ b/pxr/imaging/lib/hdSt/shaders/visibility.glslfx
@@ -40,7 +40,7 @@ void GetBitmaskBufferIndices(int id, out int arrayIndex, out int bitIndex)
 
 bool IsBitSet(uint bitmask, int bitIndex)
 {
-    return bool(bitmask & (1 << bitIndex));
+    return bool(bitmask & (1U << bitIndex));
 }
 
 bool IsElementVisible()

--- a/pxr/imaging/lib/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/lib/hdx/colorCorrectionTask.cpp
@@ -404,17 +404,7 @@ HdxColorCorrectionTask::_ApplyColorCorrection()
         glUniform1i(_locations[LUT3D_IN], 1);
     }
 
-    GLuint vao;
-    const bool isCoreProfileContext = GlfContextCaps::GetInstance().coreProfile;
-    if (isCoreProfileContext) {
-        // We must bind a VAO (Vertex Array Object) because core profile
-        // contexts do not have a default vertex array object. VAO objects are
-        // container objects which are not shared between contexts, so we create
-        // and bind a VAO here so that core rendering code does not have to
-        // explicitly manage per-GL context state.
-        glGenVertexArrays(1, &vao);
-        glBindVertexArray(vao);
-    }
+    GlfContextCaps::CoreVAO vao;
 
     glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
     glVertexAttribPointer(_locations[POSITION], 4, GL_FLOAT, GL_FALSE,
@@ -489,14 +479,6 @@ HdxColorCorrectionTask::_ApplyColorCorrection()
         glActiveTexture(GL_TEXTURE1);
         glBindTexture(GL_TEXTURE_3D, 0);
         glDisable(GL_TEXTURE_3D);
-    }
-
-    if (isCoreProfileContext) {
-        glBindVertexArray(0);
-        // XXX: We should not delete the VAO on every draw call, but we
-        // currently must because it is GL Context state and we do not control
-        // the context.
-        glDeleteVertexArrays(1, &vao);
     }
 
     GLF_POST_PENDING_GL_ERRORS();

--- a/pxr/imaging/lib/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/lib/hdx/colorCorrectionTask.cpp
@@ -196,7 +196,7 @@ HdxColorCorrectionTask::_CreateShaderResources()
 
     HioGlslfx glslfx(HdxPackageColorCorrectionShader());
 
-    std::string fragCode = "#version 120\n";
+    std::string fragCode = "#version 150\n";
 
     if (useOCIO) {
         fragCode += "#define GLSLFX_USE_OCIO\n";

--- a/pxr/imaging/lib/hdx/compositor.cpp
+++ b/pxr/imaging/lib/hdx/compositor.cpp
@@ -248,17 +248,7 @@ HdxCompositor::Draw(GLuint colorId, GLuint depthId, bool remapDepth)
 
     glUniform1i(_locations[remapDepthIn], (GLint)remapDepth);
 
-    GLuint vao;
-    const bool isCoreProfileContext = GlfContextCaps::GetInstance().coreProfile;
-    if (isCoreProfileContext) {
-        // We must bind a VAO (Vertex Array Object) because core profile
-        // contexts do not have a default vertex array object. VAO objects are
-        // container objects which are not shared between contexts, so we create
-        // and bind a VAO here so that core rendering code does not have to
-        // explicitly manage per-GL context state.
-        glGenVertexArrays(1, &vao);
-        glBindVertexArray(vao);
-    }
+    GlfContextCaps::CoreVAO vao;
 
     glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
     glVertexAttribPointer(_locations[position], 4, GL_FLOAT, GL_FALSE,
@@ -291,14 +281,6 @@ HdxCompositor::Draw(GLuint colorId, GLuint depthId, bool remapDepth)
 
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, 0);
-
-    if (isCoreProfileContext) {
-        glBindVertexArray(0);
-        // XXX: We should not delete the VAO on every draw call, but we
-        // currently must because it is GL Context state and we do not control
-        // the context.
-        glDeleteVertexArrays(1, &vao);
-    }
 
     GLF_POST_PENDING_GL_ERRORS();
 }

--- a/pxr/imaging/lib/hdx/oitRenderTask.cpp
+++ b/pxr/imaging/lib/hdx/oitRenderTask.cpp
@@ -22,6 +22,7 @@
 // language governing permissions and limitations under the Apache License.
 //
 #include "pxr/imaging/glf/glew.h"
+#include "pxr/imaging/glf/contextCaps.h"
 
 #include "pxr/imaging/hdx/package.h"
 #include "pxr/imaging/hdx/oitRenderTask.h"
@@ -134,8 +135,11 @@ HdxOitRenderTask::Execute(HdTaskContext* ctx)
     //     start to render squares (driver bug?).
     //     For now we always enable GL_POINT_SMOOTH. 
     // XXX Switch points rendering to emit quad with FS that draws circle.
-    bool oldPointSmooth = glIsEnabled(GL_POINT_SMOOTH);
-    glEnable(GL_POINT_SMOOTH);
+    bool disablePointSmooth = false;
+    if (!GlfContextCaps::GetInstance().coreProfile && !glIsEnabled(GL_POINT_SMOOTH)) {
+        glEnable(GL_POINT_SMOOTH);
+        disablePointSmooth = true;
+    }
 
     //
     // Opaque pixels pass
@@ -162,7 +166,7 @@ HdxOitRenderTask::Execute(HdTaskContext* ctx)
         glEnable(GL_MULTISAMPLE);
     }
 
-    if (!oldPointSmooth) {
+    if (disablePointSmooth) {
         glDisable(GL_POINT_SMOOTH);
     }
 }

--- a/pxr/imaging/lib/hdx/shaders/colorCorrection.glslfx
+++ b/pxr/imaging/lib/hdx/shaders/colorCorrection.glslfx
@@ -40,12 +40,12 @@
 
 -- glsl ColorCorrection.Vertex
 
-#version 120
+#version 150
 
-attribute vec4 position;
-attribute vec2 uvIn;
+in vec4 position;
+in vec2 uvIn;
 
-varying vec2 uv;
+out vec2 uv;
 
 void main(void)
 {
@@ -55,7 +55,8 @@ void main(void)
 
 -- glsl ColorCorrection.Fragment
 
-varying vec2 uv;
+in vec2 uv;
+out vec4 fragColor;
 
 uniform sampler2D colorIn;
 uniform sampler3D LUT3dIn;
@@ -77,7 +78,7 @@ vec3 FloatToSRGB(vec3 val)
 
 void main(void)
 {
-    vec4 color = texture2D(colorIn, uv);
+    vec4 color = texture(colorIn, uv);
 
     #if defined(GLSLFX_USE_OCIO)
         color = OCIODisplay(color, LUT3dIn);
@@ -86,5 +87,5 @@ void main(void)
         color.rgb = FloatToSRGB(color.rgb);
     #endif
 
-    gl_FragColor = color;
+    fragColor = color;
 }

--- a/pxr/imaging/lib/hdx/shaders/fullscreen.glslfx
+++ b/pxr/imaging/lib/hdx/shaders/fullscreen.glslfx
@@ -43,12 +43,12 @@
 
 -- glsl Fullscreen.Vertex
 
-#version 120
+#version 150
 
-attribute vec4 position;
-attribute vec2 uvIn;
+in vec4 position;
+in vec2 uvIn;
 
-varying vec2 uv;
+out vec2 uv;
 
 void main(void)
 {
@@ -58,22 +58,24 @@ void main(void)
 
 -- glsl Composite.FragmentNoDepth
 
-#version 120
+#version 150
 
-varying vec2 uv;
+in vec2 uv;
+out vec4 fragColor;
 
 uniform sampler2D colorIn;
 
 void main(void)
 {
-    gl_FragColor = texture2D(colorIn, uv);
+    fragColor = texture(colorIn, uv);
 }
 
 -- glsl Composite.FragmentWithDepth
 
-#version 120
+#version 150
 
-varying vec2 uv;
+in vec2 uv;
+out vec4 fragColor;
 
 uniform sampler2D colorIn;
 uniform sampler2D depthIn;
@@ -86,7 +88,7 @@ RemapDepth(float depth) {
 
 void main(void)
 {
-    float depth = texture2D(depthIn, uv).r;
-    gl_FragColor = texture2D(colorIn, uv);
+    float depth = texture(depthIn, uv).r;
+    fragColor = texture(colorIn, uv);
     gl_FragDepth = remapDepthIn ? RemapDepth(depth) : depth;
 }

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -1360,8 +1360,8 @@ class StageView(QtOpenGL.QGLWidget):
         self._renderParams.enableSceneMaterials = self._dataModel.viewSettings.enableSceneMaterials
         self._renderParams.colorCorrectionMode = self._dataModel.viewSettings.colorCorrectionMode
         self._renderParams.clearColor = Gf.ConvertDisplayToLinear(Gf.Vec4f(self._dataModel.viewSettings.clearColor))
-        self._renderParams.renderResolution[0] = self.width()
-        self._renderParams.renderResolution[1] = self.height()
+        self._renderParams.renderResolution = self.computeWindowSize()
+
 
         pseudoRoot = self._dataModel.stage.GetPseudoRoot()
 

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -46,6 +46,8 @@ from selectionDataModel import ALL_INSTANCES, SelectionDataModel
 from viewSettingsDataModel import ViewSettingsDataModel
 from freeCamera import FreeCamera
 
+kGLMajorVersion, kGLShaderVersion, kGLGenVertex = (0,0,0)
+
 # A viewport rectangle to be used for GL must be integer values.
 # In order to loose the least amount of precision the viewport
 # is centered and adjusted to initially contain entirely the
@@ -83,13 +85,12 @@ def ViewportMakeCenteredIntegral(viewport):
 class GLSLProgram():
     def __init__(self, VS3, FS3, VS2, FS2, uniformDict):
         from OpenGL import GL
-        self._glMajorVersion = int(GL.glGetString(GL.GL_VERSION)[0])
 
         self.program   = GL.glCreateProgram()
         vertexShader   = GL.glCreateShader(GL.GL_VERTEX_SHADER)
         fragmentShader = GL.glCreateShader(GL.GL_FRAGMENT_SHADER)
 
-        if (self._glMajorVersion >= 3):
+        if (kGLMajorVersion >= 3):
             vsSource = VS3
             fsSource = FS3
         else:
@@ -251,11 +252,11 @@ class OutlineRect(Rect):
 
         GL.glUseProgram(program.program)
 
-        if (program._glMajorVersion >= 4):
+        if (kGLMajorVersion >= 4):
             GL.glDisable(GL.GL_SAMPLE_ALPHA_TO_COVERAGE)
 
         # requires PyOpenGL 3.0.2 or later for glGenVertexArrays.
-        if (program._glMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')):
+        if kGLGenVertex:
             if (cls._vao == 0):
                 cls._vao = GL.glGenVertexArrays(1)
             GL.glBindVertexArray(cls._vao)
@@ -332,11 +333,11 @@ class FilledRect(Rect):
 
         GL.glUseProgram(program.program)
 
-        if (program._glMajorVersion >= 4):
+        if (kGLMajorVersion >= 4):
             GL.glDisable(GL.GL_SAMPLE_ALPHA_TO_COVERAGE)
 
         # requires PyOpenGL 3.0.2 or later for glGenVertexArrays.
-        if (program._glMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')):
+        if kGLGenVertex:
             if (cls._vao == 0):
                 cls._vao = GL.glGenVertexArrays(1)
             GL.glBindVertexArray(cls._vao)
@@ -474,7 +475,6 @@ class HUD():
         self._HUDFont = QtGui.QFont("Menv Mono Numeric", 9*self._pixelRatio)
         self._groups = {}
         self._glslProgram = None
-        self._glMajorVersion = 0
         self._vao = 0
 
     def compileProgram(self):
@@ -579,11 +579,11 @@ class HUD():
         width = float(qglwidget.width())
         height = float(qglwidget.height())
 
-        if (self._glslProgram._glMajorVersion >= 4):
+        if (kGLMajorVersion >= 4):
             GL.glDisable(GL.GL_SAMPLE_ALPHA_TO_COVERAGE)
 
         # requires PyOpenGL 3.0.2 or later for glGenVertexArrays.
-        if (self._glslProgram._glMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')):
+        if kGLGenVertex:
             if (self._vao == 0):
                 self._vao = GL.glGenVertexArrays(1)
             GL.glBindVertexArray(self._vao)
@@ -1046,7 +1046,7 @@ class StageView(QtOpenGL.QGLWidget):
             return
 
         # vao
-        if (glslProgram._glMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')):
+        if kGLGenVertex:
             if (self._vao == 0):
                 self._vao = GL.glGenVertexArrays(1)
             GL.glBindVertexArray(self._vao)
@@ -1390,6 +1390,14 @@ class StageView(QtOpenGL.QGLWidget):
         if not Glf.GlewInit():
             return
         Glf.RegisterDefaultDebugOutputMessageCallback()
+        from OpenGL import GL
+        self._glRenderVersion = GL.glGetString(GL.GL_VERSION)
+        self._glShaderVersion = GL.glGetString(GL.GL_SHADING_LANGUAGE_VERSION)
+        print '%s\nShader Model: %s' % (self._glRenderVersion, self._glShaderVersion)
+        global kGLMajorVersion, kGLShaderVersion, kGLGenVertex
+        kGLMajorVersion = int(self._glRenderVersion[0])
+        kGLShaderVersion = int(self._glShaderVersion[0])
+        kGLGenVertex = kGLMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')
 
     def updateGL(self):
         """We override this virtual so that we can make it a no-op during
@@ -1532,7 +1540,7 @@ class StageView(QtOpenGL.QGLWidget):
         if (glslProgram.program == 0):
             return
         # vao
-        if (glslProgram._glMajorVersion >= 3 and hasattr(GL, 'glGenVertexArrays')):
+        if kGLGenVertex:
             if (self._vao == 0):
                 self._vao = GL.glGenVertexArrays(1)
             GL.glBindVertexArray(self._vao)

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -1395,6 +1395,13 @@ class StageView(QtOpenGL.QGLWidget):
             renderer = None
         self._forceRefresh = False
 
+        from OpenGL import GL
+        err = GL.glGetError()
+        while err != GL.GL_NO_ERROR:
+            from OpenGL.GLU import gluErrorString
+            print 'OpenGL error: ', gluErrorString(err)
+            err = GL.glGetError()
+
 
     def initializeGL(self):
         if not self.isValid():

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -216,13 +216,13 @@ class OutlineRect(Rect):
 
         self._glslProgram = GLSLProgram(
             # for OpenGL 3.1 or later
-            """#version 140
+            """#version 150
                uniform vec4 rect;
                in vec2 st;
                void main() {
                  gl_Position = vec4(rect.x + rect.z*st.x,
                                     rect.y + rect.w*st.y, 0, 1); }""",
-            """#version 140
+            """#version 150
                out vec4 fragColor;
                uniform vec4 color;
               void main() { fragColor = color; }""",
@@ -293,13 +293,13 @@ class FilledRect(Rect):
 
         self._glslProgram = GLSLProgram(
             # for OpenGL 3.1 or later
-            """#version 140
+            """#version 150
                uniform vec4 rect;
                in vec2 st;
                void main() {
                  gl_Position = vec4(rect.x + rect.z*st.x,
                                     rect.y + rect.w*st.y, 0, 1); }""",
-            """#version 140
+            """#version 150
                out vec4 fragColor;
                uniform vec4 color;
               void main() { fragColor = color; }""",
@@ -491,7 +491,7 @@ class HUD():
 
         self._glslProgram = GLSLProgram(
             # for OpenGL 3.1 or later
-            """#version 140
+            """#version 150
                uniform vec4 rect;
                in vec2 st;
                out vec2 uv;
@@ -499,7 +499,7 @@ class HUD():
                  gl_Position = vec4(rect.x + rect.z*st.x,
                                     rect.y + rect.w*st.y, 0, 1);
                  uv          = vec2(st.x, 1 - st.y); }""",
-            """#version 140
+            """#version 150
                in vec2 uv;
                out vec4 color;
                uniform sampler2D tex;
@@ -1018,11 +1018,11 @@ class StageView(QtOpenGL.QGLWidget):
     def GetSimpleGLSLProgram(self):
         if self._simpleGLSLProgram == None:
             self._simpleGLSLProgram = GLSLProgram(
-            """#version 140
+            """#version 150
                uniform mat4 mvpMatrix;
                in vec3 position;
                void main() { gl_Position = vec4(position, 1)*mvpMatrix; }""",
-            """#version 140
+            """#version 150
                out vec4 outColor;
                uniform vec4 color;
                void main() { outColor = color; }""",


### PR DESCRIPTION
### Description of Change(s)
Use Qt's ability to create an OpenGL 3/4 context when possible.
Disable features OS X cannot handle (hiliting and line-stiplling, for separate reasons)
More robust error checking and exception handling to release resources on failure.

### Fixes Issue(s)
Drawing via OpenGL with usdview on OS X was rather limited (atrocious probably being a better word).

