### PR TITLE
Use GUSD_API on these whole classes rather than individual functions.…

### DIFF
--- a/third_party/houdini/lib/gusd/OP_ParmChangeMicroNode.h
+++ b/third_party/houdini/lib/gusd/OP_ParmChangeMicroNode.h
@@ -46,24 +46,21 @@ PXR_NAMESPACE_OPEN_SCOPE
     (I.e., instances of multi parms) cannot be tracked through this class.
 
     This class is not thread safe!*/
-class GusdOP_ParmChangeMicroNode : public DEP_TimedMicroNode
+class GUSD_API GusdOP_ParmChangeMicroNode : public DEP_TimedMicroNode
 {
 public:
     explicit GusdOP_ParmChangeMicroNode(OP_Parameters& node)
         : DEP_TimedMicroNode(), _node(node), _parmsAdded(false) {}
 
-    GUSD_API
     virtual ~GusdOP_ParmChangeMicroNode();
 
     /** Begin tracking the given parm.
         If @a vectorIdx is less than zero, all elements of the parm
         tuple are tracked.*/
-    GUSD_API
     void            addParm(int parmIdx, int vecIdx=-1);
 
     /** Update the resolved parm values.
         @return true if any resolved values changed.*/
-    GUSD_API
     bool            updateVals(fpreal t, int thread=SYSgetSTID());
 
     bool            updateIfNeeded(fpreal t, int thread=SYSgetSTID())

--- a/third_party/houdini/lib/gusd/primWrapper.h
+++ b/third_party/houdini/lib/gusd/primWrapper.h
@@ -84,7 +84,7 @@ class GusdContext;
 
 typedef std::map<SdfPath,UT_Matrix4D> GusdSimpleXformCache;
 
-class GusdPrimWrapper : public GT_Primitive
+class GUSD_API GusdPrimWrapper : public GT_Primitive
 {
 public:
 
@@ -114,7 +114,6 @@ public:
     /// 
     /// When writing a USD file, we refine the geometry to a set of prims that we
     /// can deal with then we call this method on each of those prims.
-    GUSD_API
     static GT_PrimitiveHandle
     defineForWrite( const GT_PrimitiveHandle& sourcePrim,
                     const UsdStagePtr& stage,
@@ -125,20 +124,17 @@ public:
     /// and returns true.
     /// So far only F3D volumes do this. They can derive a name from meta
     /// data stored in the f3d file.
-    GUSD_API
     static bool 
     getPrimName( const GT_PrimitiveHandle &sourcePrim,
                  std::string &primName );
 
     // When we write USD for the given type, we will use a name like $USDNAME_0.
     // where USDNAME is the name registered for this type
-    GUSD_API
     static const char*
     getUsdName( int gtPrimId );
 
     // When we USD for an object that is marked as a group type, we write 
     // the object and then all its children.
-    GUSD_API
     static bool
     isGroupType( int gtPrimId );
 
@@ -147,7 +143,6 @@ public:
     /// When reading a USD file, we call this function to create a Gusd_GTPrimitive
     /// for each USD prim, we then refine that to something that can be 
     /// used in a detail.
-    GUSD_API
     static GT_PrimitiveHandle
     defineForRead( const UsdGeomImageable&  sourcePrim, 
                    UsdTimeCode              time,
@@ -156,14 +151,12 @@ public:
     /// \brief Is this gt prim a point instancer?
     ///
     /// This is used to know if we need to write the instance prototypes.
-    GUSD_API
     static bool 
     isPointInstancerPrim(const GT_PrimitiveHandle& prim,
                          const GusdContext& ctxt);
 
     /// Register function for creating new USD prims from GT_Primitives and, optionally,
     /// a function for giving these prims a name.
-    GUSD_API
     static bool registerPrimDefinitionFuncForWrite(int gtPrimId,
                                                    DefinitionForWriteFunction function,
                                                    GetPrimNameFunction getNameFunction = NULL,
@@ -171,30 +164,22 @@ public:
                                                    const char* usdName = NULL );
 
     /// Register function for creating new GusdPrimWrappers from USD prim.
-    GUSD_API
     static bool registerPrimDefinitionFuncForRead(const TfToken& usdTypeName,
                                                   DefinitionForReadFunction function);
 
     /// Return true is the give prim can be supported directly in USD. This
     /// is used by the refiner to know when to stop refining.
-    GUSD_API
     static bool isGTPrimSupported(const GT_PrimitiveHandle& prim);
 
-    GUSD_API
     GusdPrimWrapper();
-    GUSD_API
     GusdPrimWrapper( const UsdTimeCode &time, const GusdPurposeSet &purposes );
-    GUSD_API
     GusdPrimWrapper( const GusdPrimWrapper &in );
-    GUSD_API
     virtual ~GusdPrimWrapper();
 
     /// Return true if the underlying USD prim is valid
-    GUSD_API
     virtual bool isValid() const;
 
     virtual const UsdGeomImageable getUsdPrim() const = 0;
-    GUSD_API
     virtual bool unpack(
         GU_Detail&          gdr,
         const UT_StringRef& fileName,
@@ -210,7 +195,6 @@ public:
     /// and all the primitives on it each frame. However, there is some
     /// data we want to persist across frames. So we keep the GusdPrimWrappers
     /// and ask them to redefine their USD prims on each frame.
-    GUSD_API
     virtual bool redefine( 
            const UsdStagePtr& stage,
            const SdfPath& path, 
@@ -222,7 +206,6 @@ public:
     ///
     /// If \p sourcePrim is an instance, \p localXform is the instance transform
     /// otherwise it is the primitive transform from the prim.
-    GUSD_API
     virtual bool updateFromGTPrim(
         const GT_PrimitiveHandle& sourcePrim,
         const UT_Matrix4D&        houXform,
@@ -242,10 +225,8 @@ public:
     void markVisible( bool in ) { m_visible = in; }
     bool isVisible() const { return  m_visible; }
 
-    GUSD_API
     virtual void setVisibility(const TfToken& visibility, UsdTimeCode time);
     
-    GUSD_API
     static GT_DataArrayHandle convertPrimvarData( 
                     const UsdGeomPrimvar& primvar, 
                     UsdTimeCode time );
@@ -253,7 +234,6 @@ public:
     // Load primvars for prim from USD.
     // remapIndicies is used to expand curve primvars into point attributes if
     // needed.
-    GUSD_API
     void loadPrimvars( 
                     UsdTimeCode               time,
                     const GT_RefineParms*     rparms,

--- a/third_party/houdini/lib/gusd/refiner.h
+++ b/third_party/houdini/lib/gusd/refiner.h
@@ -64,7 +64,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class GusdRefinerCollector;
 
-class GusdRefiner : public GT_Refine 
+class GUSD_API GusdRefiner : public GT_Refine 
 {
 public:
 
@@ -103,7 +103,6 @@ public:
     /// that we only write packed prims that have been tagged with a prim path. We
     /// kee track of the transform of the last group we wrote in parentToWorldXform
     /// \p localToWorldXform is initialized to the OBJ Node's transform by the ROP.
-    GUSD_API
     GusdRefiner(
         GusdRefinerCollector&   collector,
         const SdfPath&          pathPrefix,
@@ -114,15 +113,12 @@ public:
 
     virtual bool allowThreading() const override { return false; }
 
-    GUSD_API
     virtual void addPrimitive( const GT_PrimitiveHandle& gtPrim ) override;
 
-    GUSD_API
     void refineDetail( 
         const GU_ConstDetailHandle& detail,
         const GT_RefineParms&       parms  );
 
-    GUSD_API
     const GprimArray& finish();
 
     //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is required to build the Houdini plugins using gcc5.4 which only exports
the vtable for a class if the whole class is exported (and so the whole
class must be exported to allow the use of dynamic_cast to these classes
in the Houdini plugins).

I'm hoping these additional exports will be non-controversial because they live
off in the gusd library rather than part of the USD core...