### PR TITLE
Change the define used to identify the Houdini version

### DIFF
--- a/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
@@ -46,8 +46,8 @@
 #include <GT/GT_RefineParms.h>
 #include <GU/GU_PrimPacked.h>
 #include <GA/GA_Names.h>
-#include <UT/UT_HDKVersion.h>
 #include <UT/UT_Options.h>
+#include <SYS/SYS_Version.h>
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
@@ -630,7 +630,7 @@ int GusdGT_PackedUSDMesh::
 getStaticPrimitiveType() 
 {
     if( s_gtPackedUsdMeshId == GT_PRIM_UNDEFINED ) {
-#if HDK_API_VERSION >= 16050000
+#if SYS_VERSION_FULL_INT >= 0x10050000
         // XXX There appears to be a bug in 16.5 that prevents primitives
         // with custom primitive ids to refine in the viewport. As a 
         // workaround we'll use GT_PRIM_ALEMBIC_SHAPE_MESH for now.


### PR DESCRIPTION
Use SYS_VERSION_FULL_INT define to figure out what version of Houdini is
being built against rather than HDK_API_VERSION. This is a more predictable
value that is always tied exactly to the Houdini version number.