### PR TITLE
Add include for std::function in eventTree.h.

### DIFF
--- a/pxr/base/lib/trace/eventTree.h
+++ b/pxr/base/lib/trace/eventTree.h
@@ -38,6 +38,7 @@
 #include "pxr/base/tf/weakPtr.h"
 #include "pxr/base/tf/declarePtrs.h"
 
+#include <functional>
 #include <vector>
 #include <unordered_map>
 


### PR DESCRIPTION
Include <functional> for definition of std::function used in this header.

The absence of this include caused a build failure using gcc7.3.