### PR TITLE
[Plug] Remove unused boost include

### DIFF
--- a/pxr/base/lib/plug/plugin.h
+++ b/pxr/base/lib/plug/plugin.h
@@ -32,7 +32,6 @@
 #include "pxr/base/tf/refPtr.h"
 #include "pxr/base/tf/weakPtr.h"
 
-#include <boost/noncopyable.hpp>
 #include <atomic>
 #include <string>
 #include <utility>


### PR DESCRIPTION
### Description of Change(s)
See my other art at #621 #484 #481 #618 

This goes about removing one of the easier pieces of boost in the USD repo (those that
can be replaced with standard C++11 constructs).
