### PR TITLE
Issue #631: fixing vertex attributes on rightHanded meshes when refining for the viewport

### DIFF
--- a/third_party/houdini/lib/gusd/meshWrapper.cpp
+++ b/third_party/houdini/lib/gusd/meshWrapper.cpp
@@ -388,22 +388,6 @@ GusdMeshWrapper::refine(
                       &gtPointAttrs,
                       &gtUniformAttrs,
                       &gtDetailAttrs );
-
-        if( gtVertexAttrs->entries() > 0 ) {
-            if( reverseWindingOrder ) {
-                // Construct an index array which will be used to lookup vertex 
-                // attributes in the correct order.
-                GT_Int32Array* vertexIndirect
-                    = new GT_Int32Array(gtIndicesHandle->entries(), 1);
-                GT_DataArrayHandle vertexIndirectHandle(vertexIndirect);
-                for(int i=0; i<gtIndicesHandle->entries(); ++i) {
-                    vertexIndirect->set(i, i);     
-                }
-                _reverseWindingOrder(vertexIndirect, gtVertexCounts );
-
-                gtVertexAttrs = gtVertexAttrs->createIndirect(vertexIndirect);
-            }
-        }
     }
 
     else {
@@ -464,6 +448,22 @@ GusdMeshWrapper::refine(
                     &gtDetailAttrs );
             }
         }
+    }
+
+    if( gtVertexAttrs->entries() > 0 ) {
+	if( reverseWindingOrder ) {
+	    // Construct an index array which will be used to lookup vertex
+	    // attributes in the correct order.
+	    GT_Int32Array* vertexIndirect
+		= new GT_Int32Array(gtIndicesHandle->entries(), 1);
+	    GT_DataArrayHandle vertexIndirectHandle(vertexIndirect);
+	    for(int i=0; i<gtIndicesHandle->entries(); ++i) {
+		vertexIndirect->set(i, i);
+	    }
+	    _reverseWindingOrder(vertexIndirect, gtVertexCounts );
+
+	    gtVertexAttrs = gtVertexAttrs->createIndirect(vertexIndirect);
+	}
     }
 
     // build GT_Primitive


### PR DESCRIPTION
When refining a USD mesh packed primitive, if we have vertex attributes
and we had to reveress the winding order (i.e. the USD primitive's
orientation attribute is "rightHanded"), we need to reorganize the
vertex attribute data whether we are refining for the viewport or not.