### PR TITLE
Better error reporting if the user picks an unsupported renderer in usdview

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1222,6 +1222,16 @@ class AppController(QtCore.QObject):
                     if action.text() == self._stageView.rendererPluginName:
                         action.setChecked(True)
                         break
+                # Then display an error message to let the user know something
+                # went wrong, and disable the menu item so it can't be selected
+                # again.
+                for action in self._ui.rendererPluginActionGroup.actions():
+                    if action.pluginType == plugin:
+                        self.statusMessage(
+                            'Renderer not supported: %s' % action.text())
+                        action.setText(action.text() + " (unsupported)")
+                        action.setDisabled(True)
+                        break
 
     def _configureRendererPlugins(self):
         if self._stageView:


### PR DESCRIPTION
If the user picks a Renderer in usdview, but USD fails to set this renderer
as current (because the runtime environment doesn't support it), display an
error status message, disable the Renderer in the menu, and put the suffix
"(unsupported)" on the menu item (in case the user missed the status
message).

This is a partial replacement for PR #599.