### PR TITLE
Fix python wrappers to be explicit for RTLD_GLOBAL environments.

### DIFF
--- a/pxr/base/lib/plug/module.cpp
+++ b/pxr/base/lib/plug/module.cpp
@@ -29,9 +29,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 TF_WRAP_MODULE
 {
-    TF_WRAP( Notice );
-    TF_WRAP( Plugin );    
-    TF_WRAP( Registry );    
+    TF_WRAP( PlugNotice );
+    TF_WRAP( PlugPlugin );    
+    TF_WRAP( PlugRegistry );    
 
     TF_WRAP( _TestPlugBase );    
 }

--- a/pxr/base/lib/plug/wrapNotice.cpp
+++ b/pxr/base/lib/plug/wrapNotice.cpp
@@ -42,7 +42,7 @@ TF_INSTANTIATE_NOTICE_WRAPPER(PlugNotice::DidRegisterPlugins, PlugNotice::Base);
 } // anonymous namespace 
 
 void
-wrapNotice()
+wrapPlugNotice()
 {
     scope noticeScope = class_<PlugNotice>("Notice", no_init);
 

--- a/pxr/base/lib/plug/wrapPlugin.cpp
+++ b/pxr/base/lib/plug/wrapPlugin.cpp
@@ -68,7 +68,7 @@ _GetMetadataForType(PlugPluginPtr plugin, const TfType &type)
 
 } // anonymous namespace 
 
-void wrapPlugin()
+void wrapPlugPlugin()
 {
     typedef PlugPlugin This;
     typedef PlugPluginPtr ThisPtr;

--- a/pxr/base/lib/plug/wrapRegistry.cpp
+++ b/pxr/base/lib/plug/wrapRegistry.cpp
@@ -196,7 +196,7 @@ void _LoadPluginsConcurrently(PluginPredicateFn pred,
 
 } // anonymous namespace 
 
-void wrapRegistry()
+void wrapPlugRegistry()
 {
 
     typedef PlugRegistry This;

--- a/pxr/base/lib/tf/module.cpp
+++ b/pxr/base/lib/tf/module.cpp
@@ -33,14 +33,14 @@ TF_WRAP_MODULE {
     TF_WRAP( Debug );
     TF_WRAP( Enum );
     // Diagnostic depends on Enum so must come after it.
-    TF_WRAP( Diagnostic );
+    TF_WRAP( TfDiagnostic );
     TF_WRAP( DiagnosticBase );
     TF_WRAP( EnvSetting );
     TF_WRAP( Error );
     TF_WRAP( FileUtils );
     TF_WRAP( Function );
     TF_WRAP( MallocTag );
-    TF_WRAP( Notice );
+    TF_WRAP( TfNotice );
     TF_WRAP( PathUtils );
     TF_WRAP( PyContainerConversions );
     TF_WRAP( PyModuleNotice );

--- a/pxr/base/lib/tf/wrapDiagnostic.cpp
+++ b/pxr/base/lib/tf/wrapDiagnostic.cpp
@@ -49,7 +49,7 @@ void wrapped_TF_DIAGNOSTIC_WARNING(const string& msg)
 
 } // anonymous namespace 
 
-void wrapDiagnostic()
+void wrapTfDiagnostic()
 {
     TfPyWrapEnum<TfDiagnosticType>();
 

--- a/pxr/base/lib/tf/wrapNotice.cpp
+++ b/pxr/base/lib/tf/wrapNotice.cpp
@@ -215,7 +215,7 @@ class Tf_PyNoticeInternal
 
 } // anonymous namespace 
 
-void wrapNotice()
+void wrapTfNotice()
 {
     // Make sure we can pass callbacks from python.
     TfPyFunctionFromPython<Tf_PyNoticeInternal::Listener::CallbackSig>();

--- a/pxr/imaging/lib/glf/module.cpp
+++ b/pxr/imaging/lib/glf/module.cpp
@@ -28,7 +28,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 TF_WRAP_MODULE
 {
-    TF_WRAP( Diagnostic );
+    TF_WRAP( GlfDiagnostic );
     TF_WRAP( DrawTarget );
     TF_WRAP( Texture );
     TF_WRAP( TextureRegistry );

--- a/pxr/imaging/lib/glf/wrapDiagnostic.cpp
+++ b/pxr/imaging/lib/glf/wrapDiagnostic.cpp
@@ -30,7 +30,7 @@ using namespace boost::python;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-void wrapDiagnostic()
+void wrapGlfDiagnostic()
 {    
     def("RegisterDefaultDebugOutputMessageCallback",
         &GlfRegisterDefaultDebugOutputMessageCallback);

--- a/pxr/usd/lib/ndr/module.cpp
+++ b/pxr/usd/lib/ndr/module.cpp
@@ -33,8 +33,8 @@ TF_WRAP_MODULE
     TF_WRAP( DiscoveryPlugin );
     TF_WRAP( FilesystemDiscovery );
     TF_WRAP( FilesystemDiscoveryHelpers );
-    TF_WRAP( Node );
+    TF_WRAP( NdrNode );
     TF_WRAP( NodeDiscoveryResult );
     TF_WRAP( Property );
-    TF_WRAP( Registry );
+    TF_WRAP( NdrRegistry );
 }

--- a/pxr/usd/lib/ndr/wrapNode.cpp
+++ b/pxr/usd/lib/ndr/wrapNode.cpp
@@ -35,7 +35,7 @@ using namespace boost::python;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-void wrapNode()
+void wrapNdrNode()
 {
     typedef NdrNode This;
     typedef NdrNodePtr ThisPtr;

--- a/pxr/usd/lib/ndr/wrapRegistry.cpp
+++ b/pxr/usd/lib/ndr/wrapRegistry.cpp
@@ -54,7 +54,7 @@ struct ConstNodePtrToPython {
     } 
 };
 
-void wrapRegistry()
+void wrapNdrRegistry()
 {
     typedef NdrRegistry This;
     typedef TfWeakPtr<NdrRegistry> ThisPtr;

--- a/pxr/usd/lib/pcp/module.cpp
+++ b/pxr/usd/lib/pcp/module.cpp
@@ -38,12 +38,12 @@ TF_WRAP_MODULE
     TF_WRAP( LayerStack );
     TF_WRAP( MapExpression );
     TF_WRAP( MapFunction );
-    TF_WRAP( Node );
+    TF_WRAP( PcpNode );
     TF_WRAP( PathTranslation );
     TF_WRAP( PrimIndex );
     TF_WRAP( PropertyIndex );
     TF_WRAP( PayloadContext );
     TF_WRAP( Site );
     TF_WRAP( TestChangeProcessor );
-    TF_WRAP( Types );
+    TF_WRAP( PcpTypes );
 }

--- a/pxr/usd/lib/pcp/wrapNode.cpp
+++ b/pxr/usd/lib/pcp/wrapNode.cpp
@@ -58,7 +58,7 @@ _GetChildren(const PcpNodeRef& node)
 } // anonymous namespace 
 
 void
-wrapNode()
+wrapPcpNode()
 {
     typedef PcpNodeRef This;
 

--- a/pxr/usd/lib/pcp/wrapTypes.cpp
+++ b/pxr/usd/lib/pcp/wrapTypes.cpp
@@ -29,7 +29,7 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 void
-wrapTypes()
+wrapPcpTypes()
 {
     TfPyWrapEnum<PcpArcType>();
 }

--- a/pxr/usd/lib/sdf/module.cpp
+++ b/pxr/usd/lib/sdf/module.cpp
@@ -40,11 +40,11 @@ TF_WRAP_MODULE
     TF_WRAP( LayerOffset );
     TF_WRAP( LayerTree );
     TF_WRAP( NamespaceEdit );
-    TF_WRAP( Notice );
+    TF_WRAP( SdfNotice );
     TF_WRAP( Path );
     TF_WRAP( Payload );
     TF_WRAP( Reference );
-    TF_WRAP( Types );
+    TF_WRAP( SdfTypes );
     TF_WRAP( ValueType );
 
     TF_WRAP( Spec );

--- a/pxr/usd/lib/sdf/wrapTypes.cpp
+++ b/pxr/usd/lib/sdf/wrapTypes.cpp
@@ -305,7 +305,7 @@ _FindType(const std::string& typeName)
 
 } // anonymous namespace 
 
-void wrapTypes()
+void wrapSdfTypes()
 {
     TF_PY_WRAP_PUBLIC_TOKENS("ValueRoleNames",
                              SdfValueRoleNames, SDF_VALUE_ROLE_NAME_TOKENS);

--- a/pxr/usd/lib/sdr/module.cpp
+++ b/pxr/usd/lib/sdr/module.cpp
@@ -31,5 +31,5 @@ TF_WRAP_MODULE
 {
     TF_WRAP( ShaderProperty );
     TF_WRAP( ShaderNode );
-    TF_WRAP( Registry );
+    TF_WRAP( SdrRegistry );
 }

--- a/pxr/usd/lib/sdr/wrapRegistry.cpp
+++ b/pxr/usd/lib/sdr/wrapRegistry.cpp
@@ -38,7 +38,7 @@ using namespace boost::python;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-void wrapRegistry()
+void wrapSdrRegistry()
 {
     typedef SdrRegistry This;
     typedef TfWeakPtr<SdrRegistry> ThisPtr;

--- a/pxr/usd/lib/usdUtils/module.cpp
+++ b/pxr/usd/lib/usdUtils/module.cpp
@@ -36,7 +36,7 @@ TF_WRAP_MODULE
     TF_WRAP( Pipeline );
     TF_WRAP( RegisteredVariantSet );
     TF_WRAP( SparseValueWriter );
-    TF_WRAP( StageCache );
+    TF_WRAP( UsdUtilsStageCache );
     TF_WRAP( Stitch );
     TF_WRAP( StitchClips );
 }

--- a/pxr/usd/lib/usdUtils/wrapStageCache.cpp
+++ b/pxr/usd/lib/usdUtils/wrapStageCache.cpp
@@ -35,7 +35,7 @@ using namespace boost;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-void wrapStageCache()
+void wrapUsdUtilsStageCache()
 {
     class_<UsdUtilsStageCache>("StageCache")
 

--- a/third_party/maya/lib/usdMaya/module.cpp
+++ b/third_party/maya/lib/usdMaya/module.cpp
@@ -36,7 +36,7 @@ TF_WRAP_MODULE {
     TF_WRAP(Query);
     TF_WRAP(ReadUtil);
     TF_WRAP(RoundTripUtil);
-    TF_WRAP(StageCache);
+    TF_WRAP(UsdMayaStageCache);
     TF_WRAP(UserTaggedAttribute);
     TF_WRAP(WriteUtil);
     TF_WRAP(XformStack);

--- a/third_party/maya/lib/usdMaya/wrapStageCache.cpp
+++ b/third_party/maya/lib/usdMaya/wrapStageCache.cpp
@@ -36,7 +36,7 @@ using namespace boost;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-void wrapStageCache()
+void wrapUsdMayaStageCache()
 {
     class_<UsdMayaStageCache>("StageCache")
 


### PR DESCRIPTION
I recently ran into some problems with the Python bindings to USD. Our Python configuration uses RTLD_GLOBAL for legacy reasons.

The problem with this is that multiple USD projects contain functions with the same name. For example, there are multiple "wrapRegistry()" and "wrapNode()" functions defined in various places. We were seeing problems where, for example, ndr's module wrap function ended up calling sdr's wrapRegistry() instead of ndr's, and ndr's wrapRegistry() was never called. This led to various runtime errors.  Our workaround was to rename wrapRegistry() in sdr as "wrapSdrRegistry()", for example, and use TF_WRAP(SdrRegistry) in the module wrapper. We made a handful of changes like this to make all the wrap calls explicit.


### Description of Change(s)

This change makes all python wrappers uniquely named.

### Fixes Issue(s)
-

