### PR TITLE
[Vt] Add iterator construction for arrays.

### DIFF
--- a/pxr/base/lib/vt/array.h
+++ b/pxr/base/lib/vt/array.h
@@ -242,6 +242,18 @@ class VtArray : public Vt_ArrayBase {
     /// Create an empty array.
     VtArray() : _data(nullptr) {}
 
+    /// Create an array from a pair of iterators
+    ///
+    /// Equivalent to:
+    /// \code
+    /// VtArray<T> v;
+    /// v.assign(first, last);
+    /// \endcode
+    template <typename ForwardIterator>
+    VtArray(ForwardIterator first, ForwardIterator last) : VtArray() {
+        assign(first, last); 
+    }
+
     /// Create an array with foreign source.
     VtArray(Vt_ArrayForeignDataSource *foreignSrc,
             ElementType *data, size_t size, bool addRef = true)

--- a/pxr/base/lib/vt/array.h
+++ b/pxr/base/lib/vt/array.h
@@ -249,8 +249,15 @@ class VtArray : public Vt_ArrayBase {
     /// VtArray<T> v;
     /// v.assign(first, last);
     /// \endcode
-    template <typename ForwardIterator>
-    VtArray(ForwardIterator first, ForwardIterator last) : VtArray() {
+    ///
+    /// Note we use enable_if with a dummy parameter here to avoid clashing
+    /// with our other constructor with the following signature:
+    ///
+    /// VtArray(size_t n, value_type const &value = value_type())
+    template <typename LegacyInputIterator>
+    VtArray(LegacyInputIterator first, LegacyInputIterator last,
+            typename std::enable_if<!std::is_same<size_t, LegacyInputIterator>::value, void>::type* = nullptr) 
+        : VtArray() {
         assign(first, last); 
     }
 

--- a/pxr/base/lib/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/lib/vt/testenv/testVtCpp.cpp
@@ -138,6 +138,21 @@ static void testArray() {
     }
 
     {
+        // Construct from iterators
+        std::vector<int> v = {0,1,2,3,4,5};
+        VtIntArray v2 { v.begin(), v.end() };
+        VtIntArray v3 { v.data(), v.data()+v.size() }; 
+        
+        TF_AXIOM(v2.size() == v.size());
+        TF_AXIOM(v3.size() == v.size());
+
+        for (auto i = 0; i < v.size(); ++i) {
+            TF_AXIOM(v2[i] == i);
+            TF_AXIOM(v3[i] == i);
+        }
+    }
+
+    {
         // Array push_back and resize.
         VtDoubleArray array(0);
 


### PR DESCRIPTION
Discussed this one offline with @gitamohr , seems like a nice addition. Its useful
for us when constructing VtArrays from foreign data sources (Maya APIs, etc) which
return `T*`s or `vector<T>`s.

### Description of Change(s)
VtArray mimics much of std::vector's interface. This adds
iterator construction, which had been previously omitted.
In the past, VtArray supported dimensions, which made such
construction unwieldy; it is now a flat container, making
this a viable option.


### Fixes Issue(s)
- None filed

