### PR TITLE
[Tf] Suppress clang warning.

### DIFF
--- a/pxr/base/lib/arch/pragmas.h
+++ b/pxr/base/lib/arch/pragmas.h
@@ -51,6 +51,9 @@
     #define ARCH_PRAGMA_MACRO_REDEFINITION \
         _Pragma("GCC diagnostic ignored \"-Wbuiltin-macro-redefined\"")
 
+    // GCC Has no undefined-var-template warning
+    #define ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE
+
     #define ARCH_PRAGMA_WRITE_STRINGS \
         _Pragma("GCC diagnostic ignored \"-Wwrite-strings\"")
 
@@ -64,6 +67,9 @@
 
     #define ARCH_PRAGMA_MACRO_REDEFINITION \
         _Pragma("clang diagnostic ignored \"-Wbuiltin-macro-redefined\"")
+
+    #define ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE \
+        _Pragma("clang diagnostic ignored \"-Wundefined-var-template\"")
 
     #define ARCH_PRAGMA_WRITE_STRINGS \
         _Pragma("clang diagnostic ignored \"-Wwrite-strings\"")
@@ -84,6 +90,9 @@
 
     #define ARCH_PRAGMA_MACRO_REDEFINITION \
         __pragma(warning(disable:4005)) 
+
+    // MSVC has no undefined-var-template warning.
+    #define ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE
 
     #define ARCH_PRAGMA_QUALIFIER_HAS_NO_MEANING \
         __pragma(warning(disable:4180)) 

--- a/pxr/base/lib/tf/singleton.h
+++ b/pxr/base/lib/tf/singleton.h
@@ -135,7 +135,12 @@ public:
     /// (for example, letting only one thread at a time call a member
     /// function) are the responsibility of the class author.
     inline static T& GetInstance() {
+        ARCH_PRAGMA_PUSH
+        // Suppress warnings from clang. TfSingletons are explicitly
+        // instantiated, so the warning around this usage is a false positive.
+        ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE
         return ARCH_LIKELY(_instance) ? *_instance : _CreateInstance();
+        ARCH_PRAGMA_POP
     }
 
     /// Return whether or not the single object of type \c T is currently in


### PR DESCRIPTION
### Description of Change(s)
This addresses the issue referenced in #379(which I propose we close in favor of this PR). 

An example manifestation of this warning is as follows:
```
pxr/base/lib/tf/singleton.h:138:28: note: add an explicit instantiation declaration to suppress this warning if 'pxrInternal_v0_18__pxrReserved__::TfSingleton<pxrInternal_v0_18__pxrReserved__::SdfSchema>::_instance' is explicitly instantiated in another translation unit
        return ARCH_LIKELY(_instance) ? *_instance : _CreateInstance();
```

This warning is described in the LLVM bug tracker here: https://reviews.llvm.org/D16396

In our case, afaict, this warning is a false positive, as Tf's singletons are explicitly instantiated in the proper translation unit and won't cause an issue. Rather than suppressing the warning wholesale, this puts a targeted suppression around the code that generates it.

