### PR TITLE
Remove Some Boost Usage

### DIFF
--- a/pxr/base/lib/tf/makePyConstructor.h
+++ b/pxr/base/lib/tf/makePyConstructor.h
@@ -47,8 +47,6 @@
 
 #include "pxr/base/arch/demangle.h"
 
-#include <boost/mpl/assert.hpp>
-#include <boost/mpl/if.hpp>
 #include <boost/preprocessor/iterate.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/repetition/enum.hpp>
@@ -206,9 +204,8 @@ struct InstallPolicy {
 // Specialize install policy for refptrs.
 template <typename T>
 struct InstallPolicy<TfRefPtr<T> > {
-    BOOST_MPL_ASSERT_MSG(Tf_SupportsUniqueChanged<T>::Value,
-                         Type_must_support_refcount_unique_changed_notification,
-                         (types<T>));
+    static_assert(Tf_SupportsUniqueChanged<T>::Value,
+                  "Type T must support refcount unique changed notification.");
     static void PostInstall(object const &self, TfRefPtr<T> const &ptr,
                             const void *uniqueId) {
         // Stash a self-reference ref ptr into the python object that will

--- a/pxr/usd/lib/usd/object.h
+++ b/pxr/usd/lib/usd/object.h
@@ -34,8 +34,6 @@
 #include "pxr/usd/sdf/abstractData.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/mpl/assert.hpp>
-
 #include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -68,8 +66,8 @@ namespace _Detail {
 template <UsdObjType Type>
 struct Const { static const UsdObjType Value = Type; };
 template <class T> struct GetObjType {
-    BOOST_MPL_ASSERT_MSG(false,
-                         Type_must_be_UsdObject_subclass, (T));
+    static_assert(std::is_base_of<UsdObject, T>::value,
+                  "Type T must be a subclass of UsdObject.");
 };
 template <> struct GetObjType<UsdObject> : Const<UsdTypeObject> {};
 template <> struct GetObjType<UsdPrim> : Const<UsdTypePrim> {};
@@ -247,9 +245,8 @@ public:
     /// \endcode
     template <class T>
     bool Is() const {
-        BOOST_MPL_ASSERT_MSG((std::is_base_of<UsdObject, T>::value),
-                             Provided_type_must_derive_or_be_UsdObject,
-                             (T));
+        static_assert(std::is_base_of<UsdObject, T>::value,
+                      "Provided type T must derive from or be UsdObject");
         return UsdIsConvertible(_type, _Detail::GetObjType<T>::Value);
     }
 

--- a/third_party/houdini/plugin/OP_gusd/OBJ_usdcamera.cpp
+++ b/third_party/houdini/plugin/OP_gusd/OBJ_usdcamera.cpp
@@ -40,6 +40,7 @@
 #include "gusd/UT_Assert.h"
 #include "gusd/UT_Gf.h"
 
+#include "pxr/base/arch/hints.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usdGeom/camera.h"
 #include "pxr/usd/usdGeom/xform.h"
@@ -428,7 +429,7 @@ GusdOBJ_usdcamera::evalVariableValue(fpreal& val, int idx, int thread)
        variable, which requires evaluation of the frame parm...and we're
        stuck in a loop.*/
     _VarEvalStack*& stack = _varEvalStack.getValueForThread(thread);
-    if(BOOST_UNLIKELY(!stack)) stack = new _VarEvalStack;
+    if(ARCH_UNLIKELY(!stack)) stack = new _VarEvalStack;
     
     if(stack->Last() != idx) {
         stack->Push(idx);

--- a/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.cpp
+++ b/third_party/houdini/plugin/OP_gusd/ROP_usdoutput.cpp
@@ -82,8 +82,6 @@
 #include "gusd/context.h"
 #include "gusd/xformWrapper.h"
 
-#include "boost/foreach.hpp"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;
@@ -1369,8 +1367,7 @@ setKind( const string &path, UsdStagePtr stage )
     if( model && !model.GetKind( &kind )) {
 
         bool hasModelChildren = false;
-        BOOST_FOREACH( UsdPrim child, p.GetChildren()) {
-
+        for( const auto& child : p.GetChildren() ) {
             TfToken childKind;
             UsdModelAPI( child ).GetKind( &childKind );
             if( KindRegistry::IsA( childKind, KindTokens->model )) {


### PR DESCRIPTION
### Description of Change(s)
This cleans out usage of boost macros in USD. It hasn't tackled the preprocessor macros yet, as thats a big problem that will require quite a bit of work.

### Fixes Issue(s)
- None filed.

