### PR TITLE
[usdHoudini] Changing GusdUSD_Utils::ImageablePrimIsVisible to use ComputeVisibility

### DIFF
--- a/third_party/houdini/lib/gusd/USD_Utils.h
+++ b/third_party/houdini/lib/gusd/USD_Utils.h
@@ -270,9 +270,7 @@ GetNumericTime(UsdTimeCode time)
 inline bool
 ImageablePrimIsVisible(const UsdGeomImageable& prim, UsdTimeCode time)
 {
-    TfToken vis;
-    prim.GetVisibilityAttr().Get(&vis, time);
-    return vis == UsdGeomTokens->inherited;
+    return prim.ComputeVisibility(time) == UsdGeomTokens->inherited;
 }
 
 


### PR DESCRIPTION
Changing GusdUSD_Utils::ImageablePrimIsVisible to use ComputeVisibility
to test if the prim is visible by looking at ancestor primitives, rather
than only looking at the visibility attribute of the prim itself.
Fixes Issue #649.