### PR TITLE
Fixed typo in package resolver docs

### DIFF
--- a/pxr/usd/lib/ar/packageResolver.h
+++ b/pxr/usd/lib/ar/packageResolver.h
@@ -65,7 +65,7 @@ class VtValue;
 ///   #AR_DEFINE_PACKAGE_RESOLVER
 /// \code{.cpp}
 /// # custom resolver's .cpp file
-/// AR_DEFINE_RESOLVER(CustomResolver, ArResolver);
+/// AR_DEFINE_PACKAGE_RESOLVER(CustomPackageResolver, ArPackageResolver);
 /// \endcode
 ///
 /// - Declare the ArPackageResolver subclass in the plugin's plugInfo.json file.


### PR DESCRIPTION
### Description of Change(s)
Register as a ArPackageResolver, not as a ArResolver

### Fixes Issue(s)
Typo in docs