### PR TITLE
Add ability to register selection callbacks in usdview

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/usdviewApi.py
+++ b/pxr/usdImaging/lib/usdviewq/usdviewApi.py
@@ -191,6 +191,12 @@ class UsdviewApi(object):
         """DEPRECATED Returns the old settings object."""
 
         return self.__appController._settings
+    
+    def AddPrimSelectionChangedCallback(self, callback):
+        self.__appController._dataModel.selection.signalPrimSelectionChanged.connect(callback)
+
+    def RemovePrimSelectionChangedCallback(self, callback):
+        self.__appController._dataModel.selection.signalPrimSelectionChanged.disconnect(callback)
 
     def ClearPrimSelection(self):
         self.__appController._dataModel.selection.clearPrims()


### PR DESCRIPTION
### Description of Change(s)
The UsdviewApi class now includes two new methods: `AddPrimSelectionChangedCallback()` and `RemovePrimSelectionChangedCallback()`. These methods allow third-party plugins to connect Qt slots with the `signalPrimSelectionChanged` Qt signal that is emitted by the internal `SelectionDataModel` object.
This allows plugin views to synchronise themselves as the application selection changes.