### PR TITLE
Update JealousFocus() method to handle window modality flag

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appEventFilter.py
+++ b/pxr/usdImaging/lib/usdviewq/appEventFilter.py
@@ -93,7 +93,9 @@ class AppEventFilter(QtCore.QObject):
                 isinstance(w, QtWidgets.QComboBox) or
                 isinstance(w, QtWidgets.QTextEdit) or
                 isinstance(w, QtWidgets.QAbstractSlider) or
-                isinstance(w, QtWidgets.QAbstractSpinBox))
+                isinstance(w, QtWidgets.QAbstractSpinBox) or
+                isinstance(w, QtWidgets.QWidget) and w.windowModality() in [QtCore.Qt.WindowModal,
+                                                                            QtCore.Qt.ApplicationModal])
             
     def SetFocusFromMousePos(self, backupWidget):
         # It's possible the mouse isn't over any of our windows at the time,


### PR DESCRIPTION
### Description of Change(s)
The **AppEventFilter.JealousFocus()** focus method has been updated to also consider the **windowModality()** setting on the widget. The role of this method is to return a flag that indicates whether the widget of interest jealously maintains its input focus. If this method returns True then the auto-focus system (which usually auto-focuses the widget under the cursor as the user moves the mouse around the screen) is _not_ applied. The previous implementation only considered the widget type. However, when plugin views are implemented via PyQt (rather than PySide), all widgets in the plugin view are wrapped in a manner that they are only considered to be instances of QWidget, and deeper instance type information is lost. 
Testing the intended modality of a given widget via the **windowModality** flag is a useful way to communicate the intended focus behaviour of third-party plugin views. 