### PR TITLE
[Houdini] Test for a CH_Manager before calling CH_Manager functions.

### DIFF
--- a/third_party/houdini/lib/gusd/GEO_IOTranslator.cpp
+++ b/third_party/houdini/lib/gusd/GEO_IOTranslator.cpp
@@ -100,7 +100,10 @@ fileLoad(GEO_Detail* gdp, UT_IStream& is, bool ate_magic)
         return GA_Detail::IOStatus( false );
     }
 
-    float f = CHgetSampleFromTime( CHgetEvalTime() );
+    float f = 1.0;
+
+    if (CH_Manager::getContextExists())
+	CHgetSampleFromTime( CHgetEvalTime() );
 
     GU_Detail* detail = dynamic_cast<GU_Detail *>(gdp); 
     if( !detail ) {


### PR DESCRIPTION
This fixes a crash when running ginfo on a USD file. ginfo does not create
any node/channel infrastructure, so trying to call global CH_Manager methods
leads to a crash.

If no CH_Manager exists, use a default of "1" for the sample time.

This fixes Issue #673