### PR TITLE
Remove dependency on boost filesystem

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -45,10 +45,8 @@ if(PXR_ENABLE_PYTHON_SUPPORT)
     # --Boost
     find_package(Boost
         COMPONENTS
-            filesystem
             program_options
             python
-            system
         REQUIRED
     )
 
@@ -60,11 +58,14 @@ else()
     # --Boost
     find_package(Boost
         COMPONENTS
-            filesystem
             program_options
-            system
         REQUIRED
     )
+endif()
+
+if(WIN32)
+    # On Windows, boost automagic library linking via pragma lib is problematic, so suppress it
+    add_definitions(-DBOOST_ALL_NO_LIB)
 endif()
 
 # --TBB

--- a/cmake/macros/copyHeaderForBuild.py
+++ b/cmake/macros/copyHeaderForBuild.py
@@ -31,7 +31,7 @@
 import os, sys
 
 if len(sys.argv) != 3:
-    print "Usage: {0} src dst".format(sys.argv[0])
+    print ("Usage: {0} src dst".format(sys.argv[0]))
     sys.exit(1)
 
 srcFile = sys.argv[1]

--- a/pxr/base/lib/arch/fileSystem.h
+++ b/pxr/base/lib/arch/fileSystem.h
@@ -179,6 +179,8 @@ ArchOpenFile(char const* fileName, char const* mode);
 #   define ArchRmDir(path)   rmdir(path)
 #endif
 
+ARCH_API bool ArchMkDir(const char* path);
+
 /// Return the length of a file in bytes.
 ///
 /// Returns -1 if the file cannot be opened/read.

--- a/pxr/base/lib/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/lib/arch/testenv/testFileSystem.cpp
@@ -145,8 +145,33 @@ int main()
     // create and remove a tmp subdir
     std::string retpath;
     retpath = ArchMakeTmpSubdir(ArchGetTmpDir(), "myprefix");
-    ARCH_AXIOM (retpath != "");
+    ARCH_AXIOM(retpath != "");
     ArchRmDir(retpath.c_str());
+
+    // create a temp subdir again
+    retpath = ArchMakeTmpSubdir(ArchGetTmpDir(), "myprefix");
+    ARCH_AXIOM(retpath != "");
+
+    // ensure that MkDir on an existing directory returns true
+    ARCH_AXIOM(ArchMkDir(retpath.c_str()));
+
+    // make a nested subdir
+    std::string nestedpath = retpath + "/sub/dir/test";
+    ARCH_AXIOM(ArchMkDir(nestedpath.c_str()));
+
+    // create a file in that directory
+    std::string filename = nestedpath + "/dummy.test";
+    ARCH_AXIOM((firstFile = ArchOpenFile(filename.c_str(), "wb")) != NULL);
+    fputs(testContent, firstFile);
+    fclose(firstFile);
+
+    // ensure mkdir returns false if trying to create a directory where it can't
+    ARCH_AXIOM(!ArchMkDir(filename.c_str()));
+
+    // remove 
+    ArchRmDir(nestedpath.c_str());
+
+    printf("YAY\n");
 
     // Test other utilities
     TestArchNormPath();

--- a/pxr/imaging/lib/garch/CMakeLists.txt
+++ b/pxr/imaging/lib/garch/CMakeLists.txt
@@ -26,7 +26,6 @@ pxr_library(garch
     LIBRARIES
         arch
         tf
-        ${Boost_SYSTEM_LIBRARY}
         ${OPENGL_gl_LIBRARY}
         ${APPKIT_LIBRARY}
 

--- a/pxr/imaging/lib/glf/CMakeLists.txt
+++ b/pxr/imaging/lib/glf/CMakeLists.txt
@@ -42,7 +42,6 @@ pxr_library(glf
         trace
         sdf
         ${Boost_PYTHON_LIBRARY}
-        ${Boost_SYSTEM_LIBRARY}
         ${OPENGL_gl_LIBRARY}
         ${OPENGL_glu_LIBRARY}
         ${GLEW_LIBRARY}

--- a/third_party/houdini/lib/gusd/CMakeLists.txt
+++ b/third_party/houdini/lib/gusd/CMakeLists.txt
@@ -34,8 +34,6 @@ pxr_shared_library(${PXR_PACKAGE}
         usdRi
         usdShade
         usdUtils
-        ${Boost_FILESYSTEM_LIBRARY}
-        ${Boost_SYSTEM_LIBRARY}
         ${HOUDINI_LIB_NAMES}
 
     INCLUDE_DIRS

--- a/third_party/houdini/lib/gusd/shaderWrapper.cpp
+++ b/third_party/houdini/lib/gusd/shaderWrapper.cpp
@@ -28,6 +28,7 @@
 #include <pxr/usd/usdShade/connectableAPI.h>
 
 #include <pxr/usd/usdRi/materialAPI.h>
+#include <pxr/base/arch/filesystem.h>
 
 #include <DEP/DEP_MicroNode.h>
 #include <PRM/PRM_ParmList.h>
@@ -39,8 +40,6 @@
 #include <VOP/VOP_CodeGenerator.h>
 #include <UT/UT_Version.h>
 #include <UT/UT_EnvControl.h>
-
-#include <boost/filesystem.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -74,9 +73,7 @@ _buildCustomOslNode(const VOP_Node* vopNode,
     shaderName.prepend(shaderOutDir.c_str());
 
     // Create shaderOutDir path directories, if they don't exist.
-    try {
-        boost::filesystem::create_directories(shaderOutDir);
-    } catch (boost::filesystem::filesystem_error &e) {
+    if (!ArchMkDir(shaderOutDir.c_str()) {
         TF_CODING_ERROR("Failed to create dir '%s': %s", shaderOutDir.c_str(),
                         e.what());
         return false;

--- a/third_party/katana/lib/usdKatana/CMakeLists.txt
+++ b/third_party/katana/lib/usdKatana/CMakeLists.txt
@@ -22,7 +22,6 @@ pxr_shared_library(${PXR_PACKAGE}
         usdUtils
         cameraUtil
         katanaAttrfncApi
-        ${Boost_SYSTEM_LIBRARY} 
         ${Boost_THREAD_LIBRARY} 
 
     PUBLIC_CLASSES


### PR DESCRIPTION
### Description of Change(s)

This change introduces an implementation of MkDir to Arch that functions similarly to boost::filesystem's mkdir - it recursively builds a path as necessary. A small test is included to demonstrate functionality.

### Fixes Issue(s)

boost::filesystem is used only once, trivially, by the USD suite in the Houdini plug in to create a hierarchy of directories. It seems that retaining this boost dependency for such a simple function is unnecessary.

Linking against boost libraries in general poses continuing challenges especially in tracking compatibility between compiler and cmake versions. Removing this solitary dependency on boost::filesystem in favor of a function in Arch brings us one step closer to having only boost::python as a link dependency.


