### PR TITLE
Compile python modules with hidden default visibility

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -964,6 +964,8 @@ function(_pxr_python_module NAME)
         PROPERTIES
             PREFIX ""
             FOLDER "${folder}"
+            CXX_VISIBILITY_PRESET hidden
+            VISIBILITY_INLINES_HIDDEN ON
     )
     if(WIN32)
         # Python modules must be suffixed with .pyd on Windows.


### PR DESCRIPTION
This change should improve python module import times and make binaries smaller.

Stats for largest modules before and after:

```
           symbol count              size (stripped)
_gf.so    16561   724           9.6M (6.5M)     6.1M (3.0M)
_sdf.so   19906   1193          15M  (9.5M)     9.4M (4.2M)
_vt.so    25098   531           18M  (13M)      12M  (6.5M)
```
