### PR TITLE
[usdMaya] fix bogus name clash errors when stripping namespaces

### DIFF
--- a/third_party/maya/lib/usdMaya/CMakeLists.txt
+++ b/third_party/maya/lib/usdMaya/CMakeLists.txt
@@ -177,6 +177,7 @@ pxr_test_scripts(
         testenv/testUsdExportShadingModeDisplayColor.py
         testenv/testUsdExportShadingModePxrRis.py
         testenv/testUsdExportSkeleton.py
+        testenv/testUsdExportStripNamespaces.py
         testenv/testUsdExportUVSets.py
         testenv/testUsdImportAsAssemblies.py
         testenv/testUsdImportCamera.py
@@ -608,6 +609,17 @@ pxr_register_test(testUsdExportSkeleton
     CUSTOM_PYTHON "${MAYA_BASE_DIR}/bin/mayapy"
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdExportSkeleton"
     TESTENV testUsdExportSkeleton
+    ENV
+        MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
+        MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources
+        MAYA_DISABLE_CIP=1
+        MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile
+)
+
+pxr_register_test(testUsdExportStripNamespaces
+    CUSTOM_PYTHON "${MAYA_BASE_DIR}/bin/mayapy"
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdExportStripNamespaces"
+    TESTENV testUsdExportStripNamespaces
     ENV
         MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/plugin
         MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/third_party/maya/share/usd/plugins/usdMaya/resources

--- a/third_party/maya/lib/usdMaya/testenv/testUsdExportStripNamespaces.py
+++ b/third_party/maya/lib/usdMaya/testenv/testUsdExportStripNamespaces.py
@@ -1,0 +1,146 @@
+#!/pxrpythonsubst
+#
+# Copyright 2016 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Usd
+
+
+class testUsdExportStripNamespaces(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        standalone.initialize('usd')
+
+        cmds.loadPlugin('pxrUsd', quiet=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def testExportWithClashStripping(self):
+        mayaFilePath = os.path.abspath('UsdExportStripNamespaces.ma')
+        cmds.file(mayaFilePath, new=True, force=True)
+
+        node1 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube1" )
+        cmds.namespace(add="foo")
+        cmds.namespace(set="foo");
+        node2 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube1" )
+        cmds.namespace(set=":");
+
+        usdFilePath = os.path.abspath('UsdExportStripNamespaces_EXPORTED.usda')
+
+        errorRegexp = "Multiple dag nodes map to the same prim path" \
+            ".+|cube1 - |foo:cube1.*"
+        with self.assertRaisesRegexp(RuntimeError, errorRegexp) as cm:
+            cmds.usdExport(mergeTransformAndShape=True,
+                           selection=False,
+                           stripNamespaces=True,
+                           file=usdFilePath,
+                           shadingMode='none')
+
+        with self.assertRaisesRegexp(RuntimeError,errorRegexp) as cm:
+            cmds.usdExport(mergeTransformAndShape=False,
+                           selection=False,
+                           stripNamespaces=True,
+                           file=usdFilePath,
+                           shadingMode='none')
+
+    def testExportWithStripAndMerge(self):
+        mayaFilePath = os.path.abspath('UsdExportStripNamespaces.ma')
+        cmds.file(mayaFilePath, new=True, force=True)
+
+        cmds.namespace(add=":foo")
+        cmds.namespace(add=":bar")
+
+        node1 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube1" )
+        cmds.namespace(set=":foo");
+        node2 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube2" )
+        cmds.namespace(set=":bar");
+        node3 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube3" )
+        cmds.namespace(set=":");
+
+        usdFilePath = os.path.abspath('UsdExportStripNamespaces_EXPORTED.usda')
+
+        cmds.usdExport(mergeTransformAndShape=True,
+                       selection=False,
+                       stripNamespaces=True,
+                       file=usdFilePath,
+                       shadingMode='none')
+
+        stage = Usd.Stage.Open(usdFilePath)
+        self.assertTrue(stage)
+
+        expectedPrims = ("/cube1", "/cube2", "/cube3")
+
+        for primPath in expectedPrims:
+            prim = stage.GetPrimAtPath(primPath)
+            self.assertTrue(prim.IsValid(), "Expect " + primPath)
+
+    def testExportWithStrip(self):
+        mayaFilePath = os.path.abspath('UsdExportStripNamespaces.ma')
+        cmds.file(mayaFilePath, new=True, force=True)
+
+        cmds.namespace(add=":foo")
+        cmds.namespace(add=":bar")
+
+        node1 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube1" )
+        cmds.namespace(set=":foo");
+        node2 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube2" )
+        cmds.namespace(set=":bar");
+        node3 = cmds.polyCube( sx=5, sy=5, sz=5, name="cube3" )
+        cmds.namespace(set=":");
+
+        usdFilePath = os.path.abspath('UsdExportStripNamespaces_EXPORTED.usda')
+
+        cmds.usdExport(mergeTransformAndShape=False,
+                       selection=False,
+                       stripNamespaces=True,
+                       file=usdFilePath,
+                       shadingMode='none')
+
+        stage = Usd.Stage.Open(usdFilePath)
+        self.assertTrue(stage)
+
+        expectedPrims = (
+            "/cube1",
+            "/cube1/cube1Shape",
+            "/cube2",
+            "/cube2/cube2Shape",
+            "/cube3",
+            "/cube3/cube3Shape"
+        )
+
+        for primPath in expectedPrims:
+            prim = stage.GetPrimAtPath(primPath)
+            self.assertTrue(prim.IsValid(), "Expect " + primPath)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/third_party/maya/lib/usdMaya/writeJob.cpp
+++ b/third_party/maya/lib/usdMaya/writeJob.cpp
@@ -385,23 +385,10 @@ UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
 
                 // Write out data (non-animated/default values).
                 if (const auto& usdPrim = primWriter->GetUsdPrim()) {
-                    if (mJobCtx.mArgs.stripNamespaces) {
-                        auto foundPair = mUsdPathToDagPathMap.find(usdPrim.GetPath());
-                        if (foundPair != mUsdPathToDagPathMap.end()){
-                            TF_RUNTIME_ERROR(
-                                    "Multiple dag nodes map to the same prim "
-                                    "path after stripping namespaces: %s - %s",
-                                    foundPair->second.fullPathName().asChar(),
-                                    primWriter->GetDagPath().fullPathName()
-                                        .asChar());
-                            return false;
-                        }
-                        // Note that mUsdPathToDagPathMap is _only_ used for
-                        // stripping namespaces, so we only need to populate it
-                        // when stripping namespaces. (This is different from
-                        // mDagPathToUsdPathMap!)
-                        mUsdPathToDagPathMap[usdPrim.GetPath()] =
-                                primWriter->GetDagPath();
+                    if (!_CheckNameClashes(
+                            usdPrim.GetPath(), primWriter->GetDagPath()))
+                    {
+                        return false;
                     }
 
                     primWriter->Write(UsdTimeCode::Default());
@@ -818,6 +805,37 @@ void UsdMaya_WriteJob::_PostCallback()
     }
 }
 
+bool UsdMaya_WriteJob::_CheckNameClashes(const SdfPath &path, const MDagPath &dagPath)
+{
+    if (!mJobCtx.mArgs.stripNamespaces) {
+        return true;
+    }
+    auto foundPair = mUsdPathToDagPathMap.find(path);
+    if (foundPair != mUsdPathToDagPathMap.end()){
+        if (mJobCtx.mArgs.mergeTransformAndShape) {
+            // Shape should not conflict with xform
+            MDagPath other = foundPair->second;
+            MDagPath self = dagPath;
+            other.extendToShape();
+            self.extendToShape();
+            if (other == self) {
+                return true;
+            }
+        }
+        TF_RUNTIME_ERROR(
+            "Multiple dag nodes map to the same prim "
+            "path after stripping namespaces: %s - %s",
+            foundPair->second.fullPathName().asChar(),
+            dagPath.fullPathName().asChar());
+        return false;
+    }
+    // Note that mUsdPathToDagPathMap is _only_ used for
+    // stripping namespaces, so we only need to populate it
+    // when stripping namespaces. (This is different from
+    // mDagPathToUsdPathMap!)
+    mUsdPathToDagPathMap[path] = dagPath;
+    return true;
+}
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/third_party/maya/lib/usdMaya/writeJob.h
+++ b/third_party/maya/lib/usdMaya/writeJob.h
@@ -80,6 +80,8 @@ private:
     void _PerFrameCallback(double iFrame);
     void _PostCallback();
 
+    bool _CheckNameClashes(const SdfPath &path, const MDagPath &dagPath);
+
     // Name of the created/appended USD file
     std::string _fileName;
 


### PR DESCRIPTION
When exporter strips namespaces is checks if path was already visited and if so raises an error.

However when we also merge transforms and shapes, then it's not an error to map both of them to same primitive.

### Description of Change(s)

In addition to checking if path was already visited we check if path is parent or child of visited path.

### Fixes Issue(s)
Exporting to usd with namespace stripping and merging transforms and shapes results in error and does not work.
```
// Error: Multiple dag nodes map to the same prim path after stripping namespaces: |foo|ns:bar - |foo|ns:barShape  -- Runtime Error in _BeginWriting at line 396 of /tmp/source/third_party/maya/lib/usdMaya/writeJob.cpp //
```