### PR TITLE
Add a check for a valid UsdPrim when looping over affectedPrims in _RefreshObject

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -1304,7 +1304,15 @@ UsdImagingDelegate::_RefreshObject(SdfPath const& usdPath,
         // may or may not find an associated primInfo for every prim in
         // affectedPrims. If we find no primInfo, the prim that was previously
         // affected by this refresh no longer exists and can be ignored.
+        //
+        // It is also possible that we find a primInfo, but the prim it refers
+        // to has been deleted from the stage and is no longer valid. Such a
+        // prim may end up in the affectedPrims during the refresh of a
+        // collection that previously pointed directly to a prim that has
+        // been deleted. The primInfo for this prim will still be in the index
+        // because we haven't had the index process removals yet.
         if (primInfo != nullptr &&
+            primInfo->usdPrim.IsValid() &&
             TF_VERIFY(primInfo->adapter, "%s", affectedPrimPath.GetText())) {
             _AdapterSharedPtr &adapter = primInfo->adapter;
 


### PR DESCRIPTION
Prevent a crash when processing a stage update in hydra in which a prim is
deleted from the stage, and a collection which points directly to that prim
is updated. This would crash while processing the change to the collection,
as it would access the underlying UsdPrim from the index's PrimInfo map
without checking that it is still valid. To get around this, test the
validity of the UsdPrims that show up in the affectedPrims list.

### Fixes Issue(s)
684

