### PR TITLE
[USD] Invert the value of Simple Light's position when used as a directional light.

### DIFF
--- a/pxr/imaging/lib/glf/shaders/simpleLighting.glslfx
+++ b/pxr/imaging/lib/glf/shaders/simpleLighting.glslfx
@@ -266,7 +266,7 @@ integrateLightsDefault(vec4 Peye, vec3 Neye, LightingInterfaceProperties props)
         vec4 Plight = lightSource[i].position;
 
         vec3 l = (Plight.w == 0.0)
-                    ? normalize(Plight.xyz)
+                    ? normalize(-Plight.xyz)
                     : normalize(Plight - Peye).xyz;
 
         vec3 h = normalize(l + vec3(0,0,1));    // directional viewer

--- a/pxr/usdImaging/lib/usdShaders/shaders/previewSurface.glslfx
+++ b/pxr/usdImaging/lib/usdShaders/shaders/previewSurface.glslfx
@@ -162,7 +162,7 @@ evaluateLights(vec3 emissive, float occlusion, float ior,
         // Calculate necessary vector information for lighting
         vec4 Plight = lightSource[i].position;
         vec3 l = (Plight.w == 0.0)
-                    ? normalize(Plight.xyz)
+                    ? normalize(-Plight.xyz)
                     : normalize(Plight - Peye).xyz;
         vec3 h = normalize( e + l );
         float NdotL = max(0.0, dot(n, l));


### PR DESCRIPTION
### Description of Change(s)
When the .w coordinate of the simple light's position is set to zero, the simple light is supposed to behave as directional light. However, the direction needs to be inverted, so the rest of the math in `simpleLighting.glslfx` and `previewSurface.glslfx` behaves as it should. (the logic expects the calculated light direction to point "towards" the light)

### Fixes Issue(s)
No reported issues.

