### PR TITLE
[usdMaya] Importing instances.

### DIFF
--- a/third_party/maya/lib/usdMaya/importCommand.cpp
+++ b/third_party/maya/lib/usdMaya/importCommand.cpp
@@ -70,6 +70,9 @@ UsdMayaImportCommand::createSyntax()
     syntax.addFlag("-ar",
                    UsdMayaJobImportArgsTokens->assemblyRep.GetText(),
                    MSyntax::kString);
+    syntax.addFlag("-im",
+                   UsdMayaJobImportArgsTokens->instanceMode.GetText(),
+                   MSyntax::kString);
     syntax.addFlag("-md",
                    UsdMayaJobImportArgsTokens->metadata.GetText(),
                    MSyntax::kString);

--- a/third_party/maya/lib/usdMaya/jobArgs.cpp
+++ b/third_party/maya/lib/usdMaya/jobArgs.cpp
@@ -559,6 +559,14 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
                 UsdMayaJobImportArgsTokens->shadingMode,
                 UsdMayaShadingModeTokens->none,
                 UsdMayaShadingModeRegistry::ListImporters())),
+        instanceMode(
+            _Token(userArgs,
+                UsdMayaJobImportArgsTokens->instanceMode,
+                UsdMayaJobImportArgsTokens->buildInstances,
+                {
+                    UsdMayaJobImportArgsTokens->buildInstances,
+                    UsdMayaJobImportArgsTokens->flatten,
+                })),
         useAsAnimationCache(
             _Boolean(userArgs,
                 UsdMayaJobImportArgsTokens->useAsAnimationCache)),
@@ -599,6 +607,8 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
                 });
         d[UsdMayaJobImportArgsTokens->shadingMode] =
                 UsdMayaShadingModeTokens->displayColor.GetString();
+        d[UsdMayaJobImportArgsTokens->instanceMode] =
+                UsdMayaJobImportArgsTokens->buildInstances.GetString();
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = false;
 
         // plugInfo.json site defaults.
@@ -618,6 +628,7 @@ operator <<(std::ostream& out, const UsdMayaJobImportArgs& importArgs)
 {
     out << "shadingMode: " << importArgs.shadingMode << std::endl
         << "assemblyRep: " << importArgs.assemblyRep << std::endl
+        << "instanceMode: " << importArgs.instanceMode << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
         << "useAsAnimationCache: " << TfStringify(importArgs.useAsAnimationCache) << std::endl
         << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl;

--- a/third_party/maya/lib/usdMaya/jobArgs.h
+++ b/third_party/maya/lib/usdMaya/jobArgs.h
@@ -120,10 +120,14 @@ TF_DECLARE_PUBLIC_TOKENS(
     (metadata) \
     (shadingMode) \
     (useAsAnimationCache) \
+    (instanceMode) \
     /* assemblyRep values */ \
     (Collapsed) \
     (Full) \
     (Import) \
+    /* instanceMode values */ \
+    (flatten) \
+    (buildInstances) \
     ((Unloaded, ""))
 
 TF_DECLARE_PUBLIC_TOKENS(
@@ -260,6 +264,7 @@ struct UsdMayaJobImportArgs
     const TfToken::Set includeAPINames;
     const TfToken::Set includeMetadataKeys;
     TfToken shadingMode; // XXX can we make this const?
+    const TfToken instanceMode;
     const bool useAsAnimationCache;
 
     const bool importWithProxyShapes;

--- a/third_party/maya/lib/usdMaya/readJob.h
+++ b/third_party/maya/lib/usdMaya/readJob.h
@@ -28,6 +28,7 @@
 
 #include "usdMaya/jobArgs.h"
 #include "usdMaya/primReaderContext.h"
+#include "usdMaya/primReaderRegistry.h"
 
 #include "pxr/pxr.h"
 
@@ -71,6 +72,10 @@ public:
     void SetMayaRootDagPath(const MDagPath &mayaRootDagPath);
 
 private:
+    // Types
+    using _PrimReaderMap =
+        std::unordered_map<SdfPath, UsdMayaPrimReaderSharedPtr, SdfPath::Hash>;
+
     // XXX: Activating the 'Expanded' representation of a USD reference
     // assembly node is very much like performing a regular UsdMaya_ReadJob but with
     // a few key differences (e.g. creating proxy shapes at collapse points).
@@ -78,8 +83,12 @@ private:
     // usdImport, and an 'Expanded' representation-style import, respectively.
     // It would be great if we could combine these into a single traversal at
     // some point.
-    bool _DoImport(UsdPrimRange& range, const UsdPrim& usdRootPrim);
+    bool _DoImport(UsdPrimRange& range, const UsdPrim& usdRootPrim,
+        const UsdStageRefPtr& stage);
     bool _DoImportWithProxies(UsdPrimRange& range);
+    void _DoImportPrimIt(
+        UsdPrimRange::iterator& primIt, const UsdPrim& usdRootPrim,
+        UsdMayaPrimReaderContext& readCtx, _PrimReaderMap& primReaders);
 
     // These are helper methods for the proxy import method.
     bool _ProcessProxyPrims(

--- a/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
+++ b/third_party/maya/lib/usdMaya/usdTranslatorImport.mel
@@ -68,7 +68,7 @@ global proc int usdTranslatorImport (string $parent,
 //  Parameters:
 //    $parent - the elf parent layout for this options layout. It is
 //            always a scrollLayout.
-//    $action - the action that is to be performed with this invokation of this proc.
+//    $action - the action that is to be performed with this invocation of this proc.
 //        Valid options are:
 //        "query" - construct the options string and pass it to the resultCallback.
 //        "post" - post all the elf controls.
@@ -77,7 +77,7 @@ global proc int usdTranslatorImport (string $parent,
 //            resultCallback ( string $optionsString )
 //
 //    Returns:
-//        1 if successfull.
+//        1 if successful.
 //        0 otherwise.
 //
 {
@@ -118,9 +118,13 @@ global proc int usdTranslatorImport (string $parent,
             menuItem -l "Collapsed" -ann "Collapsed";
             menuItem -l "Full" -ann "Full";
             menuItem -l "Import" -ann "Import";
-        
+
+        optionMenuGrp -l "Instance Mode:" instanceModePopup;
+            menuItem -l "Flatten" -ann "flatten";
+            menuItem -l "Build Instances" -ann "buildInstances";
+
         setParent $parent;
-        
+
         // Now set to current settings.
         $currentOptions = $initialSettings;
         if (size($currentOptions) > 0) {
@@ -143,14 +147,16 @@ global proc int usdTranslatorImport (string $parent,
                     intFieldGrp -e -v1 $endTime endTimeField;
                 } else if ($optionBreakDown[0] == "useCustomFrameRange") {
                     usdTranslatorImport_SetCheckbox($optionBreakDown[1], "customFrameRangeCheckBox");
+                } else if ($optionBreakDown[0] == "instanceMode") {
+                    usdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], "instanceModePopup");
                 }
             }
         }
-                
+
         $bResult = 1;
-    
+
     } else if ($action == "query") {
-    
+
         $currentOptions = usdTranslatorImport_AppendFromPopup($currentOptions, "shadingMode", "shadingModePopup");
         $currentOptions = usdTranslatorImport_AppendFromCheckbox($currentOptions, "readAnimData", "readAnimDataCheckBox");
         $currentOptions = usdTranslatorImport_AppendFromCheckbox($currentOptions, "useAsAnimationCache", "useAsAnimationCacheCheckBox");
@@ -158,6 +164,7 @@ global proc int usdTranslatorImport (string $parent,
         $currentOptions = usdTranslatorImport_AppendFromIntField($currentOptions, "startTime", "startTimeField");
         $currentOptions = usdTranslatorImport_AppendFromIntField($currentOptions, "endTime", "endTimeField");
         $currentOptions = usdTranslatorImport_AppendFromCheckbox($currentOptions, "useCustomFrameRange", "customFrameRangeCheckBox");
+        $currentOptions = usdTranslatorImport_AppendFromPopup($currentOptions, "instanceMode", "instanceModePopup");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;


### PR DESCRIPTION
### Description of Change(s)
The PR fixes #142, by adding new instance modes to usdImport. Since recreating the exported Maya hierarchy during import is non-trivial, I'm providing three modes when importing instances. "As Transform" ignores the instances and creates a transform only (this is the old behaviour), "Flatten" where the meshes are de-instanced, but the resulting hierarchy is close to Maya's and "Build Sources" where we create the non-deterministic Masters generated by USD.

The PR is not finished yet, it's missing tests, and the code handling the creation of an instance could be moved to a utility module. Before fixing that, it would be good to figure out if we are happy with the current modes or want anything more. An interesting challenge is to recreate the hierarchy from the USD file, which is mostly possible, but finding the "real" master of the scene is non-deterministic.

### Fixes Issue(s)
#142 

