### PR TITLE
[Houdini] Fix for compilation errors caused by missing iostream includes.

### DIFF
--- a/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GT_PackedUSD.cpp
@@ -52,6 +52,7 @@
 #include <pxr/usd/usdGeom/xformCache.h>
 
 #include <unordered_map>
+#include <iostream>
 
 using std::cout;
 using std::cerr;

--- a/third_party/houdini/lib/gusd/GT_PrimCache.cpp
+++ b/third_party/houdini/lib/gusd/GT_PrimCache.cpp
@@ -45,6 +45,8 @@
 #include <SYS/SYS_Version.h>
 #include <UT/UT_HDKVersion.h>
 
+#include <iostream>
+
 // 0x100501BE corresponds to 16.5.446.
 #if SYS_VERSION_FULL_INT >= 0x100501BE
 #include <GT/GT_PackedAlembic.h>

--- a/third_party/houdini/lib/gusd/GT_Utils.cpp
+++ b/third_party/houdini/lib/gusd/GT_Utils.cpp
@@ -42,6 +42,8 @@
 
 #include <boost/tuple/tuple.hpp>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;

--- a/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
@@ -68,6 +68,7 @@
 #include <UT/UT_Map.h>
 
 #include <mutex>
+#include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/third_party/houdini/lib/gusd/NURBSCurvesWrapper.cpp
+++ b/third_party/houdini/lib/gusd/NURBSCurvesWrapper.cpp
@@ -42,9 +42,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-using std::cerr;
-using std::cout;
-using std::endl;
 using std::map;
 
 namespace {

--- a/third_party/houdini/lib/gusd/curvesWrapper.cpp
+++ b/third_party/houdini/lib/gusd/curvesWrapper.cpp
@@ -40,6 +40,8 @@
 #include <GT/GT_DAConstant.h>
 #include <GT/GT_DAConstantValue.h>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cerr;

--- a/third_party/houdini/lib/gusd/groupBaseWrapper.cpp
+++ b/third_party/houdini/lib/gusd/groupBaseWrapper.cpp
@@ -44,12 +44,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 #undef drand48
 #undef srand48
 
-using std::cout;
-using std::cerr;
-using std::endl;
-using std::vector;
-using std::string;
-
 #ifdef DEBUG
 #define DBG(x) x
 #else

--- a/third_party/houdini/lib/gusd/meshWrapper.cpp
+++ b/third_party/houdini/lib/gusd/meshWrapper.cpp
@@ -46,6 +46,7 @@
 #include <GT/GT_DAConstant.h>
 #include <SYS/SYS_Version.h>
 #include <numeric>
+#include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/third_party/houdini/lib/gusd/packedUsdWrapper.cpp
+++ b/third_party/houdini/lib/gusd/packedUsdWrapper.cpp
@@ -39,9 +39,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-using std::cout;
-using std::cerr;
-using std::endl;
 using std::string;
 
 namespace {

--- a/third_party/houdini/lib/gusd/pointsWrapper.cpp
+++ b/third_party/houdini/lib/gusd/pointsWrapper.cpp
@@ -33,6 +33,8 @@
 #include <GT/GT_RefineParms.h>
 #include <GT/GT_GEOPrimPacked.h>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cerr;

--- a/third_party/houdini/lib/gusd/primWrapper.cpp
+++ b/third_party/houdini/lib/gusd/primWrapper.cpp
@@ -37,6 +37,8 @@
 #include <GT/GT_DABool.h>
 #include <SYS/SYS_Version.h>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;

--- a/third_party/houdini/lib/gusd/refiner.cpp
+++ b/third_party/houdini/lib/gusd/refiner.cpp
@@ -42,6 +42,8 @@
 
 #include <SYS/SYS_Types.h>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;

--- a/third_party/houdini/lib/gusd/scopeWrapper.cpp
+++ b/third_party/houdini/lib/gusd/scopeWrapper.cpp
@@ -33,6 +33,8 @@
 
 #include <boost/foreach.hpp>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 // drand48 and srand48 defined in SYS_Math.h as of 13.5.153. and conflicts with imath.

--- a/third_party/houdini/lib/gusd/writeCtrlFlags.cpp
+++ b/third_party/houdini/lib/gusd/writeCtrlFlags.cpp
@@ -29,9 +29,6 @@
 #include <GT/GT_GEOPrimPacked.h>
 #include <GT/GT_AttributeList.h>
 
-using std::cerr;
-using std::endl;
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 void

--- a/third_party/houdini/lib/gusd/xformWrapper.cpp
+++ b/third_party/houdini/lib/gusd/xformWrapper.cpp
@@ -33,6 +33,8 @@
 
 #include <boost/foreach.hpp>
 
+#include <iostream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 // drand48 and srand48 defined in SYS_Math.h as of 13.5.153. and conflicts with imath.


### PR DESCRIPTION
Include iostream where std::cout or std:cerr are used, and remove using
declarations for these classes in files where they are not used.

These errors showed up trying to build this library against Houdini 17.4.84.
Presumably caused by some combination of include cleanup in the Houdini
and USD baselines.