### PR TITLE
[Usd] Send stage notification change on mute

### DIFF
--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -3425,6 +3425,7 @@ UsdStage::MuteAndUnmuteLayers(const std::vector<std::string> &muteLayers,
 
     UsdNotice::ObjectsChanged(self, &resyncChanges, &infoChanges)
         .Send(self);
+    UsdNotice::StageContentsChanged(self).Send(self);
 }
 
 const std::vector<std::string>&


### PR DESCRIPTION
### Description of Change(s)
It seems like this notification should also get sent during mute/unmute operations.
I ran into this while writing some widgets that need to respond to layer muting, and was surprised it wasn't firing. 
