### PR TITLE
Remove references to Python from usdImaging

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdImaging/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdImaging)
 
-# Note: both python include directives are included for compatibility.
 pxr_library(usdImaging
     LIBRARIES
         gf
@@ -19,13 +18,9 @@ pxr_library(usdImaging
         usdShade
         usdVol
         ar
-        ${Boost_PYTHON_LIBRARY}
-        ${PYTHON_LIBRARY}
         ${TBB_tbb_LIBRARY}
 
     INCLUDE_DIRS
-        ${PYTHON_INCLUDE_PATH}
-        ${PYTHON_INCLUDE_DIRS}
         ${TBB_INCLUDE_DIRS}
 
     PUBLIC_CLASSES

--- a/pxr/usdImaging/lib/usdImaging/pch.h
+++ b/pxr/usdImaging/lib/usdImaging/pch.h
@@ -144,19 +144,6 @@
 #include <boost/preprocessor/tuple/elem.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/tuple/to_seq.hpp>
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <boost/python/dict.hpp>
-#include <boost/python/extract.hpp>
-#include <boost/python/handle.hpp>
-#include <boost/python/object.hpp>
-#include <boost/python/object_fwd.hpp>
-#include <boost/python/object_operators.hpp>
-#include <boost/python/type_id.hpp>
-#if defined(__APPLE__) // Fix breakage caused by Python's pyport.h.
-#undef tolower
-#undef toupper
-#endif
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 #include <boost/range/iterator.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -198,6 +185,3 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
-#endif // PXR_PYTHON_SUPPORT_ENABLED


### PR DESCRIPTION
### Description of Change(s)
Removes includes and linkage to Python from usdImaging.
The usdImaging library no longer has any Python-related
code, so these are no longer needed.
