### PR TITLE
Cleanup usdImagingGL CMakeLists.txt

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdImagingGL/CMakeLists.txt
@@ -7,7 +7,6 @@ if (NOT ${PXR_ENABLE_GL_SUPPORT})
     return()
 endif()
 
-# Note: both python include directives are included for compatibility.
 pxr_library(usdImagingGL
     LIBRARIES
         gf
@@ -30,14 +29,13 @@ pxr_library(usdImagingGL
         usdImaging
         ar
         ${Boost_PYTHON_LIBRARY}
-        ${PYTHON_LIBRARY}
+        ${PYTHON_LIBRARIES}
         ${OPENGL_gl_LIBRARY}
         ${OPENGL_glu_LIBRARY}
         ${GLEW_LIBRARY}
         ${TBB_tbb_LIBRARY}
 
     INCLUDE_DIRS
-        ${PYTHON_INCLUDE_PATH}
         ${PYTHON_INCLUDE_DIRS}
         ${OPENGL_INCLUDE_DIR}
         ${GLEW_INCLUDE_DIR}


### PR DESCRIPTION
### Description of Change(s)
 Cleanup for CMakeLists.txt

- Remove PYTHON_INCLUDE_PATH from CMakeLists
PYTHON_INCLUDE_PATH was deprecated in favor of
PYTHON_INCLUDE_DIRS in CMake v2.8.0, and the
minimum required version for USD is v2.8.8.

- Use PYTHON_LIBRARIES in CMakeLists.txt
PYTHON_LIBRARY is a user-specified input for the
FindPython module and should not be used directly.
Use the PYTHON_LIBRARIES variable instead.