### PR TITLE
[UsdVolImaging] Fixing UsdVolImaging API defines and exposing private tokens

### DIFF
--- a/pxr/usdImaging/lib/usdVolImaging/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdVolImaging/CMakeLists.txt
@@ -8,6 +8,10 @@ pxr_library(usdVolImaging
     PUBLIC_CLASSES
         openvdbAssetAdapter
         field3dAssetAdapter
+        tokens
+
+    PUBLIC_HEADERS
+        api.h
 
     RESOURCE_FILES
         plugInfo.json

--- a/pxr/usdImaging/lib/usdVolImaging/api.h
+++ b/pxr/usdImaging/lib/usdVolImaging/api.h
@@ -21,29 +21,27 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/usdImaging/usdVolImaging/field3dAssetAdapter.h"
+#ifndef USDVOLIMAGING_API_H
+#define USDVOLIMAGING_API_H
 
-#include "pxr/usdImaging/usdVolImaging/tokens.h"
+#include "pxr/base/arch/export.h"
 
-#include "pxr/base/tf/type.h"
+#if defined(PXR_STATIC)
+#   define USDVOLIMAGING_API
+#   define USDVOLIMAGING_API_TEMPLATE_CLASS(...)
+#   define USDVOLIMAGING_API_TEMPLATE_STRUCT(...)
+#   define USDVOLIMAGING_LOCAL
+#else
+#   if defined(USDVOLIMAGING_EXPORTS)
+#       define USDVOLIMAGING_API ARCH_EXPORT
+#       define USDVOLIMAGING_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDVOLIMAGING_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#   else
+#       define USDVOLIMAGING_API ARCH_IMPORT
+#       define USDVOLIMAGING_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDVOLIMAGING_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   endif
+#   define USDVOLIMAGING_LOCAL ARCH_HIDDEN
+#endif
 
-PXR_NAMESPACE_OPEN_SCOPE
-
-TF_REGISTRY_FUNCTION(TfType)
-{
-    typedef UsdImagingField3DAssetAdapter Adapter;
-    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
-    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
-}
-
-UsdImagingField3DAssetAdapter::~UsdImagingField3DAssetAdapter() 
-{
-}
-
-TfToken
-UsdImagingField3DAssetAdapter::GetPrimTypeToken() const
-{
-    return UsdVolImagingTokens->field3dAsset;
-}
-
-PXR_NAMESPACE_CLOSE_SCOPE
+#endif // USDVOLIMAGING_API_H

--- a/pxr/usdImaging/lib/usdVolImaging/field3dAssetAdapter.h
+++ b/pxr/usdImaging/lib/usdVolImaging/field3dAssetAdapter.h
@@ -27,8 +27,8 @@
 /// \file usdImaging/field3dAssetAdapter.h
 
 #include "pxr/pxr.h"
-#include "pxr/usdImaging/usdImaging/api.h"
 #include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+#include "pxr/usdImaging/usdVolImaging/api.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -47,10 +47,10 @@ public:
         : UsdImagingFieldAdapter()
     {}
 
-    USDIMAGING_API
+    USDVOLIMAGING_API
     virtual ~UsdImagingField3DAssetAdapter();
 
-    USDIMAGING_API
+    USDVOLIMAGING_API
     virtual TfToken GetPrimTypeToken() const;
 };
 

--- a/pxr/usdImaging/lib/usdVolImaging/openvdbAssetAdapter.cpp
+++ b/pxr/usdImaging/lib/usdVolImaging/openvdbAssetAdapter.cpp
@@ -23,6 +23,8 @@
 //
 #include "pxr/usdImaging/usdVolImaging/openvdbAssetAdapter.h"
 
+#include "pxr/usdImaging/usdVolImaging/tokens.h"
+
 #include "pxr/base/tf/type.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -34,11 +36,6 @@ TF_REGISTRY_FUNCTION(TfType)
     t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
 }
 
-TF_DEFINE_PRIVATE_TOKENS(
-    _tokens,
-    (openvdbAsset)
-);
-
 UsdImagingOpenVDBAssetAdapter::~UsdImagingOpenVDBAssetAdapter() 
 {
 }
@@ -46,7 +43,7 @@ UsdImagingOpenVDBAssetAdapter::~UsdImagingOpenVDBAssetAdapter()
 TfToken
 UsdImagingOpenVDBAssetAdapter::GetPrimTypeToken() const
 {
-    return _tokens->openvdbAsset;
+    return UsdVolImagingTokens->openvdbAsset;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdVolImaging/openvdbAssetAdapter.h
+++ b/pxr/usdImaging/lib/usdVolImaging/openvdbAssetAdapter.h
@@ -27,8 +27,8 @@
 /// \file usdImaging/openvdbAssetAdapter.h
 
 #include "pxr/pxr.h"
-#include "pxr/usdImaging/usdImaging/api.h"
 #include "pxr/usdImaging/usdImaging/fieldAdapter.h"
+#include "pxr/usdImaging/usdVolImaging/api.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -47,10 +47,10 @@ public:
         : UsdImagingFieldAdapter()
     {}
 
-    USDIMAGING_API
+    USDVOLIMAGING_API
     virtual ~UsdImagingOpenVDBAssetAdapter();
 
-    USDIMAGING_API
+    USDVOLIMAGING_API
     virtual TfToken GetPrimTypeToken() const;
 };
 

--- a/pxr/usdImaging/lib/usdVolImaging/tokens.cpp
+++ b/pxr/usdImaging/lib/usdVolImaging/tokens.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Pixar
+// Copyright 2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,29 +21,10 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/usdImaging/usdVolImaging/field3dAssetAdapter.h"
-
 #include "pxr/usdImaging/usdVolImaging/tokens.h"
-
-#include "pxr/base/tf/type.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_REGISTRY_FUNCTION(TfType)
-{
-    typedef UsdImagingField3DAssetAdapter Adapter;
-    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
-    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
-}
-
-UsdImagingField3DAssetAdapter::~UsdImagingField3DAssetAdapter() 
-{
-}
-
-TfToken
-UsdImagingField3DAssetAdapter::GetPrimTypeToken() const
-{
-    return UsdVolImagingTokens->field3dAsset;
-}
+TF_DEFINE_PUBLIC_TOKENS(UsdVolImagingTokens, USDVOLIMAGING_TOKENS);
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdVolImaging/tokens.h
+++ b/pxr/usdImaging/lib/usdVolImaging/tokens.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Pixar
+// Copyright 2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,29 +21,21 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/usdImaging/usdVolImaging/field3dAssetAdapter.h"
+#ifndef USDVOLIMAGING_TOKENS_H
+#define USDVOLIMAGING_TOKENS_H
 
-#include "pxr/usdImaging/usdVolImaging/tokens.h"
-
-#include "pxr/base/tf/type.h"
+#include "pxr/pxr.h"
+#include "pxr/usdImaging/usdVolImaging/api.h"
+#include "pxr/base/tf/staticTokens.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_REGISTRY_FUNCTION(TfType)
-{
-    typedef UsdImagingField3DAssetAdapter Adapter;
-    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter> >();
-    t.SetFactory< UsdImagingPrimAdapterFactory<Adapter> >();
-}
+#define USDVOLIMAGING_TOKENS \
+    (field3dAsset)           \
+    (openvdbAsset)
 
-UsdImagingField3DAssetAdapter::~UsdImagingField3DAssetAdapter() 
-{
-}
-
-TfToken
-UsdImagingField3DAssetAdapter::GetPrimTypeToken() const
-{
-    return UsdVolImagingTokens->field3dAsset;
-}
+TF_DECLARE_PUBLIC_TOKENS(UsdVolImagingTokens, USDVOLIMAGING_API, USDVOLIMAGING_TOKENS);
 
 PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // USDVOLIMAGING_TOKENS_H


### PR DESCRIPTION
### Description of Change(s)
The PR fixes two problems. The first one is to define a separate API macro for the UsdImagingVol, which was using UsdImaging's API macro before. While this won't lead to issues, it goes against the practice seen in other modules. The other improvement is to expose the openvdbAsset and field3dAsset tokens, which are used as bprim types for Hydra Render delegates. Without exposing these tokens, the render delegates have to redefine them.

Refer to the changes in our Arnold Render Delegate to see how exposing the tokens simplifies the code: https://github.com/LumaPictures/usd-arnold/compare/usd_vol_tokens .

### Fixes Issue(s)
None reported.