### PR TITLE
Publish the normals attribute or a normals primvar from points primitives through Hydra

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
@@ -99,6 +99,24 @@ UsdImagingPointsAdapter::TrackVariability(UsdPrim const& prim,
                 timeVaryingBits,
                 /*isInherited*/false);
     }
+
+    // Check for time-varying primvars:normals, and if that attribute
+    // doesn't exist also check for time-varying normals.
+    bool normalsExists = false;
+    _IsVarying(prim,
+               UsdImagingTokens->primvarsNormals,
+               HdChangeTracker::DirtyNormals,
+               UsdImagingTokens->usdVaryingNormals,
+               timeVaryingBits,
+               /*isInherited*/false,
+               &normalsExists);
+    if (!normalsExists) {
+        _IsVarying(prim, UsdGeomTokens->normals,
+                HdChangeTracker::DirtyNormals,
+                UsdImagingTokens->usdVaryingNormals,
+                timeVaryingBits,
+                /*isInherited*/false);
+    }
 }
 
 bool
@@ -153,6 +171,26 @@ UsdImagingPointsAdapter::UpdateForTime(UsdPrim const& prim,
             }
             _MergePrimvar(&primvars, UsdGeomTokens->widths, interpolation);
             valueCache->GetWidths(cachePath) = VtValue(widths);
+        }
+    }
+
+    if (requestedBits & HdChangeTracker::DirtyNormals) {
+        // First check for "primvars:normals"
+        UsdGeomPrimvarsAPI primvarsApi(prim);
+        UsdGeomPrimvar pv = primvarsApi.GetPrimvar(
+            UsdImagingTokens->primvarsNormals);
+        if (pv) {
+            _ComputeAndMergePrimvar(prim, cachePath, pv, time, valueCache);
+        } else {
+            UsdGeomPoints points(prim);
+            VtVec3fArray normals;
+            if (points.GetNormalsAttr().Get(&normals, time)) {
+                _MergePrimvar(&primvars,
+                        UsdGeomTokens->normals,
+                        _UsdToHdInterpolation(points.GetNormalsInterpolation()),
+                        HdPrimvarRoleTokens->normal);
+                valueCache->GetNormals(cachePath) = VtValue(normals);
+            }
         }
     }
 }


### PR DESCRIPTION
Publish the normals attribute or a normals primvar from points primitives through
Hydra using the same code used for curve primitives. Generally the normals of
a points primitive will not be used by a renderer, but it is rather
unexpected that this information isn't even accessible for a render that
does want to use this information (such as to render the points as disks).