### PR TITLE
Expose the velocities attribute through Hydra to render delegates

### DIFF
--- a/pxr/imaging/lib/hd/changeTracker.cpp
+++ b/pxr/imaging/lib/hd/changeTracker.cpp
@@ -625,6 +625,7 @@ HdChangeTracker::IsAnyPrimvarDirty(HdDirtyBits dirtyBits, SdfPath const &id)
     bool isDirty = (dirtyBits & (DirtyPoints|
                                  DirtyNormals|
                                  DirtyWidths|
+                                 DirtyVelocities|
                                  DirtyPrimvar)) != 0;
     _LogCacheAccess(HdTokens->primvar, id, !isDirty);
     return isDirty;
@@ -642,6 +643,8 @@ HdChangeTracker::IsPrimvarDirty(HdDirtyBits dirtyBits, SdfPath const& id,
         isDirty = (dirtyBits & DirtyNormals) != 0;
     } else if (name == HdTokens->widths) {
         isDirty = (dirtyBits & DirtyWidths) != 0;
+    } else if (name == HdTokens->velocities) {
+        isDirty = (dirtyBits & DirtyVelocities) != 0;
     } else {
         isDirty = (dirtyBits & DirtyPrimvar) != 0;
     }
@@ -744,6 +747,8 @@ HdChangeTracker::MarkPrimvarDirty(HdDirtyBits *dirtyBits, TfToken const &name)
         setBits = DirtyNormals;
     } else if (name == HdTokens->widths) {
         setBits = DirtyWidths;
+    } else if (name == HdTokens->velocities) {
+        setBits = DirtyVelocities;
     } else {
         setBits = DirtyPrimvar;
     }
@@ -944,6 +949,9 @@ HdChangeTracker::StringifyDirtyBits(HdDirtyBits dirtyBits)
     }
     if (dirtyBits & DirtyWidths) {
         ss << "Widths ";
+    }
+    if (dirtyBits & DirtyVelocities) {
+        ss << "Velocities ";
     }
     if (dirtyBits & DirtyInstancer) {
         ss << "Instancer ";

--- a/pxr/imaging/lib/hd/changeTracker.h
+++ b/pxr/imaging/lib/hd/changeTracker.h
@@ -76,17 +76,18 @@ public:
         DirtyCullStyle              = 1 << 13,
         DirtySubdivTags             = 1 << 14,
         DirtyWidths                 = 1 << 15,
-        DirtyInstancer              = 1 << 16,
-        DirtyInstanceIndex          = 1 << 17,
-        DirtyRepr                   = 1 << 18,
-        DirtyRenderTag              = 1 << 19,
-        DirtyComputationPrimvarDesc = 1 << 20,
-        DirtyCategories             = 1 << 21,
-        AllSceneDirtyBits           = ((1<<22) - 1),
+        DirtyVelocities             = 1 << 16,
+        DirtyInstancer              = 1 << 17,
+        DirtyInstanceIndex          = 1 << 18,
+        DirtyRepr                   = 1 << 19,
+        DirtyRenderTag              = 1 << 20,
+        DirtyComputationPrimvarDesc = 1 << 21,
+        DirtyCategories             = 1 << 22,
+        AllSceneDirtyBits           = ((1<<23) - 1),
 
-        NewRepr                     = 1 << 22,
+        NewRepr                     = 1 << 23,
 
-        CustomBitsBegin             = 1 << 23,
+        CustomBitsBegin             = 1 << 24,
         CustomBitsEnd               = 1 << 30,
     };
 

--- a/pxr/imaging/lib/hd/tokens.h
+++ b/pxr/imaging/lib/hd/tokens.h
@@ -107,6 +107,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (totalItemCount)                            \
     (transform)                                 \
     (transformInverse)                          \
+    (velocities)                                \
     (visibility)                                \
     (widths)
 

--- a/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
@@ -84,6 +84,14 @@ UsdImagingBasisCurvesAdapter::TrackVariability(UsdPrim const& prim,
                timeVaryingBits,
                /*isInherited*/false);
 
+    // Discover time-varying velocities.
+    _IsVarying(prim,
+               UsdGeomTokens->velocities,
+               HdChangeTracker::DirtyVelocities,
+               UsdImagingTokens->usdVaryingPrimvar,
+               timeVaryingBits,
+               /*isInherited*/false);
+
     // Discover time-varying topology.
     //
     // Note that basis, wrap and type are all uniform attributes, so they can't
@@ -163,6 +171,18 @@ UsdImagingBasisCurvesAdapter::UpdateForTime(UsdPrim const& prim,
                       UsdGeomTokens->points,
                       HdInterpolationVertex,
                       HdPrimvarRoleTokens->point);
+    }
+
+    if (requestedBits & HdChangeTracker::DirtyVelocities) {
+        UsdGeomBasisCurves curves(prim);
+        VtVec3fArray velocities;
+        if (curves.GetVelocitiesAttr().Get(&velocities, time)) {
+            _MergePrimvar(&primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetVelocities(cachePath) = VtValue(velocities);
+        }
     }
 
     if (requestedBits & HdChangeTracker::DirtyWidths) {

--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -2351,6 +2351,13 @@ UsdImagingDelegate::Get(SdfPath const& id, TfToken const& key)
                 vec.push_back(1.0f);
                 value = VtValue(vec);
             }
+        } else if (key == HdTokens->velocities) {
+            _UpdateSingleValue(usdPath,HdChangeTracker::DirtyVelocities);
+            if (!TF_VERIFY(_valueCache.ExtractVelocities(usdPath, &value))){
+                VtFloatArray vec(1);
+                vec.push_back(0.0f);
+                value = VtValue(vec);
+            }
         } else if (key == HdTokens->transform) {
             value = VtValue(
                 UsdImaging_XfStrategy::ComputeTransform(_GetPrim(usdPath), 

--- a/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
@@ -119,6 +119,14 @@ UsdImagingMeshAdapter::TrackVariability(UsdPrim const& prim,
                timeVaryingBits,
                /*isInherited*/false);
 
+    // Discover time-varying velocities.
+    _IsVarying(prim,
+               UsdGeomTokens->velocities,
+               HdChangeTracker::DirtyVelocities,
+               UsdImagingTokens->usdVaryingPrimvar,
+               timeVaryingBits,
+               /*isInherited*/false);
+
     // Discover time-varying primvars:normals, and if that attribute
     // doesn't exist also check for time-varying normals.
     // Only do this for polygonal meshes.
@@ -277,6 +285,18 @@ UsdImagingMeshAdapter::UpdateForTime(UsdPrim const& prim,
             HdTokens->points,
             HdInterpolationVertex,
             HdPrimvarRoleTokens->point);
+    }
+
+    if (requestedBits & HdChangeTracker::DirtyVelocities) {
+        UsdGeomMesh mesh(prim);
+        VtVec3fArray velocities;
+        if (mesh.GetVelocitiesAttr().Get(&velocities, time)) {
+            _MergePrimvar(&primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetVelocities(cachePath) = VtValue(velocities);
+        }
     }
 
     if (requestedBits & HdChangeTracker::DirtyNormals) {

--- a/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
@@ -82,6 +82,14 @@ UsdImagingPointsAdapter::TrackVariability(UsdPrim const& prim,
                timeVaryingBits,
                /*isInherited*/false);
 
+    // Discover time-varying velocities.
+    _IsVarying(prim,
+               UsdGeomTokens->velocities,
+               HdChangeTracker::DirtyVelocities,
+               UsdImagingTokens->usdVaryingPrimvar,
+               timeVaryingBits,
+               /*isInherited*/false);
+
     // Check for time-varying primvars:widths, and if that attribute
     // doesn't exist also check for time-varying widths.
     bool widthsExists = false;
@@ -130,6 +138,18 @@ UsdImagingPointsAdapter::UpdateForTime(UsdPrim const& prim,
             HdTokens->points,
             HdInterpolationVertex,
             HdPrimvarRoleTokens->point);
+    }
+
+    if (requestedBits & HdChangeTracker::DirtyVelocities) {
+        UsdGeomPoints points(prim);
+        VtVec3fArray velocities;
+        if (points.GetVelocitiesAttr().Get(&velocities, time)) {
+            _MergePrimvar(&primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetVelocities(cachePath) = VtValue(velocities);
+        }
     }
 
     if (requestedBits & HdChangeTracker::DirtyWidths) {

--- a/pxr/usdImaging/lib/usdImaging/valueCache.h
+++ b/pxr/usdImaging/lib/usdImaging/valueCache.h
@@ -143,6 +143,10 @@ public:
             static TfToken attr("widths");
             return Key(path, attr);
         }
+        static Key Velocities(SdfPath const& path) {
+            static TfToken attr("velocities");
+            return Key(path, attr);
+        }
         static Key Normals(SdfPath const& path) {
             static TfToken attr("normals");
             return Key(path, attr);
@@ -309,6 +313,7 @@ public:
         _Erase<bool>(Key::Visible(path));
         _Erase<VtValue>(Key::Points(path));
         _Erase<VtValue>(Key::Widths(path));
+        _Erase<VtValue>(Key::Velocities(path));
         _Erase<VtValue>(Key::Normals(path));
         _Erase<VtValue>(Key::MaterialId(path));
         _Erase<VtValue>(Key::MaterialPrimvars(path));
@@ -378,6 +383,9 @@ public:
     }
     VtValue& GetWidths(SdfPath const& path) const {
         return _Get<VtValue>(Key::Widths(path));
+    }
+    VtValue& GetVelocities(SdfPath const& path) const {
+        return _Get<VtValue>(Key::Velocities(path));
     }
     VtValue& GetNormals(SdfPath const& path) const {
         return _Get<VtValue>(Key::Normals(path));
@@ -456,6 +464,9 @@ public:
     bool FindWidths(SdfPath const& path, VtValue* value) const {
         return _Find(Key::Widths(path), value);
     }
+    bool FindVelocities(SdfPath const& path, VtValue* value) const {
+        return _Find(Key::Velocities(path), value);
+    }
     bool FindNormals(SdfPath const& path, VtValue* value) const {
         return _Find(Key::Normals(path), value);
     }
@@ -526,6 +537,9 @@ public:
     }
     bool ExtractWidths(SdfPath const& path, VtValue* value) {
         return _Extract(Key::Widths(path), value);
+    }
+    bool ExtractVelocities(SdfPath const& path, VtValue* value) {
+        return _Extract(Key::Velocities(path), value);
     }
     bool ExtractNormals(SdfPath const& path, VtValue* value) {
         return _Extract(Key::Normals(path), value);


### PR DESCRIPTION
Expose the velocities attribute through Hydra to render delegates for
PointBased prims (Mesh, BasisCurves, and Points). This will allow renderers
to generate deformation motion blur even in the face of changing topology.