### PR TITLE
[USD] Updating material x test to match the latest spec

### DIFF
--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/NodeGraphs.mtlx
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/NodeGraphs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.35" cms="ocio" colorspace="lin_rec709">
+<materialx version="1.36" cms="ocio" colorspace="lin_rec709">
   <nodegraph name="nodegraph1" doc="this is a nodegraph" uicolor="1,1,1">
     <image name="img1" type="color3" uicolor="0,0,1">
       <parameter name="file" type="filename" value="layer1.tif" doc="foo" uicolor="0,1,1"/>
@@ -13,7 +13,7 @@
     <mix name="n0" type="color3">
       <input name="fg" type="color3" nodename="img1"/>
       <input name="bg" type="color3" nodename="img2"/>
-      <input name="mask" type="float" nodename="img3"/>
+      <input name="mix" type="float" nodename="img3"/>
     </mix>
     <output name="diffuse" type="color3" nodename="n1" doc="this is an output" xpos="0" ypos="0"/>
   </nodegraph>
@@ -34,7 +34,7 @@
     <mix name="n3" type="color3">
       <input name="fg" type="color3" nodename="img1"/>
       <input name="bg" type="color3" nodename="img2"/>
-      <input name="mask" type="float" nodename="img3"/>
+      <input name="mix" type="float" nodename="img3"/>
     </mix>
     <output name="diffuse" type="color3" nodename="n4"/>
   </nodegraph>
@@ -76,7 +76,7 @@
     <mix name="n8" type="color3">
       <input name="fg" type="color3" nodename="n7"/>
       <input name="bg" type="color3" nodename="n6"/>
-      <input name="mask" type="float" nodename="img3"/>
+      <input name="mix" type="float" nodename="img3"/>
     </mix>
     <texcoord name="t1" type="vector2"/>
     <noise2d name="n9" type="color3">
@@ -122,7 +122,7 @@
   <mix name="n8" type="color3">
     <input name="fg" type="color3" nodename="n7"/>
     <input name="bg" type="color3" nodename="n6"/>
-    <input name="mask" type="float" nodename="img3"/>
+    <input name="mix" type="float" nodename="img3"/>
   </mix>
   <texcoord name="t1" type="vector2"/>
   <multiply name="m1" type="vector2">

--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/NodeGraphs.usda
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/NodeGraphs.usda
@@ -45,7 +45,7 @@ def "MaterialX"
                 uniform token info:id = "ND_mix_color3"
                 color3f inputs:bg.connect = </MaterialX/NodeGraphs/nodegraph1/img2.outputs:result>
                 color3f inputs:fg.connect = </MaterialX/NodeGraphs/nodegraph1/img1.outputs:result>
-                float inputs:mask.connect = </MaterialX/NodeGraphs/nodegraph1/img3.outputs:result>
+                float inputs:mix.connect = </MaterialX/NodeGraphs/nodegraph1/img3.outputs:result>
                 color3f outputs:result
             }
         }
@@ -95,7 +95,7 @@ def "MaterialX"
                 uniform token info:id = "ND_mix_color3"
                 color3f inputs:bg.connect = </MaterialX/NodeGraphs/nodegraph2/img2.outputs:result>
                 color3f inputs:fg.connect = </MaterialX/NodeGraphs/nodegraph2/img1.outputs:result>
-                float inputs:mask.connect = </MaterialX/NodeGraphs/nodegraph2/img3.outputs:result>
+                float inputs:mix.connect = </MaterialX/NodeGraphs/nodegraph2/img3.outputs:result>
                 color3f outputs:result
             }
         }
@@ -193,7 +193,7 @@ def "MaterialX"
                 uniform token info:id = "ND_mix_color3"
                 color3f inputs:bg.connect = </MaterialX/NodeGraphs/nodegraph3/n6.outputs:result>
                 color3f inputs:fg.connect = </MaterialX/NodeGraphs/nodegraph3/n7.outputs:result>
-                float inputs:mask.connect = </MaterialX/NodeGraphs/nodegraph3/img3.outputs:result>
+                float inputs:mix.connect = </MaterialX/NodeGraphs/nodegraph3/img3.outputs:result>
                 color3f outputs:result
             }
 


### PR DESCRIPTION
### Description of Change(s)
Updating the material x test to accommodate for a change in the MaterialX spec: changing the name of the `mix` node's parameter from `mask` to `mix`.
