### PR TITLE
Allow round tripping of namespaced primvars from USD -> Houdini geometry -> USD

### DIFF
--- a/third_party/houdini/lib/gusd/primWrapper.cpp
+++ b/third_party/houdini/lib/gusd/primWrapper.cpp
@@ -1085,7 +1085,7 @@ GusdPrimWrapper::loadPrimvars(
                     gtData = new GT_DAIndirect( remapIndicies, gtData );
                 }
                 if( point ) {
-                    *point = (*point)->addAttribute( attr_name.c_str(), gtData, true );
+                    *point = (*point)->addAttribute( attrname.c_str(), gtData, true );
                 }
             }
         }
@@ -1099,7 +1099,7 @@ GusdPrimWrapper::loadPrimvars(
                          gtData->entries(), minVertex );
             }
             else if( vertex ) {           
-                *vertex = (*vertex)->addAttribute( attr_name.c_str(), gtData, true );
+                *vertex = (*vertex)->addAttribute( attrname.c_str(), gtData, true );
             }
         }
         else if( primvar.GetInterpolation() == UsdGeomTokens->uniform )
@@ -1112,13 +1112,13 @@ GusdPrimWrapper::loadPrimvars(
                          gtData->entries(), minUniform );
             }
             else if( primitive ) {
-                *primitive = (*primitive)->addAttribute( attr_name.c_str(), gtData, true );
+                *primitive = (*primitive)->addAttribute( attrname.c_str(), gtData, true );
             }
         }
         else if( primvar.GetInterpolation() == UsdGeomTokens->constant )
         {
             if( constant ) {
-                *constant = (*constant)->addAttribute( attr_name.c_str(), gtData, true );
+                *constant = (*constant)->addAttribute( attrname.c_str(), gtData, true );
             }
         }
     }

--- a/third_party/houdini/lib/gusd/primWrapper.cpp
+++ b/third_party/houdini/lib/gusd/primWrapper.cpp
@@ -42,6 +42,10 @@
 
 #include <iostream>
 
+#if SYS_VERSION_FULL_INT >= 0x11050000
+#include <UT/UT_VarEncode.h>
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using std::cout;
@@ -664,10 +668,17 @@ GusdPrimWrapper::updatePrimvarFromGTPrim(
         const GT_Owner owner = attrMapHandle->getOriginalOwner(attrIndex);
         GT_DataArrayHandle attrData = gtAttrs->get(attrIndex);
 
-        TfToken name( attrname );
+#if SYS_VERSION_FULL_INT >= 0x11050000
+        // Decode Houdini geometry attribute names to get back the original
+        // USD primvar name. This allows round tripping of namespaced
+        // primvars from USD -> Houdini -> USD.
+        UT_StringHolder name = UT_VarEncode::decode(attrname);
+#else
+        UT_StringHolder name = attrname;
+#endif
 
         updatePrimvarFromGTPrim( 
-                    TfToken( name ),
+                    TfToken( name.toStdString() ),
                     owner, 
                     interpolation, 
                     time, 
@@ -1050,6 +1061,15 @@ GusdPrimWrapper::loadPrimvars(
             continue;
         }
 
+#if SYS_VERSION_FULL_INT >= 0x11050000
+        // Encode the USD primvar names into something safe for the Houdini
+        // geometry attribute name. This allows round tripping of namespaced
+        // primvars from USD -> Houdini -> USD.
+        UT_StringHolder attrname = UT_VarEncode::encode(name);
+#else
+        UT_StringHolder attrname = name;
+#endif
+
         // usd vertex primvars are assigned to points
         if( primvar.GetInterpolation() == UsdGeomTokens->vertex )
         {
@@ -1065,7 +1085,7 @@ GusdPrimWrapper::loadPrimvars(
                     gtData = new GT_DAIndirect( remapIndicies, gtData );
                 }
                 if( point ) {
-                    *point = (*point)->addAttribute( name.c_str(), gtData, true );
+                    *point = (*point)->addAttribute( attr_name.c_str(), gtData, true );
                 }
             }
         }
@@ -1079,7 +1099,7 @@ GusdPrimWrapper::loadPrimvars(
                          gtData->entries(), minVertex );
             }
             else if( vertex ) {           
-                *vertex = (*vertex)->addAttribute( name.c_str(), gtData, true );
+                *vertex = (*vertex)->addAttribute( attr_name.c_str(), gtData, true );
             }
         }
         else if( primvar.GetInterpolation() == UsdGeomTokens->uniform )
@@ -1092,13 +1112,13 @@ GusdPrimWrapper::loadPrimvars(
                          gtData->entries(), minUniform );
             }
             else if( primitive ) {
-                *primitive = (*primitive)->addAttribute( name.c_str(), gtData, true );
+                *primitive = (*primitive)->addAttribute( attr_name.c_str(), gtData, true );
             }
         }
         else if( primvar.GetInterpolation() == UsdGeomTokens->constant )
         {
             if( constant ) {
-                *constant = (*constant)->addAttribute( name.c_str(), gtData, true );
+                *constant = (*constant)->addAttribute( attr_name.c_str(), gtData, true );
             }
         }
     }


### PR DESCRIPTION
Allow round tripping of namespaced primvars from USD -> Houdini
geometry -> USD. To do this, we convert the USD attribute name with the
namespace separator into a form that follows the rules for Houdini
geometry attributes using the UT_VarEncode class. This class is only
available in Houdini 17.5 and above, so this attribute name encoding is
only enabled when building against Houdini 17.5 or greater.

When SOP geometry is being converted back to USD attributes, the decode
method of UT_VarEncode is used to turn any encoded attribute names back
into their original form.