### PR TITLE
Delegate GetVolumeFieldDescriptors calls to the volume primitive adapter

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.cpp
@@ -1909,6 +1909,25 @@ UsdImagingPointInstancerAdapter::PopulateSelection(
 }
 
 /*virtual*/
+HdVolumeFieldDescriptorVector
+UsdImagingPointInstancerAdapter::GetVolumeFieldDescriptors(
+    UsdPrim const& usdPrim,
+    SdfPath const &id,
+    UsdTimeCode time) const
+{
+    if (IsChildPath(id)) {
+        // Delegate to prototype adapter and USD prim.
+        _ProtoRprim const& rproto = _GetProtoRprim(usdPrim.GetPath(), id);
+        UsdPrim protoPrim = _GetProtoUsdPrim(rproto);
+        return rproto.adapter->GetVolumeFieldDescriptors(
+            protoPrim, id, time);
+    } else {
+        return UsdImagingPrimAdapter::GetVolumeFieldDescriptors(
+            usdPrim, id, time);
+    }
+}
+
+/*virtual*/
 SdfPathVector
 UsdImagingPointInstancerAdapter::GetDependPaths(SdfPath const &instancerPath) const
 {

--- a/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.h
+++ b/pxr/usdImaging/lib/usdImaging/pointInstancerAdapter.h
@@ -188,6 +188,14 @@ public:
                                 HdSelectionSharedPtr const &result) override;
 
     // ---------------------------------------------------------------------- //
+    /// \name Volume field information
+    // ---------------------------------------------------------------------- //
+
+    virtual HdVolumeFieldDescriptorVector
+    GetVolumeFieldDescriptors(UsdPrim const& usdPrim, SdfPath const &id,
+                              UsdTimeCode time) const override;
+
+    // ---------------------------------------------------------------------- //
     /// \name Utilities 
     // ---------------------------------------------------------------------- //
 


### PR DESCRIPTION
Delegate GetVolumeFieldDescriptors calls to the volume primitive adapter
if the volume is a prototype in a point instancer prim.

This fixes an issue that volume primitives instanced with a point instancer
would not be rendered, because they would report having no fields.