### PR TITLE
Add support for Alembic Facesets as UsdGeomSubsets in usdAbc

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -66,6 +66,7 @@ pxr_test_scripts(
     testenv/testUsdAbcBugs.py
     testenv/testUsdAbcCamera.py
     testenv/testUsdAbcConversionSubdiv.py
+    testenv/testUsdAbcFaceset.py
     testenv/testUsdAbcIndexedProperties.py
     testenv/testUsdAbcInstancing.py
     testenv/testUsdAbcUvReadWrite.py
@@ -90,6 +91,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdAbcConversionSubdiv
     DEST testUsdAbcConversionSubdiv
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdAbcFaceset
+    DEST testUsdAbcFaceset
 )
 
 pxr_install_test_dir(
@@ -150,6 +156,12 @@ pxr_register_test(testUsdAbcCamera
 pxr_register_test(testUsdAbcConversionSubdiv
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionSubdiv"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdAbcFaceset
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcFaceset"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2016-2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -2849,6 +2849,65 @@ struct _CopyFaceVaryingInterpolateBoundary : _CopyGeneric<IInt32Property> {
     }
 };
 
+
+/// Base class to copy attributes of an alembic faceset to a USD GeomSubset
+struct _CopyFaceSetBase {
+    IFaceSet object;
+
+    _CopyFaceSetBase(const IFaceSet& object_) : object(object_) { }
+
+    bool operator()(_IsValidTag) const
+    {
+        return object.valid();
+    }
+
+    const MetaData& operator()(_MetaDataTag) const
+    {
+        return object.getMetaData();
+    }
+
+    _AlembicTimeSamples operator()(_SampleTimesTag) const
+    {
+        return _GetSampleTimes(object);
+    }
+};
+
+/// Class to copy faceset isPartition into the family name
+struct _CopyFaceSetFamilyName : _CopyFaceSetBase {
+    using _CopyFaceSetBase::operator();
+
+    _CopyFaceSetFamilyName(const IFaceSet& object_) 
+        : _CopyFaceSetBase(object_) {};
+
+    bool operator()(const UsdAbc_AlembicDataAny& dst,
+                    const ISampleSelector& iss) const
+    {
+        // Because the absence of the ".facesExclusive" will trigger an
+        // exception in IFaceSetSchema, we need to manually deal with the
+        // default state (and discard the exception thrown erroneously by
+        // getFaceExclusivity()).
+        //
+        // This is a bug in Alembic that has been fixed in Alembic 1.7.2, but 
+        // the mininum required version for USD is 1.5.2. This workaround must 
+        // remain until the required Alembic version is changed for USD.
+        //
+        // The Alembic issue can be tracked here:
+        // https://github.com/alembic/alembic/issues/129
+        bool isPartition = false;
+        try {
+            isPartition = object.getSchema().getFaceExclusivity() == kFaceSetExclusive;
+        }
+        catch(const Alembic::Util::Exception&) {}
+
+        if (isPartition)
+        {
+            return dst.Set(UsdGeomTokens->nonOverlapping);
+        }
+
+        return dst.Set(UsdGeomTokens->unrestricted);
+    }
+};
+
 static
 TfToken
 _ConvertCurveBasis(BasisType value)
@@ -3262,6 +3321,44 @@ _ReadSubD(_PrimReaderContext* context)
 
     // Read texture coordinates
     _ReadProperty<IV2fGeomParam, GfVec2f>(context, "uv", _GetUVPropertyName(), _GetUVTypeName());
+}
+
+static
+void
+_ReadFaceSet(_PrimReaderContext* context)
+{
+    typedef IFaceSet Type;
+
+    // Wrap the object.
+    if (!Type::matches(context->GetObject().getHeader())) {
+        // Not of type Type.
+        return;
+    }
+
+    Type object(context->GetObject(), kWrapExisting);
+
+    // Add child properties under schema.
+    context->SetSchema(Type::schema_type::info_type::defaultName());
+
+    // Set prim type.  This depends on the CurveType of the curve.
+    context->GetPrim().typeName = UsdAbcPrimTypeNames->GeomSubset;
+
+    context->AddProperty(
+        UsdGeomTokens->indices,
+        SdfValueTypeNames->IntArray,
+        _CopyGeneric<IInt32ArrayProperty, int>(
+            context->ExtractSchema(".faces")));
+    context->AddUniformProperty(
+        UsdGeomTokens->elementType,
+        SdfValueTypeNames->Token,
+        _CopySynthetic(UsdGeomTokens->face));
+    context->AddUniformProperty(
+        UsdGeomTokens->familyName,
+        SdfValueTypeNames->Token,
+        _CopyFaceSetFamilyName(object));
+
+    // Consume properties implicitly handled above.
+    context->Extract(Type::schema_type::info_type::defaultName());
 }
 
 static
@@ -3802,6 +3899,9 @@ _ReaderSchemaBuilder::_ReaderSchemaBuilder()
         .AppendReader(_ReadArbGeomParams)
         .AppendReader(_ReadUserProperties)
         .AppendReader(_ReadOther)
+        ;
+    schema.AddType(FaceSetSchemaInfo::title())
+        .AppendReader(_ReadFaceSet)
         ;
     schema.AddType(CurvesSchemaInfo::title())
         .AppendReader(_ReadOrientation)

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2016-2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -94,6 +94,7 @@ using namespace ::Alembic::Abc;
     (PseudoRoot) \
     (Scope) \
     (Xform) \
+    (GeomSubset)\
     /* end */
 TF_DECLARE_PUBLIC_TOKENS(UsdAbcPrimTypeNames, USD_ABC_PRIM_TYPE_NAMES);
 

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
@@ -1,0 +1,90 @@
+#!/pxrpythonsubst
+#
+# Copyright 2019 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Usd, UsdAbc, UsdGeom, Gf
+import unittest
+
+
+class TestUsdAbcFaceset(unittest.TestCase):
+    def test_RoundTrip(self):
+        usdFile = 'original.usda'
+        abcFile = 'converted.abc'
+        self.assertTrue(UsdAbc._WriteAlembic(usdFile, abcFile))
+
+        stage = Usd.Stage.Open(abcFile)
+        prim = stage.GetPrimAtPath('/cube1')
+        self.assertTrue(prim.IsValid())
+
+        faceset1prim = stage.GetPrimAtPath('/cube1/faceset1')
+        faceset2prim = stage.GetPrimAtPath('/cube1/faceset2')
+        self.assertTrue(faceset1prim.IsValid())
+        self.assertTrue(faceset2prim.IsValid())
+
+        faceset1 = UsdGeom.Subset(faceset1prim)
+        faceset2 = UsdGeom.Subset(faceset2prim)
+
+        self.assertEqual(faceset1.GetFamilyNameAttr().Get(), 'nonOverlapping')
+        self.assertEqual(faceset2.GetFamilyNameAttr().Get(), 'nonOverlapping')
+
+        self.assertEqual(faceset1.GetElementTypeAttr().Get(), 'face')
+        self.assertEqual(faceset2.GetElementTypeAttr().Get(), 'face')
+
+        # Validate the indices for faceset1 (which is animated)
+        indices = faceset1.GetIndicesAttr()
+
+        timeSamples = indices.GetTimeSamples()
+        expectedTimeSamples = [0.0, 1.0]
+
+        self.assertEqual(len(timeSamples), len(expectedTimeSamples))
+
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [0, 3, 5], 1.0: [3]}
+        for time, expectedValue in expectedFaceIndices.iteritems():
+            faceIndices = indices.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+        # Validate the indices for faceset2 (which was constant, but promoted
+        # to a single sample at 0 during conversion)
+        indices = faceset2.GetIndicesAttr()
+
+        timeSamples = indices.GetTimeSamples()
+        expectedTimeSamples = [0.0]
+
+        self.assertEqual(len(timeSamples), len(expectedTimeSamples))
+
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [1, 2, 4]}
+        for time, expectedValue in expectedFaceIndices.items():
+            faceIndices = indices.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
@@ -1,0 +1,44 @@
+#usda 1.0
+(
+    defaultPrim = "cube1"
+    upAxis = "Y"
+)
+
+def Mesh "cube1"
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
+    normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
+        interpolation = "vertex"
+    )
+    float2[] primvars:uv = [(0, 1), (1, 1), (1, 0), (0, 0), (0, 2), (1, 2), (1, 1), (0, 1), (0, 3), (1, 3), (1, 2), (0, 2), (0, 4), (1, 4), (1, 3), (0, 3), (1, 1), (2, 1), (2, 0), (1, 0), (-1, 1), (0, 1), (0, 0), (-1, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token subdivisionScheme = "none"
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+
+    def GeomSubset "faceset1"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "partition"
+        int[] indices.timeSamples = {
+            0: [0, 3, 5],
+            1: [3],
+        }
+    }
+
+    def GeomSubset "faceset2"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "partition"
+        int[] indices = [1, 2, 4];
+    }
+
+}


### PR DESCRIPTION
### Description of Change(s)

This work is a continuation of Adam Ferrall-Nunge's work in https://github.com/PixarAnimationStudios/USD/pull/219, which added support for Alembic facesets to USD. At that time they were represented as Faceset data on the parent prim, which was subsequently read by pxrUsdIn and expanded back to faceset nodes. That PR was never accepted because UsdGeomSubset was introduced which became the more appropriate choice for representation of Alembic Facesets. 
To a large extent this simplified the problem: The exact same hierarchy is maintained between Alembic and USD with only the type changing (Alembic "Faceset" to USD "GeomSubset"). pxrUsdIn already has support for GeomSubset, so there was no need to make any pxrUsdIn changes for Katana.

### Testing

I've added a new unit test that performs round-tripping of faceset data from USD to Alembic and back again, verifying that the data is preserved as best as possible. It's not lossless, due to schema differences between Alembic and USD, but it's as good as can be represented, in my opinion.

### Fixes Issue(s)
-

