### PR TITLE
Add faceset support to usd dev

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -67,6 +67,7 @@ pxr_test_scripts(
     testenv/testUsdAbcCamera.py
     testenv/testUsdAbcConversionBasisCurves.py
     testenv/testUsdAbcConversionSubdiv.py
+    testenv/testUsdAbcFaceset.py
     testenv/testUsdAbcIndexedProperties.py
     testenv/testUsdAbcInstancing.py
     testenv/testUsdAbcUvReadWrite.py
@@ -96,6 +97,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdAbcConversionSubdiv
     DEST testUsdAbcConversionSubdiv
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdAbcFaceset
+    DEST testUsdAbcFaceset
 )
 
 pxr_install_test_dir(
@@ -162,6 +168,12 @@ pxr_register_test(testUsdAbcConversionSubdiv
 pxr_register_test(testUsdAbcConversionBasisCurves
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionBasisCurves"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdAbcFaceset
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcFaceset"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2016-2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -2849,6 +2849,65 @@ struct _CopyFaceVaryingInterpolateBoundary : _CopyGeneric<IInt32Property> {
     }
 };
 
+
+/// Base class to copy attributes of an alembic faceset to a USD GeomSubset
+struct _CopyFaceSetBase {
+    IFaceSet object;
+
+    _CopyFaceSetBase(const IFaceSet& object_) : object(object_) { }
+
+    bool operator()(_IsValidTag) const
+    {
+        return object.valid();
+    }
+
+    const MetaData& operator()(_MetaDataTag) const
+    {
+        return object.getMetaData();
+    }
+
+    _AlembicTimeSamples operator()(_SampleTimesTag) const
+    {
+        return _GetSampleTimes(object);
+    }
+};
+
+/// Class to copy faceset isPartition into the family name
+struct _CopyFaceSetFamilyName : _CopyFaceSetBase {
+    using _CopyFaceSetBase::operator();
+
+    _CopyFaceSetFamilyName(const IFaceSet& object_) 
+        : _CopyFaceSetBase(object_) {};
+
+    bool operator()(const UsdAbc_AlembicDataAny& dst,
+                    const ISampleSelector& iss) const
+    {
+        // Because the absence of the ".facesExclusive" will trigger an
+        // exception in IFaceSetSchema, we need to manually deal with the
+        // default state (and discard the exception thrown erroneously by
+        // getFaceExclusivity()).
+        //
+        // This is a bug in Alembic that has been fixed in Alembic 1.7.2, but 
+        // the mininum required version for USD is 1.5.2. This workaround must 
+        // remain until the required Alembic version is changed for USD.
+        //
+        // The Alembic issue can be tracked here:
+        // https://github.com/alembic/alembic/issues/129
+        bool isPartition = false;
+        try {
+            isPartition = object.getSchema().getFaceExclusivity() == kFaceSetExclusive;
+        }
+        catch(const Alembic::Util::Exception&) {}
+
+        if (isPartition)
+        {
+            return dst.Set(UsdGeomTokens->nonOverlapping);
+        }
+
+        return dst.Set(UsdGeomTokens->unrestricted);
+    }
+};
+
 static
 TfToken
 _ConvertCurveBasis(BasisType value)
@@ -3262,6 +3321,44 @@ _ReadSubD(_PrimReaderContext* context)
 
     // Read texture coordinates
     _ReadProperty<IV2fGeomParam, GfVec2f>(context, "uv", _GetUVPropertyName(), _GetUVTypeName());
+}
+
+static
+void
+_ReadFaceSet(_PrimReaderContext* context)
+{
+    typedef IFaceSet Type;
+
+    // Wrap the object.
+    if (!Type::matches(context->GetObject().getHeader())) {
+        // Not of type Type.
+        return;
+    }
+
+    Type object(context->GetObject(), kWrapExisting);
+
+    // Add child properties under schema.
+    context->SetSchema(Type::schema_type::info_type::defaultName());
+
+    // Set prim type.  This depends on the CurveType of the curve.
+    context->GetPrim().typeName = UsdAbcPrimTypeNames->GeomSubset;
+
+    context->AddProperty(
+        UsdGeomTokens->indices,
+        SdfValueTypeNames->IntArray,
+        _CopyGeneric<IInt32ArrayProperty, int>(
+            context->ExtractSchema(".faces")));
+    context->AddUniformProperty(
+        UsdGeomTokens->elementType,
+        SdfValueTypeNames->Token,
+        _CopySynthetic(UsdGeomTokens->face));
+    context->AddUniformProperty(
+        UsdGeomTokens->familyName,
+        SdfValueTypeNames->Token,
+        _CopyFaceSetFamilyName(object));
+
+    // Consume properties implicitly handled above.
+    context->Extract(Type::schema_type::info_type::defaultName());
 }
 
 static
@@ -3802,6 +3899,9 @@ _ReaderSchemaBuilder::_ReaderSchemaBuilder()
         .AppendReader(_ReadArbGeomParams)
         .AppendReader(_ReadUserProperties)
         .AppendReader(_ReadOther)
+        ;
+    schema.AddType(FaceSetSchemaInfo::title())
+        .AppendReader(_ReadFaceSet)
         ;
     schema.AddType(CurvesSchemaInfo::title())
         .AppendReader(_ReadOrientation)

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -3348,12 +3348,18 @@ _ReadFaceSet(_PrimReaderContext* context)
         return;
     }
 
+    // A FaceSet must be a child of another Alembic object.
+    if (!context->GetObject().getParent()) {
+        // No parent exists.
+        return;
+    }
+
     Type object(context->GetObject(), kWrapExisting);
 
     // Add child properties under schema.
     context->SetSchema(Type::schema_type::info_type::defaultName());
 
-    // Set prim type.  This depends on the CurveType of the curve.
+    // Set prim type.
     context->GetPrim().typeName = UsdAbcPrimTypeNames->GeomSubset;
 
     context->AddProperty(
@@ -3366,21 +3372,15 @@ _ReadFaceSet(_PrimReaderContext* context)
         SdfValueTypeNames->Token,
         _CopySynthetic(UsdGeomTokens->face));
 
-    TfToken defaultFamilyName("materialBind");
     context->AddUniformProperty(
         UsdGeomTokens->familyName,
         SdfValueTypeNames->Token,
-        _CopySynthetic(defaultFamilyName));
+        _CopySynthetic(UsdAbcPropertyNames->defaultFamilyName));
 
     _PrimReaderContext parentPrimContext = context->GetParentContext();
 
-    TfToken subsetFamilyAttributeName = TfToken(TfStringJoin(std::vector<std::string>{
-        "subsetFamily",
-        defaultFamilyName.GetString(),
-        "familyType"}, ":"));
-
     parentPrimContext.AddUniformProperty(
-        subsetFamilyAttributeName,
+        UsdAbcPropertyNames->defaultFamilyTypeAttributeName,
         SdfValueTypeNames->Token,
         _CopyFaceSetFamilyType(object));
 

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -102,6 +102,8 @@ TF_DECLARE_PUBLIC_TOKENS(UsdAbcPrimTypeNames, USD_ABC_PRIM_TYPE_NAMES);
 #define USD_ABC_GPRIM_NAMES \
     (primvars) \
     (userProperties) \
+    ((defaultFamilyName, "materialBind")) \
+    ((defaultFamilyTypeAttributeName, "subsetFamily:materialBind:familyType")) \
     /* end */
 #define USD_ABC_POINTBASED_NAMES \
     ((uv, "primvars:uv")) \

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2016-2019 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -94,6 +94,7 @@ using namespace ::Alembic::Abc;
     (PseudoRoot) \
     (Scope) \
     (Xform) \
+    (GeomSubset)\
     /* end */
 TF_DECLARE_PUBLIC_TOKENS(UsdAbcPrimTypeNames, USD_ABC_PRIM_TYPE_NAMES);
 

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -2923,15 +2923,9 @@ _WriteFaceSet(_PrimWriterContext* context)
                                          context->GetParent(),
                                          SdfAbstractDataSpecId(&parentPath));
 
-    TfToken defaultFamilyName("materialBind");
-    TfToken subsetFamilyAttributeName = TfToken(TfStringJoin(std::vector<std::string>{
-        "subsetFamily",
-        defaultFamilyName.GetString(),
-        "familyType"}, ":"));
-
-    UsdSamples familyType =
-        parentPrimContext.ExtractSamples(subsetFamilyAttributeName,
-                                         SdfValueTypeNames->Token);
+    UsdSamples familyType = parentPrimContext.ExtractSamples(
+        UsdAbcPropertyNames->defaultFamilyTypeAttributeName,
+        SdfValueTypeNames->Token);
 
     // Copy all the samples.
     typedef Type::schema_type::Sample SampleT;
@@ -2954,7 +2948,8 @@ _WriteFaceSet(_PrimWriterContext* context)
     FaceSetExclusivity faceSetExclusivity = kFaceSetNonExclusive;
     if (!familyType.IsEmpty())
     {
-        const TfToken& value = familyType.Get(0.0f).UncheckedGet<TfToken>();
+        double time = UsdTimeCode::EarliestTime().GetValue();
+        const TfToken& value = familyType.Get(time).UncheckedGet<TfToken>();
         if (!value.IsEmpty() && 
             (value == UsdGeomTokens->partition || 
              value == UsdGeomTokens->nonOverlapping)) {

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
@@ -1,0 +1,90 @@
+#!/pxrpythonsubst
+#
+# Copyright 2019 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Usd, UsdAbc, UsdGeom, Gf
+import unittest
+
+
+class TestUsdAbcFaceset(unittest.TestCase):
+    def test_RoundTrip(self):
+        usdFile = 'original.usda'
+        abcFile = 'converted.abc'
+        self.assertTrue(UsdAbc._WriteAlembic(usdFile, abcFile))
+
+        stage = Usd.Stage.Open(abcFile)
+        prim = stage.GetPrimAtPath('/cube1')
+        self.assertTrue(prim.IsValid())
+
+        faceset1prim = stage.GetPrimAtPath('/cube1/faceset1')
+        faceset2prim = stage.GetPrimAtPath('/cube1/faceset2')
+        self.assertTrue(faceset1prim.IsValid())
+        self.assertTrue(faceset2prim.IsValid())
+
+        faceset1 = UsdGeom.Subset(faceset1prim)
+        faceset2 = UsdGeom.Subset(faceset2prim)
+
+        self.assertEqual(faceset1.GetFamilyNameAttr().Get(), 'nonOverlapping')
+        self.assertEqual(faceset2.GetFamilyNameAttr().Get(), 'nonOverlapping')
+
+        self.assertEqual(faceset1.GetElementTypeAttr().Get(), 'face')
+        self.assertEqual(faceset2.GetElementTypeAttr().Get(), 'face')
+
+        # Validate the indices for faceset1 (which is animated)
+        indices = faceset1.GetIndicesAttr()
+
+        timeSamples = indices.GetTimeSamples()
+        expectedTimeSamples = [0.0, 1.0]
+
+        self.assertEqual(len(timeSamples), len(expectedTimeSamples))
+
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [0, 3, 5], 1.0: [3]}
+        for time, expectedValue in expectedFaceIndices.iteritems():
+            faceIndices = indices.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+        # Validate the indices for faceset2 (which was constant, but promoted
+        # to a single sample at 0 during conversion)
+        indices = faceset2.GetIndicesAttr()
+
+        timeSamples = indices.GetTimeSamples()
+        expectedTimeSamples = [0.0]
+
+        self.assertEqual(len(timeSamples), len(expectedTimeSamples))
+
+        for c, e in zip(timeSamples, expectedTimeSamples):
+            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+
+        expectedFaceIndices = {0.0: [1, 2, 4]}
+        for time, expectedValue in expectedFaceIndices.items():
+            faceIndices = indices.Get(time)
+            for c, e in zip(faceIndices, expectedValue):
+                self.assertEqual(c, e)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
@@ -33,25 +33,22 @@ class TestUsdAbcFaceset(unittest.TestCase):
         self.assertTrue(UsdAbc._WriteAlembic(usdFile, abcFile))
 
         stage = Usd.Stage.Open(abcFile)
-        prim = stage.GetPrimAtPath('/cube1')
-        self.assertTrue(prim.IsValid())
+        prim1 = stage.GetPrimAtPath('/cube1')
+        self.assertTrue(prim1.IsValid())
 
-        faceset1prim = stage.GetPrimAtPath('/cube1/faceset1')
-        faceset2prim = stage.GetPrimAtPath('/cube1/faceset2')
-        self.assertTrue(faceset1prim.IsValid())
-        self.assertTrue(faceset2prim.IsValid())
+        faceset1prim1 = stage.GetPrimAtPath('/cube1/faceset1')
+        faceset2prim1 = stage.GetPrimAtPath('/cube1/faceset2')
+        self.assertTrue(faceset1prim1.IsValid())
+        self.assertTrue(faceset2prim1.IsValid())
 
-        faceset1 = UsdGeom.Subset(faceset1prim)
-        faceset2 = UsdGeom.Subset(faceset2prim)
+        faceset1_1 = UsdGeom.Subset(faceset1prim1)
+        faceset2_1 = UsdGeom.Subset(faceset2prim1)
 
-        self.assertEqual(faceset1.GetFamilyNameAttr().Get(), 'nonOverlapping')
-        self.assertEqual(faceset2.GetFamilyNameAttr().Get(), 'nonOverlapping')
-
-        self.assertEqual(faceset1.GetElementTypeAttr().Get(), 'face')
-        self.assertEqual(faceset2.GetElementTypeAttr().Get(), 'face')
+        self.assertEqual(faceset1_1.GetElementTypeAttr().Get(), 'face')
+        self.assertEqual(faceset2_1.GetElementTypeAttr().Get(), 'face')
 
         # Validate the indices for faceset1 (which is animated)
-        indices = faceset1.GetIndicesAttr()
+        indices = faceset1_1.GetIndicesAttr()
 
         timeSamples = indices.GetTimeSamples()
         expectedTimeSamples = [0.0, 1.0]
@@ -69,7 +66,7 @@ class TestUsdAbcFaceset(unittest.TestCase):
 
         # Validate the indices for faceset2 (which was constant, but promoted
         # to a single sample at 0 during conversion)
-        indices = faceset2.GetIndicesAttr()
+        indices = faceset2_1.GetIndicesAttr()
 
         timeSamples = indices.GetTimeSamples()
         expectedTimeSamples = [0.0]
@@ -85,6 +82,55 @@ class TestUsdAbcFaceset(unittest.TestCase):
             for c, e in zip(faceIndices, expectedValue):
                 self.assertEqual(c, e)
 
+        # Initialize checks for /cube2
+        prim2 = stage.GetPrimAtPath('/cube2')
+        self.assertTrue(prim2.IsValid())
+        faceset1prim2 = stage.GetPrimAtPath('/cube2/faceset1')
+        faceset2prim2 = stage.GetPrimAtPath('/cube2/faceset2')
+        faceset3prim2 = stage.GetPrimAtPath('/cube2/faceset3')
+        self.assertTrue(faceset1prim2.IsValid())
+        self.assertTrue(faceset2prim2.IsValid())
+        self.assertTrue(faceset3prim2.IsValid())
+
+        faceset1_2 = UsdGeom.Subset(faceset1prim2)
+        faceset2_2 = UsdGeom.Subset(faceset2prim2)
+        faceset3_2 = UsdGeom.Subset(faceset3prim2)
+
+        # Initialize checks for /cube3
+        prim3 = stage.GetPrimAtPath('/cube3')
+        self.assertTrue(prim3.IsValid())
+        faceset1prim3 = stage.GetPrimAtPath('/cube3/faceset')
+        self.assertTrue(faceset1prim3.IsValid())
+        faceset1_3 = UsdGeom.Subset(faceset1prim3)
+
+        # Check the round-tripping of familyTypes.
+
+        imageable1 = UsdGeom.Imageable(prim1)
+        imageable2 = UsdGeom.Imageable(prim2)
+        imageable3 = UsdGeom.Imageable(prim3)
+
+        # In cube1 we've used "unrestricted" as the familyType. 
+        self.assertEqual(faceset1_1.GetFamilyNameAttr().Get(), 'materialBind')
+        self.assertEqual(faceset2_1.GetFamilyNameAttr().Get(), 'materialBind')
+        self.assertEqual(UsdGeom.Subset.GetFamilyType(imageable1, "materialBind"),
+                         "unrestricted")
+
+        # In cube2 we've used "nonOverlapping" in order to ensure both 
+        # familyTypes can be round-tripped.
+        self.assertEqual(faceset1_2.GetFamilyNameAttr().Get(), 'materialBind')
+        self.assertEqual(faceset2_2.GetFamilyNameAttr().Get(), 'materialBind')
+        self.assertEqual(UsdGeom.Subset.GetFamilyType(imageable2, "materialBind"),
+                         "nonOverlapping")
+        # We've also added another familyName in addition. We should see this 
+        # being lost in the round-trip and converted to "materialBind".
+        self.assertEqual(faceset3_2.GetFamilyNameAttr().Get(), 'materialBind')
+
+        # In cube3, no familyName or familyType has been specified. Upon 
+        # round-tripping, a default value of "unrestricted" will appear on the
+        # the default "materialBind" familyName.
+        self.assertEqual(faceset1_3.GetFamilyNameAttr().Get(), 'materialBind')
+        self.assertEqual(UsdGeom.Subset.GetFamilyType(imageable3, "materialBind"),
+                         "unrestricted")
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset.py
@@ -64,17 +64,12 @@ class TestUsdAbcFaceset(unittest.TestCase):
             for c, e in zip(faceIndices, expectedValue):
                 self.assertEqual(c, e)
 
-        # Validate the indices for faceset2 (which was constant, but promoted
-        # to a single sample at 0 during conversion)
+        # Validate the indices for faceset2.
         indices = faceset2_1.GetIndicesAttr()
 
         timeSamples = indices.GetTimeSamples()
-        expectedTimeSamples = [0.0]
 
-        self.assertEqual(len(timeSamples), len(expectedTimeSamples))
-
-        for c, e in zip(timeSamples, expectedTimeSamples):
-            self.assertTrue(Gf.IsClose(c, e, 1e-5))
+        self.assertEqual(len(timeSamples), 0)
 
         expectedFaceIndices = {0.0: [1, 2, 4]}
         for time, expectedValue in expectedFaceIndices.items():
@@ -104,28 +99,28 @@ class TestUsdAbcFaceset(unittest.TestCase):
         faceset1_3 = UsdGeom.Subset(faceset1prim3)
 
         # Check the round-tripping of familyTypes.
-
         imageable1 = UsdGeom.Imageable(prim1)
         imageable2 = UsdGeom.Imageable(prim2)
         imageable3 = UsdGeom.Imageable(prim3)
 
-        # In cube1 we've used "unrestricted" as the familyType. 
+        # In cube1 we've used "partition" as the familyType. This should be
+        # converted to "nonOverlapping" as it more closely matches the Alembic
+        # definition of "partition".
         self.assertEqual(faceset1_1.GetFamilyNameAttr().Get(), 'materialBind')
         self.assertEqual(faceset2_1.GetFamilyNameAttr().Get(), 'materialBind')
         self.assertEqual(UsdGeom.Subset.GetFamilyType(imageable1, "materialBind"),
-                         "unrestricted")
+                         "nonOverlapping")
 
-        # In cube2 we've used "nonOverlapping" in order to ensure both 
-        # familyTypes can be round-tripped.
+        # In cube2 we've used "unrestricted". This should come across directly.
         self.assertEqual(faceset1_2.GetFamilyNameAttr().Get(), 'materialBind')
         self.assertEqual(faceset2_2.GetFamilyNameAttr().Get(), 'materialBind')
         self.assertEqual(UsdGeom.Subset.GetFamilyType(imageable2, "materialBind"),
-                         "nonOverlapping")
-        # We've also added another familyName in addition. We should see this 
+                         "unrestricted")
+        # We've also added another familyName in addition. We should see this
         # being lost in the round-trip and converted to "materialBind".
         self.assertEqual(faceset3_2.GetFamilyNameAttr().Get(), 'materialBind')
 
-        # In cube3, no familyName or familyType has been specified. Upon 
+        # In cube3, no familyName or familyType has been specified. Upon
         # round-tripping, a default value of "unrestricted" will appear on the
         # the default "materialBind" familyName.
         self.assertEqual(faceset1_3.GetFamilyNameAttr().Get(), 'materialBind')

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
@@ -1,0 +1,44 @@
+#usda 1.0
+(
+    defaultPrim = "cube1"
+    upAxis = "Y"
+)
+
+def Mesh "cube1"
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
+    normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
+        interpolation = "vertex"
+    )
+    float2[] primvars:uv = [(0, 1), (1, 1), (1, 0), (0, 0), (0, 2), (1, 2), (1, 1), (0, 1), (0, 3), (1, 3), (1, 2), (0, 2), (0, 4), (1, 4), (1, 3), (0, 3), (1, 1), (2, 1), (2, 0), (1, 0), (-1, 1), (0, 1), (0, 0), (-1, 0)] (
+        interpolation = "faceVarying"
+    )
+    uniform token subdivisionScheme = "none"
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+
+    def GeomSubset "faceset1"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "partition"
+        int[] indices.timeSamples = {
+            0: [0, 3, 5],
+            1: [3],
+        }
+    }
+
+    def GeomSubset "faceset2"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "partition"
+        int[] indices = [1, 2, 4];
+    }
+
+}

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
@@ -24,10 +24,12 @@ def Mesh "cube1"
 
     int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
 
+    uniform token subsetFamily:materialBind:familyType = "unrestricted"
+
     def GeomSubset "faceset1"
     {
         uniform token elementType = "face"
-        uniform token familyName = "partition"
+        uniform token familyName = "materialBind"
         int[] indices.timeSamples = {
             0: [0, 3, 5],
             1: [3],
@@ -37,8 +39,68 @@ def Mesh "cube1"
     def GeomSubset "faceset2"
     {
         uniform token elementType = "face"
-        uniform token familyName = "partition"
+        uniform token familyName = "materialBind"
         int[] indices = [1, 2, 4];
     }
 
+}
+
+def Mesh "cube2"
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
+        interpolation = "vertex"
+    )
+    uniform token subdivisionScheme = "none"
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+
+    uniform token subsetFamily:materialBind:familyType = "nonOverlapping"
+    uniform token subsetFamily:someOtherFamily:familyType = "partition"
+
+    def GeomSubset "faceset1"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "materialBind"
+        int[] indices = [0, 3, 5];
+    }
+
+    def GeomSubset "faceset2"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "materialBind"
+        int[] indices = [1, 2, 4];
+    }
+
+    def GeomSubset "faceset3"
+    {
+        uniform token elementType = "face"
+        uniform token familyName = "someOtherFamily"
+        int[] indices = [0, 1, 2, 3, 4, 5];
+    }
+}
+
+def Mesh "cube3"
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
+        interpolation = "vertex"
+    )
+    uniform token subdivisionScheme = "none"
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+
+    def GeomSubset "faceset"
+    {
+        uniform token elementType = "face"
+        int[] indices = [0, 3, 5];
+    }
 }

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcFaceset/original.usda
@@ -7,13 +7,12 @@
 def Mesh "cube1"
 {
     float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
-
     int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
     int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
     normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0)] (
         interpolation = "faceVarying"
     )
-    uniform token orientation = "leftHanded"
+    token orientation = "leftHanded"
     point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
         interpolation = "vertex"
     )
@@ -21,10 +20,7 @@ def Mesh "cube1"
         interpolation = "faceVarying"
     )
     uniform token subdivisionScheme = "none"
-
-    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
-
-    uniform token subsetFamily:materialBind:familyType = "unrestricted"
+    uniform token subsetFamily:materialBind:familyType = "partition"
 
     def GeomSubset "faceset1"
     {
@@ -40,67 +36,60 @@ def Mesh "cube1"
     {
         uniform token elementType = "face"
         uniform token familyName = "materialBind"
-        int[] indices = [1, 2, 4];
+        int[] indices = [1, 2, 4]
     }
-
 }
 
 def Mesh "cube2"
 {
     float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
-
     int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
     int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
-    uniform token orientation = "leftHanded"
+    token orientation = "leftHanded"
     point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
         interpolation = "vertex"
     )
     uniform token subdivisionScheme = "none"
-
-    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
-
-    uniform token subsetFamily:materialBind:familyType = "nonOverlapping"
+    uniform token subsetFamily:materialBind:familyType = "unrestricted"
     uniform token subsetFamily:someOtherFamily:familyType = "partition"
 
     def GeomSubset "faceset1"
     {
         uniform token elementType = "face"
         uniform token familyName = "materialBind"
-        int[] indices = [0, 3, 5];
+        int[] indices = [0, 3, 5]
     }
 
     def GeomSubset "faceset2"
     {
         uniform token elementType = "face"
         uniform token familyName = "materialBind"
-        int[] indices = [1, 2, 4];
+        int[] indices = [1, 2, 4]
     }
 
     def GeomSubset "faceset3"
     {
         uniform token elementType = "face"
         uniform token familyName = "someOtherFamily"
-        int[] indices = [0, 1, 2, 3, 4, 5];
+        int[] indices = [0, 1, 2, 3, 4, 5]
     }
 }
 
 def Mesh "cube3"
 {
     float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
-
     int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
     int[] faceVertexIndices = [2, 3, 1, 0, 6, 7, 3, 2, 4, 5, 7, 6, 0, 1, 5, 4, 3, 7, 5, 1, 6, 2, 0, 4]
-    uniform token orientation = "leftHanded"
+    token orientation = "leftHanded"
     point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5)] (
         interpolation = "vertex"
     )
     uniform token subdivisionScheme = "none"
 
-    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
-
     def GeomSubset "faceset"
     {
         uniform token elementType = "face"
-        int[] indices = [0, 3, 5];
+        int[] indices = [0, 3, 5]
     }
 }
+


### PR DESCRIPTION
### Description of Change(s)

This work is a continuation of Adam Ferrall-Nunge's work in #219, which added support for Alembic facesets to USD. At that time they were represented as Faceset data on the parent prim, which was subsequently read by pxrUsdIn and expanded back to faceset nodes. That PR was never accepted because UsdGeomSubset was introduced which became the more appropriate choice for representation of Alembic Facesets.
To a large extent this simplified the problem: The exact same hierarchy is maintained between Alembic and USD with only the type changing (Alembic "Faceset" to USD "GeomSubset"). pxrUsdIn already has support for GeomSubset, so there was no need to make any pxrUsdIn changes for Katana.

This is a rebasing of https://github.com/PixarAnimationStudios/USD/pull/754 onto dev.

### Testing

I've added a new unit test that performs round-tripping of faceset data from USD to Alembic and back again, verifying that the data is preserved as best as possible. It's not lossless, due to schema differences between Alembic and USD, but it's as good as can be represented, in my opinion.

