### PR TITLE
[usdKatana] Changing the inputType for Texcoord primvars to vector.

### DIFF
--- a/third_party/katana/lib/usdKatana/utils.cpp
+++ b/third_party/katana/lib/usdKatana/utils.cpp
@@ -607,12 +607,12 @@ _KTypeAndSizeFromUsdVec2(TfToken const &roleName,
 {
     if (roleName == SdfValueRoleNames->Point) {
         *inputTypeAttr = FnKat::StringAttribute("point2");
-    } else if (roleName == SdfValueRoleNames->Vector) {
+    } else if (roleName == SdfValueRoleNames->Vector ||
+               roleName == SdfValueRoleNames->TextureCoordinate) {
         *inputTypeAttr = FnKat::StringAttribute("vector2");
     } else if (roleName == SdfValueRoleNames->Normal) {
         *inputTypeAttr = FnKat::StringAttribute("normal2");
-    } else if (roleName == SdfValueRoleNames->TextureCoordinate ||
-               roleName.IsEmpty()) {
+    } else if (roleName.IsEmpty()) {
         *inputTypeAttr = FnKat::StringAttribute(typeStr);
         *elementSizeAttr = FnKat::IntAttribute(2);
     } else {
@@ -629,7 +629,8 @@ _KTypeAndSizeFromUsdVec3(TfToken const &roleName,
 {
     if (roleName == SdfValueRoleNames->Point) {
         *inputTypeAttr = FnKat::StringAttribute("point3");
-    } else if (roleName == SdfValueRoleNames->Vector) {
+    } else if (roleName == SdfValueRoleNames->Vector ||
+               roleName == SdfValueRoleNames->TextureCoordinate) {
         *inputTypeAttr = FnKat::StringAttribute("vector3");
     } else if (roleName == SdfValueRoleNames->Normal) {
         *inputTypeAttr = FnKat::StringAttribute("normal3");
@@ -680,7 +681,9 @@ _KTypeAndSizeFromUsdVec2(TfToken const &roleName,
                          FnKat::Attribute *inputTypeAttr, 
                          FnKat::Attribute *elementSizeAttr)
 {
-    if (roleName.IsEmpty()) {
+    if (roleName == SdfValueRoleNames->TextureCoordinate) {
+        *inputTypeAttr = FnKat::StringAttribute("vector2");
+    } else if(roleName.IsEmpty()) {
         // Deserves explanation: there is no type in prman
         // (or apparently, katana) that represents 
         // "a 2-vector with no additional behavior/meaning.


### PR DESCRIPTION
### Description of Change(s)
The PR changes how the conversion of texCoord2f/texCoord3f/texCoord2f[]/texCoord3f[] works in pxrUsdIn. Previously, we created arbitrary attributes with the inputType of float / double and elementSize respective of the tuple size of the primvar. This was changed to inputType of vector2/3.

The reason for this change is: there is no other way to create vector2 typed arbitrary values in Katana, as texcoord2f/h/d are the only attribute specs with a non-empty role name. texCoord3f was included in the change for consistency.