### PR TITLE
[usdview] Added currentFrame command line argument

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -149,10 +149,16 @@ class Launcher(object):
                                  '(0 is max, negative numbers imply max - N)')
 
         parser.add_argument('--ff', action='store',
-                            dest='firstframe', type=int)
+                            dest='firstframe', type=int,
+                            help='Set the first frame of the viewer')
 
         parser.add_argument('--lf', action='store',
-                            dest='lastframe', type=int)
+                            dest='lastframe', type=int,
+                            help='Set the last frame of the viewer')
+
+        parser.add_argument('--cf', action='store',
+                            dest='currentframe', type=int,
+                            help='Set the current frame of the viewer')
 
         parser.add_argument('--complexity', action='store',
                             type=str, default="low", dest='complexity',

--- a/pxr/usdImaging/lib/usdviewq/frameSlider.py
+++ b/pxr/usdImaging/lib/usdviewq/frameSlider.py
@@ -23,105 +23,53 @@
 #
 from qt import QtCore, QtGui, QtWidgets
 
+
 class FrameSlider(QtWidgets.QSlider):
-    # Emitted when the current frame of the slider changes and the stage's 
-    # current frame needs to be updated.
-    signalFrameChanged = QtCore.Signal(int)
-
-    # Emitted when the slider position has changed but the underlying frame 
-    # value hasn't been changed.
-    signalPositionChanged = QtCore.Signal(int)
-
-    def __init__(self, parent):
-        super(FrameSlider, self).__init__(parent)
-        self._sliderTimer = QtCore.QTimer(self)
-        self._sliderTimer.setInterval(500)
-        self._sliderTimer.timeout.connect(self.sliderTimeout)     
-        self.valueChanged.connect(self.sliderValueChanged)
-        self._mousePressed = False
-        self._scrubbing = False
-        self._updateOnFrameScrub = False
-
-    def setUpdateOnFrameScrub(self, updateOnFrameScrub):
-        self._updateOnFrameScrub = updateOnFrameScrub
-
-    def sliderTimeout(self):
-        if not self._updateOnFrameScrub and self._mousePressed:
-            self._sliderTimer.stop()
-            self.signalPositionChanged.emit(self.value())
-            return
-        self.frameChanged()
-
-    def frameChanged(self):
-        self._sliderTimer.stop()
-        self.signalFrameChanged.emit(self.value())
-
-    def sliderValueChanged(self, value):
-        self._sliderTimer.stop()
-        self._sliderTimer.start()
-
-    def setValueImmediate(self, value):
-        self.setValue(value)
-        self.frameChanged()
-
-    def setValueFromEvent(self, event, immediate=True):
-        currentValue = self.value()
-        movePosition = self.minimum() + ((self.maximum()-self.minimum()) * 
-            event.x()) / float(self.width())
-        targetPosition = round(movePosition)
-        if targetPosition == currentValue:
-            if (movePosition - currentValue) >= 0:
-                targetPosition = currentValue + 1
-            else:
-                targetPosition = currentValue - 1;
-        if immediate:
-            self.setValueImmediate(targetPosition)
-        else:
-            self.setValue(targetPosition)
+    """Custom QSlider class to allow scrubbing on left-click."""
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
-            self._mousePressed = True
-            self.setValueFromEvent(event)
-            event.accept()
-        super(FrameSlider, self).mousePressEvent(event)
+        # If the slider has no range, or the event button isn't valid,
+        # ignore the event.
+        if (self.maximum() == self.minimum() or
+                event.buttons() ^ event.button()):
+            event.ignore()
+            return
 
-    def mouseMoveEvent(self, event):
-        # Since mouseTracking is disabled by default, this event callback is 
-        # only invoked when a mouse is pressed down and moved (i.e. dragged or 
-        # scrubbed).
-        self._scrubbing = True
-        self.setValueFromEvent(event, immediate=self._updateOnFrameScrub)
         event.accept()
 
-    def mouseReleaseEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
-            self._mousePressed = False
-            # If this is just a click (and not a drag with mouse pressed), 
-            # we don't want setValue twice for the same frame value.
-            if self._scrubbing:
-                self.setValueFromEvent(event)
-            event.accept()
-            self._scrubbing = False
-        super(FrameSlider, self).mouseReleaseEvent(event)
+            # Set the slider down property.
+            # This tells the slider to obey the tracking state.
+            self.setSliderDown(True)
+            # Get the slider value from the event position.
+            value = QtGui.QStyle.sliderValueFromPosition(
+                self.minimum(), self.maximum(), event.x(), self.width()
+            )
+            # Set the slider value
+            self.setSliderPosition(value)
 
-    def advanceFrame(self):
-        newValue = self.value() + 1
-        if newValue > self.maximum():
-            newValue = self.minimum()
-        self.setValueImmediate(newValue)
+    def mouseMoveEvent(self, event):
+        # If the slider isn't currently being pressed, ignore the event.
+        if not self.isSliderDown():
+            event.ignore()
+            return
 
-    def retreatFrame(self):
-        newValue = self.value() - 1
-        if newValue < self.minimum():
-            newValue = self.maximum()
-        self.setValueImmediate(newValue)
+        event.accept()
 
-    def resetSlider(self, numTimeSamples):
-        self.setRange(0, numTimeSamples-1)
-        self.resetToMinimum()
+        # Get the slider value from the event position.
+        value = QtGui.QStyle.sliderValueFromPosition(
+            self.minimum(), self.maximum(), event.x(), self.width()
+        )
+        # Set the slider value.
+        self.setSliderPosition(value)
 
-    def resetToMinimum(self):
-        self.setValue(self.minimum())
-        # Call this here to push the update immediately.
-        self.frameChanged()
+    def mouseReleaseEvent(self, event):
+        # If the slider isn't currently being pressed, ignore the event.
+        if (not self.isSliderDown()) or event.buttons():
+            event.ignore()
+            return
+
+        event.accept()
+
+        # Unset the slider down property.
+        self.setSliderDown(False)


### PR DESCRIPTION
### Description of Change(s) 

* Added help strings to startFrame and lastFrame.

    --ff FIRSTFRAME       Set the first frame of the viewer
    --lf LASTFRAME        Set the last frame of the viewer
    --cf CURRENTFRAME     Set the current frame of the viewer

* Refactored _findIndexOfFieldContents to _findClosestFrameIndex
  * New function takes a frame value rather than being passed the text field widget.
  * Removed unnecessary string formatting which is already provided by the validator attached to the text field widget.
  * Improved time to find the frame index by using the bisect library (O(n) -> O(log n)).

* Refactored setFrame to _setFrameIndex
  * Removed the closestFrame lookup - as far as I'm aware this does nothing of value as closestFrame always equals frame.
    * This has given us a speed increase on playback - the closestFrame lookup iterated over the entire _timeSamples list every time the frame changed.
  * Removed the need for the forceUpdate variable.

* Re-purposed setFrame to be a simple wrapper that finds a frameIndex and calls _setFrameIndex.

* Split _updateOnFrameChange into _updateOnFrameChange and _updateOnFrameChangeFinish
  * Allows us to differentiate between what we want to update whilst the frame is changing (playing/scrubbing) and what we want to update when the frame change has finished.
  * Removes the need for the refreshUI variable.

* Fixed a bug that would reset the current frame when the start/end frame widgets lose focus and no changes were made.
  * Added a check to _rangeBeginChanged and _rangeEndChanged to only update if the value changes.
  * This resetting of the timeline would also not update the dataModel - so the value on the timeline and what was being shown in the viewer would not match up.
    * This was fixed by adding a call to setFrame in _UpdateTimeSamples

* Simplified the FrameSlider class.
  * Reverted to using Qt's logic for scrubbing/tracking which improves accuracy and performance.
  * In doing so, fixed a minor bug that was causing extra UI updates whilst scrubbing.
    * If the action of scrubbing happens towards the start or end, isSliderDown returns False rather than True.
  * Only using the class to override necessary mouse events.

### Fixes Issue(s)
-  #296 