### PR TITLE
 [usdview] Split _updateOnFrameChange logic. Simplified the FrameSlider class.

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -733,7 +733,7 @@ class AppController(QtCore.QObject):
 
             self._ui.frameSlider.valueChanged.connect(self.setFrame)
             self._ui.frameSlider.sliderMoved.connect(self._sliderMoved)
-            self._ui.frameSlider.sliderReleased.connect(self._updateOnFrameChangeFinish)
+            self._ui.frameSlider.sliderReleased.connect(self._updateGUIForFrameChange)
 
             self._ui.frameField.editingFinished.connect(self._frameStringChanged)
 
@@ -1248,7 +1248,8 @@ class AppController(QtCore.QObject):
                 self._ui.frameSlider.setValue(0)
             self._setPlayShortcut()
             self._ui.playButton.setCheckable(True)
-            self._ui.playButton.setChecked(False)
+            # Ensure the play button state respects the current playback state
+            self._ui.playButton.setChecked(self._dataModel.playing)
 
     def _clearCaches(self, preserveCamera=False):
         """Clears value and computation caches maintained by the controller.
@@ -3211,7 +3212,7 @@ class AppController(QtCore.QObject):
         if (self._dataModel.currentFrame != frameAtStart) or forceUpdate:
             self._updateOnFrameChange()
 
-    def _updateOnFrameChangeFinish(self):
+    def _updateGUIForFrameChange(self):
         """Called when the frame changes have finished.
         e.g When the playback/scrubbing has stopped.
         """
@@ -3232,7 +3233,7 @@ class AppController(QtCore.QObject):
         """Called when the frame changes, updates the renderer and such"""
         # do not update HUD/BBOX if scrubbing or playing
         if not (self._dataModel.playing or self._ui.frameSlider.isSliderDown()):
-            self._updateOnFrameChangeFinish()
+            self._updateGUIForFrameChange()
         if self._stageView:
             # this is the part that renders
             if self._dataModel.playing:

--- a/pxr/usdImaging/lib/usdviewq/frameSlider.py
+++ b/pxr/usdImaging/lib/usdviewq/frameSlider.py
@@ -23,105 +23,53 @@
 #
 from qt import QtCore, QtGui, QtWidgets
 
+
 class FrameSlider(QtWidgets.QSlider):
-    # Emitted when the current frame of the slider changes and the stage's 
-    # current frame needs to be updated.
-    signalFrameChanged = QtCore.Signal(int)
-
-    # Emitted when the slider position has changed but the underlying frame 
-    # value hasn't been changed.
-    signalPositionChanged = QtCore.Signal(int)
-
-    def __init__(self, parent):
-        super(FrameSlider, self).__init__(parent)
-        self._sliderTimer = QtCore.QTimer(self)
-        self._sliderTimer.setInterval(500)
-        self._sliderTimer.timeout.connect(self.sliderTimeout)     
-        self.valueChanged.connect(self.sliderValueChanged)
-        self._mousePressed = False
-        self._scrubbing = False
-        self._updateOnFrameScrub = False
-
-    def setUpdateOnFrameScrub(self, updateOnFrameScrub):
-        self._updateOnFrameScrub = updateOnFrameScrub
-
-    def sliderTimeout(self):
-        if not self._updateOnFrameScrub and self._mousePressed:
-            self._sliderTimer.stop()
-            self.signalPositionChanged.emit(self.value())
-            return
-        self.frameChanged()
-
-    def frameChanged(self):
-        self._sliderTimer.stop()
-        self.signalFrameChanged.emit(self.value())
-
-    def sliderValueChanged(self, value):
-        self._sliderTimer.stop()
-        self._sliderTimer.start()
-
-    def setValueImmediate(self, value):
-        self.setValue(value)
-        self.frameChanged()
-
-    def setValueFromEvent(self, event, immediate=True):
-        currentValue = self.value()
-        movePosition = self.minimum() + ((self.maximum()-self.minimum()) * 
-            event.x()) / float(self.width())
-        targetPosition = round(movePosition)
-        if targetPosition == currentValue:
-            if (movePosition - currentValue) >= 0:
-                targetPosition = currentValue + 1
-            else:
-                targetPosition = currentValue - 1;
-        if immediate:
-            self.setValueImmediate(targetPosition)
-        else:
-            self.setValue(targetPosition)
+    """Custom QSlider class to allow scrubbing on left-click."""
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
-            self._mousePressed = True
-            self.setValueFromEvent(event)
-            event.accept()
-        super(FrameSlider, self).mousePressEvent(event)
+        # If the slider has no range, or the event button isn't valid,
+        # ignore the event.
+        if (self.maximum() == self.minimum() or
+                event.buttons() ^ event.button()):
+            event.ignore()
+            return
 
-    def mouseMoveEvent(self, event):
-        # Since mouseTracking is disabled by default, this event callback is 
-        # only invoked when a mouse is pressed down and moved (i.e. dragged or 
-        # scrubbed).
-        self._scrubbing = True
-        self.setValueFromEvent(event, immediate=self._updateOnFrameScrub)
         event.accept()
 
-    def mouseReleaseEvent(self, event):
         if event.button() == QtCore.Qt.LeftButton:
-            self._mousePressed = False
-            # If this is just a click (and not a drag with mouse pressed), 
-            # we don't want setValue twice for the same frame value.
-            if self._scrubbing:
-                self.setValueFromEvent(event)
-            event.accept()
-            self._scrubbing = False
-        super(FrameSlider, self).mouseReleaseEvent(event)
+            # Set the slider down property.
+            # This tells the slider to obey the tracking state.
+            self.setSliderDown(True)
+            # Get the slider value from the event position.
+            value = QtGui.QStyle.sliderValueFromPosition(
+                self.minimum(), self.maximum(), event.x(), self.width()
+            )
+            # Set the slider value
+            self.setSliderPosition(value)
 
-    def advanceFrame(self):
-        newValue = self.value() + 1
-        if newValue > self.maximum():
-            newValue = self.minimum()
-        self.setValueImmediate(newValue)
+    def mouseMoveEvent(self, event):
+        # If the slider isn't currently being pressed, ignore the event.
+        if not self.isSliderDown():
+            event.ignore()
+            return
 
-    def retreatFrame(self):
-        newValue = self.value() - 1
-        if newValue < self.minimum():
-            newValue = self.maximum()
-        self.setValueImmediate(newValue)
+        event.accept()
 
-    def resetSlider(self, numTimeSamples):
-        self.setRange(0, numTimeSamples-1)
-        self.resetToMinimum()
+        # Get the slider value from the event position.
+        value = QtGui.QStyle.sliderValueFromPosition(
+            self.minimum(), self.maximum(), event.x(), self.width()
+        )
+        # Set the slider value.
+        self.setSliderPosition(value)
 
-    def resetToMinimum(self):
-        self.setValue(self.minimum())
-        # Call this here to push the update immediately.
-        self.frameChanged()
+    def mouseReleaseEvent(self, event):
+        # If the slider isn't currently being pressed, ignore the event.
+        if (not self.isSliderDown()) or event.buttons():
+            event.ignore()
+            return
+
+        event.accept()
+
+        # Unset the slider down property.
+        self.setSliderDown(False)

--- a/pxr/usdImaging/lib/usdviewq/frameSlider.py
+++ b/pxr/usdImaging/lib/usdviewq/frameSlider.py
@@ -21,7 +21,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-from qt import QtCore, QtGui, QtWidgets
+from qt import QtCore, QtWidgets
 
 
 class FrameSlider(QtWidgets.QSlider):
@@ -43,13 +43,31 @@ class FrameSlider(QtWidgets.QSlider):
         self.valueChanged.emit(self.sliderPosition())
 
     def mousePressEvent(self, event):
-        if event.button() == QtCore.Qt.LeftButton:
-            # Get the slider value from the event position.
-            value = QtGui.QStyle.sliderValueFromPosition(
-                self.minimum(), self.maximum(), event.x(), self.width()
-            )
-            # Set the slider value.
-            self.setSliderPosition(value)
+        # This is a temporary solution that should revisited in future.
+        #
+        # The issue is that the current QStyle on the application
+        # only allows the slider position to be set on a MiddleButton
+        # MouseEvent.
+        #
+        # The correct solution is for us to create a QProxyStyle for the
+        # application so we can edit the value of the
+        # QStyle.SH_Slider_AbsoluteSetButtons property (to include
+        # LeftButton). Unfortunately QProxyStyle is not yet available
+        # in this version of PySide.
+        #
+        # Instead, we are forced to duplicate the MouseEvent as a
+        # MiddleButton event. This creates the exact behavior we
+        # want to see from the QSlider.
+        styleHint = QtWidgets.QStyle.SH_Slider_AbsoluteSetButtons
+        if self.style().styleHint(styleHint) == QtCore.Qt.MiddleButton:
+            if event.button() == QtCore.Qt.LeftButton:
+                event = QtWidgets.QMouseEvent(
+                    event.type(),
+                    event.pos(),
+                    QtCore.Qt.MiddleButton,
+                    QtCore.Qt.MiddleButton,
+                    event.modifiers()
+                )
 
         super(FrameSlider, self).mousePressEvent(event)
 


### PR DESCRIPTION
The three PR's I've submitted tonight will allow me to submit a final PR for the current frame feature once they have been merged into dev!

### Description of Change(s)

* Split _updateOnFrameChange into _updateOnFrameChange and _updateOnFrameChangeFinish
  * Allows us to differentiate between what we want to update whilst the frame is changing (playing/scrubbing) and what we want to update when the frame change has finished.
  * Removes the need for the refreshUI variable.

* Simplified the FrameSlider class
  * Reverted to using Qt's logic for scrubbing/tracking which improves accuracy and performance.
  * In doing so, fixed a minor bug that was causing extra UI updates whilst scrubbing.
    * If the action of scrubbing happens towards the start or end, isSliderDown returns False rather than True.
  * Only using the class to override necessary mouse events.
  * Removed unused _playbackFrameIndex variable.
