### PR TITLE
Add DSO export visibility to UsdImagingGLEngine._UpdateHydraCollection 

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -411,6 +411,7 @@ protected:
 
     // Create a hydra collection given root paths and render params.
     // Returns true if the collection was updated.
+    USDIMAGINGGL_API
     static bool _UpdateHydraCollection(HdRprimCollection *collection,
                           SdfPathVector const& roots,
                           UsdImagingGLRenderParams const& params,


### PR DESCRIPTION
### Description of Change(s)
When upgrading AL_USDMaya to USD 19.01, see PR [here](https://github.com/AnimalLogic/AL_USDMaya/pull/133), we (actually, our friends at Luma who did the work) ended up calling _UpdateHydraCollection (see [here](https://github.com/AnimalLogic/AL_USDMaya/blob/0a119b251ea11c3b4d91c5aa6551c6c300312009/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp#L63))
This worked without problems in Linux, but failed on Windows due to the method's symbol not being exported

### Fixes Issue(s)
- Add DSO export visibility to UsdImagingGLEngine._UpdateHydraCollection in usdImagingGL/engine.h 

