### PR TITLE
[Houdini] Provide support for adding in-memory stages to the GusdStageCache

### DIFF
--- a/third_party/houdini/lib/gusd/USD_DataCache.cpp
+++ b/third_party/houdini/lib/gusd/USD_DataCache.cpp
@@ -59,8 +59,18 @@ GusdUSD_DataCache::ShouldClearPrim(
         // Always clear expired prims.
         return true;
     }
-    const std::string& path = prim.GetStage()->GetRootLayer()->GetRealPath();
-    return stagesToClear.contains(path);
+    if (prim.GetStage()->GetRootLayer()->IsAnonymous())
+    {
+	const std::string& path =
+	    prim.GetStage()->GetRootLayer()->GetIdentifier();
+	return stagesToClear.contains(path);
+    }
+    else
+    {
+	const std::string& path =
+	    prim.GetStage()->GetRootLayer()->GetRealPath();
+	return stagesToClear.contains(path);
+    }
 }
 
 

--- a/third_party/houdini/lib/gusd/boundsCache.cpp
+++ b/third_party/houdini/lib/gusd/boundsCache.cpp
@@ -89,7 +89,9 @@ GusdBoundsCache::_ComputeBound(
     if( !prim.IsValid() )
         return false;
 
-    TfToken stageId( prim.GetStage()->GetRootLayer()->GetRealPath() );
+    TfToken stageId( prim.GetStage()->GetRootLayer()->IsAnonymous()
+	    ? prim.GetStage()->GetRootLayer()->GetIdentifier()
+	    : prim.GetStage()->GetRootLayer()->GetRealPath() );
 
     MapType::accessor accessor;
     if( !m_map.find( accessor, Key( stageId, includedPurposes ))) {

--- a/third_party/houdini/lib/gusd/stageCache.cpp
+++ b/third_party/houdini/lib/gusd/stageCache.cpp
@@ -411,6 +411,11 @@ public:
     void            FindStages(const UT_StringSet& paths,
                                UT_Set<UsdStageRefPtr>& stages) const;
 
+    void	    InsertStage(UsdStageRefPtr &stage,
+                                const UT_StringRef& path,
+                                const GusdStageOpts& opts,
+                                const GusdStageEditPtr& edit);
+
     /// Load a range of [start,end) prims from the cache. The range corresponds
     /// to a *subset* of the prims in \p primPaths.
     /// The \p rangeFn functor must implement `operator()(exint)` which, given
@@ -1324,6 +1329,23 @@ GusdStageCache::_Impl::FindStages(const UT_StringSet& paths,
 }
 
 
+void
+GusdStageCache::_Impl::InsertStage(UsdStageRefPtr &stage,
+                                   const UT_StringRef& path,
+                                   const GusdStageOpts& opts,
+                                   const GusdStageEditPtr& edit)
+{
+    TF_DEBUG(GUSD_STAGECACHE).Msg(
+        "[GusdStageCache::InsertStage] Inserting stage @%s@\n",
+        path.c_str());
+
+    _StageMap::accessor a;
+    if(stage && _stageMap.insert(a, _StageKey(path, opts, edit))) {
+        a->second = stage;
+    }
+}
+
+
 UsdStageRefPtr
 GusdStageCache::_MaskedStageCache::FindStage(const SdfPath& primPath)
 {
@@ -1742,6 +1764,15 @@ GusdStageCacheWriter::FindStages(const UT_StringSet& paths,
     _cache._impl->FindStages(paths, stages);
 }
 
+
+void
+GusdStageCacheWriter::InsertStage(UsdStageRefPtr &stage,
+                                  const UT_StringRef& path,
+                                  const GusdStageOpts& opts,
+                                  const GusdStageEditPtr& edit)
+{
+    _cache._impl->InsertStage(stage, path, opts, edit);
+}
 
 void
 GusdStageCacheWriter::ReloadStages(const UT_StringSet& paths)

--- a/third_party/houdini/lib/gusd/stageCache.h
+++ b/third_party/houdini/lib/gusd/stageCache.h
@@ -297,6 +297,16 @@ public:
     void    FindStages(const UT_StringSet& paths,
                        UT_Set<UsdStageRefPtr>& stages);
 
+    /// Insert a stage into our cache. The lifetime of this stage is not
+    /// fully controlled by this cache. The cache is just a holder for the
+    /// stage for as long as the gusd library is allowed access to it (until
+    /// it is destroyed by the external owner, which must then call Clear
+    /// with the same path.
+    void    InsertStage(UsdStageRefPtr &stage,
+                        const UT_StringRef& path,
+                        const GusdStageOpts& opts,
+                        const GusdStageEditPtr& edit);
+
     /// \section GusdStageCacheWriter_ReloadAndClear Reloading And Clearing
     ///
     /// During active sessions, the contents of a cache may be refreshed


### PR DESCRIPTION
Adding support for the explicit addition of stages to the GusdStageCache. The use case here is that we have in-memory stages (with anonymous root layers) from which we would like to construct USD packed primitives. Rather than having the GusdStageCache construct new (masked) stages from these in-memory stages, it makes more sense to just tell the cache that these full stages are already in memory.

Also had to fix the cache invalidation code to properly deal with anonymous layer identifiers so that these in-memory stages can be modified, and the cache properly invalidated in response.