### PR TITLE
[Usd] Cleanup Inconsistent Override Warnings.

### DIFF
--- a/pxr/usd/lib/usd/apiSchemaBase.h
+++ b/pxr/usd/lib/usd/apiSchemaBase.h
@@ -156,7 +156,7 @@ protected:
     ///
     /// \sa UsdSchemaType
     USD_API
-    virtual UsdSchemaType _GetSchemaType() const;
+    virtual UsdSchemaType _GetSchemaType() const override;
 
 private:
     // needs to invoke _GetStaticTfType.
@@ -168,7 +168,7 @@ private:
 
     // override SchemaBase virtuals.
     USD_API
-    virtual const TfType &_GetTfType() const;
+    virtual const TfType &_GetTfType() const override;
 
 public:
     // ===================================================================== //

--- a/pxr/usd/lib/usd/typed.h
+++ b/pxr/usd/lib/usd/typed.h
@@ -101,7 +101,7 @@ protected:
 
 private:
     USD_API
-    virtual const TfType &_GetTfType() const;
+    virtual const TfType &_GetTfType() const override;
 };
 
 


### PR DESCRIPTION
### Description of Change(s)

Newer clangs warn about inconsistent usage of the override keyword(introduced in C++11). This cleans up those warnings. 

### Fixes Issue(s)
- Just general warning cleanup

