### PR TITLE
[Houdini] Changes for future Houdini release related to caching packed primitive bounding boxes

### DIFF
--- a/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
@@ -499,7 +499,7 @@ GusdGU_PackedUSD::intrinsicType() const
 {
     // Return the USD prim type so it can be displayed in the spreadsheet.
     UsdPrim prim = getUsdPrim();
-    return UT_StringHolder( prim.GetTypeName().GetText() );
+    return GusdUSD_Utils::TokenToStringHolder( prim.GetTypeName() );
 }
 
 const UT_Matrix4D &

--- a/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
@@ -661,24 +661,16 @@ GusdGU_PackedUSD::getBounds(UT_BoundingBox &box) const
     {
         TfTokenVector purposes = GusdPurposeSetToTokens(m_purposes);
 
-#if SYS_VERSION_FULL_INT >= 0x12000000
         if ( GusdBoundsCache::GetInstance().ComputeUntransformedBound(
                 prim,
                 UsdTimeCode( m_frame ),
                 purposes,
                 box )) {
+#if SYS_VERSION_FULL_INT < 0x12000000
+            m_boundsCache = box;
+#endif
             return true;
         }
-#else
-        if( GusdBoundsCache::GetInstance().ComputeUntransformedBound(
-                        prim,
-                        UsdTimeCode( m_frame ),
-                    purposes,
-                        m_boundsCache )) {
-                box = m_boundsCache;
-                return true;
-        }
-#endif
     }
     box.makeInvalid();
     return false;

--- a/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.cpp
@@ -302,7 +302,9 @@ GusdGU_PackedUSD::GusdGU_PackedUSD( const GusdGU_PackedUSD &src )
     , m_frame( src.m_frame )
     , m_purposes( src.m_purposes )
     , m_usdPrim( src.m_usdPrim )
+#if SYS_VERSION_FULL_INT < 0x12000000
     , m_boundsCache( src.m_boundsCache )
+#endif
     , m_transformCacheValid( src.m_transformCacheValid )
     , m_transformCache( src.m_transformCache )
     , m_masterPathCacheValid( src.m_masterPathCacheValid )
@@ -342,7 +344,9 @@ GusdGU_PackedUSD::typeId()
 void
 GusdGU_PackedUSD::resetCaches()
 {
+#if SYS_VERSION_FULL_INT < 0x12000000
     m_boundsCache.makeInvalid();
+#endif
     m_usdPrim = UsdPrim();
     m_transformCacheValid = false;
     m_gtPrimCache = GT_PrimitiveHandle();
@@ -495,7 +499,7 @@ GusdGU_PackedUSD::intrinsicType() const
 {
     // Return the USD prim type so it can be displayed in the spreadsheet.
     UsdPrim prim = getUsdPrim();
-    return GusdUSD_Utils::TokenToStringHolder( prim.GetTypeName() );
+    return UT_StringHolder( prim.GetTypeName().GetText() );
 }
 
 const UT_Matrix4D &
@@ -638,38 +642,56 @@ GusdGU_PackedUSD::save(UT_Options &options, const GA_SaveMap &map) const
 bool
 GusdGU_PackedUSD::getBounds(UT_BoundingBox &box) const
 {
+    // Box caching is handled in getBoundsCached()
+#if SYS_VERSION_FULL_INT < 0x12000000
     if( m_boundsCache.isValid() )
     {
         box = m_boundsCache;
         return true;
     }
+#endif
 
     UsdPrim prim = getUsdPrim();
 
     if( !prim ) {
-        cerr << "Invalid prim " << m_primPath << endl;
+        UT_ASSERT_MSG(0, "Invalid USD prim");
     }
 
     if(UsdGeomImageable visPrim = UsdGeomImageable(prim))
     {
         TfTokenVector purposes = GusdPurposeSetToTokens(m_purposes);
 
-        if( GusdBoundsCache::GetInstance().ComputeUntransformedBound( 
-                        prim, 
-                        UsdTimeCode( m_frame ), 
+#if SYS_VERSION_FULL_INT >= 0x12000000
+        if ( GusdBoundsCache::GetInstance().ComputeUntransformedBound(
+                prim,
+                UsdTimeCode( m_frame ),
+                purposes,
+                box )) {
+            return true;
+        }
+#else
+        if( GusdBoundsCache::GetInstance().ComputeUntransformedBound(
+                        prim,
+                        UsdTimeCode( m_frame ),
                     purposes,
                         m_boundsCache )) {
                 box = m_boundsCache;
-                return true;          
+                return true;
         }
+#endif
     }
+    box.makeInvalid();
     return false;
 }
 
 bool
 GusdGU_PackedUSD::getRenderingBounds(UT_BoundingBox &box) const
 {
+#if SYS_VERSION_FULL_INT >= 0x12000000
+    return getBoundsCached(box);
+#else
     return getBounds(box);
+#endif
 }
 
 void

--- a/third_party/houdini/lib/gusd/GU_PackedUSD.h
+++ b/third_party/houdini/lib/gusd/GU_PackedUSD.h
@@ -309,7 +309,9 @@ private:
 
     // caches    
     mutable UsdPrim             m_usdPrim;
+#if SYS_VERSION_FULL_INT < 0x12000000
     mutable UT_BoundingBox      m_boundsCache;
+#endif
     mutable bool                m_transformCacheValid;
     mutable UT_Matrix4D         m_transformCache;
     mutable GT_PrimitiveHandle  m_gtPrimCache;


### PR DESCRIPTION
As of the next major Houdini release, GU_PackedImpl contains a bounding box object for caching a 
calculated bounding box. Therefore, if building against this future release of Houdini:
* Removed redundant bounding box cache from GusdGU_PackedUSD, since it
  can use the one in GU_PackedImpl, and getBounds shouldn't use the cache.
* Made sure that GusdGU_PackedUSD::getBounds always initializes the box,
  even if returning false

For all currently shipping versions of Houdini, the behavior of this code is unchanged.