### PR TITLE
Build type support + Windows Debug fix 

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1092,12 +1092,12 @@ def InstallUSD(context, force, buildArgs):
                                  .format(pyIncPath=pythonInfo[2]))
 
             # Many people on Windows may not have python with the 
-            # debugging symbol ( python27_d.lib ) installed, this is the commom case 
+            # debugging symbol ( python27_d.lib ) installed, this is the common case 
             # where one downloads the python from official download website. Therefore we 
             # can still let people decide to build USD with release version of python if 
             # debugging into python land is not what they want which can be done by setting the 
-            # boostDebugPython
-            if context.buildDebug and context.boostDebugPython:
+            # --debug-python flag
+            if context.buildDebug and context.debugPython:
                 extraArgs.append('-DPXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG=ON')
             else:
                 extraArgs.append('-DPXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG=OFF')
@@ -1354,7 +1354,7 @@ subgroup.add_argument("--python", dest="build_python", action="store_true",
 subgroup.add_argument("--no-python", dest="build_python", action="store_false",
                       help="Do not build python based components")
 
-subgroup.add_argument("--boost-debug-python", dest="boostDebugPython", action="store_true",
+subgroup.add_argument("--debug-python", dest="debug_python", action="store_true",
                       help="Define Boost Python Debug if your Python library comes with Debugging symbols.")
 
 (NO_IMAGING, IMAGING, USD_IMAGING) = (0, 1, 2)
@@ -1522,7 +1522,7 @@ class InstallContext:
         self.buildRelease = args.build_release;
         self.buildRelWithDebug = args.build_relwithdebug;
 
-        self.boostDebugPython = args.boostDebugPython
+        self.debugPython = args.debug_python
 
         self.buildShared = (args.build_type == SHARED_LIBS)
         self.buildMonolithic = (args.build_type == MONOLITHIC_LIB)
@@ -1789,7 +1789,7 @@ Building with settings:
     UsdImaging                  {buildUsdImaging}
       usdview:                  {buildUsdview}
     Python support              {buildPython}
-      Boost Python Debug:       {boostDebugPython}
+      Python Debug:             {debugPython}
     Documentation               {buildDocs}
     Tests                       {buildTests}
     Alembic Plugin              {buildAlembic}
@@ -1838,7 +1838,7 @@ summaryMsg = summaryMsg.format(
     buildUsdImaging=("On" if context.buildUsdImaging else "Off"),
     buildUsdview=("On" if context.buildUsdview else "Off"),
     buildPython=("On" if context.buildPython else "Off"),
-    boostDebugPython=("On" if context.boostDebugPython else "Off"),
+    debugPython=("On" if context.debugPython else "Off"),
     buildDocs=("On" if context.buildDocs else "Off"),
     buildTests=("On" if context.buildTests else "Off"),
     buildAlembic=("On" if context.buildAlembic else "Off"),

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -45,6 +45,7 @@ option(PXR_ENABLE_OSL_SUPPORT "Enable OSL (OpenShadingLanguage) based components
 option(PXR_ENABLE_PTEX_SUPPORT "Enable Ptex support" ON)
 option(PXR_MAYA_TBB_BUG_WORKAROUND "Turn on linker flag (-Wl,-Bsymbolic) to work around a Maya TBB bug" OFF)
 option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
+option(PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG "Define BOOST_DEBUG_PYTHON flag." OFF)
 
 # Precompiled headers are a win on Windows, not on gcc.
 set(pxr_enable_pch "OFF")

--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -86,6 +86,10 @@ if (NOT Boost_USE_STATIC_LIBS)
     _add_define("BOOST_ALL_DYN_LINK")
 endif()
 
+if(${PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG})
+    _add_define(BOOST_DEBUG_PYTHON)
+endif()
+
 # Need half::_toFloat and half::_eLut.
 _add_define("OPENEXR_DLL")
 

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1297,6 +1297,11 @@ function(_pxr_library NAME)
                 )
             endif()
 
+            # Install target's PDB
+            if(WIN32)
+                install(FILES $<TARGET_PDB_FILE:${NAME}> EXPORT pxrTargets DESTINATION ${libInstallPrefix} OPTIONAL)
+            endif()
+
             export(TARGETS ${NAME}
                 APPEND
                 FILE "${PROJECT_BINARY_DIR}/pxrTargets.cmake"

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -898,13 +898,12 @@ function(pxr_toplevel_prologue)
                 ARCHIVE DESTINATION ${libInstallPrefix}
                 RUNTIME DESTINATION ${libInstallPrefix}
             )
+
+            # Install target's PDB
             if(WIN32)
-                install(
-                    FILES $<TARGET_PDB_FILE:usd_ms>
-                    DESTINATION ${libInstallPrefix}
-                    OPTIONAL
-                )
+                install(FILES $<TARGET_PDB_FILE:usd_ms> DESTINATION ${libInstallPrefix} OPTIONAL)
             endif()
+
         endif()
     endif()
 

--- a/extras/usd/examples/usdObj/pch.h
+++ b/extras/usd/examples/usdObj/pch.h
@@ -194,5 +194,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/extras/usd/examples/usdObj/pch.h
+++ b/extras/usd/examples/usdObj/pch.h
@@ -194,11 +194,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/extras/usd/examples/usdSchemaExamples/pch.h
+++ b/extras/usd/examples/usdSchemaExamples/pch.h
@@ -200,11 +200,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/extras/usd/examples/usdSchemaExamples/pch.h
+++ b/extras/usd/examples/usdSchemaExamples/pch.h
@@ -200,5 +200,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/gf/pch.h
+++ b/pxr/base/lib/gf/pch.h
@@ -151,11 +151,5 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/gf/pch.h
+++ b/pxr/base/lib/gf/pch.h
@@ -151,5 +151,11 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/plug/pch.h
+++ b/pxr/base/lib/plug/pch.h
@@ -192,5 +192,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/plug/pch.h
+++ b/pxr/base/lib/plug/pch.h
@@ -192,11 +192,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/tf/pch.h
+++ b/pxr/base/lib/tf/pch.h
@@ -251,6 +251,12 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #include <frameobject.h>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/tf/pch.h
+++ b/pxr/base/lib/tf/pch.h
@@ -251,12 +251,6 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #include <frameobject.h>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/tf/pyIdentity.cpp
+++ b/pxr/base/lib/tf/pyIdentity.cpp
@@ -21,13 +21,7 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 
 #include "pxr/pxr.h"
 #include "pxr/base/tf/hash.h"

--- a/pxr/base/lib/tf/pyIdentity.cpp
+++ b/pxr/base/lib/tf/pyIdentity.cpp
@@ -21,7 +21,13 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 
 #include "pxr/pxr.h"
 #include "pxr/base/tf/hash.h"

--- a/pxr/base/lib/tf/pyInterpreter.cpp
+++ b/pxr/base/lib/tf/pyInterpreter.cpp
@@ -41,13 +41,7 @@
 #include <atomic>
 #include <mutex>
 #include <string>
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #include <signal.h>
 
 using std::string;

--- a/pxr/base/lib/tf/pyInterpreter.cpp
+++ b/pxr/base/lib/tf/pyInterpreter.cpp
@@ -41,7 +41,13 @@
 #include <atomic>
 #include <mutex>
 #include <string>
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #include <signal.h>
 
 using std::string;

--- a/pxr/base/lib/tf/pyLock.h
+++ b/pxr/base/lib/tf/pyLock.h
@@ -28,13 +28,7 @@
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 
 #include "pxr/base/tf/api.h"
 

--- a/pxr/base/lib/tf/pyLock.h
+++ b/pxr/base/lib/tf/pyLock.h
@@ -28,7 +28,13 @@
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 
 #include "pxr/base/tf/api.h"
 

--- a/pxr/base/lib/tf/pyTracing.h
+++ b/pxr/base/lib/tf/pyTracing.h
@@ -24,13 +24,7 @@
 #ifndef TF_PYTRACING_H
 #define TF_PYTRACING_H
 
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 
 #include "pxr/pxr.h"
 

--- a/pxr/base/lib/tf/pyTracing.h
+++ b/pxr/base/lib/tf/pyTracing.h
@@ -24,7 +24,13 @@
 #ifndef TF_PYTRACING_H
 #define TF_PYTRACING_H
 
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 
 #include "pxr/pxr.h"
 

--- a/pxr/base/lib/trace/pch.h
+++ b/pxr/base/lib/trace/pch.h
@@ -184,11 +184,5 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/trace/pch.h
+++ b/pxr/base/lib/trace/pch.h
@@ -184,5 +184,11 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/vt/pch.h
+++ b/pxr/base/lib/vt/pch.h
@@ -182,11 +182,5 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/vt/pch.h
+++ b/pxr/base/lib/vt/pch.h
@@ -182,5 +182,11 @@
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/lib/vt/valueFromPython.h
+++ b/pxr/base/lib/vt/valueFromPython.h
@@ -34,7 +34,13 @@
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/singleton.h"
 
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #include <boost/noncopyable.hpp>
 #include "pxr/base/tf/hashmap.h"
 

--- a/pxr/base/lib/vt/valueFromPython.h
+++ b/pxr/base/lib/vt/valueFromPython.h
@@ -34,13 +34,7 @@
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/singleton.h"
 
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #include <boost/noncopyable.hpp>
 #include "pxr/base/tf/hashmap.h"
 

--- a/pxr/imaging/lib/cameraUtil/pch.h
+++ b/pxr/imaging/lib/cameraUtil/pch.h
@@ -133,5 +133,11 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/cameraUtil/pch.h
+++ b/pxr/imaging/lib/cameraUtil/pch.h
@@ -133,11 +133,5 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/garch/pch.h
+++ b/pxr/imaging/lib/garch/pch.h
@@ -154,11 +154,5 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/garch/pch.h
+++ b/pxr/imaging/lib/garch/pch.h
@@ -154,5 +154,11 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/glf/pch.h
+++ b/pxr/imaging/lib/glf/pch.h
@@ -215,11 +215,5 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/glf/pch.h
+++ b/pxr/imaging/lib/glf/pch.h
@@ -215,5 +215,11 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hd/pch.h
+++ b/pxr/imaging/lib/hd/pch.h
@@ -179,5 +179,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hd/pch.h
+++ b/pxr/imaging/lib/hd/pch.h
@@ -179,11 +179,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hdSt/pch.h
+++ b/pxr/imaging/lib/hdSt/pch.h
@@ -177,5 +177,11 @@
 #include <tbb/concurrent_vector.h>
 #include <tbb/enumerable_thread_specific.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hdSt/pch.h
+++ b/pxr/imaging/lib/hdSt/pch.h
@@ -177,11 +177,5 @@
 #include <tbb/concurrent_vector.h>
 #include <tbb/enumerable_thread_specific.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hdx/pch.h
+++ b/pxr/imaging/lib/hdx/pch.h
@@ -168,11 +168,5 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/hdx/pch.h
+++ b/pxr/imaging/lib/hdx/pch.h
@@ -168,5 +168,11 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/pxOsd/pch.h
+++ b/pxr/imaging/lib/pxOsd/pch.h
@@ -147,11 +147,5 @@
 #include <opensubdiv/far/topologyRefinerFactory.h>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/lib/pxOsd/pch.h
+++ b/pxr/imaging/lib/pxOsd/pch.h
@@ -147,5 +147,11 @@
 #include <opensubdiv/far/topologyRefinerFactory.h>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -169,11 +169,5 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -169,5 +169,11 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/ar/pch.h
+++ b/pxr/usd/lib/ar/pch.h
@@ -159,11 +159,5 @@
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/enumerable_thread_specific.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/ar/pch.h
+++ b/pxr/usd/lib/ar/pch.h
@@ -159,5 +159,11 @@
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/enumerable_thread_specific.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/ar/pyResolverContext.h
+++ b/pxr/usd/lib/ar/pyResolverContext.h
@@ -28,7 +28,13 @@
 /// Macros for creating Python bindings for objects used with 
 /// ArResolverContext.
 
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #include <boost/python/extract.hpp>
 #include <boost/python/object.hpp>
 

--- a/pxr/usd/lib/ar/pyResolverContext.h
+++ b/pxr/usd/lib/ar/pyResolverContext.h
@@ -28,13 +28,7 @@
 /// Macros for creating Python bindings for objects used with 
 /// ArResolverContext.
 
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/object.hpp>
 

--- a/pxr/usd/lib/kind/pch.h
+++ b/pxr/usd/lib/kind/pch.h
@@ -151,5 +151,11 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/kind/pch.h
+++ b/pxr/usd/lib/kind/pch.h
@@ -151,11 +151,5 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/ndr/pch.h
+++ b/pxr/usd/lib/ndr/pch.h
@@ -202,5 +202,11 @@
 #include <tbb/atomic.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/ndr/pch.h
+++ b/pxr/usd/lib/ndr/pch.h
@@ -202,11 +202,5 @@
 #include <tbb/atomic.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/pcp/pch.h
+++ b/pxr/usd/lib/pcp/pch.h
@@ -223,11 +223,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/pcp/pch.h
+++ b/pxr/usd/lib/pcp/pch.h
@@ -223,5 +223,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/sdf/pch.h
+++ b/pxr/usd/lib/sdf/pch.h
@@ -250,11 +250,5 @@
 #include <tbb/task.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/sdf/pch.h
+++ b/pxr/usd/lib/sdf/pch.h
@@ -250,5 +250,11 @@
 #include <tbb/task.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/sdr/pch.h
+++ b/pxr/usd/lib/sdr/pch.h
@@ -188,5 +188,11 @@
 #include <boost/utility/value_init.hpp>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/sdr/pch.h
+++ b/pxr/usd/lib/sdr/pch.h
@@ -188,11 +188,5 @@
 #include <boost/utility/value_init.hpp>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usd/pch.h
+++ b/pxr/usd/lib/usd/pch.h
@@ -249,5 +249,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usd/pch.h
+++ b/pxr/usd/lib/usd/pch.h
@@ -249,11 +249,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usd/testenv/testUsdAttributeInterpolationCpp.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdAttributeInterpolationCpp.cpp
@@ -38,7 +38,13 @@
 #include "pxr/base/tf/stringUtils.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <string>

--- a/pxr/usd/lib/usd/testenv/testUsdAttributeInterpolationCpp.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdAttributeInterpolationCpp.cpp
@@ -38,13 +38,7 @@
 #include "pxr/base/tf/stringUtils.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <string>

--- a/pxr/usd/lib/usd/testenv/testUsdCreateAttributeCpp.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdCreateAttributeCpp.cpp
@@ -36,7 +36,13 @@
 #include "pxr/base/arch/fileSystem.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <iostream>

--- a/pxr/usd/lib/usd/testenv/testUsdCreateAttributeCpp.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdCreateAttributeCpp.cpp
@@ -36,13 +36,7 @@
 #include "pxr/base/arch/fileSystem.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <iostream>

--- a/pxr/usd/lib/usd/testenv/testUsdStageNoPython.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageNoPython.cpp
@@ -27,13 +27,7 @@
 // Python.
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/pxr.h"

--- a/pxr/usd/lib/usd/testenv/testUsdStageNoPython.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageNoPython.cpp
@@ -27,7 +27,13 @@
 // Python.
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/pxr.h"

--- a/pxr/usd/lib/usd/testenv/testUsdStageNotification.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageNotification.cpp
@@ -39,7 +39,13 @@
 #include "pxr/base/tf/stringUtils.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <cstdio>

--- a/pxr/usd/lib/usd/testenv/testUsdStageNotification.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageNotification.cpp
@@ -39,13 +39,7 @@
 #include "pxr/base/tf/stringUtils.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <cstdio>

--- a/pxr/usd/lib/usd/testenv/testUsdStageThreading.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageThreading.cpp
@@ -23,7 +23,13 @@
 //
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/pxr.h"

--- a/pxr/usd/lib/usd/testenv/testUsdStageThreading.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdStageThreading.cpp
@@ -23,13 +23,7 @@
 //
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/pxr.h"

--- a/pxr/usd/lib/usd/testenv/testUsdTemplatedIO.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdTemplatedIO.cpp
@@ -32,13 +32,7 @@
 #include "pxr/base/tf/debug.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <iostream>

--- a/pxr/usd/lib/usd/testenv/testUsdTemplatedIO.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdTemplatedIO.cpp
@@ -32,7 +32,13 @@
 #include "pxr/base/tf/debug.h"
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <iostream>

--- a/pxr/usd/lib/usd/testenv/testUsdThreadedAuthoring.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdThreadedAuthoring.cpp
@@ -34,7 +34,13 @@
 #include <tbb/concurrent_vector.h>
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <string>

--- a/pxr/usd/lib/usd/testenv/testUsdThreadedAuthoring.cpp
+++ b/pxr/usd/lib/usd/testenv/testUsdThreadedAuthoring.cpp
@@ -34,13 +34,7 @@
 #include <tbb/concurrent_vector.h>
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include <string>

--- a/pxr/usd/lib/usdGeom/pch.h
+++ b/pxr/usd/lib/usdGeom/pch.h
@@ -212,5 +212,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdGeom/pch.h
+++ b/pxr/usd/lib/usdGeom/pch.h
@@ -212,11 +212,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdHydra/pch.h
+++ b/pxr/usd/lib/usdHydra/pch.h
@@ -200,11 +200,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdHydra/pch.h
+++ b/pxr/usd/lib/usdHydra/pch.h
@@ -200,5 +200,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdLux/pch.h
+++ b/pxr/usd/lib/usdLux/pch.h
@@ -208,11 +208,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdLux/pch.h
+++ b/pxr/usd/lib/usdLux/pch.h
@@ -208,5 +208,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdRi/pch.h
+++ b/pxr/usd/lib/usdRi/pch.h
@@ -205,5 +205,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdRi/pch.h
+++ b/pxr/usd/lib/usdRi/pch.h
@@ -205,11 +205,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdShade/pch.h
+++ b/pxr/usd/lib/usdShade/pch.h
@@ -206,5 +206,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdShade/pch.h
+++ b/pxr/usd/lib/usdShade/pch.h
@@ -206,11 +206,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdSkel/pch.h
+++ b/pxr/usd/lib/usdSkel/pch.h
@@ -202,11 +202,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdSkel/pch.h
+++ b/pxr/usd/lib/usdSkel/pch.h
@@ -202,5 +202,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdUI/pch.h
+++ b/pxr/usd/lib/usdUI/pch.h
@@ -200,11 +200,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdUI/pch.h
+++ b/pxr/usd/lib/usdUI/pch.h
@@ -200,5 +200,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdUtils/pch.h
+++ b/pxr/usd/lib/usdUtils/pch.h
@@ -235,5 +235,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdUtils/pch.h
+++ b/pxr/usd/lib/usdUtils/pch.h
@@ -235,11 +235,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdVol/pch.h
+++ b/pxr/usd/lib/usdVol/pch.h
@@ -212,5 +212,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/lib/usdVol/pch.h
+++ b/pxr/usd/lib/usdVol/pch.h
@@ -212,11 +212,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/sdrOsl/pch.h
+++ b/pxr/usd/plugin/sdrOsl/pch.h
@@ -151,5 +151,11 @@
 #include <boost/utility/value_init.hpp>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/sdrOsl/pch.h
+++ b/pxr/usd/plugin/sdrOsl/pch.h
@@ -151,11 +151,5 @@
 #include <boost/utility/value_init.hpp>
 #include <tbb/atomic.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/usdAbc/pch.h
+++ b/pxr/usd/plugin/usdAbc/pch.h
@@ -235,11 +235,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/usdAbc/pch.h
+++ b/pxr/usd/plugin/usdAbc/pch.h
@@ -235,5 +235,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/usdMtlx/pch.h
+++ b/pxr/usd/plugin/usdMtlx/pch.h
@@ -213,5 +213,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/plugin/usdMtlx/pch.h
+++ b/pxr/usd/plugin/usdMtlx/pch.h
@@ -213,11 +213,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdImagingGL/pch.h
+++ b/pxr/usdImaging/lib/usdImagingGL/pch.h
@@ -216,11 +216,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdImagingGL/pch.h
+++ b/pxr/usdImaging/lib/usdImagingGL/pch.h
@@ -216,5 +216,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdShaders/pch.h
+++ b/pxr/usdImaging/lib/usdShaders/pch.h
@@ -183,5 +183,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdShaders/pch.h
+++ b/pxr/usdImaging/lib/usdShaders/pch.h
@@ -183,11 +183,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdSkelImaging/pch.h
+++ b/pxr/usdImaging/lib/usdSkelImaging/pch.h
@@ -200,11 +200,5 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdSkelImaging/pch.h
+++ b/pxr/usdImaging/lib/usdSkelImaging/pch.h
@@ -200,5 +200,11 @@
 #include <tbb/task_arena.h>
 #include <tbb/tbb.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdviewq/pch.h
+++ b/pxr/usdImaging/lib/usdviewq/pch.h
@@ -196,5 +196,11 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
+#ifdef _DEBUG
+  #undef _DEBUG
+  #include <Python.h>
+  #define _DEBUG
+#else
+  #include <Python.h>
+#endif
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/lib/usdviewq/pch.h
+++ b/pxr/usdImaging/lib/usdviewq/pch.h
@@ -196,11 +196,5 @@
 #include <tbb/task.h>
 #include <tbb/task_arena.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-#ifdef _DEBUG
-  #undef _DEBUG
-  #include <Python.h>
-  #define _DEBUG
-#else
-  #include <Python.h>
-#endif
+#include <boost/python/detail/wrap_python.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED


### PR DESCRIPTION
This commit aims at supporting various build types as well as fixing python errors during Debug build on Windows.

- The build script now specifies 3 different variants options ( --build-debug, --build-release, --build-relwithdebug ). TBB, BOOST, CMAKE_BUILD_TYPE are also now set with the same Variant type. If these flags are not set the default build type will be RelWithDebInfo 

- Fix Debug build on Windows by hiding the definition of _DEBUG during the inclusion of Python.h

