### PR TITLE
[Glf] Fixed an empty GlfSimpleShadowArray instance being leaked.

### DIFF
--- a/pxr/imaging/lib/glf/simpleLightingContext.cpp
+++ b/pxr/imaging/lib/glf/simpleLightingContext.cpp
@@ -69,7 +69,7 @@ GlfSimpleLightingContext::New()
 }
 
 GlfSimpleLightingContext::GlfSimpleLightingContext() :
-    _shadows(new GlfSimpleShadowArray(GfVec2i(1024, 1024), 0)),
+    _shadows(TfCreateRefPtr(new GlfSimpleShadowArray(GfVec2i(1024, 1024), 0))),
     _worldToViewMatrix(1.0),
     _projectionMatrix(1.0),
     _sceneAmbient(0.01, 0.01, 0.01, 1.0),


### PR DESCRIPTION
### Description of Change(s)

An instance of GlfSimpleShadowArray created by GlfSimpleLightingContext was missing a TfCreateRefPtr wrapper which caused it to be leaked. In the pxrUsd Maya plugin, this happened on every frame because of a temporary lighting context used to retrieve lighting settings from Maya.

By the way, is TfRefPtr here to stay, or can it be replaced with boost or standard pointers in the future? TfCreateRefPtr is unfortunately very easy to miss.