### PR TITLE
Fix pxrConfig.cmake

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1278,8 +1278,8 @@ function(_pxr_library NAME)
                 DESTINATION ${headerInstallPrefix}
             )
         endif()
-    else()
-        if(BUILD_SHARED_LIBS AND NOT PXR_BUILD_MONOLITHIC)
+    elseif(NOT PXR_BUILD_MONOLITHIC)
+        if(BUILD_SHARED_LIBS)
             install(
                 TARGETS ${NAME}
                 EXPORT pxrTargets

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1304,13 +1304,20 @@ function(_pxr_library NAME)
         else()
             install(
                 TARGETS ${NAME}
+                EXPORT pxrTargets
                 LIBRARY DESTINATION ${libInstallPrefix}
                 ARCHIVE DESTINATION ${libInstallPrefix}
                 RUNTIME DESTINATION ${libInstallPrefix}
                 PUBLIC_HEADER DESTINATION ${headerInstallPrefix}
             )
+
+            export(TARGETS ${NAME}
+                APPEND
+                FILE "${PROJECT_BINARY_DIR}/pxrTargets.cmake"
+            )
         endif()
     endif()
+
     _install_resource_files(
         ${NAME}
         "${pluginInstallPrefix}"

--- a/pxr/CMakeLists.txt
+++ b/pxr/CMakeLists.txt
@@ -21,4 +21,6 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_PREFIX}"
 )
 
-install(EXPORT pxrTargets DESTINATION "cmake")
+if (NOT PXR_BUILD_MONOLITHIC)
+    install(EXPORT pxrTargets DESTINATION "cmake")
+endif()

--- a/pxr/CMakeLists.txt
+++ b/pxr/CMakeLists.txt
@@ -21,6 +21,4 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_PREFIX}"
 )
 
-if(BUILD_SHARED_LIBS AND NOT PXR_BUILD_MONOLITHIC)
-	install(EXPORT pxrTargets DESTINATION "cmake")
-endif()
+install(EXPORT pxrTargets DESTINATION "cmake")

--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -3,6 +3,8 @@
 # PXR_INCLUDE_DIRS  - Root include directory for the installed project.
 # PXR_LIBRARIES     - List of all libraries, by target name.
 # PXR_foo_LIBRARY   - Absolute path to individual libraries.
+# PXR_STATIC_LIBS   - True or False depending on how the libraries were built
+# The preprocessor definition PXR_STATIC will be defined if appropriate
 
 set(PXR_CMAKE_DIR "@CMAKE_INSTALL_PREFIX@")
 include("${PXR_CMAKE_DIR}/cmake/pxrTargets.cmake")
@@ -15,3 +17,10 @@ foreach(lib ${libs})
     set(PXR_${lib}_LIBRARY ${location})
     list(APPEND PXR_LIBRARIES ${lib})
 endforeach()
+if(NOT @BUILD_SHARED_LIBS@)
+    if(WIN32)
+        list(APPEND PXR_LIBRARIES Shlwapi.lib)
+        list(APPEND PXR_LIBRARIES Dbghelp.lib)
+    endif()
+    add_definitions(-DPXR_STATIC)
+endif()


### PR DESCRIPTION
### Description of Change(s)

Fixes the installation of the pxrConfig.cmake file for both static and shared USD build variants

- Adds a mechanism to export PXR_STATIC when required
- Adds DbgHelp and shlwapi to the Windows static build
- pxrConfig.cmake unconditionally includes cmake scripts that describe the libraries, so it is necessary to ensure associated cmake files are also exported properly as part of the installation process
- fix selection logic around monolithic and non-monolithic build when generating config files


### Fixes Issue(s)

- pxrConfig.cmake should enable find_package(pxr) and remove the need to write ad hoc FindUSD.cmake scripts. pxrConfig.cmake references files that were not actually exported, making the config file non-functional

- pxrConfig.cmake targets were not set up for a static build at all

- Does not address creating a valid pxrConfig.cmake for monolithic builds. usd_m is created by concatenating object files which shouldn't actually be individually exported. A different mechanism, using tricks, is likely necessary to create a pxrConfig.cmake for monolithic builds. According to this issue:  https://gitlab.kitware.com/cmake/cmake/issues/17357 - the exact situation of usd_m is not currently supported. 
