### PR TITLE
Display unloaded prims

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/delegate.h
+++ b/pxr/usdImaging/lib/usdImaging/delegate.h
@@ -267,6 +267,15 @@ public:
     USDIMAGING_API
     void SetWindowPolicy(CameraUtilConformWindowPolicy policy);
 
+    /// Sets display of unloaded prims as bounding boxes.
+    /// Unloaded prims will need bounds definition in order to see them.
+    /// Effective only for delegates that support draw modes.
+    USDIMAGING_API
+    void SetDisplayUnloadedPrimsWithBounds(bool displayUnloaded);
+    bool GetDisplayUnloadedPrimsWithBounds() const {
+        return _displayUnloadedPrimsWithBounds;
+    }
+
     // ---------------------------------------------------------------------- //
     // See HdSceneDelegate for documentation of the following virtual methods.
     // ---------------------------------------------------------------------- //
@@ -769,6 +778,15 @@ private:
 
     // Enable HdCoordSys tracking
     const bool _coordSysEnabled;
+    // Display unloaded prims with Bounds adapter
+    bool _displayUnloadedPrimsWithBounds;
+
+    Usd_PrimFlagsConjunction _getDisplayPredicate() const
+    {
+        return _hasDrawModeAdapter && _displayUnloadedPrimsWithBounds ?
+            UsdPrimIsActive && UsdPrimIsDefined && !UsdPrimIsAbstract :
+            UsdPrimDefaultPredicate;
+    }
 
     UsdImagingDelegate() = delete;
     UsdImagingDelegate(UsdImagingDelegate const &) = delete;


### PR DESCRIPTION
### Description of Change(s)
This change makes Hydra delegates consider unloaded prims, which when used with authored `extentHint` data provides solution for visualization of unloaded assets with bounding boxes (unless other explicit opinion was expressed).

This approach introduces visually appealing workflow for lazy scene loading requested by artists.

### Fixes Issue(s)
- Allows to see unloaded prims in Hydra

