### PR TITLE
[usdSkel] [usdMaya] fix skin import with explicit joint orders

### DIFF
--- a/pxr/usd/lib/usdSkel/animMapper.cpp
+++ b/pxr/usd/lib/usdSkel/animMapper.cpp
@@ -87,18 +87,14 @@ UsdSkelAnimMapper::UsdSkelAnimMapper(const TfToken* sourceOrder,
                                   sourceOrder[0]);
         const size_t pos = it - targetOrder;
         if((pos + sourceOrderSize) <= targetOrderSize) {
-            const size_t compareCount =
-                std::min(sourceOrderSize, targetOrderSize-pos);
-            if(std::equal(sourceOrder, sourceOrder+compareCount, it)) {
+            if(std::equal(sourceOrder, sourceOrder+sourceOrderSize, it)) {
                 _offset = pos;
 
-                _flags = _OrderedMap;
+                _flags = _OrderedMap | _AllSourceValuesMapToTarget;
 
-                if(pos == 0 && compareCount == targetOrderSize) {
+                if(pos == 0 && sourceOrderSize == targetOrderSize) {
                     _flags |= _SourceOverridesAllTargetValues;
                 }
-                _flags |= compareCount == sourceOrderSize ?
-                    _AllSourceValuesMapToTarget : _SomeSourceValuesMapToTarget;
                 return;
             }
         }

--- a/pxr/usd/lib/usdSkel/animMapper.h
+++ b/pxr/usd/lib/usdSkel/animMapper.h
@@ -69,11 +69,11 @@ public:
                       const TfToken* targetOrder, size_t targetOrderSize);
 
     /// Typed remapping of data in an arbitrary, stl-like container.
-    /// The \p sourc earray provides a run of \p elementSize for each path in
+    /// The \p source array provides a run of \p elementSize for each path in
     /// the \\em sourceOrder. These elements are remapped and copied over the
     /// \p target array.
     /// Prior to remapping, the \p target array is resized to the size of the
-    /// \\ em targetOrdre (as given at mapper construction time) multiplied by
+    /// \\em targetOrder (as given at mapper construction time) multiplied by
     /// the \p elementSize. New element created in the array are initialized
     /// to \p defaultValue, if provided.
     template <typename Container>

--- a/third_party/maya/lib/usdMaya/translatorSkel.cpp
+++ b/third_party/maya/lib/usdMaya/translatorSkel.cpp
@@ -1372,6 +1372,28 @@ UsdMayaTranslatorSkel::CreateSkinCluster(
         if (!skelQuery.GetJointWorldBindTransforms(&bindXforms)) {
             return false;
         }
+        VtMatrix4dArray remappedBindXforms;
+        auto mapper = skinningQuery.GetMapper();
+        if (mapper && !mapper->IsNull()) {
+            if (mapper->IsSparse()) {
+                TF_WARN("Error - not all joints for the skinned object %s could "
+                        "be found in the skeleton %s",
+                        primToSkin.GetPath().GetText(),
+                        skelQuery.GetPrim().GetPath().GetText());
+                return false;
+            }
+            mapper->Remap(bindXforms, &remappedBindXforms);
+        }
+
+        if (joints.size() > bindXforms.size())
+        {
+            TF_WARN("Error - skinned object (%s) had more joints (%lu) "
+                    "than the skeleton (%s) had bind xforms (%lu)",
+                    primToSkin.GetPath().GetText(), joints.size(),
+                    skelQuery.GetPrim().GetPath().GetText(),
+                    bindXforms.size());
+            return false;
+        }
 
         MPlug skinClusterMatrix =
             skinClusterDep.findPlug(_MayaTokens->matrix, &status);
@@ -1408,8 +1430,10 @@ UsdMayaTranslatorSkel::CreateSkinCluster(
             MPlug bindPreMatrixI =
                 bindPreMatrix.elementByLogicalIndex(i, &status);
             CHECK_MSTATUS_AND_RETURN(status, false);
+            auto& bindXform = remappedBindXforms.size() > 0 ? remappedBindXforms[i] :
+                    bindXforms[i];
             if (!UsdMayaUtil::setPlugMatrix(
-                   bindXforms[i].GetInverse(), bindPreMatrixI)) {
+                    bindXform.GetInverse(), bindPreMatrixI)) {
                 return false;
             }
         }


### PR DESCRIPTION
### Description of Change(s
This fixes the maya import of skin bindings that set an explicit joint order

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/789 (partially - HdxComputation is not fixed)

