### PR TITLE
[imaging] make image extension case-insensitive

### DIFF
--- a/pxr/imaging/lib/glf/imageRegistry.cpp
+++ b/pxr/imaging/lib/glf/imageRegistry.cpp
@@ -68,7 +68,8 @@ GlfImageRegistry::_ConstructImage(std::string const & filename)
     static GlfImageSharedPtr NULL_IMAGE;
 
     // Lookup the plug-in type name based on the filename.
-    TfToken fileExtension(ArGetResolver().GetExtension(filename));
+    TfToken fileExtension(
+            TfStringToLower(ArGetResolver().GetExtension(filename)));
 
     TfType const & pluginType = _typeMap->Find(fileExtension);
 

--- a/pxr/usd/lib/usdUtils/complianceChecker.py
+++ b/pxr/usd/lib/usdUtils/complianceChecker.py
@@ -187,7 +187,7 @@ class TextureChecker(BaseRuleChecker):
 
     def _CheckTexture(self, texAssetPath):
         self._Msg("Checking texture <%s>." % texAssetPath)
-        texFileExt = Ar.GetResolver().GetExtension(texAssetPath)
+        texFileExt = Ar.GetResolver().GetExtension(texAssetPath).lower()
         if texFileExt in \
             TextureChecker._unsupportedImageFormats:
             self._AddFailedCheck("Found texture file '%s' with unsupported "


### PR DESCRIPTION
### Description of Change(s)
so we can use, ie, .PNG, .TIF, etc
oiio already can handle this, and Glf_StbImage::_GetFilenameExtension() already converts to lowercase as well

### Fixes Issue(s)
- Loading of .PNG, .TIF, etc (ie, non-lower-case extensions)

