### PR TITLE
Fix compiler warnings generated on Windows when using the VtValue::Get method.

### DIFF
--- a/pxr/base/lib/vt/value.cpp
+++ b/pxr/base/lib/vt/value.cpp
@@ -568,7 +568,7 @@ VtStreamOut(vector<VtValue> const &val, std::ostream &stream) {
 }    
 
 #define _VT_IMPLEMENT_ZERO_VALUE_FACTORY(r, unused, elem)                \
-template <>                                                              \
+template <> VT_API                                                       \
 Vt_DefaultValueHolder Vt_DefaultValueFactory<VT_TYPE(elem)>::Invoke()    \
 {                                                                        \
     return Vt_DefaultValueHolder::Create(VtZero<VT_TYPE(elem)>());       \

--- a/pxr/base/lib/vt/value.h
+++ b/pxr/base/lib/vt/value.h
@@ -1204,8 +1204,7 @@ struct Vt_ValueShapeDataAccess {
 // the factory for these types. 
 //
 #define _VT_DECLARE_ZERO_VALUE_FACTORY(r, unused, elem)                 \
-template <>                                                             \
-VT_API Vt_DefaultValueHolder Vt_DefaultValueFactory<VT_TYPE(elem)>::Invoke();
+VT_API_TEMPLATE_STRUCT(Vt_DefaultValueFactory<VT_TYPE(elem)>);
 
 BOOST_PP_SEQ_FOR_EACH(_VT_DECLARE_ZERO_VALUE_FACTORY,
                       unused,


### PR DESCRIPTION
Fix compiler warnings generated on Windows when using the VtValue::Get
method. Mark the whole Vt_DefaultValueFactory class specializations for
matrix and vector types as "VT_API". Then in the .cpp file, specify VT_API
on the Invoke function definition. This ensures that the specializations
are exported, and external libraries calling these specializations know
that they are being imported.

It was actually generating the correct end result already, but it
complained because it thought that the Invoke method was supposed to be
inlined (but then I guess the linker would find the imported function).

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/806

