### PR TITLE
Better ptex glew find

### DIFF
--- a/cmake/modules/FindGLEW.cmake
+++ b/cmake/modules/FindGLEW.cmake
@@ -85,7 +85,9 @@ if (${CMAKE_HOST_UNIX})
             GLEW glew
         HINTS
             "${GLEW_LOCATION}/lib"
+            "${GLEW_LOCATION}/lib64"
             "$ENV{GLEW_LOCATION}/lib"
+            "$ENV{GLEW_LOCATION}/lib64"
         PATHS
             "${GLEW_LOCATION}/lib"
             /usr/lib64

--- a/cmake/modules/FindPTex.cmake
+++ b/cmake/modules/FindPTex.cmake
@@ -67,6 +67,10 @@ else ()
             "${PTEX_LOCATION}/include/wdas"
             "$ENV{PTEX_LOCATION}/include"
             "$ENV{PTEX_LOCATION}/include/wdas"
+            "${PTEX_LOCATION}/include/Ptex"
+            "${PTEX_LOCATION}/include/wdas"
+            "$ENV{PTEX_LOCATION}/include/Ptex"
+            "$ENV{PTEX_LOCATION}/include/wdas"
         PATHS
             /usr/include
             /usr/local/include

--- a/cmake/modules/FindPTex.cmake
+++ b/cmake/modules/FindPTex.cmake
@@ -64,11 +64,9 @@ else ()
             Ptexture.h
         HINTS
             "${PTEX_LOCATION}/include"
-            "${PTEX_LOCATION}/include/wdas"
-            "$ENV{PTEX_LOCATION}/include"
-            "$ENV{PTEX_LOCATION}/include/wdas"
             "${PTEX_LOCATION}/include/Ptex"
             "${PTEX_LOCATION}/include/wdas"
+            "$ENV{PTEX_LOCATION}/include/"
             "$ENV{PTEX_LOCATION}/include/Ptex"
             "$ENV{PTEX_LOCATION}/include/wdas"
         PATHS


### PR DESCRIPTION
### Description of Change(s)

This PR improves the `FindGLEW` and `FindPTex` cmake modules by allowing searching in custom `lib64` directories for GLEW and PTex include subfolder.

### Fixes Issue(s)
-

