### PR TITLE
Add ${X11_LIBRARIES} as being required by the garch library

### DIFF
--- a/pxr/imaging/lib/garch/CMakeLists.txt
+++ b/pxr/imaging/lib/garch/CMakeLists.txt
@@ -26,6 +26,7 @@ pxr_library(garch
     LIBRARIES
         arch
         tf
+        ${X11_LIBRARIES}
         ${OPENGL_gl_LIBRARY}
         ${APPKIT_LIBRARY}
 


### PR DESCRIPTION
Add ${X11_LIBRARIES} as being required by the garch library. There are calls
to various glX methods in this library. When building USD itself it seems
fine that the X11 libraries are not explicitly linked in, but when building
other libraries that link in garch, specifically when using the "gold" linker
(the standard gcc linker works fine) it complains about undefined symbols in
garch that should come from the X11 libs. It is not clear why "gold" behaves
differently in this situation, but I can't see any harm in explicitly calling out this
dependency in garch, and it fixes our build issue.