### PR TITLE
[Ar] Python bindings for resolver RefreshContext

### DIFF
--- a/pxr/usd/lib/ar/wrapResolver.cpp
+++ b/pxr/usd/lib/ar/wrapResolver.cpp
@@ -55,6 +55,7 @@ wrapResolver()
         .def("Resolve", &This::Resolve)
 
         .def("GetExtension", &This::GetExtension)
+        .def("RefreshContext", &This::RefreshContext)
         ;
 
     def("GetResolver", ArGetResolver,


### PR DESCRIPTION
### Description of Change(s)

Simply add _ArResolver::RefreshContext_ method to _wrapResolver.cpp_

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/USD/issues/694

