### PR TITLE
Expose velocities attribute to render delegates

### DIFF
--- a/pxr/imaging/lib/hd/changeTracker.cpp
+++ b/pxr/imaging/lib/hd/changeTracker.cpp
@@ -638,6 +638,8 @@ HdChangeTracker::IsPrimvarDirty(HdDirtyBits dirtyBits, SdfPath const& id,
     bool isDirty = false;
     if (name == HdTokens->points) {
         isDirty = (dirtyBits & DirtyPoints) != 0;
+    } else if (name == HdTokens->velocities) {
+        isDirty = (dirtyBits & DirtyPoints) != 0;
     } else if (name == HdTokens->normals) {
         isDirty = (dirtyBits & DirtyNormals) != 0;
     } else if (name == HdTokens->widths) {

--- a/pxr/imaging/lib/hd/tokens.h
+++ b/pxr/imaging/lib/hd/tokens.h
@@ -108,6 +108,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (totalItemCount)                            \
     (transform)                                 \
     (transformInverse)                          \
+    (velocities)                                \
     (visibility)                                \
     (widths)
 

--- a/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
@@ -199,6 +199,10 @@ UsdImagingBasisCurvesAdapter::UpdateForTime(UsdPrim const& prim,
             }
         }
     }
+
+    // Velocity information is expected to be authored at the same sample
+    // rate as points data, so use the points dirty bit to let us know when
+    // to publish velocities.
     if (requestedBits & HdChangeTracker::DirtyPoints) {
         UsdGeomBasisCurves curves(prim);
         VtVec3fArray velocities;

--- a/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/basisCurvesAdapter.cpp
@@ -199,6 +199,20 @@ UsdImagingBasisCurvesAdapter::UpdateForTime(UsdPrim const& prim,
             }
         }
     }
+    if (requestedBits & HdChangeTracker::DirtyPoints) {
+        UsdGeomBasisCurves curves(prim);
+        VtVec3fArray velocities;
+        if (curves.GetVelocitiesAttr().Get(&velocities, time)) {
+            // Expose velocities as a primvar.
+            _MergePrimvar(
+                &primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetPrimvar(cachePath,
+                UsdGeomTokens->velocities) = VtValue(velocities);
+        }
+    }
 }
 
 

--- a/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
@@ -294,6 +294,20 @@ UsdImagingMeshAdapter::UpdateForTime(UsdPrim const& prim,
             }
         }
     }
+    if (requestedBits & HdChangeTracker::DirtyPoints) {
+        UsdGeomMesh mesh(prim);
+        VtVec3fArray velocities;
+        if (mesh.GetVelocitiesAttr().Get(&velocities, time)) {
+            // Expose velocities as a primvar.
+            _MergePrimvar(
+                &primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetPrimvar(cachePath,
+                UsdGeomTokens->velocities) = VtValue(velocities);
+        }
+    }
 
     // Subdiv tags are only needed if the mesh is refined.  So
     // there's no need to fetch the data if the prim isn't refined.

--- a/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/meshAdapter.cpp
@@ -294,6 +294,10 @@ UsdImagingMeshAdapter::UpdateForTime(UsdPrim const& prim,
             }
         }
     }
+
+    // Velocity information is expected to be authored at the same sample
+    // rate as points data, so use the points dirty bit to let us know when
+    // to publish velocities.
     if (requestedBits & HdChangeTracker::DirtyPoints) {
         UsdGeomMesh mesh(prim);
         VtVec3fArray velocities;

--- a/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
@@ -185,6 +185,9 @@ UsdImagingPointsAdapter::UpdateForTime(UsdPrim const& prim,
         }
     }
 
+    // Velocity information is expected to be authored at the same sample
+    // rate as points data, so use the points dirty bit to let us know when
+    // to publish velocities.
     if (requestedBits & HdChangeTracker::DirtyPoints) {
         UsdGeomPoints points(prim);
         VtVec3fArray velocities;

--- a/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/pointsAdapter.cpp
@@ -184,6 +184,21 @@ UsdImagingPointsAdapter::UpdateForTime(UsdPrim const& prim,
             }
         }
     }
+
+    if (requestedBits & HdChangeTracker::DirtyPoints) {
+        UsdGeomPoints points(prim);
+        VtVec3fArray velocities;
+        if (points.GetVelocitiesAttr().Get(&velocities, time)) {
+            // Expose velocities as a primvar.
+            _MergePrimvar(
+                &primvars,
+                UsdGeomTokens->velocities,
+                HdInterpolationVertex,
+                HdPrimvarRoleTokens->vector);
+            valueCache->GetPrimvar(cachePath,
+                UsdGeomTokens->velocities) = VtValue(velocities);
+        }
+    }
 }
 
 


### PR DESCRIPTION
This is a greatly simplified replacement for PR #743.

After discussions with the USD team, it was decided that velocities does not need its own dirty bit or dedicated change tracker or value cache functions. Instead, use the pointsDirty bit, and publish it as a regular primvar. Using the pointsDirty bit is reasonable because the velocities attribute, according to USD standards, should be published at the same time samples where the points attribute is published.
