### PR TITLE
Fix compatibility for AbcCoreOgawa::ReadArchive with Alembic>=1.7.9

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -98,7 +98,7 @@ TF_DEFINE_ENV_SETTING(
 #if ALEMBIC_LIBRARY_VERSION >= 10709
 TF_DEFINE_ENV_SETTING(
     USD_ABC_READ_ARCHIVE_USE_MMAP, false,
-    "Collapse Xforms containing a single geometry into a single geom Prim in USD");
+    "Use mmap when reading from an Ogawa archive.");
 #endif
 
 namespace {

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -95,6 +95,12 @@ TF_DEFINE_ENV_SETTING(
     USD_ABC_XFORM_PRIM_COLLAPSE, true,
     "Collapse Xforms containing a single geometry into a single geom Prim in USD");
 
+#if ALEMBIC_LIBRARY_VERSION >= 10709
+TF_DEFINE_ENV_SETTING(
+    USD_ABC_READ_ARCHIVE_USE_MMAP, false,
+    "Collapse Xforms containing a single geometry into a single geom Prim in USD");
+#endif
+
 namespace {
 
 using namespace ::Alembic::AbcGeom;
@@ -1369,8 +1375,13 @@ _ReaderContext::_OpenOgawa(
     std::recursive_mutex** mutex) const
 {
     *format = "Ogawa";
+    #if ALEMBIC_LIBRARY_VERSION >= 10709
+    *result = IArchive(Alembic::AbcCoreOgawa::ReadArchive(_GetNumOgawaStreams(), TfGetEnvSetting(USD_ABC_READ_ARCHIVE_USE_MMAP)),
+                       filePath, ErrorHandler::kQuietNoopPolicy);
+    #else
     *result = IArchive(Alembic::AbcCoreOgawa::ReadArchive(_GetNumOgawaStreams()),
                        filePath, ErrorHandler::kQuietNoopPolicy);
+    #endif
     return *result;
 }
 


### PR DESCRIPTION
### Description of Change(s)

Alembic 1.7.9 introduced an API change in `Alembic::AbcCoreOgawa::ReadArchive`: a new boolean argument is required. This PR conforms to the new function signature for Alembic >= 1.7.9

The behavior of `Alembic::AbcCoreOgawa::ReadArchive` can be configured by a new environment variable: `USD_ABC_READ_ARCHIVE_USE_MMAP`
By default, `Alembic::AbcCoreOgawa::ReadArchive` keep on using the pre 1.7.9 behavior

### Fixes Issue(s)
- #667 

