### PR TITLE
gusd: fixed missing usdSkel dependency

### DIFF
--- a/third_party/houdini/lib/gusd/CMakeLists.txt
+++ b/third_party/houdini/lib/gusd/CMakeLists.txt
@@ -33,6 +33,7 @@ pxr_shared_library(${PXR_PACKAGE}
         usdGeom
         usdRi
         usdShade
+        usdSkel
         usdUtils
         ${HOUDINI_LIB_NAMES}
 


### PR DESCRIPTION
### Description of Change(s)

Added usdSkel to required libraries in gusd cmake .

### Fixes Issue(s)
- Fixed gusd missing usdSkel dependency [#826]

