### PR TITLE
[usdKatana] Configure resolver for asset before opening a stage

### DIFF
--- a/third_party/katana/lib/usdKatana/cache.cpp
+++ b/third_party/katana/lib/usdKatana/cache.cpp
@@ -691,12 +691,16 @@ UsdStageRefPtr UsdKatanaCache::GetStage(
         const UsdStage::InitialLoadSet load = 
             (forcePopulate ? UsdStage::LoadAll : UsdStage::LoadNone);
 
+        auto& resolver = ArGetResolver();
+        resolver.ConfigureResolverForAsset(fileName);
+        ArResolverContext resolverContext = resolver.CreateDefaultContextForAsset(fileName);
+
         auto result = stageCache.RequestStage(
                 PxrUsdIn_StageOpenRequest(
                     load,
                     rootLayer,
                     sessionLayer,
-                    ArGetResolver().GetCurrentContext(),
+                    resolverContext,
                     mask));
         
         UsdStageRefPtr stage = result.first;


### PR DESCRIPTION
### Description of Change(s)
In the Katana plugin, since "ConfigureResolverForAsset" is not called, it is not possible to use a custom asset resolver with a custom context.
### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/828
-

