### PR TITLE
[usdview] Added currentFrame command line argument

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/__init__.py
+++ b/pxr/usdImaging/lib/usdviewq/__init__.py
@@ -152,10 +152,16 @@ class Launcher(object):
                                  '(0 is max, negative numbers imply max - N)')
 
         parser.add_argument('--ff', action='store',
-                            dest='firstframe', type=int)
+                            dest='firstframe', type=int,
+                            help='Set the first frame of the viewer')
 
         parser.add_argument('--lf', action='store',
-                            dest='lastframe', type=int)
+                            dest='lastframe', type=int,
+                            help='Set the last frame of the viewer')
+
+        parser.add_argument('--cf', action='store',
+                            dest='currentframe', type=int,
+                            help='Set the current frame of the viewer')
 
         parser.add_argument('--complexity', action='store',
                             type=str, default="low", dest='complexity',

--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1219,7 +1219,7 @@ class AppController(QtCore.QObject):
         cf = self._parserData.currentframe
         if cf:
             if cf >= self.realStartTimeCode and cf <= self.realEndTimeCode:
-                self.setFrame(cf)
+                self.setFrame(float(cf))
             else:
                 sys.stderr.write('Warning: Invalid current frame specified (%s)\n' % (cf))
 
@@ -1243,11 +1243,6 @@ class AppController(QtCore.QObject):
         if self._hasTimeSamples:
             self._ui.rangeBegin.setText(str(self._timeSamples[0]))
             self._ui.rangeEnd.setText(str(self._timeSamples[-1]))
-
-        if not resetStageDataOnly:
-            # Set the current frame to the first time sample if it exists.
-            frame = 0.0 if not self._hasTimeSamples else self._timeSamples[0]
-            self.setFrame(frame)
 
         if self._playbackAvailable:
             if not resetStageDataOnly:
@@ -1856,9 +1851,8 @@ class AppController(QtCore.QObject):
             self._UpdateTimeSamples(resetStageDataOnly=False)
 
     def _frameStringChanged(self):
-        # don't convert string to float directly because of rounding error
-        frameString = str(self._ui.frameField.text())
-        self.setFrame(frameString)
+        value = float(self._ui.frameField.text())
+        self.setFrame(value)
 
     def _sliderMoved(self, frameIndex):
         """Slot called when the frame slider is moved by a user.
@@ -3190,9 +3184,9 @@ class AppController(QtCore.QObject):
         """Set the `frame`.
 
         Args:
-            frame (str|int|float): The new frame value.
+            frame (float): The new frame value.
         """
-        frameIndex = self._findClosestFrameIndex(float(frame))
+        frameIndex = self._findClosestFrameIndex(frame)
         self._setFrameIndex(frameIndex)
 
     def _setFrameIndex(self, frameIndex):
@@ -3207,15 +3201,15 @@ class AppController(QtCore.QObject):
         except IndexError:
             return
 
-        frameIndex = int(frameIndex)
-
-        if self._dataModel.currentFrame != frame:
-            self._dataModel.currentFrame = Usd.TimeCode(frame)
+        currentFrame = Usd.TimeCode(frame)
+        if self._dataModel.currentFrame != currentFrame:
+            self._dataModel.currentFrame = currentFrame
 
             self._ui.frameSlider.setValue(frameIndex)
-            self.setFrameField(self._dataModel.currentFrame.GetValue())
 
             self._updateOnFrameChange()
+
+        self.setFrameField(self._dataModel.currentFrame.GetValue())
 
     def _updateGUIForFrameChange(self):
         """Called when the frame changes have finished.


### PR DESCRIPTION
### Description of Change(s)

 * Added help strings to startFrame and lastFrame.

    --ff FIRSTFRAME       Set the first frame of the viewer
    --lf LASTFRAME        Set the last frame of the viewer
    --cf CURRENTFRAME     Set the current frame of the viewer

* Refactored setFrame to _setFrameIndex
  * Removed the closestFrame lookup - as far as I'm aware this does nothing of value as closestFrame always equals frame.
    * This has given us a speed increase on playback - the closestFrame lookup iterated over the entire _timeSamples list every time the frame changed.
  * Removed the need for the forceUpdate variable.

* Re-purposed setFrame to be a simple wrapper that finds a frameIndex and calls _setFrameIndex.

* Found bug where resetting of the timeline would also not update the dataModel - so the value on the timeline and what was being shown in the viewer would not match up.
  * This was fixed by adding a call to setFrame in _UpdateTimeSamples

### Fixes Issue(s)
- #296

