### PR TITLE
[katana] Fix reading of point instancers with external prototypes

### DIFF
--- a/third_party/katana/lib/usdKatana/readPrim.cpp
+++ b/third_party/katana/lib/usdKatana/readPrim.cpp
@@ -62,10 +62,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_ENV_SETTING(USD_KATANA_ALLOW_CUSTOM_MATERIAL_SCOPES, false,
-        "Set to true to enable custom names for the parent scope "
-        "of materials. Otherwise only scopes named Looks are allowed.");
-
 TF_DEFINE_ENV_SETTING(USD_KATANA_API_SCHEMAS_AS_GROUP_ATTR, false,
         "If true, API schemas will be imported as group attributes instead "
         "of an array of strings. This provides easier support for CEL "
@@ -75,107 +71,6 @@ TF_DEFINE_ENV_SETTING(USD_KATANA_API_SCHEMAS_AS_GROUP_ATTR, false,
 
 FnLogSetup("PxrUsdKatanaReadPrim");
 
-static FnKat::Attribute
-_GetMaterialAssignAttr(
-        const UsdPrim& prim,
-        const PxrUsdKatanaUsdInPrivateData& data)
-{
-    if (!prim || prim.GetPath() == SdfPath::AbsoluteRootPath()) {
-        // Special-case to pre-empt coding errors.
-        return FnKat::Attribute();
-    }
-
-    UsdRelationship usdRel = UsdShadeMaterial::GetBindingRel(prim);
-    if (usdRel) {
-        // USD shading binding
-        SdfPathVector targetPaths;
-        usdRel.GetForwardedTargets(&targetPaths);
-        if (targetPaths.size() > 0) {
-            if (!targetPaths[0].IsPrimPath()) {
-                FnLogWarn("Target path " << prim.GetPath().GetString() <<
-                          " is not a prim");
-                return FnKat::Attribute();
-            }
-
-            // This is a copy as it could be modified below.
-            SdfPath targetPath = targetPaths[0];
-            UsdPrim targetPrim = data.GetUsdInArgs()->GetStage()->GetPrimAtPath(targetPath);
-            // If the target is inside a master, then it needs to be re-targeted 
-            // to the instance.
-            // 
-            // XXX remove this special awareness once GetMasterWithContext is
-            //     is available as the provided prim will automatically
-            //     retarget (or provide enough context to retarget without
-            //     tracking manually).
-            if (targetPrim && targetPrim.IsInMaster()) {
-                if (!data.GetInstancePath().IsEmpty() &&
-                    !data.GetMasterPath().IsEmpty()) {
-
-                    // Check if the source and the target of the relationship 
-                    // belong to the same master.
-                    // If they do, we have the context necessary to do the 
-                    // re-mapping.
-                    if (data.GetMasterPath().GetCommonPrefix(targetPath).
-                            GetPathElementCount() > 0) {
-                        targetPath = data.GetInstancePath().AppendPath(
-                            targetPath.ReplacePrefix(targetPath.GetPrefixes()[0],
-                                SdfPath::ReflexiveRelativePath()));
-                    } else {
-                        // Warn saying the target of relationship isn't within 
-                        // the same master as the source.
-                        FnLogWarn("Target path " << prim.GetPath().GetString() 
-                            << " isn't within the master " << data.GetMasterPath());
-                        return FnKat::Attribute();
-                    }
-                } else {
-                    // XXX
-                    // When loading beneath a master via an isolatePath
-                    // opArg, we can encounter targets which are within masters
-                    // but not within the context of a material.
-                    // While that would be an error according to the below
-                    // warning, it produces the expected results.
-                    // This case can occur when expanding pointinstancers as
-                    // the sources are made via execution of PxrUsdIn again
-                    // at the sub-trees.
-                    
-                    
-                    // Warn saying target of relationship is in a master, 
-                    // but the associated instance path is unknown!
-                    // FnLogWarn("Target path " << prim.GetPath().GetString() 
-                    //         << " is within a master, but the associated "
-                    //         "instancePath is unknown.");
-                    // return FnKat::Attribute();
-                }
-            }
-
-            // Convert the target path to the equivalent katana location.
-            // XXX: Materials may have an atypical USD->Katana 
-            // path mapping
-            std::string location =
-                PxrUsdKatanaUtils::ConvertUsdMaterialPathToKatLocation(targetPath, data);
-
-            static const bool allowCustomScopes = 
-                TfGetEnvSetting(USD_KATANA_ALLOW_CUSTOM_MATERIAL_SCOPES);
-                
-            // XXX Materials containing only display terminals are causing issues
-            //     with katana material manipulation workflows.
-            //     For now: exclude any material assign which doesn't include
-            //     /Looks/ in the path
-            if (!allowCustomScopes && location.find(UsdKatanaTokens->katanaLooksScopePathSubstring)
-                    == std::string::npos)
-            {
-                return FnKat::Attribute();
-            }
-                
-                
-            // location = TfStringReplace(location, "/Looks/", "/Materials/");
-            // XXX handle multiple assignments
-            return FnKat::StringAttribute(location);
-        }
-    }
-
-    return FnKat::Attribute();
-}
 
 static bool
 _GatherRibAttributes(
@@ -830,7 +725,7 @@ PxrUsdKatanaReadPrim(
     // Set the 'materialAssign' attribute for locations that have shaders.
     //
 
-    attrs.set("materialAssign", _GetMaterialAssignAttr(prim, data));
+    attrs.set("materialAssign", PxrUsdKatanaUtils::GetMaterialAssignAttr(prim, data));
 
     //
     // Set the 'prmanStatements' attribute.

--- a/third_party/katana/lib/usdKatana/utils.cpp
+++ b/third_party/katana/lib/usdKatana/utils.cpp
@@ -65,6 +65,10 @@ FnLogSetup("PxrUsdKatanaUtils");
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+TF_DEFINE_ENV_SETTING(USD_KATANA_ALLOW_CUSTOM_MATERIAL_SCOPES, false,
+        "Set to true to enable custom names for the parent scope "
+        "of materials. Otherwise only scopes named Looks are allowed.");
+
 static const std::string&
 _ResolveAssetPath(const SdfAssetPath& assetPath)
 {
@@ -1174,6 +1178,108 @@ PxrUsdKatanaUtils::ConvertUsdMaterialPathToKatLocation(
     std::string primName = _GetDisplayName(prim);
     returnValue += primName;
     return returnValue;
+}
+
+FnKat::Attribute
+PxrUsdKatanaUtils::GetMaterialAssignAttr(
+        const UsdPrim& prim,
+        const PxrUsdKatanaUsdInPrivateData& data)
+{
+    if (!prim || prim.GetPath() == SdfPath::AbsoluteRootPath()) {
+        // Special-case to pre-empt coding errors.
+        return FnKat::Attribute();
+    }
+
+    UsdRelationship usdRel = UsdShadeMaterial::GetBindingRel(prim);
+    if (usdRel) {
+        // USD shading binding
+        SdfPathVector targetPaths;
+        usdRel.GetForwardedTargets(&targetPaths);
+        if (targetPaths.size() > 0) {
+            if (!targetPaths[0].IsPrimPath()) {
+                FnLogWarn("Target path " << prim.GetPath().GetString() <<
+                          " is not a prim");
+                return FnKat::Attribute();
+            }
+
+            // This is a copy as it could be modified below.
+            SdfPath targetPath = targetPaths[0];
+            UsdPrim targetPrim = data.GetUsdInArgs()->GetStage()->GetPrimAtPath(targetPath);
+            // If the target is inside a master, then it needs to be re-targeted 
+            // to the instance.
+            // 
+            // XXX remove this special awareness once GetMasterWithContext is
+            //     is available as the provided prim will automatically
+            //     retarget (or provide enough context to retarget without
+            //     tracking manually).
+            if (targetPrim && targetPrim.IsInMaster()) {
+                if (!data.GetInstancePath().IsEmpty() &&
+                    !data.GetMasterPath().IsEmpty()) {
+
+                    // Check if the source and the target of the relationship 
+                    // belong to the same master.
+                    // If they do, we have the context necessary to do the 
+                    // re-mapping.
+                    if (data.GetMasterPath().GetCommonPrefix(targetPath).
+                            GetPathElementCount() > 0) {
+                        targetPath = data.GetInstancePath().AppendPath(
+                            targetPath.ReplacePrefix(targetPath.GetPrefixes()[0],
+                                SdfPath::ReflexiveRelativePath()));
+                    } else {
+                        // Warn saying the target of relationship isn't within 
+                        // the same master as the source.
+                        FnLogWarn("Target path " << prim.GetPath().GetString() 
+                            << " isn't within the master " << data.GetMasterPath());
+                        return FnKat::Attribute();
+                    }
+                } else {
+                    // XXX
+                    // When loading beneath a master via an isolatePath
+                    // opArg, we can encounter targets which are within masters
+                    // but not within the context of a material.
+                    // While that would be an error according to the below
+                    // warning, it produces the expected results.
+                    // This case can occur when expanding pointinstancers as
+                    // the sources are made via execution of PxrUsdIn again
+                    // at the sub-trees.
+                    
+                    
+                    // Warn saying target of relationship is in a master, 
+                    // but the associated instance path is unknown!
+                    // FnLogWarn("Target path " << prim.GetPath().GetString() 
+                    //         << " is within a master, but the associated "
+                    //         "instancePath is unknown.");
+                    // return FnKat::Attribute();
+                }
+            }
+
+            // Convert the target path to the equivalent katana location.
+            // XXX: Materials may have an atypical USD->Katana 
+            // path mapping
+            std::string location =
+                /*PxrUsdKatanaUtils::*/ConvertUsdMaterialPathToKatLocation(targetPath, data);
+
+            static const bool allowCustomScopes = 
+                TfGetEnvSetting(USD_KATANA_ALLOW_CUSTOM_MATERIAL_SCOPES);
+                
+            // XXX Materials containing only display terminals are causing issues
+            //     with katana material manipulation workflows.
+            //     For now: exclude any material assign which doesn't include
+            //     /Looks/ in the path
+            if (!allowCustomScopes && location.find(UsdKatanaTokens->katanaLooksScopePathSubstring)
+                    == std::string::npos)
+            {
+                return FnKat::Attribute();
+            }
+                
+                
+            // location = TfStringReplace(location, "/Looks/", "/Materials/");
+            // XXX handle multiple assignments
+            return FnKat::StringAttribute(location);
+        }
+    }
+
+    return FnKat::Attribute();
 }
 
 bool 

--- a/third_party/katana/lib/usdKatana/utils.h
+++ b/third_party/katana/lib/usdKatana/utils.h
@@ -126,6 +126,9 @@ struct PxrUsdKatanaUtils {
     static std::string ConvertUsdMaterialPathToKatLocation(
             const SdfPath &path,
             const PxrUsdKatanaUsdInPrivateData& data);
+    static FnKat::Attribute GetMaterialAssignAttr(
+            const UsdPrim& prim,
+            const PxrUsdKatanaUsdInPrivateData& data);
 
     // XXX: should move these into readModel.h maybe.
     /// \name Model Utilities


### PR DESCRIPTION
### Description of Change(s)

The current logic for converting point instancer prototypes to Katana `instance source` locations was to start from the prototype prim and then walk upward until either a material binding or a (sub)component was found, at which point that location would then become the root of the generated `instance source` hierarchy. This behavior is (subjectively) somewhat unintuitive, but more importantly, it breaks in situations where the prototypes live outside of the point instancer's child hierarchy (as in #834 ).

These changes simplify the logic to the following:

- The prototype prim is always used as the root of the `instance source` location.
- If the prototype prim is not a (sub)component, we walk up the hierarchy looking for a material binding, and if one is found, that material is assigned directly to the `instance source` location.

### Fixes Issue(s)
- #834 
