### PR TITLE
Windows compatibility changes for compiling AL_USD etc.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -575,6 +575,7 @@ def InstallBoost(context, force, buildArgs):
             b2_settings.append("--with-date_time")
             b2_settings.append("--with-system")
             b2_settings.append("--with-thread")
+            b2_settings.append("--with-chrono")
 
         if context.buildOIIO:
             b2_settings.append("--with-filesystem")

--- a/extras/usd/examples/usdObj/CMakeLists.txt
+++ b/extras/usd/examples/usdObj/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(PXR_PREFIX pxr/usd)
 set(PXR_PACKAGE usdObj)
 
+IF(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ENDIF()
+
 pxr_plugin(${PXR_PACKAGE}
     LIBRARIES
         tf

--- a/pxr/imaging/plugin/hdStream/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdStream/CMakeLists.txt
@@ -16,6 +16,10 @@ if (OPENSUBDIV_HAS_GLSL_COMPUTE)
     add_definitions(-DOPENSUBDIV_HAS_GLSL_COMPUTE)
 endif()
 
+IF(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ENDIF()
+
 pxr_plugin(hdStream
     LIBRARIES
         plug

--- a/pxr/usdImaging/lib/usdShaders/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdShaders/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdShaders)
 
+IF(WIN32)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ENDIF()
+
 pxr_library(usdShaders
     LIBRARIES
         ar


### PR DESCRIPTION
adding boost chrono build script (required by AL_USD, just so it does not have to be compiled separately and we can use the same boost build as USD)
adding line that forces .lib file generation along with the .dll on Windows for hdStream, usdShaders and usdObj

### Description of Change(s)
force .lib generation on windows for hdStream, usdShaders and usdObj
adding chrono to boost build for convenience

### Fixes Issue(s)
#530

