### PR TITLE
[usdMaya] make UsdMayaTranslatorUtil::CreateShaderNode use shadingNode

### DIFF
--- a/third_party/maya/lib/usdMaya/shadingModePxrRis.cpp
+++ b/third_party/maya/lib/usdMaya/shadingModePxrRis.cpp
@@ -398,14 +398,14 @@ static
 MObject
 _CreateAndPopulateShaderObject(
         const UsdShadeShader& shaderSchema,
-        const bool asShader,
+        const UsdMayaShadingNodeType shadingNodeType,
         UsdMayaShadingModeImportContext* context);
 
 static
 MObject
 _GetOrCreateShaderObject(
         const UsdShadeShader& shaderSchema,
-        const bool asShader,
+        const UsdMayaShadingNodeType shadingNodeType,
         UsdMayaShadingModeImportContext* context)
 {
     MObject shaderObj;
@@ -417,7 +417,7 @@ _GetOrCreateShaderObject(
         return shaderObj;
     }
 
-    shaderObj = _CreateAndPopulateShaderObject(shaderSchema, asShader, context);
+    shaderObj = _CreateAndPopulateShaderObject(shaderSchema, shadingNodeType, context);
     return context->AddCreatedObject(shaderSchema.GetPrim(), shaderObj);
 }
 
@@ -450,7 +450,7 @@ _ImportAttr(const UsdAttribute& usdAttr, const MFnDependencyNode& fnDep)
 MObject
 _CreateAndPopulateShaderObject(
         const UsdShadeShader& shaderSchema,
-        const bool asShader,
+        const UsdMayaShadingNodeType shadingNodeType,
         UsdMayaShadingModeImportContext* context)
 {
     TfToken shaderId;
@@ -472,7 +472,7 @@ _CreateAndPopulateShaderObject(
     if (!(UsdMayaTranslatorUtil::CreateShaderNode(
                 MString(shaderSchema.GetPrim().GetName().GetText()),
                 mayaTypeName.GetText(),
-                asShader,
+                shadingNodeType,
                 &status,
                 &shaderObj) 
             && depFn.setObject(shaderObj))) {
@@ -512,7 +512,7 @@ _CreateAndPopulateShaderObject(
         MObject sourceObj = _GetOrCreateShaderObject(
             sourceShaderSchema,
             // any "nested" shader objects are not "shaders"
-            false, 
+            UsdMayaShadingNodeType::None,
             context);
 
         MFnDependencyNode sourceDepFn(sourceObj, &status);
@@ -580,9 +580,12 @@ DEFINE_SHADING_MODE_IMPORTER(pxrRis, context)
         displacementShader = UsdRiMaterialAPI(shadeMaterial).GetDisplacement();
     }
 
-    MObject surfaceShaderObj = _GetOrCreateShaderObject(surfaceShader, true, context);
-    MObject volumeShaderObj = _GetOrCreateShaderObject(volumeShader, true, context);
-    MObject displacementShaderObj = _GetOrCreateShaderObject(displacementShader, true, context);
+    MObject surfaceShaderObj = _GetOrCreateShaderObject(
+            surfaceShader, UsdMayaShadingNodeType::Shader, context);
+    MObject volumeShaderObj = _GetOrCreateShaderObject(
+            volumeShader, UsdMayaShadingNodeType::Shader, context);
+    MObject displacementShaderObj = _GetOrCreateShaderObject(
+            displacementShader, UsdMayaShadingNodeType::Shader, context);
 
     if (surfaceShaderObj.isNull() &&
             volumeShaderObj.isNull() &&

--- a/third_party/maya/lib/usdMaya/translatorRfMLight.cpp
+++ b/third_party/maya/lib/usdMaya/translatorRfMLight.cpp
@@ -1918,25 +1918,16 @@ UsdMayaTranslatorRfMLight::Read(
         TfStringPrintf("%sShape", usdPrim.GetName().GetText()).c_str();
 
     MObject lightObj;
-    if (!UsdMayaTranslatorUtil::CreateNode(
+    if (!UsdMayaTranslatorUtil::CreateShaderNode(
             nodeName,
             MString(mayaLightTypeToken.GetText()),
-            mayaNodeTransformObj,
+            UsdMayaShadingNodeType::Light,
             &status,
-            &lightObj)) {
+            &lightObj,
+            mayaNodeTransformObj)) {
         return _ReportError(TfStringPrintf("Failed to create %s node",
                                            mayaLightTypeToken.GetText()),
                             lightSchema.GetPath());
-    }
-
-    if (!UsdMayaTranslatorUtil::ConnectDefaultLightNode(
-            mayaNodeTransformObj,
-            &status)) {
-        return _ReportError(
-            TfStringPrintf(
-                "Could not connect %s as a default light",
-                mayaLightTypeToken.GetText()),
-            lightSchema.GetPath());
     }
 
     const std::string nodePath = lightSchema.GetPath().AppendChild(

--- a/third_party/maya/lib/usdMaya/translatorUtil.h
+++ b/third_party/maya/lib/usdMaya/translatorUtil.h
@@ -36,7 +36,15 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
+enum class UsdMayaShadingNodeType {
+    None,
+    Light,
+    PostProcess,
+    Rendering,
+    Shader,
+    Texture,
+    Utility
+};
 
 /// \brief Provides helper functions for other readers to use.
 struct UsdMayaTranslatorUtil
@@ -114,36 +122,27 @@ struct UsdMayaTranslatorUtil
             MStatus* status,
             MObject* mayaNodeObj);
 
-    /// \brief Helper to create a shadingNode.  When \p asShader is \c true,
-    /// this is intended to mimic the mel command "shadingNode ... -asShader".
+    /// \brief Helper to create shadingNodes.  Wrapper around mel "shadingNode".
     ///
-    /// In particular, this hooks up the shader to "defaultShadingList1.shaders"
-    /// which makes sure the node shows up in the Hypershade UI.
+    /// This does several things beyond just creating the node, including but
+    /// not limited to:
+    ///     - hook up the node to appropriate default groups (ie,
+    ///       defaultShadingList1 for shaders, defaultLightSet for lights)
+    ///     - handle basic color management setup for textures
+    ///     - make sure nodes show up in the hypershade
     ///
-    /// If there are other side-effects of using "shadingNode" (as opposed to
-    /// "createNode" directly), this should be udpated accordingly.
+    /// TODO: add a ShadingNodeType::Unspecified, which will make this function
+    /// determine the type of node automatically using it's classification
+    /// string
     PXRUSDMAYA_API
     static bool
     CreateShaderNode(
             const MString& nodeName,
             const MString& nodeTypeName,
-            const bool asShader,
+            UsdMayaShadingNodeType shadingNodeType,
             MStatus* status,
-            MObject* shaderObj);
-
-    /// \brief Helper to set up a light node as a default light.  
-    /// This is intended to mimic the mel command "shadingNode ... -asLight".
-    ///
-    /// In particular, this makes sure the light nodes are members of the
-    /// "defaultLightSet" which allows lights to be recognized on the stage
-    ///
-    /// If there are other side-effects of using "shadingNode" (as opposed to
-    /// "createNode" directly), this should be updated accordingly.
-    PXRUSDMAYA_API
-    static bool
-    ConnectDefaultLightNode(
-            MObject& lightNode,
-            MStatus* status);
+            MObject* shaderObj,
+            MObject parentNode=MObject::kNullObj);
 
     /// Gets an API schema of the requested type for the given \p usdPrim.
     ///


### PR DESCRIPTION
### Description of Change(s)
Turns UsdMayaTranslatorUtil::CreateShaderNode into a wrapper over the shadingNode command

The docs said it was intended to mimic this command, but it was lacking some
functionality; in theory, we might have been able to add the (known) missing
functionality, but past experience has shown attempting to replicate this
command not worth the small efficiency gain by avoiding the string conversions
needed by mel commands.

Also eliminated ConnectDefaultLightNode, since it was also mimicking this command

### Fixes Issue(s)
- shadingNodes not showing up in the hypershade
- texture nodes not being hooked into the color management system

