### PR TITLE
[tests] Checkout sdf and usda files with LF for cross-platform unit testing.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sdf		text eol=lf
+*.usda		text eol=lf
+


### PR DESCRIPTION
### Description of Change(s)

Ensures that sdf and usda test inputs and baselines use LF on all platforms; otherwise testSdfParsing* and testUsdFlatten* fail on Windows.

### Fixes Issue(s)
-

