### PR TITLE
[Hd, UsdImaging, UsdImagingGL] Render delegates explicitly specify material adapter prim type tokens

### DIFF
--- a/pxr/imaging/lib/hd/renderDelegate.cpp
+++ b/pxr/imaging/lib/hd/renderDelegate.cpp
@@ -83,6 +83,13 @@ HdRenderDelegate::GetMaterialBindingPurpose() const
     return HdTokens->preview;
 }
 
+TfToken
+HdRenderDelegate::GetMaterialAdapterKey() const
+{
+    return GetMaterialBindingPurpose() == HdTokens->preview
+        ? HdTokens->HydraPbsSurface : HdTokens->Material;
+}
+
 TfTokenVector 
 HdRenderDelegate::GetShaderSourceTypes() const
 {

--- a/pxr/imaging/lib/hd/renderDelegate.h
+++ b/pxr/imaging/lib/hd/renderDelegate.h
@@ -316,6 +316,12 @@ public:
     virtual TfToken GetMaterialBindingPurpose() const;
 
     ///
+    /// Returns a primTypeName token used to find a matching material adapter.
+    ///
+    HD_API
+    virtual TfToken GetMaterialAdapterKey() const;
+
+    ///
     /// Returns a token that can be used to select among multiple
     /// material network implementations.  The default is empty.
     ///

--- a/pxr/imaging/lib/hd/tokens.h
+++ b/pxr/imaging/lib/hd/tokens.h
@@ -68,6 +68,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (hermite)                                   \
     (hidden)                                    \
     (hullIndices)                               \
+    (HydraPbsSurface)                           \
     (indices)                                   \
     (instancer)                                 \
     (instancerTransform)                        \
@@ -81,6 +82,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (leftHanded)                                \
     (linear)                                    \
     (lightLink)                                 \
+    (Material)                                  \
     (materialParams)                            \
     (nonperiodic)                               \
     (normals)                                   \

--- a/pxr/usdImaging/lib/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/lib/usdImaging/delegate.cpp
@@ -82,8 +82,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (instance)
     (texturePath)
-    (Material)
-    (HydraPbsSurface)
 );
 
 // This environment variable matches a set of similar ones in
@@ -238,11 +236,9 @@ UsdImagingDelegate::_AdapterLookup(UsdPrim const& prim, bool ignoreInstancing)
         // treated like Materials. When not using networks,
         // we want Shaders to be treated like HydraPbsSurface
         // for backwards compatibility.
-        TfToken bindingPurpose = GetRenderIndex().
-            GetRenderDelegate()->GetMaterialBindingPurpose();
-        if (bindingPurpose == HdTokens->preview &&
-            adapterKey == _tokens->Material) {
-            adapterKey = _tokens->HydraPbsSurface;
+        if (adapterKey == HdTokens->Material) {
+            adapterKey = GetRenderIndex().
+                GetRenderDelegate()->GetMaterialAdapterKey();
         }
     }
 

--- a/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.cpp
@@ -208,7 +208,6 @@ _GetDeprecatedSurfaceShaderPrim(const UsdShadeMaterial &material)
     // Deprecated shader style - hydraLook:Surface
     // ---------------------------------------------------------------------- //
     static const TfToken hdSurf("hydraLook:surface");
-    static const TfToken surfType("HydraPbsSurface");
 
     UsdRelationship displayShaderRel = material.GetPrim().GetRelationship(
         displayLookBxdf);
@@ -249,7 +248,7 @@ _GetDeprecatedSurfaceShaderPrim(const UsdShadeMaterial &material)
 
     UsdPrim shaderPrim = displayShaderRel.GetStage()->GetPrimAtPath(targets[0]);
     if (displayShaderRel.GetName() == hdSurf) {
-        if (TF_VERIFY(shaderPrim.GetTypeName() == surfType)) {
+        if (TF_VERIFY(shaderPrim.GetTypeName() == HdTokens->HydraPbsSurface)) {
             TF_DEBUG(USDIMAGING_SHADERS).Msg(
                      "\t Deprecated hydraLook:surface binding found: %s\n", 
                      shaderPrim.GetPath().GetText());

--- a/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.h
+++ b/pxr/usdImaging/lib/usdImagingGL/hydraMaterialAdapter.h
@@ -104,12 +104,14 @@ public:
     /// \name Texture resources
     // ---------------------------------------------------------------------- //
 
+    USDIMAGING_API
     virtual HdTextureResource::ID
     GetTextureResourceID(UsdPrim const& usdPrim, 
                          SdfPath const &id, 
                          UsdTimeCode time, 
                          size_t salt) const override;
 
+    USDIMAGING_API
     virtual HdTextureResourceSharedPtr
     GetTextureResource(UsdPrim const& usdPrim, 
                        SdfPath const &id, 


### PR DESCRIPTION
We need UsdImagingDelegate to be able to create a custom material
adapter that would create shader resources for our new Maya plug-in
instead of HdSt ones. This was previously impossible because
UsdImagingDelegate selected one of the two hardcoded material adapter
prim type tokens based on the material binding purpose (full or
preview) returned by the render delegate.

We're instead suggesting a new virtual method that returns the prim
type token explicitly, thus allowing the render delegate to specify a
custom material adapter, transparently to UsdImagingDelegate.
