### PR TITLE
[usdImagingGL] fix UsdImagingGLEngine constructor w/ args

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.cpp
@@ -171,6 +171,10 @@ UsdImagingGLEngine::UsdImagingGLEngine(
     , _restoreViewport(0)
     , _useFloatPointDrawTarget(false)
 {
+    static std::once_flag initFlag;
+
+    std::call_once(initFlag, _InitGL);
+
     if (IsHydraEnabled()) {
 
         // _renderIndex, _taskController, and _delegate are initialized


### PR DESCRIPTION
### Description of Change(s)
Fixes the overload of the UsdImagingGLEngine constructor that took arguments

It did not call _InitGL, like the no-arg constructor. This resulted in an
error: `GlfContextCaps has not been initialized`

### Fixes Issue(s)
- error when calling UsdImagingGLEngine constructor w/ args

