### PR TITLE
[usdImagingGL] allow usdview to use a delegateID for it's UsdImagingDelegate

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.cpp
@@ -170,6 +170,10 @@ UsdImagingGLEngine::UsdImagingGLEngine(
     , _restoreViewport(0)
     , _useFloatPointDrawTarget(false)
 {
+    static std::once_flag initFlag;
+
+    std::call_once(initFlag, _InitGL);
+
     if (IsHydraEnabled()) {
 
         // _renderIndex, _taskController, and _delegate are initialized

--- a/pxr/usdImaging/lib/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.cpp
@@ -674,6 +674,24 @@ UsdImagingGLEngine::GetPrimPathFromInstanceIndex(
                                              instanceContext);
 }
 
+SdfPath
+UsdImagingGLEngine::ConvertCachePathToIndexPath(SdfPath const& cachePath)
+{
+    if (ARCH_LIKELY(_delegate)) {
+        return _delegate->ConvertCachePathToIndexPath(cachePath);
+    }
+    return cachePath;
+}
+
+SdfPath
+UsdImagingGLEngine::ConvertIndexPathToCachePath(SdfPath const& indexPath)
+{
+    if (ARCH_LIKELY(_delegate)) {
+        return _delegate->ConvertIndexPathToCachePath(indexPath);
+    }
+    return indexPath;
+}
+
 //----------------------------------------------------------------------------
 // Renderer Plugin Management
 //----------------------------------------------------------------------------

--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -297,6 +297,18 @@ public:
         SdfPath * rprimPath=NULL,
         SdfPathVector *instanceContext=NULL);
 
+    // Converts a cache path to a path in the render index.
+    USDIMAGINGGL_API
+    SdfPath ConvertCachePathToIndexPath(SdfPath const& cachePath);
+
+    /// Convert the given Hydra ID to a UsdImaging cache path,
+    /// by stripping the scene delegate prefix.
+    ///
+    /// The UsdImaging cache path is the same as a USD prim path,
+    /// except for instanced prims, which get a name-mangled encoding.
+    USDIMAGINGGL_API
+    SdfPath ConvertIndexPathToCachePath(SdfPath const& indexPath);
+
     /// Resolves a 4-byte pixel from an id render to an int32 prim ID.
     static inline int DecodeIDRenderColor(unsigned char const idColor[4]) {
         return HdxPickTask::DecodeIDRenderColor(idColor);

--- a/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
@@ -124,6 +124,10 @@ void wrapEngine()
             .def("GetRprimPathFromPrimId", 
                     &UsdImagingGLEngine::GetRprimPathFromPrimId)
             .def("GetPrimPathFromInstanceIndex", &_GetPrimPathFromInstanceIndex)
+            .def("ConvertCachePathToIndexPath",
+                    &UsdImagingGLEngine::ConvertCachePathToIndexPath)
+            .def("ConvertIndexPathToCachePath",
+                    &UsdImagingGLEngine::ConvertIndexPathToCachePath)
             .def("TestIntersection", &_TestIntersection)
             .def("IsHydraEnabled", &UsdImagingGLEngine::IsHydraEnabled)
                 .staticmethod("IsHydraEnabled")

--- a/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
@@ -105,7 +105,11 @@ void wrapEngine()
                 "Engine", "UsdImaging Renderer class")
             .def( init<>() )
             .def( init<const SdfPath &, const SdfPathVector&,
-                    const SdfPathVector& >() )
+                    const SdfPathVector&, const SdfPath & >
+                ((args("rootPath"),
+                  args("excludedPaths") = SdfPathVector(),
+                  args("invisedPaths") = SdfPathVector(),
+                  args("delegateID") = SdfPath::AbsoluteRootPath())))
             .def("Render", &UsdImagingGLEngine::Render)
             .def("SetCameraState", &UsdImagingGLEngine::SetCameraState)
             .def("SetLightingStateFromOpenGL",

--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -1554,7 +1554,8 @@ class AppController(QtCore.QObject):
             else:
                 self._stageView = StageView(parent=self._mainWindow,
                     dataModel=self._dataModel,
-                    printTiming=self._printTiming)
+                    printTiming=self._printTiming,
+                    delegateID=self._parserData.delegateID)
 
                 self._stageView.fpsHUDInfo = self._fpsHUDInfo
                 self._stageView.fpsHUDKeys = self._fpsHUDKeys


### PR DESCRIPTION
### Description of Change(s)

This option has the effect of making the index rprim paths clearly different
from the usd paths, ie:

```
index path: /hydra/cube1
usd path:   /cube1
```

This has two benefits:

One, it makes it easier when debugging code, and using usdview as a tool
for exploring / learning hydra, as it is clearer what type of path you are
looking at.

Two, it enforces best practices on the usdview codebase.  This codebase
will be used as a reference point by many, and by making the two types of
paths different, it forces usdview to handle path conversions "properly",
instead of relying on them being the same.  This change has already
exposed one case where an indexPath was being returned without conversion
as a usdPath


### Note on the PR

This PR depends on / includes this other PR:

https://github.com/PixarAnimationStudios/USD/pull/855
