### PR TITLE
[usdGeom] added support for indexed uint primvar values

### DIFF
--- a/pxr/usd/lib/usdGeom/primvar.cpp
+++ b/pxr/usd/lib/usdGeom/primvar.cpp
@@ -346,6 +346,7 @@ UsdGeomPrimvar::ComputeFlattened(VtValue *value, UsdTimeCode time) const
         _ComputeFlattenedArray<VtStringArray>(attrVal, indices, value)      ||
         _ComputeFlattenedArray<VtDoubleArray>(attrVal, indices, value)      ||
         _ComputeFlattenedArray<VtIntArray>(attrVal, indices, value)         ||
+        _ComputeFlattenedArray<VtUIntArray>(attrVal, indices, value)        ||
         _ComputeFlattenedArray<VtFloatArray>(attrVal, indices, value)       ||
         _ComputeFlattenedArray<VtHalfArray>(attrVal, indices, value);
 


### PR DESCRIPTION
### Description of Change(s)
Added support for indexed primvar values of type `uint[]`.

_testUsdGeomPrimvar.py_ could be extended to include a test for this in _test_PrimvarsAPI()_ but not sure if that's necessary. 
```
# make sure UIntArray can be used for indexed primvar values
uint_array = gp_pv.CreatePrimvar('uint_array', Sdf.ValueTypeNames.UIntArray)
uint_values = Vt.UIntArray([3, 1, 4])
uint_array.Set(uint_values)
indices = Vt.IntArray([0, 1, 2, 1, 2, 0])
uint_array.SetIndices(indices)
self.assertFalse(uint_array.ComputeFlattened() is None)
```