### PR TITLE
bug fix - added USD_API macro on UsdZipFileWriter rhs methods

### DIFF
--- a/pxr/usd/lib/usd/zipFile.h
+++ b/pxr/usd/lib/usd/zipFile.h
@@ -232,7 +232,10 @@ public:
     UsdZipFileWriter(const UsdZipFileWriter&) = delete;
     UsdZipFileWriter& operator=(const UsdZipFileWriter&) = delete;
 
+    USD_API
     UsdZipFileWriter(UsdZipFileWriter&& rhs);
+
+    USD_API
     UsdZipFileWriter& operator=(UsdZipFileWriter&& rhs);
 
     /// Returns true if this is a valid object, false otherwise.


### PR DESCRIPTION
### Description of Change(s)
Adding the USD_API macro to two rhs methods in zipFile.h, they were missing in the created dll for windows.

### Fixes Issue(s)
-USD_API added to methods in zipFile.h, line 235 and 236