### PR TITLE
Fixes for newer versions of pyside

### DIFF
--- a/pxr/usdImaging/lib/usdviewq/appController.py
+++ b/pxr/usdImaging/lib/usdviewq/appController.py
@@ -742,7 +742,7 @@ class AppController(QtCore.QObject):
 
             self._ui.actionFrame_Backwards.triggered.connect(self._retreatFrame)
 
-            self._ui.actionReset_View.triggered.connect(self._resetView)
+            self._ui.actionReset_View.triggered.connect(lambda: self._resetView())
 
             self._ui.topBottomSplitter.splitterMoved.connect(self._cacheViewerModeEscapeSizes)
             self._ui.primStageSplitter.splitterMoved.connect(self._cacheViewerModeEscapeSizes)

--- a/pxr/usdImaging/lib/usdviewq/debugFlagsWidget.py
+++ b/pxr/usdImaging/lib/usdviewq/debugFlagsWidget.py
@@ -78,9 +78,8 @@ class DebugFlagsWidget(QtWidgets.QWidget):
         allDebugPrefixes = [ x[:x.find('_')] if x.find('_') > 0 else x
                 for x in allDebugFlags]
         self._allDebugFlagPrefixes = list(sorted(set(allDebugPrefixes)))
-        listModel = QtGui.QStringListModel(self._allDebugFlagPrefixes)
+        listModel = QtCore.QStringListModel(self._allDebugFlagPrefixes)
         listView.setModel(listModel)
-
 
     def _populateDebugFlagsTableView(self, debugFlagPrefix):
         debugFlags = _GetDebugFlagsWithPrefix(debugFlagPrefix)

--- a/pxr/usdImaging/lib/usdviewq/qt.py
+++ b/pxr/usdImaging/lib/usdviewq/qt.py
@@ -47,10 +47,19 @@ if QtCore.__name__.startswith('PySide.'):
         QtGui.QWheelEvent.angleDelta = angleDelta
 
     # Patch missing classes to make PySide look like PySide2
-    if not hasattr(QtCore, "QItemSelectionModel"):
+    if not hasattr(QtCore, 'QItemSelectionModel'):
         QtCore.QItemSelectionModel = QtGui.QItemSelectionModel
+        
+    if not hasattr(QtCore, 'QStringListModel'):
+        QtCore.QStringListModel = QtGui.QStringListModel
 
 elif QtCore.__name__.startswith('PySide2.'):
     from PySide2 import QtGui, QtWidgets, QtOpenGL
+    
+    # Older versions still have QtGui.QStringListModel - this
+    # is apparently a bug:
+    #    https://bugreports.qt.io/browse/PYSIDE-614
+    if not hasattr(QtCore, 'QStringListModel'):
+        QtCore.QStringListModel = QtGui.QStringListModel
 else:
     raise ImportError()


### PR DESCRIPTION
### Description of Change(s)

Newer versions of PySide (ie, 5.11) have changes that break existing usdview code.
This fixes these issues, while still maintaining backwards compatibility with older versions.

Note that I've closed https://github.com/PixarAnimationStudios/USD/pull/783 in favor of this

### Fixes Issue(s)
- Usdview - reset view doesn't work with newer PySide (5.11)
- Usdview - debug flags window doesn't work with newer PySide (5.11)

