### PR TITLE
Fixes for building with gcc-6 / c++14 with PXR_STRICT_BUILD_MODE

### DIFF
--- a/pxr/base/lib/tf/pyContainerConversions.h
+++ b/pxr/base/lib/tf/pyContainerConversions.h
@@ -256,7 +256,7 @@ namespace TfPyContainerConversions {
         bool is_range = PyRange_Check(obj_ptr);
         std::size_t i=0;
         if (!all_elements_convertible(obj_iter, is_range, i)) return 0;
-        if (!is_range) assert(i == obj_size);
+        if (!is_range) assert(i == (std::size_t)obj_size);
       }
       return obj_ptr;
     }

--- a/pxr/base/lib/tf/span.h
+++ b/pxr/base/lib/tf/span.h
@@ -196,12 +196,12 @@ public:
     /// has a range of [data()+offset, data()+size()). Otherwise, the new
     /// span has range [data()+offset, data()+offset+count).
     TfSpan<T> subspan(difference_type offset, difference_type count=-1) const {
-        TF_DEV_AXIOM(offset >= 0 && offset < _size);
+        TF_DEV_AXIOM(offset >= 0 && (index_type)offset < _size);
         if (count == -1) {
             return TfSpan<T>(_data + offset, _size - offset);
         } else {
             TF_DEV_AXIOM(count >= 0);
-            TF_DEV_AXIOM((offset+count) <= _size);
+            TF_DEV_AXIOM((index_type)(offset+count) <= _size);
             return TfSpan<T>(_data + offset, count);
         }
     }

--- a/pxr/base/lib/work/filter.h
+++ b/pxr/base/lib/work/filter.h
@@ -107,7 +107,7 @@ WorkParallelFilterN(size_t N,
          &accumVector,
          &starts](size_t begin, size_t end)
            {
-                for(int j = begin; j < end; ++j){
+                for(size_t j = begin; j < end; ++j){
                     const auto& vec = *(parallelVectors.begin()+j);
                     for(unsigned int i =0; i < vec.size(); ++i){
                         accumVector[starts[j] + i] = vec[i];

--- a/pxr/imaging/plugin/hdEmbree/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderBuffer.cpp
@@ -153,7 +153,7 @@ HdEmbreeRenderBuffer::Allocate(GfVec3i const& dimensions,
 
 template<typename T>
 static void _WriteSample(HdFormat format, uint8_t *dst,
-                         int valueComponents, T const* value)
+                         size_t valueComponents, T const* value)
 {
     HdFormat componentFormat = HdGetComponentFormat(format);
     size_t componentCount = HdGetComponentCount(format);
@@ -171,7 +171,7 @@ static void _WriteSample(HdFormat format, uint8_t *dst,
 
 template<typename T>
 static void _WriteOutput(HdFormat format, uint8_t *dst,
-                         int valueComponents, T const* value)
+                         size_t valueComponents, T const* value)
 {
     HdFormat componentFormat = HdGetComponentFormat(format);
     size_t componentCount = HdGetComponentCount(format);
@@ -198,7 +198,7 @@ static void _WriteOutput(HdFormat format, uint8_t *dst,
 
 void
 HdEmbreeRenderBuffer::Write(
-    GfVec3i const& pixel, int numComponents, float const* value)
+    GfVec3i const& pixel, size_t numComponents, float const* value)
 {
     size_t idx = pixel[1]*_width+pixel[0];
     if (_multiSampled) {
@@ -215,7 +215,7 @@ HdEmbreeRenderBuffer::Write(
 
 void
 HdEmbreeRenderBuffer::Write(
-    GfVec3i const& pixel, int numComponents, int const* value)
+    GfVec3i const& pixel, size_t numComponents, int const* value)
 {
     size_t idx = pixel[1]*_width+pixel[0];
     if (_multiSampled) {
@@ -231,7 +231,7 @@ HdEmbreeRenderBuffer::Write(
 }
 
 void
-HdEmbreeRenderBuffer::Clear(int numComponents, float const* value)
+HdEmbreeRenderBuffer::Clear(size_t numComponents, float const* value)
 {
     size_t formatSize = HdDataSizeOfFormat(_format);
     for (size_t i = 0; i < _width*_height; ++i) {
@@ -246,7 +246,7 @@ HdEmbreeRenderBuffer::Clear(int numComponents, float const* value)
 }
 
 void
-HdEmbreeRenderBuffer::Clear(int numComponents, int const* value)
+HdEmbreeRenderBuffer::Clear(size_t numComponents, int const* value)
 {
     size_t formatSize = HdDataSizeOfFormat(_format);
     for (size_t i = 0; i < _width*_height; ++i) {

--- a/pxr/imaging/plugin/hdEmbree/renderBuffer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderBuffer.h
@@ -133,7 +133,7 @@ public:
     ///   \param pixel         What index to write
     ///   \param numComponents The arity of the value to write.
     ///   \param value         A float-valued vector to write. 
-    void Write(GfVec3i const& pixel, int numComponents, float const* value);
+    void Write(GfVec3i const& pixel, size_t numComponents, float const* value);
 
     /// Write an int, vec2i, vec3i, or vec4i to the renderbuffer.
     /// This should only be called on a mapped buffer. Extra components will
@@ -142,7 +142,7 @@ public:
     ///   \param pixel         What index to write
     ///   \param numComponents The arity of the value to write.
     ///   \param value         An int-valued vector to write. 
-    void Write(GfVec3i const& pixel, int numComponents, int const* value);
+    void Write(GfVec3i const& pixel, size_t numComponents, int const* value);
 
     /// Clear the renderbuffer with a float, vec2f, vec3f, or vec4f.
     /// This should only be called on a mapped buffer. Extra components will
@@ -150,7 +150,7 @@ public:
     /// remainder will be taken as 0.
     ///   \param numComponents The arity of the value to write.
     ///   \param value         A float-valued vector to write. 
-    void Clear(int numComponents, float const* value);
+    void Clear(size_t numComponents, float const* value);
 
     /// Clear the renderbuffer with an int, vec2i, vec3i, or vec4i.
     /// This should only be called on a mapped buffer. Extra components will
@@ -158,7 +158,7 @@ public:
     /// remainder will be taken as 0.
     ///   \param numComponents The arity of the value to write.
     ///   \param value         An int-valued vector to write. 
-    void Clear(int numComponents, int const* value);
+    void Clear(size_t numComponents, int const* value);
 
 private:
     // Calculate the needed buffer size, given the allocation parameters.

--- a/pxr/usd/lib/pcp/testenv/testPcpIterator.cpp
+++ b/pxr/usd/lib/pcp/testenv/testPcpIterator.cpp
@@ -215,7 +215,7 @@ _TestRandomAccessOperations(IteratorType first, IteratorType last)
 {
     TF_AXIOM(first != last);
 
-    size_t idx = 0;
+    decltype(first - last) idx = 0;
     for (IteratorType it = first; it != last; ++it, ++idx) {
         TF_AXIOM(it - first == idx);
         TF_AXIOM(it - idx == first);

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -547,6 +547,7 @@ AlembicProperty::AlembicProperty(
     // Do nothing
 }
 
+ARCH_UNUSED_FUNCTION
 const SdfPath&
 AlembicProperty::GetPath() const
 {
@@ -1979,6 +1980,7 @@ _PrimReaderContext::GetPath() const
     return _path;
 }
 
+ARCH_UNUSED_FUNCTION
 bool
 _PrimReaderContext::IsFlagSet(const TfToken& flagName) const
 {
@@ -1999,6 +2001,7 @@ _PrimReaderContext::GetPrim()
     return _context.AddPrim(GetPath());
 }
 
+ARCH_UNUSED_FUNCTION
 const _PrimReaderContext::Property&
 _PrimReaderContext::GetProperty(const TfToken& name) const
 {
@@ -2010,6 +2013,8 @@ _PrimReaderContext::GetProperty(const TfToken& name) const
     return empty;
 }
 
+
+ARCH_UNUSED_FUNCTION
 void
 _PrimReaderContext::SetPropertyConverter(
     const TfToken& name,
@@ -2069,6 +2074,7 @@ _PrimReaderContext::GetUnextractedNames() const
     return _unextracted;
 }
 
+ARCH_UNUSED_FUNCTION
 std::vector<std::string>
 _PrimReaderContext::GetUnextractedSchemaNames() const
 {

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -1030,6 +1030,7 @@ _PrimWriterContext::GetPropertyField(
     return _context.GetData().Get(propId, fieldName);
 }
 
+ARCH_UNUSED_FUNCTION
 const OArchive&
 _PrimWriterContext::GetArchive() const
 {


### PR DESCRIPTION
### Description of Change(s)

Were a few leftover warnings when I tried to build with gcc-6 / c++14... but not many, so I just fixed them up and bundled into a PR.

### Fixes Issue(s)
- Sign comparison warnings with gcc-6 / c++14
- Unused function warnings with gcc-6 / c++14

