### PR TITLE
prevent error when loading usdMaya usd-plugins

### DIFF
--- a/third_party/maya/plugin/pxrUsd/plugInfo.json
+++ b/third_party/maya/plugin/pxrUsd/plugInfo.json
@@ -13,7 +13,7 @@
                 }
             },
             "Name": "@PLUG_INFO_PLUGIN_NAME@",
-            "Type": "python"
+            "Type": "resource"
         }
     ]
 }

--- a/third_party/maya/plugin/pxrUsdPreviewSurface/plugInfo.json
+++ b/third_party/maya/plugin/pxrUsdPreviewSurface/plugInfo.json
@@ -14,7 +14,7 @@
             "Name": "pxrUsdPreviewSurface",
             "ResourcePath": "@PLUG_INFO_RESOURCE_PATH@",
             "Root": "@PLUG_INFO_ROOT@",
-            "Type": "python"
+            "Type": "resource"
         }
     ]
 }

--- a/third_party/maya/plugin/pxrUsdTranslators/plugInfo.json
+++ b/third_party/maya/plugin/pxrUsdTranslators/plugInfo.json
@@ -53,7 +53,7 @@
                 }
             },
             "Name": "@PLUG_INFO_PLUGIN_NAME@",
-            "Type": "python"
+            "Type": "resource"
         }
     ]
 }


### PR DESCRIPTION
### Description of Change(s)

The maya usd-plugins are mostly there just to provide metadata (so the
associated maya plugins can be found and loaded); however, as currently
configured, if you try to Load() them, they error.  This creates ugly
error messages in, ie, AL_USDMaya, which pre-emptively tries to load all
usd plugins.

This is because they are configured as python plugins, but there is no
associated python module. Setting them to resource plugins removes the
error.

### Fixes Issue(s)
- Error when loading the maya usd-plugins

