### PR TITLE
fix for OpenImageIO >= 1.9.1

### DIFF
--- a/pxr/imaging/lib/glf/oiioImage.cpp
+++ b/pxr/imaging/lib/glf/oiioImage.cpp
@@ -486,20 +486,19 @@ Glf_OIIOImage::ReadCropped(int const cropTop,
         image = &scaled;
     }
 
-//XXX:
-//'OpenImageIO::v1_7::ImageBuf::get_pixels': Use get_pixels(ROI, ...) instead. [1.6] 
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_DEPRECATED_POSIX_NAME
-
     // Read pixel data
     TypeDesc type = _GetOIIOBaseType(storage.type);
+
+#if OIIO_VERSION > 10603
+    if (!image->get_pixels(ROI(0, storage.width, 0, storage.height, 0, 1),
+                           type, storage.data)) {
+#else
     if (!image->get_pixels(0, storage.width, 0, storage.height, 0, 1,
-                              type, storage.data)) {
+                           type, storage.data)) {
+#endif
         TF_CODING_ERROR("unable to get_pixels");
         return false;
     }
-
-ARCH_PRAGMA_POP
 
     if (image != &_imagebuf) {
         _imagebuf.swap(*image);


### PR DESCRIPTION
### Description of Change(s)

the non-ROI get_pixels overloads were removed in this version, and USD was
still using it, despite the fact that it was deprecated.

This adds a version switch, so that the ROI version is used if available

### Fixes Issue(s)
- Building against OpenImageIO >= 1.9.1 failed

