### PR TITLE
Always mark unconfigured HdxColorizeTasks as converged on an Execute call

### DIFF
--- a/pxr/imaging/lib/hdx/colorizeTask.cpp
+++ b/pxr/imaging/lib/hdx/colorizeTask.cpp
@@ -247,6 +247,10 @@ HdxColorizeTask::Execute(HdTaskContext* ctx)
     // we failed to look up the renderBuffer in the render index,
     // in which case the error was previously reported
     if (!_aovBuffer) {
+        // If there is no aov buffer to colorize, then this task is never
+        // going to do anything, and so should immediately be marked as
+        // converged.
+        _converged = true;
         return;
     }
 


### PR DESCRIPTION
If an HdxColorizeTask has not been configured with an aov buffer, before
doing an early exit from the Execute method, set the _converged flag to
true so this task isn't left in an unconverged state forever.

### Fixes Issue(s)
#874 

