### PR TITLE
Prevent crashes when calling methods on invalid Usd.SchemaBase objects

### DIFF
--- a/pxr/usd/lib/usd/CMakeLists.txt
+++ b/pxr/usd/lib/usd/CMakeLists.txt
@@ -189,6 +189,7 @@ pxr_test_scripts(
     testenv/testUsdPrims.py
     testenv/testUsdReferences.py
     testenv/testUsdRelationships.py
+    testenv/testUsdSchemaBasePy.py
     testenv/testUsdSchemaRegistry.py
     testenv/testUsdSpecializes.py
     testenv/testUsdStage.py
@@ -827,6 +828,12 @@ pxr_register_test(testUsdRelationships
 
 pxr_register_test(testUsdSchemaBase
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBase"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdSchemaBasePy
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBasePy"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/lib/usd/testenv/testUsdSchemaBasePy.py
+++ b/pxr/usd/lib/usd/testenv/testUsdSchemaBasePy.py
@@ -1,0 +1,40 @@
+#!/pxrpythonsubst
+#
+# Copyright 2017 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Gf, Tf, Sdf, Usd, Vt
+import unittest, math
+
+class TestUsdSchemaBase(unittest.TestCase):
+
+    def test_InvalidSchemaBase(self):
+        sb = Usd.SchemaBase()
+        # It should still be safe to get the prim, but the prim will be invalid.
+        p = sb.GetPrim()
+        with self.assertRaises(RuntimeError):
+            p.IsActive()
+        # It should still be safe to get the path, but the path will be empty.
+        self.assertEqual(sb.GetPath(), Sdf.Path())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/lib/usd/testenv/testUsdSchemaBasePy.py
+++ b/pxr/usd/lib/usd/testenv/testUsdSchemaBasePy.py
@@ -1,6 +1,6 @@
 #!/pxrpythonsubst
 #
-# Copyright 2017 Pixar
+# Copyright 2019 Pixar
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in
@@ -29,12 +29,20 @@ class TestUsdSchemaBase(unittest.TestCase):
 
     def test_InvalidSchemaBase(self):
         sb = Usd.SchemaBase()
+        # Conversion to bool should return False.
+        self.assertFalse(sb)
         # It should still be safe to get the prim, but the prim will be invalid.
         p = sb.GetPrim()
         with self.assertRaises(RuntimeError):
             p.IsActive()
         # It should still be safe to get the path, but the path will be empty.
         self.assertEqual(sb.GetPath(), Sdf.Path())
+        # Try creating a CollectionAPI from it, and make sure the result is
+        # a suitably invalid CollactionAPI object.
+        coll = Usd.CollectionAPI(sb, 'newcollection')
+        self.assertFalse(coll)
+        with self.assertRaises(RuntimeError):
+            coll.CreateExpansionRuleAttr()
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/lib/usdGeom/testenv/testUsdGeomPrimvar.py
+++ b/pxr/usd/lib/usdGeom/testenv/testUsdGeomPrimvar.py
@@ -505,6 +505,12 @@ class TestUsdGeomPrimvarsAPI(unittest.TestCase):
         self.assertEqual(s4p.FindPrimvarWithInheritance(UsdGeom.Tokens.primvarsDisplayColor).GetAttr().GetPrim(),
                 s1.GetPrim())
 
+    def test_InvalidPrimvar(self):
+        p = UsdGeom.Primvar()
+        # This used to crash before the Primvar __getattribute__ method
+        # was overridden to test the validity of the underlying prim.
+        with self.assertRaises(RuntimeError):
+            p.BlockIndices()
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/lib/usdGeom/testenv/testUsdGeomPrimvar.py
+++ b/pxr/usd/lib/usdGeom/testenv/testUsdGeomPrimvar.py
@@ -507,10 +507,33 @@ class TestUsdGeomPrimvarsAPI(unittest.TestCase):
 
     def test_InvalidPrimvar(self):
         p = UsdGeom.Primvar()
+        # We can always call GetAttr, but it will return a null attribute
+        # if we don't have a prim.
+        self.assertEqual(p.GetAttr(), Usd.Attribute())
         # This used to crash before the Primvar __getattribute__ method
         # was overridden to test the validity of the underlying prim.
         with self.assertRaises(RuntimeError):
             p.BlockIndices()
+        # We can't even call GetName, because there is no attribute.
+        with self.assertRaises(RuntimeError):
+            p.BlockIndices()
+
+        # Now do some tests with a valid prim, but invalid attribute.
+        stage = Usd.Stage.CreateInMemory('myTest.usda')
+        gp = UsdGeom.Mesh.Define(stage, '/myMesh').GetPrim()
+        u1 = UsdGeom.Primvar(gp.GetAttribute('primvars:u1'))
+        # The attribute isn't valid, and the primvar isn't defined.
+        self.assertFalse(u1.GetAttr().IsValid())
+        self.assertFalse(u1.IsDefined())
+        # But we can still get back to the source primitive.
+        self.assertEqual(u1.GetAttr().GetPrim(), gp)
+        # And we can still access name information.
+        self.assertEqual(u1.GetName(), 'primvars:u1')
+        self.assertEqual(u1.GetBaseName(), 'u1')
+        # But attempting to access any real primvar information will raise
+        # a RuntimeError exception.
+        with self.assertRaises(RuntimeError):
+            u1.GetElementSize()
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/lib/usdGeom/testenv/testUsdGeomXformable.py
+++ b/pxr/usd/lib/usdGeom/testenv/testUsdGeomXformable.py
@@ -660,5 +660,18 @@ class TestUsdGeomXformable(unittest.TestCase):
         # warning.
         x.GetLocalTransformation(Usd.TimeCode.Default())
 
+    def test_InvalidXformable(self):
+        xf = UsdGeom.Xformable()
+        # This used to crash before the SchemaBase __getattribute__ method
+        # was overridden to test the validity of the underlying prim.
+        with self.assertRaises(RuntimeError):
+            xf.ClearXformOpOrder()
+        # It should still be safe to get the prim, but the prim will be invalid.
+        p = xf.GetPrim()
+        with self.assertRaises(RuntimeError):
+            p.IsActive()
+        # It should still be safe to get the path, but the path will be empty.
+        self.assertEqual(xf.GetPath(), Sdf.Path())
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/lib/usdGeom/wrapPrimvar.cpp
+++ b/pxr/usd/lib/usdGeom/wrapPrimvar.cpp
@@ -113,9 +113,25 @@ static TfStaticData<TfPyObjWrapper> _object__getattribute__;
 static object
 __getattribute__(object selfObj, const char *name) {
     // Allow attribute lookups if the attribute name starts with '__', or
-    // if the object's prim is valid.
+    // if the object's prim and attribute are both valid, or whitelist a few
+    // methods if just the prim is valid, or an even smaller subset if neither
+    // are valid.
     if ((name[0] == '_' && name[1] == '_') ||
-        extract<UsdGeomPrimvar &>(selfObj)().GetAttr().GetPrim().IsValid() ||
+        // prim and attr are valid, let everything through.
+        (extract<UsdGeomPrimvar &>(selfObj)().GetAttr().IsValid() &&
+         extract<UsdGeomPrimvar &>(selfObj)().GetAttr().GetPrim().IsValid()) ||
+        // prim is valid, but attr is invalid, let a few things through.
+        (extract<UsdGeomPrimvar &>(selfObj)().GetAttr().GetPrim().IsValid() &&
+         (strcmp(name, "IsDefined") == 0 ||
+          strcmp(name, "HasValue") == 0 ||
+          strcmp(name, "HasAuthoredValue") == 0 ||
+          strcmp(name, "GetName") == 0 ||
+          strcmp(name, "GetPrimvarName") == 0 ||
+          strcmp(name, "NameContainsNamespaces") == 0 ||
+          strcmp(name, "GetBaseName") == 0 ||
+          strcmp(name, "GetNamespace") == 0 ||
+          strcmp(name, "SplitName") == 0)) ||
+        // prim and attr are both invalid, let almost nothing through.
         strcmp(name, "GetAttr") == 0) {
         // Dispatch to object's __getattribute__.
         return (*_object__getattribute__)(selfObj, name);

--- a/pxr/usd/lib/usdRi/testenv/testUsdRiSplineAPI.py
+++ b/pxr/usd/lib/usdRi/testenv/testUsdRiSplineAPI.py
@@ -40,7 +40,8 @@ class TestUsdRiSplineAPI(unittest.TestCase):
 
         # can't use these if not properly initialized
         bogusSpline = UsdRi.SplineAPI()
-        assert not bogusSpline.Validate()[0]
+        with self.assertRaises(RuntimeError):
+            bogusSpline.Validate()[0]
 
         light = UsdLux.SphereLight.Define(stage, '/Light')
         rod = UsdRi.PxrRodLightFilter.Define(stage, '/Light/Rod')


### PR DESCRIPTION
In wrapSchemaBase, replace the __getattribute__ method as was already being
done in wrapObject. This overloaded __getattribute__ actually allows any of
the UsdSchemaBase APIs to be called (as all of the methods at this level can
still return useful information). But its purpose is to block calls to APIs
defined on subclasses.

Provided similar protection for UsdGeomPrimvar, which is an odd case that is
like a schema class, but operates on a single attribute and so is not derived
from SchemaBase.

Added some test cases, including an explicit test of issue #872, a crash when
calling UsdGeom.Xformable().ClearXformOpOrder(). TestUsdRiSplineAPI had to be
updated because a test in there was not expecting the RuntimeException from
an invalid object.

### Fixes Issue(s)
- #872 

