### PR TITLE
fix usage of MAYA_LOCATION when building on osx

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -27,9 +27,19 @@
 #  License text for the above reference.)
 
 if(APPLE)
+    # Note: according to official Autodesk sources (and how it sets up
+    # MAYA_LOCATION itself), MAYA_LOCATION should include Maya.app/Contents
+    # on MacOS - ie:
+    #   /Applications/Autodesk/maya2019/Maya.app/Contents
+    # However, for legacy reasons, and for maximum compatibility, setting
+    # it to the installation root is also supported, ie:
+    #   /Applications/Autodesk/maya2019
+
     find_path(MAYA_BASE_DIR
             include/maya/MFn.h
         HINTS
+            "${MAYA_LOCATION}/../.."
+            "$ENV{MAYA_LOCATION}/../.."
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
             "/Applications/Autodesk/maya2019"
@@ -47,6 +57,7 @@ if(APPLE)
             "$ENV{MAYA_LOCATION}"
             "${MAYA_BASE_DIR}"
         PATH_SUFFIXES
+            MacOS/
             Maya.app/Contents/MacOS/
         DOC
             "Maya's libraries path"


### PR DESCRIPTION
### Description of Change(s)
Formerly, FindMaya.cmake assumed that MAYA_LOCATION on osx was set to
the top level installation dir, ie:

    /Applications/Autodesk/maya2018

However, official Autodesk sources indicate that MAYA_LOCATION should
include Maya.app/Contents, ie:

    /Applications/Autodesk/maya2018/Maya.app/Contents

For backward compatibility (and maximum convenience), FindMaya.cmake
still supports pointing at the top-level installation dir, but pointing
inside of Maya.app/Contents is now checked first.

Formerly, if MAYA_LOCATION was set to:

    /Applications/Autodesk/maya2018/Maya.app/Contents

...but a maya 2019 install existed, at:

    /Applications/Autodesk/maya2019

...then MAYA_BASE_DIR would end up pointing at the 2019 install, but
MAYA_LOCATION would stay pointing at 2018.  This would result in some
things pointing at 2018, and some pointing at 2019, which obviously
created build problems.

For reference on the Autodesk's standard usage of MAYA_LOCATION on osx,
see:

Maya.app/Contents/Resources/mayald in the base install:

    # NOTE: MAYA_LOCATION on the Mac OS X includes the path to the
    # Maya.app/Contents directory.

/devkit/applications/Makefile in the devkit:
    # NOTE: MAYA_LOCATION on Mac OS X points to Maya.app/Contents

You can also check the value that Maya itself sets MAYA_LOCATION to
from within maya when you launch the Maya.app by double clicking it.

### Fixes Issue(s)
- Build problems on MacOS when having MAYA_LOCATION include Maya.app/Contents (the "standard" usage of MAYA_LOCATION, according to Autodesk)

