### PR TITLE
FindRenderman.cmake: export RENDERMAN_BINARY_DIR, use it to find oslc

### DIFF
--- a/cmake/modules/FindRenderman.cmake
+++ b/cmake/modules/FindRenderman.cmake
@@ -26,6 +26,8 @@
 # The module defines the following variables:
 #   RENDERMAN_INCLUDE_DIR - path to renderman header directory
 #   RENDERMAN_LIBRARY     - path to renderman library files
+#   RENDERMAN_EXECUTABLE  - path the prman executable
+#   RENDERMAN_BINARY_DIR  - path to the renderman binary directory
 #       RENDERMAN_FOUND   - true if renderman was found
 #   RENDERMAN_VERSION_MAJOR - major version of renderman found
 #   RENDERMAN_VERSION_MINOR - minor version of renderman found
@@ -68,6 +70,20 @@ find_path(RENDERMAN_INCLUDE_DIR
         "Renderman headers path"
 )
 
+find_program(RENDERMAN_EXECUTABLE
+    prman
+    HINTS
+        "${RENDERMAN_LOCATION}/bin"
+        "$ENV{RENDERMAN_LOCATION}/bin"
+        "$ENV{RMANTREE}/bin"
+    DOC
+        "Renderman prman executable path"
+)
+
+get_filename_component(RENDERMAN_BINARY_DIR
+    ${RENDERMAN_EXECUTABLE}
+    DIRECTORY)
+
 # Parse version
 if (RENDERMAN_INCLUDE_DIR AND EXISTS "${RENDERMAN_INCLUDE_DIR}/RixInterfaces.h" )
     file(STRINGS "${RENDERMAN_INCLUDE_DIR}/prmanapi.h" TMP REGEX "^#define _PRMANAPI_VERSION_MAJOR_.*$")
@@ -89,6 +105,8 @@ find_package_handle_standard_args(Renderman
     REQUIRED_VARS
         RENDERMAN_INCLUDE_DIR
         RENDERMAN_LIBRARY
+        RENDERMAN_EXECUTABLE
+        RENDERMAN_BINARY_DIR
         RENDERMAN_VERSION_MAJOR
         RENDERMAN_VERSION_MINOR
     VERSION_VAR

--- a/third_party/renderman-22/shaders/CMakeLists.txt
+++ b/third_party/renderman-22/shaders/CMakeLists.txt
@@ -5,7 +5,7 @@ function(prman_osl SHADER_NAME SHADER_DIR)
     set(outfile ${CMAKE_CURRENT_BINARY_DIR}/${SHADER_NAME}.oso)
     add_custom_command(
         OUTPUT ${outfile}
-        COMMAND ${RENDERMAN_LOCATION}/bin/oslc -o ${outfile} ${infile}
+        COMMAND ${RENDERMAN_BINARY_DIR}/oslc -o ${outfile} ${infile}
         MAIN_DEPENDENCY ${infile}
         VERBATIM
     )


### PR DESCRIPTION
### Description of Change(s)

the building of the renderman-22 plugin made use of the RENDERMAN_LOCATION
var, which is not guaranteed to be set by FindRenderman.cmake; instead,
directly export RENDERMAN_BINARY_DIR, and use that to find oslc

### Fixes Issue(s)
- error building renderman plugin if RMANTREE or RENDERMAN_LOCATION supplied only via environment variable

