### PR TITLE
[Imaging] Improvements to the Order Independent Transparency feature in HdStream

### DIFF
--- a/pxr/imaging/lib/hd/renderDelegate.h
+++ b/pxr/imaging/lib/hd/renderDelegate.h
@@ -72,6 +72,15 @@ typedef TfHashMap<TfToken, VtValue, TfToken::HashFunctor> HdRenderSettingsMap;
 /// wants to export (e.g. to UI).
 ///
 struct HdRenderSettingDescriptor {
+    // Default constructor.
+    HdRenderSettingDescriptor() = default;
+    // Constructor that allows the use of emplace_back on standard
+    // containers.
+    HdRenderSettingDescriptor(std::string const& _name,
+                              TfToken const& _key,
+                              VtValue const& _defaultValue)
+        : name(_name), key(_key), defaultValue(_defaultValue)
+    { }
     // A human readable name.
     std::string name;
     // The key for HdRenderDelegate::SetRenderSetting/GetRenderSetting.

--- a/pxr/imaging/lib/hdSt/renderDelegate.cpp
+++ b/pxr/imaging/lib/hdSt/renderDelegate.cpp
@@ -57,6 +57,12 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DEFINE_ENV_SETTING(HD_ENABLE_GPU_TINY_PRIM_CULLING, false,
                       "Enable tiny prim culling");
 
+TF_DEFINE_ENV_SETTING(HD_OIT_NUM_SAMPLES, 8,
+                      "Number of Object Independent Transparency samples per "
+                      "pixel. Increasing the value decreases translucency "
+                      "artifacts and flicker, but significantly increases "
+                      "memory usage and degrades performance");
+
 const TfTokenVector HdStRenderDelegate::SUPPORTED_RPRIM_TYPES =
 {
     HdPrimTypeTokens->mesh,
@@ -109,10 +115,13 @@ HdStRenderDelegate::_Initialize()
     }
 
     // Initialize the settings and settings descriptors.
-    _settingDescriptors.resize(1);
-    _settingDescriptors[0] = { "Enable Tiny Prim Culling",
+    _settingDescriptors.reserve(2);
+    _settingDescriptors.emplace_back("Enable Tiny Prim Culling",
         HdStRenderSettingsTokens->enableTinyPrimCulling,
-        VtValue(bool(TfGetEnvSetting(HD_ENABLE_GPU_TINY_PRIM_CULLING))) };
+        VtValue(bool(TfGetEnvSetting(HD_ENABLE_GPU_TINY_PRIM_CULLING))));
+    _settingDescriptors.emplace_back("OIT Number of Samples",
+        HdStRenderSettingsTokens->oitNumSamples,
+        VtValue(int(TfGetEnvSetting(HD_OIT_NUM_SAMPLES))));
     _PopulateDefaultSettings(_settingDescriptors);
 }
 

--- a/pxr/imaging/lib/hdSt/tokens.h
+++ b/pxr/imaging/lib/hdSt/tokens.h
@@ -56,7 +56,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (color)
 
 #define HDST_RENDER_SETTINGS_TOKENS             \
-    (enableTinyPrimCulling)
+    (enableTinyPrimCulling)                     \
+    (oitNumSamples)
 
 TF_DECLARE_PUBLIC_TOKENS(HdStGLSLProgramTokens, HDST_API,
                          HDST_GLSL_PROGRAM_TOKENS);

--- a/pxr/imaging/lib/hdx/oitRenderTask.h
+++ b/pxr/imaging/lib/hdx/oitRenderTask.h
@@ -88,6 +88,7 @@ private:
     HdBufferArrayRangeSharedPtr _depthBar;
     HdBufferArrayRangeSharedPtr _indexBar;
     HdBufferArrayRangeSharedPtr _uniformBar;
+    int _numSamples = -1;
 };
 
 

--- a/pxr/imaging/lib/hdx/oitResolveTask.h
+++ b/pxr/imaging/lib/hdx/oitResolveTask.h
@@ -79,6 +79,8 @@ private:
     HdxOitResolveTask() = delete;
     HdxOitResolveTask(const HdxOitResolveTask &) = delete;
     HdxOitResolveTask &operator =(const HdxOitResolveTask &) = delete;
+
+    int _numSamples = -1;
 };
 
 

--- a/pxr/imaging/lib/hdx/shaders/oitResolveImageShader.glslfx
+++ b/pxr/imaging/lib/hdx/shaders/oitResolveImageShader.glslfx
@@ -42,8 +42,7 @@ vec4 imageShader(vec2 uv)
 #if defined(HD_HAS_hdxOitDataBuffer)
     int screenWidth = HdGet_oitWidth();
     int screenHeight = HdGet_oitHeight();
-    int numSamples = HdGet_oitSamples();
-    int bufferSize = screenWidth * screenHeight * numSamples;
+    int bufferSize = screenWidth * screenHeight * OIT_NUM_SAMPLES;
 
     int screenIndex = int(gl_FragCoord.x) + int(gl_FragCoord.y) * screenWidth;
     int nodeIndex = hdxOitCounterBuffer[screenIndex+1];
@@ -51,13 +50,40 @@ vec4 imageShader(vec2 uv)
 
     // XXX renderPass.WriteOitLayersToBuffer does not clamp the number of
     //     depth samples we store for a pixel. Here we process no more than
-    //     'maxSamples' for a pixel. (If there are greater than 'maxSamples'
-    //     samples stored for this pixel some will currently not contribute)
-    const int maxSamples = 8;
-    vec4 sortedColor[maxSamples];
-    float sortedDepth[maxSamples];
+    //     'OIT_NUM_SAMPLES' for a pixel. (If there are greater than
+    //     'OIT_NUM_SAMPLES' samples stored for this pixel some will
+    //     currently not contribute)
+    vec4 sortedColor[OIT_NUM_SAMPLES];
+    float sortedDepth[OIT_NUM_SAMPLES];
 
-    while (nodeIndex != -1 && numDepths < maxSamples && nodeIndex < bufferSize){
+#if 1
+    // Select sorting
+    while (nodeIndex != -1 && numDepths < OIT_NUM_SAMPLES) {
+        sortedDepth[numDepths] = hdxOitDepthBuffer[nodeIndex];
+        sortedColor[numDepths] = hdxOitDataBuffer[nodeIndex];
+        nodeIndex = hdxOitIndexBuffer[nodeIndex];
+        numDepths += 1;
+    }
+
+    for (int depth = 0; depth < numDepths - 1; depth += 1) {
+        int swap = depth;
+        for (int i = depth + 1; i < numDepths; i += 1) {
+            if (sortedDepth[swap] > sortedDepth[i]) {
+                swap = i;
+            }
+        }
+        float td = sortedDepth[swap];
+        vec4 tc = sortedColor[swap];
+
+        sortedDepth[swap] = sortedDepth[depth];
+        sortedColor[swap] = sortedColor[depth];
+
+        sortedDepth[depth] = td;
+        sortedColor[depth] = tc;
+    }
+#else
+    // Insert sorting
+    while (nodeIndex != -1 && numDepths < OIT_NUM_SAMPLES) {
         float currentDepth = hdxOitDepthBuffer[nodeIndex]; 
         int insertIndex = numDepths; 
         while (insertIndex > 0 && sortedDepth[insertIndex - 1] > currentDepth) {
@@ -69,22 +95,21 @@ vec4 imageShader(vec2 uv)
         sortedDepth[insertIndex] = hdxOitDepthBuffer[nodeIndex];
         numDepths += 1; 
         nodeIndex = hdxOitIndexBuffer[nodeIndex]; 
-    } 
-    int depth = 0;
-    vec4 colorAccum = vec4(0,0,0,0);
-    while (depth < numDepths) {
-        vec3 cb = sortedColor[depth].rgb * sortedColor[depth].a; 
-        colorAccum.rgb = colorAccum.rgb + cb * (1 - colorAccum.a);
-        colorAccum.a = colorAccum.a + sortedColor[depth].a; 
+    }
+#endif
+    vec4 colorAccum = vec4(0, 0, 0, 0);
+    for (int depth = 0; depth < numDepths; depth += 1) {
+        float alpha = sortedColor[depth].a * (1 - colorAccum.a);
+        colorAccum.rgb = colorAccum.rgb + sortedColor[depth].rgb * alpha;
+        colorAccum.a = colorAccum.a + alpha;
 
         colorAccum = clamp(colorAccum, vec4(0), vec4(1));
-        if (colorAccum.a >= 1.0) break;
-
-        depth += 1; 
+        if (colorAccum.a >= 0.99) break;
     }
 
     return colorAccum;
-#else
+
+#else  // HD_HAS_hdxOitDataBuffer
     return vec4(0);
-#endif
+#endif   // HD_HAS_hdxOitDataBuffer
 }

--- a/pxr/imaging/lib/hdx/shaders/renderPass.glslfx
+++ b/pxr/imaging/lib/hdx/shaders/renderPass.glslfx
@@ -36,9 +36,11 @@ layout (location = 0) out vec4 colorOut;
 void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
 {
 #if defined(HD_HAS_hdxOitDataBuffer)
+    if (color.a < 0.0001)
+        return;
     int screenWidth = HdGet_oitWidth();
     int screenHeight = HdGet_oitHeight();
-    int numSamples = HdGet_oitSamples();
+    int numSamples = HdGet_oitNumSamples();
     int bufferSize = screenWidth * screenHeight * numSamples;
     int writeIndex = atomicAdd(hdxOitCounterBuffer[0], 1) + 1;
 

--- a/pxr/imaging/lib/hdx/tokens.h
+++ b/pxr/imaging/lib/hdx/tokens.h
@@ -54,7 +54,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (oitRenderPassState)        \
     (oitHeight)                 \
     (oitWidth)                  \
-    (oitSamples)                \
+    (oitNumSamples)             \
     (renderPassState)           \
     (renderIndexVersion)        \
     (selection)                 \


### PR DESCRIPTION
### Description of Change(s)
The following PR adds new features and fixes issues related to OIT for HdStream.
- Previously viewport resizing was slow because the OIT buffers were initialized with a default buffer source argument, leading to the creation of large CPU side buffers with the same value. This is now removed, and the new code is using the "Resize" function on the buffers. We don't need to set their default value since it's either going to be cleared, or guaranteed to be overwritten by the OIR Render Pass.
- Removed all the buffer clear for OIT, except the counter buffer. We don't need to clear the buffers before the render since the values of every other OIT buffer is going to be overwritten by the OIT render pass.
- Replaced the insert sort function with a select sorting for the oitResolveImage function. While benchmarking the shader, we found that select sorting is roughly the same performance as insert sorting with 8 samples, but it's significantly faster with more samples (about 2-3 times faster with 32-64 samples). These test results were seen on Centos, with a GTX 1060 (410.78) and the "powerplant" scene with all the faces being partially transparent. Alternatively, it's easy to make the sorting method selectable using an environment variable, if there are cases where select sorting is slower than insert sorting.
- The number of OIT samples per pixel is now a render delegate parameter and can be changed on the fly. To maintain consistency with parameter names across all the different bits of the code, I renamed all the parameter uses to oitNumSamples. Please let me know if you prefer the name being oitSamples instead.
- The PR also includes our fix for #852 . Please let me know if you would like to get it removed from this PR.
- We saw issues with OIT in Maya 2019 and 2018 on Centos, glClearNamedBuffer is not available in those contexts, so we added a simple function that falls back to glClearNamedBufferEXT if glClearNamedBuffer is not available.
- Added an early exit to RenderOutput (in hdx/renderPass.glslfx), if the alpha value of the fragment is small.

### Fixes Issues
- #852 