### PR TITLE
Adding new APIs to the render delegate for pause, resume, and getting status

### DIFF
--- a/pxr/imaging/lib/hd/renderDelegate.cpp
+++ b/pxr/imaging/lib/hd/renderDelegate.cpp
@@ -151,5 +151,27 @@ HdRenderDelegate::_PopulateDefaultSettings(
     }
 }
 
+bool
+HdRenderDelegate::IsPauseAndResumeSupported() const
+{
+    return false;
+}
+
+void
+HdRenderDelegate::Pause()
+{
+}
+
+void
+HdRenderDelegate::Resume()
+{
+}
+
+std::string
+HdRenderDelegate::GetStatusMessage() const
+{
+    return std::string();
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/lib/hd/renderDelegate.h
+++ b/pxr/imaging/lib/hd/renderDelegate.h
@@ -164,6 +164,43 @@ public:
 
     ////////////////////////////////////////////////////////////////////////////
     ///
+    /// Control and status of background rendering threads.
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+
+    ///
+    /// Advertise whether this delegate supports pausing and resuming of
+    /// background render threads. Default implementation returns false.
+    ///
+    HD_API
+    virtual bool IsPauseAndResumeSupported() const;
+
+    ///
+    /// Pause all of this delegate's background rendering threads. Default
+    /// implementation does nothing.
+    ///
+    HD_API
+    virtual void Pause();
+
+    ///
+    /// Resume all of this delegate's background rendering threads previously
+    /// paused by a call to Pause. Default implementation does nothing.
+    ///
+    HD_API
+    virtual void Resume();
+
+    ///
+    /// Return a string indicating the current status of this render delegate,
+    /// particularly its background rendering process. This string may
+    /// indicate an estimated percentage complete, a total render time, or
+    /// any other status information the user might find useful. The default
+    /// implementation returns an empty string.
+    ///
+    HD_API
+    virtual std::string GetStatusMessage() const;
+
+    ////////////////////////////////////////////////////////////////////////////
+    ///
     /// Renderpass Factory
     ///
     ////////////////////////////////////////////////////////////////////////////

--- a/pxr/imaging/lib/hd/renderThread.cpp
+++ b/pxr/imaging/lib/hd/renderThread.cpp
@@ -31,6 +31,7 @@ HdRenderThread::HdRenderThread()
     , _shutdownCallback(_DefaultShutdownCallback)
     , _requestedState(StateInitial)
     , _stopRequested(false)
+    , _pauseRender(false)
     , _rendering(false)
 {
 }
@@ -116,6 +117,18 @@ HdRenderThread::IsRendering()
     return _rendering.load();
 }
 
+void
+HdRenderThread::PauseRender()
+{
+    _pauseRender.store(true);
+}
+
+void
+HdRenderThread::ResumeRender()
+{
+    _pauseRender.store(false);
+}
+
 bool
 HdRenderThread::IsStopRequested()
 {
@@ -124,6 +137,12 @@ HdRenderThread::IsStopRequested()
     }
 
     return _stopRequested;
+}
+
+bool
+HdRenderThread::IsPauseRequested()
+{
+    return _pauseRender.load();
 }
 
 std::unique_lock<std::mutex>

--- a/pxr/imaging/lib/hd/renderThread.h
+++ b/pxr/imaging/lib/hd/renderThread.h
@@ -86,7 +86,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///             }
 ///             std::this_thread::sleep_for(std::chrono::milliseconds(10));
 ///         }
-///         if(!_renderThread.IsStopRequested()) {
+///         if(_renderThread.IsStopRequested()) {
 ///             break;
 ///         }
 ///         // generate N pixels.

--- a/pxr/imaging/lib/hd/renderThread.h
+++ b/pxr/imaging/lib/hd/renderThread.h
@@ -77,10 +77,22 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///     }
 ///   private:
 ///     void _RenderCallback() {
-///       while(!_renderThread.IsStopRequested()) {
+///       bool renderComplete = false;
+///       while(!renderComplete) {
+///         // Check if we have been asked to pause.
+///         while(_renderThread.IsPauseRequested()) {
+///             if(_renderThread.IsStopRequested()) {
+///                 break;
+///             }
+///             std::this_thread::sleep_for(std::chrono::milliseconds(10));
+///         }
+///         if(!_renderThread.IsStopRequested()) {
+///             break;
+///         }
 ///         // generate N pixels.
 ///         auto lock = _renderThread.LockFramebuffer();
 ///         // resolve pixels to shared buffer.
+///         // Set renderComplete = true when finished rendering.
 ///       }
 ///     }
 ///     HdRenderThread _renderThread;
@@ -210,6 +222,17 @@ public:
     HD_API
     bool IsRendering();
 
+    /// Ask the render thread to pause rendering. The speed at which the
+    /// renderer actually enters the pause state depends on the delegate.
+    HD_API
+    void PauseRender();
+
+    /// Ask the render thread to resume rendering. Pause and Resume calls do
+    /// not need to be paired. The last call (to Pause or Resume) decides the
+    /// current state.
+    HD_API
+    void ResumeRender();
+
     /// @}
 
     /// \anchor RenderThreadAPI
@@ -225,6 +248,12 @@ public:
     /// this to determine whether to cancel rendering.
     HD_API
     bool IsStopRequested();
+
+    /// Query whether hydra has asked to pause rendering. This will continue
+    /// to return true until a request has been made for rendering to resume.
+    /// Remember to check for a stop request while paused.
+    HD_API
+    bool IsPauseRequested();
 
     /// @}
 
@@ -302,6 +331,11 @@ private:
     // the last time the render callback was called (since _enableRender is
     // reset on read).
     bool _stopRequested;
+
+    // _pauseRender provides a properly locked boolean flag that holds the
+    // current paues state of the thread. Toggled by calling PauseRender and
+    // ResumeRender, tested by IsPauseRequested.
+    std::atomic<bool> _pauseRender;
 
     // _rendering records whether the render thread is currently inside the
     // render callback, or planning to be inside the render callback.

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
@@ -40,6 +40,8 @@
 #include "pxr/imaging/hd/bprim.h"
 //XXX: Add bprim types
 
+#include <sstream>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(HdEmbreeRenderSettingsTokens, HDEMBREE_RENDER_SETTINGS_TOKENS);
@@ -265,6 +267,34 @@ HdEmbreeRenderDelegate::GetDefaultAovDescriptor(TfToken const& name) const
     }
 
     return HdAovDescriptor();
+}
+
+bool
+HdEmbreeRenderDelegate::IsPauseAndResumeSupported() const
+{
+    return true;
+}
+
+void
+HdEmbreeRenderDelegate::Pause()
+{
+    _renderThread.PauseRender();
+}
+
+void
+HdEmbreeRenderDelegate::Resume()
+{
+    _renderThread.ResumeRender();
+}
+
+std::string
+HdEmbreeRenderDelegate::GetStatusMessage() const
+{
+    std::ostringstream os;
+
+    os << _renderer.GetCompletedSamples() << " samples done";
+
+    return os.str();
 }
 
 HdRenderPassSharedPtr

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.h
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.h
@@ -117,6 +117,18 @@ public:
     virtual HdRenderSettingDescriptorList
         GetRenderSettingDescriptors() const override;
 
+    /// Return true to indicate that pausing and resuming are supported.
+    virtual bool IsPauseAndResumeSupported() const override;
+
+    /// Pause background rendering threads.
+    virtual void Pause() override;
+
+    /// Resume background rendering threads.
+    virtual void Resume() override;
+
+    /// Return a user-readable status message.
+    virtual std::string GetStatusMessage() const override;
+
     /// Create a renderpass. Hydra renderpasses are responsible for drawing
     /// a subset of the scene (specified by the "collection" parameter) to the
     /// current framebuffer. This class creates objects of type

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -34,6 +34,9 @@
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/work/loops.h"
 
+#include <chrono>
+#include <thread>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdEmbreeRenderer::HdEmbreeRenderer()
@@ -51,6 +54,7 @@ HdEmbreeRenderer::HdEmbreeRenderer()
     , _samplesToConvergence(0)
     , _ambientOcclusionSamples(0)
     , _enableSceneColors(false)
+    , _completedSamples(0)
 {
 }
 
@@ -357,9 +361,17 @@ HdEmbreeRenderer::MarkAovBuffersUnconverged()
     }
 }
 
+int
+HdEmbreeRenderer::GetCompletedSamples() const
+{
+    return _completedSamples.load();
+}
+
 void
 HdEmbreeRenderer::Render(HdRenderThread *renderThread)
 {
+    _completedSamples.store(0);
+
     // Commit any pending changes to the scene.
     rtcCommit(_scene);
 
@@ -380,6 +392,18 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
     // We consider the image converged after N samples, which is a convenient
     // and simple heuristic.
     for (int i = 0; i < _samplesToConvergence; ++i) {
+        // Pause point.
+        while (renderThread->IsPauseRequested()) {
+            if (renderThread->IsStopRequested()) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        // Cancellation point.
+        if (renderThread->IsStopRequested()) {
+            break;
+        }
+
         unsigned int tileSize = HdEmbreeConfig::GetInstance().tileSize;
         const unsigned int numTilesX = (_width + tileSize-1) / tileSize;
         const unsigned int numTilesY = (_height + tileSize-1) / tileSize;
@@ -407,14 +431,13 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
                 }
             }
             if (!moreWork) {
+                _completedSamples.store(i+1);
                 break;
             }
         }
 
-        // Cancellation point.
-        if (renderThread->IsStopRequested()) {
-            break;
-        }
+        // Track the number of completed samples for external consumption.
+        _completedSamples.store(i+1);
     }
 
     // Mark the multisampled attachments as converged and unmap them.

--- a/pxr/imaging/plugin/hdEmbree/renderer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderer.h
@@ -36,6 +36,7 @@
 #include <embree2/rtcore_ray.h>
 
 #include <random>
+#include <atomic>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -109,6 +110,9 @@ public:
 
     /// Mark the aov buffers as unconverged.
     void MarkAovBuffersUnconverged();
+
+    /// Get the number of samples completed so far.
+    int GetCompletedSamples() const;
 
 private:
     // Validate the internal consistency of aov bindings provided to
@@ -194,6 +198,9 @@ private:
     int _ambientOcclusionSamples;
     // Should we enable scene colors?
     bool _enableSceneColors;
+
+    // How many samples have been completed.
+    std::atomic<int> _completedSamples;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/lib/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.cpp
@@ -964,6 +964,53 @@ UsdImagingGLEngine::SetEnableFloatPointDrawTarget(bool state)
     _useFloatPointDrawTarget = state;
 }
 
+// ---------------------------------------------------------------------
+// Control and status of background rendering threads.
+// ---------------------------------------------------------------------
+bool
+UsdImagingGLEngine::IsPauseAndResumeRendererSupported() const
+{
+    if (ARCH_UNLIKELY(_legacyImpl)) {
+        return false;
+    }
+
+    TF_VERIFY(_renderIndex);
+    _renderIndex->GetRenderDelegate()->IsPauseAndResumeSupported();
+}
+
+void
+UsdImagingGLEngine::PauseRenderer()
+{
+    if (ARCH_UNLIKELY(_legacyImpl)) {
+        return;
+    }
+
+    TF_VERIFY(_renderIndex);
+    _renderIndex->GetRenderDelegate()->Pause();
+}
+
+void
+UsdImagingGLEngine::ResumeRenderer()
+{
+    if (ARCH_UNLIKELY(_legacyImpl)) {
+        return;
+    }
+
+    TF_VERIFY(_renderIndex);
+    _renderIndex->GetRenderDelegate()->Resume();
+}
+
+std::string
+UsdImagingGLEngine::GetRendererStatusMessage() const
+{
+    if (ARCH_UNLIKELY(_legacyImpl)) {
+        return std::string();
+    }
+
+    TF_VERIFY(_renderIndex);
+    return _renderIndex->GetRenderDelegate()->GetStatusMessage();
+}
+
 //----------------------------------------------------------------------------
 // Color Correction
 //----------------------------------------------------------------------------

--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -397,6 +397,29 @@ public:
     /// @}
 
     // ---------------------------------------------------------------------
+    /// \name Control and status of background rendering threads.
+    /// @{
+    // ---------------------------------------------------------------------
+
+    /// Query the renderer as to whether it supports pausing and resuming.
+    USDIMAGINGGL_API
+    bool IsPauseAndResumeRendererSupported() const;
+
+    /// Pause the renderer.
+    USDIMAGINGGL_API
+    void PauseRenderer();
+
+    /// resume the renderer.
+    USDIMAGINGGL_API
+    void ResumeRenderer();
+
+    /// Return a user-facing status message from the renderer.
+    USDIMAGINGGL_API
+    std::string GetRendererStatusMessage() const;
+
+    /// @}
+
+    // ---------------------------------------------------------------------
     /// \name Color Correction
     /// @{
     // ---------------------------------------------------------------------

--- a/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
+++ b/pxr/usdImaging/lib/usdImagingGL/wrapEngine.cpp
@@ -156,6 +156,12 @@ void wrapEngine()
             .def("IsColorCorrectionCapable", 
                 &UsdImagingGLEngine::IsColorCorrectionCapable)
                 .staticmethod("IsColorCorrectionCapable")
+            .def("IsPauseAndResumeRendererSupported", 
+                &UsdImagingGLEngine::IsPauseAndResumeRendererSupported)
+            .def("PauseRenderer", &UsdImagingGLEngine::PauseRenderer)
+            .def("ResumeRenderer", &UsdImagingGLEngine::ResumeRenderer)
+            .def("GetRendererStatusMessage",
+                &UsdImagingGLEngine::GetRendererStatusMessage)
         ;
 
     }

--- a/pxr/usdImaging/lib/usdviewq/mainWindowUI.ui
+++ b/pxr/usdImaging/lib/usdviewq/mainWindowUI.ui
@@ -1406,6 +1406,7 @@
     <addaction name="menuRendererPlugin"/>
     <addaction name="menuRendererSettings"/>
     <addaction name="menuRendererAovs"/>
+    <addaction name="actionPause"/>
     <addaction name="separator"/>
     <addaction name="actionReset_View"/>
     <addaction name="actionAdjust_FOV"/>
@@ -1479,6 +1480,20 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::ApplicationShortcut</enum>
+   </property>
+  </action>
+  <action name="actionPause">
+   <property name="text">
+       <string>Pause Render</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+P</string>
    </property>
    <property name="shortcutContext">
     <enum>Qt::ApplicationShortcut</enum>

--- a/pxr/usdImaging/lib/usdviewq/stageView.py
+++ b/pxr/usdImaging/lib/usdviewq/stageView.py
@@ -841,7 +841,7 @@ class StageView(QtOpenGL.QGLWidget):
         # prep HUD regions
         self._hud = HUD()
         self._hud.addGroup("TopLeft",     250, 160)  # subtree
-        self._hud.addGroup("TopRight",    140, 32)   # Hydra: Enabled
+        self._hud.addGroup("TopRight",    160, 48)   # Hydra, AOV, status
         self._hud.addGroup("BottomLeft",  250, 160)  # GPU stats
         self._hud.addGroup("BottomRight", 210, 32)   # Camera, Complexity
 
@@ -986,6 +986,20 @@ class StageView(QtOpenGL.QGLWidget):
         if self._renderer:
             self._renderer.SetRendererSetting(name, value)
             self.updateGL()
+
+    def SetRendererPaused(self, paused):
+        if self._renderer:
+            if paused:
+                self._renderer.PauseRenderer()
+            else:
+                self._renderer.ResumeRenderer()
+
+    def IsPauseAndResumeRendererSupported(self):
+        if self._renderer:
+            if self._renderer.IsPauseAndResumeRendererSupported():
+                return True
+
+        return False
 
     def _stageReplaced(self):
         '''Set the USD Stage this widget will be displaying. To decommission
@@ -1848,14 +1862,19 @@ class StageView(QtOpenGL.QGLWidget):
             if not hydraMode:
                 hydraMode = "Enabled"
 
-        toPrint = {"Hydra": hydraMode}
+        from collections import OrderedDict
+        toPrint = OrderedDict()
+
+        toPrint["Hydra"] = hydraMode
         if self._rendererAovName != "color":
             toPrint["  AOV"] = self._rendererAovName
+        status = self._renderer.GetRendererStatusMessage()
+        if status:
+            toPrint["Status"] = status
         self._hud.updateGroup("TopRight", self.width()-160, 14, col,
                               toPrint, toPrint.keys())
 
         # bottom left
-        from collections import OrderedDict
         toPrint = OrderedDict()
 
         # GPU stats (TimeElapsed is in nano seconds)


### PR DESCRIPTION
Adding new APIs to the render delegate (exposed through the UsgImagingGLEngine)
to pause and resume a render (if supported). Also added an API to get a status
message from the render delegate that can be presented to the user to give some
indication of the progress of the render.

Added implementations of these APIs to the embree delegate, which uses matching
new methods on HdRenderThread to assist with the pause and resume operations.

Added a Pause menu item to usdview, and display the render status message in
the upper right hand corner below the render delegate name.