### PR TITLE
[imaging] fix another sign compare issue

### DIFF
--- a/pxr/imaging/lib/hd/timeSampleArray.h
+++ b/pxr/imaging/lib/hd/timeSampleArray.h
@@ -56,7 +56,7 @@ inline VtArray<T> HdResampleNeighbors(float alpha,
                                       const VtArray<T>& v1)
 {
     VtArray<T> r(v0.size());
-    for (int i=0; i < r.size(); ++i) {
+    for (size_t i=0; i < r.size(); ++i) {
         r[i] = HdResampleNeighbors(alpha, v0[i], v1[i]);
     }
     return r;


### PR DESCRIPTION
### Description of Change(s)
slipped through because it was in a template that's not used by core
(but is by HdPrman)

### Fixes Issue(s)
- building renderman-22 plugin with PXR_STRICT_BUILD_MODE enabled

