### PR TITLE
MESA AMD. Disabled directStateAccess if glNamedBufferDataEXT function pointer is NULL

### DIFF
--- a/pxr/imaging/lib/glf/contextCaps.cpp
+++ b/pxr/imaging/lib/glf/contextCaps.cpp
@@ -277,7 +277,7 @@ GlfContextCaps::_LoadCaps()
     if (!TfGetEnvSetting(GLF_ENABLE_MULTI_DRAW_INDIRECT)) {
         multiDrawIndirectEnabled = false;
     }
-    if (!TfGetEnvSetting(GLF_ENABLE_DIRECT_STATE_ACCESS)) {
+    if (!TfGetEnvSetting(GLF_ENABLE_DIRECT_STATE_ACCESS) || NULL == glNamedBufferDataEXT) {
         directStateAccessEnabled = false;
     }
     if (!TfGetEnvSetting(GLF_ENABLE_SHADER_DRAW_PARAMETERS)) {


### PR DESCRIPTION
Disables directStateAccess on systems with NULL glNamedBufferDataEXT pointers.
This was seen when using MESA Radeon Vega drivers on Ubuntu.