### PR TITLE
MESA AMD. Added VAO bind()/unbind() to HdxCompositor to stop error in Core Context.

### DIFF
--- a/pxr/imaging/lib/hdx/compositor.cpp
+++ b/pxr/imaging/lib/hdx/compositor.cpp
@@ -54,7 +54,7 @@ namespace {
 
 HdxCompositor::HdxCompositor()
     : _colorTexture(0), _depthTexture(0)
-    , _compositorProgram(), _vertexBuffer(0)
+    , _compositorProgram(), _vao(0), _vertexBuffer(0)
     , _useDepthProgram(false)
 {
 }
@@ -69,6 +69,9 @@ HdxCompositor::~HdxCompositor()
     }
     if (_vertexBuffer != 0) {
         glDeleteBuffers(1, &_vertexBuffer);
+    }
+    if (_vao != 0) {
+        glDeleteVertexArrays(1, &_vao);
     }
     if (_compositorProgram) {
         _compositorProgram.reset();
@@ -247,6 +250,10 @@ HdxCompositor::Draw(GLuint colorId, GLuint depthId, bool remapDepth)
 
     glUniform1i(_locations[remapDepthIn], (GLint)remapDepth);
 
+    if (_vao == 0) {
+        glGenVertexArrays(1, &_vao);
+    }
+    glBindVertexArray(_vao);
     glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
     glVertexAttribPointer(_locations[position], 4, GL_FLOAT, GL_FALSE,
             sizeof(float)*6, 0);
@@ -268,6 +275,7 @@ HdxCompositor::Draw(GLuint colorId, GLuint depthId, bool remapDepth)
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glDisableVertexAttribArray(_locations[position]);
     glDisableVertexAttribArray(_locations[uvIn]);
+    glBindVertexArray(0);
 
     glUseProgram(0);
 

--- a/pxr/imaging/lib/hdx/compositor.h
+++ b/pxr/imaging/lib/hdx/compositor.h
@@ -94,6 +94,7 @@ private:
 
     HdStGLSLProgramSharedPtr _compositorProgram;
     GLint _locations[5];
+    GLuint _vao;
     GLuint _vertexBuffer;
     bool _useDepthProgram;
 };


### PR DESCRIPTION
If running on a Core OpenGL context a VAO is needed before any vertex attrib binds can be done.
Errors seen on Mesa AMD Vega drivers under Ubuntu.

