### PR TITLE
fix for OIT with older glew

### DIFF
--- a/pxr/imaging/lib/hdx/oitRenderTask.cpp
+++ b/pxr/imaging/lib/hdx/oitRenderTask.cpp
@@ -232,7 +232,7 @@ _GetScreenSize()
 
     GlfContextCaps const &caps = GlfContextCaps::GetInstance();
 
-    if (ARCH_LIKELY(caps.directStateAccessEnabled)) {
+    if (ARCH_LIKELY(caps.directStateAccessEnabled) && glGetTextureLevelParameteriv) {
         if (attachType == GL_TEXTURE) {
             glGetTextureLevelParameteriv(attachId, 0, GL_TEXTURE_WIDTH, &s[0]);
             glGetTextureLevelParameteriv(attachId, 0, GL_TEXTURE_HEIGHT, &s[1]);


### PR DESCRIPTION
### Description of Change(s)

...such as that available within maya.  Older glew will mean a different set
of gl functions are available.

### Fixes Issue(s)
- Crash in maya when OIT is used

