### PR TITLE
[usd] Register missing C++ unit tests.

### DIFF
--- a/pxr/usd/lib/usd/CMakeLists.txt
+++ b/pxr/usd/lib/usd/CMakeLists.txt
@@ -619,6 +619,11 @@ pxr_register_test(testUsdCreateAttributeCpp
     EXPECTED_RETURN_CODE 0
 )
 
+pxr_register_test(testUsdHardToReach
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdHardToReach"
+    EXPECTED_RETURN_CODE 0
+)
+
 pxr_register_test(testUsdInstancing
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancing"
@@ -629,6 +634,11 @@ pxr_register_test(testUsdInstancing
 pxr_register_test(testUsdInstanceProxy
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstanceProxy"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdIntegerCoding
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdIntegerCoding"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -868,5 +878,9 @@ pxr_register_test(testUsdUsdzFileFormat
 pxr_register_test(testUsdZipFile
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdZipFile"
+    EXPECTED_RETURN_CODE 0
+)
+pxr_register_test(testUsdUsdzResolver
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzResolver"
     EXPECTED_RETURN_CODE 0
 )


### PR DESCRIPTION
Some C++ tests were not being run by ctest due to missing registration.