### PR TITLE
Missing export for Windows build of classes based on UsdImagingGLEngine

### DIFF
--- a/pxr/usdImaging/lib/usdImagingGL/engine.h
+++ b/pxr/usdImaging/lib/usdImagingGL/engine.h
@@ -485,8 +485,10 @@ protected:
     static bool _UpdateHydraCollection(HdRprimCollection *collection,
                           SdfPathVector const& roots,
                           UsdImagingGLRenderParams const& params);
+    USDIMAGINGGL_API
     static HdxRenderTaskParams _MakeHydraUsdImagingGLRenderParams(
                           UsdImagingGLRenderParams const& params);
+    USDIMAGINGGL_API
     static void _ComputeRenderTags(UsdImagingGLRenderParams const& params,
                           TfTokenVector *renderTags);
 


### PR DESCRIPTION
### Description of Change(s)
On windows classes derived from UsdImagingGLEngine don't have export properly set for protected method.

### Fixes Issue(s)
- Fix windows build of AL plugin and USD dev.

