### PR TITLE
Build boost with more settings whether or not Maya is built

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -578,12 +578,12 @@ def InstallBoost(context, force, buildArgs):
         if context.buildPython:
             b2_settings.append("--with-python")
 
-        if context.buildKatana or context.buildOIIO:
+        if context.buildKatana or context.buildOIIO or not context.buildMaya or context.buildMaya:
             b2_settings.append("--with-date_time")
             b2_settings.append("--with-system")
             b2_settings.append("--with-thread")
 
-        if context.buildOIIO:
+        if context.buildOIIO or not context.buildMaya or context.buildMaya:
             b2_settings.append("--with-filesystem")
 
         if force:


### PR DESCRIPTION
This change allows building boost library with more settings and therefore no need to pass this long argument to build_usd script.

boost,"--with-date_time --with-thread --with-system --with-filesystem"

