### PR TITLE
Adding a validity check on a UsdSkelAnimQuery object before using it

### DIFF
--- a/pxr/usd/lib/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/lib/usdSkel/bakeSkinning.cpp
@@ -605,7 +605,7 @@ _SkelAdapter::_SkelAdapter(const UsdSkelBakeSkinningParms& parms,
     if (parms.deformationFlags & UsdSkelBakeSkinningParms::DeformWithLBS) {
         if (const UsdSkelSkeleton& skel = skelQuery.GetSkeleton()) {
             const auto& animQuery = skelQuery.GetAnimQuery();
-            if ((animQuery&& !skelQuery.GetMapper().IsNull()) ||
+            if ((animQuery && !skelQuery.GetMapper().IsNull()) ||
                 skel.GetRestTransformsAttr().HasAuthoredValue()) {
 
                 // XXX: Activate computations, but tag them as not required;
@@ -614,9 +614,13 @@ _SkelAdapter::_SkelAdapter(const UsdSkelBakeSkinningParms& parms,
                 _skinningInvTransposeXformsTask.SetActive(
                     true, /*required*/ false);
 
-                if (animQuery.JointTransformsMightBeTimeVarying()) {
+                if (animQuery&& animQuery.JointTransformsMightBeTimeVarying()) {
                     _skinningXformsTask.SetMightBeTimeVarying(true);
                     _skinningInvTransposeXformsTask.SetMightBeTimeVarying(true);
+                }
+                else {
+                    _skinningXformsTask.SetMightBeTimeVarying(false);
+                    _skinningInvTransposeXformsTask.SetMightBeTimeVarying(false);
                 }
 
                 // Also active computation for skel's local to world transform.

--- a/pxr/usd/lib/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/lib/usdSkel/bakeSkinning.cpp
@@ -601,7 +601,7 @@ _SkelAdapter::_SkelAdapter(const UsdSkelBakeSkinningParms& parms,
         skelQuery.GetPrim().GetPath().GetText());
 
     // Activate skinning transform computations if we have a mappable anim,
-    // or if restTransforms are auathored as a fallback.
+    // or if restTransforms are authored as a fallback.
     if (parms.deformationFlags & UsdSkelBakeSkinningParms::DeformWithLBS) {
         if (const UsdSkelSkeleton& skel = skelQuery.GetSkeleton()) {
             const auto& animQuery = skelQuery.GetAnimQuery();
@@ -614,7 +614,9 @@ _SkelAdapter::_SkelAdapter(const UsdSkelBakeSkinningParms& parms,
                 _skinningInvTransposeXformsTask.SetActive(
                     true, /*required*/ false);
 
-                if (animQuery&& animQuery.JointTransformsMightBeTimeVarying()) {
+                // The animQuery object may not be valid if the skeleton has a
+                // rest transform attribute.
+                if (animQuery && animQuery.JointTransformsMightBeTimeVarying()) {
                     _skinningXformsTask.SetMightBeTimeVarying(true);
                     _skinningInvTransposeXformsTask.SetMightBeTimeVarying(true);
                 }


### PR DESCRIPTION
In this block of code, it is possible to make a call into an invalid UsdSkelAnimQuery object. This results in error messages being generated for no reason. I'm not certain that calling SetMightBeTimeVarying(false) if the anim query is invalid is the right thing to do.

This error was being triggered when calling BakeSkinning on a scene containing skeletons with a restTransforms attribute.