### PR TITLE
Fix crash in BakeSkinning

### DIFF
--- a/pxr/usd/lib/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/lib/usdSkel/bakeSkinning.cpp
@@ -1861,6 +1861,12 @@ _ComputeTimeSamples(
 
     // Pre-compute time samples for each skel adapter.
     std::unordered_map<_SkelAdapterRefPtr, std::vector<double> > skelTimesMap;
+    // Pre-populate the skelTimesMap on a single thread. Each worker thread
+    // will only access its own members in this map, so access to each vector
+    // is safe.
+    for (auto &&adapter : skelAdapters)
+        skelTimesMap[adapter] = std::vector<double>();
+
     WorkParallelForN(
         skelAdapters.size(),
         [&](size_t start, size_t end) {


### PR DESCRIPTION
Fix crash in BakeSkinning caused by multiple threads populating a shared map object at the same time.

### Description of Change(s)
Pre-populate the shared map before giving the mutliple threads access to it.

### Fixes Issue(s)
- I believe this fixes the crash in #952, though the geometry still disappears after calling BakeSkinning.