### PR TITLE
[HdSt] Installing domeLight.glslfx.

### DIFF
--- a/pxr/imaging/lib/hdSt/CMakeLists.txt
+++ b/pxr/imaging/lib/hdSt/CMakeLists.txt
@@ -124,6 +124,7 @@ pxr_library(hdSt
         plugInfo.json
         shaders/basisCurves.glslfx
         shaders/compute.glslfx
+        shaders/domeLight.glslfx
         shaders/edgeId.glslfx
         shaders/fallbackLighting.glslfx
         shaders/fallbackLightingShader.glslfx


### PR DESCRIPTION
### Description of Change(s)
Domelight glslfx is not installed as part of HdSt, the PR addresses this issue.