### PR TITLE
Check instance prim validity

### DIFF
--- a/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/lib/usdImaging/instanceAdapter.cpp
@@ -135,8 +135,16 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
     if (prim.IsInMaster()) {
         instancerChain.push_back(parentProxyPath);
     }
-    const TfToken& instanceDrawMode = GetModelDrawMode(_GetPrim(
-        _GetPrimPathFromInstancerChain(instancerChain)));
+
+    const UsdPrim& instancePrim = _GetPrim(
+        _GetPrimPathFromInstancerChain(instancerChain));
+    if (!TF_VERIFY(
+            instancePrim, "Cannot get instance prim for <%s>",
+            instancePath.GetString().c_str())) {
+        return SdfPath();
+    }
+
+    const TfToken& instanceDrawMode = GetModelDrawMode(instancePrim);
 
     // Check if there's an instance in use as a hydra instancer for this master
     // with the appropriate inherited attributes.


### PR DESCRIPTION
### Description of Change(s)
Introduce additional test for `instancePrim` validity to avoid crashes in some cases.

### Fixes Issue(s)
- Crash when instance prim becomes invalid e.g. master was unloaded

