### PR TITLE
MESA AMD. Fixed syntax arror with ';' after function body.

### DIFF
--- a/pxr/imaging/lib/hdSt/codeGen.cpp
+++ b/pxr/imaging/lib/hdSt/codeGen.cpp
@@ -1628,7 +1628,7 @@ HdSt_CodeGen::_GenerateDrawingCoord()
                << "  hd_instanceIndex r; r.indices[0] = 0; return r; }\n";
         if (_geometricShader->IsCullingPass()) {
             _genVS << "void SetCulledInstanceIndex(uint instance) "
-                      "{ /*no-op*/ };\n";
+                      "{ /*no-op*/ }\n";
         }
     }
 


### PR DESCRIPTION
### Description of Change(s)
MESA AMD Vega drivers failed with the extra ';' in GLSL. 

Seen on Ubuntu.
### Fixes Issue(s)
- Filed as Pixar-internal issue #USD-5434

