### PR TITLE
If Embree fails to validate the requested AOVs, mark all buffers as converged

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -376,6 +376,14 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
     rtcCommit(_scene);
 
     if (!_ValidateAovBindings()) {
+        // We aren't going to render anything. Just mark all AOVs as converged
+        // so that we will stop rendering.
+        for (size_t i = 0; i < _aovBindings.size(); ++i) {
+            HdEmbreeRenderBuffer *rb = static_cast<HdEmbreeRenderBuffer*>(
+                _aovBindings[i].renderBuffer);
+            rb->SetConverged(true);
+        }
+        TF_RUNTIME_ERROR("Could not validate Aovs. Render will not complete");
         return;
     }
 


### PR DESCRIPTION
If Embree fails to validate the requested AOVs, mark all buffers as 
converged so the render will exit. Also raise a runtime error indicating
that the render will not complete.

### Fixes Issue(s)
- After invoking the Embree render delegate with unsupported buffer formats (asking for 16bit float color values, for example), the delegate would never reach a converged state even though it wouldn't actually be doing any rendering.