### PR TITLE
[imaging, usdImaging] Fix PXR_ENABLE_GL_SUPPORT=FALSE builds.

### DIFF
--- a/pxr/imaging/lib/hgiGL/CMakeLists.txt
+++ b/pxr/imaging/lib/hgiGL/CMakeLists.txt
@@ -1,6 +1,12 @@
 set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hgiGL)
 
+if (NOT ${PXR_ENABLE_GL_SUPPORT})
+    message(STATUS
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
+    return()
+endif()
+
 pxr_library(hgiGL
     LIBRARIES
         arch

--- a/pxr/usdImaging/lib/usdAppUtils/CMakeLists.txt
+++ b/pxr/usdImaging/lib/usdAppUtils/CMakeLists.txt
@@ -1,6 +1,12 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdAppUtils)
 
+if (NOT ${PXR_ENABLE_GL_SUPPORT})
+    message(STATUS
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
+    return()
+endif()
+
 pxr_library(usdAppUtils
     LIBRARIES
         garch


### PR DESCRIPTION
### Description of Change(s)

[imaging, usdImaging] Fix PXR_ENABLE_GL_SUPPORT=FALSE builds.

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/972

