### PR TITLE
Fix out of range access in Hd_SortedIds

### DIFF
--- a/pxr/imaging/lib/hd/sortedIds.cpp
+++ b/pxr/imaging/lib/hd/sortedIds.cpp
@@ -147,9 +147,14 @@ Hd_SortedIds::Remove(const SdfPath &id)
             if (idToRemove != lastElement) {
                 std::iter_swap(idToRemove, lastElement);
 
+                if (std::distance(idToRemove, lastElement) == 1) {
+                    // idToRemove points to the last element after pop_back()
+                    _afterLastDeletePoint = INVALID_DELETE_POINT;
+                } else {
+                    _afterLastDeletePoint = idToRemove - _ids.begin();
+                    ++_afterLastDeletePoint;
+                }
                 _ids.pop_back();
-                _afterLastDeletePoint = idToRemove - _ids.begin();
-                ++_afterLastDeletePoint;
 
                 // As we've moved an element from the end into the middle
                 // the list is now only sorted up to the place where the element


### PR DESCRIPTION
### Description of Change
Validate _afterLastDeletePoint before accessing an array element pointed by it.

### Fixes Issues
- Debug assert on Windows
- Undefined behavior in release build

### How to Reproduce
```
Hd_SortedIds sortedIds;
sortedIds.Insert(SdfPath("/Test2"));
sortedIds.Insert(SdfPath("/Test1"));
sortedIds.Remove(SdfPath("/Test2"));
sortedIds.Remove(SdfPath("/Test1")); // Crash
```
