### PR TITLE
Fix crash in case of unknown error passed to gluErrorString

### DIFF
--- a/pxr/imaging/lib/glf/diagnostic.cpp
+++ b/pxr/imaging/lib/glf/diagnostic.cpp
@@ -69,7 +69,11 @@ GlfPostPendingGLErrors(std::string const & where)
         const GLubyte *errorString = gluErrorString(error);
 
         std::ostringstream errorMessage;
-        errorMessage << "GL error: " << errorString;
+        if (!errorString) {
+            errorMessage << "GL error code: 0x" << std::hex << error;
+        } else {
+            errorMessage << "GL error: " << errorString;
+        }
 
         if (!where.empty()) {
             errorMessage << ", reported from " << where;

--- a/pxr/imaging/lib/hgiGL/diagnostic.cpp
+++ b/pxr/imaging/lib/hgiGL/diagnostic.cpp
@@ -76,7 +76,11 @@ HgiGLPostPendingGLErrors(std::string const & where)
         const GLubyte *errorString = gluErrorString(error);
 
         std::ostringstream errorMessage;
-        errorMessage << "GL error: " << errorString;
+        if (!errorString) {
+            errorMessage << "GL error code: 0x" << std::hex << error;
+        } else {
+            errorMessage << "GL error: " << errorString;
+        }
 
         if (!where.empty()) {
             errorMessage << ", reported from " << where;


### PR DESCRIPTION
### How to reproduce
Run usdview with Storm renderer. Enable of one those AOVs: normal, primvars:st, primId.

### System Information (OS, Hardware)
Windows10, AMD Radeon VII (19.8.1 driver)

### Description of Problem
"gluErrorString" in case of unknown error passed to it returns nullptr, which passed then to "std::ostream::operator<<" which is calling "strlen" on input pointer. "strlen" in turn, according to the standard, do not check the input pointer and immediately dereference it

### Description of Change(s)
- Add check for returned errorString

Surely the main problem here in those AOVs that does not work for some reason on my machine (I have not looked into why). But we must not allow the possibility of such thing as nullptr coming from gluErrorString to crash whole application.

Initially, I experienced this crash in hgiGL module only, but there is the same function in glf module. So I just added the same check there too.