### PR TITLE
 Fix TBB library linkage in hdEmbree

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -21,7 +21,7 @@ pxr_plugin(hdEmbree
         hf
         hd
         hdx
-        ${TBB_LIBRARIES}
+        ${TBB_tbb_LIBRARY}
         ${EMBREE_LIBRARY}
 
     INCLUDE_DIRS


### PR DESCRIPTION
Same motivation and changes as in https://github.com/PixarAnimationStudios/USD/commit/a29529b44b608a4fa2dffd77826444614860ff37