### PR TITLE
Glf_StbImage. Added 'jpeg' extension alongside 'jpg'

### DIFF
--- a/pxr/imaging/lib/glf/plugInfo.json
+++ b/pxr/imaging/lib/glf/plugInfo.json
@@ -11,7 +11,7 @@
                     },
                     "Glf_StbImage" : {
                         "bases": ["GlfImage"],
-                        "imageTypes": ["bmp", "jpg", "png", "tga", "hdr"],
+                        "imageTypes": ["bmp", "jpg", "jpeg", "png", "tga", "hdr"],
                         "precedence": 2
                     },
                     "GlfPtexTexture" : {

--- a/pxr/imaging/lib/glf/plugInfo_NoOIIO.json
+++ b/pxr/imaging/lib/glf/plugInfo_NoOIIO.json
@@ -6,7 +6,7 @@
                 "Types": {                                                                  
                     "Glf_StbImage" : {
                         "bases": ["GlfImage"],
-                        "imageTypes": ["bmp", "jpg", "png", "tga", "hdr"],
+                        "imageTypes": ["bmp", "jpg", "jpeg", "png", "tga", "hdr"],
                         "precedence": -1 
                     },
                     "GlfPtexTexture" : {


### PR DESCRIPTION
### Description of Change(s)
Glf_StbImage. Added 'jpeg' extension for Glf_StbImage as it already supports 'jpg'
### Fixes Issue(s)
- Allows .jpeg files to be loaded instead of rendering as black/missing texture data.

