### PR TITLE
[hdx] we shouldn't be checking an uninitialized value

### DIFF
--- a/pxr/imaging/lib/hdx/oitResolveTask.cpp
+++ b/pxr/imaging/lib/hdx/oitResolveTask.cpp
@@ -265,9 +265,7 @@ HdxOitResolveTask::Prepare(HdTaskContext* ctx,
     } else {
         // Without AOVs we don't know the window / screen size.
         const int oitScreenSizeFallback = 2048;
-        if (screenSize[0] != oitScreenSizeFallback) {
-            TF_WARN("Invalid AOVs for Oit Resolve Task");
-        }
+        TF_WARN("Invalid AOVs for Oit Resolve Task");
         screenSize[0] = oitScreenSizeFallback;
         screenSize[1] = oitScreenSizeFallback;
     }


### PR DESCRIPTION
### Description of Change(s)
I was checking the changes in 1e193cce4e2568ac66a84b1a82e18493929035b7 to verify they made https://github.com/PixarAnimationStudios/USD/pull/920 obsolete (which they did!), but happened to stumble across this.

Perhaps this was supposed to be checking something else, or there is some other step which is missing?

### Fixes Issue(s)
- OIT with no AOV results in checking against an uninitialized value.

