### PR TITLE
Fix crash when printing an expired stage python object

### DIFF
--- a/pxr/usd/lib/usd/wrapStage.cpp
+++ b/pxr/usd/lib/usd/wrapStage.cpp
@@ -86,6 +86,10 @@ _ExportToString(const UsdStagePtr &self, bool addSourceFileComment=true)
 static string
 __repr__(const UsdStagePtr &self)
 {
+    if (self.IsExpired()) {
+        return "";
+    }
+    
     string result = TF_PY_REPR_PREFIX + TfStringPrintf(
         "Stage.Open(rootLayer=%s, sessionLayer=%s",
         TfPyRepr(self->GetRootLayer()).c_str(),


### PR DESCRIPTION
### Description of Change(s)
Test weak pointer's validity in `__repr__`.

### Fixes Issue(s)
- Crash when printing an expired stage python object

