### PR TITLE
fix build errors with PXR_STRICT_BUILD_MODE

### DIFF
--- a/pxr/usd/lib/usd/stage.cpp
+++ b/pxr/usd/lib/usd/stage.cpp
@@ -5390,18 +5390,6 @@ void TypedStrongestValueComposer<VtArray<SdfTimeCode>>::_ResolveValueImpl(
         _value, layerOffsetAccess);
 }
 
-template <>
-void TypedStrongestValueComposer<SdfTimeSampleMap>::_ResolveValueImpl(
-    const PcpNodeRef &node,
-    const SdfLayerRefPtr &layer)
-{
-    // Create a layer offset accessor so we don't compute the layer
-    // offset unless one of the resolve functions actually needs it.
-    LayerOffsetAccess layerOffsetAccess(node, layer);
-    _TryApplyLayerOffsetToValue<SdfTimeSampleMap>(
-        _value, layerOffsetAccess);
-}
-
 struct ExistenceComposer
 {
     static const bool ProducesValue = false;


### PR DESCRIPTION
### Description of Change(s)

This is to fix an error we were getting with PXR_STRICT_BUILD_MODE - specifically, an unused-function error, due to this template function specialization in stage.cpp:

template <>
void TypedStrongestValueComposer<SdfTimeSampleMap>::_ResolveValueImpl(
    const PcpNodeRef &node,
    const SdfLayerRefPtr &layer)

After looking at the code, it looked like this overload is unneeded - as far as I could tell, it would only be needed if SdfTimeSampleMap was a valid attribute value type (though I could easily be misreading the code!), so I simply removed it

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1013

