### PR TITLE
Fix a bug in UdsGeomImageable::MakeVisible

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -116,6 +116,7 @@ pxr_test_scripts(
     testenv/testUsdGeomConsts.py
     testenv/testUsdGeomCurves.py
     testenv/testUsdGeomExtentTransform.py
+    testenv/testUsdGeomImageable.py
     testenv/testUsdGeomMesh.py
     testenv/testUsdGeomMetrics.py
     testenv/testUsdGeomMotionAPI.py
@@ -200,6 +201,10 @@ pxr_install_test_dir(
     SRC testenv/testUsdGeomComputeAtTime
     DEST testUsdGeomComputeAtTime
 )
+
+pxr_install_test_dir(
+    SRC testenv/testUsdGeomImageable
+    DEST testUsdGeomImageable)
 
 pxr_register_test(testUsdGeomBasisCurves
     PYTHON
@@ -329,3 +334,10 @@ pxr_register_test(testUsdGeomComputeAtTime
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomComputeAtTime"
     EXPECTED_RETURN_CODE 0
 )
+
+pxr_register_test(testUsdGeomImageable
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomImageable"
+    EXPECTED_RETURN_CODE 0
+)
+

--- a/pxr/usd/usdGeom/imageable.cpp
+++ b/pxr/usd/usdGeom/imageable.cpp
@@ -329,8 +329,8 @@ _MakeVisible(const UsdPrim &prim, UsdTimeCode const &time,
         if (UsdGeomImageable imageableParent = UsdGeomImageable(parent)) {
 
             // Change visibility of parent to inherited if it is invisible.
-            if (*hasInvisibleAncestor ||
-                _SetInheritedIfInvisible(imageableParent, time))  {
+            if (_SetInheritedIfInvisible(imageableParent, time) ||
+                *hasInvisibleAncestor) {
 
                 *hasInvisibleAncestor = true;
 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomImageable.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomImageable.py
@@ -1,0 +1,41 @@
+#!/pxrpythonsubst
+#
+# Copyright 2019 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Gf, Tf, Sdf, Usd, UsdGeom, Vt
+import unittest, math
+
+class TestUsdGeomImageable(unittest.TestCase):
+    def test_MakeVisible(self):
+        testFile = "AllInvisible.usda"
+        s = Usd.Stage.Open(testFile)
+        bar2 = UsdGeom.Imageable(s.GetPrimAtPath("/foo/bar2"))
+        thing1 = UsdGeom.Imageable(s.GetPrimAtPath("/foo/bar1/thing1"))
+        thing2 = UsdGeom.Imageable(s.GetPrimAtPath("/foo/bar1/thing2"))
+        thing1.MakeVisible()
+        self.assertEqual(bar2.ComputeVisibility(), UsdGeom.Tokens.invisible)
+        self.assertEqual(thing1.ComputeVisibility(), UsdGeom.Tokens.inherited)
+        self.assertEqual(thing2.ComputeVisibility(), UsdGeom.Tokens.invisible)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/usdGeom/testenv/testUsdGeomImageable/AllInvisible.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomImageable/AllInvisible.usda
@@ -1,0 +1,31 @@
+#usda 1.0
+def Xform "foo"
+{
+    token visibility = "invisible"
+
+    def Xform "bar1"
+    {
+        token visibility = "invisible"
+
+        def Sphere "thing1"
+        {
+            token visibility = "invisible"
+        }
+
+        def Sphere "thing2"
+        {
+            token visibility = "invisible"
+        }
+    }
+
+    def Xform "bar2"
+    {
+        token visibility = "invisible"
+
+        def Sphere "thing"
+        {
+            token visibility = "invisible"
+        }
+    }
+}
+


### PR DESCRIPTION
Fix a bug in UdsGeomImageable::MakeVisible, in which the recursive setting
of the visibility attribute to "inherited" would only be done to the invisible
ancestor prim closest to the root. If other ancestors were also marked as
invisible (redundantly, but legally) the original prim would not end up
being visible.

### Description of Change(s)
Reversed the order of a conditional inside the recursive _MakeVisible function so
that the setting of the visibility attribute to "inherited" on ancestors is not short
circuited after the first ancestor has this attribute changed.

### Fixes Issue(s)
The provided test case will fail without this change. The prim will not be visible
after calling MakeVisible on it.