### PR TITLE
Allow disabling building CLI tools

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -25,6 +25,7 @@ option(PXR_STRICT_BUILD_MODE "Turn on additional warnings. Enforce all warnings 
 option(PXR_VALIDATE_GENERATED_CODE "Validate script generated code" OFF)
 option(PXR_HEADLESS_TEST_MODE "Disallow GUI based tests, useful for running under headless CI systems." OFF)
 option(PXR_BUILD_TESTS "Build tests" ON)
+option(PXR_BUILD_USD_TOOLS "Build commandline tools" ON)
 option(PXR_BUILD_IMAGING "Build imaging components" ON)
 option(PXR_BUILD_EMBREE_PLUGIN "Build embree imaging plugin" OFF)
 option(PXR_BUILD_OPENIMAGEIO_PLUGIN "Build OpenImageIO plugin" OFF)

--- a/pxr/usd/CMakeLists.txt
+++ b/pxr/usd/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(DIRS
     lib
-    bin
     plugin
 )
 
@@ -8,3 +7,8 @@ foreach(d ${DIRS})
     add_subdirectory(${d})
 endforeach()
 
+if (PXR_BUILD_USD_TOOLS)
+    add_subdirectory(bin)
+else()
+    message(STATUS "Skipping commandline tools because PXR_BUILD_USD_TOOLS=OFF")
+endif()


### PR DESCRIPTION
When building Blender with USD support, we don't want to include the USD CLI tools.

### Description of Change(s)

This commit adds a CMake option `PXR_BUILD_USD_TOOLS` to disable building CLI tools. By default this is option is ON.
