### PR TITLE
[build_usd] fix for building usd from a symlinked directory

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -260,7 +260,7 @@ def RunCMake(context, force, extraArgs = None):
     # Create a directory for out-of-source builds in the build directory
     # using the name of the current working directory.
     srcDir = os.getcwd()
-    instDir = (context.usdInstDir if srcDir == context.usdSrcDir
+    instDir = (context.usdInstDir if context.currentDependency.name == "USD"
                else context.instDir)
     buildDir = os.path.join(context.buildDir, os.path.split(srcDir)[1])
     if force and os.path.isdir(buildDir):
@@ -485,6 +485,12 @@ class Dependency(object):
 
         AllDependencies.append(self)
         AllDependenciesByName.setdefault(name.lower(), self)
+
+    def Install(self, context):
+        context.currentDependency = self
+        self.installer(context, 
+                       buildArgs=context.GetBuildArguments(self),
+                       force=context.ForceBuildDependency(self))
 
     def Exists(self, context):
         return all([os.path.isfile(os.path.join(context.instDir, f))
@@ -1466,6 +1472,8 @@ args = parser.parse_args()
 
 class InstallContext:
     def __init__(self, args):
+        self.currentDependency = None
+
         # Assume the USD source directory is in the parent directory
         self.usdSrcDir = os.path.normpath(
             os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
@@ -1887,9 +1895,7 @@ try:
     # Download and install 3rd-party dependencies, followed by USD.
     for dep in dependenciesToBuild + [USD]:
         PrintStatus("Installing {dep}...".format(dep=dep.name))
-        dep.installer(context, 
-                      buildArgs=context.GetBuildArguments(dep),
-                      force=context.ForceBuildDependency(dep))
+        dep.Install(context)
 except Exception as e:
     PrintError(str(e))
     sys.exit(1)


### PR DESCRIPTION
[build_usd] fix for building usd from a symlinked directory

Currently (on MacOS anyway, haven't tested on linux), invoking
build_usd.py from inside a symlinked directory results in usd installing
in the incorrect location - the dependency install dir (if you've
specified a separate one, with --inst).

This fixes this by explicitly storing which dependency we're building on
the context, instead of trying to implicitly figure it out by doing a
text comparison of the current directory.

We could attempt to fix this by applying path regularization - at minimum, you'd
need to do:

```
   def regularize_path(path):
       return os.normcase(os.normpath(os.realpath(os.abspath(path))))
    if regularize_path(srcDir) == regularize_path(context.usdSrcDir)
```

However, there might still be contingencies these don't account for - comparing
directories via string comparison is a fairly unreliable technique.  A more
reliable method would be to compare, ie, inodes, but this makes it less cross-
platform... and even that is still an indirect way of answering the question
we really want to answer: what project / dependency are we currently building?

This is information that the build system itself obviously knows, so I thought
it would make more sense to just pass it through directly.

One note on why dealing correctly with symlinks might be important: I came
across this bug after upgrading MacOS to catalina... which puts restrictions on
itmes you can put at root level.  The only way around it is to use "synthetic
firmlinks", which create symlinks:

    https://apple.stackexchange.com/questions/371908/how-to-make-root-volume-writeable-again-in-catalina

...so we may be seeing a lot more usage of symlinks from MacOS users.