### PR TITLE
Use the current UsdTimeCode to get geometry subset indices

### DIFF
--- a/pxr/usdImaging/usdImaging/meshAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/meshAdapter.cpp
@@ -335,7 +335,7 @@ UsdImagingMeshAdapter::_GetMeshTopology(UsdPrim const& prim,
              VtIntArray indices;
              TfToken elementType;
              if (subset.GetElementTypeAttr().Get(&elementType) &&
-                 subset.GetIndicesAttr().Get(&indices)) {
+                 subset.GetIndicesAttr().Get(&indices, time)) {
                  if (elementType == UsdGeomTokens->face) {
                      geomSubsets.emplace_back(
                         HdGeomSubset {


### PR DESCRIPTION
When getting the indices attribute from a UsdGeomSubset, pass in the current
UsdTimeCode, otherwise the default value will always be returned (or no value
if a default value isn't explicitly authored).

### Description of Change(s)
Add the current time code to the call that loads the indices attribute value.

### Fixes Issue(s)
- #1058 