### PR TITLE
Fixed usdview warnings with valid UsdGeomMesh face-varying options

### DIFF
--- a/pxr/imaging/pxOsd/refinerFactory.cpp
+++ b/pxr/imaging/pxOsd/refinerFactory.cpp
@@ -131,8 +131,12 @@ Converter::GetOptions() const {
     if (!faceVaryingLinearInterpolation.IsEmpty()) {
         if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->all) {
             options.SetFVarLinearInterpolation(Options::FVAR_LINEAR_ALL);
+        } else if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->cornersOnly) {
+            options.SetFVarLinearInterpolation(Options::FVAR_LINEAR_CORNERS_ONLY);
         } else if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->cornersPlus1) {
             options.SetFVarLinearInterpolation(Options::FVAR_LINEAR_CORNERS_PLUS1);
+        } else if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->cornersPlus2) {
+            options.SetFVarLinearInterpolation(Options::FVAR_LINEAR_CORNERS_PLUS2);
         } else if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->none) {
             options.SetFVarLinearInterpolation(Options::FVAR_LINEAR_NONE);
         } else if (faceVaryingLinearInterpolation==PxOsdOpenSubdivTokens->boundaries) {


### PR DESCRIPTION
usdview emits warnings when UsdGeomMesh's FaceVaryingLinearInterpolation attribute is set with the valid values "cornersOnly" or "cornersPlus2", i.e.:

        Warning: in GetOptions at line 142 of src/pxr/imaging/lib/pxOsd/refinerFactory.cpp -- Unknown face-varying boundary interpolation rule (cornersOnly) (...)

### Description of Change(s)

This change adds the two missing conditions to the conversion of attribute values to corresponding OpenSubdiv options.