### PR TITLE
[sdf] Fix for PXR_STRICT_BUILD_MODE with wrap of SdfLayer::Traverse

### DIFF
--- a/pxr/usd/sdf/wrapLayer.cpp
+++ b/pxr/usd/sdf/wrapLayer.cpp
@@ -24,6 +24,11 @@
 /// \file wrapLayer.cpp
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/pragmas.h"
+
+ARCH_PRAGMA_PUSH
+ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
+
 #include "pxr/usd/sdf/layer.h"
 #include "pxr/usd/sdf/layerUtils.h"
 #include "pxr/usd/sdf/attributeSpec.h"
@@ -921,3 +926,5 @@ void wrapLayer()
 }
 
 TF_REFPTR_CONST_VOLATILE_GET(SdfLayer)
+
+ARCH_PRAGMA_POP


### PR DESCRIPTION
# Description of Change(s)

This fixes a build issue introduced by:

[sdf] wrap SdfLayer::Traverse.
2357a7b694c0a5752af09f87465bbe7a3b172ffe

...when building with PXR_STRICT_BUILD_MODE + gcc 6 + boost 1.61.

The fix is the same applied by:

Locally disable placement-new warnings in later versions of gcc.
898b8c12f26869b0b20b24c75dc4a185fdd534a2

Note - this was fixed in boost 1.62:

https://github.com/boostorg/function/pull/9

Since this placement-new problem is only a problem on specific versions of boost, I wonder if we should add a boost-version check to the places where ARCH_PRAGMA_PLACEMENT_NEW is used?

Alternatively, since vfxplatform-CY2019 is already advocating 1.66 (where this is not an issue), I wonder if it might be better to provide a more "general" solution, by doing a check at the CMAKE level... and if PXR_STRICT_BUILD_MODE is used, and we're using gcc 6+, AND we're using boost<1.62, we simply add a "-Wno-placement-new".

### Fixes Issue(s)
- Building with PXR_STRICT_BUILD_MODE + gcc-6 + boost-1.61

