### PR TITLE
Fixes for calling into a USD library built with MSVC, from code built with clang-cl

### DIFF
--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -254,6 +254,17 @@ struct Arch_ConstructorEntry {
     };                                                                         \
     static void _name(__VA_ARGS__)
 
+#elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+
+// The used attribute is required to prevent these apparently unused functions
+// from being removed by the linker.
+#   define ARCH_CONSTRUCTOR(_name, _priority, ...) \
+        __attribute__((used, section(".pxrctor"), constructor((_priority) + 100))) \
+        static void _name(__VA_ARGS__)
+#   define ARCH_DESTRUCTOR(_name, _priority, ...) \
+        __attribute__((used, section(".pxrdtor"), destructor((_priority) + 100))) \
+        static void _name(__VA_ARGS__)
+
 #elif defined(ARCH_OS_WINDOWS)
     
 #    include "pxr/base/arch/api.h"
@@ -311,17 +322,6 @@ struct Arch_ConstructorInit {
     }                                                                          \
     _ARCH_ENSURE_PER_LIB_INIT(Arch_ConstructorInit, _archCtorInit);            \
     static void _name(__VA_ARGS__)
-
-#elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
-
-// The used attribute is required to prevent these apparently unused functions
-// from being removed by the linker.
-#   define ARCH_CONSTRUCTOR(_name, _priority, ...) \
-        __attribute__((used, section(".pxrctor"), constructor((_priority) + 100))) \
-        static void _name(__VA_ARGS__)
-#   define ARCH_DESTRUCTOR(_name, _priority, ...) \
-        __attribute__((used, section(".pxrdtor"), destructor((_priority) + 100))) \
-        static void _name(__VA_ARGS__)
 
 #else
 

--- a/pxr/base/tf/preprocessorUtils.h
+++ b/pxr/base/tf/preprocessorUtils.h
@@ -46,7 +46,7 @@
 #include <boost/preprocessor/tuple/eat.hpp>
 #include <boost/preprocessor/tuple/to_list.hpp>
 #include <boost/preprocessor/tuple/to_seq.hpp>
-#if defined(ARCH_OS_WINDOWS)
+#if defined(ARCH_COMPILER_MSVC)
 #include <boost/preprocessor/variadic/size.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
@@ -66,7 +66,7 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
 ///
 /// \ingroup group_tf_Preprocessor
 /// \hideinitializer
-#if defined(ARCH_OS_WINDOWS)
+#if defined(ARCH_COMPILER_MSVC)
 #define TF_NUM_ARGS(...) \
     BOOST_PP_IIF(BOOST_VMD_IS_EMPTY(__VA_ARGS__),\
         0, BOOST_PP_VARIADIC_SIZE(__VA_ARGS__))
@@ -189,7 +189,7 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
 /// Exapnds to 1 if the argument is a tuple, and 0 otherwise.
 /// \ingroup group_tf_Preprocessor
 /// \hideinitializer
-#if defined(ARCH_OS_WINDOWS)
+#if defined(ARCH_COMPILER_MSVC)
     #define TF_PP_IS_TUPLE(sequence) \
         BOOST_VMD_IS_TUPLE(sequence)
 #else

--- a/pxr/usd/ar/asset.h
+++ b/pxr/usd/ar/asset.h
@@ -45,10 +45,8 @@ public:
     AR_API
     virtual ~ArAsset();
 
-    AR_API 
     ArAsset(const ArAsset&) = delete;
 
-    AR_API 
     ArAsset& operator=(const ArAsset&) = delete;
 
     /// Returns size of the asset.

--- a/pxr/usd/sdf/fileFormat.h
+++ b/pxr/usd/sdf/fileFormat.h
@@ -256,7 +256,7 @@ protected:
         const SdfSchemaBase& schema);
 
     /// Disallow temporary SdfSchemaBase objects being passed to the c'tor.
-    SDF_API SdfFileFormat(
+    SdfFileFormat(
         const TfToken& formatId,
         const TfToken& versionString,
         const TfToken& target,
@@ -280,7 +280,7 @@ protected:
         const SdfSchemaBase& schema);
 
     /// Disallow temporary SdfSchemaBase objects being passed to the c'tor.
-    SDF_API SdfFileFormat(
+    SdfFileFormat(
         const TfToken& formatId,
         const TfToken& versionString,
         const TfToken& target,


### PR DESCRIPTION
### Description of Change(s)

Submitting these changes on behalf of @e4lam.

From a clang-cl project that uses a pre-built USD library (with MSVC, but that's fine because they're ABI compatible). A few source header adjustments that clang complained about:

* pxr/base/tf/preprocessorUtils.h: Replace uses of ARCH_OS_WINDOWS with ARCH_COMPILER_MSVC because clang-cl's preprocessor is better. This fixes many compiler errors with the use of boost cpp.
* pxr/usd/sdf/fileFormat.h: Remove SDF_API from "= delete" methods because it doesn't make sense to export deleted methods. I'm surprised that the other compilers allow this.
* pxr/usd/ar/asset.h: Remove AR_API from "= delete" methods for same reason as previous.
* pxr/base/arch/attributes.h: Fix ARCH_CONSTRUCTOR and ARCH_DESTRUCTOR. This issue only showed up when trying to use AR_DEFINE_RESOLVER() in client code and then noticing that it had failed to register the resolver because the ctor (and presumably the dtor as well) never gets called when the plugin library is loaded.

### Fixes Issue(s)
- #1030 

