### PR TITLE
gcc: disable placement-new warnings for boost<1.62

### DIFF
--- a/cmake/defaults/gccdefaults.cmake
+++ b/cmake/defaults/gccdefaults.cmake
@@ -24,4 +24,13 @@
 
 include(gccclangshareddefaults)
 
+if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6)
+	if (Boost_VERSION LESS 106200)
+		# gcc-6 introduces a placement-new warning, which causes problems
+		# in boost-1.61 or less, in the boost::function code.
+		# boost-1.62 fixes the warning
+		_disable_warning("placement-new")
+	endif()
+endif()
+
 set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")

--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -54,11 +54,6 @@
     #define ARCH_PRAGMA_WRITE_STRINGS \
         _Pragma("GCC diagnostic ignored \"-Wwrite-strings\"")
 
-#if ARCH_COMPILER_GCC_MAJOR >= 6
-    #define ARCH_PRAGMA_PLACEMENT_NEW \
-        _Pragma("GCC diagnostic ignored \"-Wplacement-new\"")
-#endif
-
 #elif defined(ARCH_COMPILER_CLANG)
 
     #define ARCH_PRAGMA_PUSH \
@@ -202,10 +197,6 @@
 
 #if !defined ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE
     #define ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE
-#endif
-
-#if !defined ARCH_PRAGMA_PLACEMENT_NEW
-    #define ARCH_PRAGMA_PLACEMENT_NEW
 #endif
 
 #endif // PXR_BASE_ARCH_PRAGMAS_H

--- a/pxr/base/plug/wrapRegistry.cpp
+++ b/pxr/base/plug/wrapRegistry.cpp
@@ -23,12 +23,6 @@
 //
 
 #include "pxr/pxr.h"
-
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/base/plug/registry.h"
 #include "pxr/base/plug/plugin.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -244,5 +238,3 @@ void wrapRegistry()
         _LoadPluginsConcurrently,
         (arg("predicate"), arg("numThreads")=0, arg("verbose")=false));
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/base/tf/wrapFunction.cpp
+++ b/pxr/base/tf/wrapFunction.cpp
@@ -23,11 +23,6 @@
 //
 
 #include "pxr/pxr.h"
-
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
 #include "pxr/base/tf/pyFunction.h"
 
 #include <boost/python/object.hpp>
@@ -47,5 +42,3 @@ void wrapFunction() {
     TfPyFunctionFromPython<std::string ()>();
     TfPyFunctionFromPython<python::object ()>();
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/base/tf/wrapNotice.cpp
+++ b/pxr/base/tf/wrapNotice.cpp
@@ -23,12 +23,6 @@
 //
 
 #include "pxr/pxr.h"
-
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/base/tf/type.h"
 #include "pxr/base/tf/notice.h"
 #include "pxr/base/tf/pyFunction.h"
@@ -317,5 +311,3 @@ void wrapNotice()
         )
         ;
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/base/tf/wrapTestTfPython.cpp
+++ b/pxr/base/tf/wrapTestTfPython.cpp
@@ -24,11 +24,6 @@
 
 #include "pxr/pxr.h"
 
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/enum.h"
 #include "pxr/base/tf/error.h"
@@ -580,5 +575,3 @@ TF_REFPTR_CONST_VOLATILE_GET(Tf_TestBase)
 TF_REFPTR_CONST_VOLATILE_GET(Tf_TestDerived)
 TF_REFPTR_CONST_VOLATILE_GET(polymorphic_Tf_TestBase<class Tf_TestBase>)
 TF_REFPTR_CONST_VOLATILE_GET(polymorphic_Tf_TestDerived<class Tf_TestDerived>)
-
-ARCH_PRAGMA_POP

--- a/pxr/base/vt/wrapValue.cpp
+++ b/pxr/base/vt/wrapValue.cpp
@@ -23,11 +23,6 @@
 //
 
 #include "pxr/pxr.h"
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/base/vt/value.h"
 
 #include "pxr/base/vt/array.h"
@@ -344,5 +339,3 @@ void wrapValue()
     TfPyFunctionFromPython<VtValue ()>();
     
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/ndr/wrapFilesystemDiscovery.cpp
+++ b/pxr/usd/ndr/wrapFilesystemDiscovery.cpp
@@ -23,11 +23,6 @@
 //
 
 #include "pxr/pxr.h"
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/makePyConstructor.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -117,5 +112,3 @@ void wrapFilesystemDiscovery()
 
     wrapFilesystemDiscoveryContext();
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/sdf/wrapCopyUtils.cpp
+++ b/pxr/usd/sdf/wrapCopyUtils.cpp
@@ -21,11 +21,6 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include <boost/python/def.hpp>
 #include <boost/python/tuple.hpp>
 
@@ -186,5 +181,3 @@ wrapCopyUtils()
         (arg("srcLayer"), arg("srcPath"), arg("dstLayer"), arg("dstPath"),
          arg("shouldCopyValueFn"), arg("shouldCopyChildrenFn")));
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/usd/wrapFlattenUtils.cpp
+++ b/pxr/usd/usd/wrapFlattenUtils.cpp
@@ -24,9 +24,6 @@
 #include "pxr/pxr.h"
 #include "pxr/base/arch/pragmas.h"
 
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include <boost/python/def.hpp>
 
 #include "pxr/usd/usd/flattenUtils.h"
@@ -83,5 +80,3 @@ void wrapUsdFlattenUtils()
         UsdFlattenLayerStackResolveAssetPath,
         (arg("sourceLayer"), arg("assetPath")));
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/usd/wrapPrim.cpp
+++ b/pxr/usd/usd/wrapPrim.cpp
@@ -22,11 +22,6 @@
 // language governing permissions and limitations under the Apache License.
 //
 #include "pxr/pxr.h"
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/attribute.h"
 #include "pxr/usd/usd/payloads.h"
@@ -372,5 +367,3 @@ void wrapUsdPrim()
 
     TfPyRegisterStlSequencesFromPython<UsdPrim>();
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/usdUtils/wrapDependencies.cpp
+++ b/pxr/usd/usdUtils/wrapDependencies.cpp
@@ -25,13 +25,6 @@
 /// \file usdUtils/wrapDependencies.cpp
 
 #include "pxr/pxr.h"
-
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
-
 #include <boost/python/def.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/tuple.hpp>
@@ -109,5 +102,3 @@ void wrapDependencies()
         (bp::arg("layer"), bp::arg("modifyFn")));
 
 }
-
-ARCH_PRAGMA_POP

--- a/pxr/usd/usdUtils/wrapFlattenLayerStack.cpp
+++ b/pxr/usd/usdUtils/wrapFlattenLayerStack.cpp
@@ -22,11 +22,6 @@
 // language governing permissions and limitations under the Apache License.
 //
 #include "pxr/pxr.h"
-#include "pxr/base/arch/pragmas.h"
-
-ARCH_PRAGMA_PUSH
-ARCH_PRAGMA_PLACEMENT_NEW  // because of pyFunction.h and boost::function
-
 #include <boost/python/def.hpp>
 
 #include "pxr/usd/usdUtils/flattenLayerStack.h"
@@ -81,5 +76,3 @@ void wrapFlattenLayerStack()
         UsdUtilsFlattenLayerStackResolveAssetPath,
         (arg("sourceLayer"), arg("assetPath")));
 }
-
-ARCH_PRAGMA_POP


### PR DESCRIPTION
### Description of Change(s)

This is an alternative solution to the same problem addressed by:

Locally disable placement-new warnings in later versions of gcc.
898b8c1

After discussion (#1074), we decided that the best solution would be to globally disable
this for the affected combo of gcc + boost versions, since newer
versions of boost are not affected.

### Fixes Issue(s)
- Building with PXR_STRICT_BUILD_MODE + gcc-6 + boost-1.61

