### PR TITLE
[build_scripts, cmake, glf] Remove OpenEXR from default dependencies.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1756,16 +1756,14 @@ if context.buildImaging:
     if context.enablePtex:
         requiredDependencies += [PTEX]
 
-    requiredDependencies += [OPENEXR, GLEW, 
+    requiredDependencies += [GLEW,
                              OPENSUBDIV]
 
     if context.enableOpenVDB:
-        # OpenVDB requires Half type from IlmBase which is already
-        # pulled in through OPENEXR.
-        requiredDependencies += [BLOSC, OPENVDB]
+        requiredDependencies += [BLOSC, OPENEXR, OPENVDB]
     
     if context.buildOIIO:
-        requiredDependencies += [JPEG, TIFF, PNG, OPENIMAGEIO]
+        requiredDependencies += [JPEG, TIFF, PNG, OPENEXR, OPENIMAGEIO]
 
     if context.buildOCIO:
         requiredDependencies += [OPENCOLORIO]

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -96,10 +96,9 @@ endif()
 # ----------------------------------------------
 
 if (PXR_BUILD_IMAGING)
-    # --OpenEXR
-    find_package(OpenEXR REQUIRED)
     # --OpenImageIO
     if (PXR_BUILD_OPENIMAGEIO_PLUGIN)
+        find_package(OpenEXR REQUIRED)
         find_package(OpenImageIO REQUIRED)
         add_definitions(-DPXR_OIIO_PLUGIN_ENABLED)
     endif()
@@ -123,6 +122,7 @@ if (PXR_BUILD_IMAGING)
     endif()
     # --OpenVDB
     if (PXR_ENABLE_OPENVDB_SUPPORT)
+        find_package(OpenEXR REQUIRED)
         find_package(OpenVDB REQUIRED)
         add_definitions(-DPXR_OPENVDB_SUPPORT_ENABLED)
     endif()
@@ -184,6 +184,7 @@ endif()
 
 if(PXR_ENABLE_OSL_SUPPORT)
     find_package(OSL REQUIRED)
+    find_package(OpenEXR REQUIRED)
 endif()
 
 # ----------------------------------------------

--- a/pxr/imaging/glf/CMakeLists.txt
+++ b/pxr/imaging/glf/CMakeLists.txt
@@ -25,8 +25,8 @@ set (plugInfo plugInfo_NoOIIO.json)
 if (PXR_BUILD_OPENIMAGEIO_PLUGIN)
     set (plugInfo plugInfo.json)
     list(APPEND optionalCppFiles oiioImage.cpp)
-    list(APPEND optionalLibs ${OIIO_LIBRARIES})
-    list(APPEND optionalIncludeDirs ${OIIO_INCLUDE_DIRS})
+    list(APPEND optionalLibs ${OIIO_LIBRARIES} ${OPENEXR_LIBRARY})
+    list(APPEND optionalIncludeDirs ${OIIO_INCLUDE_DIRS} ${OPENEXR_INCLUDE_DIRS})
 endif()
 
 if (PXR_ENABLE_OPENVDB_SUPPORT)
@@ -52,13 +52,11 @@ pxr_library(glf
         ${OPENGL_glu_LIBRARY}
         ${GLEW_LIBRARY}
         ${X11_LIBRARIES}
-        ${OPENEXR_LIBRARY}
         ${optionalLibs}
 
     INCLUDE_DIRS
         ${Boost_INCLUDE_DIRS}
         ${GLEW_INCLUDE_DIR}
-        ${OPENEXR_INCLUDE_DIRS}
         ${optionalIncludeDirs}
 
     PUBLIC_CLASSES


### PR DESCRIPTION
See discussion in https://groups.google.com/d/msg/usd-interest/hmb7ZVVtscY/DmqNROd8BwAJ