### PR TITLE
[usdedit] Don't keep a file descriptor open for the temporary usda.

### DIFF
--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -91,6 +91,9 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
     import tempfile
     (usdaFile, usdaFileName) = tempfile.mkstemp(
         prefix=fullPrefix, suffix='.usda', dir=os.getcwd())
+
+    # No need for an open file descriptor, as it locks the file in Windows.
+    os.close(usdaFile)
  
     os.system(usdcatCmd + ' ' + usdFileName + '> ' + usdaFileName)
 
@@ -102,7 +105,7 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
     if os.stat(usdaFileName).st_size == 0:
         sys.exit("Error: Failed to open file %s, exiting." % usdFileName)
 
-    return usdaFile, usdaFileName
+    return usdaFileName
 
 # allow the user to edit the temporary file, and return whether or
 # not they made any changes.
@@ -206,8 +209,8 @@ def main():
     usdcatCmd, editorCmd = _findEditorTools(usdFileName, readOnly)
     
     # generate our temporary file with proper permissions and edit.
-    usdaFile, usdaFileName = _generateTemporaryFile(usdcatCmd, usdFileName,
-                                                    readOnly, prefix)
+    usdaFileName = _generateTemporaryFile(usdcatCmd, usdFileName,
+                                          readOnly, prefix)
     tempFileChanged = _editTemporaryFile(editorCmd, usdaFileName)
     
 
@@ -220,7 +223,8 @@ def main():
                      ". Your edits can be found in %s. " \
                      %(usdFileName, usdaFileName))
 
-    os.close(usdaFile)
+    if readOnly:
+        os.chmod(usdaFileName, 0644)
     os.remove(usdaFileName)
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of Change(s)

[usdedit] Don't keep a file descriptor open for the temporary usda.

It is not needed, and prevents usdcat from writing to it in Windows.
Also ensure write permissions when removing the temporary usda,
otherwise usdedit -n will be unable to remove it on Windows.


### Fixes Issue(s)

`usdedit extras\usd\tutorials\convertingLayerFormats\Sphere.usd`
The process cannot access the file because it is being used by another process.
Error: Failed to open file extras\usd\tutorials\convertingLayerFormats\Sphere.usd, exiting.

