### PR TITLE
[usdImaging] Fix default values for displayColor, displayOpacity, and widths

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -2231,23 +2231,20 @@ UsdImagingDelegate::Get(SdfPath const& id, TfToken const& key)
             // XXX: Getting all primvars here when we only want color is wrong.
             _UpdateSingleValue(cachePath,HdChangeTracker::DirtyPrimvar);
             if (!TF_VERIFY(_valueCache.ExtractColor(cachePath, &value))){
-                VtVec3fArray vec(1);
-                vec.push_back(GfVec3f(.5,.5,.5));
+                VtVec3fArray vec(1, GfVec3f(.5,.5,.5));
                 value = VtValue(vec);
             }
         } else if (key == HdTokens->displayOpacity) {
             // XXX: Getting all primvars here when we only want opacity is bad.
             _UpdateSingleValue(cachePath,HdChangeTracker::DirtyPrimvar);
             if (!TF_VERIFY(_valueCache.ExtractOpacity(cachePath, &value))){
-                VtFloatArray vec(1);
-                vec.push_back(1.0f);
+                VtFloatArray vec(1, 1.0f);
                 value = VtValue(vec);
             }
         } else if (key == HdTokens->widths) {
             _UpdateSingleValue(cachePath,HdChangeTracker::DirtyWidths);
             if (!TF_VERIFY(_valueCache.ExtractWidths(cachePath, &value))){
-                VtFloatArray vec(1);
-                vec.push_back(1.0f);
+                VtFloatArray vec(1, 1.0f);
                 value = VtValue(vec);
             }
         } else if (key == HdTokens->transform) {


### PR DESCRIPTION
Changes the usdImaging delegate to deliver a proper single value instead of current return of GfVec3f[2] or float[2] when the ExtractXXX function fails for displayColor, displayOpacity, and widths.

.