### PR TITLE
[garch] Fix GarchGLDebugWindow window creation

### DIFF
--- a/pxr/imaging/garch/glPlatformDebugWindowWindows.cpp
+++ b/pxr/imaging/garch/glPlatformDebugWindowWindows.cpp
@@ -55,6 +55,7 @@ Garch_GLPlatformDebugWindow::Garch_GLPlatformDebugWindow(GarchGLDebugWindow *w)
     , _hWND(NULL)
     , _hDC(NULL)
     , _hGLRC(NULL)
+    , _callback(w)
 {
 }
 
@@ -64,7 +65,7 @@ Garch_GLPlatformDebugWindow::Init(const char *title,
 {
     // platform initialize
     WNDCLASS wc;
-    HINSTANCE _hInstnace = GetModuleHandle(NULL);
+    _hInstance = GetModuleHandle(NULL);
     if (GetClassInfo(_hInstance, _className, &wc) == 0) {
         ZeroMemory(&wc, sizeof(WNDCLASS));
 
@@ -166,7 +167,7 @@ Garch_GLPlatformDebugWindow::_MsgProc(HWND hWnd, UINT msg,
     Garch_GLPlatformDebugWindow *window
         = Garch_GLPlatformDebugWindow::_GetWindowByHandle(hWnd);
     if (!TF_VERIFY(window)) {
-        return 0;
+        return DefWindowProc(hWnd, msg, wParam, lParam);
     }
 
     int x = LOWORD(lParam);


### PR DESCRIPTION
This allows a GarchGLDebugWindow to be created on Windows as well.

### Description of Change(s)
- _callback is initialised
- _hInstance used as intended
- Fixed _MsgProc to call DefWindowProc during window creation

### Fixes Issue(s)
- Garch_GLPlatformDebugWindow aborted during Init() on Windows

