### PR TITLE
[usdGenSchema] Fix incorrect get attribute docstrings being written in tokens.h

### DIFF
--- a/pxr/usd/usd/usdGenSchema.py
+++ b/pxr/usd/usd/usdGenSchema.py
@@ -829,7 +829,7 @@ def GatherTokens(classes, libName, libTokens):
             if attr.typeName == Sdf.ValueTypeNames.Token and attr.fallback:
                 fallbackName = _CamelCase(attr.fallback)
                 desc = 'Default value for %s::Get%sAttr()' % \
-                       (cls.cppClassName, _ProperCase(attr.name))
+                       (cls.cppClassName, _ProperCase(attr.apiName))
                 cls.tokens.add(fallbackName)
                 _AddToken(tokenDict, fallbackName, attr.fallback, desc)
             
@@ -841,7 +841,7 @@ def GatherTokens(classes, libName, libTokens):
                     if val != '':
                         tokenId = _CamelCase(val)
                         desc = 'Possible value for %s::Get%sAttr()' % \
-                               (cls.cppClassName, _ProperCase(attr.name))
+                               (cls.cppClassName, _ProperCase(attr.apiName))
                         cls.tokens.add(tokenId)
                         _AddToken(tokenDict, tokenId, val, desc)
 

--- a/pxr/usd/usdShade/tokens.h
+++ b/pxr/usd/usdShade/tokens.h
@@ -88,7 +88,7 @@ struct UsdShadeTokensType {
     const TfToken full;
     /// \brief "id"
     /// 
-    /// Possible value for UsdShadeShader::GetInfoImplementationSourceAttr(), Default value for UsdShadeShader::GetInfoImplementationSourceAttr()
+    /// Possible value for UsdShadeShader::GetImplementationSourceAttr(), Default value for UsdShadeShader::GetImplementationSourceAttr()
     const TfToken id;
     /// \brief "info:id"
     /// 
@@ -148,11 +148,11 @@ struct UsdShadeTokensType {
     const TfToken sdrMetadata;
     /// \brief "sourceAsset"
     /// 
-    /// Possible value for UsdShadeShader::GetInfoImplementationSourceAttr()
+    /// Possible value for UsdShadeShader::GetImplementationSourceAttr()
     const TfToken sourceAsset;
     /// \brief "sourceCode"
     /// 
-    /// Possible value for UsdShadeShader::GetInfoImplementationSourceAttr()
+    /// Possible value for UsdShadeShader::GetImplementationSourceAttr()
     const TfToken sourceCode;
     /// \brief "strongerThanDescendants"
     /// 

--- a/pxr/usd/usdUI/tokens.h
+++ b/pxr/usd/usdUI/tokens.h
@@ -64,15 +64,15 @@ struct UsdUITokensType {
     USDUI_API UsdUITokensType();
     /// \brief "closed"
     /// 
-    /// Possible value for UsdUINodeGraphNodeAPI::GetUiNodegraphNodeExpansionStateAttr()
+    /// Possible value for UsdUINodeGraphNodeAPI::GetExpansionStateAttr()
     const TfToken closed;
     /// \brief "minimized"
     /// 
-    /// Possible value for UsdUINodeGraphNodeAPI::GetUiNodegraphNodeExpansionStateAttr()
+    /// Possible value for UsdUINodeGraphNodeAPI::GetExpansionStateAttr()
     const TfToken minimized;
     /// \brief "open"
     /// 
-    /// Possible value for UsdUINodeGraphNodeAPI::GetUiNodegraphNodeExpansionStateAttr()
+    /// Possible value for UsdUINodeGraphNodeAPI::GetExpansionStateAttr()
     const TfToken open;
     /// \brief "ui:description"
     /// 


### PR DESCRIPTION
### Description of Change(s)

1. in `usdGenSchema.py`, use `AttrInfo.apiName` instead of `name` to write the get attribute docstrings in `token.h`.
2. With the change from above, ran `usdGenSchema` against `schema.usda` for each schema library.

### Fixes Issue(s)
- #1105

