### PR TITLE
Balance HdxPrman_InteractiveContext::_Initialize and HdxPrman_InteractiveContext::End a bit better.

### DIFF
--- a/third_party/renderman-23/plugin/hdxPrman/context.cpp
+++ b/third_party/renderman-23/plugin/hdxPrman/context.cpp
@@ -552,19 +552,23 @@ void HdxPrman_InteractiveContext::End()
     }
 
     // Reset to initial state.
-    if (riley) {
-        riley->End();
-    }
     if (mgr) {
-        if(riley) {
+        if (riley) {
+            if (_didBeginRiley) {
+                _didBeginRiley = false;
+                riley->End();
+            }
             mgr->DestroyRiley(riley);
+            riley = nullptr;
         }
         mgr = nullptr;
     }
-    riley = nullptr;
-    if (rix) {
+
+    // k_RixXcpt has only been regsitered after a succesful ri instatiation
+    if (rix && ri) {
         RixXcpt* rix_xcpt = (RixXcpt*)rix->GetRixInterface(k_RixXcpt);
         rix_xcpt->Unregister(&xcpt);
+        rix = nullptr;
     }
     if (ri) {
         ri->PRManEnd();


### PR DESCRIPTION
### Description of Change(s)
Balance HdxPrman_InteractiveContext::_Initialize and HdxPrman_InteractiveContext::End a bit better.
 
### Fixes Issue(s)
https://github.com/Autodesk/maya-usd loads up each delegate once to get their settings, and Prman can intermittently segfault on destruction.
