### PR TITLE
Fix the typo for building USD on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ then build and install USD into ```/opt/local/USD```.
 Launch the "Developer Command Prompt" for your version of Visual Studio and 
 run the script in the opened shell. Make sure to use the 64-bit (x64) command
 prompt and not the 32-bit (x86) command prompt.  (Note if you're trying to
-build with Visual Studio 2017, use the "x86 Native Tools Command Prompt for VS
+build with Visual Studio 2017, use the "x64 Native Tools Command Prompt for VS
 2017").
 
 See https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs for more details.


### PR DESCRIPTION
Visual Studio is a 32 bit application, however certain components (e.g. MSBuild, compilers, etc... ) are 64-bit if available.

https://developercommunity.visualstudio.com/content/problem/517541/vs-2019-downloaded-x64-version-installed-x86.html