### PR TITLE
Fix libGLEW.2.0.0.dylib entry containing hardcoded name in it's LC_LOAD_DYLIB entry.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -40,6 +40,7 @@ import sys
 import tarfile
 import urllib2
 import zipfile
+import string
 
 # Helpers for printing output
 verbosity = 1
@@ -211,6 +212,13 @@ def Run(cmd, logCommandOutput = True):
                 Print(logfile.read())
         raise RuntimeError("Failed to run '{cmd}'\nSee {log} for more details."
                            .format(cmd=cmd, log=os.path.abspath("log.txt")))
+
+def CallCmd(cmd, args):
+    try:
+        syscmd = cmd + ' ' + string.join(args)
+        os.system(syscmd)
+    except Exception as exp:
+        PrintError("System error executing : {exp}".format(exp=exp))
 
 @contextlib.contextmanager
 def CurrentWorkingDirectory(dir):
@@ -797,6 +805,10 @@ def InstallGLEW_LinuxOrMacOS(context, force, buildArgs):
             .format(instDir=context.instDir,
                     procs=context.numJobs,
                     buildArgs=" ".join(buildArgs)))
+        if MacOS():
+            libGLEW = "libGLEW.2.0.0.dylib"
+            path = os.path.join(context.instDir, "lib", libGLEW)
+            CallCmd('install_name_tool', ['-id', "@rpath/" + libGLEW, path])
 
 GLEW = Dependency("GLEW", InstallGLEW, "include/GL/glew.h")
 


### PR DESCRIPTION
### Description of Problem

libGLEW.2.0.0.dylib  is currently installed with a hardcoded path in it's `LC_ID_DYLIB` entry, making it impossible to relocate the USD code base around.

We started hitting this issue after shipping USD with Maya. In Maya, we are not installing certain libraries that comes with USD(e.g GLEW, TBB, OSD) and rather we link against the versions that are shipped with Maya.

However, libGLEW.2.0.0.dylib  entry name that is installed with USD comes with a hardcoded path, causing all the USD shared libraries that link against this library to end up with a hardcoded path in their names.

For example when libGLEW.2.0.0.dylib is installed via "build_usd.py" script, it's LC_ID_DYLIB comes with a hardcoded path

otool -l libGLEW.2.0.0.dylib

```
cmd LC_ID_DYLIB
cmdsize 80
name /Users/sabrih/Desktop/USD2002/lib/libGLEW.2.0.0.dylib (offset 24)
```

Now another library (e.g libhgiGL) that has a dependency to libglew ends up with the hard-coded name in it's `LC_LOAD_DYLIB` entry:

otool -l libhgiGL.dylib

```
Load command 12
cmd LC_LOAD_DYLIB
cmdsize 80
name /Users/sabrih/Desktop/USD2002/lib/libGLEW.2.0.0.dylib (offset 24)
```

On MacOSX, a *.dylib has an entry for its own name `LC_ID_DYLIB` and an entry for for its dependencies `LC_LOAD_DYLIB`. The entries should always have either @loader_path or @rpath to make the code relocatable.

### Fixes Issue(s)
After libGLEW.2.0.0.dylib is installed, I use `install_name_tool` to set the `LC_ID_DYLIB` with `@rpath ` entry.

```
Load command 3
cmd LC_ID_DYLIB
cmdsize 56
name @rpath/libGLEW.2.0.0.dylib (offset 24)
```

### Platform

MacOS
