### PR TITLE
[extras] Don't build imaging extras if imaging is disabled.

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(usd)
-add_subdirectory(imaging)
+if (${PXR_BUILD_IMAGING})
+    add_subdirectory(imaging)
+endif()


### PR DESCRIPTION
### Description of Change(s)

Don't try to build hdTiny if imaging is disabled.

### Fixes Issue(s)
--no-imaging fails when building hdTiny.

