### PR TITLE
[hdx] Report GL errors during teardown only if GL operations were actually performed.

### DIFF
--- a/pxr/imaging/hdx/colorChannelTask.cpp
+++ b/pxr/imaging/hdx/colorChannelTask.cpp
@@ -70,12 +70,16 @@ HdxColorChannelTask::HdxColorChannelTask(HdSceneDelegate* delegate,
 
 HdxColorChannelTask::~HdxColorChannelTask()
 {
+    bool performedGLOperation = false;
+
     if (_texture != 0) {
         glDeleteTextures(1, &_texture);
+        performedGLOperation = true;
     }
 
     if (_vertexBuffer != 0) {
         glDeleteBuffers(1, &_vertexBuffer);
+        performedGLOperation = true;
     }
 
     if (_shaderProgram) {
@@ -84,9 +88,12 @@ HdxColorChannelTask::~HdxColorChannelTask()
 
     if (_copyFramebuffer != 0) {
         glDeleteFramebuffers(1, &_copyFramebuffer);
+        performedGLOperation = true;
     }
 
-    GLF_POST_PENDING_GL_ERRORS();
+    if (performedGLOperation) {
+        GLF_POST_PENDING_GL_ERRORS();
+    }
 }
 
 bool

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -81,16 +81,21 @@ HdxColorCorrectionTask::HdxColorCorrectionTask(HdSceneDelegate* delegate,
 
 HdxColorCorrectionTask::~HdxColorCorrectionTask()
 {
+    bool performedGLOperation = false;
+
     if (_texture != 0) {
         glDeleteTextures(1, &_texture);
+        performedGLOperation = true;
     }
 
     if (_texture3dLUT != 0) {
         glDeleteTextures(1, &_texture3dLUT);
+        performedGLOperation = true;
     }
 
     if (_vertexBuffer != 0) {
         glDeleteBuffers(1, &_vertexBuffer);
+        performedGLOperation = true;
     }
 
     if (_shaderProgram) {
@@ -99,13 +104,16 @@ HdxColorCorrectionTask::~HdxColorCorrectionTask()
 
     if (_copyFramebuffer != 0) {
         glDeleteFramebuffers(1, &_copyFramebuffer);
+        performedGLOperation = true;
     }
 
     if (_aovFramebuffer != 0) {
         glDeleteFramebuffers(1, &_aovFramebuffer);
+        performedGLOperation = true;
     }
-
-    GLF_POST_PENDING_GL_ERRORS();
+    if (performedGLOperation) {
+        GLF_POST_PENDING_GL_ERRORS();
+    }
 }
 
 std::string


### PR DESCRIPTION
This isn't urgent per se, but we've noticed cases where errors get reported during hdx teardown even when gl operations are not performed. It's arguable that this change is hiding real problems, but reporting them during teardown hasn't been really helpful to developers and certainly not users, and has sometimes led to drastic measures like disabling tf diagnostics entirely.

Figured I'd float it by you all before 20.05 enters codefreeze. Thanks!