### PR TITLE
Allow displaying of unloaded prims as bounding boxes

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -253,12 +253,13 @@ public:
     void SetWindowPolicy(CameraUtilConformWindowPolicy policy);
 
     /// Sets display of unloaded prims as bounding boxes.
-    /// Unloaded prims will need to satisfay one of the following set of
+    /// Unloaded prims will need to satisfy one of the following set of
     /// conditions in order to see them:
     ///   1. The prim is a UsdGeomBoundable with an authored 'extent' attribute.
     ///   2. The prim is a UsdPrim.IsModel() and has an authored 'extentsHint'
     ///      attribute (see UsdGeomModelAPI::GetExtentsHint).
-    /// Effective only for delegates that support draw modes.
+    /// Effective only for delegates that support draw modes (see
+    /// GetUsdDrawModesEnabled()).
     USDIMAGING_API
     void SetDisplayUnloadedPrimsWithBounds(bool displayUnloaded);
     bool GetDisplayUnloadedPrimsWithBounds() const {

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -252,6 +252,19 @@ public:
     USDIMAGING_API
     void SetWindowPolicy(CameraUtilConformWindowPolicy policy);
 
+    /// Sets display of unloaded prims as bounding boxes.
+    /// Unloaded prims will need to satisfay one of the following set of
+    /// conditions in order to see them:
+    ///   1. The prim is a UsdGeomBoundable with an authored 'extent' attribute.
+    ///   2. The prim is a UsdPrim.IsModel() and has an authored 'extentsHint'
+    ///      attribute (see UsdGeomModelAPI::GetExtentsHint).
+    /// Effective only for delegates that support draw modes.
+    USDIMAGING_API
+    void SetDisplayUnloadedPrimsWithBounds(bool displayUnloaded);
+    bool GetDisplayUnloadedPrimsWithBounds() const {
+        return _displayUnloadedPrimsWithBounds;
+    }
+
     /// Setup for the shutter open and close to be used for motion sampling.
     USDIMAGING_API
     void SetCameraForSampling(SdfPath const& id);
@@ -744,6 +757,16 @@ private:
 
     // Enable HdCoordSys tracking
     const bool _coordSysEnabled;
+
+    // Display unloaded prims with Bounds adapter
+    bool _displayUnloadedPrimsWithBounds;
+
+    Usd_PrimFlagsConjunction _GetDisplayPredicate() const
+    {
+        return _displayUnloadedPrimsWithBounds ?
+            UsdPrimIsActive && UsdPrimIsDefined && !UsdPrimIsAbstract :
+            UsdPrimDefaultPredicate;
+    }
 
     UsdImagingDelegate() = delete;
     UsdImagingDelegate(UsdImagingDelegate const &) = delete;

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -230,7 +230,7 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
         // Allocate prototype prims.
         // -------------------------------------------------------------- //
 
-        UsdPrimRange range(masterPrim);
+        UsdPrimRange range(masterPrim, _GetDisplayPredicate());
         int protoID = 0;
         int primCount = 0;
 

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -253,7 +253,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
     size_t instantiatedPrimCount = 0;
 
     std::vector<UsdPrimRange> treeStack;
-    treeStack.push_back(UsdPrimRange(protoRootPrim));
+    treeStack.push_back(UsdPrimRange(protoRootPrim, _GetDisplayPredicate()));
     while (!treeStack.empty()) {
         if (!treeStack.back()) {
             treeStack.pop_back();
@@ -275,7 +275,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
         // XXX: Should we delegate to instanceAdapter here?
         if (iter->IsInstance()) {
             UsdPrim master = iter->GetMaster();
-            UsdPrimRange masterRange(master);
+            UsdPrimRange masterRange(master, _GetDisplayPredicate());
             treeStack.push_back(masterRange);
 
             // Make sure to register a dependency on this instancer with the

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -876,6 +876,12 @@ UsdImagingPrimAdapter::_GetCurrentTimeSamplingInterval()
     return _delegate->GetCurrentTimeSamplingInterval();
 }
 
+Usd_PrimFlagsConjunction
+UsdImagingPrimAdapter::_GetDisplayPredicate() const
+{
+    return _delegate->_GetDisplayPredicate();
+}
+
 size_t
 UsdImagingPrimAdapter::SampleTransform(
     UsdPrim const& prim, 

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -580,6 +580,9 @@ protected:
     GfInterval _GetCurrentTimeSamplingInterval();
 
     USDIMAGING_API
+    Usd_PrimFlagsConjunction _GetDisplayPredicate() const;
+
+    USDIMAGING_API
     bool _DoesDelegateSupportCoordSys() const;
 
     // Conversion functions between usd and hydra enums.

--- a/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
+++ b/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
@@ -1096,6 +1096,9 @@ UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
     TfTokenVector purposes = { UsdGeomTokens->default_, UsdGeomTokens->proxy,
                                UsdGeomTokens->render };
 
+    // XXX: The use of UsdTimeCode::EarliestTime() in the code below is
+    // problematic, as it may produce unexpected results for animated models.
+
     if (prim.IsLoaded()) {
         UsdGeomBBoxCache bboxCache(
             UsdTimeCode::EarliestTime(), purposes, true);
@@ -1115,7 +1118,9 @@ UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
         }
         else if ((attr = UsdGeomModelAPI(prim).GetExtentsHintAttr()) &&
             attr.Get(&extentsHint, UsdTimeCode::EarliestTime()) &&
-            extentsHint.size() >= 2 && extentsHint.size() <= 8) {
+            extentsHint.size() >= 2) {
+            // XXX: This code to merge the extentsHint values over a set of
+            // purposes probably belongs in UsdGeomBBoxCache.
             const TfTokenVector &purposeTokens =
                 UsdGeomImageable::GetOrderedPurposeTokens();
             for (size_t i = 0; i < purposeTokens.size(); ++i) {

--- a/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
+++ b/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
@@ -140,9 +140,9 @@ UsdImagingGLDrawModeAdapter::Populate(UsdPrim const& prim,
     SdfPath instancer = instancerContext ?
         instancerContext->instancerCachePath : SdfPath();
 
-    // The draw mode adapter only supports models. This is enforced in
-    // UsdImagingDelegate::_IsDrawModeApplied.
-    if (!TF_VERIFY(prim.IsModel(), "<%s>",
+    // The draw mode adapter only supports models or unloaded prims.
+    // This is enforced in UsdImagingDelegate::_IsDrawModeApplied.
+    if (!TF_VERIFY(prim.IsModel() || !prim.IsLoaded(), "<%s>",
                    prim.GetPath().GetText())) {
         return SdfPath();
     }
@@ -1095,8 +1095,51 @@ UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
 
     TfTokenVector purposes = { UsdGeomTokens->default_, UsdGeomTokens->proxy,
                                UsdGeomTokens->render };
-    UsdGeomBBoxCache bboxCache(UsdTimeCode::EarliestTime(), purposes, true);
-    return bboxCache.ComputeUntransformedBound(prim).ComputeAlignedBox();
+
+    if (prim.IsLoaded()) {
+        UsdGeomBBoxCache bboxCache(
+            UsdTimeCode::EarliestTime(), purposes, true);
+        return bboxCache.ComputeUntransformedBound(prim).ComputeAlignedBox();
+    } else {
+        GfRange3d extent;
+        UsdAttribute attr;
+        VtVec3fArray extentsHint;
+        // Get the extent either from the authored extent attribute of a
+        // UsdGeomBoundable prim, or get the extentsHint attribute from the
+        // prim.
+        if (prim.IsA<UsdGeomBoundable>() &&
+            (attr = UsdGeomBoundable(prim).GetExtentAttr()) &&
+            attr.Get(&extentsHint, UsdTimeCode::EarliestTime()) &&
+            extentsHint.size() == 2) {
+            extent = GfRange3d(extentsHint[0], extentsHint[1]);
+        }
+        else if ((attr = UsdGeomModelAPI(prim).GetExtentsHintAttr()) &&
+            attr.Get(&extentsHint, UsdTimeCode::EarliestTime()) &&
+            extentsHint.size() >= 2 && extentsHint.size() <= 8) {
+            const TfTokenVector &purposeTokens =
+                UsdGeomImageable::GetOrderedPurposeTokens();
+            for (size_t i = 0; i < purposeTokens.size(); ++i) {
+                size_t idx = i*2;
+                // If extents are not available for the value of purpose,
+                // it implies that the rest of the bounds are empty.
+                if ((idx + 2) > extentsHint.size())
+                    break;
+                // If this purpose isn't one we are interested in, skip it.
+                if (std::find(purposes.begin(), purposes.end(),
+                              purposeTokens[i]) == purposes.end())
+                    continue;
+
+                GfRange3d purposeExtent =
+                    GfRange3d(extentsHint[idx], extentsHint[idx+1]);
+                // Extents for an unauthored geometry purpose may be empty,
+                // even though the extent for a later purpose may exist.
+                if (!purposeExtent.IsEmpty()) {
+                    extent.ExtendBy(purposeExtent);
+                }
+            }
+        }
+        return extent;
+    }
 }
 
 HdTextureResource::ID


### PR DESCRIPTION
Provide an optional feature in the UsdImagingDelegate to display unloaded
prims with payloads as bounding boxes. Requires that the prim is of Model
kind and has an extentsHint authored, or is a UsdGeomBoundable and has
an extent authored.

Built on the work from Animal Logic here:
https://github.com/AnimalLogic/USD/tree/display_unloaded_prims
And taking into account Pixar's recommendations here:
https://github.com/PixarAnimationStudios/USD/pull/788
And also adding support for native and point instanced primitives.
