### PR TITLE
boost: ignore potentially interfering site configs

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -618,7 +618,8 @@ def InstallBoost(context, force, buildArgs):
                 .format(variant="debug" if context.buildDebug else "release"),
             '--with-atomic',
             '--with-program_options',
-            '--with-regex'
+            '--with-regex',
+            '--ignore-site-config'
         ]
 
         if context.buildPython:


### PR DESCRIPTION
### Description of Change(s)
Some Linux distros have boost-jam site configurations which interfere with the boost build within the build_usd Python script.

### Fixes Issue(s)
- Ignoring boost site configs fixes this error:
```
./b2 --prefix="/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt" --build-dir="/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/build" -j32 address-model=64 link=shared runtime-link=shared threading=multi variant=release --with-atomic --with-program_options --with-regex --with-python install
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build/feature.jam:494: in feature.validate-value-string from module feature
error: "none" is not a known value of feature <optimization>
error: legal values: "off" "speed" "space"
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build/property.jam:276: in validate1 from module property
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build/property.jam:302: in property.validate from module property
/home/<redacted>dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/tools/builtin.jam:381: in variant from module builtin
/usr/share/boost-build/site-config.jam:9: in modules.load from module site-config
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build-system.jam:249: in load-config from module build-system
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build-system.jam:351: in load-configuration-files from module build-system
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/build-system.jam:524: in load from module build-system
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/kernel/modules.jam:295: in import from module modules
/home/<redacted>/dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/tools/build/src/kernel/bootstrap.jam:139: in boost-build from module
/home/<redacted>dev/libs/usd/USD.git-pybuild-opt/src/boost_1_61_0/boost-build.jam:17: in module scope from module
```

