### PR TITLE
Provide a virtual destructor for PcpDynamicFileFormatInterface

### DIFF
--- a/pxr/usd/pcp/dynamicFileFormatInterface.h
+++ b/pxr/usd/pcp/dynamicFileFormatInterface.h
@@ -47,9 +47,7 @@ class VtValue;
 class PcpDynamicFileFormatInterface
 {
 public:
-    /// Provide a virtual destructor defined in the header for better
-    /// compatibility with various compiler/linker combinations that may need
-    /// this to build plugins classes derived from this class.
+    /// Empty virtual destructor to prevent build errors with some compilers.
     virtual ~PcpDynamicFileFormatInterface() {}
 
     /// Derived classes must implement this function to compose prim fields 

--- a/pxr/usd/pcp/dynamicFileFormatInterface.h
+++ b/pxr/usd/pcp/dynamicFileFormatInterface.h
@@ -47,6 +47,11 @@ class VtValue;
 class PcpDynamicFileFormatInterface
 {
 public:
+    /// Provide a virtual destructor defined in the header for better
+    /// compatibility with various compiler/linker combinations that may need
+    /// this to build plugins classes derived from this class.
+    virtual ~PcpDynamicFileFormatInterface() {}
+
     /// Derived classes must implement this function to compose prim fields 
     /// using the given \p context and use them to generate file format 
     /// arguments for the layer at \p assetPath. The context provides methods 


### PR DESCRIPTION
Provide a virtual destructor for PcpDynamicFileFormatInterface to prevent
build errors with some compiler/linker combinations when building plugins
containing subclasses of this class. In particular, gcc compilers with
-Werror=non-virtual-dtor would fail without this.

### Description of Change(s)
Add an empty virtual destructor to the abstract PcpDynamicFileFormatInterface base class.