### PR TITLE
[usdMtlx] Use Export in test instead of ExportToString

### DIFF
--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.py
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.py
@@ -115,8 +115,7 @@ class TestFileFormat(unittest.TestCase):
         """
 
         stage = UsdMtlx._TestFile('NodeGraphs.mtlx', nodeGraphs=True)
-        with open('NodeGraphs.usda', 'w') as f:
-            print(stage.GetRootLayer().ExportToString(), file=f)
+        stage.GetRootLayer().Export('NodeGraphs.usda')
 
     def test_MultiBindInputs(self):
         """
@@ -151,8 +150,7 @@ class TestFileFormat(unittest.TestCase):
         """
 
         stage = UsdMtlx._TestFile('Looks.mtlx')
-        with open('Looks.usda', 'w') as f:
-            print(stage.GetRootLayer().ExportToString(), file=f)
+        stage.GetRootLayer().Export('Looks.usda')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
@@ -586,4 +586,3 @@ def "ModelRoot" (
     }
 }
 
-

--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/NodeGraphs.usda
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/NodeGraphs.usda
@@ -230,4 +230,3 @@ def "MaterialX"
     }
 }
 
-


### PR DESCRIPTION
Updating this test based on conversations when we reviewed some python 3 related changes. This switches to using a layer export instead of opening a file and writing to it using ExportToString. Each baseline needed to have a new line removed from the end, but they are identical aside from that.
