### PR TITLE
Fix UsdFlattenLayerStack to handle time sampled asset paths

### DIFF
--- a/pxr/usd/usd/flattenUtils.cpp
+++ b/pxr/usd/usd/flattenUtils.cpp
@@ -325,53 +325,65 @@ _FixAssetPaths(const SdfLayerHandle &sourceLayer,
                const UsdFlattenResolveAssetPathFn& resolveAssetPathFn,
                VtValue *val)
 {
+    static auto updateAssetPathFn = [](
+        const SdfLayerHandle &sourceLayer,
+        const UsdFlattenResolveAssetPathFn& resolveAssetPathFn,
+        VtValue &val) {
+            SdfAssetPath ap;
+            val.Swap(ap);
+            ap = SdfAssetPath(
+                    resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
+            val.Swap(ap);
+        };
+    static auto updateAssetPathArrayFn = [](
+        const SdfLayerHandle &sourceLayer,
+        const UsdFlattenResolveAssetPathFn& resolveAssetPathFn,
+        VtValue &val) {
+            VtArray<SdfAssetPath> a;
+            val.Swap(a);
+            for (SdfAssetPath &ap: a) {
+                ap = SdfAssetPath(
+                        resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
+            }
+            val.Swap(a);
+        };
+
     if (val->IsHolding<SdfAssetPath>()) {
-        SdfAssetPath ap;
-        val->Swap(ap);
-        ap = SdfAssetPath(resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
-        val->Swap(ap);
+        updateAssetPathFn(sourceLayer, resolveAssetPathFn, *val);
         return;
     }
     else if (val->IsHolding<VtArray<SdfAssetPath>>()) {
-        VtArray<SdfAssetPath> a;
-        val->Swap(a);
-        for (SdfAssetPath &ap: a) {
-            ap = SdfAssetPath(
-                    resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
-        }
-        val->Swap(a);
+        updateAssetPathArrayFn(sourceLayer, resolveAssetPathFn, *val);
         return;
     }
     else if (val->IsHolding<SdfTimeSampleMap>()) {
-        // Quick test that the first entry of the time sample map is holding
-        // either an asset path or an array of asset paths.
         const SdfTimeSampleMap &tsmc = val->UncheckedGet<SdfTimeSampleMap>();
-        if (!tsmc.empty() &&
-            (tsmc.begin()->second.IsHolding<SdfAssetPath>() ||
-             tsmc.begin()->second.IsHolding<VtArray<SdfAssetPath>>())) {
-            SdfTimeSampleMap tsmap;
-            val->Swap(tsmap);
-            // Go through each time sampled value and execute the resolve
-            // function on each asset path (or array of asset paths).
-            TF_FOR_ALL(ts, tsmap) {
-                if (ts->second.IsHolding<SdfAssetPath>()) {
-                    SdfAssetPath ap;
-                    ts->second.Swap(ap);
-                    ap = SdfAssetPath(
-                        resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
-                    ts->second.Swap(ap);
-                }
-                else if (ts->second.IsHolding<VtArray<SdfAssetPath>>()) {
-                    VtArray<SdfAssetPath> a;
-                    ts->second.Swap(a);
-                    for (SdfAssetPath &ap: a) {
-                        ap = SdfAssetPath(
-                            resolveAssetPathFn(sourceLayer, ap.GetAssetPath()));
+        if (!tsmc.empty()) {
+            // Quick test that the first entry of the time sample map is
+            // holding either an asset path or an array of asset paths.
+            bool holdingAssetPath = 
+                tsmc.begin()->second.IsHolding<SdfAssetPath>();
+            bool holdingAssetPathArray = 
+                tsmc.begin()->second.IsHolding<VtArray<SdfAssetPath>>();
+            if (holdingAssetPath || holdingAssetPathArray) {
+                SdfTimeSampleMap tsmap;
+                val->Swap(tsmap);
+                // Go through each time sampled value and execute the resolve
+                // function on each asset path (or array of asset paths).
+                if (holdingAssetPath) {
+                    for (auto &ts : tsmap) {
+                        updateAssetPathFn(
+                            sourceLayer, resolveAssetPathFn, ts.second);
                     }
-                    ts->second.Swap(a);
                 }
+                else { // holdingAssetPathArray must be true
+                    for (auto &ts : tsmap) {
+                        updateAssetPathArrayFn(
+                            sourceLayer, resolveAssetPathFn, ts.second);
+                    }
+                }
+                val->Swap(tsmap);
             }
-            val->Swap(tsmap);
         }
     }
     else if (val->IsHolding<SdfReference>()) {

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack/time_sampled_assets.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack/time_sampled_assets.usda
@@ -1,0 +1,64 @@
+#usda 1.0
+(
+    doc = """Generated from Composed Stage of root layer /home/mtucker/USD/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack/combined.usda
+"""
+    endTimeCode = 2
+    framesPerSecond = 24
+    metersPerUnit = 1
+    startTimeCode = 1
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+def Volume "volume"
+{
+    custom rel field:density = </volume/density>
+
+    def OpenVDBAsset "density"
+    {
+        token fieldName.timeSamples = {
+            1: "density",
+            2: "density",
+        }
+        asset filePath.timeSamples = {
+            1: @/home/mtucker/USD/pxr/usd/usdUtils/testenv/volumes/vol.1.vdb@,
+            2: @/home/mtucker/USD/pxr/usd/usdUtils/testenv/volumes/vol.2.vdb@,
+        }
+    }
+}
+
+def Cube "cube"
+{
+    rel material:binding = </materials/usdpreviewsurface1>
+    double size = 2
+    matrix4d xformOp:transform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+    uniform token[] xformOpOrder = ["xformOp:transform"]
+}
+
+def Scope "materials"
+{
+    def Material "usdpreviewsurface1"
+    {
+        token outputs:displacement.connect = </materials/usdpreviewsurface1/usdpreviewsurface1.outputs:displacement>
+        token outputs:surface.connect = </materials/usdpreviewsurface1/usdpreviewsurface1.outputs:surface>
+
+        def Shader "usdpreviewsurface1"
+        {
+            uniform token info:id = "UsdPreviewSurface"
+            color3f inputs:diffuseColor.connect = </materials/usdpreviewsurface1/usduvtexture1.outputs:rgb>
+            token outputs:displacement
+            token outputs:surface
+        }
+
+        def Shader "usduvtexture1"
+        {
+            uniform token info:id = "UsdUVTexture"
+            asset[] inputs:file.timeSamples = {
+                1: [@/home/mtucker/USD/pxr/usd/usdUtils/testenv/textures/clr.1.png@, @/home/mtucker/USD/pxr/usd/usdUtils/testenv/textures/clr.1.png@],
+                2: [@/home/mtucker/USD/pxr/usd/usdUtils/testenv/textures/clr.2.png@, @/home/mtucker/USD/pxr/usd/usdUtils/testenv/textures/clr.2.png@],
+            }
+            vector3f outputs:rgb
+        }
+    }
+}
+


### PR DESCRIPTION
### Description of Change(s)

Add code to handle time sampled asset paths or arrays of asset paths when
flattening a layer stack. This complements the existing code for fixing
single asset paths or arrays of asset paths.

### Fixes Issue(s)
- #1168 
