### PR TITLE
Fix O(N^2) algorithm on the number of geometry subsets in Hydra

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -59,6 +59,7 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/hashset.h"
+#include "pxr/base/tf/denseHashset.h"
 
 #include <boost/container/flat_map.hpp>
 #include <tbb/spin_rw_mutex.h>
@@ -591,7 +592,8 @@ private:
         HdDirtyBits       timeVaryingBits;  // Dirty Bits to set when
                                             // time changes
         HdDirtyBits       dirtyBits;        // Current dirty state of the prim.
-        SdfPathSet        extraDependencies;// Dependencies that aren't usdPrim.
+        TfDenseHashSet<SdfPath, SdfPath::Hash>
+                          extraDependencies;// Dependencies that aren't usdPrim.
     };
 
     typedef TfHashMap<SdfPath, _HdPrimInfo, SdfPath::Hash> _HdPrimInfoMap;

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -591,7 +591,7 @@ private:
         HdDirtyBits       timeVaryingBits;  // Dirty Bits to set when
                                             // time changes
         HdDirtyBits       dirtyBits;        // Current dirty state of the prim.
-        SdfPathVector     extraDependencies;// Dependencies that aren't usdPrim.
+        SdfPathSet        extraDependencies;// Dependencies that aren't usdPrim.
     };
 
     typedef TfHashMap<SdfPath, _HdPrimInfo, SdfPath::Hash> _HdPrimInfoMap;

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -59,7 +59,7 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/hashset.h"
-#include "pxr/base/tf/denseHashset.h"
+#include "pxr/base/tf/denseHashSet.h"
 
 #include <boost/container/flat_map.hpp>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/usdImaging/usdImaging/indexProxy.cpp
+++ b/pxr/usdImaging/usdImaging/indexProxy.cpp
@@ -152,9 +152,7 @@ UsdImagingIndexProxy::AddDependency(SdfPath const& cachePath,
     }
 
     SdfPath usdPath = usdPrim.GetPath();
-    if (std::find(primInfo->extraDependencies.cbegin(),
-                  primInfo->extraDependencies.cend(),
-                  usdPath) != primInfo->extraDependencies.cend()) {
+    if (primInfo->extraDependencies.count(usdPath) != 0) {
         // XXX: Ideally, we'd TF_VERIFY here, but usd resyncs can
         // sometimes cause double-inserts (see _AddHdPrimInfo), so we need to
         // silently guard against this.
@@ -163,7 +161,7 @@ UsdImagingIndexProxy::AddDependency(SdfPath const& cachePath,
 
     _delegate->_dependencyInfo.insert(
         UsdImagingDelegate::_DependencyMap::value_type(usdPath, cachePath));
-    primInfo->extraDependencies.push_back(usdPath);
+    primInfo->extraDependencies.insert(usdPath);
 
     TF_DEBUG(USDIMAGING_CHANGES).Msg("[Add dependency] <%s> -> <%s>\n",
         usdPath.GetText(), cachePath.GetText());


### PR DESCRIPTION
Fix O(N^2) algorithm when displaying a mesh with a very large number of geometry subsets on it. Use a Set instead of a Vector for extraDependencies. This was resulting in extremely long update times in Hydra when asked to display a mesh with 500K geomsubsets in the Moana island scene (ignoring the wisdom of organizing the USD that way).

### Description of Change(s)
Replace the use of an SdfPathVector with an SdfPathSet to avoid linear search costs.