### PR TITLE
Make SdfPathTable::_EraseSubtreeAndSiblings non-recursive

### DIFF
--- a/pxr/usd/sdf/pathTable.h
+++ b/pxr/usd/sdf/pathTable.h
@@ -631,9 +631,13 @@ private:
         _EraseSubtree(entry);
 
         // And siblings.
-        if (_Entry * const nextSibling = entry->GetNextSibling()) {
-            _EraseSubtreeAndSiblings(nextSibling);
-            _EraseFromTable(nextSibling);
+        _Entry *sibling = entry->GetNextSibling();
+        _Entry *nextSibling = sibling ? sibling->GetNextSibling() : nullptr;
+        while (sibling) {
+            _EraseSubtree(sibling);
+            _EraseFromTable(sibling);
+            sibling = nextSibling;
+            nextSibling = sibling ? sibling->GetNextSibling() : nullptr;
         }
     }
 


### PR DESCRIPTION
Make the SdfPathTable::_EraseSubtreeAndSiblings function non-recursive, so there is no risk of running out of stack space even with an incredibly large number of siblings.

### Description of Change(s)
Replaced a recursive implementation of iteration with a non-recursive iteration. The resulting ordering of calls to _EraseFromTable is reversed (first to last instead of last to first), but looking at _EraseFromTable I don't think this should make any difference.

### Fixes Issue(s)
- Relates to https://github.com/PixarAnimationStudios/USD/pull/1170 which describes performance issues when viewing a mesh with 500K subsets. This recursive algorithm was crashing when I then tried to remove this mesh from hydra.