### PR TITLE
Multithread calls to RefreshUsdObject.

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -472,6 +472,7 @@ public:
 private:
     // Internal friend class.
     class _Worker;
+    class _RefreshWorker;
     friend class UsdImagingIndexProxy;
     friend class UsdImagingPrimAdapter;
 
@@ -501,15 +502,19 @@ private:
     void _OnUsdObjectsChanged(UsdNotice::ObjectsChanged const&,
                               UsdStageWeakPtr const& sender);
 
+    // Execute all object refresh tasks that have been added to the given
+    // worker.
+    void _ExecuteWorkForObjectRefresh(_RefreshWorker* worker);
+
     // The lightest-weight update, it does fine-grained invalidation of
     // individual properties at the given path (prim or property).
     //
     // If \p path is a prim path, changedPrimInfoFields will be populated
     // with the list of scene description fields that caused this prim to
     // be refreshed.
-    void _RefreshUsdObject(SdfPath const& usdPath, 
-                           TfTokenVector const& changedPrimInfoFields,
-                           UsdImagingIndexProxy* proxy);
+    void _RefreshUsdObject(_RefreshWorker *worker,
+                           SdfPath const& usdPath, 
+                           TfTokenVector const* changedPrimInfoFields=nullptr);
 
     // Heavy-weight invalidation of an entire prim subtree. All cached data is
     // reconstructed for all prims below \p rootPath.


### PR DESCRIPTION
The goal of this commit is to multithread calls to TrackVariability in the face of a large number of changes being processed by Hydra at once. Basically trying to fulfill the comment in _RefreshUsdObject which says "PERFORMANCE: We could execute this in parallel, for large numbers of prims."

This addresses performance issues when hiding or display large number of prims. The ApplyPendingChanges call would consume the vast bulk of the time calling TrackVariability in a single thread. Hiding half your prims could take several times longer than displaying them all in the first place (depending on the number of CPUs).

### Description of Change(s)
The goal was to execute TrackVariability (invoked by RefreshUsdObject) in parallel during an update. The implementation was complicated by the intermingling of _ResyncUsdPrim calls which I believe are not thread safe with the RefreshUsdObject calls. Also, in some cases we get a large number of small changes, where multithreading within RefreshUsdObject wouldn't help. So I moved the multithreading up to ApplyPendingUpdates method. _RefreshUsdObject now just collects a bunch of work to be done, and _ResyncUsdPrim calls are similarly queued up. Then the actual work of RefreshUsdObject is done in multiple threads, followed by all the ResyncUsdPrim calls in a single thread. This is managed by a new _RefreshWorker class.

Obviously the ordering of operations is not maintained faithfully but I believe the overall work done by the single and multithreaded versions should be the same.

One obvious downside to all this is that it adds useless overhead for small numbers of changes. I'm not sure how to address this without branching the code. And this question is complicated by the fact that you can't in general tell how many changes there will be until you've already gone through the changes.