### PR TITLE
Clear primInfo->extraDependencies in _RemoveDependencies

### DIFF
--- a/pxr/usdImaging/usdImaging/indexProxy.cpp
+++ b/pxr/usdImaging/usdImaging/indexProxy.cpp
@@ -115,6 +115,7 @@ UsdImagingIndexProxy::_RemoveDependencies(SdfPath const& cachePath)
             UsdImagingDelegate::_DependencyMap::value_type(
                 dep, cachePath));
     }
+    primInfo->extraDependencies.clear();
 }
 
 void


### PR DESCRIPTION
Clear primInfo->extraDependencies in _RemoveDependencies after they have been
added to _dependenciesToRemove. Previously the contents of this set were never
cleared, and removing many prims would add N copies of the N extraDependencies
to the _dependenciesToRemove vector, chewing up enormous time and memory.

### Description of Change(s)
The extraDependencies data on the UsdImagingDelegate::_HdPrimInfo object is currently never cleared. This change is an experiment requested by @c64kernal on https://github.com/PixarAnimationStudios/USD/pull/1170 to see if your internal regression tests still pass with this change in place. My testing in Houdini so far shows no ill effects from clearing this, and shows massive performance improvements when removing a mesh prim with many thousands of geometry subsets on it. I believe this change should be independent of whether PR 1170 (which changes extraDependencies from an SdfPathVector to a DenseHashSet) is applied.