### PR TITLE
Resolve UDIM tiles path

### DIFF
--- a/pxr/usdImaging/usdImaging/textureUtils.cpp
+++ b/pxr/usdImaging/usdImaging/textureUtils.cpp
@@ -58,7 +58,7 @@ UsdImaging_GetUdimTiles(
                 layerHandle, TfStringPrintf(formatString.c_str(), t))
             : TfStringPrintf(formatString.c_str(), t);
         if (!resolver.Resolve(path).empty()) {
-            ret.emplace_back(t - startTile, TfToken(path));
+            ret.emplace_back(t - startTile, TfToken(resolver.Resolve(path)));
         }
     }
     ret.shrink_to_fit();


### PR DESCRIPTION
### Description of Change(s)
Resolve UDIM tiles path instead of using the original asset path.

### Fixes Issue(s)
- UDIM textures are not loaded when they are referenced using URLs instead of file paths.

