### PR TITLE
[usdview] Fix _reopenStage for cases when launched with --norender

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -2639,7 +2639,8 @@ class AppController(QtCore.QObject):
 
         try:
             # Pause the stage view while we update
-            self._stageView.setUpdatesEnabled(False)
+            if self._stageView:
+                self._stageView.setUpdatesEnabled(False)
 
             # Clear out any Usd objects that may become invalid.
             self._dataModel.selection.clear()
@@ -2663,8 +2664,8 @@ class AppController(QtCore.QObject):
             self._resetView()
 
             self._stepSizeChanged()
-            self._stepSizeChanged()
-            self._stageView.setUpdatesEnabled(True)
+            if self._stageView:
+                self._stageView.setUpdatesEnabled(True)
         except Exception as err:
             self.statusMessage('Error occurred reopening Stage: %s' % err)
             traceback.print_exc()


### PR DESCRIPTION
### Description of Change(s)
Guard `self._stageView` usage and remove redundant `_stepSizeChanged` call.

### Fixes Issue(s)
Triggering a stage reload from **usdview** without an active renderer will currently fail.

