### PR TITLE
[hdx] Be more defensive about picking and buffer bounds.

### DIFF
--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -586,6 +586,12 @@ HdxPickResult::HdxPickResult(
     , _bufferSize(bufferSize)
     , _subRect(subRect)
 {
+    // Clamp _subRect [x,y,w,h] to render buffer [0,0,w,h]
+    _subRect[0] = std::max(0, _subRect[0]);
+    _subRect[1] = std::max(0, _subRect[1]);
+    _subRect[2] = std::min(_bufferSize[0]-_subRect[0], _subRect[2]);
+    _subRect[3] = std::min(_bufferSize[1]-_subRect[1], _subRect[3]);
+
     _eyeToWorld = viewMatrix.GetInverse();
     _ndcToWorld = (viewMatrix * projectionMatrix).GetInverse();
 }


### PR DESCRIPTION
### Description of Change(s)
Clamp subRect passed to `HdxPickResult` to `renderBuffer` bounds.
Verify `index` into buffer is in its memory range.
### Fixes Issue(s)
Possible out of bounds access in picking which will bring the application down.

