### PR TITLE
Adding IsInternal() to SdfReference

### DIFF
--- a/pxr/usd/sdf/reference.cpp
+++ b/pxr/usd/sdf/reference.cpp
@@ -65,6 +65,12 @@ SdfReference::SetCustomData(const std::string &name, const VtValue &value)
 }
 
 bool
+SdfReference::IsInternal() const
+{
+    return _assetPath.empty() ? true : false;
+}
+
+bool
 SdfReference::operator==(const SdfReference &rhs) const
 {
     return _assetPath   == rhs._assetPath   &&

--- a/pxr/usd/sdf/reference.h
+++ b/pxr/usd/sdf/reference.h
@@ -148,6 +148,10 @@ public:
         _customData.swap(customData);
     }
 
+    /// Returns true in the case of an internal reference.
+    ///
+    SDF_API bool IsInternal() const;
+
     friend inline size_t hash_value(const SdfReference &r) {
         size_t h = 0;
         boost::hash_combine(h, r._assetPath);

--- a/pxr/usd/sdf/testenv/testSdfReference.py
+++ b/pxr/usd/sdf/testenv/testSdfReference.py
@@ -94,5 +94,8 @@ class TestSdfReferences(unittest.TestCase):
         self.assertTrue(r1 < r2)
         self.assertFalse(r2 < r1)
 
+        # r2 can not be an internal reference since it's assetPath is not empty
+        self.assertFalse(r2.IsInternal())
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/wrapReference.cpp
+++ b/pxr/usd/sdf/wrapReference.cpp
@@ -77,7 +77,7 @@ _Repr(const SdfReference &self)
 
 void wrapReference()
 {    
-    typedef SdfReference This;
+    using This = SdfReference;
 
     // Register conversion for python list <-> vector<SdfReference>
     to_python_converter<
@@ -118,6 +118,8 @@ void wrapReference()
             make_function(
                 &This::GetCustomData, return_value_policy<return_by_value>()))
 
+        .def("IsInternal", &This::IsInternal)
+
         .def(self == self)
         .def(self != self)
         .def(self < self)
@@ -128,5 +130,4 @@ void wrapReference()
         .def("__repr__", _Repr)
 
         ;
-
 }


### PR DESCRIPTION
### Description of Change(s)

Added a new function called IsInternal() for the sake of clarity. This function returns true if _assetPath is empty, indicating an internal reference.


