### PR TITLE
[glf] Support uint16 type for GL tetxures and OpenImageIO.

### DIFF
--- a/pxr/imaging/glf/baseTextureData.cpp
+++ b/pxr/imaging/glf/baseTextureData.cpp
@@ -41,6 +41,7 @@ GlfBaseTextureData::_GLInternalFormatFromImageData(
 {
     int numElements = GlfGetNumElements(format);
     switch (type) {
+    case GL_UNSIGNED_SHORT:
     case GL_UNSIGNED_INT:
         switch (numElements) {
         case 1:

--- a/pxr/imaging/glf/oiioImage.cpp
+++ b/pxr/imaging/glf/oiioImage.cpp
@@ -134,8 +134,10 @@ static GLenum
 _GLTypeFromImageData(TypeDesc typedesc)
 {
     switch (typedesc.basetype) {
-    case TypeDesc::UINT:
+    case TypeDesc::UINT32:
         return GL_UNSIGNED_INT;
+    case TypeDesc::UINT16:
+        return GL_UNSIGNED_SHORT;
     case TypeDesc::HALF:
         return GL_HALF_FLOAT;
     case TypeDesc::FLOAT:
@@ -153,11 +155,17 @@ _GetOIIOBaseType(GLenum type)
 {
     switch (type) {
     case GL_UNSIGNED_BYTE:
-    case GL_BYTE:
         return TypeDesc::UINT8;
+    case GL_BYTE:
+        return TypeDesc::INT8;
+    case GL_UNSIGNED_SHORT:
+        return TypeDesc::UINT16;
+    case GL_SHORT:
+        return TypeDesc::INT16;
     case GL_UNSIGNED_INT:
+        return TypeDesc::UINT32;
     case GL_INT:
-        return TypeDesc::UINT;
+        return TypeDesc::INT32;
     case GL_HALF_FLOAT:
         return TypeDesc::HALF;
     case GL_FLOAT:


### PR DESCRIPTION
### Description of Change(s)
Allow usage of GL_UNSIGNED_SHORT for texture creation, and support proper type conversion for OIIO writing of a GlfImage.

Make sure to use sized OIIO constants, as OpenGL's constants are sized (https://www.khronos.org/opengl/wiki/OpenGL_Type)
### Fixes Issue(s)
GLF/Hydra support 16-bit textures for `half` and `unsigned int` already, but `uint16` textures will be downgraded to 8-bit.
