### PR TITLE
Fix potential crash in BakeSkinning.

### DIFF
--- a/pxr/usd/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/usdSkel/bakeSkinning.cpp
@@ -1885,16 +1885,16 @@ _ComputeTimeSamples(
 
     // Extend the time samples of each skel adapter with the time samples
     // of each skinning adapter.
-    WorkParallelForN(
-        skinningAdapters.size(),
-        [&](size_t start, size_t end) {   
-            for (size_t i = start; i < end; ++i) {
-                skinningAdapters[i]->ExtendTimeSamples(
-                    interval,
-                    &skelTimesMap[skinningAdapters[i]->GetSkelAdapter()]);
-            }
-        });
-    
+    // NOTE: multiple skinning adapters may share the same skel adapter, so in
+    // order for this work to be done in parallel the skinning adapters would
+    // need to be grouped such that that the same skel adapter isn't modified
+    // by multiple threads.
+    for (const _SkinningAdapterRefPtr &adapter : skinningAdapters) {
+        adapter->ExtendTimeSamples(
+            interval,
+            &skelTimesMap[adapter->GetSkelAdapter()]);
+    }
+
     // Each times array may now hold duplicate entries. 
     // Sort and remove dupes from each array.
     WorkParallelForN(


### PR DESCRIPTION
The crash occurs in `_ExtendWorldTransformTimeSamples()` if the skinned prim or its parent has time-sampled transforms. Since multiple skinning adapters can share the same skel adapter, this could result in modifying the same list of time samples from multiple threads.

This change just removes the parallel for loop over the skinning adapters, but it would be possible to achieve some parallelism if extra preprocessing work is done.

To reproduce, load the attached file ([agents.usda.zip](https://github.com/PixarAnimationStudios/USD/files/4652567/agents.usda.zip)) with `usdview --numThreads 24`, and then run `UsdSkel.BakeSkinning(usdviewApi.stage.Traverse())` in the interpreter

