### PR TITLE
Fix crash when a updating a primvar

### DIFF
--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -855,18 +855,22 @@ UsdImagingPrimAdapter::_ProcessPrefixedPrimvarPropertyChange(
     bool primvarOnPrim = false;
     UsdAttribute attr;
     TfToken interpOnPrim;
+    HdInterpolation hdInterpOnPrim = HdInterpolationConstant;
     UsdGeomPrimvarsAPI api(prim);
     if (inherited) {
         UsdGeomPrimvar pv = api.FindPrimvarWithInheritance(propertyName);
         attr = pv;
-        interpOnPrim = pv.GetInterpolation();
+        if (pv)
+            interpOnPrim = pv.GetInterpolation();
     } else {
         UsdGeomPrimvar localPv = api.GetPrimvar(propertyName);
         attr = localPv;
-        interpOnPrim = localPv.GetInterpolation();
+        if (localPv)
+            interpOnPrim = localPv.GetInterpolation();
     }
     if (attr && attr.HasValue()) {
         primvarOnPrim = true;
+        hdInterpOnPrim = _UsdToHdInterpolation(interpOnPrim);
     }
 
     // Determine if primvar is in the value cache.
@@ -875,7 +879,7 @@ UsdImagingPrimAdapter::_ProcessPrefixedPrimvarPropertyChange(
         _GetValueCache()->GetPrimvars(cachePath);  
     
     PrimvarChange changeType = _ProcessPrimvarChange(primvarOnPrim,
-                                 _UsdToHdInterpolation(interpOnPrim),
+                                 hdInterpOnPrim,
                                  primvarName, &primvarDescs, cachePath);
 
     return _GetDirtyBitsForPrimvarChange(changeType, valueChangeDirtyBit);          


### PR DESCRIPTION
Fix crash when a primvar gets removed from a primitive. The call to get the
interpolation of the primvar would crash because the primvar doesn't exist.

### Description of Change(s)
Make sure the primvar exists before trying to fetch its interpolation metadata.
Avoid calling _UsdToHdInterpolation on an empty string in this scenario, as doing so would result in TF_CODING_ERROR being triggered.

### Fixes Issue(s)
- #1222 

