### PR TITLE
Fix Windows junction handling in Tf layer

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -154,8 +154,9 @@ TfIsDir(string const& path, bool resolveSymlinks)
 #if defined (ARCH_OS_WINDOWS)
     // Report not a directory if path is a symlink and resolveSymlinks is
     // false.
+    if (!resolveSymlinks && TfIsLink((path)))
+        return false;
     return Tf_HasAttribute(path, resolveSymlinks,
-                    FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT,
                     FILE_ATTRIBUTE_DIRECTORY);
 #else
     ArchStatType st;
@@ -171,8 +172,10 @@ TfIsFile(string const& path, bool resolveSymlinks)
 {
 #if defined (ARCH_OS_WINDOWS)
     // Report not a file if path is a symlink and resolveSymlinks is false.
+    if (!resolveSymlinks && TfIsLink((path)))
+        return false;
     return Tf_HasAttribute(path, resolveSymlinks,
-                    FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT,
+                    FILE_ATTRIBUTE_DIRECTORY,
                     0);
 #else
     ArchStatType st;
@@ -188,7 +191,8 @@ TfIsLink(string const& path)
 {
 #if defined(ARCH_OS_WINDOWS)
     return Tf_HasAttribute(path, /* resolveSymlinks = */ false,
-                           FILE_ATTRIBUTE_REPARSE_POINT);
+                           FILE_ATTRIBUTE_REPARSE_POINT) &&
+                           !TfReadLink(path).empty();
 #else
     ArchStatType st;
     if (Tf_Stat(path, /* resolveSymlinks */ false, &st)) {

--- a/pxr/base/tf/testenv/fileUtils.cpp
+++ b/pxr/base/tf/testenv/fileUtils.cpp
@@ -234,6 +234,28 @@ TestTfIsFile()
     return true;
 }
 
+#if defined(ARCH_OS_WINDOWS)
+static bool
+TestTfJunction()
+{
+    cout << "Testing Windows junctions" << endl;
+
+    TF_AXIOM(TfMakeDir("junction-target"));
+    TF_AXIOM(system("mklink /j junction junction-target") == 0);
+    TF_AXIOM(TfTouchFile("junction/test-file"));
+    TF_AXIOM(!TfIsLink("junction"));
+    TF_AXIOM(TfIsDir("junction", false));
+    TF_AXIOM(TfIsDir("junction", true));
+    TF_AXIOM(TfIsFile("junction/test-file", false));
+    TF_AXIOM(TfIsFile("junction/test-file", true));
+    TF_AXIOM(TfDeleteFile("junction-target/test-file"));
+    (void)ArchRmDir("junction");
+    (void)ArchRmDir("junction-target");
+
+    return true;
+}
+#endif
+
 static bool
 TestTfIsWritable()
 {
@@ -675,6 +697,9 @@ Test_TfFileUtils()
            TestTfPathExists() &&
            TestTfIsDir() &&
            TestTfIsFile() &&
+#if defined(ARCH_OS_WINDOWS)
+           TestTfJunction() &&
+#endif
            TestTfIsWritable() &&
            TestTfIsDirEmpty() &&
            TestTfSymlink() &&


### PR DESCRIPTION
### Description of Change(s)

The Tf layer TfIsDir, TfIsFile and TfIsLink were acting as though any file with FILE_FLAG_REPARSE_POINT is a symlink.

On Windows, reparse points can have all sorts of purposes, such as folder junctions (like mounts), or hierarchal storage systems like OneDrive.

This change ensures that a file with the reparse point flag is actually a symlink, by attempting to parse its contents, before treating it as such.

The cost is an extra GetFileAttributes call in the common codepaths of TfIsDir and TfIsFile when followSymLinks is false (the default), and attempting to parse the symlink when one is detected.

### Fixes Issue(s)

Saving a file to any folder which is a junction or a subfolder of a junction will fail.

```python
from pxr import Sdf
fn = r'c:\normal-dir\test.usda'
root_layer = Sdf.Layer.CreateNew(fn)
root_layer.Save()
fn = r'c:\junction-to-normal-dir\test.usda'
root_layer = Sdf.Layer.CreateNew(fn)
root_layer.Save()
```

The latter fails with:

```
    root_layer = Sdf.Layer.CreateNew(fn)
pxr.Tf.ErrorException:
        Error in 'pxrInternal_v0_20__pxrReserved__::SdfLayer::_WriteToFile' at line 4247 in file C:\Users\Wade\USD\pxr\usd\sdf\layer.cpp : 'Cannot create destination directory c:\junction\'
```