### PR TITLE
Add some defensive coding when calling UsdImagingDelegate::Get

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -2336,8 +2336,7 @@ UsdImagingDelegate::Get(SdfPath const& id, TfToken const& key)
             // but should do the proper transformation.  Maybe we can use
             // the primInfo.usdPrim?
             UsdPrim prim = _GetUsdPrim(cachePath);
-            UsdAttribute attr = prim ? prim.GetAttribute(key) : UsdAttribute();
-            TF_VERIFY(attr && attr.Get(&value, _time),
+            TF_VERIFY(prim && prim.GetAttribute(key).Get(&value, _time),
                       "%s, %s\n", id.GetText(), key.GetText());
         }
     }

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -2335,8 +2335,9 @@ UsdImagingDelegate::Get(SdfPath const& id, TfToken const& key)
             // XXX(UsdImaging): We use cachePath directly as usdPath here,
             // but should do the proper transformation.  Maybe we can use
             // the primInfo.usdPrim?
-            TF_VERIFY(_GetUsdPrim(cachePath).GetAttribute(key)
-                      .Get(&value, _time),
+            UsdPrim prim = _GetUsdPrim(cachePath);
+            UsdAttribute attr = prim ? prim.GetAttribute(key) : UsdAttribute();
+            TF_VERIFY(attr && attr.Get(&value, _time),
                       "%s, %s\n", id.GetText(), key.GetText());
         }
     }


### PR DESCRIPTION
Add some defensive coding when calling UsdImagingDelegate::Get with an arbitrary USD Primitive and Attribute name. Render delegates can call this function with any primpath or attribute name, and the existing code could crash in this case. Obviously render delegates shouldn't make these invalid calls, but printing out an error message seems like punishment enough.

This change was inspired by a crash discovered in the Houdini GL render delegate, which I believe is being fed bad Sync requests on UsdVolVDBAsset sprims. I will try to narrow that down to a github issue. This change makes no attempt to address any underlying issue there, but at least it stops the crash (and I didn't see any harm in making this code generally more robust to bad input).

### Description of Change(s)
Check for valid UsdPrim and UsdAttribute before using them.