### PR TITLE
Allow RenderBuffer::Resolve() to change the size of the image

### DIFF
--- a/pxr/imaging/hdx/colorizeTask.cpp
+++ b/pxr/imaging/hdx/colorizeTask.cpp
@@ -520,6 +520,12 @@ HdxColorizeTask::Execute(HdTaskContext* ctx)
         return;
     }
 
+    // Resolve the buffers before we read them.
+    _aovBuffer->Resolve();
+    if (_depthBuffer) {
+        _depthBuffer->Resolve();
+    }
+
     // Allocate the scratch space, if needed.
     size_t size = _aovBuffer->GetWidth() * _aovBuffer->GetHeight();
     if (!_applyColorQuantization && _aovName == HdAovTokens->color) {
@@ -535,12 +541,6 @@ HdxColorizeTask::Execute(HdTaskContext* ctx)
     _converged = _aovBuffer->IsConverged();
     if (_depthBuffer) {
         _converged = _converged && _depthBuffer->IsConverged();
-    }
-
-    // Resolve the buffers before we read them.
-    _aovBuffer->Resolve();
-    if (_depthBuffer) {
-        _depthBuffer->Resolve();
     }
 
     // XXX: Right now, we colorize on the CPU, before uploading data to the


### PR DESCRIPTION
### Description of Change(s)
Moves aov buffer resolve ahead of outputBuffer allocation to ensure correct buffer sizing in the event of image size change

### Fixes Issue(s)
This was actually working before, but it looks like it is possible for
this to allocate outputBuffer at the wrong size and write over the end
of it.

