### PR TITLE
Colorize Task improvements

### DIFF
--- a/pxr/imaging/hdx/colorizeTask.cpp
+++ b/pxr/imaging/hdx/colorizeTask.cpp
@@ -149,10 +149,15 @@ static void _colorizeST(
     {
         for (size_t i=begin; i<end; ++i) {
             float s = buffer[i*2+0];
+            float fs = floorf(s);
+            if (s == fs && fs > 0) --fs;
+            dest[i*4+0] = (uint8_t)((s - fs) * 255.0f);
             float t = buffer[i*2+1];
-            dest[i*4+0] = (uint8_t)(s * 255.0f);
-            dest[i*4+1] = (uint8_t)(t * 255.0f);
-            dest[i*4+2] = (uint8_t)(floorf(s)+floorf(t)*10); // put udim tile in blue
+            float ft = floorf(t);
+            if (t == ft && ft > 0) --ft;
+            dest[i*4+1] = (uint8_t)((t - ft) * 255.0f);
+            dest[i*4+2] = (uint8_t)((unsigned)(10 * ft + fs) * 177u); // put udim tile in blue
+            dest[i*4+3] = 255;
         }
     });
 }
@@ -483,6 +488,7 @@ static _Colorizer _colorizerTable[] = {
     { HdAovTokens->primId, HdFormatInt32, _colorizeId },
     { HdAovTokens->elementId, HdFormatInt32, _colorizeId },
     { HdAovTokens->instanceId, HdFormatInt32, _colorizeId },
+    { pxr::TfToken("primvars:st"), HdFormatFloat32Vec3, _colorizePrimvar }, // match _colorizeST for 3-channel st
     // fallback converters
     { HdPrimvarRoleTokens->none, HdFormatFloat32, _colorizeCameraDepth },
     { HdPrimvarRoleTokens->none, HdFormatFloat32Vec2, _colorizeST },

--- a/pxr/imaging/hdx/colorizeTask.cpp
+++ b/pxr/imaging/hdx/colorizeTask.cpp
@@ -186,7 +186,6 @@ static void _colorizeNormal(
 static void _colorizeId(
     uint8_t* dest, uint8_t* src, size_t nPixels, uint32_t imageWidth)
 {
-    // XXX: this is legacy ID-display behavior, but an alternative is to
     // hash the ID to 3 bytes and use those as color. Even fancier,
     // hash to hue and stratified (saturation, value) levels, etc.
     int32_t *idBuffer = reinterpret_cast<int32_t*>(src);
@@ -195,8 +194,8 @@ static void _colorizeId(
         [&dest, &src, &nPixels, &imageWidth, &idBuffer]
         (size_t begin, size_t end)
     {
-            for (size_t i=begin; i<end; ++i) {
-            int32_t id = idBuffer[i];
+        for (size_t i=begin; i<end; ++i) {
+            int32_t id = (idBuffer[i] + 1) * 0xb17223; // prime number near ln(2)*2^24
             dest[i*4+0] = (uint8_t)(id & 0xff);
             dest[i*4+1] = (uint8_t)((id >> 8) & 0xff);
             dest[i*4+2] = (uint8_t)((id >> 16) & 0xff);


### PR DESCRIPTION
### Description of Change(s)
Primary fix is to choose a colorizeTask based on the data type in the buffer, if no specific colorizeTask is found. This also changes a few of the colorizeTask methods.

### Fixes Issue(s)
Primary fix is to be able to display any AOV that a renderDelegate can produce (as long as it turns into VecNf for N=1..4).

Also some improvements to existing colorizeTask to make it easier to distinguish integer id's for prims and instances, and improves display for UDIM tiles.

