### PR TITLE
[build] Fix Draco's check files

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1284,7 +1284,7 @@ def InstallDraco(context, force, buildArgs):
         cmakeOptions += buildArgs
         RunCMake(context, force, cmakeOptions)
 
-DRACO = Dependency("Draco", InstallDraco, "include/Draco/src/draco/compression/decode.h")
+DRACO = Dependency("Draco", InstallDraco, "include/draco/compression/decode.h")
 
 ############################################################
 # MaterialX


### PR DESCRIPTION
### Description of Change(s)
Replace Draco's dependency `filesToCheck` with the valid file path.  Here is [Draco Installation Log](https://github.com/PixarAnimationStudios/USD/files/4757677/dracoInstallationLog.txt), as you might see there is no `include/Draco/src/draco` directory.


### Fixes Issue(s)
- Redundant Draco dependency build calls

