### PR TITLE
[usdAbc] Fix conversion of UsdGeomMesh subd interpolation options

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -3285,7 +3285,7 @@ _ReadSubD(_PrimReaderContext* context)
         UsdGeomTokens->faceVaryingLinearInterpolation,
         SdfValueTypeNames->Token,
         _CopyFaceVaryingInterpolateBoundary(
-            context->ExtractSchema(".faceVaryingLinearInterpolation")));
+            context->ExtractSchema(".faceVaryingInterpolateBoundary")));
     context->AddProperty(
         UsdGeomTokens->holeIndices,
         SdfValueTypeNames->IntArray,

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcConversionSubdiv.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcConversionSubdiv.py
@@ -37,7 +37,21 @@ class TestUsdAbcConversionSubdiv(unittest.TestCase):
         origStage = Usd.Stage.Open(usdFile)
         stage = Usd.Stage.Open(abcFile)
 
-        prim = stage.GetPrimAtPath('/World/geom/CenterCross/UpLeft')
+        testMeshPath = '/World/geom/CenterCross/UpLeft'
+
+        origPrim = origStage.GetPrimAtPath(testMeshPath)
+        prim = stage.GetPrimAtPath(testMeshPath)
+
+        # Check subdivision scheme and interpolation options
+        self.assertEqual(prim.GetAttribute('subdivisionScheme').Get(time),
+                    origPrim.GetAttribute('subdivisionScheme').Get(time));
+
+        self.assertEqual(prim.GetAttribute('interpolateBoundary').Get(time),
+                    origPrim.GetAttribute('interpolateBoundary').Get(time));
+        self.assertEqual(prim.GetAttribute('faceVaryingLinearInterpolation').Get(time),
+                    origPrim.GetAttribute('faceVaryingLinearInterpolation').Get(time));
+
+        # Check crease indices, lengths and sharpness
         creaseIndices = prim.GetAttribute('creaseIndices').Get(time)
         expectedCreaseIndices = [0, 1, 3, 2, 0, 4, 5, 7, 
                                  6, 4, 1, 5, 0, 4, 2, 6, 3, 7]
@@ -54,12 +68,13 @@ class TestUsdAbcConversionSubdiv(unittest.TestCase):
         for c, e in zip(creaseSharpnesses, expectedCreaseSharpness):
             self.assertTrue(Gf.IsClose(c, e, 1e-5))
 
+        # Check face vertices
         faceVertexCounts = prim.GetAttribute('faceVertexCounts').Get(time)
         expectedFaceVertexCounts = [4, 4, 4, 4, 4, 4]
         for c, e in zip(faceVertexCounts, expectedFaceVertexCounts):
             self.assertTrue(Gf.IsClose(c, e, 1e-5))
 
-        # The writer will revrse the orientation because alembic only supports
+        # The writer will reverse the orientation because alembic only supports
         # left handed winding order.
         faceVertexIndices = prim.GetAttribute('faceVertexIndices').Get(time)
         expectedFaceVertexIndices = [2, 6, 4, 0, 4, 5, 1, 0, 6, 7, 5, 

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcConversionSubdiv/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcConversionSubdiv/original.usda
@@ -166,7 +166,8 @@ def Xform "World" (
                 float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 4, 6, 2, 0, 1, 5, 4, 4, 5, 7, 6, 3, 7, 5, 1, 6, 7, 3, 2, 2, 3, 1, 0]
-                token interpolateBoundary = "none"
+                token interpolateBoundary = "edgeOnly"
+                token faceVaryingLinearInterpolation = "boundaries"
                 point3f[] points = [(-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5)]
                 color3f[] primvars:displayColor = [(1, 1, 0)]
                 float[] primvars:displayOpacity = [1]
@@ -184,7 +185,8 @@ def Xform "World" (
                 float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 4, 6, 2, 0, 1, 5, 4, 4, 5, 7, 6, 3, 7, 5, 1, 6, 7, 3, 2, 2, 3, 1, 0]
-                token interpolateBoundary = "none"
+                token interpolateBoundary = "edgeOnly"
+                token faceVaryingLinearInterpolation = "boundaries"
                 point3f[] points = [(-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5)]
                 color3f[] primvars:displayColor = [(1, 1, 0)]
                 float[] primvars:displayOpacity = [1]


### PR DESCRIPTION
### Description of Change(s)
These changes correct errors in the conversion of mesh subdivision interpolation options between UsdGeomMesh and AbcGeom's ISubD and OSubD schemas:
- the Abc reader was modified to use the correct name for Alembic's face-varying interpolation property (".faceVaryingInterpolateBoundary").
- the Abc writer was modified to include two missing legal values values when converting faceVaryingLinearInterpolation, and to write the correct default value for interpolateBoundary.
- the existing test for subdivision conversion between USD and Abc was updated to compare boundary and face-varying interpolation values after round trip conversion.

### Fixes Issue(s)
- conversion of faceVaryingLinearInterpolation from Abc ignores original values and results in the USD default.
- conversion of faceVaryingLinearInterpolation to Abc generates errors for two legal USD values.
- conversion of interpolateBoundary to Abc does not write the correct value for the USD default.

