### PR TITLE
[doc] Improved documentation for UsdGeomMesh

### DIFF
--- a/pxr/usd/usdGeom/generatedSchema.usda
+++ b/pxr/usd/usdGeom/generatedSchema.usda
@@ -1388,27 +1388,76 @@ class "PointBased" (
 }
 
 class Mesh "Mesh" (
-    doc = '''Encodes a mesh surface whose definition and feature-set
-    will converge with that of OpenSubdiv, http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html.
-    Certain interpolation ("tag") parameters are not yet supported.
-    
-    A key property of this mesh schema is that it encodes both subdivision
-    surfaces, and non-subdivided "polygonal meshes", by varying the
-    subdivisionScheme attribute.
-    
-    A Note About Normals
+    doc = """Encodes a mesh with optional subdivision properties and features.
 
-    Normals should not be authored on a subdivided mesh, since subdivision
+    As a point-based primitive, meshes are defined in terms of points that 
+    are connected into edges and faces. Many references to meshes use the
+    term 'vertex' in place of or interchangeably with 'points', while some
+    use 'vertex' to refer to the 'face-vertices' that define a face.  To
+    avoid confusion, the term 'vertex' is intentionally avoided in favor of
+    'points' or 'face-vertices'.
+
+    The connectivity between points, edges and faces is encoded using a
+    common minimal topological description of the faces of the mesh.  Each
+    face is defined by a set of face-vertices using indices into the Mesh's
+    _points_ array (inherited from UsdGeomPointBased) and laid out in a
+    single linear _faceVertexIndices_ array for efficiency.  A companion
+    _faceVertexCounts_ array provides, for each face, the number of
+    consecutive face-vertices in _faceVertexIndices_ that define the face.
+    No additional connectivity information is required or constructed, so
+    no adjacency or neighborhood queries are available.
+
+    A key property of this mesh schema is that it encodes both subdivision
+    surfaces and simpler polygonal meshes. This is achieved by varying the
+    _subdivisionScheme_ attribute, which is set to specify Catmull-Clark
+    subdivision by default, so polygonal meshes must always be explicitly
+    declared. The available subdivision schemes and additional subdivision
+    features encoded in optional attributes conform to the feature set of
+    OpenSubdiv
+    (https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html).
+
+    \\anchor UsdGeom_Mesh_Primvars
+    __A Note About Primvars__
+
+    The following list clarifies the number of elements for and the
+    interpolation behavior of the different primvar interpolation types
+    for meshes:
+
+    - __constant__: One element for the entire mesh; no interpolation.
+    - __uniform__: One element for each face of the mesh; elements are
+      typically not interpolated but are inherited by other faces derived
+      from a given face (via subdivision, tessellation, etc.).
+    - __varying__: One element for each point of the mesh;
+      interpolation of point data is always linear.
+    - __vertex__: One element for each point of the mesh;
+      interpolation of point data is applied according to the
+      _subdivisionScheme_ attribute.
+    - __faceVarying__: One element for each of the face-vertices that
+      define the mesh topology; interpolation of face-vertex data may
+      be smooth or linear, according to the _subdivisionScheme_ and
+      _faceVaryingLinearInterpolation_ attributes.
+
+    Primvar interpolation types and related utilities are described more
+    generally in \\ref Usd_InterpolationVals.
+
+    \\anchor UsdGeom_Mesh_Normals
+    __A Note About Normals__
+
+    Normals should not be authored on a subdivision mesh, since subdivision
     algorithms define their own normals. They should only be authored for
-    polygonal meshes (_subdivisionScheme_ = "None").
+    polygonal meshes (_subdivisionScheme_ = \"none\").
 
     The _normals_ attribute inherited from UsdGeomPointBased is not a generic
     primvar, but the number of elements in this attribute will be determined by
     its _interpolation_.  See .
     If _normals_ and _primvars:normals_ are both specified, the latter has
-    precedence.  If a polygonal Mesh specifies __neither__ _normals_ nor
+    precedence.  If a polygonal mesh specifies __neither__ _normals_ nor
     _primvars:normals_, then it should be treated and rendered as faceted,
-    with no attempt to compute smooth normals.'''
+    with no attempt to compute smooth normals.
+
+    The normals generated for smooth subdivision schemes, e.g. Catmull-Clark
+    and Loop, will likewise be smooth, but others, e.g. Bilinear, may be
+    discontinuous between faces and/or within non-planar irregular faces."""
 )
 {
     vector3f[] accelerations (
@@ -1420,37 +1469,39 @@ class Mesh "Mesh" (
         square of UsdStage::GetTimeCodesPerSecond()."""
     )
     int[] cornerIndices = [] (
-        doc = "The point indices of sharp corners."
+        doc = """The indices of points for which a corresponding sharpness
+        value is specified in _cornerSharpnesses_ (so the size of this array
+        must match that of _cornerSharpnesses_)."""
     )
     float[] cornerSharpnesses = [] (
-        doc = """The sharpness values for corners: each corner gets a single
-        sharpness value (Usd.Mesh.SHARPNESS_INFINITE for a perfectly sharp
-        corner), so the size of this array must match that of
-        'cornerIndices'"""
+        doc = """The sharpness values associated with a corresponding set of
+        points specified in _cornerIndices_ (so the size of this array must
+        match that of _cornerIndices_). Use the constant `SHARPNESS_INFINITE`
+        for a perfectly sharp corner."""
     )
     int[] creaseIndices = [] (
-        doc = """The point indices forming creased edges.  The size of 
-        this array must be equal to the sum of all elements of the 
-        'creaseLengths' attribute. Neighboring indices should correspond with the
-        valid edges indices."""
+        doc = """The indices of points grouped into sets of successive pairs
+        that identify edges to be creased. The size of this array must be
+        equal to the sum of all elements of the _creaseLengths_ attribute."""
     )
     int[] creaseLengths = [] (
-        doc = """The length of this array specifies the number of creases on the
-        surface. Each element gives the number of (must be adjacent) vertices in
-        each crease, whose indices are linearly laid out in the 'creaseIndices'
-        attribute. Since each crease must be at least one edge long, each
-        element of this array should be greater than one."""
+        doc = """The length of this array specifies the number of creases
+        (sets of adjacent sharpened edges) on the mesh. Each element gives
+        the number of points of each crease, whose indices are successively
+        laid out in the _creaseIndices_ attribute. Since each crease must
+        be at least one edge long, each element of this array must be at
+        least two."""
     )
     float[] creaseSharpnesses = [] (
-        doc = """The per-crease or per-edge sharpness for all creases
-        (Usd.Mesh.SHARPNESS_INFINITE for a perfectly sharp crease).  Since
-        'creaseLengths' encodes the number of vertices in each crease, the
-        number of elements in this array will be either len(creaseLengths) or
-        the sum over all X of (creaseLengths[X] - 1). Note that while
+        doc = """The per-crease or per-edge sharpness values for all creases.
+        Since _creaseLengths_ encodes the number of points in each crease,
+        the number of elements in this array will be either len(creaseLengths)
+        or the sum over all X of (creaseLengths[X] - 1). Note that while
         the RI spec allows each crease to have either a single sharpness
         or a value per-edge, USD will encode either a single sharpness
         per crease on a mesh, or sharpnesses for all edges making up
-        the creases on a mesh."""
+        the creases on a mesh.  Use the constant `SHARPNESS_INFINITE` for a
+        perfectly sharp crease."""
     )
     uniform bool doubleSided = 0 (
         doc = """Although some renderers treat all parametric or polygonal
@@ -1485,37 +1536,63 @@ class Mesh "Mesh" (
         during traversal."""
     )
     token faceVaryingLinearInterpolation = "cornersPlus1" (
-        allowedTokens = ["all", "none", "boundaries", "cornersOnly", "cornersPlus1", "cornersPlus2"]
-        doc = '''Specifies how face varying data is interpolated.  Valid values
-        are "all" (no smoothing), "cornersPlus1" (the default, Smooth UV),
-        "none" (Same as "cornersPlus1" but does not infer the presence 
-        of corners where two faceVarying edges meet at a single face), or 
-        "boundaries" (smooth only near vertices that are not at a
-        discontinuous boundary).
+        allowedTokens = ["none", "cornersOnly", "cornersPlus1", "cornersPlus2", "boundaries", "all"]
+        doc = '''Specifies how elements of a primvar of interpolation type
+        "faceVarying" are interpolated for subdivision surfaces. Interpolation
+        can be as smooth as a "vertex" primvar or constrained to be linear at
+        features specified by several options.  Valid values correspond to
+        choices available in OpenSubdiv:
 
-        See http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#face-varying-interpolation-rules'''
+        - __none__: No linear constraints or sharpening, smooth everywhere
+        - __cornersOnly__: Sharpen corners of discontinuous boundaries only,
+          smooth everywhere else
+        - __cornersPlus1__: The default, same as "cornersOnly" plus additional
+          sharpening at points where three or more distinct face-varying
+          values occur
+        - __cornersPlus2__: Same as "cornersPlus1" plus additional sharpening
+          at points with at least one discontinuous boundary corner or
+          only one discontinuous boundary edge (a dart)
+        - __boundaries__: Piecewise linear along discontinuous boundaries,
+          smooth interior
+        - __all__: Piecewise linear everywhere
+
+        These are illustrated and described in more detail in the OpenSubdiv
+        documentation:
+        https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#face-varying-interpolation-rules'''
     )
     int[] faceVertexCounts (
         doc = """Provides the number of vertices in each face of the mesh, 
-        which is also the number of consecutive indices in 'faceVertexIndices'
+        which is also the number of consecutive indices in _faceVertexIndices_
         that define the face.  The length of this attribute is the number of
         faces in the mesh.  If this attribute has more than
         one timeSample, the mesh is considered to be topologically varying."""
     )
     int[] faceVertexIndices (
-        doc = """Flat list of the index (into the 'points' attribute) of each
+        doc = """Flat list of the index (into the _points_ attribute) of each
         vertex of each face in the mesh.  If this attribute has more than
         one timeSample, the mesh is considered to be topologically varying."""
     )
     int[] holeIndices = [] (
-        doc = """The face indices (indexing into the 'faceVertexCounts'
-        attribute) of all faces that should be made invisible."""
+        doc = """The indices of all faces that should be treated as holes,
+        i.e. made invisible. This is traditionally a feature of subdivision
+        surfaces and not generally applied to polygonal meshes."""
     )
     token interpolateBoundary = "edgeAndCorner" (
-        allowedTokens = ["none", "edgeAndCorner", "edgeOnly"]
-        doc = '''Specifies how interpolation boundary face edges are
-        interpolated. Valid values are "none", 
-        "edgeAndCorner" (the default), or "edgeOnly".'''
+        allowedTokens = ["none", "edgeOnly", "edgeAndCorner"]
+        doc = '''Specifies how subdivision is applied for faces adjacent to
+        boundary edges and boundary points. Valid values correspond to choices
+        available in OpenSubdiv:
+
+        - __none__: No boundary interpolation is applied and boundary faces are
+          effectively treated as holes
+        - __edgeOnly__: A sequence of boundary edges defines a smooth curve to
+          which the edges of subdivided boundary faces converge
+        - __edgeAndCorner__: The default, similar to "edgeOnly" but the smooth
+          boundary curve is made sharp at corner points
+
+        These are illustrated and described in more detail in the OpenSubdiv
+        documentation:
+        https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#boundary-interpolation-rules'''
     )
     normal3f[] normals (
         doc = """Provide an object-space orientation for individual points, 
@@ -1585,25 +1662,33 @@ class Mesh "Mesh" (
     )
     uniform token subdivisionScheme = "catmullClark" (
         allowedTokens = ["catmullClark", "loop", "bilinear", "none"]
-        doc = '''The subdivision scheme to be applied to the surface.  
-        Valid values are "catmullClark" (the default), "loop", "bilinear", and
-        "none" (i.e. a polymesh with no subdivision - the primary difference
-        between schemes "bilinear" and "none" is that bilinearly subdivided
-        meshes can be considered watertight, whereas there is no such guarantee
-        for un-subdivided polymeshes, and more mesh features (e.g. holes) may
-        apply to bilinear meshes but not polymeshes.   Further, if a polymesh 
-        does not provide normals, then it should be treated and rendered as 
-        faceted, whereas a "bilinear" Mesh should compute smooth normals. 
-        For primarily this latter reason, polymeshes may be lighterweight 
-        and faster to render, depending on renderer and render mode.)'''
+        doc = '''The subdivision scheme to be applied to the surface.
+        Valid values are:
+
+        - __catmullClark__: The default, Catmull-Clark subdivision; preferred
+          for quad-dominant meshes (generalizes B-splines); interpolation
+          of point data is smooth (non-linear)
+        - __loop__: Loop subdivision; preferred for purely triangular meshes;
+          interpolation of point data is smooth (non-linear)
+        - __bilinear__: Subdivision reduces all faces to quads (topologically
+          similar to "catmullClark"); interpolation of point data is bilinear
+        - __none__: No subdivision, i.e. a simple polygonal mesh; interpolation
+          of point data is linear
+
+        Polygonal meshes are typically lighter weight and faster to render,
+        depending on renderer and render mode.  Use of "bilinear" will produce
+        a similar shape to a polygonal mesh and may offer additional guarantees
+        of watertightness and additional subdivision features (e.g. holes) but
+        may also not respect authored normals.'''
     )
     token triangleSubdivisionRule = "catmullClark" (
         allowedTokens = ["catmullClark", "smooth"]
-        doc = '''Specifies what weights are used during triangle subdivision for
-        the Catmull-Clark scheme. Valid values are "catmullClark" (the default) 
-        and "smooth".
+        doc = '''Specifies an option to the subdivision rules for the
+        Catmull-Clark scheme to try and improve undesirable artifacts when
+        subdividing triangles.  Valid values are "catmullClark" for the
+        standard rules (the default) and "smooth" for the improvement.
 
-        See http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#triangle-subdivision-rule'''
+        See https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#triangle-subdivision-rule'''
     )
     vector3f[] velocities (
         doc = """If provided, 'velocities' should be used by renderers to 

--- a/pxr/usd/usdGeom/schema.usda
+++ b/pxr/usd/usdGeom/schema.usda
@@ -747,40 +747,89 @@ class Mesh "Mesh" (
         string extraIncludes = """
 #include "pxr/usd/usd/timeCode.h" """
     }
-    doc="""Encodes a mesh surface whose definition and feature-set
-    will converge with that of OpenSubdiv, http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html.
-    Certain interpolation ("tag") parameters are not yet supported.
-    
-    A key property of this mesh schema is that it encodes both subdivision
-    surfaces, and non-subdivided "polygonal meshes", by varying the
-    \\em subdivisionScheme attribute.
-    
-    \\section UsdGeom_Mesh_Normals A Note About Normals
+    doc="""Encodes a mesh with optional subdivision properties and features.
 
-    Normals should not be authored on a subdivided mesh, since subdivision
+    As a point-based primitive, meshes are defined in terms of points that 
+    are connected into edges and faces. Many references to meshes use the
+    term 'vertex' in place of or interchangeably with 'points', while some
+    use 'vertex' to refer to the 'face-vertices' that define a face.  To
+    avoid confusion, the term 'vertex' is intentionally avoided in favor of
+    'points' or 'face-vertices'.
+
+    The connectivity between points, edges and faces is encoded using a
+    common minimal topological description of the faces of the mesh.  Each
+    face is defined by a set of face-vertices using indices into the Mesh's
+    _points_ array (inherited from UsdGeomPointBased) and laid out in a
+    single linear _faceVertexIndices_ array for efficiency.  A companion
+    _faceVertexCounts_ array provides, for each face, the number of
+    consecutive face-vertices in _faceVertexIndices_ that define the face.
+    No additional connectivity information is required or constructed, so
+    no adjacency or neighborhood queries are available.
+
+    A key property of this mesh schema is that it encodes both subdivision
+    surfaces and simpler polygonal meshes. This is achieved by varying the
+    _subdivisionScheme_ attribute, which is set to specify Catmull-Clark
+    subdivision by default, so polygonal meshes must always be explicitly
+    declared. The available subdivision schemes and additional subdivision
+    features encoded in optional attributes conform to the feature set of
+    OpenSubdiv
+    (https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html).
+
+    \\anchor UsdGeom_Mesh_Primvars
+    __A Note About Primvars__
+
+    The following list clarifies the number of elements for and the
+    interpolation behavior of the different primvar interpolation types
+    for meshes:
+
+    - __constant__: One element for the entire mesh; no interpolation.
+    - __uniform__: One element for each face of the mesh; elements are
+      typically not interpolated but are inherited by other faces derived
+      from a given face (via subdivision, tessellation, etc.).
+    - __varying__: One element for each point of the mesh;
+      interpolation of point data is always linear.
+    - __vertex__: One element for each point of the mesh;
+      interpolation of point data is applied according to the
+      _subdivisionScheme_ attribute.
+    - __faceVarying__: One element for each of the face-vertices that
+      define the mesh topology; interpolation of face-vertex data may
+      be smooth or linear, according to the _subdivisionScheme_ and
+      _faceVaryingLinearInterpolation_ attributes.
+
+    Primvar interpolation types and related utilities are described more
+    generally in \\ref Usd_InterpolationVals.
+
+    \\anchor UsdGeom_Mesh_Normals
+    __A Note About Normals__
+
+    Normals should not be authored on a subdivision mesh, since subdivision
     algorithms define their own normals. They should only be authored for
-    polygonal meshes (_subdivisionScheme_ = "None").
+    polygonal meshes (_subdivisionScheme_ = "none").
 
     The _normals_ attribute inherited from UsdGeomPointBased is not a generic
     primvar, but the number of elements in this attribute will be determined by
     its _interpolation_.  See \\ref UsdGeomPointBased::GetNormalsInterpolation() .
     If _normals_ and _primvars:normals_ are both specified, the latter has
-    precedence.  If a polygonal Mesh specifies __neither__ _normals_ nor
+    precedence.  If a polygonal mesh specifies __neither__ _normals_ nor
     _primvars:normals_, then it should be treated and rendered as faceted,
-    with no attempt to compute smooth normals."""
+    with no attempt to compute smooth normals.
+
+    The normals generated for smooth subdivision schemes, e.g. Catmull-Clark
+    and Loop, will likewise be smooth, but others, e.g. Bilinear, may be
+    discontinuous between faces and/or within non-planar irregular faces."""
 ) {
     #
     # Common Properties
     #
     int[] faceVertexIndices (
-        doc = """Flat list of the index (into the 'points' attribute) of each
+        doc = """Flat list of the index (into the _points_ attribute) of each
         vertex of each face in the mesh.  If this attribute has more than
         one timeSample, the mesh is considered to be topologically varying."""
     )
     
     int[] faceVertexCounts (
         doc = """Provides the number of vertices in each face of the mesh, 
-        which is also the number of consecutive indices in 'faceVertexIndices'
+        which is also the number of consecutive indices in _faceVertexIndices_
         that define the face.  The length of this attribute is the number of
         faces in the mesh.  If this attribute has more than
         one timeSample, the mesh is considered to be topologically varying."""
@@ -792,80 +841,116 @@ class Mesh "Mesh" (
     
     uniform token subdivisionScheme = "catmullClark" (
         allowedTokens = ["catmullClark", "loop", "bilinear", "none"]
-        doc = """The subdivision scheme to be applied to the surface.  
-        Valid values are "catmullClark" (the default), "loop", "bilinear", and
-        "none" (i.e. a polymesh with no subdivision - the primary difference
-        between schemes "bilinear" and "none" is that bilinearly subdivided
-        meshes can be considered watertight, whereas there is no such guarantee
-        for un-subdivided polymeshes, and more mesh features (e.g. holes) may
-        apply to bilinear meshes but not polymeshes.   Further, if a polymesh 
-        does not provide normals, then it should be treated and rendered as 
-        faceted, whereas a "bilinear" Mesh should compute smooth normals. 
-        For primarily this latter reason, polymeshes \\em may be lighterweight 
-        and faster to render, depending on renderer and render mode.)""")
+        doc = """The subdivision scheme to be applied to the surface.
+        Valid values are:
+
+        - __catmullClark__: The default, Catmull-Clark subdivision; preferred
+          for quad-dominant meshes (generalizes B-splines); interpolation
+          of point data is smooth (non-linear)
+        - __loop__: Loop subdivision; preferred for purely triangular meshes;
+          interpolation of point data is smooth (non-linear)
+        - __bilinear__: Subdivision reduces all faces to quads (topologically
+          similar to "catmullClark"); interpolation of point data is bilinear
+        - __none__: No subdivision, i.e. a simple polygonal mesh; interpolation
+          of point data is linear
+
+        Polygonal meshes are typically lighter weight and faster to render,
+        depending on renderer and render mode.  Use of "bilinear" will produce
+        a similar shape to a polygonal mesh and may offer additional guarantees
+        of watertightness and additional subdivision features (e.g. holes) but
+        may also not respect authored normals.""")
 
     token interpolateBoundary = "edgeAndCorner" (
-        allowedTokens = ["none", "edgeAndCorner", "edgeOnly"]
-        doc = """Specifies how interpolation boundary face edges are
-        interpolated. Valid values are "none", 
-        "edgeAndCorner" (the default), or "edgeOnly".""")
+        allowedTokens = ["none", "edgeOnly", "edgeAndCorner"]
+        doc = """Specifies how subdivision is applied for faces adjacent to
+        boundary edges and boundary points. Valid values correspond to choices
+        available in OpenSubdiv:
+
+        - __none__: No boundary interpolation is applied and boundary faces are
+          effectively treated as holes
+        - __edgeOnly__: A sequence of boundary edges defines a smooth curve to
+          which the edges of subdivided boundary faces converge
+        - __edgeAndCorner__: The default, similar to "edgeOnly" but the smooth
+          boundary curve is made sharp at corner points
+
+        These are illustrated and described in more detail in the OpenSubdiv
+        documentation:
+        https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#boundary-interpolation-rules""")
 
     token faceVaryingLinearInterpolation = "cornersPlus1" (
-        allowedTokens = ["all", "none", "boundaries", "cornersOnly", 
-                         "cornersPlus1", "cornersPlus2"]
-        doc = """Specifies how face varying data is interpolated.  Valid values
-        are "all" (no smoothing), "cornersPlus1" (the default, Smooth UV),
-        "none" (Same as "cornersPlus1" but does not infer the presence 
-        of corners where two faceVarying edges meet at a single face), or 
-        "boundaries" (smooth only near vertices that are not at a
-        discontinuous boundary).
+        allowedTokens = ["none", "cornersOnly", "cornersPlus1",
+                         "cornersPlus2", "boundaries", "all"]
+        doc = """Specifies how elements of a primvar of interpolation type
+        "faceVarying" are interpolated for subdivision surfaces. Interpolation
+        can be as smooth as a "vertex" primvar or constrained to be linear at
+        features specified by several options.  Valid values correspond to
+        choices available in OpenSubdiv:
 
-        See http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#face-varying-interpolation-rules""")
+        - __none__: No linear constraints or sharpening, smooth everywhere
+        - __cornersOnly__: Sharpen corners of discontinuous boundaries only,
+          smooth everywhere else
+        - __cornersPlus1__: The default, same as "cornersOnly" plus additional
+          sharpening at points where three or more distinct face-varying
+          values occur
+        - __cornersPlus2__: Same as "cornersPlus1" plus additional sharpening
+          at points with at least one discontinuous boundary corner or
+          only one discontinuous boundary edge (a dart)
+        - __boundaries__: Piecewise linear along discontinuous boundaries,
+          smooth interior
+        - __all__: Piecewise linear everywhere
+
+        These are illustrated and described in more detail in the OpenSubdiv
+        documentation:
+        https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#face-varying-interpolation-rules""")
 
     token triangleSubdivisionRule = "catmullClark" (
         allowedTokens = ["catmullClark", "smooth"]
-        doc = """Specifies what weights are used during triangle subdivision for
-        the Catmull-Clark scheme. Valid values are "catmullClark" (the default) 
-        and "smooth".
+        doc = """Specifies an option to the subdivision rules for the
+        Catmull-Clark scheme to try and improve undesirable artifacts when
+        subdividing triangles.  Valid values are "catmullClark" for the
+        standard rules (the default) and "smooth" for the improvement.
 
-        See http://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#triangle-subdivision-rule""")
+        See https://graphics.pixar.com/opensubdiv/docs/subdivision_surfaces.html#triangle-subdivision-rule""")
     
     int[] holeIndices = [] (
-        doc = """The face indices (indexing into the 'faceVertexCounts'
-        attribute) of all faces that should be made invisible.""")
+        doc = """The indices of all faces that should be treated as holes,
+        i.e. made invisible. This is traditionally a feature of subdivision
+        surfaces and not generally applied to polygonal meshes.""")
 
     int[] cornerIndices = [] (
-        doc = """The point indices of sharp corners.""")
+        doc = """The indices of points for which a corresponding sharpness
+        value is specified in _cornerSharpnesses_ (so the size of this array
+        must match that of _cornerSharpnesses_).""")
 
     float[] cornerSharpnesses = [] (
-        doc = """The sharpness values for corners: each corner gets a single
-        sharpness value (Usd.Mesh.SHARPNESS_INFINITE for a perfectly sharp
-        corner), so the size of this array must match that of
-        'cornerIndices'""")
+        doc = """The sharpness values associated with a corresponding set of
+        points specified in _cornerIndices_ (so the size of this array must
+        match that of _cornerIndices_). Use the constant `SHARPNESS_INFINITE`
+        for a perfectly sharp corner.""")
 
     int[] creaseIndices = [] (
-        doc = """The point indices forming creased edges.  The size of 
-        this array must be equal to the sum of all elements of the 
-        'creaseLengths' attribute. Neighboring indices should correspond with the
-        valid edges indices.""")
+        doc = """The indices of points grouped into sets of successive pairs
+        that identify edges to be creased. The size of this array must be
+        equal to the sum of all elements of the _creaseLengths_ attribute.""")
 
     int[] creaseLengths = [] (
-        doc = """The length of this array specifies the number of creases on the
-        surface. Each element gives the number of (must be adjacent) vertices in
-        each crease, whose indices are linearly laid out in the 'creaseIndices'
-        attribute. Since each crease must be at least one edge long, each
-        element of this array should be greater than one.""")
+        doc = """The length of this array specifies the number of creases
+        (sets of adjacent sharpened edges) on the mesh. Each element gives
+        the number of points of each crease, whose indices are successively
+        laid out in the _creaseIndices_ attribute. Since each crease must
+        be at least one edge long, each element of this array must be at
+        least two.""")
 
     float[] creaseSharpnesses = [] (
-        doc = """The per-crease or per-edge sharpness for all creases
-        (Usd.Mesh.SHARPNESS_INFINITE for a perfectly sharp crease).  Since
-        'creaseLengths' encodes the number of vertices in each crease, the
-        number of elements in this array will be either len(creaseLengths) or
-        the sum over all X of (creaseLengths[X] - 1). Note that while
+        doc = """The per-crease or per-edge sharpness values for all creases.
+        Since _creaseLengths_ encodes the number of points in each crease,
+        the number of elements in this array will be either len(creaseLengths)
+        or the sum over all X of (creaseLengths[X] - 1). Note that while
         the RI spec allows each crease to have either a single sharpness
         or a value per-edge, USD will encode either a single sharpness
         per crease on a mesh, or sharpnesses for all edges making up
-        the creases on a mesh.""")
+        the creases on a mesh.  Use the constant `SHARPNESS_INFINITE` for a
+        perfectly sharp crease.""")
 }
 
 class GeomSubset "GeomSubset" (


### PR DESCRIPTION

### Description of Change(s)
Changes here improve the documentation generated for UsdGeomMesh, including:
- the Detailed Description was expanded to include more about terminology and topology
- the term "vertex" was specifically avoided in favor or "point" or "face-vertex"
- a list describing primvar interpolation behaviors specific to meshes was added
- descriptions of subdivision options were corrected and aligned more closely with OpenSubdiv

Updates were applied to usdGeom/schema.usda and remaining files generated with usdGenSchema.

### Fixes Issue(s)
Hopefully reduces confusion and errors previously encountered when using UsdGeomMesh.

