### PR TITLE
UsdSkelCache instancing support

### DIFF
--- a/pxr/usd/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/usdSkel/bakeSkinning.cpp
@@ -2259,9 +2259,16 @@ UsdSkelBakeSkinning(const UsdSkelCache& skelCache,
     // Get the stage from the first valid binding.
     UsdStagePtr stage;
     for (const auto& binding : parms.bindings) {
-        if (binding.GetSkeleton()) {
+        if (!stage && binding.GetSkeleton()) {
             stage = binding.GetSkeleton().GetPrim().GetStage();
-            break;
+        }
+        for (const auto& query: binding.GetSkinningTargets()) {
+            if (query.GetPrim().IsInstance() || query.GetPrim().IsInstanceProxy()) {
+                // TODO: support BakeSkinning for instances
+                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkinningQuery <%s>\n",
+                        query.GetPrim().GetPath().GetText());
+                return false;
+            }
         }
     }
     if (!stage) {
@@ -2424,6 +2431,12 @@ UsdSkelBakeSkinning(const UsdPrimRange& range, const GfInterval& interval)
     for (auto it = range.begin(); it != range.end(); ++it) {
         if (it->IsA<UsdSkelRoot>()) {
 
+            if (it->IsInstance() || it->IsInstanceProxy()) {
+                // TODO: support BakeSkinning for instances
+                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkelRoot <%s>\n",
+                        it->GetPath().GetText());
+            }
+
             TF_DEBUG(USDSKEL_BAKESKINNING).Msg(
                 "[UsdSkelBakeSkinning] Populating cache for <%s>\n",
                 it->GetPath().GetText());
@@ -2455,6 +2468,13 @@ UsdSkelBakeSkinning(const UsdPrimRange& range, const GfInterval& interval)
 bool
 UsdSkelBakeSkinning(const UsdSkelRoot& skelRoot, const GfInterval& interval)
 {
+    if (skelRoot.GetPrim().IsInstance() || skelRoot.GetPrim().IsInstanceProxy()) {
+        // TODO: support BakeSkinning for instances
+        TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkelRoot <%s>\n",
+                skelRoot.GetPrim().GetPath().GetText());
+        return false;
+    }
+
     UsdSkelBakeSkinningParms parms;
     // Backwards-compatibility: do not save during skinning.
     parms.saveLayers = false;

--- a/pxr/usd/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/usdSkel/bakeSkinning.cpp
@@ -2265,7 +2265,8 @@ UsdSkelBakeSkinning(const UsdSkelCache& skelCache,
         for (const auto& query: binding.GetSkinningTargets()) {
             if (query.GetPrim().IsInstance() || query.GetPrim().IsInstanceProxy()) {
                 // TODO: support BakeSkinning for instances
-                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkinningQuery <%s>\n",
+                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning "
+                        "for instanced SkinningQuery <%s>\n",
                         query.GetPrim().GetPath().GetText());
                 return false;
             }
@@ -2433,8 +2434,10 @@ UsdSkelBakeSkinning(const UsdPrimRange& range, const GfInterval& interval)
 
             if (it->IsInstance() || it->IsInstanceProxy()) {
                 // TODO: support BakeSkinning for instances
-                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkelRoot <%s>\n",
+                TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for "
+                        "instanced SkelRoot <%s>\n",
                         it->GetPath().GetText());
+                return false;
             }
 
             TF_DEBUG(USDSKEL_BAKESKINNING).Msg(
@@ -2470,7 +2473,8 @@ UsdSkelBakeSkinning(const UsdSkelRoot& skelRoot, const GfInterval& interval)
 {
     if (skelRoot.GetPrim().IsInstance() || skelRoot.GetPrim().IsInstanceProxy()) {
         // TODO: support BakeSkinning for instances
-        TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for instanced SkelRoot <%s>\n",
+        TF_WARN("[UsdSkelBakeSkinning] Cannot bake skinning for "
+                "instanced SkelRoot <%s>\n",
                 skelRoot.GetPrim().GetPath().GetText());
         return false;
     }

--- a/pxr/usd/usdSkel/cache.cpp
+++ b/pxr/usd/usdSkel/cache.cpp
@@ -138,11 +138,8 @@ UsdSkelCache::ComputeSkelBindings(const UsdSkelRoot& skelRoot,
     // This is done to handle inherited skel:skeleton bindings.
 
     std::vector<UsdSkelSkeleton> skelStack(1);
-    
-    // TODO: Consider traversing instance proxies at this point.
-    // But when doing so, must ensure that UsdSkelBakeSkinning, et.al.,
-    // take instancing into account.
-    const auto range = UsdPrimRange::PreAndPostVisit(skelRoot.GetPrim());
+
+    const auto range = UsdPrimRange::PreAndPostVisit(skelRoot.GetPrim(), UsdTraverseInstanceProxies());
     for (auto it = range.begin(); it != range.end(); ++it) {
 
         if (ARCH_UNLIKELY(!it->IsA<UsdGeomImageable>())) {
@@ -233,11 +230,8 @@ UsdSkelCache::ComputeSkelBinding(const UsdSkelRoot& skelRoot,
 
     std::vector<UsdSkelSkeleton> skelStack(1);
     VtArray<UsdSkelSkinningQuery> skinningQueries;
-    
-    // TODO: Consider traversing instance proxies at this point.
-    // But when doing so, must ensure that UsdSkelBakeSkinning, et.al.,
-    // take instancing into account.
-    const auto range = UsdPrimRange::PreAndPostVisit(skelRoot.GetPrim());
+
+    const auto range = UsdPrimRange::PreAndPostVisit(skelRoot.GetPrim(), UsdTraverseInstanceProxies());
     for (auto it = range.begin(); it != range.end(); ++it) {
 
         if (ARCH_UNLIKELY(!it->IsA<UsdGeomImageable>())) {

--- a/pxr/usd/usdSkel/cache.h
+++ b/pxr/usd/usdSkel/cache.h
@@ -59,7 +59,7 @@ class UsdSkelCache
 {
 public:
     USDSKEL_API
-    UsdSkelCache();
+    UsdSkelCache(bool includeInstances=false);
 
     USDSKEL_API
     void Clear();
@@ -104,8 +104,13 @@ public:
                             const UsdSkelSkeleton& skel,
                             UsdSkelBinding* binding) const;
 
+    /// Does this cache include instances?
+    USDSKEL_API
+    bool IncludesInstances() const { return _includeInstances; }
+
 private:
     std::shared_ptr<class UsdSkel_CacheImpl> _impl;
+    bool _includeInstances;
 
     friend class UsdSkelAnimQuery;
     friend class UsdSkelSkeletonQuery;

--- a/pxr/usd/usdSkel/cacheImpl.cpp
+++ b/pxr/usd/usdSkel/cacheImpl.cpp
@@ -221,13 +221,9 @@ UsdSkel_CacheImpl::ReadScope::Populate(const UsdSkelRoot& root)
 
     std::vector<std::pair<_SkinningQueryKey,UsdPrim> > stack(1);
 
-    // TODO: Consider traversing instance proxies at this point.
-    // But when doing so, must ensure that UsdSkelBakeSkinning, et.al.,
-    // take instancing into account.
     const UsdPrimRange range =
         UsdPrimRange::PreAndPostVisit(root.GetPrim(),
-                                      UsdPrimDefaultPredicate);
-                                      // UsdTraverseInstanceProxies());
+                                      UsdTraverseInstanceProxies());
 
     for (auto it = range.begin(); it != range.end(); ++it) {
         

--- a/pxr/usd/usdSkel/cacheImpl.h
+++ b/pxr/usd/usdSkel/cacheImpl.h
@@ -104,7 +104,8 @@ public:
         /// Method for populating the cache with cache properties, for
         /// the set of properties that depend on inherited state.
         /// Returns true if any skinnable prims were populated.
-        bool Populate(const UsdSkelRoot& root);
+        bool Populate(const UsdSkelRoot& root,
+                      bool includeInstanceable);
 
         // Getters for properties added to the cache through Populate().
 

--- a/pxr/usd/usdSkel/testenv/testUsdSkelCache.py
+++ b/pxr/usd/usdSkel/testenv/testUsdSkelCache.py
@@ -114,13 +114,9 @@ class TestUsdSkelCache(unittest.TestCase):
         skel1 = UsdSkel.Skeleton.Get(stage, "/Skel1")
         skel2 = UsdSkel.Skeleton.Get(stage, "/Skel2")
 
-        # TODO: Skel population does not currently traverse instance proxies,
-        # so the resolved bindings below will not include skinned meshes within
-        # instances.
-
         binding1 = cache.ComputeSkelBinding(root, skel1)
         self.assertEqual(binding1.GetSkeleton().GetPrim(), skel1.GetPrim())
-        self.assertEqual(len(binding1.GetSkinningTargets()), 1)
+        self.assertEqual(len(binding1.GetSkinningTargets()), 2)
         skinningQuery1 = binding1.GetSkinningTargets()[0]
         self.assertEqual(skinningQuery1.GetPrim().GetPath(),
                          Sdf.Path("/SkelBinding/Scope/Inherit"))
@@ -163,9 +159,9 @@ class TestUsdSkelCache(unittest.TestCase):
                          Sdf.Path("/SkelBinding/Scope/Override"))
 
         allBindings = cache.ComputeSkelBindings(root)
-        # Expecting two resolved bindings. This should *not* include bindings
-        # for any inactive skels.
-        self.assertEqual(len(allBindings), 2)
+        # Expecting three resolved bindings. This should *not* include bindings
+        # for any inactive skels, but does include instances
+        self.assertEqual(len(allBindings), 3)
 
         self.assertEqual(binding1.GetSkeleton().GetPrim(),
                          allBindings[0].GetSkeleton().GetPrim())

--- a/pxr/usd/usdSkel/wrapCache.cpp
+++ b/pxr/usd/usdSkel/wrapCache.cpp
@@ -69,6 +69,10 @@ _ComputeSkelBinding(const UsdSkelCache& self,
     return binding;
 }
 
+static UsdSkelCache *__init__()
+{
+    return new UsdSkelCache(false);
+}
 
 } // namespace
 
@@ -77,7 +81,10 @@ void wrapUsdSkelCache()
 {
     using This = UsdSkelCache;
 
-    class_<This>("Cache")
+    class_<This>("Cache", no_init)
+        .def("__init__", make_constructor(__init__))
+        .def(init<bool>(arg("includeInstances")))
+
         .def("Clear", &This::Clear)
 
         .def("Populate", &This::Populate)
@@ -100,5 +107,7 @@ void wrapUsdSkelCache()
              return_value_policy<TfPySequenceToList>())
 
         .def("ComputeSkelBinding", &_ComputeSkelBinding)
+
+        .def("IncludesInstances", &This::IncludesInstances)
         ;
 }            

--- a/pxr/usdImaging/usdSkelImaging/skelRootAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skelRootAdapter.cpp
@@ -63,6 +63,10 @@ UsdSkelImagingSkelRootAdapter::Populate(
     if(!TF_VERIFY(prim.IsA<UsdSkelRoot>())) {
         return SdfPath();
     }
+    if(prim.IsInstance() || prim.IsInstanceProxy() || prim.IsInMaster()) {
+        // TODO: support UsdSkel with instancing
+        return SdfPath();
+    }
 
     // Find skeletons and skinned prims under this skel root.
     UsdSkelRoot skelRoot(prim);

--- a/pxr/usdImaging/usdSkelImaging/skelRootAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skelRootAdapter.cpp
@@ -63,7 +63,7 @@ UsdSkelImagingSkelRootAdapter::Populate(
     if(!TF_VERIFY(prim.IsA<UsdSkelRoot>())) {
         return SdfPath();
     }
-    if(prim.IsInstance() || prim.IsInstanceProxy() || prim.IsInMaster()) {
+    if(instancerContext != nullptr) {
         // TODO: support UsdSkel with instancing
         return SdfPath();
     }

--- a/pxr/usdImaging/usdSkelImaging/skelRootAdapter.h
+++ b/pxr/usdImaging/usdSkelImaging/skelRootAdapter.h
@@ -62,6 +62,9 @@ public:
              const UsdImagingInstancerContext*
                  instancerContext=nullptr) override;
 
+    USDSKELIMAGING_API
+    bool CanPopulateMaster() const override { return true; }
+
     // ---------------------------------------------------------------------- //
     /// \name Parallel Setup and Resolve
     // ---------------------------------------------------------------------- //

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -141,7 +141,7 @@ UsdSkelImagingSkeletonAdapter::Populate(
     if(!TF_VERIFY(prim.IsA<UsdSkelSkeleton>())) {
         return SdfPath();
     }
-    if(prim.IsInstance() || prim.IsInstanceProxy() || prim.IsInMaster()) {
+    if(instancerContext != nullptr) {
         // TODO: support UsdSkel with instancing
         return SdfPath();
     }

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -141,6 +141,10 @@ UsdSkelImagingSkeletonAdapter::Populate(
     if(!TF_VERIFY(prim.IsA<UsdSkelSkeleton>())) {
         return SdfPath();
     }
+    if(prim.IsInstance() || prim.IsInstanceProxy() || prim.IsInMaster()) {
+        // TODO: support UsdSkel with instancing
+        return SdfPath();
+    }
 
     SdfPath const& skelPath = prim.GetPath();
     // Populate may be called via Resync processing for skinned prims, in which


### PR DESCRIPTION
### Description of Change(s)

Small changes to allow UsdSkelCache to operate on an instanceable SkelRoot. There are matching changes to UsdSkelBakeSkinning to prevent it from attempting to bake skinning on an instance proxy below an instanceable SkelRoot, with notes to implement this later (or not? this could be a pandora's box of managing de-instancing).

Additional changes to UsdSkelImaging stop the Hydra adapter from populating if a Skeleton or SkelRoot is an instance, instance proxy, or master. UsdSkelImaging currently doesn't support instancing with UsdSkel, so this just stops it from trying, failing, and flooding error messages into the terminal.

