### PR TITLE
Fix UsdUtilsFlattenLayerStack to apply the resolveAssetPathFn to clip manifest and asset paths

### DIFF
--- a/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack.py
@@ -136,8 +136,14 @@ class TestUsdUtilsFlattenLayerStack(unittest.TestCase):
                 resolveAssetPathFn=replaceWithFoo)
         result_stage = Usd.Stage.Open(layer)
 
-        # Confirm clip asset paths have been updated.
+        # Confirm offsets have been folded into value clips.
         p = layer.GetPrimAtPath('/SphereUsingClip')
+        self.assertEqual( p.GetInfo('clips')['default']['active'],
+           Vt.Vec2dArray(1, [(-9.0, 0)]) )
+        self.assertEqual( p.GetInfo('clips')['default']['times'],
+           Vt.Vec2dArray(2, [(-9.0, 1), (0.0, 10)]) )
+
+        # And confirm clip asset paths have been updated.
         self.assertEqual( p.GetInfo('clips')['default']['manifestAssetPath'],
            Sdf.AssetPath('foo') )
         self.assertEqual( list(p.GetInfo('clips')['default']['assetPaths']),

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack.py
@@ -30,7 +30,7 @@ import os, unittest
 class TestUsdUtilsFlattenLayerStack(unittest.TestCase):
     def test_Basic(self):
         src_stage = Usd.Stage.Open('root.usda')
-        layer = UsdUtils.FlattenLayerStack(src_stage, tag="test.usda")
+        layer = UsdUtils.FlattenLayerStack(src_stage, tag='test.usda')
         result_stage = Usd.Stage.Open(layer)
 
         # Confirm that the tag makde it into the display name.
@@ -126,6 +126,22 @@ class TestUsdUtilsFlattenLayerStack(unittest.TestCase):
         # Confirm nested variant sets still exist
         self.assertTrue(layer.GetObjectAtPath(
             '/Sphere{vset_1=default}{vset_2=default}ChildFromNestedVariant'))
+
+    def test_ClipAssetPaths(self):
+        src_stage = Usd.Stage.Open('root.usda')
+
+        def replaceWithFoo(layer, s):
+            return 'foo'
+        layer = UsdUtils.FlattenLayerStack(src_stage, 
+                resolveAssetPathFn=replaceWithFoo)
+        result_stage = Usd.Stage.Open(layer)
+
+        # Confirm clip asset paths have been updated.
+        p = layer.GetPrimAtPath('/SphereUsingClip')
+        self.assertEqual( p.GetInfo('clips')['default']['manifestAssetPath'],
+           Sdf.AssetPath('foo') )
+        self.assertEqual( list(p.GetInfo('clips')['default']['assetPaths']),
+           [Sdf.AssetPath('foo')] )
 
     def test_EmptyAssetPaths(self):
         src_stage = Usd.Stage.Open('emptyAssetPaths.usda')

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack/sub.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsFlattenLayerStack/sub.usda
@@ -58,6 +58,7 @@ def Sphere "SphereUsingClip" (
     clips = {
         dictionary default = {
             asset[] assetPaths = [@./clip_moving_sphere.usda@]
+            asset manifestAssetPath = @./clip_static_sphere.usda@
             string primPath = "/Sphere"
             double2[] active = [(1, 0)]
             double2[] times = [(1, 1), (10,10)]


### PR DESCRIPTION
### Description of Change(s)
In the _FixAssetPaths function, check for a clip dictionary. If found, update the manifestAssetPath and assetPaths data, also using _FixAssetPaths. Updated the FlattenLayerStack test to validate that the paths are updated. Because the clip times and asset paths are updated independently, this could be made more efficient at the expense of greater code rearrangement and complexity. But, as validated by the test, updating the clip info twice (in _ApplyLayerOffset and again in _FixAssetPaths) does work properly.

Note that this change does not apply the resolve function to the templateAssetPath metadata, because it's not totally clear how that kind of patterned path should be resolved.

### Fixes Issue(s)
- Brought up in #1264 

