### PR TITLE
Fix crash while destroying HdSt_TextureHandleRegistry

### DIFF
--- a/pxr/imaging/hdSt/textureHandleRegistry.h
+++ b/pxr/imaging/hdSt/textureHandleRegistry.h
@@ -157,9 +157,9 @@ private:
     // the texture).
     tbb::concurrent_vector<HdStShaderCodePtr> _dirtyShaders;
 
-    std::unique_ptr<_TextureToHandlesMap> _textureToHandlesMap;
     std::unique_ptr<class HdSt_SamplerObjectRegistry> _samplerObjectRegistry;
     std::unique_ptr<class HdSt_TextureObjectRegistry> _textureObjectRegistry;
+    std::unique_ptr<_TextureToHandlesMap> _textureToHandlesMap;
 
 };
 


### PR DESCRIPTION
### Description of Change(s)
Move the _textureToHandlesMap to be the last data member so it is the
first to get destructed by the default destructor implementation. The
_textureToHandlesMap must be destroyed before the _textureObjectRegistry
because the destruction of the texture objects involves accessing the
_textureObjectRegistry.

This bug is unlikely to show up in builds that don't immediately write over the memory
of deleted objects. But it will crash every time on a Windows debug build when you shut
down usdview after viewing a scene with textures.