### PR TITLE
Attempt to make UsdUtilsModifyAssetPaths more flexible

### DIFF
--- a/pxr/usd/sdf/listOp.cpp
+++ b/pxr/usd/sdf/listOp.cpp
@@ -614,6 +614,21 @@ _ModifyCallbackHelper(const typename SdfListOp<T>::ModifyCallback& cb,
     }
 
     if (didModify) {
+        // Make sure the updated itemVector doesn't have multiple copies of
+        // the same entry. If it does, just keep the first occurrence of
+        // each value. This is an n^2 operation, but the item counts here
+        // are very likely small enough that it doesn't matter.
+        std::vector<T> uniqueItems;
+        for (auto it = modifiedVector.begin(); it != modifiedVector.end();) {
+            if (std::find(uniqueItems.begin(), uniqueItems.end(), *it) !=
+                    uniqueItems.end()) {
+                it = modifiedVector.erase(it);
+            }
+            else {
+                uniqueItems.push_back(*it);
+                ++it;
+            }
+        }
         itemVector->swap(modifiedVector);
     }
 

--- a/pxr/usd/usdUtils/dependencies.cpp
+++ b/pxr/usd/usdUtils/dependencies.cpp
@@ -296,8 +296,10 @@ _FileAnalyzer::_ProcessSublayers()
         for (auto &subLayer: subLayerPaths) {
             std::string newPath =
                 _ProcessDependency(subLayer, _DepType::Sublayer);
-            // Avoid duplicates that may occur depending on the remap function.
-            if (std::find(newSubLayerPaths.begin(),
+            // Avoid duplicates and skip empty asset paths that may be
+            // returned depending on the remap function.
+            if (!newPath.empty() &&
+                std::find(newSubLayerPaths.begin(),
                     newSubLayerPaths.end(), newPath) ==
                     newSubLayerPaths.end()) {
                 newSubLayerPaths.push_back(newPath);


### PR DESCRIPTION
When using a ModifyCallback to edit a listOp, after running the modify
function on all the paths in each list type, remove any duplicates from
the new path vector. The remap function doesn't have enoug global context
to prevent remapping several input files to the same output file and having
them show up as duplicates. If the duplicates are left in, the validation
of the array fails and the modifications are not committed to the layer.

Added a similar test for duplicates after remapping sublayers from within
UsdUtilsModifyAssetPaths (which was the original impetus for the above
changes to list editing with a ModifyCallback).

### Description of Change(s)

I know this is unlikely to be accepted, but I'm using this to start a conversation about how to address an issue (that may be very local to our use case). In Houdini, when saving USD from a LOP network we make extensive use of UsdUtilsModifyAssetPaths (as a replacement for UpdateExternalReferences and some custom code to cover cases not addressed by UpdateExternalReferences). The problem is that one of the tricks we pull involves having a sequence of unique USD file references/payloads/sublayers all resolve to the same single USD file. Because of the way the resolve function in UsdUtilsModifyAssetPaths works, we have no global knowledge, and only get to replace one file at a time. So our callback does all the replacements, and generates a bunch of duplicates. Our old code would collapse the duplicates, and just put the single resolved file into the reference/payload/sublayer list. UsdUtilsModifyAssetPaths uses the List Op editing code, which flags this as a coding error and rejects the edit.

This change does the de-duplication before attempting to do the actual edits. It also handles having the resolve function return an empty path to indicate that the reference/payload/sublayer should be removed.

So I think the use case I'm describing here is reasonable, I just don't know the right way to address it. The changes here seems too far-reaching than I intend it to be. Maybe the change in dependencies.cpp could be left as-is (since it's local to UsdUtilsModifyAssetPaths), but I worry about unintentional behavior changes caused by the listOp.cpp change, since it is used in other code paths. Maybe this behavior could be made optional in listOp somehow?