### PR TITLE
[usdUtils] don't recreate st and pref tokens every time

### DIFF
--- a/pxr/usd/usdUtils/pipeline.cpp
+++ b/pxr/usd/usdUtils/pipeline.cpp
@@ -71,6 +71,9 @@ TF_DEFINE_PRIVATE_TOKENS(
 
     ((DefaultMaterialsScopeName, "Looks"))
     ((DefaultPrimaryCameraName, "main_cam"))
+
+    (pref)
+    (st)
 );
 
 
@@ -245,12 +248,12 @@ UsdUtilsUninstancePrimAtPath(const UsdStagePtr &stage,
 
 TfToken UsdUtilsGetPrimaryUVSetName()
 {
-    return TfToken("st");
+    return _tokens->st;
 }
 
 TfToken UsdUtilsGetPrefName()
 {
-    return TfToken("pref");
+    return _tokens->pref;
 }
 
 using _TokenToTokenMap = TfHashMap<TfToken, TfToken, TfToken::HashFunctor>;


### PR DESCRIPTION
### Description of Change(s)

This is admittedly a pretty minor performance fix - but it bothered me that we were always dynamically creating the "st" and "pref" tokens in UsdUtils.  Sort of goes against the point of the whole TfToken system.  This PR fixes this by making static tokens for these, and returning those.

