### PR TITLE
Fix extent computation plugins for simple primitive types (sphere/cube/cone/etc)

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -117,6 +117,7 @@ pxr_test_scripts(
     testenv/testUsdGeomConstraintTarget.py
     testenv/testUsdGeomConsts.py
     testenv/testUsdGeomCurves.py
+    testenv/testUsdGeomExtentFromPlugins.py
     testenv/testUsdGeomExtentTransform.py
     testenv/testUsdGeomHermiteCurves.py
     testenv/testUsdGeomImageable.py
@@ -193,6 +194,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdGeomBBoxCache
     DEST testUsdGeomBBoxCache
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdGeomExtentFromPlugins
+    DEST testUsdGeomExtentFromPlugins
 )
 
 pxr_install_test_dir(
@@ -327,6 +333,12 @@ pxr_register_test(testUsdGeomXformCache
 pxr_register_test(testUsdGeomXformCommonAPI
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCommonAPI"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdGeomExtentFromPlugins
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentFromPlugins"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdGeom/capsule.cpp
+++ b/pxr/usd/usdGeom/capsule.cpp
@@ -291,17 +291,17 @@ _ComputeExtentForCapsule(
     }
 
     double height;
-    if (!capsuleSchema.GetHeightAttr().Get(&height)) {
+    if (!capsuleSchema.GetHeightAttr().Get(&height, time)) {
         return false;
     }
 
     double radius;
-    if (!capsuleSchema.GetRadiusAttr().Get(&radius)) {
+    if (!capsuleSchema.GetRadiusAttr().Get(&radius, time)) {
         return false;
     }
 
     TfToken axis;
-    if (!capsuleSchema.GetAxisAttr().Get(&axis)) {
+    if (!capsuleSchema.GetAxisAttr().Get(&axis, time)) {
         return false;
     }
 

--- a/pxr/usd/usdGeom/cone.cpp
+++ b/pxr/usd/usdGeom/cone.cpp
@@ -287,17 +287,17 @@ _ComputeExtentForCone(
     }
 
     double height;
-    if (!coneSchema.GetHeightAttr().Get(&height)) {
+    if (!coneSchema.GetHeightAttr().Get(&height, time)) {
         return false;
     }
 
     double radius;
-    if (!coneSchema.GetRadiusAttr().Get(&radius)) {
+    if (!coneSchema.GetRadiusAttr().Get(&radius, time)) {
         return false;
     }
 
     TfToken axis;
-    if (!coneSchema.GetAxisAttr().Get(&axis)) {
+    if (!coneSchema.GetAxisAttr().Get(&axis, time)) {
         return false;
     }
 

--- a/pxr/usd/usdGeom/cube.cpp
+++ b/pxr/usd/usdGeom/cube.cpp
@@ -224,7 +224,7 @@ _ComputeExtentForCube(
     }
 
     double size;
-    if (!cubeSchema.GetSizeAttr().Get(&size)) {
+    if (!cubeSchema.GetSizeAttr().Get(&size, time)) {
         return false;
     }
 

--- a/pxr/usd/usdGeom/cylinder.cpp
+++ b/pxr/usd/usdGeom/cylinder.cpp
@@ -287,17 +287,17 @@ _ComputeExtentForCylinder(
     }
 
     double height;
-    if (!cylinderSchema.GetHeightAttr().Get(&height)) {
+    if (!cylinderSchema.GetHeightAttr().Get(&height, time)) {
         return false;
     }
 
     double radius;
-    if (!cylinderSchema.GetRadiusAttr().Get(&radius)) {
+    if (!cylinderSchema.GetRadiusAttr().Get(&radius, time)) {
         return false;
     }
 
     TfToken axis;
-    if (!cylinderSchema.GetAxisAttr().Get(&axis)) {
+    if (!cylinderSchema.GetAxisAttr().Get(&axis, time)) {
         return false;
     }
 

--- a/pxr/usd/usdGeom/sphere.cpp
+++ b/pxr/usd/usdGeom/sphere.cpp
@@ -224,7 +224,7 @@ _ComputeExtentForSphere(
     }
 
     double radius;
-    if (!sphereSchema.GetRadiusAttr().Get(&radius)) {
+    if (!sphereSchema.GetRadiusAttr().Get(&radius, time)) {
         return false;
     }
 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomExtentFromPlugins.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomExtentFromPlugins.py
@@ -1,0 +1,78 @@
+#!/pxrpythonsubst
+#
+# Copyright 2019 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import Gf, Vt, Usd, UsdGeom
+import unittest
+
+class TestUsdGeomExtentFromPlugins(unittest.TestCase):
+    primpaths = [ '/capsule', '/cone', '/cube', '/cylinder', '/sphere' ]
+
+    def test_Default(self):
+        extents = {
+            '/capsule' :  Vt.Vec3fArray(2, (Gf.Vec3f(-2.0, -2.0, -3.0),
+                                            Gf.Vec3f(2.0, 2.0, 3.0))),
+            '/cone' :     Vt.Vec3fArray(2, (Gf.Vec3f(-2.0, -2.0, -2.0),
+                                            Gf.Vec3f(2.0, 2.0, 2.0))),
+            '/cube' :     Vt.Vec3fArray(2, (Gf.Vec3f(-2.0, -2.0, -2.0),
+                                            Gf.Vec3f(2.0, 2.0, 2.0))),
+            '/cylinder' : Vt.Vec3fArray(2, (Gf.Vec3f(-2.0, -2.0, -2.0),
+                                            Gf.Vec3f(2.0, 2.0, 2.0))),
+            '/sphere' :   Vt.Vec3fArray(2, (Gf.Vec3f(-2.0, -2.0, -2.0),
+                                            Gf.Vec3f(2.0, 2.0, 2.0)))
+        }
+        testFile = "test.usda"
+        s = Usd.Stage.Open(testFile)
+        for primpath in self.primpaths:
+            p = s.GetPrimAtPath(primpath)
+            b = UsdGeom.Boundable(p)
+            tc = Usd.TimeCode.Default()
+            e = UsdGeom.Boundable.ComputeExtentFromPlugins(b, tc)
+            print primpath, e
+            self.assertEqual(extents[primpath], e)
+
+    def test_TimeSampled(self):
+        extents = {
+            '/capsule' :  Vt.Vec3fArray(2, (Gf.Vec3f(-4.0, -4.0, -6.0),
+                                            Gf.Vec3f(4.0, 4.0, 6.0))),
+            '/cone' :     Vt.Vec3fArray(2, (Gf.Vec3f(-4.0, -4.0, -3.0),
+                                            Gf.Vec3f(4.0, 4.0, 3.0))),
+            '/cube' :     Vt.Vec3fArray(2, (Gf.Vec3f(-3.0, -3.0, -3.0),
+                                            Gf.Vec3f(3.0, 3.0, 3.0))),
+            '/cylinder' : Vt.Vec3fArray(2, (Gf.Vec3f(-4.0, -4.0, -3.0),
+                                            Gf.Vec3f(4.0, 4.0, 3.0))),
+            '/sphere' :   Vt.Vec3fArray(2, (Gf.Vec3f(-4.0, -4.0, -4.0),
+                                            Gf.Vec3f(4.0, 4.0, 4.0)))
+        }
+        testFile = "test.usda"
+        s = Usd.Stage.Open(testFile)
+        for primpath in self.primpaths:
+            p = s.GetPrimAtPath(primpath)
+            b = UsdGeom.Boundable(p)
+            tc = Usd.TimeCode(2.0)
+            e = UsdGeom.Boundable.ComputeExtentFromPlugins(b, tc)
+            print primpath, e
+            self.assertEqual(extents[primpath], e)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/usdGeom/testenv/testUsdGeomExtentFromPlugins/test.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomExtentFromPlugins/test.usda
@@ -1,0 +1,97 @@
+#usda 1.0
+(
+    endTimeCode = 5
+    framesPerSecond = 24
+    metersPerUnit = 1
+    startTimeCode = 1
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+def Cube "cube"
+{
+    double size = 4
+    double size.timeSamples = {
+        1: 5,
+        2: 6,
+        3: 7,
+        4: 8,
+        5: 9,
+    }
+}
+
+def Cone "cone"
+{
+    token axis = "Z"
+    double height = 4
+    double height.timeSamples = {
+        1: 5,
+        2: 6,
+        3: 7,
+        4: 8,
+        5: 9,
+    }
+    double radius = 2
+    double radius.timeSamples = {
+        1: 3,
+        2: 4,
+        3: 5,
+        4: 6,
+        5: 7,
+    }
+}
+
+def Sphere "sphere"
+{
+    double radius = 2
+    double radius.timeSamples = {
+        1: 3,
+        2: 4,
+        3: 5,
+        4: 6,
+        5: 7,
+    }
+}
+
+def Cylinder "cylinder"
+{
+    token axis = "Z"
+    double height = 4
+    double height.timeSamples = {
+        1: 5,
+        2: 6,
+        3: 7,
+        4: 8,
+        5: 9,
+    }
+    double radius = 2
+    double radius.timeSamples = {
+        1: 3,
+        2: 4,
+        3: 5,
+        4: 6,
+        5: 7,
+    }
+}
+
+def Capsule "capsule"
+{
+    token axis = "Z"
+    double height = 2
+    double height.timeSamples = {
+        1: 3,
+        2: 4,
+        3: 5,
+        4: 6,
+        5: 7,
+    }
+    double radius = 2
+    double radius.timeSamples = {
+        1: 3,
+        2: 4,
+        3: 5,
+        4: 6,
+        5: 7,
+    }
+}
+


### PR DESCRIPTION
The extent computation functions for these basic primitive types were not passing
the time argument to the UsdAttribute.Get calls.

### Description of Change(s)
Use the timecode argument passed to extent computation plugins when fetching
attribute values from the primitive. Otherwise the default value for the
attribute would always be used. Implementations for other primitive types
already use the timecode this way.