### PR TITLE
Fix for invalid value clip template asset path in dependency compute

### DIFF
--- a/pxr/usd/usdUtils/dependencies.cpp
+++ b/pxr/usd/usdUtils/dependencies.cpp
@@ -474,6 +474,11 @@ _FileAnalyzer::_ProcessMetadata(const SdfPrimSpecHandle &primSpec)
                     const std::string clipsDir = TfGetPathName(
                             templateAssetPath);
                     // Resolve clipsDir relative to this layer. 
+                    if (clipsDir.empty()) {
+                        TF_WARN("Invalid template asset path '%s'.",
+                            templateAssetPath.c_str());
+                        continue;
+                    }
                     const std::string clipsDirAssetPath = 
                         SdfComputeAssetPathRelativeToLayer(_layer, clipsDir);
 


### PR DESCRIPTION
### Description of Change(s)
Adds a check for an empty clips directory before resolving and globbing for files.
This catches an error when an invalid templateAssetPath is specified in a Value Clip.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1288

