### PR TITLE
Speed up first assets read of a day

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -77,6 +77,20 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
     return fopen(fileName, mode);
 }
 
+FILE* ArchOpenFileForReadOnly(char const* fileName, bool isBinary)
+{
+    char const* mode = isBinary ? "rb" : "r";
+#ifdef O_NOATIME
+    int fd = open(fileName, O_RDONLY | O_NOATIME);
+    if (ARCH_UNLIKELY(fd < 0)) {
+        return nullptr;
+    }
+    return fdopen(fd, mode);
+#else /* O_NOATIME */
+    return fopen(fileName, mode);
+#endif /* O_NOATIME */
+}
+
 #if defined(ARCH_OS_WINDOWS)
 int ArchRmDir(const char* path)
 {

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -130,6 +130,8 @@ typedef struct stat ArchStatType;
 ///
 ARCH_API FILE*
 ArchOpenFile(char const* fileName, char const* mode);
+ARCH_API FILE*
+ArchOpenFileForReadOnly(char const* fileName, bool isBinary);
 
 #if defined(ARCH_OS_WINDOWS)
 #   define ArchChmod(path, mode)        _chmod(path, mode)

--- a/pxr/usd/ar/defaultResolver.cpp
+++ b/pxr/usd/ar/defaultResolver.cpp
@@ -286,7 +286,8 @@ std::shared_ptr<ArAsset>
 ArDefaultResolver::OpenAsset(
     const std::string& resolvedPath)
 {
-    FILE* f = ArchOpenFile(resolvedPath.c_str(), "rb");
+    FILE* f = ArchOpenFileForReadOnly(resolvedPath.c_str(), true);
+
     if (!f) {
         return nullptr;
     }


### PR DESCRIPTION
## Description of Change(s)
### What is the "atime" meta data ?
According to Redhat document, "atime" is "the last time the file (or directory) data was accessed". atime is updated when the file is read. This means writing to disk occurs even when just reading a file.
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/global_file_system_2/s1-manage-atimeconf

### What is the "relatime" mount option ?
To avoid this issue, the Linux has "relatime" mount option. By this mount option, the Linux only update atime per one day (default). And the mount option is defaultly enabled on modern Linux distribution (for example Ubuntu 20.04).
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/power_management_guide/relatime
The mount option of a device could be checked by this command on Linux.
```
$ mount | grep relatime
```
### What is a issue of "relatime" mount option ?
Despite this feature, the atime update will be performed on the first read of the day still.

### How much time does "atime update" spend on USD ?
The atime update spends about 11.4 micro seconds per a file. This time is measured with ArchPRead().

```
atime update enabled: 13.908 (micro seconds)
atime update disabled: 2.494 (micro seconds)
Average of ten times measurement. The time is Linux monotonic time.
```

So if a USD file has 100,000 USD file references, atime update causes 1.14 second delay.

### What this patch do ?
This patch avoids this issue by omitting atime update.