### PR TITLE
[usdview] Fix StageView.pickObject when doubles are extremely small or out of image-bounds.

### DIFF
--- a/pxr/usdImaging/usdviewq/stageView.py
+++ b/pxr/usdImaging/usdviewq/stageView.py
@@ -2192,11 +2192,13 @@ class StageView(QtOpenGL.QGLWidget):
                 # camera guides are on), treat that as a de-select.
                 selectedPoint, selectedPrimPath, \
                 selectedInstanceIndex, selectedTLPath, selectedTLIndex = \
-                    None, Sdf.Path.emptyPath, -1, Sdf.Path.emptyPath, -1
-        
+                    [-1,-1], Sdf.Path.emptyPath, -1, Sdf.Path.emptyPath, -1
+
             # Correct for high DPI displays
-            coord = self._scaleMouseCoords( \
-                QtCore.QPoint(selectedPoint[0], selectedPoint[1]))
+            # Cast to int explicitly as some versions of PySide/Shiboken throw
+            # when converting extremely small doubles held in selectedPoint
+            coord = self._scaleMouseCoords(QtCore.QPoint(
+                int(selectedPoint[0]), int(selectedPoint[1])))
             selectedPoint[0] = coord.x()
             selectedPoint[1] = coord.y()
 


### PR DESCRIPTION
### Description of Change(s)
Add explicit double->int conversion, and saner default value of _[-1,-1]_ instead of _None_

### Fixes Issue(s)
When the values returned by _TestIntersection_ are extremely small, PySide/Shiboken will complain/throw when converting them in QtCore.QPoint.

_TestIntersection_ problem can be demonstrated by picking just to the right of the outliner/render view's splitter.
