### PR TITLE
PrimCompositionQuery garbage collection fix

### DIFF
--- a/pxr/usd/usd/wrapPrimCompositionQuery.cpp
+++ b/pxr/usd/usd/wrapPrimCompositionQuery.cpp
@@ -88,7 +88,7 @@ void wrapUsdPrimCompositionQuery()
 {
     using This = UsdPrimCompositionQuery;
         
-    scope s = class_<This, This*>
+    scope s = class_<This>
         ("PrimCompositionQuery", no_init)
         .def(init<const UsdPrim &>(arg("prim")))
         .def(init<const UsdPrim &, const This::Filter &>((arg("prim"), arg("filter"))))


### PR DESCRIPTION
### Description of Change(s)
When a `PrimCompositionQuery` python is created then garbage collected, the underlying c++ objects are not properly destructed. Among other things, this prevents unused layers to be discarded.

```python
from pxr import Sdf, Usd

def func():
    s = Usd.Stage.CreateInMemory()
    Usd.PrimCompositionQuery(s.GetPseudoRoot())

func()

assert not Sdf.Layer.GetLoadedLayers()
```

### Fixes Issue(s)
- Layers are not destroyed upon the garbage collection of a python `PrimCompositionQuery` object

