### PR TITLE
Fixwinenv

### DIFF
--- a/pxr/base/arch/env.cpp
+++ b/pxr/base/arch/env.cpp
@@ -82,7 +82,7 @@ ArchSetEnv(const std::string &name, const std::string &value, bool overwrite)
 #if defined(ARCH_OS_WINDOWS)
     if (!overwrite) {
         const DWORD size = GetEnvironmentVariable(name.c_str(), nullptr, 0);
-        if (size == 0) {
+        if (size != 0) {
             // Already exists.
             return true;
         }

--- a/pxr/base/arch/env.cpp
+++ b/pxr/base/arch/env.cpp
@@ -47,7 +47,7 @@ ArchHasEnv(const std::string &name)
 {
 #if defined(ARCH_OS_WINDOWS)
     const DWORD size = GetEnvironmentVariable(name.c_str(), nullptr, 0);
-    return size != 0 && size != ERROR_ENVVAR_NOT_FOUND;
+    return size != 0;
 #else
     return static_cast<bool>(getenv(name.c_str()));
 #endif
@@ -82,8 +82,8 @@ ArchSetEnv(const std::string &name, const std::string &value, bool overwrite)
 #if defined(ARCH_OS_WINDOWS)
     if (!overwrite) {
         const DWORD size = GetEnvironmentVariable(name.c_str(), nullptr, 0);
-        if (size == 0 || size != ERROR_ENVVAR_NOT_FOUND) {
-            // Already exists or error.
+        if (size == 0) {
+            // Already exists.
             return true;
         }
     }


### PR DESCRIPTION
### Description of Change(s)
Windows ArchSetEnv(overwrite: false) never sets variable

Issue was reported before in #781 , but was only fixed for ArchGetEnv in 51f51dddfb00a0c28c0bb205d24c20967cc94ed5 this fixes also for ArchSetEnv and ArchHasEnv.

### Fixes Issue(s)
- Fixes #1303 

