### PR TITLE
Fix for building libtiff with Xcode 12

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -863,6 +863,12 @@ def InstallTIFF(context, force, buildArgs):
         PatchFile("CMakeLists.txt", 
                    [("add_subdirectory(tools)", "# add_subdirectory(tools)"),
                     ("add_subdirectory(test)", "# add_subdirectory(test)")])
+
+        if MacOS() or iOS():
+            PatchFile("CMakeLists.txt",
+                      [("option(ld-version-script \"Enable linker version script\" ON)",
+                        "option(ld-version-script \"Enable linker version script\" OFF)")])
+
         RunCMake(context, force, buildArgs)
 
 TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -864,12 +864,16 @@ def InstallTIFF(context, force, buildArgs):
                    [("add_subdirectory(tools)", "# add_subdirectory(tools)"),
                     ("add_subdirectory(test)", "# add_subdirectory(test)")])
 
-        if MacOS() or iOS():
-            PatchFile("CMakeLists.txt",
-                      [("option(ld-version-script \"Enable linker version script\" ON)",
-                        "option(ld-version-script \"Enable linker version script\" OFF)")])
-
-        RunCMake(context, force, buildArgs)
+        # The libTIFF CMakeScript says the ld-version-script 
+        # functionality is only for compilers using GNU ld on 
+        # ELF systems or systems which provide an emulation; therefore
+        # skipping it completely on mac and windows.
+        if MacOS() or Windows():
+            extraArgs = ["-Dld-version-script=OFF"]
+        else:
+            extraArgs = []
+        extraArgs += buildArgs
+        RunCMake(context, force, extraArgs)
 
 TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")
 


### PR DESCRIPTION
### Description of Change(s)

This fix elides an option from the build command line sent to libtiff, to deal with the --version-script option no longer being recognized as of Xcode 12.

### Fixes Issue(s)

Ld /Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/Release/libtiff.5.2.5.dylib normal x86_64
    cd /Users/dp/Projects/usd-py3env/src/tiff-4.0.7
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -target x86_64-apple-macos10.15 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -L/Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/Release -F/Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/Release -filelist /Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/tiff.build/Release/tiff.build/Objects-normal/x86_64/tiff.5.2.5.LinkFileList -install_name /libtiff.5.2.5.dylib -Xlinker -rpath -Xlinker /Users/dp/Projects/usd-py3env/lib -Xlinker -rpath -Xlinker /Users/dp/opt/miniconda3/envs/usd-py3env/lib -Wl,--version-script=/Users/dp/Projects/usd-py3env/src/tiff-4.0.7/libtiff/libtiff.map -dynamiclib -Wl,-headerpad_max_install_names -install_name @rpath/libtiff.5.dylib /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/libm.tbd /Users/dp/Projects/usd-py3env/lib/libz.dylib /Users/dp/Projects/usd-py3env/lib/libjpeg.dylib /Users/dp/opt/miniconda3/envs/usd-py3env/lib/liblzma.dylib -compatibility_version 5.0.0 -current_version 5.2.5 -Xlinker -dependency_info -Xlinker /Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/tiff.build/Release/tiff.build/Objects-normal/x86_64/tiff.5.2.5_dependency_info.dat -o /Users/dp/Projects/usd-py3env/build/tiff-4.0.7/libtiff/Release/libtiff.5.2.5.dylib
ld: unknown option: --version-script=/Users/dp/Projects/usd-py3env/src/tiff-4.0.7/libtiff/libtiff.map
clang: error: linker command failed with exit code 1 (use -v to see invocation)

** BUILD FAILED **

