### PR TITLE
[usdviewq] Fix errors from stricter PySide2 5.15.1 checks.

### DIFF
--- a/pxr/usdImaging/usdviewq/mainWindowUI.ui
+++ b/pxr/usdImaging/usdviewq/mainWindowUI.ui
@@ -640,7 +640,7 @@
                </attribute>
                <layout class="QHBoxLayout" name="horizontalLayout">
                 <item>
-                 <widget class="QFrame" name="attributeBrowserFrame">
+                 <widget class="QFrame" name="attributeBrowserFrame_1">
                   <property name="frameShape">
                    <enum>QFrame::NoFrame</enum>
                   </property>
@@ -650,7 +650,7 @@
                   <property name="lineWidth">
                    <number>0</number>
                   </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <layout class="QVBoxLayout" name="verticalLayout_71">
                    <property name="leftMargin">
                     <number>2</number>
                    </property>


### PR DESCRIPTION
### Description of Change(s)

Fixes the build when building on Windows with PySide2 5.15.1

### Fixes Issue(s)

To repro, build with python 3.6 with PySide2 5.15.1 installed on Windows

python.exe build_scripts\build_usd.py _install

Build will error out with the diagnostics below. This PR renames the offending components.

[10:06:07] :	 [Step 3/6] CUSTOMBUILD : error : E:\w\da639afa0455b478\USD\pxr\usdImaging\usdviewq\mainWindowUI.ui: Warning: The name 'attributeBrowserFrame' (QFrame) is already in use, defaulting to 'attributeBrowserFrame1'. [E:\w\da639afa0455b478\_build\win64_py36_release\USD\pxr\usdImaging\usdviewq\_usdviewq_pysideuifiles.vcxproj]
[10:06:07] :	 [Step 3/6] 
[10:06:07] :	 [Step 3/6]   
[10:06:07] :	 [Step 3/6] 
[10:06:07] :	 [Step 3/6] E:\w\da639afa0455b478\USD\pxr\usdImaging\usdviewq\mainWindowUI.ui : warning : The name 'verticalLayout_7' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_71'. [E:\w\da639afa0455b478\_build\win64_py36_release\USD\pxr\usdImaging\usdviewq\_usdviewq_pysideuifiles.vcxproj]


