### PR TITLE
[usdview] Fixed poor framerate when moving free camera.

### DIFF
--- a/pxr/usdImaging/usdviewq/stageView.py
+++ b/pxr/usdImaging/usdviewq/stageView.py
@@ -767,7 +767,7 @@ class StageView(QtOpenGL.QGLWidget):
         self._overrideNear = value
         self.switchToFreeCamera()
         self._dataModel.viewSettings.freeCamera.overrideNear = value
-        self.updateGL()
+        self.update()
 
     @property
     def overrideFar(self):
@@ -780,7 +780,7 @@ class StageView(QtOpenGL.QGLWidget):
         self._overrideFar = value
         self.switchToFreeCamera()
         self._dataModel.viewSettings.freeCamera.overrideFar = value
-        self.updateGL()
+        self.update()
 
     @property
     def allSceneCameras(self):
@@ -976,7 +976,7 @@ class StageView(QtOpenGL.QGLWidget):
         if self._renderer:
             if self._renderer.SetRendererPlugin(plugId):
                 self._handleRendererChanged(plugId)
-                self.updateGL()
+                self.update()
                 return True
             else:
                 return False
@@ -992,7 +992,7 @@ class StageView(QtOpenGL.QGLWidget):
         if self._renderer:
             if self._renderer.SetRendererAov(aov):
                 self._rendererAovName = aov
-                self.updateGL()
+                self.update()
                 return True
             else:
                 return False
@@ -1013,7 +1013,7 @@ class StageView(QtOpenGL.QGLWidget):
     def SetRendererSetting(self, name, value):
         if self._renderer:
             self._renderer.SetRendererSetting(name, value)
-            self.updateGL()
+            self.update()
 
     def SetRendererPaused(self, paused):
         if self._renderer and (not self._renderer.IsConverged()):
@@ -1021,7 +1021,7 @@ class StageView(QtOpenGL.QGLWidget):
                 self._renderPauseState = self._renderer.PauseRenderer()
             else:
                 self._renderPauseState = not self._renderer.ResumeRenderer()
-            self.updateGL()
+            self.update()
 
     def IsPauseRendererSupported(self):
         if self._renderer:
@@ -1039,7 +1039,7 @@ class StageView(QtOpenGL.QGLWidget):
                 self._renderStopState = self._renderer.StopRenderer()
             else:
                 self._renderStopState = not self._renderer.RestartRenderer()
-            self.updateGL()
+            self.update()
 
     def IsStopRendererSupported(self):
         if self._renderer:
@@ -1314,7 +1314,7 @@ class StageView(QtOpenGL.QGLWidget):
         if resetCam:
             self.resetCam(frameFit)
 
-        self.updateGL()
+        self.update()
 
     def updateSelection(self):
         try:
@@ -1427,17 +1427,17 @@ class StageView(QtOpenGL.QGLWidget):
             return
         Glf.RegisterDefaultDebugOutputMessageCallback()
 
-    def updateGL(self):
+    def update(self):
         """We override this virtual so that we can make it a no-op during
         playback.  The client driving playback at a particular rate should
         instead call updateForPlayback() to image the next frame."""
         if not self._dataModel.playing:
-            super(StageView, self).updateGL()
+            super(StageView, self).update()
 
     def updateForPlayback(self):
         """If playing, update the GL canvas.  Otherwise a no-op"""
         if self._dataModel.playing:
-            super(StageView, self).updateGL()
+            super(StageView, self).update()
 
     def getActiveSceneCamera(self):
         cameraPrim = self._dataModel.viewSettings.cameraPrim
@@ -2038,7 +2038,7 @@ class StageView(QtOpenGL.QGLWidget):
 
             self._lastX = x
             self._lastY = y
-            self.updateGL()
+            self.update()
 
             self.signalMouseDrag.emit()
         elif self._cameraMode == "none":
@@ -2053,7 +2053,7 @@ class StageView(QtOpenGL.QGLWidget):
         self.switchToFreeCamera()
         self._dataModel.viewSettings.freeCamera.AdjustDistance(
                 1-max(-0.5,min(0.5,(event.angleDelta().y()/1000.))))
-        self.updateGL()
+        self.update()
 
     def detachAndReClipFromCurrentCamera(self):
         """If we are currently rendering from a prim camera, switch to the


### PR DESCRIPTION
### Description of Change(s)
- Replaced all uses of updateGL() in StageView with plain update(), which aggregates updates to avoid spurious rendering.
- Added ability to "abort" a setting change with AbortSettingChange exception so it does not emit signals causing unnecessary work, especially during rendering (see commit message for more details).

Both of these lead to much smoother rendering when manipulating the free camera, especially with heavier scenes or during playback.

For reference, some changes from the original commit that at least Spiff looked at:
- Removed unconditional AbortSettingChange.
- Replaced updateGL() override in StageView with an update() override. Both update() and updateForPlayback() now call the plain super.update(). This was done because the updateGL() override wasn't actually being called since everything switched to update(), so moving the camera caused extra rendering during playback which slowed playback. This is fixed if everything just uses update().

### Fixes Issue(s)
- Usdview: Poor framerate when moving free camera. #1317

