### PR TITLE
Fix wrong usd tool executable finding on Windows

### DIFF
--- a/pxr/usd/bin/usddiff/usddiff.py
+++ b/pxr/usd/bin/usddiff/usddiff.py
@@ -67,7 +67,7 @@ def __findExe_Win(name):
     if cmd and os.access(cmd + '.cmd', os.X_OK):
         return cmd + '.cmd'
 
-    # find_executable under Windows only returns *.EXE files (Python 3.7+)
+    # find_executable under Windows only returns *.EXE files
     # so we need to traverse PATH.
     for path in os.environ['PATH'].split(os.pathsep):
         base = os.path.join(path, name)

--- a/pxr/usd/bin/usddiff/usddiff.py
+++ b/pxr/usd/bin/usddiff/usddiff.py
@@ -51,30 +51,27 @@ def _generateCatCommand(usdcatCmd, inPath, outPath, flatten=None, fmt=None):
 
     return command
 
-def _findExe(name):
+def __findExe(name):
     from distutils.spawn import find_executable
     cmd = find_executable(name)
-    
     if cmd:
         return cmd
     else:
         cmd = find_executable(name, path=os.path.abspath(os.path.dirname(sys.argv[0])))
         if cmd:
             return cmd
-
-    if isWindows:
-        # find_executable under Windows only returns *.EXE files
-        # so we need to traverse PATH.
-        for path in os.environ['PATH'].split(os.pathsep):
-            base = os.path.join(path, name)
-            # We need to test for name.cmd first because on Windows, the USD
-            # executables are wrapped due to lack of N*IX style shebang support
-            # on Windows.
-            for ext in ['.cmd', '']:
-                cmd = base + ext
-                if os.access(cmd, os.X_OK):
-                    return cmd
     return None
+
+def __findExe_Win(name):
+    cmd = __findExe(name)
+    if cmd and os.access(cmd + '.cmd', os.X_OK):
+        return cmd + '.cmd'
+    return cmd
+
+if isWindows:
+    _findExe = __findExe_Win
+else:
+    _findExe = __findExe
 
 # looks up a suitable diff tool, and locates usdcat
 def _findDiffTools():

--- a/pxr/usd/bin/usddiff/usddiff.py
+++ b/pxr/usd/bin/usddiff/usddiff.py
@@ -66,7 +66,19 @@ def __findExe_Win(name):
     cmd = __findExe(name)
     if cmd and os.access(cmd + '.cmd', os.X_OK):
         return cmd + '.cmd'
-    return cmd
+
+    # find_executable under Windows only returns *.EXE files (Python 3.7+)
+    # so we need to traverse PATH.
+    for path in os.environ['PATH'].split(os.pathsep):
+        base = os.path.join(path, name)
+        # We need to test for name.cmd first because on Windows, the USD
+        # executables are wrapped due to lack of N*IX style shebang support
+        # on Windows.
+        for ext in ['.cmd', '']:
+            cmd = base + ext
+            if os.access(cmd, os.X_OK):
+                return cmd
+    return None
 
 if isWindows:
     _findExe = __findExe_Win

--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -45,7 +45,19 @@ def __findExe_Win(name):
     cmd = __findExe(name)
     if cmd and os.access(cmd + '.cmd', os.X_OK):
         return cmd + '.cmd'
-    return cmd
+
+    # find_executable under Windows only returns *.EXE files (Python 3.7+)
+    # so we need to traverse PATH.
+    for path in os.environ['PATH'].split(os.pathsep):
+        base = os.path.join(path, name)
+        # We need to test for name.cmd first because on Windows, the USD
+        # executables are wrapped due to lack of N*IX style shebang support
+        # on Windows.
+        for ext in ['.cmd', '']:
+            cmd = base + ext
+            if os.access(cmd, os.X_OK):
+                return cmd
+    return None
 
 if isWindows:
     _findExe = __findExe_Win

--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -46,7 +46,7 @@ def __findExe_Win(name):
     if cmd and os.access(cmd + '.cmd', os.X_OK):
         return cmd + '.cmd'
 
-    # find_executable under Windows only returns *.EXE files (Python 3.7+)
+    # find_executable under Windows only returns *.EXE files
     # so we need to traverse PATH.
     for path in os.environ['PATH'].split(os.pathsep):
         base = os.path.join(path, name)

--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -30,7 +30,7 @@ import os, sys
 import platform
 isWindows = (platform.system() == 'Windows')
 
-def _findExe(name):
+def __findExe(name):
     from distutils.spawn import find_executable
     cmd = find_executable(name)
     if cmd:
@@ -39,20 +39,18 @@ def _findExe(name):
         cmd = find_executable(name, path=os.path.abspath(os.path.dirname(sys.argv[0])))
         if cmd:
             return cmd
-    
-    if isWindows:
-        # find_executable under Windows only returns *.EXE files
-        # so we need to traverse PATH.
-        for path in os.environ['PATH'].split(os.pathsep):
-            base = os.path.join(path, name)
-            # We need to test for name.cmd first because on Windows, the USD
-            # executables are wrapped due to lack of N*IX style shebang support
-            # on Windows.
-            for ext in ['.cmd', '']:
-                cmd = base + ext
-                if os.access(cmd, os.X_OK):
-                    return cmd
     return None
+
+def __findExe_Win(name):
+    cmd = __findExe(name)
+    if cmd and os.access(cmd + '.cmd', os.X_OK):
+        return cmd + '.cmd'
+    return cmd
+
+if isWindows:
+    _findExe = __findExe_Win
+else:
+    _findExe = __findExe
 
 # lookup usdcat and a suitable text editor. if none are available, 
 # this will cause the program to abort with a suitable error message.


### PR DESCRIPTION
### Description of Change(s)

Refactored executable finding function for returning correct `usddiff`, `usdcat`, .. executables on Windows.

<details><summary>Outdated description</summary>

**The following infomation is misunderstood, see comments below**

Since usd bin tools already (for a long while) being using this ..

https://github.com/PixarAnimationStudios/USD/blob/71b4baace2044ea4400ba802e91667f9ebe342f0/cmake/macros/Public.cmake#L55

https://github.com/PixarAnimationStudios/USD/blob/71b4baace2044ea4400ba802e91667f9ebe342f0/pxr/usd/bin/usddiff/CMakeLists.txt#L4-L8

.. to wrap python script into executable, this part of code in `usddiff.py` and `usdedit.py` won't run on Windows and leads to wrong finding.

```python
# in _findExe
cmd = find_executable(name)
...
# already returned at this point, and it returns `usddiff`, not `usddiff.cmd`
if Windows:
    ...
```

</details>

For example, when looking for `usddiff` executable, it returns `usddiff` instead of `usddiff.cmd` and end up with this error :
```
OSError: [WinError 193] %1 is not a valid Win32 application
```

This PR fixed this.
