### PR TITLE
[build_usd.py] on macOS include ABI flags in python library name

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -192,7 +192,7 @@ def GetPythonInfo():
         elif Linux():
             return sysconfig.get_config_var("LDLIBRARY")
         elif MacOS():
-            return "libpython" + pythonVersion + ".dylib"
+            return sysconfig.get_config_var("INSTSONAME")
         else:
             raise RuntimeError("Platform not supported")
 

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -192,7 +192,13 @@ def GetPythonInfo():
         elif Linux():
             return sysconfig.get_config_var("LDLIBRARY")
         elif MacOS():
-            return sysconfig.get_config_var("INSTSONAME")
+            # non-framework builds have the dylib name in INSTSONAME
+            # framework builds have just the path of the framework
+            instsoname = sysconfig.get_config_var("INSTSONAME")
+            if os.path.splitext(instsoname)[1] == ".dylib":
+                return instsoname
+            else:
+                return "libpython" + pythonVersion + ".dylib"
         else:
             raise RuntimeError("Platform not supported")
 


### PR DESCRIPTION
### Description of Change(s)

Prior to this change build_usd.py assumed the name of the python library on MacOS is always "libpython#.#.dylib".  However, in practice the library name may also contain ABI flags ("d", "m" and "u") that indicate how the python installation was compiled.

Because of changes in the use of Python ABI flags, this patch is relevant for Python 2.7 and Python 3.x builds up to
3.7. Starting with Python 3.8 there is no longer an ABI distinction when the interpreter is compiled with pydebug ("d") or pymalloc ("m"). Starting with Python 3.3 and newer there is no longer an ABI distinction for wide Unicode ("u") support.

### Fixes Issue(s)
- USD doesn't build properly on macos with a Python dylib that has pydebug, pymalloc or wide unicode enabled.

