### PR TITLE
Fix UDIM resolution for symlinks pointing to non-UDIM textures.

### DIFF
--- a/pxr/usdImaging/usdImaging/materialParamUtils.cpp
+++ b/pxr/usdImaging/usdImaging/materialParamUtils.cpp
@@ -190,6 +190,16 @@ _ResolveAssetAttribute(
     const std::string::size_type prefixLength =
         firstTilePath.size() - suffix.size() - UDIM_TILE_NUMBER_LENGTH;
 
+    // If this new path is not a valid UDIM til, then just pass back the original UDIM path.
+    // i.e. /inpath/myImage.1001.exr may be a sym-link to /outpath/myImage_otherconvention.exr
+    // XXX: This may break down if other-convention also uses integer-frame
+    char* endPtr = nullptr;
+    const char* udimValue = firstTilePath.c_str() + prefixLength;
+    if ((strtol(udimValue, &endPtr, 10) < UDIM_START_TILE) ||
+        (endPtr-UDIM_TILE_NUMBER_LENGTH) != udimValue) {
+        return assetPath;
+    }
+
     return
         SdfAssetPath( 
             assetPath.GetAssetPath(),


### PR DESCRIPTION
### Description of Change(s)
Checks that the resolved path returned, has a valid UDIM tile name.

As I was writing up the description for #1329, it occurred to me that my solution solves our problem, but the whole idea of resolving the sym-links might just be totally broken, given that there could be two UDIM paths that resolve to the same first-tile, but diverge on subsequent tiles:
```
/symlink/a_1001.exr => /realpath/realfile_1001.exr
/symlink/a_1002.exr => /realpath/another_1002.exr

/symlink/b_1001.exr => /realpath/realfile_1001.exr
/symlink/b_1002.exr => /realpath/totallydifferent_1002.exr
```
### Fixes Issue(s)
#1329
