### PR TITLE
Minor documentation fix - non-existent Car2.usda in instancing.dox

### DIFF
--- a/pxr/usd/usd/doxygen/instancing.dox
+++ b/pxr/usd/usd/doxygen/instancing.dox
@@ -460,14 +460,14 @@ def "ParkingLot"
 {
     def "Car_1" (
         instanceable = true
-        references = @./Car2.usda@</Car>
+        references = @./Car.usd@</Car>
     )
     {
     }
 
     def "Car_2" (
         instanceable = true
-        references = @./Car2.usda@</Car>
+        references = @./Car.usd@</Car>
     )
     {
     }


### PR DESCRIPTION
### Description of Change(s)

Just happened to notice that the instancing documentation referred to "Car2.usda", which presumably should be "Car.usd", since "Car2.usda" isn't referenced anywhere else in the doc.
