### PR TITLE
Add BlockVariantSelection to VariantSets

### DIFF
--- a/pxr/usd/sdf/primSpec.cpp
+++ b/pxr/usd/sdf/primSpec.cpp
@@ -762,6 +762,18 @@ SdfPrimSpec::SetVariantSelection(const std::string& variantSetName,
     }
 }
 
+void
+SdfPrimSpec::BlockVariantSelection(const std::string& variantSetName)
+{
+    if (_ValidateEdit(SdfFieldKeys->VariantSelection)) {
+        SdfVariantSelectionProxy proxy = GetVariantSelections();
+        if (proxy) {
+            SdfChangeBlock block;
+            proxy[variantSetName] = std::string();
+        }
+    }
+}
+
 //
 // Relocates
 //

--- a/pxr/usd/sdf/primSpec.h
+++ b/pxr/usd/sdf/primSpec.h
@@ -695,6 +695,11 @@ public:
     void SetVariantSelection(const std::string& variantSetName,
                              const std::string& variantName);
 
+    /// Blocks the variant selected for the given variant set by setting
+    /// the variant selection to empty.
+    SDF_API
+    void BlockVariantSelection(const std::string& variantSetName);
+
     /// @}
     /// \name Relocates
     /// @{

--- a/pxr/usd/sdf/wrapPrimSpec.cpp
+++ b/pxr/usd/sdf/wrapPrimSpec.cpp
@@ -361,6 +361,7 @@ void wrapPrimSpec()
         .def("GetAttributeAtPath", &This::GetAttributeAtPath)
         .def("GetRelationshipAtPath", &This::GetRelationshipAtPath)
         .def("GetVariantNames", &This::GetVariantNames)
+        .def("BlockVariantSelection", &This::BlockVariantSelection)
 
         .add_property("variantSelections",
             &This::GetVariantSelections,

--- a/pxr/usd/usd/testenv/testUsdVariants.py
+++ b/pxr/usd/usd/testenv/testUsdVariants.py
@@ -62,6 +62,19 @@ class TestUsdVariants(unittest.TestCase):
                          "localDanglingVariant"))
         self.assertFalse(prim.GetVariantSets().HasVariantSet(
                          "referencedDanglingVariant"))
+        # ClearVariantSelection clears the variant set selection from the edit target,
+        # permitting any weaker layer selection to take effect
+        stage.SetEditTarget(stage.GetSessionLayer())
+        prim.GetVariantSet('modelingVariant').SetVariantSelection('Carton_Sealed')
+        self.assertEqual(prim.GetVariantSet('modelingVariant').GetVariantSelection(),
+                        'Carton_Sealed')
+        prim.GetVariantSet('modelingVariant').ClearVariantSelection()
+        self.assertEqual(prim.GetVariantSet('modelingVariant').GetVariantSelection(),
+                        'Carton_Opened')
+        # BlockVariantSelection sets the selection to empty, which blocks weaker variant
+        # selection opinions
+        prim.GetVariantSet('modelingVariant').BlockVariantSelection()
+        self.assertEqual(prim.GetVariantSet('modelingVariant').GetVariantSelection(), '')
 
     def test_VariantSelectionPathAbstraction(self):
         for fmt in allFormats:

--- a/pxr/usd/usd/variantSets.cpp
+++ b/pxr/usd/usd/variantSets.cpp
@@ -148,6 +148,17 @@ UsdVariantSet::ClearVariantSelection()
     return SetVariantSelection(string());
 }
 
+bool
+UsdVariantSet::BlockVariantSelection()
+{
+    if (SdfPrimSpecHandle spec = _CreatePrimSpecForEditing()) {
+        spec->BlockVariantSelection(_variantSetName);
+        return true;
+    }
+
+    return false;
+}
+
 UsdEditTarget
 UsdVariantSet::GetVariantEditTarget(const SdfLayerHandle &layer) const
 {

--- a/pxr/usd/usd/variantSets.h
+++ b/pxr/usd/usd/variantSets.h
@@ -110,6 +110,11 @@ public:
     USD_API
     bool ClearVariantSelection();
 
+    /// Blocks any weaker selection for this VariantSet, setting it to empty in
+    /// the stage's current EditTarget. Return true on success, false otherwise.
+    USD_API
+    bool BlockVariantSelection();
+
     /// Return a \a UsdEditTarget that edits the currently selected variant in
     /// this VariantSet in \a layer.  If there is no currently
     /// selected variant in this VariantSet, return an invalid EditTarget.

--- a/pxr/usd/usd/wrapVariantSets.cpp
+++ b/pxr/usd/usd/wrapVariantSets.cpp
@@ -83,6 +83,7 @@ void wrapUsdVariantSets()
         .def("SetVariantSelection", &UsdVariantSet::SetVariantSelection,
              arg("variantName"))
         .def("ClearVariantSelection", &UsdVariantSet::ClearVariantSelection)
+        .def("BlockVariantSelection", &UsdVariantSet::BlockVariantSelection)
         .def("GetVariantEditTarget", &UsdVariantSet::GetVariantEditTarget,
              arg("layer")=SdfLayerHandle())
         .def("GetVariantEditContext", _GetVariantEditContext,


### PR DESCRIPTION
### Description of Change(s)

Adds the ability to block selections to variantsets with an empty string, overriding weaker variant selections. This is different from the existing clear selection methods, which removes the variant selections from the layer, but the selection from weaker layers can still take effect. Also adds unit tests for both variant selection blocking and clearing.

### Fixes Issue(s)
- #1319 

