### PR TITLE
Add missing #include <algorithm>

### DIFF
--- a/pxr/imaging/hgi/types.cpp
+++ b/pxr/imaging/hgi/types.cpp
@@ -25,6 +25,8 @@
 #include "pxr/imaging/hgi/types.h"
 #include "pxr/base/tf/diagnostic.h"
 
+#include <algorithm>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 size_t


### PR DESCRIPTION
### Description of Change(s)

Under CentOS 7.4 / devtoolset-6 compilation fails with:

```
/devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.cpp:158:75: error: no matching function for call to ‘max(<brace-enclosed initializer list>)’
     const int dim = std::max({dimensions[0], dimensions[1], dimensions[2]});
                                                                           ^
In file included from /opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/char_traits.h:39:0,
                 from /opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/string:40,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/arch/function.h:37,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/tf/diagnostic.h:39,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/gf/vec3i.h:35,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.h:28,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.cpp:25:
/opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/stl_algobase.h:219:5: note: candidate: template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)
     max(const _Tp& __a, const _Tp& __b)
     ^~~
/opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/stl_algobase.h:219:5: note:   template argument deduction/substitution failed:
/devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.cpp:158:75: note:   candidate expects 2 arguments, 1 provided
     const int dim = std::max({dimensions[0], dimensions[1], dimensions[2]});
                                                                           ^
In file included from /opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/char_traits.h:39:0,
                 from /opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/string:40,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/arch/function.h:37,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/tf/diagnostic.h:39,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/base/gf/vec3i.h:35,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.h:28,
                 from /devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.cpp:25:
/opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/stl_algobase.h:265:5: note: candidate: template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)
     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/opt/rh/devtoolset-6/root/usr/include/c++/6.3.1/bits/stl_algobase.h:265:5: note:   template argument deduction/substitution failed:
/devLocal/src/rodeofx/usd_rez/build/platform-linux/devtoolset-6/python-3/!maya/USD-prefix/src/USD/pxr/imaging/hgi/types.cpp:158:75: note:   candidate expects 3 arguments, 1 provided
     const int dim = std::max({dimensions[0], dimensions[1], dimensions[2]});
                                                                           ^

```

This PR adds the missing `#include <algorithm>`. It follows the canceled PR https://github.com/PixarAnimationStudios/USD/pull/1358 where I branched from release but PR'ed into dev by mistake.

### Fixes Issue(s)
- No issue logged

