### PR TITLE
Support animated extents when using draw modes

### DIFF
--- a/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
+++ b/pxr/usdImaging/usdImagingGL/drawModeAdapter.cpp
@@ -309,6 +309,22 @@ UsdImagingGLDrawModeAdapter::MarkMaterialDirty(UsdPrim const& prim,
     }
 }
 
+bool
+UsdImagingGLDrawModeAdapter::_HasVaryingExtent(UsdPrim const& prim) const
+{
+    UsdAttribute attr;
+
+    attr = prim.GetAttribute(UsdGeomTokens->extent);
+    if (attr && attr.ValueMightBeTimeVarying())
+        return true;
+
+    attr = prim.GetAttribute(UsdGeomTokens->extentsHint);
+    if (attr && attr.ValueMightBeTimeVarying())
+        return true;
+
+    return false;
+}
+
 void
 UsdImagingGLDrawModeAdapter::_ComputeGeometryData(
     UsdPrim const& prim,
@@ -322,11 +338,13 @@ UsdImagingGLDrawModeAdapter::_ComputeGeometryData(
     VtValue* assign) const
 {
     if (drawMode == UsdGeomTokens->origin) {
-        *extent = _ComputeExtent(prim);
+        *extent = _ComputeExtent(prim,
+            _HasVaryingExtent(prim) ? time : UsdTimeCode::EarliestTime());
         _GenerateOriginGeometry(topology, points, *extent);
 
     } else if (drawMode == UsdGeomTokens->bounds) {
-        *extent = _ComputeExtent(prim);
+        *extent = _ComputeExtent(prim,
+            _HasVaryingExtent(prim) ? time : UsdTimeCode::EarliestTime());
         _GenerateBoundsGeometry(topology, points, *extent);
 
     } else if (drawMode == UsdGeomTokens->cards) {
@@ -348,7 +366,8 @@ UsdImagingGLDrawModeAdapter::_ComputeGeometryData(
 
         } else {
             // First compute the extents.
-            *extent = _ComputeExtent(prim);
+            *extent = _ComputeExtent(prim,
+                _HasVaryingExtent(prim) ? time : UsdTimeCode::EarliestTime());
 
             // Generate mask for suppressing axes with no textures
             uint8_t axes_mask = 0;
@@ -763,6 +782,21 @@ UsdImagingGLDrawModeAdapter::TrackVariability(UsdPrim const& prim,
             timeVaryingBits,
             true);
 
+    // Discover time-varying extents. Look for time samples on either the
+    // extent or extentsHint attribute.
+    if (!_IsVarying(prim,
+            UsdGeomTokens->extent,
+            HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyExtent,
+            UsdImagingTokens->usdVaryingExtent,
+            timeVaryingBits,
+            false)) {
+        _IsVarying(prim,
+            UsdGeomTokens->extentsHint,
+            HdChangeTracker::DirtyPoints | HdChangeTracker::DirtyExtent,
+            UsdImagingTokens->usdVaryingExtent,
+            timeVaryingBits,
+            false);
+    }
 }
 
 void
@@ -1374,7 +1408,8 @@ UsdImagingGLDrawModeAdapter::_GenerateTextureCoordinates(
 }
 
 GfRange3d
-UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
+UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim,
+        const UsdTimeCode& timecode) const
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
@@ -1382,12 +1417,8 @@ UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
     TfTokenVector purposes = { UsdGeomTokens->default_, UsdGeomTokens->proxy,
                                UsdGeomTokens->render };
 
-    // XXX: The use of UsdTimeCode::EarliestTime() in the code below is
-    // problematic, as it may produce unexpected results for animated models.
-
     if (prim.IsLoaded()) {
-        UsdGeomBBoxCache bboxCache(
-            UsdTimeCode::EarliestTime(), purposes, true);
+        UsdGeomBBoxCache bboxCache(timecode, purposes, true);
         return bboxCache.ComputeUntransformedBound(prim).ComputeAlignedBox();
     } else {
         GfRange3d extent;
@@ -1398,12 +1429,12 @@ UsdImagingGLDrawModeAdapter::_ComputeExtent(UsdPrim const& prim) const
         // prim.
         if (prim.IsA<UsdGeomBoundable>() &&
             (attr = UsdGeomBoundable(prim).GetExtentAttr()) &&
-            attr.Get(&extentsHint, UsdTimeCode::EarliestTime()) &&
+            attr.Get(&extentsHint, timecode) &&
             extentsHint.size() == 2) {
             extent = GfRange3d(extentsHint[0], extentsHint[1]);
         }
         else if ((attr = UsdGeomModelAPI(prim).GetExtentsHintAttr()) &&
-            attr.Get(&extentsHint, UsdTimeCode::EarliestTime()) &&
+            attr.Get(&extentsHint, timecode) &&
             extentsHint.size() >= 2) {
             // XXX: This code to merge the extentsHint values over a set of
             // purposes probably belongs in UsdGeomBBoxCache.

--- a/pxr/usdImaging/usdImagingGL/drawModeAdapter.h
+++ b/pxr/usdImaging/usdImagingGL/drawModeAdapter.h
@@ -189,15 +189,18 @@ private:
     // Check whether the given cachePath is a path to a draw mode texture.
     bool _IsTexturePath(SdfPath const& path) const;
 
+    // Return true if prim has a time varying extent or extentsHint attribute.
+    bool _HasVaryingExtent(UsdPrim const& prim) const;
+
     // Check if any of the cards texture attributes are marked as time-varying.
     void _CheckForTextureVariability(UsdPrim const& prim,
                                      HdDirtyBits dirtyBits,
                                      HdDirtyBits *timeVaryingBits) const;
 
     // Computes the extents of the given prim, using UsdGeomBBoxCache.
-    // The extents are computed at UsdTimeCode::EarliestTime() (and are not
-    // animated), and they are computed for purposes default/proxy/render.
-    GfRange3d _ComputeExtent(UsdPrim const& prim) const;
+    // The extents are computed for purposes default/proxy/render.
+    GfRange3d _ComputeExtent(UsdPrim const& prim,
+                             const UsdTimeCode& timecode) const;
 
     // Generate geometry for "origin" draw mode.
     void _GenerateOriginGeometry(VtValue* topo, VtValue* points,


### PR DESCRIPTION
As discussed in https://groups.google.com/u/1/g/usd-interest/c/oqt13R4wDdo/m/zkScXGwkCQAJ,
handle animated extent and extentsHint attributes in the draw mode adapter by
recomputing the bounds at each time sample, rather than always computing bounds
at the UsdTimeCode::EarliestTime.

### Description of Change(s)
Added tests for varying extent and extentsHint attributes on prims that use the draw mode adapter.

### Fixes Issue(s)
- #1364

