### PR TITLE
Return the thread limit stored in TBB instead of the local _threadLimit value

### DIFF
--- a/pxr/base/work/threadLimits.cpp
+++ b/pxr/base/work/threadLimits.cpp
@@ -31,6 +31,7 @@
 
 #include <tbb/atomic.h>
 #include <tbb/task_scheduler_init.h>
+#include <tbb/task_arena.h>
 
 #include <algorithm>
 
@@ -185,7 +186,7 @@ WorkSetConcurrencyLimitArgument(int n)
 unsigned
 WorkGetConcurrencyLimit()
 {
-    return _threadLimit;
+    return tbb::this_task_arena::max_concurrency();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Return the thread limit stored in TBB instead of the local _threadLimit
value when checking the max concurrency value. These two should be equal
except in cases like running within Houdini where the TBB thread limit is
set without explicitly telling USD that the value has been set.

### Description of Change(s)
Houdini (and I suspect other DCCs that use TBB) have their own code for setting the TBB max concurrency in the global scheduler object. Houdini therefore avoids calling WorkSetConcurrencyLimit to avoid having the USD library also configure (and hold a pointer to) the global scheduler. Work_InitializeThreading does get called, which sets _threadLimit based on the available hardware.

This almost works fine, except WorkGetConcurrencyLimit returns the _threadLimit variable when using a TBB task arena. So algorithms that use task arenas will still use the hardware limited number of threads.

This change proposes to return tbb::this_task_arena::max_concurrency() from this function instead of _threadLimit. This function will return the limit from the global scheduler object (which is exactly what Houdini needs it to do). And for apps that do call WorkSetConcurrencyLimit to set the thread limit, the return value from this function should match _threadLimit, and so there should be no change in behavior.