### PR TITLE
Fixes to handling of Windows symbolic links and mount points

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1178,6 +1178,24 @@ std::string ArchReadLink(const char* path)
 
             return str;
         }
+        else if (reparse->ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
+            const size_t length =
+                reparse->MountPointReparseBuffer.PrintNameLength /
+                                                                sizeof(WCHAR);
+            std::unique_ptr<WCHAR[]> reparsePath(new WCHAR[length + 1]);
+            wcsncpy(reparsePath.get(),
+              &reparse->MountPointReparseBuffer.PathBuffer[
+              reparse->MountPointReparseBuffer.PrintNameOffset / sizeof(WCHAR)
+              ], length);
+
+            reparsePath.get()[length] = 0;
+
+            // Convert wide-char to narrow char
+            std::wstring ws(reparsePath.get());
+            string str(ws.begin(), ws.end());
+
+            return str;
+        }
     }
 
     return std::string();

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -78,6 +78,13 @@ Tf_HasAttribute(
         SetLastError(ERROR_SUCCESS);
         return false;
     }
+
+    // On Linux, a trailing slash forces the resolution of symlinks
+    // (https://man7.org/linux/man-pages/man7/path_resolution.7.html).
+    // We need to provide the same behavior on Windows.
+    if (path.back() == '/' || path.back() == '\\')
+        resolveSymlinks = true;
+
     const DWORD attribs = GetFileAttributes(path.c_str());
     if (attribs == INVALID_FILE_ATTRIBUTES) {
         if (attribute == 0 && GetLastError() == ERROR_FILE_NOT_FOUND) {

--- a/pxr/base/tf/testenv/fileUtils.cpp
+++ b/pxr/base/tf/testenv/fileUtils.cpp
@@ -669,6 +669,37 @@ TestTfTouchFile()
 }
 
 static bool
+TestSymlinkBehavior()
+{
+    if (testSymlinks)
+    {
+        cout << "Testing symlink behavior" << endl;
+
+        (void) ArchUnlinkFile("junction");
+
+        TF_AXIOM(TfMakeDir("junction-target"));
+#if defined(ARCH_OS_WINDOWS)
+        TF_AXIOM(system("mklink /j junction junction-target") == 0);
+#else
+        TF_AXIOM(TfSymlink("junction-target", "junction"));
+#endif
+        TF_AXIOM(TfIsLink("junction"));
+        TF_AXIOM(!TfIsDir("junction", false));
+        TF_AXIOM(TfIsDir("junction", true));
+        TF_AXIOM(TfIsDir("junction/", false));
+        TF_AXIOM(TfIsDir("junction/", true));
+        TF_AXIOM(TfTouchFile("junction/test-file"));
+        TF_AXIOM(TfIsFile("junction/test-file", false));
+        TF_AXIOM(TfIsFile("junction/test-file", true));
+        TF_AXIOM(TfDeleteFile("junction/test-file"));
+
+        (void) ArchUnlinkFile("junction");
+    }
+
+    return true;
+}
+
+static bool
 Test_TfFileUtils()
 {
     return Setup() &&
@@ -684,7 +715,8 @@ Test_TfFileUtils()
            TestTfWalkDirs() &&
            TestTfListDir() &&
            TestTfRmTree() &&
-           TestTfTouchFile()
+           TestTfTouchFile() &&
+           TestSymlinkBehavior()
            ;
 }
 


### PR DESCRIPTION
### Description of Change(s)
Two fixes to low level handling of symbolic links and mount points on Windows. One handles Windows "Junction" mount points the same way symbolic links are currently handled (junctions are able to span between local drives, whereas symbolic links can only point to the same drive). The other change causes Tf_HasAttribute in tf/fileUtils.cpp to treat paths with trailing slashes the same way lstat handles them on Linux, which is that is resolves the link (even though the same path without the trailing slash would cause lstat to return information about the link itself, not the destination of the link).

I'm not sure how to submit a regression test for this fix since any such test would require setting up a mount point between two drives on a Windows machine (which requires administrative priveleges and knowing that two separate drives exist onthe machine).

### Fixes Issue(s)
- #1377