### PR TITLE
Add version for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ Supported Platforms
 USD is currently supported on Linux platforms and has been built and tested
 on CentOS 7 and RHEL 7.
 
-We are actively working on porting USD to both Windows and Mac platforms. 
-Support for both platforms should be considered experimental at this time.
-Currently, the tree will build on Mac (macOS version 10.14 and above) and Windows, 
-but only limited testing has been done on these platforms.
+We are actively working on porting USD to both Windows and Mac platforms (Please see [Versions.md](VERSIONS.md) for supported software versions). Support for both platforms should be considered experimental at this time. Currently, the tree will build on Mac and Windows, but only limited testing has been done on these platforms.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ on CentOS 7 and RHEL 7.
 
 We are actively working on porting USD to both Windows and Mac platforms. 
 Support for both platforms should be considered experimental at this time.
-Currently, the tree will build on Mac and Windows, but only limited testing
-has been done on these platforms.
+Currently, the tree will build on Mac (macOS version 10.14 and above) and Windows, 
+but only limited testing has been done on these platforms.
 
 Dependencies
 ------------

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -14,6 +14,7 @@ Our test machines have the following software versions installed
 
 | Software      | Linux                | macOS                        | Windows                        |
 | ------------- | -------------------- | ---------------------------- | ------------------------------ |
+| OS            |                      | 10.14 or above               |                 |
 | C++ Compiler  | gcc 6.3.1            | Apple LLVM 10.0.0 (Xcode 10.1) | MSVC 14.0 (Visual Studio 2015) |
 | CMake         | 3.14.6               | 3.16.5                       | 3.16.5                         |
 | Python        | 2.7.16, 3.6.8        | 2.7.10, 3.7.7                | 2.7.12, 3.7.4                  |


### PR DESCRIPTION
### Description of Change(s)
While building USD on MacOs I ran into errors that I had to debug for several hours. Posting my errors in the google forum I came across others who had the same issue. Attempting to fix theses issues with the help of the forum I found out that the error was with my MacOs operating system version.
