### PR TITLE
Fix some display crashes after resyncing skeletons.

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -984,8 +984,7 @@ UsdSkelImagingSkeletonAdapter::_RemovePrim(const SdfPath& cachePath,
     
     // Alternative way of finding whether this is a callback for the skeleton/
     // bone mesh.
-    bool isSkelPath = _skelBindingMap.find(cachePath) != _skelBindingMap.end();
-    if (isSkelPath) {
+    if (_GetSkelData(cachePath)) {
 
         TF_DEBUG(USDIMAGING_CHANGES).Msg(
                 "[SkeletonAdapter::_RemovePrim] Remove skeleton"


### PR DESCRIPTION
### Description of Change(s)

This fixes an issue where `UsdSkelImagingSkeletonAdapter::_RemovePrim()` failed to remove skeletons that did not have any bindings to skinned prims, which could lead to crashes later on from accessing expired prims.

`UsdSkelImagingSkeletonAdapter::_RemovePrim()` checks `_skelBindingMap` to determine whether the provided path is the skeleton prim. This was inconsistent with `UsdSkelImagingSkeletonAdapter::ProcessPrimResync()`, which checks `_skelDataCache` via `_GetSkelData()`. If there aren't any bindings, the skeleton is in `_skelDataCache` but not `_skelBindingMap`.

### Fixes Issue(s)
Fixes: #1228,  #1248