### PR TITLE
Linux compilation

### DIFF
--- a/pxr/base/tf/token.cpp
+++ b/pxr/base/tf/token.cpp
@@ -39,6 +39,7 @@
 
 #include <tbb/spin_mutex.h>
 
+#include <algorithm>
 #include <string>
 #include <ostream>
 #include <vector>

--- a/pxr/base/trace/eventTreeBuilder.cpp
+++ b/pxr/base/trace/eventTreeBuilder.cpp
@@ -27,7 +27,7 @@
 #include "pxr/pxr.h"
 
 #include "pxr/base/trace/trace.h"
-
+#include <algorithm>
 PXR_NAMESPACE_OPEN_SCOPE
 
 Trace_EventTreeBuilder::Trace_EventTreeBuilder() 

--- a/pxr/imaging/glf/udimTexture.cpp
+++ b/pxr/imaging/glf/udimTexture.cpp
@@ -42,6 +42,7 @@
 #include "pxr/base/trace/trace.h"
 #include "pxr/base/work/loops.h"
 
+#include <algorithm>
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {

--- a/pxr/imaging/hio/stbImage.cpp
+++ b/pxr/imaging/hio/stbImage.cpp
@@ -48,6 +48,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "pxr/imaging/hio/stb/stb_image_write.h"
 
+#include <algorithm>
 PXR_NAMESPACE_OPEN_SCOPE
 
 class Hio_StbImage final : public HioImage
@@ -137,7 +138,7 @@ Hio_StbImage::_GetFilenameExtension()
 {
     std::string fileExtension = ArGetResolver().GetExtension(_filename);
     //convert to lowercase
-    transform(fileExtension.begin(), 
+    std::transform(fileExtension.begin(), 
               fileExtension.end(), 
               fileExtension.begin(), ::tolower);
     return fileExtension;

--- a/pxr/usd/sdr/shaderMetadataHelpers.cpp
+++ b/pxr/usd/sdr/shaderMetadataHelpers.cpp
@@ -28,6 +28,7 @@
 #include "pxr/usd/sdr/shaderProperty.h"
 
 #include <iostream>
+#include <algorithm>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/usd/sdr/shaderNode.cpp
+++ b/pxr/usd/sdr/shaderNode.cpp
@@ -29,6 +29,7 @@
 #include "pxr/usd/sdr/shaderProperty.h"
 
 #include <unordered_set>
+#include <algorithm>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
### Description of Change(s)
Fixed the compilation on Linux for different versions of gcc and clang:
- missing `<algorithm>` header and missing `std::` for clang 10.0 using libstdc++
- `std::max(std::initializer_list<T>>)` is not available on gcc 9.3.1 (the one suggested by https://vfxplatform.com/ for 2021)
- `std::less<>` is not available for gcc < 8.0
