### PR TITLE
Add support for python 3.8 on Windows.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2017,16 +2017,6 @@ if find_executable("python"):
         PrintError("64bit python not found -- please install it and adjust your"
                    "PATH")
         sys.exit(1)
-
-    # Error out on Windows with Python 3.8+. USD currently does not support
-    # these versions due to:
-    # https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
-    isPython38 = (sys.version_info.major >= 3 and
-                  sys.version_info.minor >= 8)
-    if Windows() and isPython38:
-        PrintError("Python 3.8+ is not supported on Windows")
-        sys.exit(1)
-
 else:
     PrintError("python not found -- please ensure python is included in your "
                "PATH")

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -379,6 +379,16 @@ function(pxr_setup_python)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
          "__all__ = [${pyModulesStr}]\n")
 
+    # On windows also write out code to add the dll import directory
+    if (WIN32)
+        set(PY_WIN32_DLL_IMPORT_CODE_STRING "\nimport os, sys\n"
+            "if sys.version_info >= (3, 8, 0):\n"
+            "    dllPath = os.path.split(os.path.realpath(__file__))[0]\n"
+            "    os.add_dll_directory(dllPath)\n")
+        file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
+             ${PY_WIN32_DLL_IMPORT_CODE_STRING})
+    endif()
+
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
         DESTINATION ${installPrefix}


### PR DESCRIPTION
With python 3.8 and newer there is a Windows only function that adds a
directory to the dll search path. We need to use that to indicate where
the USD dlls are, instead of using the PATH.

### Description of Change(s)
This works for me in testing on windows with python 3.7 and python 3.8. In both cases I'm able to run usdview and other usd python scripts.

I am not an expert on cmake, so please let me know if there's a better way to do this multi-line string concatenation. I feel like this one looks pretty clean though. The resulting `__init__.py` looks like

```
__all__ = ['Tf', ...etc]

import os, sys
if sys.version_info >= (3, 8, 0):
    dllPath = os.path.split(os.path.realpath(__file__))[0]
    os.add_dll_directory(dllPath)

```

### Fixes Issue(s)
- 1404

