### PR TITLE
Attempt to fix a crash on Hydra update when a prototype primitive is removed

### DIFF
--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -679,13 +679,23 @@ UsdImagingPointInstancerAdapter::ProcessPropertyChange(UsdPrim const& prim,
             return HdChangeTracker::Clean;
         }
 
+        UsdPrim protoUsdPrim = _GetProtoUsdPrim(proto);
+        if (!protoUsdPrim) {
+            // It's possible that we will get a property change that was
+            // actually directed at a parent primitive for an inherited
+            // primvar. We need to verify that the prototype UsdPrim still
+            // exists, as it may have been deactivated or otherwise removed,
+            // in which case we can return clean (no-work).
+            return HdChangeTracker::Clean;
+        }
+
         // XXX: Specifically disallow visibility and transform updates: in
         // these cases, it's hard to tell which prims we should dirty but
         // probably we need to dirty both prototype & instancer. This is a
         // project for later. In the meantime, returning AllDirty causes
         // a re-sync.
         HdDirtyBits dirtyBits = proto.adapter->ProcessPropertyChange(
-            _GetProtoUsdPrim(proto), cachePath, propertyName);
+            protoUsdPrim, cachePath, propertyName);
 
         if (dirtyBits & (HdChangeTracker::DirtyTransform |
                          HdChangeTracker::DirtyVisibility)) {
@@ -1037,7 +1047,7 @@ UsdImagingPointInstancerAdapter::_GetProtoUsdPrim(
     //   /Instance
     // ... in which case, we want to return /Instance since prototypes drop all
     // attributes.
-    if (prim.IsPrototype() && TF_VERIFY(proto.paths.size() > 1)) {
+    if (prim && prim.IsPrototype() && TF_VERIFY(proto.paths.size() > 1)) {
         prim = _GetPrim(proto.paths.at(1));
     }
     return prim;


### PR DESCRIPTION
Attempt to fix a crash on Hydra update when a prototype primitive is removed
(deleted or deactivated) in the same update cycle where an inheritable primvar
is added or changed to an ancestor of the prototype that used to exist.

### Description of Change(s)
In UsdImagingPointInstancerAdapter::_GetProtoUsdPrim, test that prim is valid before calling prim.IsPrototype().
In UsdImagingPointInstancerAdapter::ProcessPropertyChange, if the prototype UsdPrim is invalid, set the dirty bits to "clean".

### Fixes Issue(s)
- #1417 