### PR TITLE
Added support for python 3.8 on windows by explicitely loading dlls

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2014,16 +2014,6 @@ if find_executable("python"):
         PrintError("64bit python not found -- please install it and adjust your"
                    "PATH")
         sys.exit(1)
-
-    # Error out on Windows with Python 3.8+. USD currently does not support
-    # these versions due to:
-    # https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
-    isPython38 = (sys.version_info.major >= 3 and
-                  sys.version_info.minor >= 8)
-    if Windows() and isPython38:
-        PrintError("Python 3.8+ is not supported on Windows")
-        sys.exit(1)
-
 else:
     PrintError("python not found -- please ensure python is included in your "
                "PATH")

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -364,8 +364,17 @@ function(pxr_setup_python)
     # Install a pxr __init__.py with an appropriate __all__
     _get_install_dir(lib/python/pxr installPrefix)
 
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
-         "__all__ = [${pyModulesStr}]\n")
+    if(WIN32)
+        install(
+            FILES ${PROJECT_SOURCE_DIR}/extras/windows_check.py
+            DESTINATION ${installPrefix}
+        )
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
+            "import pxr.windows_check\n\n")
+    endif()
+
+    file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
+        "__all__ = [${pyModulesStr}]\n")
 
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"

--- a/extras/windows_check.py
+++ b/extras/windows_check.py
@@ -1,0 +1,19 @@
+import os
+import platform
+import sys
+
+if platform.system() == 'Windows':
+    """
+    Since python 3.8 we need to explicitely set
+    the dll search path on windows
+    """
+    major = sys.version_info[0]
+    minor = sys.version_info[1]
+    if major > 3 or (major == 3 and minor >= 8):
+        base_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+        bin_dir = os.path.join(base_dir, 'bin')
+        lib_dir = os.path.join(base_dir, 'lib')
+
+        os.add_dll_directory(bin_dir)
+        os.add_dll_directory(lib_dir)
+

--- a/extras/windows_check.py
+++ b/extras/windows_check.py
@@ -4,7 +4,7 @@ import sys
 
 if platform.system() == 'Windows':
     """
-    Since python 3.8 we need to explicitely set
+    Since python 3.8 we need to explicitly set
     the dll search path on windows
     """
     major = sys.version_info[0]


### PR DESCRIPTION
Hi everyone, this patch adds support for python >= 3.8 on windows systems.

The fix works by explicitly adding the dll paths at runtime (by importing an ad-hoc module in the pxr/__init__.py module)

It should fix #1404

