### PR TITLE
[usdImaging] Allow prototypes from overs, per https://graphics.pixar.com/usd/docs/api/class_usd_geom_point_instancer.html#UsdGeomPointInstancer_protoProcessing

### DIFF
--- a/pxr/usdImaging/bin/testusdview/CMakeLists.txt
+++ b/pxr/usdImaging/bin/testusdview/CMakeLists.txt
@@ -197,6 +197,16 @@ if (NOT PXR_HEADLESS_TEST_MODE)
     )
 
     pxr_install_test_dir(
+        SRC testenv/testUsdviewInstancingPrototypes
+        DEST testUsdviewPointInstancingPrototypes
+    )
+
+    pxr_install_test_dir(
+        SRC testenv/testUsdviewInstancingPrototypes
+        DEST testUsdviewNativeInstancingPrototypes
+    )
+
+    pxr_install_test_dir(
         SRC testenv/testUsdviewAnimatedBounds
         DEST testUsdviewAnimatedBounds
     )
@@ -431,6 +441,24 @@ if (NOT PXR_HEADLESS_TEST_MODE)
     pxr_register_test(testUsdviewInstancingEdits
         PYTHON
         COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInstancingEdits.py test.usda"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testUsdviewPointInstancingPrototypes
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInstancingPrototypes.py ni_pi.usda"
+        ENV TF_DEBUG=USDIMAGING_INSTANCER
+        STDOUT_REDIRECT point_instancing_proto_test_out
+        DIFF_COMPARE point_instancing_proto_test_out 
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testUsdviewNativeInstancingPrototypes
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInstancingPrototypes.py internal_ni.usda"
+        ENV TF_DEBUG=USDIMAGING_INSTANCER
+        STDOUT_REDIRECT native_instancing_proto_test_out
+        DIFF_COMPARE native_instancing_proto_test_out 
         EXPECTED_RETURN_CODE 0
     )
 

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/baseline/native_instancing_proto_test_out
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/baseline/native_instancing_proto_test_out
@@ -1,0 +1,8 @@
+[Populate NI] prim=/World/Xform_01
+[Add Instance NI] </World/Xform_01>  /World/Xform_01.proto_Sphere_id0 (Sphere), adapter = UsdImagingSphereAdapter
+[Instancer Inserted] /World/Xform_01, adapter = UsdImagingInstanceAdapter
+[Add Instance NI] </World/Xform_01>  /World/Xform_01
+[Populate NI] prim=/World/Xform_02
+[Add Instance NI] </World/Xform_01>  /World/Xform_02
+[Populate NI] prim=/World/Xform_03
+[Add Instance NI] </World/Xform_01>  /World/Xform_03

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/baseline/point_instancing_proto_test_out
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/baseline/point_instancing_proto_test_out
@@ -1,0 +1,10 @@
+[Populate NI] prim=/World/sphereInstancer
+[Add PI] /__Prototype_1/Instancer, parentInstancerCachePath </World/sphereInstancer>
+[Instancer Inserted] /__Prototype_1/Instancer, adapter = UsdImagingInstanceAdapter
+[Add Instance PI] </__Prototype_1/Instancer>  /__Prototype_1/Instancer.proto0_ValidPrototype_id0
+[Add Instance NI] </World/sphereInstancer>  /__Prototype_1/Instancer (Instancer), adapter = UsdImagingPointInstancerAdapter
+[Instancer Inserted] /World/sphereInstancer, adapter = UsdImagingInstanceAdapter
+[Add Instance NI] </World/sphereInstancer>  /World/sphereInstancer
+[Populate NI] prim=/World/sphereInstancer_2
+[Add Instance NI] </World/sphereInstancer>  /World/sphereInstancer_2
+[PointInstancer::_UpdateInstancerVisibility] /__Prototype_1/Instancer

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/internal_ni.usda
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/internal_ni.usda
@@ -1,0 +1,64 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+
+    over Xform "Xform"
+    {
+        double3 xformOp:rotateXYZ = (0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+
+        def Sphere "Sphere"
+        {
+            float3[] extent = [(-50, -50, -50), (50, 50, 50)]
+            double radius = 50
+            double3 xformOp:rotateXYZ = (0, 0, 0)
+            double3 xformOp:scale = (1, 1, 1)
+            double3 xformOp:translate = (0, 0, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+        }
+    }
+
+    def Xform "Xform_01" (
+        instanceable = true
+        prepend references = </World/Xform>
+    )
+    {
+        token visibility = "inherited"
+        double3 xformOp:rotateXYZ = (0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (200, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+
+    def Xform "Xform_02" (
+        instanceable = true
+        prepend references = </World/Xform>
+    )
+    {
+        token visibility = "inherited"
+        double3 xformOp:rotateXYZ = (0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (200, 0, -200)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+
+    def Xform "Xform_03" (
+        instanceable = true
+        prepend references = </World/Xform>
+    )
+    {
+        token visibility = "inherited"
+        double3 xformOp:rotateXYZ = (0, 0, 0)
+        double3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (200, 0, 200)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+    }
+}
+

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/ni_pi.usda
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/ni_pi.usda
@@ -1,0 +1,37 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+    metersPerUnit = 0.01
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+def Xform "World"
+{
+    def Xform "sphereInstancer" (
+        instanceable = true
+        prepend references = @sphereinstancer.usda@</World>
+
+    )
+    {
+        float3 xformOp:rotateZYX = (0, 0, 0)
+        float3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (100, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale"]
+
+    }
+
+    def Xform "sphereInstancer_2" (
+        instanceable = true
+        prepend references = @sphereinstancer.usda@</World>
+
+    )
+    {
+        float3 xformOp:rotateZYX = (0, 0, 0)
+        float3 xformOp:scale = (1, 1, 1)
+        double3 xformOp:translate = (-1000, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateZYX", "xformOp:scale"]
+
+    }
+}
+

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/sphereInstancer.usda
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/sphereInstancer.usda
@@ -1,0 +1,36 @@
+#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def Xform "World"
+{
+    def PointInstancer "Instancer"
+    {
+        point3f[] positions = [(0, 0, 0), (200, 0, 0), (400, 0, 0), (600, 0, 0), (800, 0, 0), (0, 200, 0), (200, 200, 0), (400, 200, 0), (600, 200, 0), (800, 200, 0), (0, 400, 0), (200, 400, 0), (400, 400, 0), (600, 400, 0), (800, 400, 0), (0, 600, 0), (200, 600, 0), (400, 600, 0), (600, 600, 0), (800, 600, 0), (0, 800, 0), (200, 800, 0), (400, 800, 0), (600, 800, 0), (800, 800, 0)]
+        int[] protoIndices = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        prepend rel prototypes = [
+            </World/Instancer/Dumb/ValidPrototype>,
+            </World/Instancer/Dumb/Dumber>
+        ]
+        double3 xformOp:translate = (0, 0, 0)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+
+        over "Dumb"
+        {
+            def Sphere "ValidPrototype"
+            {
+                double radius = 20.0
+            }
+
+            over "Dumber"
+            {
+                def Sphere "IgnoredPrototype"
+                {
+                    double radius = 20.0
+                }
+            }
+        }
+    }
+}
+

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/testUsdviewInstancingPrototypes.py
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInstancingPrototypes/testUsdviewInstancingPrototypes.py
@@ -1,0 +1,43 @@
+#!/pxrpythonsubst
+#
+# Copyright 2019 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+def _waitForRefresh():
+    from pxr.Usdviewq.qt import QtWidgets
+    import time
+    time.sleep(0.5)
+    QtWidgets.QApplication.processEvents()
+
+# Remove any unwanted visuals from the view, and enable autoClip
+def _modifySettings(appController):
+    appController._dataModel.viewSettings.showBBoxes = False
+    appController._dataModel.viewSettings.showHUD = False
+    appController._dataModel.viewSettings.autoComputeClippingPlanes = True
+
+def _testInstancingPrototypes(appController):
+    _waitForRefresh()
+
+def testUsdviewInputFunction(appController):
+    _modifySettings(appController)
+    _testInstancingPrototypes(appController)

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -289,6 +289,14 @@ UsdImagingDelegate::_GetDisplayPredicate() const
             UsdPrimDefaultPredicate;
 }
 
+Usd_PrimFlagsConjunction
+UsdImagingDelegate::_GetDisplayPredicateForPrototypes() const
+{
+    return _displayUnloadedPrimsWithBounds ?
+        UsdPrimIsActive && UsdPrimHasDefiningSpecifier && !UsdPrimIsAbstract :
+        UsdPrimIsActive && UsdPrimHasDefiningSpecifier && UsdPrimIsLoaded && !UsdPrimIsAbstract;
+}
+
 // -------------------------------------------------------------------------- //
 // Parallel Dispatch
 // -------------------------------------------------------------------------- //

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -660,6 +660,7 @@ private:
     _HdPrimInfo *_GetHdPrimInfo(const SdfPath &cachePath);
 
     Usd_PrimFlagsConjunction _GetDisplayPredicate() const;
+    Usd_PrimFlagsConjunction _GetDisplayPredicateForPrototypes() const;
 
     // Mark render tags dirty for all prims.
     // This is done in response to toggling the purpose-based display settings.

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -232,6 +232,9 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
         // Allocate hydra prototype prims for the prims in the USD prototype.
         // -------------------------------------------------------------- //
 
+        // We do not need _GetDisplayPredicateForPrototypes here because
+        // Usd_PrimData::_ComposeAndCacheFlags special-cases
+        // native instancing prototypes with Usd_PrimDefinedFlag
         UsdPrimRange range(prototypePrim, _GetDisplayPredicate());
         int protoID = 0;
         int primCount = 0;

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -255,7 +255,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
     size_t instantiatedPrimCount = 0;
 
     std::vector<UsdPrimRange> treeStack;
-    treeStack.push_back(UsdPrimRange(protoRootPrim, _GetDisplayPredicate()));
+    treeStack.push_back(UsdPrimRange(protoRootPrim, _GetDisplayPredicateForPrototypes()));
     while (!treeStack.empty()) {
         if (!treeStack.back()) {
             treeStack.pop_back();
@@ -277,7 +277,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
         // XXX: Should we delegate to instanceAdapter here?
         if (iter->IsInstance()) {
             UsdPrim prototype = iter->GetPrototype();
-            UsdPrimRange prototypeRange(prototype, _GetDisplayPredicate());
+            UsdPrimRange prototypeRange(prototype, _GetDisplayPredicateForPrototypes());
             treeStack.push_back(prototypeRange);
 
             // Make sure to register a dependency on this instancer with the

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -1055,6 +1055,12 @@ UsdImagingPrimAdapter::_GetDisplayPredicate() const
     return _delegate->_GetDisplayPredicate();
 }
 
+Usd_PrimFlagsConjunction
+UsdImagingPrimAdapter::_GetDisplayPredicateForPrototypes() const
+{
+    return _delegate->_GetDisplayPredicateForPrototypes();
+}
+
 size_t
 UsdImagingPrimAdapter::SampleTransform(
     UsdPrim const& prim, 

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -756,6 +756,9 @@ protected:
     Usd_PrimFlagsConjunction _GetDisplayPredicate() const;
 
     USDIMAGING_API
+    Usd_PrimFlagsConjunction _GetDisplayPredicateForPrototypes() const;
+
+    USDIMAGING_API
     bool _DoesDelegateSupportCoordSys() const;
 
     // Conversion functions between usd and hydra enums.


### PR DESCRIPTION

### Description of Change(s)

Allows instancer prototypes to come from within overs, as described in https://graphics.pixar.com/usd/docs/api/class_usd_geom_point_instancer.html#UsdGeomPointInstancer_protoProcessing and https://groups.google.com/g/usd-interest/c/RJnYoYWbgo8/m/Rh6UV2rlCwAJ . Tested with the attached City_set.


[city_protos_over.zip](https://github.com/PixarAnimationStudios/USD/files/5878839/city_protos_over.zip)

