### PR TITLE
Fix for Windows _ExpandSymlinks function

### DIFF
--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -66,7 +66,13 @@ _ExpandSymlinks(const std::string& path)
     // and the remaining part of the path.
     std::string::size_type i = path.find_first_of("/\\");
     while (i != std::string::npos) {
-        const std::string prefix = path.substr(0, i);
+        std::string prefix = path.substr(0, i);
+        // If the prefix is "X:", this will access the "current" directory on
+        // drive X, when what we really want is the root of drive X, so append
+        // a backslash.
+        if (prefix.at(i-1) == ':') {
+            prefix.push_back('\\');
+        }
         if (TfIsLink(prefix)) {
             // Expand the link and repeat with the new path.
             return _ExpandSymlinks(TfReadLink(prefix) + path.substr(i));


### PR DESCRIPTION
### Description of Change(s)

Fix for Windows _ExpandSymlinks function which would try to look for symlinks defining "X:", which looks at the "current directory" on that drive, not the root of that drive. So if the USD-using process was started in "X:/foo", where "X:/foo" is a junction to "Y:/foo", "X:" would expand to "Y:/foo".

So this change appends a "\" before trying to resolve symlinks on a path that ends with a ":", causing the expansion to be attempted on the root directory of the drive as intended, not on whatever the current directory on that drive happens to be.

### Fixes Issue(s)
- #1440