### PR TITLE
Usd 6554 -- Python3 shebang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,13 @@ include(Packages)
 
 # This has to be defined after Packages is included, because it relies on the
 # discovered path to the python executable.
-set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
-    CACHE 
-    STRING
-    "Replacement path for Python #! line."
-)
+if (NOT PXR_PYTHON_SHEBANG)
+    set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}"
+        CACHE
+        STRING
+        "Replacement path for Python #! line."
+    )
+endif()
 
 # CXXDefaults will set a variety of variables for the project.
 # Consume them here. This is an effort to keep the most common
@@ -58,6 +60,6 @@ endif()
 
 if (PXR_BUILD_DOCUMENTATION)
     pxr_build_documentation()
-endif()   
+endif()
 
 pxr_toplevel_epilogue()

--- a/cmake/macros/shebang.py
+++ b/cmake/macros/shebang.py
@@ -35,13 +35,18 @@
 from __future__ import print_function
 import sys
 
+
 if len(sys.argv) < 3 or len(sys.argv) > 4:
     print("Usage: %s {shebang-str source.py dest|file output.cmd}" % sys.argv[0])
     sys.exit(1)
 
 if len(sys.argv) == 3:
     with open(sys.argv[2], 'w') as f:
-        print('@python "%%~dp0%s" %%*' % (sys.argv[1], ), file=f)
+        if sys.version_info.major == 3:
+            cmdName = 'python3'
+        else:
+            cmdName = 'python'
+        print('@%s "%%~dp0%s" %%*' % (cmdName, sys.argv[1], ), file=f)
 
 else:
     with open(sys.argv[2], 'r') as s:


### PR DESCRIPTION
### Description of Change(s)
The shebang.py uses the PYTHON_EXECUTABLE as the shebang, and uses "python" as the commands in the windows cmd files. The changes in theis PR make the PXR_PYTHON_SHEBANG settable via cmake, if the caller wants to customize that, and uses "python3" in the windows cmd files for python3 builds.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1438

