### PR TITLE
Clips template asset path support sdf file format arguments

### DIFF
--- a/pxr/usd/usd/clipSetDefinition.cpp
+++ b/pxr/usd/usd/clipSetDefinition.cpp
@@ -34,6 +34,7 @@
 #include "pxr/usd/pcp/layerStack.h"
 #include "pxr/usd/pcp/mapExpression.h"
 #include "pxr/usd/pcp/primIndex.h"
+#include "pxr/usd/sdf/layer.h"
 #include "pxr/usd/sdf/layerOffset.h"
 #include "pxr/usd/sdf/layerUtils.h"
 
@@ -174,8 +175,12 @@ _DeriveClipInfo(const std::string& templateAssetPath,
         return;
     }
 
-    auto path = TfGetPathName(templateAssetPath);
-    auto basename = TfGetBaseName(templateAssetPath);
+    std::string templateLayerPath;
+    SdfLayer::FileFormatArguments args;
+    SdfLayer::SplitIdentifier(templateAssetPath, &templateLayerPath, &args);
+
+    auto path = TfGetPathName(templateLayerPath);
+    auto basename = TfGetBaseName(templateLayerPath);
     auto tokenizedBasename = TfStringTokenize(basename, ".");
 
     size_t integerHashSectionIndex = std::numeric_limits<size_t>::max();
@@ -272,7 +277,9 @@ _DeriveClipInfo(const std::string& templateAssetPath,
             path + TfStringJoin(tokenizedBasename, "."));
 
         if (!resolver.Resolve(filePath).empty()) {
-            (*clipAssetPaths)->push_back(SdfAssetPath(filePath));
+            (*clipAssetPaths)->push_back(SdfAssetPath(
+                SdfLayer::CreateIdentifier(filePath, args)));
+
             (*clipTimes)->push_back(GfVec2d(clipTime, clipTime));
             if (activeOffsetProvided) {
                 const double offsetTime = (t + (activeOffset*(double)promotion))

--- a/pxr/usd/usd/testenv/testUsdValueClips.py
+++ b/pxr/usd/usd/testenv/testUsdValueClips.py
@@ -2351,5 +2351,18 @@ class TestUsdValueClips(unittest.TestCase):
              os.path.abspath('template/int1/p.003.usd'),
              os.path.abspath('template/int1/p.004.usd')])
 
+    def test_TemplateFileFormatArguments(self):
+        stage = Usd.Stage.Open('template/args/root.usda')
+        prim = stage.GetPrimAtPath('/World/points')
+        attr = prim.GetAttribute('extent')
+
+        self.CheckValue(attr, time=1, expected=Vt.Vec3fArray(2, (1,1,1)))
+        self.CheckValue(attr, time=2, expected=Vt.Vec3fArray(2, (2,2,2)))
+
+        args = ':SDF_FORMAT_ARGS:a=1&b=str'
+        layer = Sdf.Layer.Find(os.path.abspath("template/args/p.002.usd") + args)
+        self.assertTrue(layer)
+        self.assertEqual(layer.GetFileFormatArguments(), {'a': '1', 'b': 'str'})
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/usd/testenv/testUsdValueClips/template/args/p.001.usd
+++ b/pxr/usd/usd/testenv/testUsdValueClips/template/args/p.001.usd
@@ -1,0 +1,21 @@
+#usda 1.0
+(
+    endTimeCode = 1
+    startTimeCode = 1
+)
+
+def Xform "World" (
+    customData = {
+        bool zUp = 1
+    }
+    kind = "group"
+)
+{
+    def Points "points"
+    {
+        Vec3f[] extent.timeSamples = {
+            1: [(1, 1, 1), (1, 1, 1)],
+        }
+    }
+}
+

--- a/pxr/usd/usd/testenv/testUsdValueClips/template/args/p.002.usd
+++ b/pxr/usd/usd/testenv/testUsdValueClips/template/args/p.002.usd
@@ -1,0 +1,21 @@
+#usda 1.0
+(
+    endTimeCode = 2
+    startTimeCode = 2
+)
+
+def Xform "World" (
+    customData = {
+        bool zUp = 1
+    }
+    kind = "group"
+)
+{
+    def Points "points"
+    {
+        Vec3f[] extent.timeSamples = {
+            2: [(2, 2, 2), (2, 2, 2)],
+        }
+    }
+}
+

--- a/pxr/usd/usd/testenv/testUsdValueClips/template/args/root.usda
+++ b/pxr/usd/usd/testenv/testUsdValueClips/template/args/root.usda
@@ -1,0 +1,26 @@
+#usda 1.0
+(
+    startTimeCode = 1
+    endTimeCode = 2
+)
+
+def "World" (
+    add references = @./topology.usda@</World>
+)
+{
+    over "points" (
+        clips = {
+            dictionary default = {
+                string templateAssetPath = "./p.###.usd:SDF_FORMAT_ARGS:a=1&b=str"
+                double templateStartTime = 1
+                double templateEndTime   = 2
+                double templateStride    = 1
+                asset manifestAssetPath = @./topology.usda@
+                string primPath = "/World/points"
+            }
+        }
+    )
+    {
+    }
+}
+

--- a/pxr/usd/usd/testenv/testUsdValueClips/template/args/topology.usda
+++ b/pxr/usd/usd/testenv/testUsdValueClips/template/args/topology.usda
@@ -1,0 +1,19 @@
+#usda 1.0
+(
+    startTimeCode = 1
+    endTimeCode = 2
+)
+
+def Xform "World" (
+    customData = {
+        bool zUp = 1
+    }
+    kind = "group"
+)
+{
+    def Points "points"
+    {
+        Vec3f[] extent
+    }
+}
+


### PR DESCRIPTION
### Description of Change(s)
Clips template asset paths support sdf file format arguments.
Discussion is here:
https://groups.google.com/g/usd-interest/c/7SxzTgBVfv4

### Fixes Issue(s)
- Unable to provide file format arguments when clips with template filename are used.

