### PR TITLE
[build_scripts] fix find_executable for windows .bat (ie, pyside2-uic.bat)

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -23,8 +23,6 @@
 #
 from __future__ import print_function
 
-from distutils.spawn import find_executable
-
 import argparse
 import codecs
 import contextlib
@@ -48,8 +46,13 @@ import zipfile
 
 if sys.version_info.major >= 3:
     from urllib.request import urlopen
+    from shutil import which
 else:
     from urllib2 import urlopen
+
+    # Doesn't deal with .bat / .cmd like shutil.which, but only option
+    # available with stock python-2
+    from distutils.spawn import find_executable as which
 
 # Helpers for printing output
 verbosity = 1
@@ -119,7 +122,7 @@ def GetVisualStudioCompilerAndVersion():
     if not Windows():
         return None
 
-    msvcCompiler = find_executable('cl')
+    msvcCompiler = which('cl')
     if msvcCompiler:
         # VisualStudioVersion environment variable should be set by the
         # Visual Studio Command Prompt.
@@ -1777,10 +1780,10 @@ class InstallContext:
         # use urllib2 all the time is that some older versions of Python
         # don't support TLS v1.2, which is required for downloading some
         # dependencies.
-        if find_executable("curl"):
+        if which("curl"):
             self.downloader = DownloadFileWithCurl
             self.downloaderName = "curl"
-        elif Windows() and find_executable("powershell"):
+        elif Windows() and which("powershell"):
             self.downloader = DownloadFileWithPowershell
             self.downloaderName = "powershell"
         else:
@@ -1975,8 +1978,8 @@ for dep in requiredDependencies:
             dependenciesToBuild.append(dep)
 
 # Verify toolchain needed to build required dependencies
-if (not find_executable("g++") and
-    not find_executable("clang") and
+if (not which("g++") and
+    not which("clang") and
     not GetXcodeDeveloperDirectory() and
     not GetVisualStudioCompilerAndVersion()):
     PrintError("C++ compiler not found -- please install a compiler")
@@ -1998,7 +2001,7 @@ if Windows() and isPython38:
     PrintError("Python 3.8+ is not supported on Windows")
     sys.exit(1)
 
-if find_executable("cmake"):
+if which("cmake"):
     # Check cmake requirements
     if Windows():
         # Windows build depend on boost 1.70, which is not supported before
@@ -2024,11 +2027,11 @@ else:
     sys.exit(1)
 
 if context.buildDocs:
-    if not find_executable("doxygen"):
+    if not which("doxygen"):
         PrintError("doxygen not found -- please install it and adjust your PATH")
         sys.exit(1)
         
-    if not find_executable("dot"):
+    if not which("dot"):
         PrintError("dot not found -- please install graphviz and adjust your "
                    "PATH")
         sys.exit(1)
@@ -2038,9 +2041,9 @@ if PYSIDE in requiredDependencies:
     # not found, so check for it here to avoid confusing users. This list of 
     # PySide executable names comes from cmake/modules/FindPySide.cmake
     pyside2Uic = ["pyside2-uic", "python2-pyside2-uic", "pyside2-uic-2.7"]
-    found_pyside2Uic = any([find_executable(p) for p in pyside2Uic])
+    found_pyside2Uic = any([which(p) for p in pyside2Uic])
     pysideUic = ["pyside-uic", "python2-pyside-uic", "pyside-uic-2.7"]
-    found_pysideUic = any([find_executable(p) for p in pysideUic])
+    found_pysideUic = any([which(p) for p in pysideUic])
     if not found_pyside2Uic and not found_pysideUic:
         if Windows():
             # Windows does not support PySide2 with Python2.7
@@ -2057,7 +2060,7 @@ if PYSIDE in requiredDependencies:
 
 if JPEG in requiredDependencies:
     # NASM is required to build libjpeg-turbo
-    if (Windows() and not find_executable("nasm")):
+    if (Windows() and not which("nasm")):
         PrintError("nasm not found -- please install it and adjust your PATH")
         sys.exit(1)
 


### PR DESCRIPTION
### Description of Change(s)

There was a known issue with `distutils.spawn.find_executable` - that it fails to find `.bat` files (it only looks for `.exe`):
https://bugs.python.org/issue2200

I noticed this problem because the executable for pyside2-uic that got installed on my system is `pyside2-uic.bat` - presumably this is the same for many other windows users.

Unfortunately, since `distutils` is now deprecated, this will never be fixed, so just made a fixed version in `build.py` and renamed it `FindExecutable`.

For comparison, original code for `find_executable`:
https://github.com/python/cpython/blob/master/Lib/distutils/spawn.py#L91

### Fixes Issue(s)
- Building with pyside2 on windows (when pyside2-uic.bat is created)

