### PR TITLE
Support time-sampled computed primvars

### DIFF
--- a/pxr/imaging/hd/CMakeLists.txt
+++ b/pxr/imaging/hd/CMakeLists.txt
@@ -114,3 +114,14 @@ pxr_library(hd
         overview.dox
 )
 
+pxr_build_test(testHdExtComputationUtils
+    LIBRARIES
+        hd
+
+    CPPFILES
+        testenv/testHdExtComputationUtils.cpp
+)
+
+pxr_register_test(testHdExtComputationUtils
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdExtComputationUtils"
+)

--- a/pxr/imaging/hd/extComputationUtils.h
+++ b/pxr/imaging/hd/extComputationUtils.h
@@ -46,6 +46,9 @@ using HdExtComputationConstPtrVector = std::vector<HdExtComputationConstPtr>;
 // use of computations shared by multiple Rprims, since the chain of
 // computations for a computation primvar is executed for each Rprim.
 class HdExtComputationUtils {   
+
+    static constexpr unsigned int SAMPLE_CAPACITY = 4;
+
 public:
     using ValueStore =
         std::unordered_map<TfToken, VtValue, TfToken::HashFunctor>;
@@ -59,6 +62,21 @@ public:
     GetComputedPrimvarValues(
         HdExtComputationPrimvarDescriptorVector const& compPrimvars,
         HdSceneDelegate* sceneDelegate);
+
+    using SampleValueArray = HdTimeSampleArray<VtValue, SAMPLE_CAPACITY>;
+    using SampledValueStore =
+        std::unordered_map<TfToken, SampleValueArray, TfToken::HashFunctor>;
+
+    /// Returns a map containing the (token, samples) pairs for each
+    /// computation primvar, with up to \a maxSampleCount samples.
+    /// The participating computations are ordered based on their dependency
+    /// and then, the CPU kernel is executed for each computation.
+    HD_API
+    static SampledValueStore
+    SampleComputedPrimvarValues(
+        HdExtComputationPrimvarDescriptorVector const& compPrimvars,
+        HdSceneDelegate* sceneDelegate,
+        size_t maxSampleCount);
 
     // Helper methods (these are public for testing purposes)
     using ComputationDependencyMap =

--- a/pxr/imaging/hd/extComputationUtils.h
+++ b/pxr/imaging/hd/extComputationUtils.h
@@ -26,8 +26,10 @@
 
 #include "pxr/pxr.h"
 #include "pxr/imaging/hd/api.h"
+#include "pxr/imaging/hd/extComputation.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 
+#include "pxr/base/tf/span.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/value.h"
 
@@ -46,9 +48,6 @@ using HdExtComputationConstPtrVector = std::vector<HdExtComputationConstPtr>;
 // use of computations shared by multiple Rprims, since the chain of
 // computations for a computation primvar is executed for each Rprim.
 class HdExtComputationUtils {   
-
-    static constexpr unsigned int SAMPLE_CAPACITY = 4;
-
 public:
     using ValueStore =
         std::unordered_map<TfToken, VtValue, TfToken::HashFunctor>;
@@ -63,20 +62,22 @@ public:
         HdExtComputationPrimvarDescriptorVector const& compPrimvars,
         HdSceneDelegate* sceneDelegate);
 
-    using SampleValueArray = HdTimeSampleArray<VtValue, SAMPLE_CAPACITY>;
+    template <unsigned int CAPACITY>
     using SampledValueStore =
-        std::unordered_map<TfToken, SampleValueArray, TfToken::HashFunctor>;
+        std::unordered_map<TfToken, HdTimeSampleArray<VtValue, CAPACITY>,
+                           TfToken::HashFunctor>;
 
     /// Returns a map containing the (token, samples) pairs for each
     /// computation primvar, with up to \a maxSampleCount samples.
     /// The participating computations are ordered based on their dependency
     /// and then, the CPU kernel is executed for each computation.
-    HD_API
-    static SampledValueStore
+    template <unsigned int CAPACITY>
+    static void
     SampleComputedPrimvarValues(
         HdExtComputationPrimvarDescriptorVector const& compPrimvars,
         HdSceneDelegate* sceneDelegate,
-        size_t maxSampleCount);
+        size_t maxSampleCount,
+        SampledValueStore<CAPACITY> *computedPrimvarValueStore);
 
     // Helper methods (these are public for testing purposes)
     using ComputationDependencyMap =
@@ -96,7 +97,183 @@ public:
     HD_API
     static void
     PrintDependencyMap(ComputationDependencyMap const& cdm);
+
+private:
+    HD_API
+    static ComputationDependencyMap
+    _GenerateDependencyMap(
+        HdExtComputationPrimvarDescriptorVector const& compPrimvars,
+        HdSceneDelegate* sceneDelegate);
+
+    template <unsigned int CAPACITY>
+    static void
+    _ExecuteSampledComputations(
+        HdExtComputationConstPtrVector computations,
+        HdSceneDelegate* sceneDelegate,
+        size_t maxSampleCount,
+        SampledValueStore<CAPACITY>* valueStore);
+
+    // Limits the list of the computation input time samples to the specified
+    // maximum number of (unique) samples.
+    HD_API
+    static void
+    _LimitTimeSamples(size_t maxSampleCount, std::vector<double>* times);
+
+    // Internal method to invoke the computation with the specified input
+    // values, storing the output values in the provided buffer. The value
+    // arrays correspond to GetSceneInputNames(), GetComputationInputs(), and
+    // GetComputationOutputs() from the HdExtComputation, respectively, and are
+    // required to have the same lengths.
+    HD_API
+    static bool
+    _InvokeComputation(
+        HdSceneDelegate& sceneDelegate,
+        HdExtComputation const& computation,
+        TfSpan<const VtValue> sceneInputValues,
+        TfSpan<const VtValue> compInputValues,
+        TfSpan<VtValue> compOutputValues);
 };
+
+template <unsigned int CAPACITY>
+/*static*/ void
+HdExtComputationUtils::SampleComputedPrimvarValues(
+    HdExtComputationPrimvarDescriptorVector const& compPrimvars,
+    HdSceneDelegate* sceneDelegate,
+    size_t maxSampleCount,
+    SampledValueStore<CAPACITY> *computedPrimvarValueStore
+)
+{
+    HD_TRACE_FUNCTION();
+
+    // Directed graph representation of the participating computations
+    ComputationDependencyMap cdm =
+        _GenerateDependencyMap(compPrimvars, sceneDelegate);
+
+    // Topological ordering of the computations
+    HdExtComputationConstPtrVector sortedComputations;
+    bool success = DependencySort(cdm, &sortedComputations);
+    if (!success) {
+        return;
+    }
+
+    // Execution
+    SampledValueStore<CAPACITY> valueStore;
+    _ExecuteSampledComputations<CAPACITY>(sortedComputations, sceneDelegate,
+                                          maxSampleCount, &valueStore);
+
+    // Output extraction
+    for (auto const& pv : compPrimvars) {
+        TfToken const& compOutputName = pv.sourceComputationOutputName;
+        (*computedPrimvarValueStore)[pv.name] = valueStore[compOutputName];
+    }
+}
+
+template <unsigned int CAPACITY>
+/*static*/ void
+HdExtComputationUtils::_ExecuteSampledComputations(
+    HdExtComputationConstPtrVector computations,
+    HdSceneDelegate* sceneDelegate,
+    size_t maxSampleCount,
+    SampledValueStore<CAPACITY> *valueStore
+)
+{
+    HD_TRACE_FUNCTION();
+
+    for (auto const& comp : computations) {
+        SdfPath const& compId = comp->GetId();
+
+        TfTokenVector const& sceneInputNames = comp->GetSceneInputNames();
+        HdExtComputationInputDescriptorVector const& compInputs =
+            comp->GetComputationInputs();
+        HdExtComputationOutputDescriptorVector const& compOutputs =
+            comp->GetComputationOutputs();
+
+        // Add all the scene inputs to the value store
+        std::vector<double> times;
+        for (TfToken const& input : sceneInputNames) {
+            auto &samples = (*valueStore)[input];
+            sceneDelegate->SampleExtComputationInput(compId, input, &samples);
+
+            for (size_t i = 0; i < samples.count; ++i)
+                times.push_back(samples.times[i]);
+        }
+
+        if (comp->IsInputAggregation()) {
+            // An aggregator computation produces no output, and thus
+            // doesn't need to be executed.
+            continue;
+        }
+
+        // Also find all the time samples from the computed inputs.
+        for (auto const& computedInput : compInputs) {
+            auto const& samples =
+                valueStore->at(computedInput.sourceComputationOutputName);
+            for (size_t i = 0; i < samples.count; ++i) {
+                times.push_back(samples.times[i]);
+            }
+        }
+
+        // Determine the time samples to evaluate the computation at.
+        _LimitTimeSamples(maxSampleCount, &times);
+
+        // Allocate enough space for the evaluated outputs.
+        for (const TfToken &name : comp->GetOutputNames())
+        {
+            auto &output_samples = (*valueStore)[name];
+            output_samples.Resize(times.size());
+            output_samples.count = 0;
+        }
+
+        TfSmallVector<VtValue, CAPACITY> sceneInputValues;
+        sceneInputValues.reserve(sceneInputNames.size());
+
+        TfSmallVector<VtValue, CAPACITY> compInputValues;
+        compInputValues.reserve(compInputs.size());
+
+        TfSmallVector<VtValue, CAPACITY> compOutputValues;
+
+        // Evaluate the computation for each time sample.
+        for (double t : times) {
+
+            // Retrieve all the inputs (scene, computed) from the value store,
+            // resampled to the required time.
+            sceneInputValues.clear();
+            for (auto const& sceneInput : comp->GetSceneInputNames()) {
+                auto const& samples = valueStore->at(sceneInput);
+                sceneInputValues.push_back(samples.Resample(t));
+            }
+
+            compInputValues.clear();
+            for (auto const& computedInput : compInputs) {
+                auto const& samples =
+                    valueStore->at(computedInput.sourceComputationOutputName);
+                compInputValues.push_back(samples.Resample(t));
+            }
+
+            compOutputValues.resize(compOutputs.size());
+            if (!_InvokeComputation(*sceneDelegate, *comp,
+                                    TfMakeSpan(sceneInputValues),
+                                    TfMakeSpan(compInputValues),
+                                    TfMakeSpan(compOutputValues))) {
+                // We could bail here, or choose to execute other computations.
+                // Choose the latter.
+                continue;
+            }
+
+            // Add outputs to the value store (subsequent computations may need
+            // them as computation inputs)
+            for (size_t i = 0; i < compOutputValues.size(); ++i) {
+                auto &output_samples = (*valueStore)[compOutputs[i].name];
+
+                output_samples.times[output_samples.count] = t;
+                output_samples.values[output_samples.count] =
+                    std::move(compOutputValues[i]);
+                ++output_samples.count;
+            }
+        }
+
+    } // for each computation
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hd/sceneDelegate.cpp
+++ b/pxr/imaging/hd/sceneDelegate.cpp
@@ -406,6 +406,22 @@ HdSceneDelegate::GetExtComputationInput(SdfPath const& computationId,
 }
 
 /*virtual*/
+size_t
+HdSceneDelegate::SampleExtComputationInput(SdfPath const& computationId,
+                                           TfToken const& input,
+                                           size_t maxSampleCount,
+                                           float *sampleTimes,
+                                           VtValue *sampleValues)
+{
+    if (maxSampleCount > 0) {
+        sampleTimes[0] = 0.0;
+        sampleValues[0] = GetExtComputationInput(computationId, input);
+        return 1;
+    }
+    return 0;
+}
+
+/*virtual*/
 std::string
 HdSceneDelegate::GetExtComputationKernel(SdfPath const& id)
 {

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -704,6 +704,20 @@ public:
     virtual VtValue GetExtComputationInput(SdfPath const& computationId,
                                            TfToken const& input);
 
+    /// Return up to \a maxSampleCount samples for a given computation id and
+    /// input token.
+    /// The token may be a computation input or a computation config parameter.
+    /// Returns the union of the authored samples and the boundaries
+    /// of the current camera shutter interval. If this number is greater
+    /// than maxSampleCount, you might want to call this function again
+    /// to get all the authored data.
+    HD_API
+    virtual size_t SampleExtComputationInput(SdfPath const& computationId,
+                                             TfToken const& input,
+                                             size_t maxSampleCount,
+                                             float *sampleTimes,
+                                             VtValue *sampleValues);
+
     /// Returns the kernel source assigned to the computation at the path id.
     /// If the string is empty the computation has no GPU kernel and the
     /// CPU callback should be used.

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -718,6 +718,30 @@ public:
                                              float *sampleTimes,
                                              VtValue *sampleValues);
 
+    /// Convenience form of SampleExtComputationInput() that takes an
+    /// HdTimeSampleArray.
+    /// Returns the union of the authored samples and the boundaries
+    /// of the current camera shutter interval.
+    template <unsigned int CAPACITY>
+    void SampleExtComputationInput(SdfPath const& computationId,
+                                   TfToken const& input,
+                                   HdTimeSampleArray<VtValue, CAPACITY> *sa) {
+        size_t authoredSamples = SampleExtComputationInput(
+                computationId, input, CAPACITY,
+                sa->times.data(), sa->values.data());
+
+        if (authoredSamples > CAPACITY) {
+            sa->Resize(authoredSamples);
+            size_t authoredSamplesSecondAttempt = SampleExtComputationInput(
+                    computationId, input, authoredSamples,
+                    sa->times.data(), sa->values.data());
+            // Number of samples should be consisntent through multiple
+            // invokations of the sampling function.
+            TF_VERIFY(authoredSamples == authoredSamplesSecondAttempt);
+        }
+        sa->count = authoredSamples;
+    }
+
     /// Returns the kernel source assigned to the computation at the path id.
     /// If the string is empty the computation has no GPU kernel and the
     /// CPU callback should be used.

--- a/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
+++ b/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
@@ -1,0 +1,282 @@
+//
+// Copyright 2020 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/pxr.h"
+
+#include "pxr/base/tf/errorMark.h"
+
+#include "pxr/imaging/hd/extComputation.h"
+#include "pxr/imaging/hd/extComputationContext.h"
+#include "pxr/imaging/hd/extComputationUtils.h"
+#include "pxr/imaging/hd/renderDelegate.h"
+#include "pxr/imaging/hd/unitTestDelegate.h"
+
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static const SdfPath pathA("/path/to/A");
+static const SdfPath compA("/path/to/A/computation");
+static const TfToken input1("input1");
+static const TfToken input2("input2");
+static const TfToken primvarName("outputPV");
+static const TfToken compOutputName("compOutput");
+
+// Delegate that implements a simple computation (adding together two inputs).
+class ExtComputationTestDelegate : public HdUnitTestDelegate {
+public:
+    ExtComputationTestDelegate(HdRenderIndex *parentIndex)
+      : HdUnitTestDelegate(parentIndex, SdfPath::AbsoluteRootPath())
+    {
+    }
+
+    HdExtComputationPrimvarDescriptorVector
+    virtual GetExtComputationPrimvarDescriptors(
+        SdfPath const &id, HdInterpolation interpolationMode) override {
+
+        if (id == pathA && interpolationMode == HdInterpolationConstant) {
+            HdTupleType valueType;
+            valueType.type = HdTypeFloat;
+            valueType.count = 1;
+
+            HdExtComputationPrimvarDescriptorVector primvars;
+            primvars.emplace_back(primvarName, HdInterpolationConstant,
+                    HdPrimvarRoleTokens->none, compA, compOutputName,
+                    valueType);
+            return primvars;
+        }
+
+        return {};
+    }
+
+    virtual TfTokenVector
+    GetExtComputationSceneInputNames(SdfPath const& computationId) override {
+        if (computationId == compA) {
+            return {input1, input2};
+        }
+
+        return {};
+    }
+
+    virtual HdExtComputationOutputDescriptorVector
+    GetExtComputationOutputDescriptors(SdfPath const& computationId) override {
+        HdExtComputationOutputDescriptorVector outputs;
+        if (computationId == compA) {
+            HdTupleType valueType;
+            valueType.type = HdTypeFloat;
+            valueType.count = 1;
+            outputs.emplace_back(compOutputName, valueType);
+        }
+
+        return outputs;
+    }
+
+    virtual size_t SampleExtComputationInput(SdfPath const& computationId,
+                                             TfToken const& input,
+                                             size_t maxSampleCount,
+                                             float *sampleTimes,
+                                             VtValue *sampleValues) override {
+        if (computationId != compA) {
+            return 0;
+        }
+
+        const size_t numSamples = std::min(size_t(4), maxSampleCount);
+
+        // The two inputs have different sample times (0,1,2,3 and 0,2,4,6).
+        if (input == input1) {
+            for (size_t i = 0; i < numSamples; ++i) {
+                sampleTimes[i] = i;
+                sampleValues[i] = VtValue(double(i));
+            }
+            return numSamples;
+        }
+        else if (input == input2) {
+            for (size_t i = 0; i < numSamples; ++i) {
+                sampleTimes[i] = i * 2;
+                sampleValues[i] = VtValue(double(i));
+            }
+            return numSamples;
+        }
+
+        return 0;
+    }
+
+    virtual void InvokeExtComputation(SdfPath const& computationId,
+                                      HdExtComputationContext *context) override {
+        if (computationId != compA) {
+            return;
+        }
+
+        VtValue val1 = context->GetInputValue(input1);
+        VtValue val2 = context->GetInputValue(input2);
+        context->SetOutputValue(
+            compOutputName, VtValue(val1.Get<double>() + val2.Get<double>()));
+    }
+};
+
+// Mock render delegate for testing - just handles the ExtComputation sprims.
+class ExtCompTestRenderDelegate : public HdRenderDelegate {
+private:
+    static const TfTokenVector _emptyTypes;
+    static const TfTokenVector _sprimTypes;
+
+public:
+    virtual HdResourceRegistrySharedPtr GetResourceRegistry() const override {
+        return nullptr;
+    }
+
+    virtual HdRenderPassSharedPtr CreateRenderPass(
+                                HdRenderIndex *index,
+                                HdRprimCollection const& collection) override {
+        return nullptr;
+    }
+
+    virtual HdInstancer *CreateInstancer(HdSceneDelegate *delegate,
+                                         SdfPath const& id) override {
+        return nullptr;
+    }
+    virtual void DestroyInstancer(HdInstancer *instancer) override {
+    }
+
+    virtual HdRprim *CreateRprim(TfToken const& typeId,
+                                 SdfPath const& rprimId) override {
+        return nullptr;
+    }
+    virtual void DestroyRprim(HdRprim *rPrim) override {
+    }
+
+    virtual HdSprim *CreateSprim(TfToken const& typeId,
+                                 SdfPath const& sprimId) override {
+        if (typeId == HdPrimTypeTokens->extComputation) {
+            return new HdExtComputation(sprimId);
+        } else {
+            TF_CODING_ERROR("Unknown Sprim Type %s", typeId.GetText());
+        }
+
+        return nullptr;
+    }
+    virtual HdSprim *CreateFallbackSprim(TfToken const& typeId) override {
+        return nullptr;
+    }
+    virtual void DestroySprim(HdSprim *sprim) override {
+        delete sprim;
+    }
+
+    virtual HdBprim *CreateBprim(TfToken const& typeId,
+                                 SdfPath const& bprimId) override {
+        return nullptr;
+    }
+    virtual HdBprim *CreateFallbackBprim(TfToken const& typeId) override {
+        return nullptr;
+    }
+    virtual void DestroyBprim(HdBprim *bPrim) override {
+    }
+
+    virtual void CommitResources(HdChangeTracker *tracker) override {
+    }
+
+    virtual const TfTokenVector &GetSupportedRprimTypes() const override {
+        return _emptyTypes;
+    }
+    virtual const TfTokenVector &GetSupportedSprimTypes() const override {
+        return _sprimTypes;
+    }
+    virtual const TfTokenVector &GetSupportedBprimTypes() const override {
+        return _emptyTypes;
+    }
+};
+
+const TfTokenVector ExtCompTestRenderDelegate::_emptyTypes;
+const TfTokenVector ExtCompTestRenderDelegate::_sprimTypes = {
+    HdPrimTypeTokens->extComputation
+};
+
+void RunTest()
+{
+    ExtCompTestRenderDelegate renderDelegate;
+    std::unique_ptr<HdRenderIndex> index(
+        HdRenderIndex::New(&renderDelegate, {}));
+    ExtComputationTestDelegate delegate(index.get());
+
+    // Create an sprim for the computation.
+    index->InsertSprim(HdPrimTypeTokens->extComputation, &delegate, compA);
+    auto sprim = index->GetSprim(HdPrimTypeTokens->extComputation, compA);
+    HdDirtyBits dirty = HdExtComputation::DirtyBits::AllDirty;
+    sprim->Sync(&delegate, nullptr, &dirty);
+
+    auto compPrimvars = delegate.GetExtComputationPrimvarDescriptors(
+        pathA, HdInterpolationConstant);
+
+    // Evaluate the computation, and verify the output sample times and values.
+    const size_t maxSamples = 5;
+    auto valueStore = HdExtComputationUtils::SampleComputedPrimvarValues(
+            compPrimvars, &delegate, maxSamples);
+
+    if (valueStore.size() != 1) {
+        TF_RUNTIME_ERROR("Incorrect number of computed primvars %d",
+                         static_cast<int>(valueStore.size()));
+        return;
+    }
+
+    auto &&pvSamples = valueStore.at(primvarName);
+    if (pvSamples.count != maxSamples) {
+        TF_RUNTIME_ERROR("Unexpected number of samples %d",
+                         static_cast<int>(pvSamples.count));
+        return;
+    }
+
+#define CHECK_SAMPLE(index, time, val)                                \
+    if (pvSamples.times[index] != time) {                             \
+        TF_RUNTIME_ERROR("Unexpected sample time %f vs %f",           \
+                         pvSamples.times[index], time);               \
+        return;                                                       \
+    }                                                                 \
+    if (pvSamples.values[index].Get<double>() != val) {               \
+        TF_RUNTIME_ERROR("Unexpected sample value %f vs %f",          \
+                         pvSamples.values[index].Get<double>(), val); \
+        return;                                                       \
+    }
+
+    CHECK_SAMPLE(0, 0.f, 0.0);
+    CHECK_SAMPLE(1, 1.f, 1.5);
+    CHECK_SAMPLE(2, 2.f, 3.0);
+    CHECK_SAMPLE(3, 3.f, 4.5);
+    CHECK_SAMPLE(4, 4.f, 5.0);
+}
+
+int main(int argc, char *argv[])
+{
+    TfErrorMark mark;
+
+    RunTest();
+
+    // If no error messages were logged, return success.
+    if (mark.IsClean()) {
+        std::cout << "OK" << std::endl;
+        return EXIT_SUCCESS;
+    } else {
+        std::cerr << "FAILED" << std::endl;
+        TfReportActiveErrorMarks();
+        return EXIT_FAILURE;
+    }
+}

--- a/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
+++ b/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
@@ -228,9 +228,10 @@ void RunTest()
         pathA, HdInterpolationConstant);
 
     // Evaluate the computation, and verify the output sample times and values.
+    HdExtComputationUtils::SampledValueStore<4> valueStore;
     const size_t maxSamples = 5;
-    auto valueStore = HdExtComputationUtils::SampleComputedPrimvarValues(
-            compPrimvars, &delegate, maxSamples);
+    HdExtComputationUtils::SampleComputedPrimvarValues(
+        compPrimvars, &delegate, maxSamples, &valueStore);
 
     if (valueStore.size() != 1) {
         TF_RUNTIME_ERROR("Incorrect number of computed primvars %d",

--- a/pxr/imaging/hd/timeSampleArray.cpp
+++ b/pxr/imaging/hd/timeSampleArray.cpp
@@ -64,9 +64,9 @@ HdResampleNeighbors(float alpha, const VtValue &v0, const VtValue &v1)
     BOOST_PP_SEQ_FOR_EACH(_HANDLE_TYPE, ~, USD_LINEAR_INTERPOLATION_TYPES)
 #undef _HANDLE_TYPE
 
-    TF_RUNTIME_ERROR("Unable to interpolate sample value type '%s'",
-                     v0.GetTypeName().c_str());
-    return v0;
+    // If the value can't be interpolated, just hold the preceding time
+    // sample's value.
+    return (alpha < 1.f) ? v0 : v1;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hd/timeSampleArray.h
+++ b/pxr/imaging/hd/timeSampleArray.h
@@ -64,7 +64,7 @@ inline VtArray<T> HdResampleNeighbors(float alpha,
 }
 
 /// Specialization for VtValue: interpolate the held values.
-VtValue HdResampleNeighbors(float alpha, const VtValue &v0, const VtValue &v1);
+VtValue HdResampleNeighbors(float alpha, const VtValue& v0, const VtValue& v1);
 
 /// Resample a function described by an ordered array of samples,
 /// using a linear reconstruction filter evaluated at the given

--- a/pxr/imaging/hd/timeSampleArray.h
+++ b/pxr/imaging/hd/timeSampleArray.h
@@ -63,6 +63,9 @@ inline VtArray<T> HdResampleNeighbors(float alpha,
     return r;
 }
 
+/// Specialization for VtValue: interpolate the held values.
+VtValue HdResampleNeighbors(float alpha, const VtValue &v0, const VtValue &v1);
+
 /// Resample a function described by an ordered array of samples,
 /// using a linear reconstruction filter evaluated at the given
 /// parametric position u.  The function is considered constant

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -2821,6 +2821,28 @@ UsdImagingDelegate::GetExtComputationInput(SdfPath const& computationId,
     return VtValue();
 }
 
+size_t
+UsdImagingDelegate::SampleExtComputationInput(SdfPath const& computationId,
+                                              TfToken const& input,
+                                              size_t maxSampleCount,
+                                              float *sampleTimes,
+                                              VtValue *sampleValues)
+{
+    TRACE_FUNCTION();
+
+    SdfPath cachePath = ConvertIndexPathToCachePath(computationId);
+    _HdPrimInfo *primInfo = _GetHdPrimInfo(cachePath);
+
+    if (TF_VERIFY(primInfo)) {
+        return primInfo->adapter->SampleExtComputationInput(
+            primInfo->usdPrim, cachePath, input, GetTime(),
+            nullptr /* instancerContext */, maxSampleCount, sampleTimes,
+            sampleValues);
+    }
+
+    return 0;
+}
+
 std::string
 UsdImagingDelegate::GetExtComputationKernel(SdfPath const& computationId)
 {

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -429,6 +429,13 @@ public:
                                    TfToken const& input) override;
 
     USDIMAGING_API
+    size_t SampleExtComputationInput(SdfPath const& computationId,
+                                     TfToken const& input,
+                                     size_t maxSampleCount,
+                                     float *sampleTimes,
+                                     VtValue *sampleValues) override;
+
+    USDIMAGING_API
     std::string GetExtComputationKernel(SdfPath const& computationId) override;
 
     USDIMAGING_API

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -1325,6 +1325,27 @@ UsdImagingPrimAdapter::GetExtComputationInput(
     return VtValue();
 }
 
+/*virtual*/
+size_t
+UsdImagingPrimAdapter::SampleExtComputationInput(
+    UsdPrim const& prim,
+    SdfPath const& cachePath,
+    TfToken const& name,
+    UsdTimeCode time,
+    const UsdImagingInstancerContext* instancerContext,
+    size_t maxSampleCount,
+    float *sampleTimes,
+    VtValue *sampleValues)
+{
+    if (maxSampleCount > 0) {
+        sampleTimes[0] = 0.0;
+        sampleValues[0] = GetExtComputationInput(prim, cachePath, name, time,
+                                                 instancerContext);
+        return 1;
+    }
+    return 0;
+}
+
 /*virtual*/ 
 std::string 
 UsdImagingPrimAdapter::GetExtComputationKernel(

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -549,6 +549,18 @@ public:
             const UsdImagingInstancerContext* instancerContext) const;
 
     USDIMAGING_API
+    virtual size_t
+    SampleExtComputationInput(
+            UsdPrim const& prim,
+            SdfPath const& cachePath,
+            TfToken const& name,
+            UsdTimeCode time,
+            const UsdImagingInstancerContext* instancerContext,
+            size_t maxSampleCount,
+            float *sampleTimes,
+            VtValue *sampleValues);
+
+    USDIMAGING_API
     virtual std::string 
     GetExtComputationKernel(
             UsdPrim const& prim,

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
@@ -233,6 +233,18 @@ public:
             const UsdImagingInstancerContext* instancerContext) const override;
 
     USDIMAGING_API
+    virtual size_t
+    SampleExtComputationInput(
+            UsdPrim const& prim,
+            SdfPath const& cachePath,
+            TfToken const& name,
+            UsdTimeCode time,
+            const UsdImagingInstancerContext* instancerContext,
+            size_t maxSampleCount,
+            float *sampleTimes,
+            VtValue *sampleValues) override;
+
+    USDIMAGING_API
     virtual std::string 
     GetExtComputationKernel(
             UsdPrim const& prim,
@@ -362,6 +374,28 @@ private:
             UsdTimeCode time,
             const UsdImagingInstancerContext* instancerContext) const;
 
+    size_t
+    _SampleExtComputationInputForSkinningComputation(
+            UsdPrim const& prim,
+            SdfPath const& cachePath,
+            TfToken const& name,
+            UsdTimeCode time,
+            const UsdImagingInstancerContext* instancerContext,
+            size_t maxSampleCount,
+            float *sampleTimes,
+            VtValue *sampleValues);
+
+    size_t
+    _SampleExtComputationInputForInputAggregator(
+            UsdPrim const& prim,
+            SdfPath const& cachePath,
+            TfToken const& name,
+            UsdTimeCode time,
+            const UsdImagingInstancerContext* instancerContext,
+            size_t maxSampleCount,
+            float *sampleTimes,
+            VtValue *sampleValues);
+
 
     // ---------------------------------------------------------------------- //
     /// Populated skeleton state
@@ -410,6 +444,7 @@ private:
 
         std::shared_ptr<UsdSkelBlendShapeQuery> blendShapeQuery;
         UsdSkelSkinningQuery skinningQuery;
+        UsdSkelAnimQuery animQuery;
         SdfPath skelPath, skelRootPath;
         bool hasJointInfluences = false;
     };


### PR DESCRIPTION
### Description of Change(s)

This adds support for evaluating time samples of computed primvars (ExtComputation) - the primary use case is motion blur for skinned primitives.

- Added methods to the scene delegate and prim adapter for sampling an `ExtComputation` scene input, similar to `SamplePrimvar()` and related methods
- Implemented `SampleExtComputationInput()` for the skinning computation.
- Added `HdExtComputationUtils::SampleComputedPrimvarValues()` for evaluating time samples of the computed primvars, along with a basic unit test

A couple notes from prior discussions with @rajabala
- We may want to consider adjusting the strategy used when clamping the samples, or make that a parameter. Currently it matches the behaviour of `SamplePrimvar()`
- The hardcoded static capacity for the `HdTimeSampleArray` in `extComputationUtils.h` is a bit unfortunate, but I'm not sure we want to turn `SampleComputedPrimvarValues` into a templated function