### PR TITLE
Fix for resolving symlinks on Windows from multiple processes simultaneously

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1141,7 +1141,8 @@ typedef struct _REPARSE_DATA_BUFFER {
 
 std::string ArchReadLink(const char* path)
 {
-    HANDLE handle = ::CreateFile(path, GENERIC_READ, 0, NULL, OPEN_EXISTING,
+    HANDLE handle = ::CreateFile(path, GENERIC_READ, FILE_SHARE_READ,
+        NULL, OPEN_EXISTING,
         FILE_FLAG_OPEN_REPARSE_POINT |
         FILE_FLAG_BACKUP_SEMANTICS, NULL);
 


### PR DESCRIPTION
Attempt to fix issue where two threads or processes may try to read a Windows
symlink location at the same time. The file handle was being created without
any sharing flag. And although we keep the file open only very briefly, this
could still disrupt another process from reading the same symlink at the
same time.

### Description of Change(s)
Add a FILE_SHARE_READ flag to the CreateFile call that is used to open a symlink location on Windows. This failure was manifesting as a rare intermittent failure to properly resolve a file path inside a symlinked directory on Windows when running many simultaneous processes reading and writing USD files inside this symlinked directory.