### PR TITLE
A collection of fixes for Windows path handling, especially involving symlinks

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1138,6 +1138,7 @@ typedef struct _REPARSE_DATA_BUFFER {
         } GenericReparseBuffer;
     };
 } REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+#define SYMLINK_FLAG_RELATIVE 0x00000001
 
 std::string ArchReadLink(const char* path)
 {
@@ -1176,6 +1177,22 @@ std::string ArchReadLink(const char* path)
             std::wstring ws(reparsePath.get());
             string str(ws.begin(), ws.end());
 
+            // Symlinks can be absolute, or relative to the parent directory.
+            // Deal with the relative case here by prepending the parent path.
+            if ((reparse->SymbolicLinkReparseBuffer.Flags &
+                 SYMLINK_FLAG_RELATIVE) == SYMLINK_FLAG_RELATIVE)
+            {
+                string fullpath = ArchAbsPath(path);
+                string::size_type i = fullpath.find_last_of("/\\");
+                if (i != string::npos)
+                {
+                    // Grab the parent directory path, including the trailing
+                    // slash, and insert it ahead of the relative symlink path.
+                    string dirpath = fullpath.substr(0, i+1);
+                    str.insert(0, dirpath);
+                }
+            }
+
             return str;
         }
         else if (reparse->ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
@@ -1193,6 +1210,9 @@ std::string ArchReadLink(const char* path)
             // Convert wide-char to narrow char
             std::wstring ws(reparsePath.get());
             string str(ws.begin(), ws.end());
+
+            // Note that junctions do not support the relative path form
+            // like SYMLINKS do, so nothing more to do here.
 
             return str;
         }

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -308,7 +308,7 @@ Tf_MakeDirsRec(string const& path, int mode, bool existOk)
     const string head = TfStringTrimRight(TfGetPathName(path), pathsep.c_str());
     const string tail = TfGetBaseName(path);
 
-    if (!head.empty() && !tail.empty() && !TfPathExists(head)) {
+    if (!head.empty() && !tail.empty() && !TfPathExists(head) && head != path) {
         if (!Tf_MakeDirsRec(head, mode, existOk)) {
 #if defined(ARCH_OS_WINDOWS)
             if (GetLastError() != ERROR_ALREADY_EXISTS)

--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -69,8 +69,9 @@ _ExpandSymlinks(const std::string& path)
         std::string prefix = path.substr(0, i);
         // If the prefix is "X:", this will access the "current" directory on
         // drive X, when what we really want is the root of drive X, so append
-        // a backslash.
-        if (prefix.at(i-1) == ':') {
+        // a backslash. Also check that i>0. An i==0 value can happen if the
+        // passed in path is a non-canonical Windows path such as "/tmp/foo".
+        if (i > 0 && prefix.at(i-1) == ':') {
             prefix.push_back('\\');
         }
         if (TfIsLink(prefix)) {


### PR DESCRIPTION
### Description of Change(s)
This started as an attempt to fix a possible exception when handling paths starting with "/" in the code for #1441 and then write some additional tests. But my test cases kept failing. Turns out there were still issues in handling on non-mountpoint symlinks on Windows. There was also the potential for infinite recursion in Tf_MakeDirsRec when it was passed a malformed path.

Also adding the test cases that were failing without all these fixes.

Relates to #1441, #1378.