### PR TITLE
Full debug (with debug python) build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,31 +19,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
                       ${CMAKE_SOURCE_DIR}/cmake/macros)
 
 include(Options)
-# If we were given a python executable, we'll extract the name from that to use in
-# the python shebang replacement. This will make these files more portable by not
-# having some full path to a python executable which may not exist on another machine.
-if (DEFINED PYTHON_EXECUTABLE)
-    get_filename_component(PYTHON_EXE_BASENAME ${PYTHON_EXECUTABLE} NAME)
-endif()
-
 include(ProjectDefaults)
 include(Packages)
 
 # This has to be defined after Packages is included, because it relies on the
 # discovered path to the python executable.
-if (DEFINED PYTHON_EXE_BASENAME)
-    set(PXR_PYTHON_SHEBANG "${PYTHON_EXE_BASENAME}" 
-        CACHE 
-        STRING
-        "Replacement path for Python #! line."
-    )
-else()
-    set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
-        CACHE 
-        STRING
-        "Replacement path for Python #! line."
-    )
-endif()
+set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
+    CACHE 
+    STRING
+    "Replacement path for Python #! line."
+)
 
 # CXXDefaults will set a variety of variables for the project.
 # Consume them here. This is an effort to keep the most common

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,31 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
                       ${CMAKE_SOURCE_DIR}/cmake/macros)
 
 include(Options)
+# If we were given a python executable, we'll extract the name from that to use in
+# the python shebang replacement. This will make these files more portable by not
+# having some full path to a python executable which may not exist on another machine.
+if (DEFINED PYTHON_EXECUTABLE)
+    get_filename_component(PYTHON_EXE_BASENAME ${PYTHON_EXECUTABLE} NAME)
+endif()
+
 include(ProjectDefaults)
 include(Packages)
 
 # This has to be defined after Packages is included, because it relies on the
 # discovered path to the python executable.
-set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
-    CACHE 
-    STRING
-    "Replacement path for Python #! line."
-)
+if (DEFINED PYTHON_EXE_BASENAME)
+    set(PXR_PYTHON_SHEBANG "${PYTHON_EXE_BASENAME}" 
+        CACHE 
+        STRING
+        "Replacement path for Python #! line."
+    )
+else()
+    set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
+        CACHE 
+        STRING
+        "Replacement path for Python #! line."
+    )
+endif()
 
 # CXXDefaults will set a variety of variables for the project.
 # Consume them here. This is an effort to keep the most common

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -41,12 +41,12 @@ option(PXR_ENABLE_MATERIALX_SUPPORT "Enable MaterialX support" OFF)
 option(PXR_BUILD_DOCUMENTATION "Generate doxygen documentation" OFF)
 option(PXR_ENABLE_PYTHON_SUPPORT "Enable Python based components for USD" ON)
 option(PXR_USE_PYTHON_3 "Build Python bindings for Python 3" OFF)
+option(PXR_USE_DEBUG_PYTHON "Build with debug python" OFF)
 option(PXR_ENABLE_HDF5_SUPPORT "Enable HDF5 backend in the Alembic plugin for USD" ON)
 option(PXR_ENABLE_OSL_SUPPORT "Enable OSL (OpenShadingLanguage) based components" OFF)
 option(PXR_ENABLE_PTEX_SUPPORT "Enable Ptex support" ON)
 option(PXR_ENABLE_OPENVDB_SUPPORT "Enable OpenVDB support" OFF)
 option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
-option(PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG "Define BOOST_DEBUG_PYTHON flag." OFF)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -46,6 +46,7 @@ option(PXR_ENABLE_OSL_SUPPORT "Enable OSL (OpenShadingLanguage) based components
 option(PXR_ENABLE_PTEX_SUPPORT "Enable Ptex support" ON)
 option(PXR_ENABLE_OPENVDB_SUPPORT "Enable OpenVDB support" OFF)
 option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
+option(PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG "Define BOOST_DEBUG_PYTHON flag." OFF)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -71,7 +71,7 @@ if(PXR_ENABLE_PYTHON_SUPPORT)
         find_package(PythonLibs 2.7 REQUIRED)
     endif()
 
-    if(WIN32 AND PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+    if(WIN32 AND PXR_USE_DEBUG_PYTHON)
         set(Boost_USE_DEBUG_PYTHON ON)
     endif()
 

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -71,6 +71,10 @@ if(PXR_ENABLE_PYTHON_SUPPORT)
         find_package(PythonLibs 2.7 REQUIRED)
     endif()
 
+    if(WIN32 AND PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+        set(Boost_USE_DEBUG_PYTHON ON)
+    endif()
+
     # This option indicates that we don't want to explicitly link to the python
     # libraries. See BUILDING.md for details.
     if(PXR_PY_UNDEFINED_DYNAMIC_LOOKUP AND NOT WIN32 )

--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -99,6 +99,11 @@ if (NOT Boost_USE_STATIC_LIBS)
     _add_define("BOOST_ALL_DYN_LINK")
 endif()
 
+if(${PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG})
+    _add_define(BOOST_DEBUG_PYTHON)
+    _add_define(BOOST_LINKING_PYTHON)
+endif()
+
 # Need half::_toFloat and half::_eLut.
 _add_define("OPENEXR_DLL")
 

--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -99,9 +99,9 @@ if (NOT Boost_USE_STATIC_LIBS)
     _add_define("BOOST_ALL_DYN_LINK")
 endif()
 
-if(${PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG})
-    _add_define(BOOST_DEBUG_PYTHON)
-    _add_define(BOOST_LINKING_PYTHON)
+if(${PXR_USE_DEBUG_PYTHON})
+    _add_define("BOOST_DEBUG_PYTHON")
+    _add_define("BOOST_LINKING_PYTHON")
 endif()
 
 # Need half::_toFloat and half::_eLut.

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -84,7 +84,7 @@ function(_get_python_module_name LIBRARY_FILENAME MODULE_NAME)
     # or _tf.pyd/_tf_d.pyd for Python module libraries.
     # We want to strip off the leading "_" and the trailing "_d".
     set(LIBNAME ${LIBRARY_FILENAME})
-    if (PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+    if (PXR_USE_DEBUG_PYTHON)
         string(REGEX REPLACE "_d$" "" LIBNAME ${LIBNAME})
     endif()
     string(REGEX REPLACE "^_" "" LIBNAME ${LIBNAME})
@@ -900,7 +900,7 @@ function(_pxr_python_module NAME)
         return()
     endif()
 
-    if (WIN32 AND PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+    if (WIN32 AND PXR_USE_DEBUG_PYTHON)
         # On Windows when compiling with debug python the library must be named with _d.
         set(LIBRARY_NAME "_${NAME}_d")
     else()

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -265,10 +265,17 @@ function(_install_pyside_ui_files LIBRARY_NAME)
         get_filename_component(outFileName ${uiFile} NAME_WE)
         get_filename_component(uiFilePath ${uiFile} ABSOLUTE)
         set(outFilePath "${CMAKE_CURRENT_BINARY_DIR}/${outFileName}.py")
+        get_filename_component(pysideUicBinName ${PYSIDEUICBINARY} NAME_WLE)
+        if("${pysideUicBinName}" STREQUAL "uic")
+            # Newer versions of Qt have deprecated pyside2-uic. It
+            # has been replaced by "uic" which needs extra arg for
+            # generating python output (instead of default C++ ).
+            set(PYSIDEUIC_EXTRA_ARGS -g python)
+        endif()
         add_custom_command(
             OUTPUT ${outFilePath}
             COMMAND "${PYSIDEUICBINARY}"
-            ARGS -o ${outFilePath} ${uiFilePath}
+            ARGS ${PYSIDEUIC_EXTRA_ARGS} -o ${outFilePath} ${uiFilePath}
             MAIN_DEPENDENCY "${uiFilePath}"
             COMMENT "Generating Python for ${uiFilePath} ..."
             VERBATIM

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -81,9 +81,13 @@ endfunction() # _copy_headers
 # our naming conventions, e.g. Tf
 function(_get_python_module_name LIBRARY_FILENAME MODULE_NAME)
     # Library names are either something like tf.so for shared libraries
-    # or _tf.so for Python module libraries. We want to strip the leading
-    # "_" off.
-    string(REPLACE "_" "" LIBNAME ${LIBRARY_FILENAME})
+    # or _tf.pyd/_tf_d.pyd for Python module libraries.
+    # We want to strip off the leading "_" and the trailing "_d".
+    set(LIBNAME ${LIBRARY_FILENAME})
+    if (PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+        string(REGEX REPLACE "_d$" "" LIBNAME ${LIBNAME})
+    endif()
+    string(REGEX REPLACE "^_" "" LIBNAME ${LIBNAME})
     string(SUBSTRING ${LIBNAME} 0 1 LIBNAME_FL)
     string(TOUPPER ${LIBNAME_FL} LIBNAME_FL)
     string(SUBSTRING ${LIBNAME} 1 -1 LIBNAME_SUFFIX)
@@ -605,14 +609,11 @@ function(_pxr_install_rpath rpathRef NAME)
     # Canonicalize and uniquify paths.
     set(final "")
     foreach(path ${rpath})
-        # Absolutize on Mac.  SIP disallows relative rpaths.
+        # Replace $ORIGIN with @loader_path
         if(APPLE)
             if("${path}/" MATCHES "^[$]ORIGIN/")
                 # Replace with origin path.
-                string(REPLACE "$ORIGIN/" "${origin}/" path "${path}/")
-
-                # Simplify.
-                get_filename_component(path "${path}" REALPATH)
+                string(REPLACE "$ORIGIN/" "@loader_path/" path "${path}/")
             endif()
         endif()
 
@@ -892,7 +893,12 @@ function(_pxr_python_module NAME)
         return()
     endif()
 
-    set(LIBRARY_NAME "_${NAME}")
+    if (WIN32 AND PXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
+        # On Windows when compiling with debug python the library must be named with _d.
+        set(LIBRARY_NAME "_${NAME}_d")
+    else()
+        set(LIBRARY_NAME "_${NAME}")
+    endif()
 
     # Install .py files.
     if(args_PYTHON_FILES)
@@ -1026,7 +1032,7 @@ function(_pxr_python_module NAME)
     target_include_directories(${LIBRARY_NAME}
         SYSTEM
         PUBLIC
-            ${PYTHON_INCLUDE_DIR}
+            ${PYTHON_INCLUDE_DIRS}
     )
 
     install(

--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -51,10 +51,12 @@ if (pySideImportResult EQUAL 1 OR PYSIDE_USE_PYSIDE)
     endif()
 endif()
 
+# If nothing is found, the result will be <VAR>-NOTFOUND.
 find_program(PYSIDEUICBINARY NAMES ${pySideUIC} HINTS ${PYSIDE_BIN_DIR})
 
 if (pySideImportResult)
-    if (EXISTS ${PYSIDEUICBINARY})
+    # False if the constant ends in the suffix -NOTFOUND.
+    if (PYSIDEUICBINARY)
         message(STATUS "Found ${pySideImportResult}: with ${PYTHON_EXECUTABLE}, will use ${PYSIDEUICBINARY} for pyside-uic binary")
         set(PYSIDE_AVAILABLE True)
     else()

--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -34,7 +34,7 @@ execute_process(
 )
 if (pySideImportResult EQUAL 0)
     set(pySideImportResult "PySide2")
-    set(pySideUIC pyside2-uic python2-pyside2-uic pyside2-uic-2.7)
+    set(pySideUIC pyside2-uic python2-pyside2-uic pyside2-uic-2.7 uic)
 endif()
 
 # PySide2 not found OR PYSIDE explicitly requested

--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -17,7 +17,7 @@ pxr_library(tf
         ${TBB_tbb_LIBRARY}
 
     INCLUDE_DIRS
-        ${PYTHON_INCLUDE_DIR}
+        ${PYTHON_INCLUDE_DIRS}
         ${Boost_INCLUDE_DIRS}
         ${TBB_INCLUDE_DIRS}
 


### PR DESCRIPTION
### Description of Change(s):

#### Full debug python support and portable USD builds:
* Use @loader_path instead of absolute path for plugins and libraries. On Mac @loader_path is equivalent to $ORIGIN on Linux.
* With the new changes, it would be possible for people to decide if they want to build USD with python debug/release.
* One can now set this flag via both build_usd python script as well as CMake.
  * CMake flag is: -DPXR_DEFINE_BOOST_DEBUG_PYTHON_FLAG
  * build_usd flag is: _--debug-python_
* Full python debug support.
  * Must build boost with python debugging flag.
  * On Windows when using debug python the libraries must have _d in name.
* Option to not put full path of python executable in python shebang. For portable USD builds.

#### Added ability to use custom python
* With new flag _--build-python-info_ you can pass in which python to use rather than automatically finding system one.
* Added ability to use custom PYSIDEUICBINARY.

### Fixes Issue(s):
- Allows full debug builds, built with debug python.
- Makes builds portable.

