### PR TITLE
Windows: Fix output values reported by PcpPrimIndex::PrintStatistics()

### DIFF
--- a/pxr/usd/pcp/statistics.cpp
+++ b/pxr/usd/pcp/statistics.cpp
@@ -170,11 +170,7 @@ public:
     struct _Helper {
         static std::string FormatNumber(size_t n)
         {
-            #if defined(ARCH_OS_WINDOWS)
-                return TfStringPrintf("%zd", n);
-            #else
-                return TfStringPrintf("%'zd", n);
-            #endif
+            return TfStringPrintf("%zd", n);
         }
 
         static std::string FormatAverage(size_t n, size_t d)

--- a/pxr/usd/pcp/statistics.cpp
+++ b/pxr/usd/pcp/statistics.cpp
@@ -170,7 +170,11 @@ public:
     struct _Helper {
         static std::string FormatNumber(size_t n)
         {
-            return TfStringPrintf("%'zd", n);
+            #if defined(ARCH_OS_WINDOWS)
+                return TfStringPrintf("%zd", n);
+            #else
+                return TfStringPrintf("%'zd", n);
+            #endif
         }
 
         static std::string FormatAverage(size_t n, size_t d)


### PR DESCRIPTION
### Description of Change(s)

This PR fixes the values displayed incorrectly when PcpPrimIndex::PrintStatistics() routine is called on Windows. 

According to Linux manual page for printf 

```
      '      For decimal conversion (i, d, u, f, F, g, G) the output is
              to be grouped with thousands' grouping characters if the
              locale information indicates any.  (See setlocale(3).)
              Note that many versions of gcc(1) cannot parse this option
              and will issue a warning.  (SUSv2 did not include %'F, but
              SUSv3 added it.)
```

https://man7.org/linux/man-pages/man3/printf.3.html

There is no such flag for Windows:

https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160

hence the output values show up wrong on Windows and correct on Linux:

**Windows:**
![windows_statistic_printf](https://user-images.githubusercontent.com/48299423/112030562-c70a2300-8b10-11eb-82b7-34f94bcc78dc.PNG)

**Linux:**
![linux_statistic_printf](https://user-images.githubusercontent.com/48299423/112032930-47ca1e80-8b13-11eb-92cf-3e99228ad17e.png)

**After the Fix:**

![fix_me](https://user-images.githubusercontent.com/48299423/112033064-6af4ce00-8b13-11eb-8871-7920759d7ab7.PNG)

