### PR TITLE
base: Use std::atomic instead of tbb.

### DIFF
--- a/pxr/base/tf/diagnosticMgr.cpp
+++ b/pxr/base/tf/diagnosticMgr.cpp
@@ -188,7 +188,7 @@ TfDiagnosticMgr::AppendError(TfError const &e) {
     } else {
         ErrorList &errorList = _errorList.local();
         errorList.push_back(e);
-        errorList.back()._serial = _nextSerial.fetch_and_increment();
+        errorList.back()._serial = _nextSerial.fetch_add(1);
         _AppendErrorsToLogText(std::prev(errorList.end())); 
     }
 }
@@ -203,7 +203,7 @@ TfDiagnosticMgr::_SpliceErrors(ErrorList &src)
         }
     } else {
         // Reassign new serial numbers to the errors.
-        size_t serial = _nextSerial.fetch_and_add(src.size());
+        size_t serial = _nextSerial.fetch_add(src.size());
         for (auto& error : src) {
             error._serial = serial++;
         }

--- a/pxr/base/tf/diagnosticMgr.h
+++ b/pxr/base/tf/diagnosticMgr.h
@@ -45,8 +45,8 @@
 
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
-#include <tbb/atomic.h>
 
+#include <atomic>
 #include <cstdarg>
 #include <list>
 #include <string>
@@ -434,7 +434,7 @@ private:
     mutable tbb::spin_rw_mutex _delegatesMutex;
 
     // Global serial number for sorting.
-    tbb::atomic<size_t> _nextSerial;
+    std::atomic<size_t> _nextSerial;
 
     // Thread-specific error list.
     tbb::enumerable_thread_specific<ErrorList> _errorList;

--- a/pxr/base/tf/error.cpp
+++ b/pxr/base/tf/error.cpp
@@ -39,7 +39,7 @@ TfError::TfError(TfEnum errorCode, const char* errorCodeString,
     : TfDiagnosticBase(errorCode, errorCodeString, context, commentary, info,
                        quiet)
 {
-    _serial = TfDiagnosticMgr::GetInstance()._nextSerial.fetch_and_increment();
+    _serial = TfDiagnosticMgr::GetInstance()._nextSerial.fetch_add(1);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/work/threadLimits.cpp
+++ b/pxr/base/work/threadLimits.cpp
@@ -29,10 +29,10 @@
 
 #include "pxr/base/tf/envSetting.h"
 
-#include <tbb/atomic.h>
 #include <tbb/task_scheduler_init.h>
 
 #include <algorithm>
+#include <atomic>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -63,7 +63,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // if PXR_WORK_THREAD_LIMIT is set to some nonzero value, otherwise we leave it
 // up to others.  So there's no guarantee that calling
 // WorkSetConcurrencyLimit(n) will actually limit Work to n threads.
-static tbb::atomic<unsigned> _threadLimit;
+static std::atomic<unsigned> _threadLimit;
 
 // We create a task_scheduler_init instance at static initialization time if
 // PXR_WORK_THREAD_LIMIT is set to a nonzero value.  Otherwise this stays NULL.


### PR DESCRIPTION
This converts the code in `pxr/base` to use `std::atomic` instead of `tbb::atomic`, which is deprecated.

This leaves only a couple of remaining usages of `tbb::atomic` in the codebase.