### PR TITLE
[usdImagingGL,usdview] Add support to set the OCIO display, view, and colorspace

### DIFF
--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -274,7 +274,8 @@ UsdImagingGLEngine::RenderBatch(
 
     _PrepareRender(params);
 
-    SetColorCorrectionSettings(params.colorCorrectionMode);
+    SetColorCorrectionSettings(params.colorCorrectionMode, params.ocioDisplay,
+        params.ocioView, params.ocioColorSpace, params.ocioLook);
 
     // XXX App sets the clear color via 'params' instead of setting up Aovs 
     // that has clearColor in their descriptor. So for now we must pass this
@@ -1185,7 +1186,11 @@ UsdImagingGLEngine::RestartRenderer()
 //----------------------------------------------------------------------------
 void 
 UsdImagingGLEngine::SetColorCorrectionSettings(
-    TfToken const& id)
+    TfToken const& colorCorrectionMode,
+    TfToken const& ocioDisplay,
+    TfToken const& ocioView,
+    TfToken const& ocioColorSpace,
+    TfToken const& ocioLook)
 {
     if (ARCH_UNLIKELY(_legacyImpl)) {
         return;
@@ -1198,7 +1203,11 @@ UsdImagingGLEngine::SetColorCorrectionSettings(
     TF_VERIFY(_taskController);
 
     HdxColorCorrectionTaskParams hdParams;
-    hdParams.colorCorrectionMode = id;
+    hdParams.colorCorrectionMode = colorCorrectionMode;
+    hdParams.displayOCIO = ocioDisplay.GetString();
+    hdParams.viewOCIO = ocioView.GetString();
+    hdParams.colorspaceOCIO = ocioColorSpace.GetString();
+    hdParams.looksOCIO = ocioLook.GetString();
     _taskController->SetColorCorrectionParams(hdParams);
 }
 

--- a/pxr/usdImaging/usdImagingGL/engine.h
+++ b/pxr/usdImaging/usdImagingGL/engine.h
@@ -465,7 +465,11 @@ public:
     /// Set \p id to one of the HdxColorCorrectionTokens.
     USDIMAGINGGL_API
     void SetColorCorrectionSettings(
-        TfToken const& id);
+        TfToken const& ccType,
+        TfToken const& ocioDisplay = {},
+        TfToken const& ocioView = {},
+        TfToken const& ocioColorSpace = {},
+        TfToken const& ocioLook = {});
 
     /// @}
 

--- a/pxr/usdImaging/usdImagingGL/renderParams.h
+++ b/pxr/usdImaging/usdImagingGL/renderParams.h
@@ -100,7 +100,12 @@ public:
     bool enableUsdDrawModes;
     GfVec4f clearColor;
     TfToken colorCorrectionMode;
+    // Optional OCIO color setings, only valid when colorCorrectionMode==HdxColorCorrectionTokens->openColorIO
     int lut3dSizeOCIO;
+    TfToken ocioDisplay;
+    TfToken ocioView;
+    TfToken ocioColorSpace;
+    TfToken ocioLook;
 
     inline UsdImagingGLRenderParams();
 
@@ -168,6 +173,10 @@ UsdImagingGLRenderParams::operator==(const UsdImagingGLRenderParams &other)
         && enableUsdDrawModes          == other.enableUsdDrawModes
         && clearColor                  == other.clearColor
         && colorCorrectionMode         == other.colorCorrectionMode
+        && ocioDisplay                 == other.ocioDisplay
+        && ocioView                    == other.ocioView
+        && ocioColorSpace              == other.ocioColorSpace
+        && ocioLook                    == other.ocioLook
         && lut3dSizeOCIO               == other.lut3dSizeOCIO;
 }
 

--- a/pxr/usdImaging/usdImagingGL/wrapRenderParams.cpp
+++ b/pxr/usdImaging/usdImagingGL/wrapRenderParams.cpp
@@ -85,6 +85,9 @@ wrapRenderParams()
         .def_readwrite("enableUsdDrawModes", &Params::enableUsdDrawModes)
         .def_readwrite("colorCorrectionMode", &Params::colorCorrectionMode)
         .def_readwrite("clearColor", &Params::clearColor)
-        .def_readwrite("lut3dSizeOCIO", &Params::lut3dSizeOCIO)
+        .def_readwrite("ocioDisplay", &Params::ocioDisplay)
+        .def_readwrite("ocioView", &Params::ocioView)
+        .def_readwrite("ocioColorSpace", &Params::ocioColorSpace)
+        .def_readwrite("ocioLook", &Params::ocioLook)
         ;
 }

--- a/pxr/usdImaging/usdviewq/stageView.py
+++ b/pxr/usdImaging/usdviewq/stageView.py
@@ -1452,8 +1452,15 @@ class StageView(QtOpenGL.QGLWidget):
         self._renderParams.highlight = renderSelHighlights
         self._renderParams.enableSceneMaterials = self._dataModel.viewSettings.enableSceneMaterials
         self._renderParams.enableSceneLights = self._dataModel.viewSettings.enableSceneLights
-        self._renderParams.colorCorrectionMode = self._dataModel.viewSettings.colorCorrectionMode
         self._renderParams.clearColor = Gf.Vec4f(self._dataModel.viewSettings.clearColor)
+
+        ccMode = self._dataModel.viewSettings.colorCorrectionMode
+        self._renderParams.colorCorrectionMode = ccMode
+        self._renderParams.ocioDisplay, self._renderParams.ocioView, self._renderParams.ocioColorSpace = \
+            (self._dataModel.viewSettings.ocioConfig.display,
+               self._dataModel.viewSettings.ocioConfig.view,
+               self._dataModel.viewSettings.ocioConfig.colorSpace) if ccMode == ColorCorrectionModes.OPENCOLORIO else \
+            ('','','')
 
         pseudoRoot = self._dataModel.stage.GetPseudoRoot()
 

--- a/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
+++ b/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
@@ -73,6 +73,25 @@ def invisibleViewSetting(f):
         self.signalSettingChanged.emit()
     return wrapper
 
+"""Class to hold OCIO display, view, and colorSpace settings.
+The underlying data is somewhat opaque (for view it is strings, but
+for an app-controler it may be the Qt object)
+"""
+class OCIOSettings():
+    def __init__(self, dflt=None):
+        self._display, self._view, self._colorSpace = dflt, dflt, dflt
+
+    @property
+    def display(self):
+        return self._display
+
+    @property
+    def view(self):
+        return self._view
+
+    @property
+    def colorSpace(self):
+        return self._colorSpace
 
 class ViewSettingsDataModel(QtCore.QObject, StateSource):
     """Data model containing settings related to the rendered view of a USD
@@ -110,6 +129,7 @@ class ViewSettingsDataModel(QtCore.QObject, StateSource):
         self._renderMode = self.stateProperty("renderMode", default=RenderModes.SMOOTH_SHADED)
         self._freeCameraFOV = self.stateProperty("freeCameraFOV", default=60.0)
         self._colorCorrectionMode = self.stateProperty("colorCorrectionMode", default=ColorCorrectionModes.SRGB)
+        self._ocioSettings = OCIOSettings('')
         self._pickMode = self.stateProperty("pickMode", default=PickModes.PRIMS)
 
         # We need to store the trinary selHighlightMode state here,
@@ -310,6 +330,23 @@ class ViewSettingsDataModel(QtCore.QObject, StateSource):
     @visibleViewSetting
     def colorCorrectionMode(self, value):
         self._colorCorrectionMode = value
+
+    @property
+    def ocioConfig(self):
+        return self._colorCorrectionMode
+
+    @property
+    def ocioConfig(self):
+        return self._ocioSettings
+
+    def setOCIOConfig(self, colorSpace=None, display=None, view=None):
+        if display:
+            assert view, 'Cannot set a display without a view'
+            self._ocioSettings._display = display
+            self._ocioSettings._view = view
+        if colorSpace:
+            self._ocioSettings._colorSpace = colorSpace
+        self.colorCorrectionMode = ColorCorrectionModes.OPENCOLORIO
 
     @property
     def pickMode(self):


### PR DESCRIPTION
As we're testing more assets and images in usdview, there have been some request to be able to actual configure OCIO.
Additionally some internal usage of **usdImagingGL** will benefit from being able to tweak the profile in use.
For usdview:
- This keeps the behavior that selecting *openColorIO* from the *Color Mangement* menu will load a configs default behavior.
- It adds a sub menu where one can set the *display*, *view*, and *colorspace* for more fine-grained control.

### Description of Change(s)
Just pushes through some string to the right place to get picked up in **HdxColorCorrectionTaskParams**
Dynamically builds an *OpenColorIO* menu in usdview based on the current config if **PyOpenColorIO** is available.

Open to suggestions on how to make this better.
