### PR TITLE
Fixing vector iterator error found using Debug build

### DIFF
--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -3231,10 +3231,14 @@ SdfLayer::_ListFields(SdfSchemaBase const &schema,
             // more than one additional allocation here.
             if (mightAlloc && dataList.size() == dataList.capacity()) {
                 dataList.reserve(dataList.size() + (reqSz - reqIdx));
-                dataListBegin = dataList.begin(), dataListEnd = dataList.end();
                 mightAlloc = false;
+                dataList.push_back(reqName);
+                dataListBegin = dataList.begin();
+                dataListEnd = dataList.end();
             }
-            dataList.push_back(reqName);
+            else {
+                dataList.push_back(reqName);
+            }
         }
     }
     return dataList;


### PR DESCRIPTION
### Description of Change(s)
In the maya-usd repo during the configure stage (when calling usdGenSchema) I encountered the following runtime error:
![image](https://user-images.githubusercontent.com/23455376/115300502-0a66aa00-a12e-11eb-9c74-6b3b97031393.png)


### Fixes Issue(s)
- According to the vector::push_back() doc, _If the new size() is greater than capacity() then all iterators and references (including the past-the-end iterator) are invalidated. Otherwise only the past-the-end iterator is invalidated._ Therefore after the resize and push_back the end iterator is invalid and on the next iteration of the for loop, during the find() it will throw this error.