### PR TITLE
[hio] Don't export stbimage functions for linkage with things that may also use stbimage.

### DIFF
--- a/pxr/imaging/hio/stbImage.cpp
+++ b/pxr/imaging/hio/stbImage.cpp
@@ -39,12 +39,15 @@
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/type.h"
 
+#define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include "pxr/imaging/hio/stb/stb_image.h"
 
+#define STB_IMAGE_RESIZE_STATIC
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
 #include "pxr/imaging/hio/stb/stb_image_resize.h"
 
+#define STB_IMAGE_WRITE_STATIC
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "pxr/imaging/hio/stb/stb_image_write.h"
 


### PR DESCRIPTION
### Description of Change(s)
Add pre-processor macros so _stbimage_ functions aren't exported.

### Fixes Issue(s)
When building/linking with other things that use _stbimage_, symbols can be defined multiple times.  

