### PR TITLE
[tf,arch] Add missing includes.

### DIFF
--- a/pxr/base/arch/stackTrace.h
+++ b/pxr/base/arch/stackTrace.h
@@ -38,6 +38,7 @@
 #include <vector>
 #include <string>
 #include <iosfwd>
+#include <ctime>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/base/tf/stackTrace.h
+++ b/pxr/base/tf/stackTrace.h
@@ -28,6 +28,7 @@
 #include "pxr/base/tf/api.h"
 
 #include <cstdio>
+#include <ctime>
 #include <iosfwd>
 #include <string>
 


### PR DESCRIPTION
Explicitly include `<ctime>` which doesn't automatically get included when compiling for Android or [emscripten](https://github.com/PixarAnimationStudios/USD/issues/1492).

