### PR TITLE
Support building of usdDraco plugin with monolithic build on Windows

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -178,10 +178,3 @@ if (${PXR_BUILD_PRMAN_PLUGIN})
         set(PXR_BUILD_PRMAN_PLUGIN "OFF" CACHE BOOL "" FORCE)
     endif()
 endif()
-
-# Error out if user is building monolithic library on windows with draco plugin
-# enabled. This currently results in missing symbols.
-if (${PXR_BUILD_DRACO_PLUGIN} AND ${PXR_BUILD_MONOLITHIC} AND WIN32)
-    message(FATAL_ERROR 
-        "Draco plugin can not be enabled for monolithic builds on Windows")
-endif()

--- a/pxr/usd/plugin/usdDraco/CMakeLists.txt
+++ b/pxr/usd/plugin/usdDraco/CMakeLists.txt
@@ -22,11 +22,14 @@ pxr_plugin(${PXR_PACKAGE}
 
     CPPFILES
         attributeDescriptor.cpp
-	attributeFactory.cpp
+	    attributeFactory.cpp
         exportTranslator.cpp
         fileFormat.cpp
         importTranslator.cpp
         writer.cpp
+
+    PRIVATE_HEADERS
+        api.h
 
     PYTHON_CPPFILES
         moduleDeps.cpp
@@ -48,4 +51,3 @@ pxr_plugin(${PXR_PACKAGE}
 if(USD_DRACO_SET_WINDOWS_EXPORT)
   unset(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS)
 endif()
-

--- a/pxr/usd/plugin/usdDraco/api.h
+++ b/pxr/usd/plugin/usdDraco/api.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_PLUGIN_USD_DRACO_API_H
+#define PXR_USD_PLUGIN_USD_DRACO_API_H
+
+#include "pxr/base/arch/export.h"
+
+#if defined(PXR_STATIC)
+#   define USDDRACO_API
+#   define USDDRACO_API_TEMPLATE_CLASS(...)
+#   define USDDRACO_API_TEMPLATE_STRUCT(...)
+#   define USDDRACO_LOCAL
+#else
+#   if defined(USDDRACO_EXPORTS)
+#       define USDDRACO_API ARCH_EXPORT
+#       define USDDRACO_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDDRACO_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#   else
+#       define USDDRACO_API ARCH_IMPORT
+#       define USDDRACO_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDDRACO_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   endif
+#   define USDDRACO_LOCAL ARCH_HIDDEN
+#endif
+
+#endif /* PXR_USD_PLUGIN_USD_DRACO_API_H */

--- a/pxr/usd/plugin/usdDraco/writer.h
+++ b/pxr/usd/plugin/usdDraco/writer.h
@@ -26,6 +26,7 @@
 #define PXR_USD_PLUGIN_USD_DRACO_WRITER_H
 
 #include "pxr/pxr.h"
+#include "pxr/usd/plugin/usdDraco/api.h"
 #include "pxr/usd/usdGeom/mesh.h"
 
 #include <string>
@@ -35,6 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 /// Encodes mesh and writes it in Draco format to a file at \p fileName.
+USDDRACO_API
 bool UsdDraco_WriteDraco(const UsdGeomMesh &mesh,
                          const std::string &fileName,
                          int qp,
@@ -48,6 +50,7 @@ bool UsdDraco_WriteDraco(const UsdGeomMesh &mesh,
 /// Checks whether a USD primvar can be encoded to Draco. It is called from
 /// usdcompress.py script to determine whether a primvar should be deleted from
 /// USD mesh or remain in USD mesh.
+USDDRACO_API
 bool UsdDraco_PrimvarSupported(const UsdGeomPrimvar &primvar);
 
 


### PR DESCRIPTION
Previously when building a monolithic library of USD, the `usdDraco` plugin would result in missing symbols. This is because the python bindings require the methods in `writer.h` to be exported. This change exports those required symbols, and `usdDraco` can now be built with a monolithic build of USD on Windows.

