### PR TITLE
[arch] Fix demangling of symbols that have keywords as substrings.

### DIFF
--- a/pxr/base/arch/demangle.cpp
+++ b/pxr/base/arch/demangle.cpp
@@ -98,17 +98,17 @@ _FixupStringNames(string* name)
 
 #if defined(ARCH_OS_WINDOWS)
     pos = 0;
-    while ((pos = name->find("class", pos)) != string::npos) {
+    while ((pos = name->find("class ", pos)) != string::npos) {
         name->erase(pos, 6);
     }
 
     pos = 0;
-    while ((pos = name->find("struct", pos)) != string::npos) {
+    while ((pos = name->find("struct ", pos)) != string::npos) {
         name->erase(pos, 7);
     }
 
     pos = 0;
-    while ((pos = name->find("enum", pos)) != string::npos) {
+    while ((pos = name->find("enum ", pos)) != string::npos) {
         name->erase(pos, 5);
     }
 #endif


### PR DESCRIPTION
On Windows, USD schemas with "struct' in their names, such as "DestructionAPI" for fracture simulations, were not getting their TfType aliases registered properly, due to the demangling of their symbols. The relevant logic in Arch demangling was already stripping off a trailing space, so the fix is for the substring search to also include the trailing space for  "class ", "struct ", and "enum ".