### PR TITLE
Support for Python 3.8+ on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -603,3 +603,10 @@ platforms to avoid issues with Boost config files (introduced in Boost version
 to use Boost specified config files for their USD build, specify 
 -DBoost_NO_BOOST_CMAKE=OFF when running cmake.
 
+2. Windows and Python 3.8+
+Python 3.8 and later on Windows will no longer search PATH for DLL dependencies.
+Instead, clients can call `os.add_dll_directory(p)` to set paths to search.
+By default on that platform USD will iterate over PATH and add all paths using
+`os.add_dll_directory()` when importing Python modules. Users may override
+this by setting the environment variable `PXR_USD_WINDOWS_DLL_PATH` to a PATH-like
+string. If this is set, USD will use these paths instead.

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1964,15 +1964,6 @@ if not isPython64Bit:
                "PATH")
     sys.exit(1)
 
-# Error out on Windows with Python 3.8+. USD currently does not support
-# these versions due to:
-# https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
-isPython38 = (sys.version_info.major >= 3 and
-              sys.version_info.minor >= 8)
-if Windows() and isPython38:
-    PrintError("Python 3.8+ is not supported on Windows")
-    sys.exit(1)
-
 if find_executable("cmake"):
     # Check cmake requirements
     if Windows():


### PR DESCRIPTION
### Description of Change(s)

Previously this had been disabled because of a change to how the python
interpreter searches for DLLs. This change should restore the old
behavior, and give software builders the ability to opt into the new
python behavior where possible. See

https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

We've discussed a few approaches to this and went with this full path searching approach to try to be as close to the pre python 3.8 behavior as possible. You can disable it with an environment variable, which we'll make use of in the python pypi packages, since those are better off not searching the path.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1404

