### PR TITLE
Enable building PyPI packages for Python 3.9

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -603,3 +603,10 @@ platforms to avoid issues with Boost config files (introduced in Boost version
 to use Boost specified config files for their USD build, specify 
 -DBoost_NO_BOOST_CMAKE=OFF when running cmake.
 
+2. Windows and Python 3.8+
+Python 3.8 and later on Windows will no longer search PATH for DLL dependencies.
+Instead, clients can call `os.add_dll_directory(p)` to set paths to search.
+By default on that platform USD will iterate over PATH and add all paths using
+`os.add_dll_directory()` when importing Python modules. Users may override
+this by setting the environment variable `PXR_USD_WINDOWS_DLL_PATH` to a PATH-like
+string. If this is set, USD will use these paths instead.

--- a/azure-pypi-pipeline.yml
+++ b/azure-pypi-pipeline.yml
@@ -33,6 +33,9 @@ stages:
         Python38:
           PYTHON_INTERPRETER: /opt/python/cp38-cp38/bin/python
           PYTHON_TAG: cp38
+        Python39:
+          PYTHON_INTERPRETER: /opt/python/cp39-cp39/bin/python
+          PYTHON_TAG: cp39
     timeoutInMinutes: 90
     pool:
       vmImage: Ubuntu-18.04
@@ -80,6 +83,9 @@ stages:
         Python38:
           PYTHON_VERSION_SPEC: 3.8
           PYTHON_TAG: cp38
+        Python39:
+          PYTHON_VERSION_SPEC: 3.9
+          PYTHON_TAG: cp39
     timeoutInMinutes: 90
     pool:
       vmImage: 'VS2017-Win2016'
@@ -131,6 +137,10 @@ stages:
           PYTHON_VERSION_SPEC: 3.8
           PYTHON_INTERPRETER: python3.8
           PYTHON_TAG: cp38
+        Python39:
+          PYTHON_VERSION_SPEC: 3.9
+          PYTHON_INTERPRETER: python3.9
+          PYTHON_TAG: cp39
     timeoutInMinutes: 90
     pool:
       vmImage: 'macOS-10.14'
@@ -222,6 +232,10 @@ stages:
           PYTHON_VERSION_SPEC: 3.8
           IMAGE: 'Ubuntu-18.04'
           PYTHON_INTERPRETER: python3
+        Linux_Python39:
+          PYTHON_VERSION_SPEC: 3.9
+          IMAGE: 'Ubuntu-18.04'
+          PYTHON_INTERPRETER: python3
         Windows_Python36:
           PYTHON_VERSION_SPEC: 3.6
           IMAGE: 'VS2017-Win2016'
@@ -234,6 +248,10 @@ stages:
           PYTHON_VERSION_SPEC: 3.8
           IMAGE: 'VS2017-Win2016'
           PYTHON_INTERPRETER: python
+        Windows_Python39:
+          PYTHON_VERSION_SPEC: 3.9
+          IMAGE: 'VS2017-Win2016'
+          PYTHON_INTERPRETER: python
         Mac_Python36:
           PYTHON_VERSION_SPEC: 3.6
           IMAGE: 'macOS-10.14'
@@ -244,6 +262,10 @@ stages:
           PYTHON_INTERPRETER: python3
         Mac_Python38:
           PYTHON_VERSION_SPEC: 3.8
+          IMAGE: 'macOS-10.14'
+          PYTHON_INTERPRETER: python3
+        Mac_Python39:
+          PYTHON_VERSION_SPEC: 3.9
           IMAGE: 'macOS-10.14'
           PYTHON_INTERPRETER: python3
     timeoutInMinutes: 10

--- a/azure-pypi-pipeline.yml
+++ b/azure-pypi-pipeline.yml
@@ -30,6 +30,9 @@ stages:
         Python37:
           PYTHON_INTERPRETER: /opt/python/cp37-cp37m/bin/python
           PYTHON_TAG: cp37
+        Python38:
+          PYTHON_INTERPRETER: /opt/python/cp38-cp38/bin/python
+          PYTHON_TAG: cp38
     timeoutInMinutes: 90
     pool:
       vmImage: Ubuntu-18.04
@@ -74,6 +77,9 @@ stages:
         Python37:
           PYTHON_VERSION_SPEC: 3.7
           PYTHON_TAG: cp37
+        Python38:
+          PYTHON_VERSION_SPEC: 3.8
+          PYTHON_TAG: cp38
     timeoutInMinutes: 90
     pool:
       vmImage: 'VS2017-Win2016'
@@ -121,6 +127,10 @@ stages:
           PYTHON_VERSION_SPEC: 3.7
           PYTHON_INTERPRETER: python3.7
           PYTHON_TAG: cp37
+        Python38:
+          PYTHON_VERSION_SPEC: 3.8
+          PYTHON_INTERPRETER: python3.8
+          PYTHON_TAG: cp38
     timeoutInMinutes: 90
     pool:
       vmImage: 'macOS-10.14'
@@ -208,6 +218,10 @@ stages:
           PYTHON_VERSION_SPEC: 3.7
           IMAGE: 'Ubuntu-18.04'
           PYTHON_INTERPRETER: python3
+        Linux_Python38:
+          PYTHON_VERSION_SPEC: 3.8
+          IMAGE: 'Ubuntu-18.04'
+          PYTHON_INTERPRETER: python3
         Windows_Python36:
           PYTHON_VERSION_SPEC: 3.6
           IMAGE: 'VS2017-Win2016'
@@ -216,12 +230,20 @@ stages:
           PYTHON_VERSION_SPEC: 3.7
           IMAGE: 'VS2017-Win2016'
           PYTHON_INTERPRETER: python
+        Windows_Python38:
+          PYTHON_VERSION_SPEC: 3.8
+          IMAGE: 'VS2017-Win2016'
+          PYTHON_INTERPRETER: python
         Mac_Python36:
           PYTHON_VERSION_SPEC: 3.6
           IMAGE: 'macOS-10.14'
           PYTHON_INTERPRETER: python3
         Mac_Python37:
           PYTHON_VERSION_SPEC: 3.7
+          IMAGE: 'macOS-10.14'
+          PYTHON_INTERPRETER: python3
+        Mac_Python38:
+          PYTHON_VERSION_SPEC: 3.8
           IMAGE: 'macOS-10.14'
           PYTHON_INTERPRETER: python3
     timeoutInMinutes: 10

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1964,15 +1964,6 @@ if not isPython64Bit:
                "PATH")
     sys.exit(1)
 
-# Error out on Windows with Python 3.8+. USD currently does not support
-# these versions due to:
-# https://docs.python.org/3.8/whatsnew/3.8.html#bpo-36085-whatsnew
-isPython38 = (sys.version_info.major >= 3 and
-              sys.version_info.minor >= 8)
-if Windows() and isPython38:
-    PrintError("Python 3.8+ is not supported on Windows")
-    sys.exit(1)
-
 if find_executable("cmake"):
     # Check cmake requirements
     if Windows():

--- a/build_scripts/pypi/package_files/setup.py
+++ b/build_scripts/pypi/package_files/setup.py
@@ -128,5 +128,5 @@ setuptools.setup(
         "Environment :: Console",
         "Topic :: Multimedia :: Graphics",
     ],
-    python_requires='>=3.6, <3.9',
+    python_requires='>=3.6, <3.10',
 )

--- a/build_scripts/pypi/package_files/setup.py
+++ b/build_scripts/pypi/package_files/setup.py
@@ -73,7 +73,7 @@ if windows():
 import os, sys
 dllPath = os.path.split(os.path.realpath(__file__))[0]
 if sys.version_info >= (3, 8, 0):
-    os.add_dll_directory(dllPath)
+    os.environ['PXR_USD_WINDOWS_DLL_PATH'] = dllPath
 else:
     os.environ['PATH'] = dllPath + os.pathsep + os.environ['PATH']
 ''')
@@ -128,5 +128,5 @@ setuptools.setup(
         "Environment :: Console",
         "Topic :: Multimedia :: Graphics",
     ],
-    python_requires='>=3.6, <3.8',
+    python_requires='>=3.6, <3.9',
 )


### PR DESCRIPTION
### Description of Change(s)

Now that we can support python 3.8+ on our main platforms, we can also enable builds for python 3.9. This is a followup for https://github.com/PixarAnimationStudios/USD/pull/1512 that also adds 3.9.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1405

