### PR TITLE
Screen-space based scaling of curve width

### DIFF
--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -509,6 +509,25 @@ void main()
     MAT4 transform = ApplyInstanceTransform(HdGet_transform());
     vec4 scaledDirection = GetWorldToViewMatrix() * transform 
                   * vec4(direction, 0);
+
+    //
+    // Screen space curve width scaling
+    // if the width falls below one pixel we widen it 
+    // optional minCurveWidth() for user driven controls 
+    //
+    MAT4 projMat = GetProjectionMatrix();
+    vec4 viewport = GetViewport();
+    vec2 screen_size = vec2(viewport.z, viewport.w);
+    float scaleWidth = 2/(projMat[1][1] * screen_size.y);
+    float widthScreen = width/(-position.z * scaleWidth);
+    float widthMultiplier = 1.0;
+#ifdef HD_HAS_minCurveWidth
+    widthMultiplier = min(width, HdGet_minCurveWidth());
+#endif
+
+    if (widthScreen < 1.0)
+        width = position.z * scaleWidth * min(widthMultiplier, 1.0);
+
     vec3 offset = direction * length(scaledDirection.xyz) * width * 0.5;
     position.xyz = position.xyz + offset;
     position.w = 1;


### PR DESCRIPTION
Submitting this pull request on behalf of Rakesh Roopavataram.

### About the proposed feature
The proposed change introduces a new feature for screen-space based widening of OpenGL curve rendering in HdStorm. It is in effect during the patch rendering mode of the curve only. The widening is based on simple metrics computed in screen space. The automatic widening kicks in when the computed curve width during the tessellation stage falls below one pixel. 

### Previous discussions and usage
The above change has been developed and tested at our site. The proposed change was also discussed with a few Pixar engineers offline. It was agreed upon that this feature might be general enough to be included in the PR.

### Implementation details
The current code change is structured in a way that is "always on". While this mechanism works for our production needs, we do realize other users may have different workflows. So the proposed code change is only for the core feature. We are open to adding "opt-in" features such as conditional execution of the shader code. 

### Steps to reproduce
We are attaching a simple USD scene file. 
[hairLayerLow_USD.usda.txt](https://github.com/PixarAnimationStudios/USD/files/6588509/hairLayerLow_USD.usda.txt)

Before
1. Open the scene file in USDView.
2. Set complexity to High  or Very High (View->Complexity->(High/VeryHigh)

Introduce changes to basisCurves.glslfx as shared

After
Repeat 1 and 2. 

The curve rendering should look widened and less aliased.

Before:
![widening_before](https://user-images.githubusercontent.com/1923494/120577790-a6e0c500-c3d9-11eb-8ff1-2c860ac31507.jpeg)

After:
![widening_after](https://user-images.githubusercontent.com/1923494/120577786-a6482e80-c3d9-11eb-9056-cbb31007d250.jpeg)

Before:
![hairWidth_before](https://user-images.githubusercontent.com/1923494/120577898-cb3ca180-c3d9-11eb-8ee4-62148c003fa3.jpeg)

After:
![hairWidth_after1](https://user-images.githubusercontent.com/1923494/120577897-caa40b00-c3d9-11eb-8b04-36ad68de1365.jpeg)

