### PR TITLE
[usdview] Call ActivateWindow on MainWindow after Show

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -426,6 +426,7 @@ class AppController(QtCore.QObject):
             # statusBar saves considerable GUI configuration time.
             self._mainWindow.show()
             self._mainWindow.setFocus()
+            self._mainWindow.activateWindow()
             
             # Install our custom event filter.  The member assignment of the
             # filter is just for lifetime management


### PR DESCRIPTION
### Description of Change(s)
Calling qtWidget::activateWindow on mainWindow after it is created to bring it to the foreground. On Windows this will call Win32 SetForegroundWindow.

### Fixes Issue(s)
- #1535 

