### PR TITLE
Add missing quotes in examples of UsdGeom overview

### DIFF
--- a/pxr/usd/usdGeom/overview.dox
+++ b/pxr/usd/usdGeom/overview.dox
@@ -162,7 +162,7 @@ def "Root" {
     def Xform "RenderXform" {
         token purpose = "render"
 
-        def "Prim {
+        def "Prim" {
             token purpose = "default"
 
             def Xform "InheritXform" {
@@ -174,7 +174,7 @@ def "Root" {
         }
     }
 
-    def Xform "Xform {
+    def Xform "Xform" {
     }
 }
 \endcode


### PR DESCRIPTION
### Description of Change(s)

This patch adds missing quotes around prim names in the example USD of the Imageable Purpose section of the UsdGeom overview.

### Fixes Issue(s)


