### PR TITLE
Fix a bug which could cause a crash during composition

### DIFF
--- a/pxr/usd/pcp/layerStack.cpp
+++ b/pxr/usd/pcp/layerStack.cpp
@@ -430,8 +430,7 @@ PcpLayerStack::~PcpLayerStack()
     // Update layer-stack-to-layer maps in the registry.
     _BlowLayers();
     if (_registry) {
-        _registry->_SetLayers(this);
-        _registry->_Remove(_identifier, this);
+        _registry->_SetLayersAndRemove(_identifier, this);
     }
 }
 

--- a/pxr/usd/pcp/layerStackRegistry.cpp
+++ b/pxr/usd/pcp/layerStackRegistry.cpp
@@ -244,9 +244,13 @@ Pcp_LayerStackRegistry::_SetLayersAndRemove(
     // map if a FindOrCreate call intercedes between the moment when the
     // layer stack's ref count drops to zero and the time the layer stack
     // destructor is called (which is how we get into this method).
+    // Always call _SetLayers to clear this (now empty) layer stack's
+    // pointer from the maps inside _data, even if a new layer stack with the
+    // same identifier has already been added to the identifierToLayerStack
+    // map.
+    _SetLayers(layerStack);
     if (i != _data->identifierToLayerStack.end() &&
         i->second.operator->() == layerStack) {
-        _SetLayers(layerStack);
         _data->identifierToLayerStack.erase(identifier);
     }
 }

--- a/pxr/usd/pcp/layerStackRegistry.cpp
+++ b/pxr/usd/pcp/layerStackRegistry.cpp
@@ -238,7 +238,6 @@ Pcp_LayerStackRegistry::_SetLayersAndRemove(
 {
     tbb::queuing_rw_mutex::scoped_lock lock(_data->mutex, /*write=*/true);
 
-    _SetLayers(layerStack);
     Pcp_LayerStackRegistryData::IdentifierToLayerStack::const_iterator i =
         _data->identifierToLayerStack.find(identifier);
     // It's possible that layerStack has already been removed from the
@@ -247,6 +246,7 @@ Pcp_LayerStackRegistry::_SetLayersAndRemove(
     // destructor is called (which is how we get into this method).
     if (i != _data->identifierToLayerStack.end() &&
         i->second.operator->() == layerStack) {
+        _SetLayers(layerStack);
         _data->identifierToLayerStack.erase(identifier);
     }
 }

--- a/pxr/usd/pcp/layerStackRegistry.h
+++ b/pxr/usd/pcp/layerStackRegistry.h
@@ -132,7 +132,7 @@ private:
     const Pcp_MutedLayers& _GetMutedLayers() const;
 
     // PcpLayerStack can access private _GetFileFormatTarget(), 
-    // _Remove(), and _SetLayers().
+    // _SetLayersAndRemove(), and _SetLayers().
     friend class PcpLayerStack;
 
 private:

--- a/pxr/usd/pcp/layerStackRegistry.h
+++ b/pxr/usd/pcp/layerStackRegistry.h
@@ -112,8 +112,8 @@ private:
     PcpLayerStackPtr _Find(const PcpLayerStackIdentifier&) const;
 
     // Remove the layer stack with the given identifier from the registry.
-    void _Remove(const PcpLayerStackIdentifier&,
-                 const PcpLayerStack *);
+    void _SetLayersAndRemove(const PcpLayerStackIdentifier&,
+                             const PcpLayerStack *);
 
     // Update the layer-stack-by-layer maps by setting the layers for the
     // given layer stack.


### PR DESCRIPTION
Fix a bug which could cause a crash during composition or recomposition
after a change to a stage. Sufficiently frequent/repetitive calls to
_EvalRefOrPayloadArcs in primIndex.cpp, where ComputeLayerStack is called
many times for the same layer could result in Pcp_LayerStackRegistry
returning a PcpLayerStack that was either already deleted, or about to be
deleted. Fixing this required moe careful management of the table mapping
identifiers to layer stacks in the registry object.

### Description of Change(s)
I believe there was unsafe code in the layer stack registry. Given enough threads simultaneously being in _EvalRefOrPayloadArcs in pcp/primIndex.cpp, with all those threads calling ComputeLayerStack for the same layer file, there is lots of opportunity for the registry cleanup code in the PcpLayerStack destructor to interact badly with the Pcp_LayerStackRegistry::FindOrCreate method.

I wish I could provide a reproduceable test case for this crash, but I was only able to make it happen within Houdini. But the crash would happen within a call to UsdUtilsFlattenLayerStack, in the SdfChangeBlock destructor when exiting UsdFlattenLayerStack. With this change I can no longer reproduce the crash in Houdini, and all the USD tests still pass (so at least I'm pretty sure I didn't break anything). Really curious to hear thoughts about this change...