### PR TITLE
Fix OpenEXR libraries installation

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -930,6 +930,7 @@ def InstallOpenEXR(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(OPENEXR_URL, context, force)):
         RunCMake(context, force, 
                  ['-DOPENEXR_BUILD_PYTHON_LIBS=OFF',
+                  '-DOPENEXR_PACKAGE_PREFIX="{}"'.format(context.instDir),
                   '-DOPENEXR_ENABLE_TESTS=OFF'] + buildArgs)
 
 OPENEXR = Dependency("OpenEXR", InstallOpenEXR, "include/OpenEXR/ImfVersion.h")


### PR DESCRIPTION
### Description of Change(s)
Add `OPENEXR_PACKAGE_PREFIX` option to OpenEXR build script. This is required to install the `IlmImf` library into the correct directory. Without `OPENEXR_PACKAGE_PREFIX` option this [line](https://github.com/AcademySoftwareFoundation/openexr/blob/v2.3.0/OpenEXR/IlmImf/CMakeLists.txt#L6) sets `RUNTIME_DIR` to `/bin` which leads the `IlmImf` library to be [installed](https://github.com/AcademySoftwareFoundation/openexr/blob/v2.3.0/OpenEXR/IlmImf/CMakeLists.txt#L259) to the root of the filesystem.

### Fixes Issue(s)
- `IlmImf` library is not installing to `instDir/bin`

