### PR TITLE
Cache usdz archive traversal for subsequent lookup/queries on external references.

### DIFF
--- a/pxr/usd/ar/packageUtils.cpp
+++ b/pxr/usd/ar/packageUtils.cpp
@@ -85,11 +85,11 @@ _FindMatchingOpeningDelimiter(
 {
     size_t numOpenNeeded = 1;
     std::string::const_reverse_iterator revIt(closingDelimIt);
-    for (; revIt != path.rend() && numOpenNeeded != 0; ++revIt) {
+    for (const auto rend = path.rend(); revIt != rend && numOpenNeeded != 0; ++revIt) {
         if (*revIt == '[' || *revIt == ']') {
             // Ignore this delimiter if it's been escaped.
             auto prevCharIt = revIt + 1;
-            if (prevCharIt != path.rend() && *prevCharIt == '\\') {
+            if (prevCharIt != rend && *prevCharIt == '\\') {
                 continue;
             }
             numOpenNeeded += (*revIt == '[') ? -1 : 1;

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -429,6 +429,15 @@ pxr_build_test(testUsdUsdzResolver
         testenv/testUsdUsdzResolver.cpp
 )
 
+pxr_build_test(testUsdUsdzLargeArchive
+    LIBRARIES
+        tf
+        usd
+        usdGeom
+    CPPFILES
+        testenv/testUsdUsdzLargeArchive.cpp
+)
+
 pxr_install_test_dir(
     SRC testenv/testUsdAppliedAPISchemas
     DEST testUsdAppliedAPISchemas
@@ -644,6 +653,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdZipFile.testenv
     DEST testUsdZipFile
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdUsdzLargeArchive
+    DEST testUsdUsdzLargeArchive
 )
 
 pxr_register_test(testUsdAppliedAPISchemas
@@ -1082,5 +1096,9 @@ pxr_register_test(testUsdZipFile
 )
 pxr_register_test(testUsdUsdzResolver
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzResolver"
+    EXPECTED_RETURN_CODE 0
+)
+pxr_register_test(testUsdUsdzLargeArchive
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzLargeArchive"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usd/testenv/testUsdUsdzLargeArchive.cpp
+++ b/pxr/usd/usd/testenv/testUsdUsdzLargeArchive.cpp
@@ -1,0 +1,106 @@
+//
+// Copyright 2021 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/pxr.h"
+
+#include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usdGeom/mesh.h"
+
+#include <ctime>
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE;
+
+static bool
+AttributesEqual(UsdAttribute a, UsdAttribute b)
+{
+    if (a.IsValid() != b.IsValid()) {
+        return false;
+    }
+    if (!a.IsValid()) {
+        return true;
+    }
+    VtValue va, vb;
+    if (!a.Get(&va) || !b.Get(&vb)) {
+        return false;
+    }
+    return va == vb;
+}
+
+// Test that calling ArResolver::OpenAsset on a file within a .usdz
+// file produces the expected result.
+static void
+TestOpenLargeArchive()
+{
+    std::cout << "TestOpenLargeArchive...";
+    const std::string usdzFile("test.usdz");
+    const auto startTime = std::clock();
+    auto stage = UsdStage::Open(usdzFile);
+    const auto endTime = std::clock();
+
+    // Testing the time to open is possibly not the greatest, but the file in question
+    // took over 15 seconds without caching, and less than 2.5 seconds with;
+    // So conservatively, we should be able to open it in 5 seconds in processor time ?
+    //
+    const auto elapsedTime = float(endTime - startTime) / CLOCKS_PER_SEC;
+    std::cout << "stage creation took " << elapsedTime << std::endl;
+
+    if (!stage) {
+        TF_FATAL_ERROR("Failed to load stage at '%s'", usdzFile.c_str());
+    }
+    if (elapsedTime > 5.f) {
+        TF_FATAL_ERROR("Open of '%s' took %f seconds in proc time", usdzFile.c_str(), elapsedTime);
+    }
+
+    UsdPrim scene = stage->GetPrimAtPath(SdfPath("/scene"));
+    TF_AXIOM(scene);
+
+    UsdGeomMesh baseMesh;
+    size_t numChildren = 0;
+    for (UsdPrim child : scene.GetAllChildren()) {
+        TF_AXIOM(child.IsA<UsdGeomMesh>());
+
+        UsdGeomMesh mesh(child);
+        if (baseMesh) {
+            TF_AXIOM(AttributesEqual(baseMesh.GetFaceVertexCountsAttr(), mesh.GetFaceVertexCountsAttr()));
+            TF_AXIOM(AttributesEqual(baseMesh.GetFaceVertexIndicesAttr(), mesh.GetFaceVertexIndicesAttr()));
+            TF_AXIOM(AttributesEqual(baseMesh.GetPointsAttr(), mesh.GetPointsAttr()));
+            TF_AXIOM(AttributesEqual(baseMesh.GetSubdivisionSchemeAttr(), mesh.GetSubdivisionSchemeAttr()));
+        }
+        else {
+            baseMesh = std::move(mesh);
+        }
+        ++numChildren;
+    }
+    TF_AXIOM(numChildren == 25000);
+}
+
+int main(int argc, char** argv)
+{
+    TestOpenLargeArchive();
+
+    std::cout << "Passed!" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/pxr/usd/usd/zipFile.h
+++ b/pxr/usd/usd/zipFile.h
@@ -107,17 +107,17 @@ public:
         bool encrypted = false;
     };
 
+    /// \class _LocalFileHeader
+    /// Private struct holding header information.
+    struct _LocalFileHeader;
+
     /// \class Iterator
     /// Iterator for traversing and inspecting the contents of the zip archive.
     class Iterator 
     {
-    public:
-        USD_API
-        Iterator();
-
         // Proxy type for operator->(), needed since this iterator's value
         // is generated on the fly.
-        class _ArrowProxy 
+        class _ArrowProxy
         {
         public:
             explicit _ArrowProxy(const std::string& s) : _s(s) { }
@@ -125,6 +125,13 @@ public:
         private:
             std::string _s;
         };
+
+    public:
+        USD_API
+        Iterator();
+
+        USD_API
+        ~Iterator();
 
         using difference_type = std::ptrdiff_t;
         using value_type = std::string;
@@ -166,10 +173,11 @@ public:
 
     private:
         friend class UsdZipFile;
-        Iterator(const _Impl* impl);
+        Iterator(const _Impl* impl, size_t offset = 0);
 
         const _Impl* _impl;
         size_t _offset;
+        std::shared_ptr<_LocalFileHeader> _fileHeader;
     };
 
     /// Returns iterator pointing to the first file in the zip archive.


### PR DESCRIPTION
### Description of Change(s)
While linearly traversing the **usdz** archive, cache the path and header information so that subsequent lookups can be accelerated.

### Fixes Issue(s)
#1577, #1579

This brings down load time of a **usdz** file that was taking ~3 minutes to ~16 seconds, and can often wind up performing better than parsing the original **usdc** file that generated the **usdz** (likely because IO is avoided on the references as the files are _in memory_ from the archive).

The test case is an example that takes more than 15 seconds to load currently, but with caching goes down to 2 seconds.  It has 25000 entries, chosen to demonstrate the time difference in a way that can be tested against regression.  The amount of entries is also good to  test against any race conditions filling in the cache (though per the comments in code, a relatively simplistic filling is used to as it performs well enough and keeps the code simple)
