### PR TITLE
Explicit unicode support for windows

### DIFF
--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -51,6 +51,8 @@
 #include <glob.h>
 #elif defined(ARCH_OS_WINDOWS)
 #include <io.h>
+#include <windows.h>
+#include <stringapiset.h>
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -420,6 +422,38 @@ enum ArchFileAdvice {
 ARCH_API
 void ArchFileAdvise(FILE *file, int64_t offset, size_t count,
                     ArchFileAdvice adv);
+
+#if defined(ARCH_OS_WINDOWS)
+
+/// Converts UTF-16 windows string to regular std::string - Windows-only
+inline std::string ArchWindowsUtf16ToUtf8(const std::wstring &wstr)
+{
+    if (wstr.empty()) return std::string();
+    // first call is only to get required size for string
+    int size = WideCharToMultiByte(CP_UTF8, 0, wstr.data(), (int)wstr.size(), NULL, 0, NULL, NULL);
+    if (size == 0) return std::string();
+    std::string str(size, 0);
+    if (WideCharToMultiByte(CP_UTF8, 0, wstr.data(), (int)wstr.size(), &str[0], size, NULL, NULL) == 0){
+        return std::string();
+    }
+    return str;
+}
+
+/// Converts regular std::string to UTF-16 windows string - Windows-only
+inline std::wstring ArchWindowsUtf8ToUtf16(const std::string &str)
+{
+    if (str.empty()) return std::wstring();
+    // first call is only to get required size for wstring
+    int size = MultiByteToWideChar(CP_UTF8, 0, str.data(), (int)str.size(), NULL, 0);
+    if (size == 0) return std::wstring();
+    std::wstring wstr(size, 0);
+    if(MultiByteToWideChar(CP_UTF8, 0, str.data(), (int)str.size(), &wstr[0], size) == 0){
+        return std::wstring();
+    }
+    return wstr;
+}
+
+#endif
 
 ///@}
 

--- a/pxr/base/tf/atomicOfstreamWrapper.cpp
+++ b/pxr/base/tf/atomicOfstreamWrapper.cpp
@@ -84,8 +84,13 @@ TfAtomicOfstreamWrapper::Open(
     // with the same file name.
     ArchCloseFile(tmpFd);
 
-    _stream.open(_tmpFilePath.c_str(),
+#if defined(ARCH_OS_WINDOWS)
+    _stream.open(ArchWindowsUtf8ToUtf16(_tmpFilePath).c_str(),
                  std::fstream::out|std::fstream::binary|std::fstream::trunc);
+#else
+    _stream.open(_tmpFilePath.c_str(),
+        std::fstream::out | std::fstream::binary | std::fstream::trunc);
+#endif
     if (!_stream) {
         if (reason) {
             *reason = TfStringPrintf(

--- a/pxr/base/tf/atomicRenameUtil.cpp
+++ b/pxr/base/tf/atomicRenameUtil.cpp
@@ -49,8 +49,10 @@ Tf_AtomicRenameFileOver(std::string const &srcFileName,
 {
     bool result = true;
 #if defined(ARCH_OS_WINDOWS)
-    bool moved = MoveFileEx(srcFileName.c_str(),
-                            dstFileName.c_str(),
+    const std::wstring wsrc{ ArchWindowsUtf8ToUtf16(srcFileName) };
+    const std::wstring wdst{ ArchWindowsUtf8ToUtf16(dstFileName) };
+    bool moved = MoveFileExW(wsrc.c_str(),
+                            wdst.c_str(),
                             MOVEFILE_REPLACE_EXISTING |
                             MOVEFILE_COPY_ALLOWED) != FALSE;
     if (!moved) {

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -85,7 +85,7 @@ Tf_HasAttribute(
     if (path.back() == '/' || path.back() == '\\')
         resolveSymlinks = true;
 
-    const DWORD attribs = GetFileAttributes(path.c_str());
+    const DWORD attribs = GetFileAttributesW(ArchWindowsUtf8ToUtf16(path).c_str());
     if (attribs == INVALID_FILE_ATTRIBUTES) {
         if (attribute == 0 && GetLastError() == ERROR_FILE_NOT_FOUND) {
             // Don't report an error if we're just testing existence.
@@ -228,7 +228,7 @@ TfIsDirEmpty(string const& path)
     if (!TfIsDir(path))
         return false;
 #if defined(ARCH_OS_WINDOWS)
-    return PathIsDirectoryEmpty(path.c_str()) == TRUE;
+    return PathIsDirectoryEmptyW(ArchWindowsUtf8ToUtf16(path).c_str()) == TRUE;
 #else
     if (DIR *dirp = opendir(path.c_str()))
     {
@@ -253,7 +253,7 @@ bool
 TfSymlink(string const& src, string const& dst)
 {
 #if defined(ARCH_OS_WINDOWS)
-    if (CreateSymbolicLink(dst.c_str(), src.c_str(),
+    if (CreateSymbolicLinkW(ArchWindowsUtf8ToUtf16(dst).c_str(), ArchWindowsUtf8ToUtf16(src).c_str(),
                            TfIsDir(src) ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0)) {
         return true;
     }
@@ -286,7 +286,7 @@ bool
 TfMakeDir(string const& path, int mode)
 {
 #if defined(ARCH_OS_WINDOWS)
-    return CreateDirectory(path.c_str(), nullptr) == TRUE;
+    return CreateDirectoryW(ArchWindowsUtf8ToUtf16(path).c_str(), nullptr) == TRUE;
 #else
     // Default mode is 0777
     if (mode == -1)
@@ -346,13 +346,13 @@ TfReadDir(
     string *errMsg)
 {
 #if defined(ARCH_OS_WINDOWS)
-    char szPath[MAX_PATH];
-    WIN32_FIND_DATA fdFile;
+    wchar_t szPath[MAX_PATH];
+    WIN32_FIND_DATAW fdFile;
     HANDLE hFind = NULL;
 
-    PathCombine(szPath, dirPath.c_str(), "*.*");
+    PathCombineW(szPath, ArchWindowsUtf8ToUtf16(dirPath).c_str(), L"*.*");
 
-    if((hFind = FindFirstFile(szPath, &fdFile)) == INVALID_HANDLE_VALUE)
+    if((hFind = FindFirstFileW(szPath, &fdFile)) == INVALID_HANDLE_VALUE)
     {
         if (errMsg) {
             *errMsg = TfStringPrintf("Path not found: %s", szPath);
@@ -363,22 +363,22 @@ TfReadDir(
     {
         do
         {
-            if(strcmp(fdFile.cFileName, ".") != 0
-                && strcmp(fdFile.cFileName, "..") != 0)
+            if(wcscmp(fdFile.cFileName, L".") != 0
+                && wcscmp(fdFile.cFileName, L"..") != 0)
             {
                 if(fdFile.dwFileAttributes &FILE_ATTRIBUTE_DIRECTORY)
                 {
                     if (dirnames)
-                        dirnames->push_back(fdFile.cFileName);
+                        dirnames->push_back(ArchWindowsUtf16ToUtf8(fdFile.cFileName));
                 }
                 else
                 {
                     if (filenames)
-                        filenames->push_back(fdFile.cFileName);
+                        filenames->push_back(ArchWindowsUtf16ToUtf8(fdFile.cFileName));
                 }
             }
         }
-        while (FindNextFile(hFind, &fdFile));
+        while (FindNextFileW(hFind, &fdFile));
 
         FindClose(hFind);
 
@@ -666,7 +666,7 @@ TfTouchFile(string const &fileName, bool create)
             return false;
         close(fd);
 #else
-        HANDLE fileHandle = ::CreateFile(fileName.c_str(),
+            HANDLE fileHandle = ::CreateFileW(ArchWindowsUtf8ToUtf16(fileName).c_str(),
             GENERIC_WRITE,          // open for write
             0,                      // not for sharing
             NULL,                   // default security

--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -282,7 +282,7 @@ bool TfIsRelativePath(std::string const& path)
 {
 #if defined(ARCH_OS_WINDOWS)
     return path.empty() ||
-        (PathIsRelative(path.c_str()) && path[0] != '/' && path[0] != '\\');
+        (PathIsRelativeW(ArchWindowsUtf8ToUtf16(path).c_str()) && path[0] != '/' && path[0] != '\\');
 #else
     return path.empty() || path[0] != '/';
 #endif
@@ -338,7 +338,7 @@ Tf_Glob(
         // Conveniently GetFileAttributes() works on paths with a trailing
         // backslash.
         string path = prefix + pattern;
-        const DWORD attributes = GetFileAttributes(path.c_str());
+            const DWORD attributes = GetFileAttributesW(ArchWindowsUtf8ToUtf16(path).c_str());
         if (attributes != INVALID_FILE_ATTRIBUTES) {
             // File exists.
 
@@ -371,14 +371,14 @@ Tf_Glob(
         const string leftmostDir = TfGetPathName(leftmostPattern);
 
         // Glob the leftmost pattern.
-        WIN32_FIND_DATA data;
-        HANDLE find = FindFirstFile(leftmostPattern.c_str(), &data);
+        WIN32_FIND_DATAW data;
+            HANDLE find = FindFirstFileW(ArchWindowsUtf8ToUtf16(leftmostPattern).c_str(), &data);
         if (find != INVALID_HANDLE_VALUE) {
             do {
                 // Recurse with next pattern.
-                Tf_Glob(result, leftmostDir + data.cFileName,
+                Tf_Glob(result, leftmostDir + ArchWindowsUtf16ToUtf8(data.cFileName),
                         remainingPattern, flags);
-            } while (FindNextFile(find, &data));
+            } while (FindNextFileW(find, &data));
             FindClose(find);
         }
     }

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -321,21 +321,22 @@ TfGetBaseName(const string& fileName)
     if (i == fileName.size() - 1)    // ends in directory delimiter
         return TfGetBaseName(fileName.substr(0, i));
 #if defined(ARCH_OS_WINDOWS)
-    PTSTR result = PathFindFileName(fileName.c_str());
+    const std::wstring wfileName{ ArchWindowsUtf8ToUtf16(fileName) };
+    LPWSTR result = PathFindFileNameW(wfileName.c_str());
 
     // If PathFindFilename returns the same string back, that means it didn't
     // do anything.  That could mean that the patch has no basename, in which
     // case we want to return the empty string, or it could mean that the
     // fileName was already basename, in which case we want to return the
     // string back.
-    if (result == fileName.c_str()) {
+    if (result == wfileName.c_str()) {
         const bool hasDriveLetter = fileName.find(":") != string::npos;
         const bool hasPathSeparator  = i != string::npos;
         if (hasDriveLetter || hasPathSeparator) {
             return std::string();
         }
     }
-    return result;
+    return ArchWindowsUtf16ToUtf8(result);
 
 #else
     if (i == string::npos)                      // no / in name

--- a/pxr/imaging/hio/stb/stb_image.h
+++ b/pxr/imaging/hio/stb/stb_image.h
@@ -538,6 +538,8 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 
 
 #ifdef _MSC_VER
+#include <windows.h>
+#include <stringapiset.h>
 typedef unsigned short stbi__uint16;
 typedef   signed short stbi__int16;
 typedef unsigned int   stbi__uint32;
@@ -1147,7 +1149,13 @@ static FILE *stbi__fopen(char const *filename, char const *mode)
 {
    FILE *f;
 #if defined(_MSC_VER) && _MSC_VER >= 1400
-   if (0 != fopen_s(&f, filename, mode))
+    int size = MultiByteToWideChar(CP_UTF8, 0, &filename[0], -1, NULL, 0);
+    std::wstring wfilename(size, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &filename[0], -1, &wfilename[0], size);
+    size = MultiByteToWideChar(CP_UTF8, 0, &mode[0], -1, NULL, 0);
+    std::wstring wmode(size, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &mode[0], -1, &wmode[0], size);
+    if (0 != _wfopen_s(&f, wfilename.c_str(), wmode.c_str()))
       f=0;
 #else
    f = fopen(filename, mode);

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -2542,6 +2542,9 @@ CrateFile::Packer::Close()
                                /*hasOwnership=*/true);
     }
 
+    if (fileRange.file == nullptr) {
+        return false;
+    }
     // Reset the filename we've read content from.
     _crate->_fileReadFrom = ArchGetFileName(fileRange.file);
 

--- a/pxr/usd/usd/testenv/testUsdStage.py
+++ b/pxr/usd/usd/testenv/testUsdStage.py
@@ -1,4 +1,5 @@
 #!/pxrpythonsubst
+# -*- coding: utf-8 -*-
 #
 # Copyright 2017 Pixar
 #
@@ -525,6 +526,24 @@ class TestUsdStage(unittest.TestCase):
                         [rootLayer, rootSubLayer, rootAnonLayer, rootRefLayer,
                          sessionAnonLayer, sessionRefLayer]])
             assert not any([l.dirty for l in [sessionLayer, sessionSubLayer]])
+
+            # Check saving with UTF-8 characters
+            (rootLayer, rootSubLayer, rootAnonLayer, rootRefLayer) = \
+                _CreateLayers('root_utf8_umlaute_ß_3')
+            (sessionLayer, sessionSubLayer, sessionAnonLayer, sessionRefLayer) = \
+                _CreateLayers('session_utf8_bigA_Ä_3')
+
+            stage = Usd.Stage.Open(rootLayer, sessionLayer)
+            assert all([l.dirty for l in 
+                        [rootLayer, rootSubLayer, rootAnonLayer, rootRefLayer,
+                         sessionLayer, sessionSubLayer, sessionAnonLayer,
+                         sessionRefLayer]])
+            stage.SaveSessionLayers()
+            assert all([l.dirty for l in 
+                        [rootLayer, rootSubLayer, rootAnonLayer, rootRefLayer,
+                         sessionAnonLayer, sessionRefLayer]])
+            assert not any([l.dirty for l in [sessionLayer, sessionSubLayer]])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)
This change adds explicit windows support for UTF-8 characters in file paths.
As discussed in #1443 these changes are not necessary if the calling executable is patched to use the UTF-8 code page on recent versions of Windows (see https://docs.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page for details).
Unfortunately these changes are necessary for applications that need to be used without changing the OS default settings.

### Fixes Issue(s)
- #1443

