### PR TITLE
[usdPhysics] Fix python bindings for metrics and kilogramsPerUnit metadata registration.

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -278,6 +278,13 @@ pxr_register_test(testUsdGeomMesh
     EXPECTED_RETURN_CODE 0
 )
 
+pxr_register_test(testUsdGeomMetrics
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomMetrics"
+    EXPECTED_RETURN_CODE 0
+)
+
+
 pxr_register_test(testUsdGeomSubset
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSubset"

--- a/pxr/usd/usdPhysics/CMakeLists.txt
+++ b/pxr/usd/usdPhysics/CMakeLists.txt
@@ -87,3 +87,14 @@ pxr_library(usdPhysics
         examples/usdPhysicsSpheresWithMaterial.usda
 )
 
+pxr_test_scripts(
+    testenv/testUsdPhysicsMetrics.py
+)
+
+
+pxr_register_test(testUsdPhysicsMetrics
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPhysicsMetrics"
+    EXPECTED_RETURN_CODE 0
+)
+

--- a/pxr/usd/usdPhysics/module.cpp
+++ b/pxr/usd/usdPhysics/module.cpp
@@ -43,6 +43,8 @@ TF_WRAP_MODULE
 	TF_WRAP(UsdPhysicsMaterialAPI);
 	TF_WRAP(UsdPhysicsScene);	
 
+	TF_WRAP(Metrics);
+
 	// Mass
 	TF_WRAP(UsdPhysicsMassAPI);
 

--- a/pxr/usd/usdPhysics/plugInfo.json
+++ b/pxr/usd/usdPhysics/plugInfo.json
@@ -5,6 +5,16 @@
     "Plugins": [
         {
             "Info": {
+                "SdfMetadata": {
+                    "kilogramsPerUnit": {
+                        "appliesTo": [
+                            "layers"
+                        ],
+                        "default": 1.0,
+                        "displayGroup": "Stage",
+                        "type": "double"
+                    }
+                },
                 "Types": {
                     "UsdPhysicsArticulationRootAPI": {
                         "alias": {

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsMetrics.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsMetrics.py
@@ -1,0 +1,46 @@
+#!/pxrpythonsubst
+#
+# Copyright 2021 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+import sys, os, unittest
+from pxr import Tf, Usd, UsdPhysics
+
+class TestUsdPhysicsMetrics(unittest.TestCase):
+
+    def test_kilogramsPerUnit(self):
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        self.assertEqual(UsdPhysics.GetStageKilogramsPerUnit(stage),
+                         UsdPhysics.MassUnits.kilograms)
+        self.assertFalse(UsdPhysics.StageHasAuthoredKilogramsPerUnit(stage))
+
+        self.assertTrue(UsdPhysics.SetStageKilogramsPerUnit(stage,
+                        UsdPhysics.MassUnits.grams))
+        self.assertTrue(UsdPhysics.StageHasAuthoredKilogramsPerUnit(stage))
+        authored = UsdPhysics.GetStageKilogramsPerUnit(stage)
+        self.assertTrue(UsdPhysics.MassUnitsAre(authored, UsdPhysics.MassUnits.grams))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
[usdPhysics] Fix python bindings for metrics and kilogramsPerUnit metadata registration.

(Also register testUsdGeomMetrics with tests)
