### PR TITLE
Improve UsdImagingDelegate performance when editing many instances of the same prototype

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -566,7 +566,8 @@ private:
     // be refreshed.
     void _RefreshUsdObject(SdfPath const& usdPath, 
                            TfTokenVector const& changedPrimInfoFields,
-                           UsdImagingIndexProxy* proxy);
+                           UsdImagingIndexProxy* proxy,
+                           SdfPathSet &allTrackedVariabilityPaths); 
 
     // Heavy-weight invalidation of an entire prim subtree. All cached data is
     // reconstructed for all prims below \p rootPath.


### PR DESCRIPTION
Address a performance issue when applying a large number of edits to
instanceable references of the same prototype. The TrackVariability call
is O(n) on the number of instances, and it was being called for each
modified instance, resulting in O(n^2) cost to such an edit. This change
globally keeps track of all paths for which we call TrackVariability as
part of an update to avoid calling it more than once for any particular
primitive.

### Fixes Issue(s)
- #1607 

