### PR TITLE
Make mtlx functionality stack relocatable

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -21,9 +21,6 @@ set(optionalIncludeDirs "")
 set(optionalPublicClasses "")
 set(optionalPrivateClasses "")
 if (${PXR_ENABLE_MATERIALX_SUPPORT})
-    add_definitions(-DPXR_MATERIALX_STDLIB_DIR="${MATERIALX_STDLIB_DIR}")
-    add_definitions(-DPXR_MATERIALX_BASE_DIR="${MATERIALX_BASE_DIR}")
-
     list(APPEND optionalLibs ${MATERIALX_LIBRARIES} hdMtlx)
     list(APPEND optionalIncludeDirs ${MATERIALX_INCLUDE_DIRS})
     list(APPEND optionalPrivateClasses
@@ -44,6 +41,7 @@ pxr_library(hdSt
         glf
         hd
         hgiGL
+        usd
         sdr
         tf
         trace

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -25,6 +25,7 @@
 #include "pxr/imaging/hdSt/materialXShaderGen.h"
 #include "pxr/imaging/hdMtlx/hdMtlx.h"
 
+#include "pxr/usd/usd/utils.h"
 #include "pxr/usd/sdr/registry.h"
 #include "pxr/imaging/hio/glslfx.h"
 
@@ -458,9 +459,12 @@ HdSt_ApplyMaterialXFilter(
     if (mtlxSdrNode) {
 
         // Load Standard Libraries/setup SearchPaths (for mxDoc and mxShaderGen)
-        mx::FilePathVec libraryFolders;
+        std::string baseDir = UsdGetRootDir();
+        std::string stdlibDir = baseDir + "/libraries";
+        mx::FilePathVec libraryFolders = { "libraries" };
         mx::FileSearchPath searchPath;
-        searchPath.append(mx::FilePath(PXR_MATERIALX_STDLIB_DIR));
+        searchPath.append(mx::FilePath(baseDir));
+        searchPath.append(mx::FilePath(stdlibDir));
         mx::DocumentPtr stdLibraries = mx::createDocument();
         mx::loadLibraries(libraryFolders, searchPath, stdLibraries);
 

--- a/pxr/usd/plugin/usdMtlx/CMakeLists.txt
+++ b/pxr/usd/plugin/usdMtlx/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(PXR_PREFIX pxr/usd)
 set(PXR_PACKAGE usdMtlx)
 
-if (MATERIALX_STDLIB_DIR)
-    add_definitions(-DPXR_MATERIALX_STDLIB_DIR="${MATERIALX_STDLIB_DIR}")
-endif()
-
 pxr_plugin(usdMtlx
     LIBRARIES
         arch

--- a/pxr/usd/plugin/usdMtlx/utils.cpp
+++ b/pxr/usd/plugin/usdMtlx/utils.cpp
@@ -23,6 +23,7 @@
 //
 #include "pxr/pxr.h"
 #include "pxr/usd/plugin/usdMtlx/utils.h"
+#include "pxr/usd/usd/utils.h"
 #include "pxr/usd/ar/asset.h"
 #include "pxr/usd/ar/packageUtils.h"
 #include "pxr/usd/ar/resolver.h"
@@ -195,17 +196,27 @@ UsdMtlxMergeSearchPaths(const NdrStringVec& stronger,
     return result;
 }
 
+static NdrStringVec
+_GetEmbeddedMtlxStdlibPaths()
+{
+    NdrStringVec result;
+
+    std::string usdRootDir = UsdGetRootDir();
+    std::string stdlibDir = usdRootDir + "/libraries";
+    if (TfIsDir(stdlibDir)) {
+        result.push_back(stdlibDir);
+    }
+
+    return result;
+}
+
 const NdrStringVec&
 UsdMtlxStandardLibraryPaths()
 {
     static const auto materialxLibraryPaths =
         UsdMtlxMergeSearchPaths(
             UsdMtlxGetSearchPathsFromEnvVar("PXR_USDMTLX_STDLIB_SEARCH_PATHS"),
-            NdrStringVec{
-#ifdef PXR_MATERIALX_STDLIB_DIR
-                PXR_MATERIALX_STDLIB_DIR
-#endif
-            }
+            _GetEmbeddedMtlxStdlibPaths()
         );
     return materialxLibraryPaths;
 }

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -67,6 +67,7 @@ pxr_library(usd
         usdaFileFormat
         usdcFileFormat
         usdzFileFormat
+        utils
         variantSets
         zipFile
 

--- a/pxr/usd/usd/utils.cpp
+++ b/pxr/usd/usd/utils.cpp
@@ -1,0 +1,44 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usd/usd/utils.h"
+#include "pxr/base/tf/pathUtils.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/plug/plugin.h"
+#include "pxr/base/plug/thisPlugin.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+std::string
+UsdGetRootDir()
+{
+    if (PlugPluginPtr plugin = PLUG_THIS_PLUGIN) {
+        std::string usdLibPath = plugin->GetPath();
+        std::string usdLibDir = TfGetPathName(usdLibPath);
+        return TfNormPath(usdLibDir + "..");
+    }
+
+    return {};
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usd/utils.h
+++ b/pxr/usd/usd/utils.h
@@ -1,0 +1,38 @@
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_USD_UTILS_H
+#define PXR_USD_USD_UTILS_H
+
+#include "pxr/usd/usd/api.h"
+
+#include <string>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+USD_API
+std::string UsdGetRootDir();
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_USD_UTILS_H


### PR DESCRIPTION
### Description of Change(s)
Instead of using compile-time constant paths to MaterialX stdlib, evaluate those paths in runtime.

This allows us to move the USD installation directory without the need to set many different additional environment settings that are not that straightforward to use (see https://github.com/PixarAnimationStudios/USD/issues/1586)

This [commit](https://github.com/PixarAnimationStudios/USD/commit/225138be467814849882688e25adcc1f0074d1a6) allegedly fixes this issue. But it still uses compile-time constant...

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/1586

