### PR TITLE
'cameraFacing' and 'pixelScale' attributes for HdMesh and HdBasisCurves in hdStorm

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -40,6 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (bezier)                                    \
     (bSpline)                                   \
     (camera)                                    \
+    (cameraFacing)                              \
     (catmullRom)                                \
     (collection)                                \
     (computeShader)                             \

--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -84,6 +84,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (patchParam)                                \
     (periodic)                                  \
     (pinned)                                    \
+    (pixelScale)                                \
     (points)                                    \
     (pointsIndices)                             \
     (power)                                     \

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -179,6 +179,7 @@ pxr_library(hdSt
         shaders/ptexTexture.glslfx
         shaders/renderPass.glslfx
         shaders/renderPassShader.glslfx
+        shaders/secondaryGraphics.glslfx
         shaders/simpleLightingShader.glslfx
         shaders/terminals.glslfx
         shaders/visibility.glslfx

--- a/pxr/imaging/hdSt/basisCurvesShaderKey.cpp
+++ b/pxr/imaging/hdSt/basisCurvesShaderKey.cpp
@@ -106,8 +106,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((curvesFragmentWire,              "Curves.Fragment.Wire"))
     ((curvesFragmentPatch,             "Curves.Fragment.Patch"))
 
-    // instancing related mixins
+    // instancing and secondary graphics related mixins
     ((instancing,                      "Instancing.Transform"))
+    ((secondaryGraphics,               "SecondaryGraphics.Vertex.Transform"))
 
     // terminals
     ((commonFS,                        "Fragment.CommonTerminals"))
@@ -165,6 +166,7 @@ HdSt_BasisCurvesShaderKey::HdSt_BasisCurvesShaderKey(
 
     uint8_t vsIndex = 0;
     VS[vsIndex++]  = _tokens->instancing;
+    VS[vsIndex++]  = _tokens->secondaryGraphics;
     VS[vsIndex++]  = drawThick ? _tokens->curvesVertexPatch 
                        : _tokens->curvesVertexWire;
     VS[vsIndex++]  = oriented ? _tokens->curvesVertexNormalOriented 

--- a/pxr/imaging/hdSt/basisCurvesShaderKey.h
+++ b/pxr/imaging/hdSt/basisCurvesShaderKey.h
@@ -88,7 +88,7 @@ struct HdSt_BasisCurvesShaderKey : public HdSt_ShaderKey
 
     HdSt_GeometricShader::PrimitiveType primType;
     TfToken glslfx;
-    TfToken VS[7];
+    TfToken VS[8];
     TfToken TCS[4];
     TfToken TES[9];
     TfToken FS[8];

--- a/pxr/imaging/hdSt/meshShaderKey.cpp
+++ b/pxr/imaging/hdSt/meshShaderKey.cpp
@@ -114,8 +114,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((mainQuadGS,              "Mesh.Geometry.Quad"))
     ((mainFS,                  "Mesh.Fragment"))
 
-    // instancing related mixins
+    // instancing and secondary graphics related mixins
     ((instancing,              "Instancing.Transform"))
+    ((secondaryGraphics,       "SecondaryGraphics.Vertex.Transform"))
 
     // terminals
     ((customDisplacementGS,    "Geometry.CustomDisplacement"))
@@ -208,6 +209,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     // vertex shader
     uint8_t vsIndex = 0;
     VS[vsIndex++] = _tokens->instancing;
+    VS[vsIndex++] = _tokens->secondaryGraphics;
 
     VS[vsIndex++] = (normalsSource == NormalSourceSmooth) ?
         _tokens->normalsSmooth :

--- a/pxr/imaging/hdSt/meshShaderKey.h
+++ b/pxr/imaging/hdSt/meshShaderKey.h
@@ -107,7 +107,7 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
     TfToken const *GetFS()  const override { return FS; }
 
     TfToken glslfx;
-    TfToken VS[7];
+    TfToken VS[8];
     TfToken TCS[3];
     TfToken TES[4];
     TfToken GS[10];

--- a/pxr/imaging/hdSt/primUtils.cpp
+++ b/pxr/imaging/hdSt/primUtils.cpp
@@ -736,6 +736,16 @@ HdStPopulateConstantPrimvars(
                 camFacing);
             sources.push_back(camFacingSource);
         }
+
+        // add pixelScale primvar
+        const VtValue pixelScale = delegate->Get(id, HdTokens->pixelScale);
+        if (!pixelScale.IsEmpty())
+        {
+            HdBufferSourceSharedPtr pixelScaleSource = std::make_shared<HdVtBufferSource>(
+                HdTokens->pixelScale,
+                pixelScale);
+            sources.push_back(pixelScaleSource);
+        }
     }
 
     if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, id)) {
@@ -792,7 +802,8 @@ HdStPopulateConstantPrimvars(
             HdTokens->bboxLocalMin,
             HdTokens->bboxLocalMax,
             HdTokens->primID,
-            HdTokens->cameraFacing
+            HdTokens->cameraFacing,
+            HdTokens->pixelScale
         };
         removedSpecs = HdStGetRemovedPrimvarBufferSpecs(bar, constantPrimvars, 
             internallyGeneratedPrimvars, id);

--- a/pxr/imaging/hdSt/primUtils.cpp
+++ b/pxr/imaging/hdSt/primUtils.cpp
@@ -725,6 +725,19 @@ HdStPopulateConstantPrimvars(
         sources.push_back(source);
     }
 
+    if ((*dirtyBits) & HdChangeTracker::DirtyPrimvar)
+    {
+        // add cameraFacing primvar
+        const VtValue camFacing = delegate->Get(id, HdTokens->cameraFacing);
+        if (!camFacing.IsEmpty())
+        {
+            HdBufferSourceSharedPtr camFacingSource = std::make_shared<HdVtBufferSource>(
+                HdTokens->cameraFacing,
+                camFacing);
+            sources.push_back(camFacingSource);
+        }
+    }
+
     if (HdChangeTracker::IsAnyPrimvarDirty(*dirtyBits, id)) {
         sources.reserve(sources.size()+constantPrimvars.size());
         for (const HdPrimvarDescriptor& pv: constantPrimvars) {
@@ -778,7 +791,8 @@ HdStPopulateConstantPrimvars(
             HdTokens->isFlipped,
             HdTokens->bboxLocalMin,
             HdTokens->bboxLocalMax,
-            HdTokens->primID
+            HdTokens->primID,
+            HdTokens->cameraFacing
         };
         removedSpecs = HdStGetRemovedPrimvarBufferSpecs(bar, constantPrimvars, 
             internallyGeneratedPrimvars, id);

--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -31,6 +31,7 @@
 #import $TOOLS/hdSt/shaders/terminals.glslfx
 #import $TOOLS/hdSt/shaders/pointId.glslfx
 #import $TOOLS/hdSt/shaders/visibility.glslfx
+#import $TOOLS/hdSt/shaders/secondaryGraphics.glslfx
 
 // Known issues:
 // * The direction of the 'v' post tessellation is inconsistent between 
@@ -77,28 +78,14 @@ void main(void)
 #if defined(HD_HAS_pixelScale)
     if (HdGet_pixelScale())
     {
-        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
-
-        // projectionMatrix[0][0] equals to nearZ / right
-        // so that the final result equals to
-        // (eyeZ * right) / (nearZ * viewportWidth)
-        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
-
-        point.xyz *= pixelScale;
+        point.xyz *= pixelScaleValue(projectionMatrix, worldToViewMatrix, transform);
     }
 #endif
 
 #if defined(HD_HAS_cameraFacing)
     if (HdGet_cameraFacing())
     {
-        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
-        
-        // set rotation part to identity to turn the mesh towards the camera
-        objectToViewMatrix[0].xyz = vec3(1,0,0);
-        objectToViewMatrix[1].xyz = vec3(0,1,0);
-        objectToViewMatrix[2].xyz = vec3(0,0,1);
-
-        outData.Peye = vec4(objectToViewMatrix * point);
+        outData.Peye = vec4(cameraFacingMatrix(worldToViewMatrix, transform) * point);
         outData.Neye = vec3(0, 0, 1);
     }
     else
@@ -160,28 +147,14 @@ void main(void)
 #if defined(HD_HAS_pixelScale)
     if (HdGet_pixelScale())
     {
-        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
-
-        // projectionMatrix[0][0] equals to nearZ / right
-        // so that the final result equals to
-        // (eyeZ * right) / (nearZ * viewportWidth)
-        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
-
-        point.xyz *= pixelScale;
+        point.xyz *= pixelScaleValue(projectionMatrix, worldToViewMatrix, transform);
     }
 #endif
 
 #if defined(HD_HAS_cameraFacing)
     if (HdGet_cameraFacing())
     {
-        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
-        
-        // set rotation part to identity to turn the mesh towards the camera
-        objectToViewMatrix[0].xyz = vec3(1,0,0);
-        objectToViewMatrix[1].xyz = vec3(0,1,0);
-        objectToViewMatrix[2].xyz = vec3(0,0,1);
-
-        outData.Peye = vec4(objectToViewMatrix * point);
+        outData.Peye = vec4(cameraFacingMatrix(worldToViewMatrix, transform) * point);
     }
     else
 #endif

--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -71,10 +71,30 @@ void main(void)
     MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
     MAT4 transformInv = ApplyInstanceTransformInverse(HdGet_transformInverse());
 
-    outData.Peye = vec4(GetWorldToViewMatrix() * transform *
+    bool cameraFacing = false;
+#if defined(HD_HAS_cameraFacing)
+    cameraFacing = HdGet_cameraFacing();
+#endif
+
+    if (cameraFacing)
+    {
+        transform = GetWorldToViewMatrix() * transform;
+        
+        // set rotation part to identity to turn the mesh towards the camera
+        transform[0].xyz = vec3(1,0,0);
+        transform[1].xyz = vec3(0,1,0);
+        transform[2].xyz = vec3(0,0,1);
+
+        outData.Peye = vec4(transform * vec4(HdGet_points(), 1));
+        outData.Neye = vec3(0, 0, 1);
+    }
+    else
+    {
+        outData.Peye = vec4(GetWorldToViewMatrix() * transform *
                         vec4(HdGet_points(), 1));
-    outData.Neye = getNormal(transpose(transformInv *
+        outData.Neye = getNormal(transpose(transformInv *
                                   GetWorldToViewInverseMatrix()));
+    }
 
     ProcessPrimvars();
 
@@ -121,8 +141,27 @@ void main(void)
 {
     MAT4 transform  = ApplyInstanceTransform(HdGet_transform());
 
-    outData.Peye = vec4(GetWorldToViewMatrix() * transform *
+    bool cameraFacing = false;
+#if defined(HD_HAS_cameraFacing)
+    cameraFacing = HdGet_cameraFacing();
+#endif
+
+    if (cameraFacing)
+    {
+        transform = GetWorldToViewMatrix() * transform;
+        
+        // set rotation part to identity to turn the mesh towards the camera
+        transform[0].xyz = vec3(1,0,0);
+        transform[1].xyz = vec3(0,1,0);
+        transform[2].xyz = vec3(0,0,1);
+
+        outData.Peye = vec4(transform * vec4(HdGet_points(), 1));
+    }
+    else
+    {
+        outData.Peye = vec4(GetWorldToViewMatrix() * transform *
                         vec4(HdGet_points(), 1));
+    }
 
     ProcessPrimvars();
 
@@ -313,7 +352,7 @@ void determineLODSettings();
 void main(void)
 {
     if(gl_InvocationID == 0) {
-	     determineLODSettings();
+         determineLODSettings();
     }
 
     outData[gl_InvocationID].Peye = inData[gl_InvocationID].Peye;

--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -68,37 +68,50 @@ void ProcessPointId(int);
 
 void main(void)
 {
-    MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
-    MAT4 transformInv = ApplyInstanceTransformInverse(HdGet_transformInverse());
+    const MAT4 worldToViewMatrix = GetWorldToViewMatrix();
+    const MAT4 projectionMatrix = GetProjectionMatrix();
+    const MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
+    const MAT4 transformInv = ApplyInstanceTransformInverse(HdGet_transformInverse());
+    vec4 point = vec4(HdGet_points().xyz, 1);
 
-    bool cameraFacing = false;
-#if defined(HD_HAS_cameraFacing)
-    cameraFacing = HdGet_cameraFacing();
+#if defined(HD_HAS_pixelScale)
+    if (HdGet_pixelScale())
+    {
+        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
+
+        // projectionMatrix[0][0] equals to nearZ / right
+        // so that the final result equals to
+        // (eyeZ * right) / (nearZ * viewportWidth)
+        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
+
+        point.xyz *= pixelScale;
+    }
 #endif
 
-    if (cameraFacing)
+#if defined(HD_HAS_cameraFacing)
+    if (HdGet_cameraFacing())
     {
-        transform = GetWorldToViewMatrix() * transform;
+        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
         
         // set rotation part to identity to turn the mesh towards the camera
-        transform[0].xyz = vec3(1,0,0);
-        transform[1].xyz = vec3(0,1,0);
-        transform[2].xyz = vec3(0,0,1);
+        objectToViewMatrix[0].xyz = vec3(1,0,0);
+        objectToViewMatrix[1].xyz = vec3(0,1,0);
+        objectToViewMatrix[2].xyz = vec3(0,0,1);
 
-        outData.Peye = vec4(transform * vec4(HdGet_points(), 1));
+        outData.Peye = vec4(objectToViewMatrix * point);
         outData.Neye = vec3(0, 0, 1);
     }
     else
+#endif
     {
-        outData.Peye = vec4(GetWorldToViewMatrix() * transform *
-                        vec4(HdGet_points(), 1));
+        outData.Peye = vec4(worldToViewMatrix * transform * point);
         outData.Neye = getNormal(transpose(transformInv *
                                   GetWorldToViewInverseMatrix()));
     }
 
     ProcessPrimvars();
 
-    gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
+    gl_Position = vec4(projectionMatrix * outData.Peye);
     ApplyClipPlanes(outData.Peye);
 
     int pointId = GetPointId();
@@ -139,33 +152,46 @@ void ProcessPointId(int);
 
 void main(void)
 {
-    MAT4 transform  = ApplyInstanceTransform(HdGet_transform());
+    const MAT4 worldToViewMatrix = GetWorldToViewMatrix();
+    const MAT4 projectionMatrix = GetProjectionMatrix();
+    const MAT4 transform  = ApplyInstanceTransform(HdGet_transform());
+    vec4 point = vec4(HdGet_points().xyz, 1);
 
-    bool cameraFacing = false;
-#if defined(HD_HAS_cameraFacing)
-    cameraFacing = HdGet_cameraFacing();
+#if defined(HD_HAS_pixelScale)
+    if (HdGet_pixelScale())
+    {
+        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
+
+        // projectionMatrix[0][0] equals to nearZ / right
+        // so that the final result equals to
+        // (eyeZ * right) / (nearZ * viewportWidth)
+        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
+
+        point.xyz *= pixelScale;
+    }
 #endif
 
-    if (cameraFacing)
+#if defined(HD_HAS_cameraFacing)
+    if (HdGet_cameraFacing())
     {
-        transform = GetWorldToViewMatrix() * transform;
+        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
         
         // set rotation part to identity to turn the mesh towards the camera
-        transform[0].xyz = vec3(1,0,0);
-        transform[1].xyz = vec3(0,1,0);
-        transform[2].xyz = vec3(0,0,1);
+        objectToViewMatrix[0].xyz = vec3(1,0,0);
+        objectToViewMatrix[1].xyz = vec3(0,1,0);
+        objectToViewMatrix[2].xyz = vec3(0,0,1);
 
-        outData.Peye = vec4(transform * vec4(HdGet_points(), 1));
+        outData.Peye = vec4(objectToViewMatrix * point);
     }
     else
+#endif
     {
-        outData.Peye = vec4(GetWorldToViewMatrix() * transform *
-                        vec4(HdGet_points(), 1));
+        outData.Peye = vec4(worldToViewMatrix * transform * point);
     }
 
     ProcessPrimvars();
 
-    gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
+    gl_Position = vec4(projectionMatrix * outData.Peye);
     ApplyClipPlanes(outData.Peye);
 
     int pointId = GetPointId();

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -59,11 +59,31 @@ void main(void)
 {
     ProcessPrimvars();
 
-    MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
-    vec4 point        = vec4(HdGet_points().xyz, 1);
-    outData.Peye = vec4(GetWorldToViewMatrix() * transform * point);
+    MAT4 transform = ApplyInstanceTransform(HdGet_transform());
+    vec4 point     = vec4(HdGet_points().xyz, 1);
+    
+    bool cameraFacing = false;
+#if defined(HD_HAS_cameraFacing)
+    cameraFacing = HdGet_cameraFacing();
+#endif
 
-    outData.Neye = GetNormal(vec3(0), 0); // normalized
+    if (cameraFacing)
+    {
+        transform = GetWorldToViewMatrix() * transform;
+        
+        // set rotation part to identity to turn the mesh towards the camera
+        transform[0].xyz = vec3(1,0,0);
+        transform[1].xyz = vec3(0,1,0);
+        transform[2].xyz = vec3(0,0,1);
+
+        outData.Peye = vec4(transform * point);
+        outData.Neye = vec3(0, 0, 1);
+    }
+    else
+    {
+        outData.Peye = vec4(GetWorldToViewMatrix() * transform * point);
+        outData.Neye = GetNormal(vec3(0), 0); // normalized
+    }
 
     // Fill out redundantly, since at this point we don't know
     // the following stages include tessellation or geometry shader.

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -35,6 +35,7 @@
 #import $TOOLS/hdSt/shaders/edgeId.glslfx
 #import $TOOLS/hdSt/shaders/pointId.glslfx
 #import $TOOLS/hdSt/shaders/visibility.glslfx
+#import $TOOLS/hdSt/shaders/secondaryGraphics.glslfx
 
 --- --------------------------------------------------------------------------
 -- glsl Mesh.Vertex
@@ -67,28 +68,14 @@ void main(void)
 #if defined(HD_HAS_pixelScale)
     if (HdGet_pixelScale())
     {
-        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
-
-        // projectionMatrix[0][0] equals to nearZ / right
-        // so that the final result equals to
-        // (eyeZ * right) / (nearZ * viewportWidth)
-        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
-
-        point.xyz *= pixelScale;
+        point.xyz *= pixelScaleValue(projectionMatrix, worldToViewMatrix, transform);
     }
 #endif
 
 #if defined(HD_HAS_cameraFacing)
     if (HdGet_cameraFacing())
     {
-        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
-        
-        // set rotation part to identity to turn the mesh towards the camera
-        objectToViewMatrix[0].xyz = vec3(1,0,0);
-        objectToViewMatrix[1].xyz = vec3(0,1,0);
-        objectToViewMatrix[2].xyz = vec3(0,0,1);
-
-        outData.Peye = vec4(objectToViewMatrix * point);
+        outData.Peye = vec4(cameraFacingMatrix(worldToViewMatrix, transform) * point);
         outData.Neye = vec3(0, 0, 1);
     }
     else

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -59,29 +59,42 @@ void main(void)
 {
     ProcessPrimvars();
 
-    MAT4 transform = ApplyInstanceTransform(HdGet_transform());
-    vec4 point     = vec4(HdGet_points().xyz, 1);
+    const MAT4 worldToViewMatrix = GetWorldToViewMatrix();
+    const MAT4 projectionMatrix = GetProjectionMatrix();
+    const MAT4 transform = ApplyInstanceTransform(HdGet_transform());
+    vec4 point = vec4(HdGet_points().xyz, 1);
     
-    bool cameraFacing = false;
-#if defined(HD_HAS_cameraFacing)
-    cameraFacing = HdGet_cameraFacing();
+#if defined(HD_HAS_pixelScale)
+    if (HdGet_pixelScale())
+    {
+        vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
+
+        // projectionMatrix[0][0] equals to nearZ / right
+        // so that the final result equals to
+        // (eyeZ * right) / (nearZ * viewportWidth)
+        float pixelScale = abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
+
+        point.xyz *= pixelScale;
+    }
 #endif
 
-    if (cameraFacing)
+#if defined(HD_HAS_cameraFacing)
+    if (HdGet_cameraFacing())
     {
-        transform = GetWorldToViewMatrix() * transform;
+        MAT4 objectToViewMatrix = worldToViewMatrix * transform;
         
         // set rotation part to identity to turn the mesh towards the camera
-        transform[0].xyz = vec3(1,0,0);
-        transform[1].xyz = vec3(0,1,0);
-        transform[2].xyz = vec3(0,0,1);
+        objectToViewMatrix[0].xyz = vec3(1,0,0);
+        objectToViewMatrix[1].xyz = vec3(0,1,0);
+        objectToViewMatrix[2].xyz = vec3(0,0,1);
 
-        outData.Peye = vec4(transform * point);
+        outData.Peye = vec4(objectToViewMatrix * point);
         outData.Neye = vec3(0, 0, 1);
     }
     else
+#endif
     {
-        outData.Peye = vec4(GetWorldToViewMatrix() * transform * point);
+        outData.Peye = vec4(worldToViewMatrix * transform * point);
         outData.Neye = GetNormal(vec3(0), 0); // normalized
     }
 
@@ -96,7 +109,7 @@ void main(void)
     gl_PointSize = GetPointRasterSize(pointId);
     ProcessPointId(pointId);
 
-    gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
+    gl_Position = vec4(projectionMatrix * outData.Peye);
     ApplyClipPlanes(outData.Peye);
 }
 

--- a/pxr/imaging/hdSt/shaders/secondaryGraphics.glslfx
+++ b/pxr/imaging/hdSt/shaders/secondaryGraphics.glslfx
@@ -32,11 +32,21 @@
 
 float pixelScaleValue(MAT4 projectionMatrix, MAT4 worldToViewMatrix, MAT4 transform)
 {
-    vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
+    // if projectionMatrix specifies a perspective projection,
+    // eyeC is set to the model center in view space,
+    // otherwise it is set to vec4(1,1,1,1) 
+    vec4 eyeC = (projectionMatrix[3][3] == 0.f) ? 
+        vec4(worldToViewMatrix * transform * vec4(0,0,0,1)) :
+        vec4(1,1,1,1);
 
+    // if projectionMatrix specifies a perspective projection,
     // projectionMatrix[0][0] equals to nearZ / right
     // so that the final result equals to
-    // (eyeZ * right) / (nearZ * viewportWidth)
+    // (eyeZ * right) / (nearZ * viewportWidth).
+    // in case of orthogonal projection, 
+    // projectionMatrix[0][0] equals to 1 / right
+    // and the final result equals to
+    // right / viewportWidth
     return abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
 }
 
@@ -49,5 +59,5 @@ MAT4 cameraFacingMatrix(MAT4 worldToViewMatrix, MAT4 transform)
     objectToViewMatrix[1].xyz = vec3(0,1,0);
     objectToViewMatrix[2].xyz = vec3(0,0,1);
 
-	return objectToViewMatrix;
+    return objectToViewMatrix;
 }

--- a/pxr/imaging/hdSt/shaders/secondaryGraphics.glslfx
+++ b/pxr/imaging/hdSt/shaders/secondaryGraphics.glslfx
@@ -1,0 +1,53 @@
+-- glslfx version 0.1
+
+//
+// Copyright 2018 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+--- This is what an import might look like.
+--- #import $TOOLS/hdSt/shaders/secondaryGraphics.glslfx
+
+--- --------------------------------------------------------------------------
+-- glsl SecondaryGraphics.Vertex.Transform
+
+float pixelScaleValue(MAT4 projectionMatrix, MAT4 worldToViewMatrix, MAT4 transform)
+{
+    vec4 eyeC = vec4(worldToViewMatrix * transform * vec4(0,0,0,1));
+
+    // projectionMatrix[0][0] equals to nearZ / right
+    // so that the final result equals to
+    // (eyeZ * right) / (nearZ * viewportWidth)
+    return abs(eyeC.z / (projectionMatrix[0][0] * GetViewport().z));
+}
+
+MAT4 cameraFacingMatrix(MAT4 worldToViewMatrix, MAT4 transform)
+{
+    MAT4 objectToViewMatrix = worldToViewMatrix * transform;
+        
+    // set rotation part to identity to turn the geometry towards the camera
+    objectToViewMatrix[0].xyz = vec3(1,0,0);
+    objectToViewMatrix[1].xyz = vec3(0,1,0);
+    objectToViewMatrix[2].xyz = vec3(0,0,1);
+
+	return objectToViewMatrix;
+}


### PR DESCRIPTION
### Description of Change(s)

In order for Autodesk to use HdStorm as a viewport solution in its products, it has to support secondary graphics functionality.

This submission implements 'cameraFacing' and 'pixelScale' attributes for HdMesh and HdBasisCurves in hdStorm.

- A new attribute 'primvars:cameraFacing' was introduced in HdStorm that forces the rendered geometry to be always turned towards the camera.

Video: https://user-images.githubusercontent.com/71097162/133627981-f0cd9208-423a-4f74-bb2d-6c0ca9082b4a.mp4 

- A new attribute 'primvars:pixelScale' was introduced in HdStorm that forces the rendered geometry to have always the same size on the screen, which is independent on its position in 3d space.

Video: https://user-images.githubusercontent.com/71097162/133628187-6b1e40dc-57e3-4784-9da8-b869bbc657f3.mp4









