### PR TITLE
complianceChecker.py returns false error for not recognizing the UsdTransform2d node

### DIFF
--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -356,7 +356,7 @@ class ARKitShaderChecker(BaseRuleChecker):
 
         shaderId = shader.GetShaderId()
         if not shaderId or \
-           not (shaderId in ['UsdPreviewSurface', 'UsdUVTexture'] or
+           not (shaderId in ['UsdPreviewSurface', 'UsdUVTexture', 'UsdTransform2d'] or
                 shaderId.startswith('UsdPrimvarReader')) :
             self._AddFailedCheck("Shader <%s> has unsupported info:id '%s'." 
                     % (prim.GetPath(), shaderId))


### PR DESCRIPTION
### Description of Change(s)
I found a bug in the UsdUtils.ComplianceChecker code where it was throwing a false `ARKitShaderChecker` error due to not recognizing the `UsdTransform2d` prim.
### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1624

