### PR TITLE
Fix display of materials on instanceable prototype on point instancers.

### DIFF
--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -387,7 +387,10 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
                     populatePrim = _GetPrim(instancerChain.at(1));
                 }
 
-                SdfPath const& materialId = GetMaterialUsdPath(instanceProxyPrim);
+                SdfPath const& materialId =
+                    populatePrim.IsInstance()
+                        ? GetMaterialUsdPath(instanceProxyPrim)
+                        : GetMaterialUsdPath(populatePrim);
                 TfToken const& drawMode = GetModelDrawMode(instanceProxyPrim);
                 TfToken const& inheritablePurpose = 
                     GetInheritablePurpose(instanceProxyPrim);


### PR DESCRIPTION
### Description of Change(s)

The fix for #1449 looks like it broke material bindings in the case where
a point instancer prototype was marked as instanceable, but the material
was bound inside the prototype (on an instance proxy). The bound material
was being expressed with the instance proxy path instead of the prototype
path, which is how the material is actually identified in hydra. So now
the fix for #1449 is only applied to the instanceable prim, not the
contained instance proxy prims.

In my limited testing, this change seems to fix #1626 without breaking #1449.
But I don't understand this stuff deeply enough to really be sure this is right.

### Fixes Issue(s)
- #1626

