### PR TITLE
Adding support for MaterialX namespaces declared in stdlibs

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -52,7 +52,18 @@ _GetMxNodeType(mx::DocumentPtr const& mxDoc, TfToken const& hdNodeType)
                 hdNodeType.GetText());
         return TfToken();
     }
-    return TfToken(mxNodeDef->getNodeString());
+
+    std::string namespaceName = mxNodeDef->getNamespace();
+    if (!namespaceName.empty())
+    {
+        // in case the nodedef is in a namespace, 
+        // we need to add it to the node name 
+        return TfToken(namespaceName + ":" + mxNodeDef->getNodeString());
+    }
+    else
+    {
+        return TfToken(mxNodeDef->getNodeString());
+    }
 }
 
 // Determine if the given mxInputName is of type mx::Vector3 

--- a/pxr/usd/plugin/usdMtlx/overview.dox
+++ b/pxr/usd/plugin/usdMtlx/overview.dox
@@ -62,7 +62,6 @@ token substitutions to be primvar-based.
 
 \section usdMtlx_unsupported Unsupported MaterialX Features
 
-+ _materialx_ **namespace** attribute.  This attribute is ignored.
 + Geometry Name Expressions are not supported.  USD cannot yet represent path
 expressions. Paths that require glob-like pattern matching are discarded with a
 warning.

--- a/pxr/usd/plugin/usdMtlx/reader.cpp
+++ b/pxr/usd/plugin/usdMtlx/reader.cpp
@@ -224,8 +224,21 @@ static
 TfToken
 _MakeName(const std::string& mtlxName)
 {
-    // MaterialX names are valid USD names so we can use the name as is.
-    return TfToken(mtlxName);
+    // A MaterialX name may have a namespace name included,
+    // which then will be separated by a colon
+    auto colonPos = mtlxName.find(':');
+    if (colonPos != std::string::npos)
+    {
+        // Replace the colon with "__" to 
+        // make a valid USD name token
+        std::string modifiedName = mtlxName;
+        modifiedName.replace(colonPos, 1, "__");
+        return TfToken(modifiedName);
+    }
+    else
+    {
+        return TfToken(mtlxName);
+    }
 }
 
 // Convert a MaterialX name into a valid USD name token.

--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxParser.py
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxParser.py
@@ -36,13 +36,13 @@ class TestParser(unittest.TestCase):
         # Find our nodes.
         nodes = Sdr.Registry().GetShaderNodesByFamily('UsdMtlxTestNode')
         self.assertEqual(sorted([node.GetName() for node in nodes]), [
-            'nd_boolean',
-            'nd_customtype',
-            'nd_float',
-            'nd_integer',
-            'nd_string',
-            'nd_surface',
-            'nd_vector',
+            'UsdMtlxTestNamespace:nd_boolean',
+            'UsdMtlxTestNamespace:nd_customtype',
+            'UsdMtlxTestNamespace:nd_float',
+            'UsdMtlxTestNamespace:nd_integer',
+            'UsdMtlxTestNamespace:nd_string',
+            'UsdMtlxTestNamespace:nd_surface',
+            'UsdMtlxTestNamespace:nd_vector',
         ])
 
         # Verify common info.
@@ -64,8 +64,8 @@ class TestParser(unittest.TestCase):
                                  # array size is not represented in the Type
         }
         for node in nodes:
-            # Strip leading nd_ from name.
-            name = node.GetName()[3:]
+            # Strip leading UsdMtlxTestNamespace:nd_ from name.
+            name = node.GetName()[24:]
 
             # Get the input.
             prop = node.GetInput('in')

--- a/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxParser.testenv/test.mtlx
+++ b/pxr/usd/plugin/usdMtlx/testenv/testUsdMtlxParser.testenv/test.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.38" namespace="UsdMtlxTestNamespace">
   <nodedef name="nd_integer" node="UsdMtlxTestNode">
     <input name="in" type="integer" />
     <input name="note" type="string" value="" uniform="true" />

--- a/pxr/usd/plugin/usdMtlx/utils.cpp
+++ b/pxr/usd/plugin/usdMtlx/utils.cpp
@@ -392,10 +392,6 @@ UsdMtlxGetDocument(const std::string& resolvedUri)
         document = UsdMtlxReadDocument(resolvedUri);
     }
 
-    //mx::XmlWriteOptions wo;
-    //wo.writeXIncludeEnable = false;
-    //mx::writeToXmlFile(document, "d:\CopiedMtlx.mtlx", &wo);
-
     if (!m.IsClean()) {
         for (const auto& error : m) {
             TF_DEBUG(NDR_PARSING).Msg("%s\n", error.GetCommentary().c_str());


### PR DESCRIPTION
### Description of Change(s)

- Make sure MtlxPlugin properly merges all stdlib files into a single library by calling 'importLibarary', thus preserving namespaces among other attributes
- Make sure HdStorm properly reconstructs MaterialX namespace name when assembling MaterialX document from HdMaterialNetwork2

### Fixes Issue(s)

- Partially addresses https://github.com/PixarAnimationStudios/USD/issues/1614

