### PR TITLE
support for MaterialX-1.38.1

### DIFF
--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -135,8 +135,8 @@ HdSt_GenMaterialXShaderCode(
     mx::TypedElementPtr renderableElem = renderableElements.at(0);
     mx::NodePtr node = renderableElem->asA<mx::Node>();
     if (node && node->getType() == mx::MATERIAL_TYPE_STRING) {
-        std::unordered_set<mx::NodePtr> mxShaderNodes;
-        mxShaderNodes = mx::getShaderNodes(node, mx::SURFACE_SHADER_TYPE_STRING);
+        // Use auto so can compile against MaterialX 1.38.0 or 1.38.1
+        auto mxShaderNodes = mx::getShaderNodes(node, mx::SURFACE_SHADER_TYPE_STRING);
         if (!mxShaderNodes.empty()) {
             renderableElem = *mxShaderNodes.begin();
         }


### PR DESCRIPTION
### Description of Change(s)
Allows building against MaterialX-1.38.1 or 1.38.0

1.38.1 changes the return type of `getShaderNodes` from an `unordered_set` to a `vector`.

I use `auto` to handle this - I know `auto` isn't generally encouraged at Pixar, but since MaterialX apparently provides [no way to tell the version at compile time](https://github.com/materialx/MaterialX/issues/704), `#define` isn't an option (and I didn't want to use run-time branching, which would result in a lot of duplicated code!)

### Fixes Issue(s)
- Building against MaterialX-1.38.1

