### PR TITLE
fix for importing pxr.Tf on windows anaconda 3.8+ interpreters

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -603,10 +603,15 @@ platforms to avoid issues with Boost config files (introduced in Boost version
 to use Boost specified config files for their USD build, specify 
 -DBoost_NO_BOOST_CMAKE=OFF when running cmake.
 
-2. Windows and Python 3.8+
+2. Windows and Python 3.8+ (non-Anaconda)
 Python 3.8 and later on Windows will no longer search PATH for DLL dependencies.
 Instead, clients can call `os.add_dll_directory(p)` to set paths to search.
 By default on that platform USD will iterate over PATH and add all paths using
 `os.add_dll_directory()` when importing Python modules. Users may override
 this by setting the environment variable `PXR_USD_WINDOWS_DLL_PATH` to a PATH-like
 string. If this is set, USD will use these paths instead.
+
+Note that the above does not apply to Anaconda python 3.8+ interpreters, as they
+are modified to behave like pre-3.8 python interpreters, and so continue to use
+the PATH for DLL dependencies.  When running under Anaconda users should
+configure their system the same way they did for pre-python 3.8.

--- a/build_scripts/pypi/package_files/setup.py
+++ b/build_scripts/pypi/package_files/setup.py
@@ -74,8 +74,15 @@ import os, sys
 dllPath = os.path.split(os.path.realpath(__file__))[0]
 if sys.version_info >= (3, 8, 0):
     os.environ['PXR_USD_WINDOWS_DLL_PATH'] = dllPath
-else:
-    os.environ['PATH'] = dllPath + os.pathsep + os.environ['PATH']
+# Note that we ALWAYS modify the PATH, even for python-3.8+. This is because:
+#    - Anaconda python interpreters are modified to use the old, pre-3.8, PATH-
+#      based method of loading dlls
+#    - extra calls to os.add_dll_directory won't hurt these anaconda
+#      interpreters
+#    - similarly, adding the extra PATH entry shouldn't hurt standard python
+#      interpreters
+#    - there's no canonical/bulletproof way to check for an anaconda interpreter
+os.environ['PATH'] = dllPath + os.pathsep + os.environ['PATH']
 ''')
 
 # Get the readme text


### PR DESCRIPTION
cpython changed the way the dlls are loaded on windows for python-3.8+.  USD implemented a workaround for this change, installed into `pxr.__init__` (and `Tf.__init__`).  However, anaconda python interpreters were patched to behave more like pre-3.8:

   https://github.com/conda-forge/python-feedstock/blob/8195ba1178041b7461238e8c5680eee62f5ea9d0/recipe/patches/0020-Add-CondaEcosystemModifyDllSearchPath.patch#L37

Note: I'm not crazy about adding code that does a filesystem operation (`os.path.exists`) when the `pxr` module is imported.  However, it [seems to be the most robust way to check for conda](https://stackoverflow.com/a/47610844/920545).  The best alternative I could come up with was to search through the `CDLL.__init__` code object varnames:

```python
import ctypes
is_conda = 'LOAD_WITH_ALTERED_SEARCH_PATH' in ctypes.CDLL.__init__.__code__.co_varnames
```

...but for some reason that feels more fragile to me.  I can switch to use that approach if you'd prefer, though.

### Description of Change(s)

We now check for anaconda interpreters before using the 3.8+ only fix.

### Fixes Issue(s)
- #1602

