### PR TITLE
Enable selection highlighting for MaterialX shaders in HdStorm

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -420,6 +420,9 @@ HdStMaterialXShaderGen::_EmitMxSurfaceShader(
                 emitLine(finalOutputReturn + outputValue, mxStage);
             }
         }
+
+        // Emit color overrides (mainly for selection highlighting)
+        emitLine("mxOut = ApplyColorOverrides(mxOut)", mxStage);
     }
     emitLine("return mxOut", mxStage);
 


### PR DESCRIPTION
### Description of Change(s)

Emit shader code that enables selection highlightin during MaterialX shader generation.

### Fixes Issue(s)

- The submission fixes the bug in HdStorm where there was no selection highlighting for geomteric primitives with MaterialX materials applied.

