### PR TITLE
Ensure light collections are dirtied on creation

### DIFF
--- a/pxr/usdImaging/usdImaging/collectionCache.h
+++ b/pxr/usdImaging/usdImaging/collectionCache.h
@@ -68,7 +68,7 @@ public:
 
     /// Remove any cached entry for the given collection.
     /// Does nothing if no cache entry exists.
-    void RemoveCollection(UsdCollectionAPI const& collection);
+    void RemoveCollection(UsdStageWeakPtr const& stage, SdfPath const& path);
 
     /// Return the cached entry for the given collection.
     TfToken
@@ -78,6 +78,24 @@ public:
     // the given path.
     VtArray<TfToken>
     ComputeCollectionsContainingPath(SdfPath const& path) const;
+
+    /// Return the cached MembershipQuery for a given id
+    void
+    GetMembershipQuery(TfToken const& id, const Query** query) const;
+
+    /// Returns true if all paths should be considered dirty
+    /// This happens when a collection containing an exclusion is updated
+    bool
+    AreAllPathsDirty() const;
+
+    /// Returns a set of dirty paths
+    /// Should only be used if AreAllPathsDirty returned false
+    SdfPathSet const&
+    GetDirtyPaths() const;
+
+    /// Clears the internal dirty flags
+    void
+    ClearDirtyPaths();
 
 private:
     // The cache boils down to tracking the correspondence of
@@ -94,6 +112,12 @@ private:
     std::unordered_map<TfToken, Query, TfToken::HashFunctor> _queryForId;
     std::unordered_map<SdfPath, TfToken, SdfPath::Hash> _idForPath;
     std::unordered_map<Query, SdfPathSet, Query::Hash> _pathsForQuery;
+
+    void
+    _MarkCollectionContentDirty(UsdStageWeakPtr const& stage, UsdCollectionAPI::MembershipQuery const& query);
+
+    SdfPathSet _dirtyPaths;
+    bool _allPathsDirty = false;
 
     std::mutex _mutex;
 };

--- a/pxr/usdImaging/usdImaging/collectionCache.h
+++ b/pxr/usdImaging/usdImaging/collectionCache.h
@@ -86,11 +86,6 @@ public:
     void
     GetMembershipQuery(TfToken const& id, const Query** query) const;
 
-    /// Returns true if all paths should be considered dirty
-    /// This happens when a collection containing an exclusion is updated
-    bool
-    AreAllPathsDirty() const;
-
     /// Returns a set of dirty paths
     /// Should only be used if AreAllPathsDirty returned false
     SdfPathSet const&
@@ -120,7 +115,6 @@ private:
     _MarkCollectionContentDirty(UsdStageWeakPtr const& stage, UsdCollectionAPI::MembershipQuery const& query);
 
     SdfPathSet _dirtyPaths;
-    bool _allPathsDirty = false;
 
     std::mutex _mutex;
 };

--- a/pxr/usdImaging/usdImaging/collectionCache.h
+++ b/pxr/usdImaging/usdImaging/collectionCache.h
@@ -64,11 +64,14 @@ public:
     /// given collection, and establishes a cache entry.  If a
     /// prior entry existed for the collection at this path,
     /// it is removed first.
-    TfToken UpdateCollection(UsdCollectionAPI const& collection);
-
-    /// Remove any cached entry for the given collection.
-    /// Does nothing if no cache entry exists.
-    void RemoveCollection(UsdStageWeakPtr const& stage, SdfPath const& path);
+    /// Returns true for newly created collection or
+    /// if the hash of the collection is different from the previous collection
+    bool
+    UpdateCollection(UsdCollectionAPI const& collection);
+ 
+    /// Returns the hash of the removed collection, or 0 if no collection existed
+    size_t
+    RemoveCollection(UsdStageWeakPtr const& stage, SdfPath const& path);
 
     /// Return the cached entry for the given collection.
     TfToken

--- a/pxr/usdImaging/usdImaging/cylinderLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/cylinderLightAdapter.cpp
@@ -56,6 +56,7 @@ UsdImagingCylinderLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->cylinderLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -64,6 +65,7 @@ void
 UsdImagingCylinderLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->cylinderLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -1082,6 +1082,39 @@ UsdImagingDelegate::ApplyPendingUpdates()
     indexProxy._UniqueifyPathsToRepopulate();
     _Populate(&indexProxy);
     _ExecuteWorkForVariabilityUpdate(&worker);
+
+    // Mark all dirty collection prims
+    if (_collectionCache.AreAllPathsDirty())
+    {
+        TRACE_SCOPE("Mark all dirty collection members");
+        TF_FOR_ALL(it, _hdPrimInfoMap) {
+            UsdImagingPrimAdapterSharedPtr& adapter = it->second.adapter;
+            TF_DEBUG(USDIMAGING_CHANGES).Msg("[Update]: invalidate collection member prim (all paths dirty) %s\n", it->first.GetText());
+            adapter->MarkDirty(it->second.usdPrim, it->first,
+                HdChangeTracker::DirtyCategories, &indexProxy);
+        }
+        _collectionCache.ClearDirtyPaths();
+    }
+    else
+    {
+        const SdfPathSet& pathsDirtiedByCollections = _collectionCache.GetDirtyPaths();
+        if(!pathsDirtiedByCollections.empty())
+        {
+            TRACE_SCOPE("Mark dirty collection members");
+            for(const SdfPath& dirtyPath : pathsDirtiedByCollections)
+            {
+                TF_DEBUG(USDIMAGING_CHANGES).Msg("[Update]: invalidate collection member prim %s\n", dirtyPath.GetText());
+                _HdPrimInfo* primInfo = _GetHdPrimInfo(dirtyPath);
+                if (primInfo && primInfo->usdPrim.IsValid() &&
+                    TF_VERIFY(primInfo->adapter, "%s", dirtyPath.GetText())) {
+                    UsdImagingPrimAdapterSharedPtr& adapter = primInfo->adapter;
+                    adapter->MarkDirty(primInfo->usdPrim, dirtyPath,
+                        HdChangeTracker::DirtyCategories, &indexProxy);
+                }
+            }
+            _collectionCache.ClearDirtyPaths();
+        }
+    }
 }
 
 void 
@@ -1348,35 +1381,10 @@ UsdImagingDelegate::_ResyncUsdPrim(SdfPath const& usdPath,
     // Otherwise, this is a totally new branch of the scene, so populate
     // from the resync target path. Note: we need to verify that usdPath exists,
     // since we can get resync notices for prims that were deleted.
-    UsdPrim usdPrim = _stage->GetPrimAtPath(usdPath);
-    if (usdPrim) {
+    if (_stage->GetPrimAtPath(usdPath)) {
         TF_DEBUG(USDIMAGING_CHANGES).Msg("  - affected new prim: <%s>\n",
             usdPath.GetText());
         proxy->Repopulate(usdPath);
-
-        if (usdPrim.HasAPI<UsdLuxLightAPI>()) {
-            // If a new light was added, ensure collections are dirtied
-            TRACE_SCOPE("Resync light/shadow link targets");
-            auto _MarkLinkPathsDirty = [&](const SdfPathSet& linkedPaths) {
-                for (SdfPath affectedCachePath : linkedPaths) {
-                    TF_DEBUG(USDIMAGING_CHANGES).Msg("[Refresh Object]: "
-                        "Light <%s> modified; invalidate linked prim %s\n", 
-                        usdPath.GetText(), affectedCachePath.GetText());
-                    _HdPrimInfo* primInfo = _GetHdPrimInfo(affectedCachePath);
-                    if (primInfo && primInfo->usdPrim.IsValid() &&
-                        TF_VERIFY(primInfo->adapter, "%s", affectedCachePath.GetText())) {
-                        UsdImagingPrimAdapterSharedPtr& adapter = primInfo->adapter;
-                        adapter->MarkDirty(primInfo->usdPrim, affectedCachePath,
-                            HdChangeTracker::DirtyCategories, proxy);
-                    }
-                }
-            };
-            UsdLuxLightAPI light(usdPrim);
-            UsdCollectionAPI lightLink{ light.GetLightLinkCollectionAPI() };
-            _MarkLinkPathsDirty(lightLink.ComputeIncludedPaths(lightLink.ComputeMembershipQuery(), _stage));
-            UsdCollectionAPI shadowLink{ light.GetShadowLinkCollectionAPI() };
-            _MarkLinkPathsDirty(shadowLink.ComputeIncludedPaths(shadowLink.ComputeMembershipQuery(), _stage));
-        }
     } else {
         TF_DEBUG(USDIMAGING_CHANGES).Msg("  - affected deleted prim: <%s>\n",
             usdPath.GetText());

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -1087,11 +1087,10 @@ UsdImagingDelegate::ApplyPendingUpdates()
     if (_collectionCache.AreAllPathsDirty())
     {
         TRACE_SCOPE("Mark all dirty collection members");
-        TF_FOR_ALL(it, _hdPrimInfoMap) {
-            UsdImagingPrimAdapterSharedPtr& adapter = it->second.adapter;
-            TF_DEBUG(USDIMAGING_CHANGES).Msg("[Update]: invalidate collection member prim (all paths dirty) %s\n", it->first.GetText());
-            adapter->MarkDirty(it->second.usdPrim, it->first,
-                HdChangeTracker::DirtyCategories, &indexProxy);
+        for(auto& it : _hdPrimInfoMap) {
+            UsdImagingPrimAdapterSharedPtr& adapter = it.second.adapter;
+            TF_DEBUG(USDIMAGING_CHANGES).Msg("[Update]: invalidate collection member prim (all paths dirty) %s\n", it.first.GetText());
+            adapter->MarkCollectionsDirty(it.second.usdPrim, it.first, &indexProxy);
         }
         _collectionCache.ClearDirtyPaths();
     }
@@ -1108,8 +1107,7 @@ UsdImagingDelegate::ApplyPendingUpdates()
                 if (primInfo && primInfo->usdPrim.IsValid() &&
                     TF_VERIFY(primInfo->adapter, "%s", dirtyPath.GetText())) {
                     UsdImagingPrimAdapterSharedPtr& adapter = primInfo->adapter;
-                    adapter->MarkDirty(primInfo->usdPrim, dirtyPath,
-                        HdChangeTracker::DirtyCategories, &indexProxy);
+                    adapter->MarkCollectionsDirty(primInfo->usdPrim, dirtyPath, &indexProxy);
                 }
             }
             _collectionCache.ClearDirtyPaths();

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -520,6 +520,12 @@ public:
     USDIMAGING_API
     bool IsInInvisedPaths(const SdfPath &usdPath) const;
 
+    USDIMAGING_API
+    UsdStageRefPtr GetStage() const
+    {
+        return _stage;
+    }
+
 private:
     // Internal Get and SamplePrimvar
     VtValue _Get(SdfPath const& id, TfToken const& key, VtIntArray *outIndices);

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -520,12 +520,6 @@ public:
     USDIMAGING_API
     bool IsInInvisedPaths(const SdfPath &usdPath) const;
 
-    USDIMAGING_API
-    UsdStageRefPtr GetStage() const
-    {
-        return _stage;
-    }
-
 private:
     // Internal Get and SamplePrimvar
     VtValue _Get(SdfPath const& id, TfToken const& key, VtIntArray *outIndices);

--- a/pxr/usdImaging/usdImaging/diskLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/diskLightAdapter.cpp
@@ -56,6 +56,7 @@ UsdImagingDiskLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->diskLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -64,7 +65,7 @@ void
 UsdImagingDiskLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
-    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->diskLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/diskLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/diskLightAdapter.cpp
@@ -64,6 +64,7 @@ void
 UsdImagingDiskLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
     index->RemoveSprim(HdPrimTypeTokens->diskLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/distantLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/distantLightAdapter.cpp
@@ -64,6 +64,7 @@ void
 UsdImagingDistantLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
     index->RemoveSprim(HdPrimTypeTokens->distantLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/distantLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/distantLightAdapter.cpp
@@ -56,6 +56,7 @@ UsdImagingDistantLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->distantLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -64,7 +65,7 @@ void
 UsdImagingDistantLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
-    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->distantLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/domeLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/domeLightAdapter.cpp
@@ -64,6 +64,7 @@ void
 UsdImagingDomeLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
     index->RemoveSprim(HdPrimTypeTokens->domeLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/domeLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/domeLightAdapter.cpp
@@ -56,6 +56,7 @@ UsdImagingDomeLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->domeLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -64,7 +65,7 @@ void
 UsdImagingDomeLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
-    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->domeLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/gprimAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.cpp
@@ -586,6 +586,14 @@ UsdImagingGprimAdapter::MarkMaterialDirty(UsdPrim const& prim,
     index->MarkRprimDirty(cachePath, HdChangeTracker::DirtyMaterialId);
 }
 
+void
+UsdImagingGprimAdapter::MarkCollectionsDirty(UsdPrim const& prim,
+                                             SdfPath const& cachePath,
+                                             UsdImagingIndexProxy* index)
+{
+    index->MarkRprimDirty(cachePath, HdChangeTracker::DirtyCategories);
+}
+
 /*virtual*/
 VtValue
 UsdImagingGprimAdapter::GetPoints(UsdPrim const& prim,

--- a/pxr/usdImaging/usdImaging/gprimAdapter.h
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.h
@@ -128,6 +128,11 @@ public:
                                    SdfPath const& cachePath,
                                    UsdImagingIndexProxy* index) override;
 
+    USDIMAGING_API
+    virtual void MarkCollectionsDirty(UsdPrim const& prim,
+                                      SdfPath const& cachePath,
+                                      UsdImagingIndexProxy* index) override;
+
     // ---------------------------------------------------------------------- //
     /// \name Utility methods
     // ---------------------------------------------------------------------- //

--- a/pxr/usdImaging/usdImaging/lightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightAdapter.cpp
@@ -82,40 +82,19 @@ UsdImagingLightAdapter::_RemovePrim(SdfPath const& cachePath,
     index->RemoveSprim(HdPrimTypeTokens->light, cachePath);
     UsdImaging_CollectionCache &collectionCache = _GetCollectionCache();
     SdfPath lightLinkPath = cachePath.AppendProperty(UsdImagingTokens->collectionLightLink);
-    collectionCache.RemoveCollection(GetDelegate()->GetStage(), lightLinkPath);
+    collectionCache.RemoveCollection(_GetStage(), lightLinkPath);
     SdfPath shadowLinkPath = cachePath.AppendProperty(UsdImagingTokens->collectionShadowLink);
-    collectionCache.RemoveCollection(GetDelegate()->GetStage(), shadowLinkPath);
+    collectionCache.RemoveCollection(_GetStage(), shadowLinkPath);
 }
 
 bool
 UsdImagingLightAdapter::_UpdateCollectionsChanged(UsdPrim const& prim, SdfPath const& cachePath) const
 {
     UsdImaging_CollectionCache &collectionCache = _GetCollectionCache();
-    auto getCollectionHash = [&collectionCache] (const UsdCollectionAPI& api) -> size_t {
-        const TfToken id = collectionCache.UpdateCollection(api);
-        const UsdImaging_CollectionCache::Query* query = nullptr;
-        collectionCache.GetMembershipQuery(id, &query);
-        return query != nullptr ? query->GetHash() : 0;
-    };
     UsdLuxLight light(prim);
-    const size_t newLightCollectionHash = getCollectionHash(light.GetLightLinkCollectionAPI());
-    const size_t newShadowCollectionHash = getCollectionHash(light.GetShadowLinkCollectionAPI());
-    auto hashesIt = _collectionHashes.find(cachePath);
-    if(hashesIt == _collectionHashes.end()){
-        hashesIt = _collectionHashes.insert({cachePath, {0, 0}}).first;
-    }
-    HashPair& hashes = hashesIt->second;
-    if (newLightCollectionHash != hashes.lightCollectionHash || newShadowCollectionHash != hashes.shadowCollectionHash)
-    {
-        
-        hashes.lightCollectionHash = newLightCollectionHash;
-        hashes.shadowCollectionHash = newShadowCollectionHash;
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    bool lightColChanged = collectionCache.UpdateCollection(light.GetLightLinkCollectionAPI());
+    bool shadowColChanged = collectionCache.UpdateCollection(light.GetShadowLinkCollectionAPI());
+    return lightColChanged || shadowColChanged;
 }
 
 void 
@@ -161,18 +140,6 @@ UsdImagingLightAdapter::TrackVariability(UsdPrim const& prim,
 
     UsdImagingPrimvarDescCache* primvarDescCache = _GetPrimvarDescCache();
 
-    UsdLuxLightAPI light(prim);
-    if (TF_VERIFY(light)) {
-        if (_UpdateCollectionsChanged(prim, cachePath))
-        {
-            *timeVaryingBits |= HdLight::DirtyBits::DirtyCollection;
-        }
-        else
-        {
-            *timeVaryingBits &= ~HdLight::DirtyBits::DirtyCollection;
-        }
-    }
-
     // XXX Cache primvars for lights.
     {
         // Establish a primvar desc cache entry.
@@ -217,7 +184,11 @@ UsdImagingLightAdapter::ProcessPropertyChange(UsdPrim const& prim,
         return HdLight::DirtyBits::DirtyTransform;
     }
 
-    _UpdateCollectionsChanged(prim, cachePath);
+    if (TfStringStartsWith(propertyName.GetString(), UsdImagingTokens->collectionShadowLink.GetString()) || 
+        TfStringStartsWith(propertyName.GetString(), UsdImagingTokens->collectionLightLink.GetString()))
+    {
+        _UpdateCollectionsChanged(prim, cachePath);
+    }
 
     // "DirtyParam" is the catch-all bit for light params.
     return HdLight::DirtyBits::DirtyParams;

--- a/pxr/usdImaging/usdImaging/lightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightAdapter.cpp
@@ -77,6 +77,14 @@ UsdImagingLightAdapter::Populate(UsdPrim const& prim,
 }
 
 void
+UsdImagingLightAdapter::_RemovePrim(SdfPath const& cachePath,
+                                         UsdImagingIndexProxy* index)
+{
+    _UnregisterLightCollections(cachePath);
+    index->RemoveSprim(HdPrimTypeTokens->domeLight, cachePath);
+}
+
+void
 UsdImagingLightAdapter::MarkCollectionsDirty(UsdPrim const& prim,
                                              SdfPath const& cachePath,
                                              UsdImagingIndexProxy* index)

--- a/pxr/usdImaging/usdImaging/lightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightAdapter.cpp
@@ -107,16 +107,6 @@ UsdImagingLightAdapter::_RegisterLightCollections(UsdPrim const& prim) {
     _UpdateCollectionsChanged(prim);
 }
 
-bool
-UsdImagingLightAdapter::_UpdateCollectionsChanged(UsdPrim const& prim) const {
-{
-    UsdImaging_CollectionCache &collectionCache = _GetCollectionCache();
-    UsdLuxLightAPI light(prim);
-    bool lightColChanged = collectionCache.UpdateCollection(light.GetLightLinkCollectionAPI());
-    bool shadowColChanged = collectionCache.UpdateCollection(light.GetShadowLinkCollectionAPI());
-    return lightColChanged || shadowColChanged;
-}
-
 void 
 UsdImagingLightAdapter::TrackVariability(UsdPrim const& prim,
                                         SdfPath const& cachePath,

--- a/pxr/usdImaging/usdImaging/lightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightAdapter.cpp
@@ -87,7 +87,7 @@ UsdImagingLightAdapter::MarkCollectionsDirty(UsdPrim const& prim,
 bool
 UsdImagingLightAdapter::_UpdateCollectionsChanged(UsdPrim const& prim) const {
     UsdImaging_CollectionCache &collectionCache = _GetCollectionCache();
-    UsdLuxLight light(prim);
+    UsdLuxLightAPI light(prim);
     bool lightColChanged = collectionCache.UpdateCollection(light.GetLightLinkCollectionAPI());
     bool shadowColChanged = collectionCache.UpdateCollection(light.GetShadowLinkCollectionAPI());
     return lightColChanged || shadowColChanged;
@@ -111,7 +111,7 @@ bool
 UsdImagingLightAdapter::_UpdateCollectionsChanged(UsdPrim const& prim) const {
 {
     UsdImaging_CollectionCache &collectionCache = _GetCollectionCache();
-    UsdLuxLight light(prim);
+    UsdLuxLightAPI light(prim);
     bool lightColChanged = collectionCache.UpdateCollection(light.GetLightLinkCollectionAPI());
     bool shadowColChanged = collectionCache.UpdateCollection(light.GetShadowLinkCollectionAPI());
     return lightColChanged || shadowColChanged;

--- a/pxr/usdImaging/usdImaging/lightAdapter.h
+++ b/pxr/usdImaging/usdImaging/lightAdapter.h
@@ -128,6 +128,18 @@ protected:
     void _RemovePrim(SdfPath const& cachePath,
                      UsdImagingIndexProxy* index) override;
 
+private:
+    /// Updates the collection cache content
+    /// Checks for collection hash change and returns true if they are different
+    bool _UpdateCollectionsChanged(UsdPrim const& prim, SdfPath const& cachePath) const;
+
+    // Cache to detect collection changes
+    struct HashPair{
+        size_t lightCollectionHash = 0;
+        size_t shadowCollectionHash = 0;
+    };
+    mutable std::unordered_map<SdfPath, HashPair, SdfPath::Hash> _collectionHashes;
+
 };
 
 

--- a/pxr/usdImaging/usdImaging/lightAdapter.h
+++ b/pxr/usdImaging/usdImaging/lightAdapter.h
@@ -115,6 +115,11 @@ public:
                               SdfPath const& cachePath,
                               UsdImagingIndexProxy* index) override;
 
+    USDIMAGING_API
+    virtual void MarkCollectionsDirty(UsdPrim const& prim,
+                                      SdfPath const& cachePath,
+                                      UsdImagingIndexProxy* index) override;
+
     // ---------------------------------------------------------------------- //
     /// \name Utilities 
     // ---------------------------------------------------------------------- //
@@ -128,17 +133,17 @@ protected:
     void _RemovePrim(SdfPath const& cachePath,
                      UsdImagingIndexProxy* index) override;
 
+    // To be called from the Light Populate method
+    void _UnregisterLightCollections(SdfPath const& cachePath);
+
+    // To be called from the Light _RemovePrim method
+    void _RegisterLightCollections(UsdPrim const& prim);
+
 private:
     /// Updates the collection cache content
     /// Checks for collection hash change and returns true if they are different
-    bool _UpdateCollectionsChanged(UsdPrim const& prim, SdfPath const& cachePath) const;
+    bool _UpdateCollectionsChanged(UsdPrim const& prim) const;
 
-    // Cache to detect collection changes
-    struct HashPair{
-        size_t lightCollectionHash = 0;
-        size_t shadowCollectionHash = 0;
-    };
-    mutable std::unordered_map<SdfPath, HashPair, SdfPath::Hash> _collectionHashes;
 
 };
 

--- a/pxr/usdImaging/usdImaging/pluginLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pluginLightAdapter.cpp
@@ -65,6 +65,7 @@ void
 UsdImagingPluginLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->pluginLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -249,6 +249,14 @@ UsdImagingPrimAdapter::MarkReprDirty(UsdPrim const& prim,
 
 /*virtual*/
 void
+UsdImagingPrimAdapter::MarkCollectionsDirty(UsdPrim const& prim,
+                                            SdfPath const& cachePath,
+                                            UsdImagingIndexProxy* index)
+{
+}
+
+/*virtual*/
+void
 UsdImagingPrimAdapter::MarkCullStyleDirty(UsdPrim const& prim,
                                           SdfPath const& cachePath,
                                           UsdImagingIndexProxy* index)
@@ -1020,6 +1028,12 @@ UsdImaging_CollectionCache&
 UsdImagingPrimAdapter::_GetCollectionCache() const
 {
     return _delegate->_collectionCache;
+}
+
+UsdStageRefPtr
+UsdImagingPrimAdapter::_GetStage() const
+{
+    return _delegate->_stage;
 }
 
 UsdImaging_CoordSysBindingStrategy::value_type

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -271,6 +271,11 @@ public:
                                        SdfPath const& cachePath,
                                        UsdImagingIndexProxy* index);
 
+    USDIMAGING_API
+    virtual void MarkCollectionsDirty(UsdPrim const& prim,
+                                      SdfPath const& cachePath,
+                                      UsdImagingIndexProxy* index);
+
     // ---------------------------------------------------------------------- //
     /// \name Computations 
     // ---------------------------------------------------------------------- //
@@ -805,6 +810,9 @@ protected:
 
     USDIMAGING_API
     UsdImaging_CollectionCache& _GetCollectionCache() const;
+
+    USDIMAGING_API
+    UsdStageRefPtr _GetStage() const;
 
     USDIMAGING_API
     UsdImaging_CoordSysBindingStrategy::value_type

--- a/pxr/usdImaging/usdImaging/rectLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/rectLightAdapter.cpp
@@ -65,6 +65,7 @@ void
 UsdImagingRectLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
     index->RemoveSprim(HdPrimTypeTokens->rectLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/rectLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/rectLightAdapter.cpp
@@ -57,6 +57,7 @@ UsdImagingRectLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->rectLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -65,7 +66,7 @@ void
 UsdImagingRectLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
-    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->rectLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/sphereLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/sphereLightAdapter.cpp
@@ -65,6 +65,7 @@ void
 UsdImagingSphereLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
+    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
     index->RemoveSprim(HdPrimTypeTokens->sphereLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/sphereLightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/sphereLightAdapter.cpp
@@ -57,6 +57,7 @@ UsdImagingSphereLightAdapter::Populate(UsdPrim const& prim,
 {
     index->InsertSprim(HdPrimTypeTokens->sphereLight, prim.GetPath(), prim);
     HD_PERF_COUNTER_INCR(UsdImagingTokens->usdPopulatedPrimCount);
+    _RegisterLightCollections(prim);
 
     return prim.GetPath();
 }
@@ -65,7 +66,7 @@ void
 UsdImagingSphereLightAdapter::_RemovePrim(SdfPath const& cachePath,
                                          UsdImagingIndexProxy* index)
 {
-    UsdImagingLightAdapter::_RemovePrim(cachePath, index);
+    _UnregisterLightCollections(cachePath);
     index->RemoveSprim(HdPrimTypeTokens->sphereLight, cachePath);
 }
 

--- a/pxr/usdImaging/usdImaging/tokens.h
+++ b/pxr/usdImaging/usdImaging/tokens.h
@@ -32,6 +32,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 #define USDIMAGING_TOKENS   \
+    ((collectionLightLink, "collection:lightLink")) \
+    ((collectionShadowLink, "collection:shadowLink")) \
     ((infoSource, "info:source")) \
     (faceIndexPrimvar)      \
     (faceOffsetPrimvar)     \


### PR DESCRIPTION
### Description of Change(s)

We found that when undoing the deletion of a light with an active collection, the re-creation of that light was not dirtying the content of the collection.

It is unfortunately quite tricky to provide a test for this use case, but we have one internally in Omniverse...
Our test goes like this:
* create 2 cubes
* create a light
* set the light's lightLink collection to refer to cube2
* check in viewport with a light-collection-enabled renderer that things are OK
* delete the light
* undo that deletion
* check in viewport with a light-collection-enabled renderer that things are OK again (it wasn't without this fix)
