### PR TITLE
[HdMtlx] Fix duplicate name error when processing HdNetwork from Houdini

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -277,7 +277,7 @@ _GatherUpstreamNodes(
 
     // Initilize the mxNodeGraph if needed
     if (!(*mxNodeGraph)) {
-        const std::string & nodeGraphName  = hdNodePath.GetParentPath().GetName();
+        std::string nodeGraphName = hdNodePath.GetParentPath().GetName() + "_Graph";
         *mxNodeGraph = mxDoc->addNodeGraph(nodeGraphName);
     }
     


### PR DESCRIPTION
### Description of Change(s)
Resolve duplicate names by appending a suffix to nodegraph that encapsulates HdNetwork nodes.
The reason why there are duplicates is that [this name](https://github.com/PixarAnimationStudios/USD/blob/release/pxr/imaging/hdMtlx/hdMtlx.cpp#L280) and [this one](https://github.com/PixarAnimationStudios/USD/blob/release/pxr/imaging/hdMtlx/hdMtlx.cpp#L335) are the same. It leads to attempting to create nodegraph with the same name as the already created material node.

### Fixes Issue(s)
#1658

