### PR TITLE
[usdGeom] avoid crash from UsdGeomCamera::SetFromCamera

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -187,6 +187,11 @@ pxr_install_test_dir(
 )
 
 pxr_install_test_dir(
+    SRC testenv/testUsdGeomCamera
+    DEST testUsdGeomCamera
+)
+
+pxr_install_test_dir(
     SRC testenv/testUsdGeomConsts
     DEST testUsdGeomConsts
 )

--- a/pxr/usd/usdGeom/camera.cpp
+++ b/pxr/usd/usdGeom/camera.cpp
@@ -552,7 +552,15 @@ UsdGeomCamera::SetFromCamera(const GfCamera &camera, const UsdTimeCode &time)
 
     const GfMatrix4d camMatrix = camera.GetTransform() * parentToWorldInverse;
 
-    MakeMatrixXform().Set(camMatrix, time);
+    UsdGeomXformOp xformOp = MakeMatrixXform();
+    if (!xformOp) {
+        // The returned xformOp may be invalid if there are xform op
+        // opinions in the composed layer stack stronger than that of
+        // the current edit target.
+        return;
+    }
+    xformOp.Set(camMatrix, time);
+
     GetProjectionAttr().Set(_ProjectionToToken(camera.GetProjection()), time);
     GetHorizontalApertureAttr().Set(camera.GetHorizontalAperture(), time);
     GetVerticalApertureAttr().Set(camera.GetVerticalAperture(), time);

--- a/pxr/usd/usdGeom/camera.h
+++ b/pxr/usd/usdGeom/camera.h
@@ -552,6 +552,24 @@ public:
     GfCamera GetCamera(const UsdTimeCode &time) const;
 
     /// Write attribute values from \p camera for \p time.
+    /// These attributes will be updated:
+    ///  - projection
+    ///  - horizontalAperture
+    ///  - horizontalApertureOffset
+    ///  - verticalAperture
+    ///  - verticalApertureOffset
+    ///  - focalLength
+    ///  - clippingRange
+    ///  - clippingPlanes
+    ///  - fStop
+    ///  - focalDistance
+    ///  - xformOpOrder and xformOp:transform **
+    /// **NOTE: This will clear any existing xformOpOrder and replace
+    /// it with a single xformOp:transform entry. The xformOp:transform
+    /// property is created or updated here to match the transform
+    /// on \p camera . This operation will fail if there are stronger xform op
+    /// opinions in the composed layer stack that are stronger than that of
+    /// the current edit target.
     ///
     USDGEOM_API
     void SetFromCamera(const GfCamera &camera, const UsdTimeCode &time);

--- a/pxr/usd/usdGeom/testenv/testUsdGeomCamera.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomCamera.py
@@ -22,7 +22,7 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 
-from pxr import Gf, Usd, UsdGeom
+from pxr import Gf, Usd, UsdGeom, Sdf, Tf
 import unittest, math
 
 class TestUsdGeomCamera(unittest.TestCase):
@@ -127,6 +127,34 @@ class TestUsdGeomCamera(unittest.TestCase):
 
         for a, e in zip(actual, expected):
             self.assertTrue(Gf.IsClose(a, e, 1e-2))
+
+    def test_SetFromCameraWithComposition(self):
+        stage = Usd.Stage.Open("layers_a_b.usda")
+        layerA = Sdf.Layer.FindOrOpen("a.usda")
+        layerB = Sdf.Layer.FindOrOpen("b.usda")
+        stage.SetEditTarget(layerB)
+
+        usdCamera = UsdGeom.Camera.Define(stage, '/camera')
+
+        camera = Gf.Camera()
+        newXform = Gf.Matrix4d().SetTranslate(Gf.Vec3d(100, 200, 300))
+        camera.transform = newXform
+        camera.horizontalAperture = 500.0
+
+        # Verify that trying to SetFromCamera from a weaker edit target does not crash,
+        # and does not modify any existing camera attributes.
+        usdCamera.SetFromCamera(camera, 1.0)
+        self.assertEqual(usdCamera.GetHorizontalApertureAttr().Get(1.0), 1.0)
+
+        # Now use the stronger layer
+        stage.SetEditTarget(layerA)
+
+        # This should succeed
+        usdCamera.SetFromCamera(camera, 1.0)
+
+        self.assertEqual(usdCamera.GetHorizontalApertureAttr().Get(1.0), 500.0)
+        self.assertEqual(usdCamera.ComputeLocalToWorldTransform(1.0), newXform)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/usdGeom/testenv/testUsdGeomCamera/a.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomCamera/a.usda
@@ -1,0 +1,13 @@
+#usda 1.0
+(
+    defaultPrim = "camera"
+)
+
+over "camera"
+{
+    matrix4d xformOp:transform = ((1, 0, 0, 0), 
+                                  (0, 1, 0, 0),
+                                  (0, 0, 1, 0),
+                                  (0, 0, 0, 1))
+    uniform token[] xformOpOrder = ["xformOp:transform"]
+}

--- a/pxr/usd/usdGeom/testenv/testUsdGeomCamera/b.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomCamera/b.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    defaultPrim = "camera"
+)
+
+def Camera "camera"
+{
+    float horizontalAperture = 1.0
+}

--- a/pxr/usd/usdGeom/testenv/testUsdGeomCamera/layers_a_b.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomCamera/layers_a_b.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    defaultPrim = "camera"
+    subLayers = [
+        @./a.usda@,
+        @./b.usda@
+    ]
+)
+

--- a/pxr/usd/usdGeom/xformable.cpp
+++ b/pxr/usd/usdGeom/xformable.cpp
@@ -428,6 +428,12 @@ UsdGeomXformOp
 UsdGeomXformable::MakeMatrixXform() const
 {
     ClearXformOpOrder();
+    bool unused = false;
+    if (!GetOrderedXformOps(&unused).empty()) {
+        TF_WARN("Could not clear xformOps for <%s>",
+            GetPrim().GetPath().GetText());
+        return UsdGeomXformOp();
+    }
     return AddTransformOp();
 }
 


### PR DESCRIPTION
### Description of Change(s)

Small change to avoid a crash from UsdGeomCamera::SetFromCamera where EditTarget is set to a weaker layer and a stronger layer  on the stage defines the xformOpList on the camera (which results in an invalid UsdGeomXformOp returned from MakeMatrixXform())

New behavior issues a TF_CODING_ERROR instead of a crash.

Also updates the docstring for SetFromCamera.
