### PR TITLE
HdStorm: Move MaterialX parameter values out of the shader and into parameter buffer

### DIFF
--- a/pxr/imaging/hdSt/materialNetwork.cpp
+++ b/pxr/imaging/hdSt/materialNetwork.cpp
@@ -1228,7 +1228,8 @@ HdStMaterialNetwork::ProcessMaterialNetwork(
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
         if (!isVolume) {
             HdSt_ApplyMaterialXFilter(&surfaceNetwork, materialId,
-                                      *surfTerminal, surfTerminalPath);
+                                      *surfTerminal, surfTerminalPath,
+                                      &_materialParams);
         }
 #endif
         // Extract the glslfx and metadata for surface/volume.

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -446,35 +446,66 @@ void _AddMaterialXParams(mx::ShaderPtr glslfxShader,
     }
 
     mx::ShaderStage& pixelStage = glslfxShader->getStage(mx::Stage::PIXEL);
-    const auto& paramsBlock = pixelStage.getUniformBlock("PublicUniforms");
+    const auto& paramsBlock = pixelStage.getUniformBlock(mx::HW::PUBLIC_UNIFORMS);
 
     for (size_t i = 0; i < paramsBlock.size(); ++i)
     {
         auto variable = paramsBlock[i];
+        auto varValue = variable->getValue();
+        std::istringstream valueStream(
+            varValue ? varValue->getValueString() : std::string());
+        std::string separator;
 
         HdSt_MaterialParam param;
         param.paramType = HdSt_MaterialParam::ParamTypeFallback;
-        param.name = TfToken(variable->getName());
+        param.name = TfToken(variable->getVariable());
 
         auto varType = variable->getType();
         if (varType->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT) {
             if (varType->getSize() == 1) {
-                param.fallbackValue = VtValue(float(0.f));
+                float val;
+                valueStream >> val;
+                param.fallbackValue = VtValue(val);
             }
             else if (varType->getSize() == 2) {
-                param.fallbackValue = VtValue(GfVec2f(0.f, 0.f));
+                GfVec2f val;
+                valueStream >> val[0] >> separator >> val[1];
+                param.fallbackValue = VtValue(val);
             }
             else if (varType->getSize() == 3) {
-                param.fallbackValue = VtValue(GfVec3f(0.f, 0.f, 0.f));
+                GfVec3f val;
+                valueStream >> val[0] >> separator >> val[1] >> separator >> val[2];
+                param.fallbackValue = VtValue(val);
             }
             else if (varType->getSize() == 4) {
-                param.fallbackValue = VtValue(GfVec4f(0.f, 0.f, 0.f, 0.f));
+                GfVec4f val;
+                valueStream >> val[0] >> separator >> val[1] >> separator
+                            >> val[2] >> separator >> val[3];
+                param.fallbackValue = VtValue(val);
             }
         }
         else if (varType->getBaseType() == mx::TypeDesc::BASETYPE_INTEGER)
         {
             if (varType->getSize() == 1) {
-                param.fallbackValue = VtValue(int(0.f));
+                int val;
+                valueStream >> val;
+                param.fallbackValue = VtValue(val);
+            }
+            else if (varType->getSize() == 2) {
+                GfVec2i val;
+                valueStream >> val[0] >> separator >> val[1];
+                param.fallbackValue = VtValue(val);
+            }
+            else if (varType->getSize() == 3) {
+                GfVec3i val;
+                valueStream >> val[0] >> separator >> val[1] >> separator >> val[2];
+                param.fallbackValue = VtValue(val);
+            }
+            else if (varType->getSize() == 4) {
+                GfVec4i val;
+                valueStream >> val[0] >> separator >> val[1] >> separator
+                    >> val[2] >> separator >> val[3];
+                param.fallbackValue = VtValue(val);
             }
         }
 

--- a/pxr/imaging/hdSt/materialXFilter.h
+++ b/pxr/imaging/hdSt/materialXFilter.h
@@ -26,6 +26,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/imaging/hd/material.h"
+#include "pxr/imaging/hdSt/materialNetwork.h"
 #include "pxr/imaging/hdSt/tokens.h"
 #include "pxr/usd/sdf/path.h"
 #include <MaterialXCore/Document.h>
@@ -52,13 +53,8 @@ void HdSt_ApplyMaterialXFilter(
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& materialPath,
     HdMaterialNode2 const& terminalNode,
-    SdfPath const& terminalNodePath);
-
-// Generates the glsfx source code for the given MaterialX Document
-std::string HdSt_GenMaterialXShaderCode(
-    MaterialX::DocumentPtr const& mxDoc,
-    MaterialX::FileSearchPath const& searchPath,
-    MxHdInfo const& mxHdInfo=MxHdInfo());
+    SdfPath const& terminalNodePath,
+    HdSt_MaterialParamVector* materialParams);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -472,6 +472,33 @@ HdStMaterialXShaderGen::_EmitMxInitFunction(
         emitLineBreak(mxStage);
     }
 
+    // Initialize MaterialX parameters with HdGet_ equivalents
+    emitComment("Initialize Material Parameters", mxStage);
+    const auto& paramsBlock = mxStage.getUniformBlock("PublicUniforms");
+    for (size_t i = 0; i < paramsBlock.size(); ++i)
+    {
+        auto variable = paramsBlock[i];
+        auto varType = variable->getType();
+
+        bool canInit = false;
+        if (varType->getBaseType() == mx::TypeDesc::BASETYPE_FLOAT) {
+            canInit = true;
+        }
+        else if (varType->getBaseType() == mx::TypeDesc::BASETYPE_INTEGER)
+        {
+            if (varType->getSize() == 1) {
+                canInit = true;
+            }
+        }
+        
+        if (canInit)
+        {
+            emitLine(variable->getName() + " = HdGet_" +
+                variable->getName() + "()", mxStage);
+        }
+    }
+    emitLineBreak(mxStage);
+
     // Gather Direct light data from Hydra and apply the Hydra transformation 
     // matrix to the environment map matrix (u_envMatrix) to account for the
     // domeLight's transform. 


### PR DESCRIPTION
### Description of Change(s)

- MaterialX input parameters are no longer hardcoded in the shader but set from the parameter buffer
- Support float and integer types with sizes between 1 and 4. Make sure that all other types are still hardcoded, so that there are no gaps

### Fixes Issue(s)

- This change is the first step (out of two) to make MaterialX parameter updates interactive in HdStorm.

- The second step will be in fixing this issue in MaterialX code: https://github.com/materialx/MaterialX/issues/710 (Shader code generated by MaterialX is not deterministic)

- With the two steps in, shader source code caching in HdStorm will work as expected, HdStorm will be no longer recompiling shaders on MaterialX parameter changes, thus allowing for their interactive updates/editing


