### PR TITLE
Add an optional parameter to specify the tolerance for UsdSkelNormalizeWeights()

### DIFF
--- a/pxr/usd/usdSkel/utils.cpp
+++ b/pxr/usd/usdSkel/utils.cpp
@@ -920,7 +920,8 @@ _ValidateArrayShape(size_t size, int numInfluencesPerComponent)
 
 bool
 UsdSkelNormalizeWeights(TfSpan<float> weights,
-                        int numInfluencesPerComponent)
+                        int numInfluencesPerComponent,
+                        float eps)
 {
     TRACE_FUNCTION();
     
@@ -943,7 +944,7 @@ UsdSkelNormalizeWeights(TfSpan<float> weights,
                     sum += weightSet[j];
                 }
 
-                if (std::abs(sum) > std::numeric_limits<float>::epsilon()) {
+                if (std::abs(sum) > eps) {
                     for(int j = 0; j < numInfluencesPerComponent; ++j) {
                         weightSet[j] /= sum;
                     }

--- a/pxr/usd/usdSkel/utils.h
+++ b/pxr/usd/usdSkel/utils.h
@@ -388,9 +388,12 @@ UsdSkelMakeTransforms(const GfVec3f* translations,
 
 /// Helper method to normalize weight values across each consecutive run of
 /// \p numInfluencesPerComponent elements.
+/// If the total weight for a run of elements is smaller than \p eps, the
+/// elements' weights are set to zero.
 USDSKEL_API
 bool
-UsdSkelNormalizeWeights(TfSpan<float> weights, int numInfluencesPerComponent);
+UsdSkelNormalizeWeights(TfSpan<float> weights, int numInfluencesPerComponent,
+                        float eps = std::numeric_limits<float>::epsilon());
 
 
 /// \overload

--- a/pxr/usd/usdSkel/wrapUtils.cpp
+++ b/pxr/usd/usdSkel/wrapUtils.cpp
@@ -346,9 +346,10 @@ void wrapUsdSkelUtils()
         (arg("translations"), arg("rotations"), arg("scales")));
 
     def("NormalizeWeights",
-        static_cast<bool (*)(TfSpan<float>,int)>(
+        static_cast<bool (*)(TfSpan<float>,int,float)>(
             &UsdSkelNormalizeWeights),
-        (arg("weights"), arg("numInfluencesPerComponent")));
+        (arg("weights"), arg("numInfluencesPerComponent"),
+         arg("eps")=std::numeric_limits<float>::epsilon()));
 
     def("SortInfluences",
         static_cast<bool (*)(TfSpan<int>, TfSpan<float>,int)>(


### PR DESCRIPTION
In Houdini, `UsdSkelNormalizeWeights()` is used when converting geometry to USD, but this uses a different tolerance than Houdini's skinning operator. Being able to specify our own tolerance would let us get consistent behaviour in edge cases where the total weight is nearly zero