### PR TITLE
Workaround issue 1475 by comparing types by name

### DIFF
--- a/pxr/base/tf/safeTypeCompare.h
+++ b/pxr/base/tf/safeTypeCompare.h
@@ -38,7 +38,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Returns \c true if \p t1 and \p t2 denote the same type.
 inline bool TfSafeTypeCompare(const std::type_info& t1, const std::type_info& t2) {
+#if defined(__APPLE__)
+    // Workaround until issue 1475 aka USD-6608 is properly fixed. This way USD
+    // containers, in particular VtArray objects, can be passed between DSOs
+    // linked with USD (e.g. plugins) compiled with hidden visibility and have
+    // their contents safely accessed. USD itself still has to be compiled with
+    // default visibility.
+    // The two types are compared by name explicitly, as opposed to the default
+    // implementation which compares them as pointers and relies on typeinfos
+    // from different DSOs being properly merged at load time. __builtin_strcmp
+    // is used to avoid bringing in unneeded headers.
+    return __builtin_strcmp(t1.name(), t2.name()) == 0;
+#else
     return t1 == t2;
+#endif
 }
 
 /// Safely perform a dynamic cast.


### PR DESCRIPTION
The default implementation of operator== for typeinfo objects in
Appple's libc++ relies on typeinfos for the same type in different DSOs
being merged. For this to happen, USD classes have to be marked with
default visibility. USD doesn't have visibility set on core classes,
which makes the RTTI machinery, on which classes such as VtArray rely,
fail at runtime and compare typeinfos for the same type from different
DSOs as different. This can be worked around by explicitly comparing the
types by name.

Disclaimer: I am currently employed by Chaos (formerly Chaos Group). My employer does *not* claim ownership of my open-source contributions and I have explicit permission to submit this pull request as an individual contributor.

### Description of Change(s)
Changed TfSafeTypeCompare to compare types by name, so it works when USD is
used in DSOs compiled with -fvisibility=hidden.

### Fixes Issue(s)
- 1475 (not a proper fix, just a workaround)

