### PR TITLE
collection of fixes for building without pre-compiled headers

### DIFF
--- a/pxr/base/arch/stackTrace.cpp
+++ b/pxr/base/arch/stackTrace.cpp
@@ -32,6 +32,11 @@
 #include "pxr/base/arch/error.h"
 #include "pxr/base/arch/errno.h"
 #include "pxr/base/arch/export.h"
+#if defined(ARCH_OS_WINDOWS)
+// Need to include Winsock2.h BEFORE windows.h - which is included in
+// fileSystem.h
+#include <Winsock2.h>
+#endif
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/arch/inttypes.h"
 #include "pxr/base/arch/symbols.h"
@@ -39,7 +44,6 @@
 #if defined(ARCH_OS_WINDOWS)
 #include <io.h>
 #include <process.h>
-#include <Winsock2.h>
 #include <DbgHelp.h>
 #ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN 64

--- a/pxr/base/trace/dataBuffer.cpp
+++ b/pxr/base/trace/dataBuffer.cpp
@@ -26,6 +26,8 @@
 
 #include "pxr/pxr.h"
 
+#include <algorithm>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 constexpr size_t _GetMaxAlign() {

--- a/pxr/imaging/hd/extComputationContextInternal.h
+++ b/pxr/imaging/hd/extComputationContextInternal.h
@@ -28,6 +28,8 @@
 
 #include "pxr/imaging/hd/extComputationContext.h"
 
+#include <map>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 ///

--- a/pxr/imaging/hdx/fullscreenShader.h
+++ b/pxr/imaging/hdx/fullscreenShader.h
@@ -35,6 +35,7 @@
 #include "pxr/imaging/hgi/shaderProgram.h"
 #include "pxr/imaging/hgi/texture.h"
 
+#include <map>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hgiGL/scopedStateHolder.h
+++ b/pxr/imaging/hgiGL/scopedStateHolder.h
@@ -27,6 +27,7 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/hgiGL/api.h"
 
+#include <cstdint>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/hgiGL/shaderGenerator.h
+++ b/pxr/imaging/hgiGL/shaderGenerator.h
@@ -29,6 +29,8 @@
 #include "pxr/imaging/hgiGL/shaderSection.h"
 #include "pxr/imaging/hgiGL/api.h"
 
+#include <map>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using HgiGLShaderSectionUniquePtrVector =

--- a/pxr/imaging/plugin/hdEmbree/config.cpp
+++ b/pxr/imaging/plugin/hdEmbree/config.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/instantiateSingleton.h"
 
+#include <algorithm>
 #include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/plugin/hdEmbree/meshSamplers.h
+++ b/pxr/imaging/plugin/hdEmbree/meshSamplers.h
@@ -32,6 +32,8 @@
 #include <embree3/rtcore.h>
 #include <embree3/rtcore_geometry.h>
 
+#include <bitset>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class HdEmbreeRTCBufferAllocator

--- a/pxr/usd/ndr/registry.h
+++ b/pxr/usd/ndr/registry.h
@@ -36,6 +36,7 @@
 #include "pxr/usd/ndr/nodeDiscoveryResult.h"
 #include "pxr/usd/ndr/parserPlugin.h"
 #include "pxr/usd/sdf/assetPath.h"
+#include <map>
 #include <mutex>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/usd/plugin/usdMtlx/discovery.cpp
+++ b/pxr/usd/plugin/usdMtlx/discovery.cpp
@@ -31,6 +31,7 @@
 #include "pxr/base/tf/stringUtils.h"
 #include <algorithm>
 #include <cctype>
+#include <map>
 
 namespace mx = MaterialX;
 

--- a/pxr/usd/sdf/fileIO.h
+++ b/pxr/usd/sdf/fileIO.h
@@ -35,6 +35,7 @@
 #include "pxr/usd/ar/writableAsset.h"
 #include "pxr/base/tf/diagnosticLite.h"
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
### Description of Change(s)

ie, if -DPXR_ENABLE_PRECOMPILED_HEADERS=OFF

wanted to build without precompiled headers to help with debugging a
strange build issue (ie, create more transparent + atomic build steps)

also, turning off PCH usage allows stashed.io (a
caching compiler wrapper for MSVC) to operate when using PDB
(see: https://github.com/playscale/stashed.io/wiki/PDB-and-PCH-generation)

most fixes are pretty self-explanatory - adding some missing headers to
individual source / header files

in stackTrace.cpp, the include of Winsock2.h must happen before windows.h,
which is brought in via fileSystem.h

