### PR TITLE
Fix build_usd.py failure on WSL2(ubuntu)

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -233,9 +233,13 @@ def GetPythonInfo(context):
                                          _GetPythonLibraryFilename(context))
         elif Linux():
             pythonLibDir = sysconfig.get_config_var("LIBDIR")
-            pythonMultiarchSubdir = sysconfig.get_config_var("multiarchsubdir")
-            if pythonMultiarchSubdir:
-                pythonLibDir = pythonLibDir + pythonMultiarchSubdir
+            if sysconfig.get_config_var("MULTIARCH"):
+                pythonMultiarchSubdir = sysconfig.get_config_var("multiarchsubdir")
+                if pythonMultiarchSubdir:
+                    if pythonMultiarchSubdir.startswith(os.sep):
+                        pythonMultiarchSubdir = pythonMultiarchSubdir[len(os.sep):]
+                    if not pythonLibDir.endswith(pythonMultiarchSubdir):
+                        pythonLibDir = os.path.join(pythonLibDir, pythonMultiarchSubdir)
             pythonLibPath = os.path.join(pythonLibDir,
                                          _GetPythonLibraryFilename(context))
         elif MacOS():


### PR DESCRIPTION
Fix build_usd.py, WSL2(ubuntu) incorrect pythonLibDir due to Multiarch causing make failure

### Description of Change(s)

The script goes though and examines the return value of the multiarchsubdir config var to determine if the value should be concatenated to the pythonLibDir.  It appears that this returns something different on Linux in Windows than it does on a pure Linux install.

### Fixes Issue(s)

Build fail on WSL (Windows Subsystem for Linux) -- makefile fails with a "don't know how to build target libpythonX.Y.so" when it does it's dependency check.  The failure is because the library path env is incorrect.

---

On my machine, the makefile was looking for /usr/lib/**x86_64-linux-gnu**/**x86_64-linux-gnu**/libpython3.9.so (there's an extra x86_64-linux-gnu in there).  The multiarch part of the Linux install double concatenated part of the path to the python library.  This is a known issue and I found a fix in another repository, which I dropped in.  This needs to be regression tested on Linux systems that worked before to insure it still works.

The code I based this fix on was found [here](https://github.com/pykaldi/pykaldi/blob/b4e7a15a31286e57c01259edfda54d113b5ceb0e/tools/find_python_library.py#L68) (and similarly in some other spots).

System specs:  WSL2 (ubuntu on windows community preview), Windows 11, & python 3.9.
