### PR TITLE
Fix compiling with -Werror=format-security

### DIFF
--- a/pxr/imaging/hd/dirtyList.cpp
+++ b/pxr/imaging/hd/dirtyList.cpp
@@ -191,7 +191,7 @@ HdDirtyList::UpdateRenderTagsAndReprSelectors(
                 std::stringstream ss;
                 ss << "Resetting tracked reprs in dirty list from "
                    << _trackedReprs << " to " << reprs << "\n";
-                TfDebug::Helper().Msg(ss.str().c_str());
+                TfDebug::Helper().Msg(ss.str());
             }
             _trackedReprs = reprs;
             trackedReprsChanged = true;

--- a/pxr/imaging/hd/renderIndex.cpp
+++ b/pxr/imaging/hd/renderIndex.cpp
@@ -1412,7 +1412,7 @@ HdRenderIndex::SyncAll(HdTaskSharedPtrVector *tasks,
                     << ratioNonVarying * 100.0f << "% ("
                     << numNonVarying << " / "  << numDirtyRprims << ") \n";
 
-                TfDebug::Helper().Msg(ss.str().c_str());
+                TfDebug::Helper().Msg(ss.str());
             }
         }
     }

--- a/pxr/imaging/hdSt/drawItemsCache.cpp
+++ b/pxr/imaging/hdSt/drawItemsCache.cpp
@@ -114,7 +114,7 @@ HdSt_DrawItemsCache::GetDrawItems(
             << collection << ", render tags " << renderTags << "\n";
         }
 
-        TfDebug::Helper().Msg(ss.str().c_str());
+        TfDebug::Helper().Msg(ss.str());
     }
     
     if (cacheMiss || staleEntry) {


### PR DESCRIPTION
### Description of Change(s)

Use the `std::string` copied from a stringstream’s value, rather than the `char const *` obtained from that `std::string`’s `c_str()` method, so that the correct overload of `TfDebug::Helper::Msg` is selected, and the message built in the stringstream is not accidentally treated as a `printf`-style format string.

### Fixes Issue(s)
- #1675

