### PR TITLE
Add shadowing support to MaterialX shaders in HdStorm

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.h
+++ b/pxr/imaging/hdSt/materialXShaderGen.h
@@ -49,6 +49,14 @@ public:
                            MaterialX::ElementPtr mxElement,
                            MaterialX::GenContext& mxContext) const override;
 
+    void emitLine(const std::string& str, 
+            MaterialX::ShaderStage& stage, 
+            bool semicolon = true) const override;
+
+    void setEmittingSurfaceNode(bool emittingSurfaceNode) {
+        _emittingSurfaceNode = emittingSurfaceNode;
+    }
+
 protected:
     void _EmitGlslfxShader(const MaterialX::ShaderGraph& mxGraph,
                            MaterialX::GenContext& mxContext,
@@ -97,6 +105,8 @@ private:
     MaterialX::StringMap _mxHdPrimvarMap;
     std::string _defaultTexcoordName;
     std::string _materialTag;
+
+    bool _emittingSurfaceNode = false;
 };
 
 


### PR DESCRIPTION
### Description of Change(s)

Insert HdStorm's shadowing code into MaterialX shader during the code gen.

### Fixes Issue(s)

Fixes the bug that there are no shadows in HdStorm on geometry with MaterialX material applied 

