### PR TITLE
Do not search for the end of the list of children if there are no children

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -924,12 +924,19 @@ UsdImagingDelegate::_GatherDependencies(SdfPath const& subtree,
         return;
     }
 
-    // Binary search for the first path not in the subtree, starting at "start".
-    _DependencyMap::const_iterator end =
-        std::upper_bound(start, _dependencyInfo.cend(), subtree,
-            [](SdfPath const& lhs, _DependencyMap::value_type const& rhs) {
-                    return !rhs.first.HasPrefix(lhs);
-                });
+    // std::upper_bound makes O(N) iterator increments and O(log N) HasPrefix calls,
+    // because _DependencyMap::iterator is not a LegacyRandomAccessIterator. Test to
+    // see if there are any children at all before making this expensive call.
+    _DependencyMap::const_iterator end = start;
+    end++;
+    if (end->first.HasPrefix(subtree))
+    {
+        // Binary search for the first path not in the subtree, starting at "end".
+        end = std::upper_bound(end, _dependencyInfo.cend(), subtree,
+                               [](SdfPath const& lhs, _DependencyMap::value_type const& rhs) {
+                                   return !rhs.first.HasPrefix(lhs);
+                               });
+    }
 
     SdfPathVector affectedPaths;
     for (_DependencyMap::const_iterator it = start; it != end; ++it) {


### PR DESCRIPTION
### Description of Change(s)
Do not do the O(N) search for the first path that does not have subtree as a prefix if subtree has no children.

Please see https://github.com/PixarAnimationStudios/USD/issues/1689 for a detailed description of the problem.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1689