### PR TITLE
[build-script] exclude boost lib 'wave' utf-8 test files from extraction

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -711,7 +711,11 @@ def InstallBoost_Helper(context, force, buildArgs):
     # To avoid this, we skip extracting all documentation.
     #
     # For some examples, see: https://svn.boost.org/trac10/ticket/11677
-    dontExtract = ["*/doc/*", "*/libs/*/doc/*", "*/libs/*/utf8-test-*"]
+    dontExtract = [
+        "*/doc/*",
+        "*/libs/*/doc/*",
+        "*/libs/wave/test/testwave/testfiles/utf8-test-*"
+    ]
 
     with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
                                              dontExtract=dontExtract)):

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -711,7 +711,7 @@ def InstallBoost_Helper(context, force, buildArgs):
     # To avoid this, we skip extracting all documentation.
     #
     # For some examples, see: https://svn.boost.org/trac10/ticket/11677
-    dontExtract = ["*/doc/*", "*/libs/*/doc/*"]
+    dontExtract = ["*/doc/*", "*/libs/*/doc/*", "*/libs/*/utf8-test-*"]
 
     with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
                                              dontExtract=dontExtract)):


### PR DESCRIPTION
### Description of Change(s)
In build-script, exclude `libs/wave/test/testwave/testfiles/utf8-test-ßµ™∃` dir from the extraction of Boost archive.

### Fixes Issue(s)
When buliding USD with Python-2, I keep getting following error (on Windows)

```
Building with settings:
  USD source directory          c:\..\usd\21.08\build\platform-windows\python-2.7\USD-21.08
  USD install directory         D:\payload
  3rd-party source directory    D:\payload\src
  3rd-party install directory   D:\payload
  Build directory               D:\payload\build
  CMake generator               Default
  CMake toolset                 Default
  Downloader                    curl

  Building                      Shared libraries
    Config                      Release
    Imaging                     On
      Ptex support:             Off
      OpenVDB support:          Off
      OpenImageIO support:      Off
      OpenColorIO support:      Off
      PRMan support:            Off
    UsdImaging                  On
      usdview:                  On
    Python support              On
      Python 3:                 Off
    Documentation               Off
    Tests                       Off
    Examples                    On
    Tutorials                   On
    Tools                       On
    Alembic Plugin              Off
      HDF5 support:             Off
    Draco Plugin                Off
    MaterialX Plugin            Off

  Dependencies                  zlib, boost, TBB, OpenSubdiv
  Build arguments               USD: "-DPXR_STRICT_BUILD_MODE=OFF"
STATUS: Installing zlib...
STATUS: Installing boost...
ERROR: Failed to extract archive boost_1_70_0.tar.gz: [Error 123] The filename, directory name, or volume label syntax is incorrect.: 'D:\\payload\\src\\extract_dir\\boost_1_70_0\\libs\\wave\\test\\testwave\\testfiles
\\utf8-test-\xc3\x9f\xc2\xb5\xe2\x84\xa2\xe2\x88\x83'
Traceback (most recent call last):
  File "c:\..\usd\21.08/rezbuild.py", line 115, in <module>
    targets=sys.argv[1:])
  File "c:\..\usd\21.08/rezbuild.py", line 82, in build
    env=env,
  File "C:\python27_64\lib\subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['python', 'c:\\..\\usd\\21.08\\build\\platform-windows\\python-2.7\\USD-21.08/build_scripts/build_usd.py', '--build-arg=USD,"-DPXR_STRICT_BUILD_MODE=OFF"', 'D:payload']' returned non-zero exit status 1

```

Thanks to the `DownloadURL()` function's arg `dontExtract`, this issue can be handled easily.

The other [route](https://gist.github.com/davidlatwe/2fe0e54209b77b190a540ef4b98f3a4f) that I've tried was to make `DownloadURL()` able to handle unicode in Python-2, but just excluding that specific dir is enough for now.
