### PR TITLE
Address a compilation error with Clang

### DIFF
--- a/pxr/imaging/hd/command.cpp
+++ b/pxr/imaging/hd/command.cpp
@@ -25,8 +25,4 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdCommandArgDescriptor::HdCommandArgDescriptor() = default;
-
-HdCommandDescriptor::HdCommandDescriptor() = default;
-
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hd/command.h
+++ b/pxr/imaging/hd/command.h
@@ -44,7 +44,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 struct HdCommandArgDescriptor
 {
-    HdCommandArgDescriptor();
+    HdCommandArgDescriptor() noexcept = default;
 
     HdCommandArgDescriptor(const TfToken &argName,
                            const VtValue &defaultValue_) 
@@ -77,7 +77,7 @@ using HdCommandArgs = VtDictionary;
 ///
 struct HdCommandDescriptor
 {
-    HdCommandDescriptor();
+    HdCommandDescriptor() noexcept = default;
 
     explicit HdCommandDescriptor(
                const TfToken &name_, 

--- a/pxr/imaging/hd/command.h
+++ b/pxr/imaging/hd/command.h
@@ -44,7 +44,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 struct HdCommandArgDescriptor
 {
-    HdCommandArgDescriptor() noexcept = default;
+    HdCommandArgDescriptor() = default;
 
     HdCommandArgDescriptor(const TfToken &argName,
                            const VtValue &defaultValue_) 


### PR DESCRIPTION
### Description of Change(s)

Address a couple of compilation errors from Clang related to default constructors:

```
usd/pxr/imaging/hd/command.cpp:30:22: error: defaulting this default constructor would delete it after its first declaration
HdCommandDescriptor::HdCommandDescriptor() = default;
                     ^
usd/pxr/imaging/hd/command.h:104:35: note: default constructor of 'HdCommandDescriptor' is implicitly deleted because field 'commandArgs' of const-qualified type 'const pxrInternal_v0_21__pxrReserved__::HdCommandArgDescriptors' (aka 'const vector<pxrInternal_v0_21__pxrReserved__::HdCommandArgDescriptor>') would not be initialized
    const HdCommandArgDescriptors commandArgs;
```

Tested with Clang 14.