### PR TITLE
Dependencies

### DIFF
--- a/pxr/imaging/hioOpenVDB/CMakeLists.txt
+++ b/pxr/imaging/hioOpenVDB/CMakeLists.txt
@@ -14,7 +14,6 @@ pxr_library(hioOpenVDB
         hio
         tf
         usd
-        ${OPENEXR_Half_LIBRARY}
         ${OPENVDB_LIBRARY}
 
     INCLUDE_DIRS

--- a/pxr/imaging/hioOpenVDB/CMakeLists.txt
+++ b/pxr/imaging/hioOpenVDB/CMakeLists.txt
@@ -18,7 +18,7 @@ pxr_library(hioOpenVDB
         ${OPENVDB_LIBRARY}
 
     INCLUDE_DIRS
-        ${OPENVDB_INCLUDE_DIRS}
+        ${OPENVDB_INCLUDE_DIR}
 
     PUBLIC_CLASSES
         utils


### PR DESCRIPTION
### Description of Change(s)

Use the variable `${OPENVDB_INCLUDE_DIR}` in place of `${OPENVDB_INCLUDE_DIRS}`.

When using the provided `build_usd.py` file, the headers for all external dependencies are installed within a same `include` directory and every compiles just fine, however when explicitly setting the path to the OpenVDB library using CMake's `-DOPENVDB_LOCATION` flag, then the module `hioOpenVDB` fails to compile because the OpenVDB headers cannot be found due to the wrong include variable being used:

```
usd/pxr/imaging/hioOpenVDB/utils.h:31:10: fatal error: 'openvdb/openvdb.h' file not found
#include "openvdb/openvdb.h"
         ^~~~~~~~~~~~~~~~~~~
```

Also remove the dependency towards OpenEXR's Half library from the `hioOpenVDB` module since it doesn't seem to be needed.