### PR TITLE
Find boost program_option when building tests

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -123,7 +123,7 @@ else()
 endif()
 
 # --USD tools
-if(PXR_BUILD_USD_TOOLS)
+if(PXR_BUILD_USD_TOOLS OR PXR_BUILD_TESTS)
     find_package(Boost
     COMPONENTS
         program_options


### PR DESCRIPTION
### Description of Change(s)

https://github.com/PixarAnimationStudios/USD/pull/1649 introduced a bug that prevents test to link when USD is built statically. This PR fixes it by finding boost program_option if either `PXR_BUILD_USD_TOOLS` or `PXR_BUILD_TESTS` are `ON`.

### Fixes Issue(s)
- #1698 

