### PR TITLE
Restore Dependency to OpenEXR's Half Lirbary

### DIFF
--- a/pxr/imaging/hioOpenVDB/CMakeLists.txt
+++ b/pxr/imaging/hioOpenVDB/CMakeLists.txt
@@ -14,6 +14,7 @@ pxr_library(hioOpenVDB
         hio
         tf
         usd
+        ${OPENEXR_Half_LIBRARY}
         ${OPENVDB_LIBRARY}
 
     INCLUDE_DIRS


### PR DESCRIPTION
### Description of Change(s)

Revert commit 52bfa939cf83980efcb94e61be0bd446f8c2f674.

### Fixes Issue(s)
- an oversight on my end that causes a compilation error, as described by @asluk here: https://github.com/PixarAnimationStudios/USD/commit/52bfa939cf83980efcb94e61be0bd446f8c2f674#r62233360.

