### PR TITLE
Support OpenVDB without depending on OpenEXR

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1068,7 +1068,7 @@ BLOSC = Dependency("Blosc", InstallBLOSC, "include/blosc.h")
 # not require additional dependencies such as GLFW. Note that version
 # 6.1.0 does require CMake 3.3 though.
 
-OPENVDB_URL = "https://github.com/AcademySoftwareFoundation/openvdb/archive/v6.1.0.zip"
+OPENVDB_URL = "https://github.com/AcademySoftwareFoundation/openvdb/archive/v8.1.0.zip"
 
 def InstallOpenVDB(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(OPENVDB_URL, context, force)):
@@ -1087,9 +1087,10 @@ def InstallOpenVDB(context, force, buildArgs):
                          .format(instDir=context.instDir))
         extraArgs.append('-DTBB_ROOT="{instDir}"'
                          .format(instDir=context.instDir))
-        # OpenVDB needs Half type from IlmBase
-        extraArgs.append('-DILMBASE_ROOT="{instDir}"'
-                         .format(instDir=context.instDir))
+        # Use built-in libHalf instead of depending on IlmBase via OpenEXR
+        # https://github.com/PixarAnimationStudios/USD/pull/1727#issuecomment-998263059
+        # https://github.com/AcademySoftwareFoundation/openvdb/pull/927
+        extraArgs.append('-DUSE_IMATH_HALF=OFF')
 
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
@@ -2036,7 +2037,7 @@ if context.buildImaging:
     requiredDependencies += [OPENSUBDIV]
 
     if context.enableOpenVDB:
-        requiredDependencies += [BLOSC, BOOST, OPENEXR, OPENVDB, TBB]
+        requiredDependencies += [BLOSC, BOOST, OPENVDB, TBB]
     
     if context.buildOIIO:
         requiredDependencies += [BOOST, JPEG, TIFF, PNG, OPENEXR, OPENIMAGEIO]

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -253,7 +253,6 @@ if (PXR_BUILD_IMAGING)
     endif()
     # --OpenVDB
     if (PXR_ENABLE_OPENVDB_SUPPORT)
-        find_package(OpenEXR REQUIRED)
         find_package(OpenVDB REQUIRED)
         add_definitions(-DPXR_OPENVDB_SUPPORT_ENABLED)
     endif()

--- a/pxr/imaging/hioOpenVDB/vdbTextureData.cpp
+++ b/pxr/imaging/hioOpenVDB/vdbTextureData.cpp
@@ -22,6 +22,12 @@
 // language governing permissions and limitations under the Apache License.
 //
 
+#include "pxr/base/arch/defines.h"
+#ifdef ARCH_OS_WINDOWS
+    // Otherwise M_PI_2 is undefined from openvdb's Mat.h
+    #define _USE_MATH_DEFINES
+#endif
+
 #include "pxr/imaging/hioOpenVDB/vdbTextureData.h"
 #include "pxr/imaging/hioOpenVDB/debugCodes.h"
 #include "pxr/imaging/hioOpenVDB/utils.h"


### PR DESCRIPTION
Posting for further discussion... this seems to be the minimal change contents to support OpenVDB without depending on IlmBase for libHalf via OpenEXR.

See https://github.com/PixarAnimationStudios/USD/pull/1727 and https://github.com/AcademySoftwareFoundation/openvdb/pull/927

In particular, it appears that OpenVDB v8.1.0 is the first release that doesn't require IlmBase, even if flags are set to disable the OpenEXR dependency, per the change contents in https://github.com/AcademySoftwareFoundation/openvdb/pull/927/files#diff-6fcdb7772bbfb37017a5b670d3d3a51342f3242a0e0bc8fb46d2def275867c83L451