### PR TITLE
Make no-python build ABI compatible with python build

### DIFF
--- a/pxr/base/plug/info.h
+++ b/pxr/base/plug/info.h
@@ -43,9 +43,7 @@ public:
     enum Type {
         UnknownType,
         LibraryType,
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
         PythonType,
-#endif // PXR_PYTHON_SUPPORT_ENABLED
         ResourceType
     };
 

--- a/pxr/base/plug/plugin.h
+++ b/pxr/base/plug/plugin.h
@@ -117,9 +117,7 @@ public:
 private:
     enum _Type {
         LibraryType, 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED        
         PythonType, 
-#endif // PXR_PYTHON_SUPPORT_ENABLED
         ResourceType 
     };
 

--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -55,6 +55,8 @@ pxr_library(tf
         patternMatcher
         pointerAndBits
         pyLock
+        pyObjWrapper
+        pyTracing
         refBase
         refCount
         refPtr
@@ -103,14 +105,12 @@ pxr_library(tf
         pyModuleNotice
         pyNoticeWrapper
         pyObjectFinder
-        pyObjWrapper
         pyOptional
         pyOverride
         pyPolymorphic
         pyPtrHelpers
         pyResultConversions
         pySingleton
-        pyTracing
         pyUtils
         pyWrapContext
         scriptModuleLoader

--- a/pxr/base/tf/anyWeakPtr.cpp
+++ b/pxr/base/tf/anyWeakPtr.cpp
@@ -69,13 +69,11 @@ TfAnyWeakPtr::_EmptyHolder::_IsConst() const
     return true;
 }
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-boost::python::api::object
+TfPyObjWrapper
 TfAnyWeakPtr::_EmptyHolder::GetPythonObject() const
 {
-    return boost::python::api::object();
+    return {};
 }
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 const std::type_info &
 TfAnyWeakPtr::_EmptyHolder::GetTypeInfo() const
@@ -164,7 +162,7 @@ boost::python::api::object
 TfAnyWeakPtr::_GetPythonObject() const
 {
     TfPyLock pyLock;
-    return _Get()->GetPythonObject();
+    return _Get()->GetPythonObject().Get();
 }
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 

--- a/pxr/base/tf/anyWeakPtr.h
+++ b/pxr/base/tf/anyWeakPtr.h
@@ -36,9 +36,9 @@
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pyUtils.h"
-#include <boost/python/object.hpp>
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
+#include "pxr/base/tf/pyObjWrapper.h"
 #include <boost/operators.hpp>
 
 #include <cstddef>
@@ -157,9 +157,7 @@ public:
         virtual TfWeakBase const *GetWeakBase() const = 0;
         virtual operator bool() const = 0;
         virtual bool _IsConst() const = 0;
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-        virtual boost::python::api::object GetPythonObject() const = 0;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
+        virtual TfPyObjWrapper GetPythonObject() const = 0;
         virtual const std::type_info & GetTypeInfo() const = 0;
         virtual TfType const& GetType() const = 0;
         virtual const void* _GetMostDerivedPtr() const = 0;
@@ -174,9 +172,7 @@ public:
         TF_API virtual TfWeakBase const *GetWeakBase() const;
         TF_API virtual operator bool() const;
         TF_API virtual bool _IsConst() const;
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-        TF_API virtual boost::python::api::object GetPythonObject() const;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
+        TF_API virtual TfPyObjWrapper GetPythonObject() const;
         TF_API virtual const std::type_info & GetTypeInfo() const;
         TF_API virtual TfType const& GetType() const;
         TF_API virtual const void* _GetMostDerivedPtr() const;
@@ -195,9 +191,7 @@ public:
         virtual TfWeakBase const *GetWeakBase() const;
         virtual operator bool() const;
         virtual bool _IsConst() const;
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-        virtual boost::python::api::object GetPythonObject() const;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
+        virtual TfPyObjWrapper GetPythonObject() const;
         virtual const std::type_info & GetTypeInfo() const;
         virtual TfType const& GetType() const;
         virtual const void* _GetMostDerivedPtr() const;
@@ -263,15 +257,16 @@ TfAnyWeakPtr::_PointerHolder<Ptr>::operator bool() const
     return bool(_ptr);
 }
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
 template <class Ptr>
-boost::python::api::object
+TfPyObjWrapper
 TfAnyWeakPtr::_PointerHolder<Ptr>::GetPythonObject() const
 {
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
     return TfPyObject(_ptr);
-}
+#else
+    return {};
 #endif // PXR_PYTHON_SUPPORT_ENABLED
-
+}
 template <class Ptr>
 const std::type_info &
 TfAnyWeakPtr::_PointerHolder<Ptr>::GetTypeInfo() const

--- a/pxr/base/tf/pyObjWrapper.cpp
+++ b/pxr/base/tf/pyObjWrapper.cpp
@@ -26,6 +26,7 @@
 
 #include "pxr/base/tf/pyObjWrapper.h"
 
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pyLock.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/type.h"
@@ -94,3 +95,5 @@ TfPyObjWrapper::operator!=(TfPyObjWrapper const &other) const
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/tf/pyObjWrapper.h
+++ b/pxr/base/tf/pyObjWrapper.h
@@ -28,6 +28,7 @@
 
 #include "pxr/base/tf/api.h"
 
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
 // Include this header first to pick up additional mitigations
 // for build issues when including Python.h
 #include "pxr/base/tf/pySafePython.h"
@@ -39,7 +40,26 @@
 #include <iosfwd>
 #include <memory>
 
+#else
+
+#include <type_traits>
+
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
+
+// We define the empty stub for ABI compatibility even if Python support is
+// enabled so we can make sure size and alignment is the same.
+class TfPyObjWrapperStub
+{
+public:
+    static constexpr std::size_t Size = 16;
+    static constexpr std::size_t Align = 8;
+
+private:
+    std::aligned_storage<Size, Align>::type _stub;
+};
+
 
 /// \class TfPyObjWrapper
 ///
@@ -67,6 +87,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// provides, by virtue of deriving from boost::python::api::object_operators<T>.
 /// However it is important to note that callers must ensure the GIL is held
 /// before using these operators!
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
 class TfPyObjWrapper
     : public boost::python::api::object_operators<TfPyObjWrapper>
 {
@@ -129,6 +150,19 @@ private:
     // Store a shared_ptr to a python object.
     std::shared_ptr<object> _objectPtr;
 };
+
+static_assert(sizeof(TfPyObjWrapper) == sizeof(TfPyObjWrapperStub),
+              "ABI break: Incompatible class sizes.");
+static_assert(alignof(TfPyObjWrapper) == alignof(TfPyObjWrapperStub),
+              "ABI break: Incompatible class alignments.");
+
+#else // PXR_PYTHON_SUPPORT_ENABLED
+
+class TfPyObjWrapper : TfPyObjWrapperStub
+{
+};
+
+#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/base/tf/pyTracing.cpp
+++ b/pxr/base/tf/pyTracing.cpp
@@ -26,6 +26,7 @@
 
 #include "pxr/base/tf/pyTracing.h"
 
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pyInterpreter.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/staticData.h"
@@ -153,3 +154,4 @@ void Tf_PyTracingPythonInitialized()
 }
             
 PXR_NAMESPACE_CLOSE_SCOPE
+#endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/base/tf/pyTracing.h
+++ b/pxr/base/tf/pyTracing.h
@@ -24,9 +24,11 @@
 #ifndef PXR_BASE_TF_PY_TRACING_H
 #define PXR_BASE_TF_PY_TRACING_H
 
-#include "pxr/base/tf/pySafePython.h"
-
 #include "pxr/pxr.h"
+
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
+#include "pxr/base/tf/pySafePython.h"
+#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/base/tf/api.h"
 
@@ -35,6 +37,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+#ifdef PXR_PYTHON_SUPPORT_ENABLED
 /// \struct TfPyTraceInfo
 /// Structure passed to python trace functions.  See the Python C API
 /// documentation reference for the meaning of \a what and \a arg.
@@ -59,6 +62,13 @@ void Tf_PyFabricateTraceEvent(TfPyTraceInfo const &info);
 
 // For internal use only.  Do not use.
 void Tf_PyTracingPythonInitialized();
+#else
+/// \struct For storage alignment when PXR_PYTHON_SUPPORT_ENABLED
+/// is not enabled.
+struct TfPyTraceInfo;
+typedef std::function<void (TfPyTraceInfo const &)> TfPyTraceFn;
+typedef std::shared_ptr<TfPyTraceFn> TfPyTraceFnId;
+#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/base/trace/collector.h
+++ b/pxr/base/trace/collector.h
@@ -37,9 +37,7 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pyTracing.h"
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/refBase.h"
@@ -605,13 +603,11 @@ private:
             //
             TraceThreadId _threadIndex;
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
             // When auto-tracing python frames, this stores the stack of scopes.
             struct PyScope {
                 Key key;
             };
             std::vector<PyScope> _pyScopes;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
     };
 
     TRACE_API static std::atomic<int> _isEnabled;
@@ -623,10 +619,8 @@ private:
 
     TimeStamp _measuredScopeOverhead;
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
     std::atomic<int> _isPythonTracingEnabled;
     TfPyTraceFnId _pyTraceFnId;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 };
  
 TRACE_API_TEMPLATE_CLASS(TfSingleton<TraceCollector>);

--- a/pxr/base/vt/value.cpp
+++ b/pxr/base/vt/value.cpp
@@ -492,14 +492,12 @@ operator<<(std::ostream &out, const VtValue &self) {
     return self.IsEmpty() ? out : self._info->StreamOut(self._storage, out);
 }
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
 TfPyObjWrapper
 VtValue::_GetPythonObject() const
 {
     return _info.GetLiteral() ?
         _info.Get()->GetPyObj(_storage) : TfPyObjWrapper();
 }
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 
 static void const *
 _FindOrCreateDefaultValue(std::type_info const &type,

--- a/pxr/usd/ar/resolverContext_v2.h
+++ b/pxr/usd/ar/resolverContext_v2.h
@@ -41,8 +41,9 @@
 // incompatible macro definitions in pyport.h on macOS.
 #include <locale>
 #include "pxr/base/tf/pyLock.h"
-#include "pxr/base/tf/pyObjWrapper.h"
 #endif
+
+#include "pxr/base/tf/pyObjWrapper.h"
 
 #include <algorithm>
 #include <memory>
@@ -263,10 +264,7 @@ private:
         virtual bool Equals(const _Untyped& rhs) const = 0;
         virtual size_t Hash() const = 0;
         virtual std::string GetDebugString() const = 0;
-
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
         virtual TfPyObjWrapper GetPythonObj() const = 0;
-#endif
     };
 
     template <class Context>
@@ -308,13 +306,15 @@ private:
             return ArGetDebugString(_context);            
         }
 
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
         virtual TfPyObjWrapper GetPythonObj() const
         {
+ #ifdef PXR_PYTHON_SUPPORT_ENABLED
             TfPyLock lock;
             return boost::python::object(_context);
-        }
+#else
+            return {};
 #endif
+        }
 
         Context _context;
     };


### PR DESCRIPTION
### Description of Change(s)
This change makes sure clients compiling against builds with Python
support disabled can still run their application with a runtime USD
with Python enabled.

This is mainly done by wrapping Python binding types in wrappers which
have the same size and alignment in no-python builds.

This is mainly done in existing pyObjWrapper.h and new
pyBoostObjWrapper.h.   For example, the applied pattern looks like:

```
#ifdef PXR_PYTHON_SUPPORT_ENABLED

PXR_NAMESPACE_OPEN_SCOPE

// We define the empty stub for ABI compatibility even if Python support is 
// enabled so we can make sure size and alignment is the same.
class TfPyObjWrapperStub
{
public:
    static constexpr std::size_t Size = 16;
    static constexpr std::size_t Align = 8;

private:
    std::aligned_storage<Size, Align>::type _stub;
};

/// \class TfPyObjWrapper
///
/// Boost Python object wrapper.
/// …
#ifdef PXR_PYTHON_SUPPORT_ENABLED
class TfPyObjWrapper
    : public boost::python::api::object_operators<TfPyObjWrapper>
{
    typedef boost::python::object object;

public:

    TF_API TfPyObjWrapper();

    TF_API TfPyObjWrapper(object obj);

    object const &Get() const {
        return *_objectPtr;
    }

    TF_API PyObject *ptr() const;

    friend inline size_t hash_value(TfPyObjWrapper const &o) {
        return (size_t) o.ptr();
    }

    TF_API bool operator==(TfPyObjWrapper const &other) const;

    TF_API bool operator!=(TfPyObjWrapper const &other) const;

private:

    // Befriend object_operators to allow it access to implicit conversion to
    // boost::python::object.
    friend class boost::python::api::object_operators<TfPyObjWrapper>;
    operator object const &() const {
        return Get();
    }

    // Store a shared_ptr to a python object.
    std::shared_ptr<object> _objectPtr;
};

static_assert(sizeof(TfPyObjWrapper) == sizeof(TfPyObjWrapperStub),
              "ABI break: Incompatible class sizes.");
static_assert(alignof(TfPyObjWrapper) == alignof(TfPyObjWrapperStub),
              "ABI break: Incompatible class alignments.");

#else // PXR_PYTHON_SUPPORT_ENABLED

class TfPyObjWrapper : TfPyObjWrapperStub
{
};

#endif // PXR_PYTHON_SUPPORT_ENABLED

```

### Fixes Issue(s)
- External issue https://github.com/PixarAnimationStudios/USD/issues/1716

Co-authored-by: Martin Bisson <martin.bisson@autodesk.com>
