### PR TITLE
Improve point instancer support for primvars

### DIFF
--- a/pxr/usdImaging/usdImaging/gprimAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.cpp
@@ -962,22 +962,6 @@ UsdImagingGprimAdapter::GetOpacity(UsdPrim const& prim,
     return true;
 }
 
-UsdGeomPrimvar
-UsdImagingGprimAdapter::_GetInheritedPrimvar(UsdPrim const& prim,
-                                             TfToken const& primvarName) const
-{
-    UsdImaging_InheritedPrimvarStrategy::value_type inheritedPrimvarRecord =
-        _GetInheritedPrimvars(prim.GetParent());
-    if (inheritedPrimvarRecord) {
-        for (UsdGeomPrimvar const& pv : inheritedPrimvarRecord->primvars) {
-            if (pv.GetPrimvarName() == primvarName) {
-                return pv;
-            }
-        }
-    }
-    return UsdGeomPrimvar();
-}
-
 TfTokenVector
 UsdImagingGprimAdapter::_CollectMaterialPrimvars(
     SdfPathVector const& materialUsdPaths, 

--- a/pxr/usdImaging/usdImaging/gprimAdapter.h
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.h
@@ -215,11 +215,6 @@ protected:
     USDIMAGING_API
     virtual bool _IsBuiltinPrimvar(TfToken const& primvarName) const;
 
-    // Utility for derived classes to try to find an inherited primvar.
-    USDIMAGING_API
-    UsdGeomPrimvar _GetInheritedPrimvar(UsdPrim const& prim,
-                                        TfToken const& primvarName) const;
-
     // Utility for gathering the names of primvars used by the gprim's 
     // materials, used in primvar filtering.
     USDIMAGING_API 

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -983,6 +983,22 @@ UsdImagingPrimAdapter::_GetInheritedPrimvars(UsdPrim const& prim) const
     return _delegate->_inheritedPrimvarCache.GetValue(prim);
 }
 
+UsdGeomPrimvar
+UsdImagingPrimAdapter::_GetInheritedPrimvar(UsdPrim const& prim,
+                                            TfToken const& primvarName) const
+{
+    UsdImaging_InheritedPrimvarStrategy::value_type inheritedPrimvarRecord =
+        _GetInheritedPrimvars(prim.GetParent());
+    if (inheritedPrimvarRecord) {
+        for (UsdGeomPrimvar const& pv : inheritedPrimvarRecord->primvars) {
+            if (pv.GetPrimvarName() == primvarName) {
+                return pv;
+            }
+        }
+    }
+    return UsdGeomPrimvar();
+}
+
 bool
 UsdImagingPrimAdapter::_DoesDelegateSupportCoordSys() const
 {

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -785,6 +785,10 @@ protected:
     _GetInheritedPrimvars(UsdPrim const& prim) const;
 
     USDIMAGING_API
+    UsdGeomPrimvar _GetInheritedPrimvar(UsdPrim const& prim,
+                                        TfToken const& primvarName) const;
+
+    USDIMAGING_API
     GfInterval _GetCurrentTimeSamplingInterval();
 
     USDIMAGING_API


### PR DESCRIPTION
### Description of Change(s)

The scene index emulation scene delegate lost the ability to query velocities and accelerations from point instancer primitives. The first commit here restores that ability by registering velocites and accelerations as primvars on point isntancer prims.

The second commit additionally registeres inherited primvars and constant primvars on point instancer primitives. This allows access to such primvars through the point instancer primitive's HdInstancer. I believe there was also a regression here (as UsdImagingDelegate::Get would have at least pulled out constant primvar values set directly on the point instancer prim). But the support for inherited primvars is new. Constant and inherited primvars on point instancers serve two purposes. One is to allow the render delegate to have instancer-specific settings (karma and other renderers use namespaced primvars for prim-specific settings). A setting on the point instancer itself is not the same as a (inherited) setting on each prototype.

The other use case is allowing a constant-interpolation primvar to be a more efficient representation of a per-instance varying primvar (when the per-instance value is meant to be the same for all instances). Again, this is different than allowing the primvar to inherit down to each prototype because the prototype may be marked instanceable, or may not be a child of the point instancer prim.
