### PR TITLE
Prevent double-creation of Bprims when using scene index emulation

### DIFF
--- a/pxr/imaging/hd/renderIndex.cpp
+++ b/pxr/imaging/hd/renderIndex.cpp
@@ -608,6 +608,7 @@ HdRenderIndex::InsertBprim(TfToken const& typeId,
     // the prim information
     if (_IsEnabledSceneIndexEmulation()) {
         _emulationSceneIndex->AddLegacyPrim(bprimId, typeId, sceneDelegate);
+        return;
     }
 
     _InsertBprim(typeId, sceneDelegate, bprimId);


### PR DESCRIPTION
### Description of Change(s)

When using scene index emulation, return after calling AddLegacyPrim when
inserting a new Bprim (otherwise it would be created twice).