### PR TITLE
Adding vectorized version of GetScenePrimPath to HdSceneDelegate

### DIFF
--- a/pxr/imaging/hd/sceneDelegate.cpp
+++ b/pxr/imaging/hd/sceneDelegate.cpp
@@ -304,6 +304,14 @@ HdSceneDelegate::GetScenePrimPath(SdfPath const& rprimId,
     return rprimId.ReplacePrefix(_delegateID, SdfPath::AbsoluteRootPath());
 }
 
+/*virtual*/
+SdfPathVector
+HdSceneDelegate::GetScenePrimPaths(SdfPath const& rprimId,
+                                   std::vector<int> instanceIndices,
+                                   std::vector<HdInstancerContext> *instancerContexts)
+{
+    return SdfPathVector(instanceIndices.size());
+}
 
 
 // -----------------------------------------------------------------------//

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -623,6 +623,16 @@ public:
                                      int instanceIndex,
                                      HdInstancerContext *instancerContext = nullptr);
 
+    /// A vectorized version of GetScenePrimPath that allows the prim adapter
+    /// to amortize expensive calculations across a number of path evaluations
+    /// in a single call. Note that only a single rprimId is supported. This
+    /// allows this call to be forwarded directly to a single prim adapter
+    /// rather than requiring a lot of data shuffling.
+    HD_API
+    virtual SdfPathVector GetScenePrimPaths(SdfPath const& rprimId,
+                                     std::vector<int> instanceIndices,
+                                     std::vector<HdInstancerContext> *instancerContexts = nullptr);
+
     // -----------------------------------------------------------------------//
     /// \name Material Aspects
     // -----------------------------------------------------------------------//

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -2254,6 +2254,23 @@ UsdImagingDelegate::GetScenePrimPath(SdfPath const& rprimId,
     return protoPath;
 }
 
+SdfPathVector
+UsdImagingDelegate::GetScenePrimPaths(SdfPath const& rprimId,
+                      std::vector<int> instanceIndices,
+                      std::vector<HdInstancerContext> *instancerContexts)
+{
+    SdfPath cachePath = ConvertIndexPathToCachePath(rprimId);
+    _HdPrimInfo *primInfo = _GetHdPrimInfo(cachePath);
+    if (!primInfo || !primInfo->adapter) {
+        TF_WARN("GetScenePrimPaths: Couldn't find rprim <%s>",
+                rprimId.GetText());
+        return SdfPathVector(instanceIndices.size(), cachePath);
+    }
+
+    return primInfo->adapter->GetScenePrimPaths(
+        cachePath, instanceIndices, instancerContexts);
+}
+
 bool
 UsdImagingDelegate::PopulateSelection(
               HdSelection::HighlightMode const& highlightMode,

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -411,6 +411,12 @@ public:
                      int instanceIndex,
                      HdInstancerContext *instancerContext = nullptr) override;
 
+    USDIMAGING_API
+    virtual SdfPathVector
+    GetScenePrimPaths(SdfPath const& rprimId,
+                      std::vector<int> instanceIndices,
+                      std::vector<HdInstancerContext> *instancerContexts = nullptr) override;
+
     // ExtComputation support
     USDIMAGING_API
     TfTokenVector

--- a/pxr/usdImaging/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.h
@@ -314,6 +314,11 @@ public:
         int instanceIndex,
         HdInstancerContext *instancerContext) const override;
 
+    virtual SdfPathVector GetScenePrimPaths(
+        SdfPath const& cachePath,
+        std::vector<int> const& instanceIndices,
+        std::vector<HdInstancerContext> *instancerCtxs) const override;
+
     virtual bool PopulateSelection( 
         HdSelection::HighlightMode const& highlightMode,
         SdfPath const &cachePath,
@@ -455,6 +460,7 @@ private:
 
     struct _PopulateInstanceSelectionFn;
     struct _GetScenePrimPathFn;
+    struct _GetScenePrimPathsFn;
 
     // Helper functions for dealing with "actual" instances to be drawn.
     //

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -1359,6 +1359,29 @@ UsdImagingPointInstancerAdapter::GetScenePrimPath(
     return _GetPrimPathFromInstancerChain(paths);
 }
 
+/* virtual */
+SdfPathVector
+UsdImagingPointInstancerAdapter::GetScenePrimPaths(
+    SdfPath const& cachePath,
+    std::vector<int> const& instanceIndices,
+    std::vector<HdInstancerContext> *instancerCtxs) const
+{
+    SdfPathVector result;
+    HdInstancerContext instanceCtx;
+
+    result.reserve(instanceIndices.size());
+    if (instancerCtxs)
+        instancerCtxs->reserve(instanceIndices.size());
+    for (size_t i = 0; i < instanceIndices.size(); i++) {
+        result.push_back(
+            GetScenePrimPath(cachePath, instanceIndices[i], &instanceCtx));
+        if (instancerCtxs)
+            instancerCtxs->push_back(std::move(instanceCtx));
+    }
+
+    return result;
+}
+
 static 
 size_t
 _GatherAuthoredTransformTimeSamples(

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.h
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.h
@@ -260,6 +260,11 @@ public:
         int instanceIndex,
         HdInstancerContext *instancerContext) const override;
 
+    virtual SdfPathVector GetScenePrimPaths(
+        SdfPath const& cachePath,
+        std::vector<int> const& instanceIndices,
+        std::vector<HdInstancerContext> *instancerCtxs) const override;
+
     virtual bool PopulateSelection(
         HdSelection::HighlightMode const& highlightMode,
         SdfPath const &cachePath,

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -479,6 +479,17 @@ UsdImagingPrimAdapter::GetScenePrimPath(
 }
 
 /*virtual*/
+SdfPathVector
+UsdImagingPrimAdapter::GetScenePrimPaths(SdfPath const& cachePath,
+    std::vector<int> const& instanceIndices,
+    std::vector<HdInstancerContext> *instancerCtxs) const
+{
+    // Note: if we end up here, we're not instanced, since primInfo
+    // holds the instance adapter for instanced gprims.
+    return SdfPathVector(instanceIndices.size(), cachePath);
+}
+
+/*virtual*/
 bool
 UsdImagingPrimAdapter::PopulateSelection(
     HdSelection::HighlightMode const& mode,

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -344,8 +344,13 @@ public:
 
     USDIMAGING_API
     virtual SdfPath GetScenePrimPath(SdfPath const& cachePath,
-                                     int instanceIndex,
-                                     HdInstancerContext *instancerCtx) const;
+        int instanceIndex,
+        HdInstancerContext *instancerCtx) const;
+
+    USDIMAGING_API
+    virtual SdfPathVector GetScenePrimPaths(SdfPath const& cachePath,
+        std::vector<int> const& instanceIndices,
+        std::vector<HdInstancerContext> *instancerCtxs) const;
 
     // Add the given usdPrim to the HdSelection object, to mark it for
     // selection highlighting. cachePath is the path of the object referencing


### PR DESCRIPTION
Adding GetScenePrimPaths method to HdSceneDelegate which allows a single
method call to fetch prim paths for a large number of instances in a single
method call. Especially useful for native instances which use an O(n)
algorithm to discover the path of a single instance.

### Description of Change(s)
For applications which make extensive use of GetScenePrimPath (as Houdini does), the performance of this function for large numbers of native instances makes it a huge bottleneck. A vectorized version of this method allows the native instancer implementation to amortize the expensive parts of this operation (creating the vector of instance ids and iterating through that vector) across all the instances being queried at once.

The alternative approach to this would have been to make GetScenePrimPath on instanceAdapter much, much faster, but I wasn't able to figure out how to accomplish that without making a change to the GetScenePrimPath signature, which would have made any solution that much more intrusive. The downside of this approach is that any custom prim adapters that implement GetScenePrimPath will also have to explicitly implement GetScenePrimPaths (even if it just runs a simple loop as the pointInstancerAdapter implementation does).