### PR TITLE
Path resolution for mounted volumes in Windows does not work correctly

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1225,6 +1225,14 @@ std::string ArchReadLink(const char* path)
             std::wstring ws(reparsePath.get());
             string str(ws.begin(), ws.end());
 
+            // Mount point paths starting with \?? are NT Object Manager paths
+            // and cannot be used as file paths, so disable converting the path
+            // by returning the original path.
+            //
+            // See: https://superuser.com/questions/1069055/what-is-the-function-of-question-marks-in-file-system-paths-in-windows-registry
+            if (str.length() >= 3 && str.substr(0, 3) == "\\??")
+                return path;
+
             // Note that junctions do not support the relative path form
             // like SYMLINKS do, so nothing more to do here.
 

--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -75,12 +75,14 @@ _ExpandSymlinks(const std::string& path)
             prefix.push_back('\\');
         }
         if (TfIsLink(prefix)) {
-            // Expand the link and repeat with the new path.
-            return _ExpandSymlinks(TfReadLink(prefix) + path.substr(i));
+            // Expand the link and repeat with the new path if the path changed.
+            // The path may remain unchanged or be empty if the link type is
+            // unsupported or the mount destination is not available.
+            auto newPrefix = TfReadLink(prefix);
+            if (!newPrefix.empty() && newPrefix != prefix)
+                return _ExpandSymlinks(newPrefix + path.substr(i));
         }
-        else {
-            i = path.find_first_of("/\\", i + 1);
-        }
+        i = path.find_first_of("/\\", i + 1);
     }
 
     // No ancestral symlinks.


### PR DESCRIPTION
### Description of Change(s)

Some Windows reparse points represent drives mounted on an arbitrary directory. The data kept in the reparse point is an internal Windows object reference that cannot be used as a path. The change avoids trying to use it as a path by detecting its format: it starts with `\??` (backslash and double question marks).

### Fixes Issue(s)
- #1520

