### PR TITLE
Add GetInstanceIndicesChangeCount to detect changes to instance indexing

### DIFF
--- a/pxr/imaging/hd/changeTracker.cpp
+++ b/pxr/imaging/hd/changeTracker.cpp
@@ -60,6 +60,7 @@ HdChangeTracker::HdChangeTracker()
     , _instancerIndexVersion(1)
     , _sceneStateVersion(1)
     , _visChangeCount(1)
+    , _instanceIndicesChangeCount(1)
     , _rprimRenderTagVersion(1)
     , _taskRenderTagsVersion(1)
     , _emulationSceneIndex(nullptr)
@@ -192,6 +193,10 @@ void HdChangeTracker::_MarkRprimDirty(SdfPath const& id, HdDirtyBits bits)
 
     if ((bits & DirtyVisibility) != 0) {
         ++_visChangeCount;
+    }
+
+    if ((bits & DirtyInstanceIndex) != 0) {
+        ++_instanceIndicesChangeCount;
     }
 
     if ((bits & DirtyRenderTag) != 0) {
@@ -527,6 +532,7 @@ HdChangeTracker::_MarkInstancerDirty(SdfPath const& id, HdDirtyBits bits)
     }
     if (bits & DirtyInstanceIndex) {
         toPropagate |= DirtyInstanceIndex;
+        ++_instanceIndicesChangeCount;
     }
 
     // Now mark any associated rprims or instancers dirty.
@@ -1011,6 +1017,9 @@ HdChangeTracker::MarkAllRprimsDirty(HdDirtyBits bits)
     if ((bits & DirtyVisibility) != 0) {
         ++_visChangeCount;
     }
+    if ((bits & DirtyInstanceIndex) != 0) {
+        ++_instanceIndicesChangeCount;
+    }
     if ((bits & DirtyRenderTag) != 0) {
         ++_rprimRenderTagVersion;
     }
@@ -1097,6 +1106,12 @@ unsigned
 HdChangeTracker::GetVisibilityChangeCount() const
 {
     return _visChangeCount;
+}
+
+unsigned
+HdChangeTracker::GetInstanceIndicesChangeCount() const
+{
+    return _instanceIndicesChangeCount;
 }
 
 void

--- a/pxr/imaging/hd/changeTracker.h
+++ b/pxr/imaging/hd/changeTracker.h
@@ -479,6 +479,12 @@ public:
     HD_API
     unsigned GetVisibilityChangeCount() const;
 
+    /// Returns the number of changes to instance index. This is intended to be used
+    /// to detect when instance indices changed for *any* Rprim. Use in with
+    /// GetInstancerIndexVersion() to detect all changes to instance indices.
+    HD_API
+    unsigned GetInstanceIndicesChangeCount() const;
+
     /// Returns the current version of varying state. This is used to refresh
     /// cached DirtyLists
     unsigned GetVaryingStateVersion() const {
@@ -636,6 +642,9 @@ private:
 
     // Used to detect that visibility changed somewhere in the render index.
     unsigned _visChangeCount;
+
+    // Used to detect that instance indices changed somewhere in the render index.
+    unsigned _instanceIndicesChangeCount;
 
     // Used to detect changes to the render tag opinion of rprims.
     unsigned _rprimRenderTagVersion;


### PR DESCRIPTION
### Description of Change(s)
Add GetInstanceIndicesChangeCount to HdChangeTracker to detect changes to instance indexing. This helps MayaUSD know when to call populateSelection to correctly draw selection highlighting for instanced objects when the instance indexing changes.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1516

