### PR TITLE
Expand Python exception for debug output

### DIFF
--- a/pxr/base/tf/pyError.cpp
+++ b/pxr/base/tf/pyError.cpp
@@ -35,6 +35,8 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/tuple.hpp>
+#include <boost/python/str.hpp>
+#include <boost/python/import.hpp>
 
 #include <vector>
 


### PR DESCRIPTION
When converting an exception that originates in Python code, add the
error message and traceback to the TF_ERROR message to allow clients to
debug their Python callbacks.
