### PR TITLE
Support shapes with blendshapes but no skinning when using the CPU computation

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -915,51 +915,54 @@ UsdSkelImagingSkeletonAdapter::InvokeComputation(
                             blendShapeWeights.UncheckedGet<VtFloatArray>(),
                             skinnedPoints);
 
-    if (!hasConstantInfluences.UncheckedGet<bool>()) {
+    if (numInfluencesPerComponent.UncheckedGet<int>() > 0) {
 
-        UsdSkelSkinPointsLBS(
-            geomBindXform.UncheckedGet<GfMatrix4f>(),
-            skinningXforms.UncheckedGet<VtMatrix4fArray>(),
-            influences.UncheckedGet<VtVec2fArray>(),
-            numInfluencesPerComponent.UncheckedGet<int>(),
-            skinnedPoints);
+        if (!hasConstantInfluences.UncheckedGet<bool>()) {
 
-        // The points returned above are in skel space, and need to be
-        // transformed to prim local space.
-        const GfMatrix4d skelToPrimLocal =
-            skelLocalToWorld.UncheckedGet<GfMatrix4d>() *
-            primWorldToLocal.UncheckedGet<GfMatrix4d>();
-
-        _TransformPoints(skinnedPoints, skelToPrimLocal);
-
-    } else {
-        // Have constant influences. Compute a rigid deformation.
-        GfMatrix4f skinnedTransform;
-        if (UsdSkelSkinTransformLBS(
+            UsdSkelSkinPointsLBS(
                 geomBindXform.UncheckedGet<GfMatrix4f>(),
                 skinningXforms.UncheckedGet<VtMatrix4fArray>(),
                 influences.UncheckedGet<VtVec2fArray>(),
-                &skinnedTransform)) {
-            
-            // The computed skinnedTransform is the transform which, when
-            // applied to the points of the skinned prim, results in skinned
-            // points in *skel* space, and need to be xformed to prim
-            // local space.
+                numInfluencesPerComponent.UncheckedGet<int>(),
+                skinnedPoints);
 
-            const GfMatrix4d restToPrimLocalSkinnedXf =
-                GfMatrix4d(skinnedTransform)*
-                skelLocalToWorld.UncheckedGet<GfMatrix4d>()*
+            // The points returned above are in skel space, and need to be
+            // transformed to prim local space.
+            const GfMatrix4d skelToPrimLocal =
+                skelLocalToWorld.UncheckedGet<GfMatrix4d>() *
                 primWorldToLocal.UncheckedGet<GfMatrix4d>();
 
-            // XXX: Ideally we would modify the xform of the skinned prim,
-            // rather than its underlying points (which is particularly
-            // important if we want to preserve instancing!).
-            // For now, bake the rigid deformation into the points.
-            _TransformPoints(skinnedPoints, restToPrimLocalSkinnedXf);
+            _TransformPoints(skinnedPoints, skelToPrimLocal);
 
         } else {
-            // Nothing to do. We initialized skinnedPoints to the restPoints,
-            // so just return that.
+            // Have constant influences. Compute a rigid deformation.
+            GfMatrix4f skinnedTransform;
+            if (UsdSkelSkinTransformLBS(
+                    geomBindXform.UncheckedGet<GfMatrix4f>(),
+                    skinningXforms.UncheckedGet<VtMatrix4fArray>(),
+                    influences.UncheckedGet<VtVec2fArray>(),
+                    &skinnedTransform)) {
+
+                // The computed skinnedTransform is the transform which, when
+                // applied to the points of the skinned prim, results in skinned
+                // points in *skel* space, and need to be xformed to prim
+                // local space.
+
+                const GfMatrix4d restToPrimLocalSkinnedXf =
+                    GfMatrix4d(skinnedTransform)*
+                    skelLocalToWorld.UncheckedGet<GfMatrix4d>()*
+                    primWorldToLocal.UncheckedGet<GfMatrix4d>();
+
+                // XXX: Ideally we would modify the xform of the skinned prim,
+                // rather than its underlying points (which is particularly
+                // important if we want to preserve instancing!).
+                // For now, bake the rigid deformation into the points.
+                _TransformPoints(skinnedPoints, restToPrimLocalSkinnedXf);
+
+            } else {
+                // Nothing to do. We initialized skinnedPoints to the restPoints,
+                // so just return that.
+            }
         }
     }
 


### PR DESCRIPTION
Currently, a shape that has blendshapes but no skinning isn't visible when using the CPU ExtComputation, but the GPU version in Storm behaves okay.
To reproduce, load the [attached file](https://github.com/PixarAnimationStudios/USD/files/7989033/blendshapes.usda.tar.gz) with `usdview blendshapes.usda --camera /cameras/camera1` and use a delegate such as Embree, or set `USDSKELIMAGING_FORCE_CPU_COMPUTE=1` in the environment to reproduce with Storm
