### PR TITLE
Implement reverse lookup table in instanceAdapter to improve performance of getting proto prim

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.h
@@ -621,6 +621,12 @@ private:
     typedef TfHashMultiMap<SdfPath, SdfPath, SdfPath::Hash>
         _PrototypeToInstancerMap;
     _PrototypeToInstancerMap _prototypeToInstancerMap;
+
+    // Map from instance cache path to their instancer path.
+    // Note: this is for reducing proto prim lookup in _GetProtoPrim method.
+    typedef std::unordered_map<SdfPath, SdfPath, SdfPath::Hash>
+        _ProtoPrimCacheMap;
+    _ProtoPrimCacheMap _protoPrimCacheMap;
 };
 
 

--- a/pxr/usdImaging/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.h
@@ -625,8 +625,8 @@ private:
     // Map from instance cache path to their instancer path.
     // Note: this is for reducing proto prim lookup in _GetProtoPrim method.
     typedef std::unordered_map<SdfPath, SdfPath, SdfPath::Hash>
-        _ProtoPrimCacheMap;
-    _ProtoPrimCacheMap _protoPrimCacheMap;
+        _ProtoPrimToInstancerMap;
+    _ProtoPrimToInstancerMap _protoPrimToInstancerMap;
 };
 
 


### PR DESCRIPTION
This PR is for the issue created earlier here to improve the Maya playback performance: https://github.com/PixarAnimationStudios/USD/issues/1740

### Description of Change(s)

- Implemented the "reverse lookup table" mentioned in _GetProtoPrim() method, which can improve the performance of UsdImagingInstanceAdapter::UpdateForTime().



