### PR TITLE
[arch] Fix aarch64 build

### DIFF
--- a/pxr/base/arch/timing.h
+++ b/pxr/base/arch/timing.h
@@ -137,7 +137,7 @@ ArchGetStopTickTime()
     return ArchGetTickTime();
 #elif defined (ARCH_CPU_ARM)
     std::atomic_signal_fence(std::memory_order_seq_cst);
-    asm volatile("mrs %0, cntvct_e l0" : "=r"(t));
+    asm volatile("mrs %0, cntvct_el0" : "=r"(t));
     std::atomic_signal_fence(std::memory_order_seq_cst);
 #elif defined (ARCH_COMPILER_MSVC)
     std::atomic_signal_fence(std::memory_order_seq_cst);


### PR DESCRIPTION
Fixes aarch64 build errors from https://github.com/PixarAnimationStudios/USD/commit/4d88d85d7930b46eccbbf3fa470ee53d23370cbd

`     /tmp/ccfaGvpg.s: Assembler messages:
     /tmp/ccfaGvpg.s:28: Error: unknown or missing system register name at operand 2 -- `mrs x1,cntvct_e l0'
     /tmp/ccfaGvpg.s:39: Error: unknown or missing system register name at operand 2 -- `mrs x0,cntvct_e l0'
     /tmp/ccfaGvpg.s:577: Error: unknown or missing system register name at operand 2 -- `mrs x0,cntvct_e l0'
     /tmp/ccfaGvpg.s:618: Error: unknown or missing system register name at operand 2 -- `mrs x0,cntvct_e l0'
     pxr/base/arch/CMakeFiles/arch.dir/build.make:488: recipe for target 'pxr/base/arch/CMakeFiles/arch.dir/timing.cpp.o' failed
     make[2]: *** [pxr/base/arch/CMakeFiles/arch.dir/timing.cpp.o] Error 1`



