### PR TITLE
[hdx] Expose secondary selection hilight color as a settable value.

### DIFF
--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -1557,6 +1557,38 @@ HdxTaskController::SetSelectionColor(GfVec4f const& color)
 }
 
 void
+HdxTaskController::SetSelectionLocateColor(GfVec4f const& color)
+{
+    if (!_selectionTaskId.IsEmpty()) {
+        HdxSelectionTaskParams params =
+            _delegate.GetParameter<HdxSelectionTaskParams>(
+                _selectionTaskId, HdTokens->params);
+
+        if (params.locateColor != color) {
+            params.locateColor = color;
+            _delegate.SetParameter(_selectionTaskId,
+                HdTokens->params, params);
+            GetRenderIndex()->GetChangeTracker().MarkTaskDirty(
+                _selectionTaskId, HdChangeTracker::DirtyParams);
+        }
+    }
+
+    if (!_colorizeSelectionTaskId.IsEmpty()) {
+        HdxColorizeSelectionTaskParams params =
+            _delegate.GetParameter<HdxColorizeSelectionTaskParams>(
+                _colorizeSelectionTaskId, HdTokens->params);
+
+        if (params.locateColor != color) {
+            params.locateColor = color;
+            _delegate.SetParameter(_colorizeSelectionTaskId,
+                HdTokens->params, params);
+            GetRenderIndex()->GetChangeTracker().MarkTaskDirty(
+                _colorizeSelectionTaskId, HdChangeTracker::DirtyParams);
+        }
+    }
+}
+
+void
 HdxTaskController::SetSelectionEnableOutline(bool enableOutline)
 {
     if (!_colorizeSelectionTaskId.IsEmpty()) {

--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -208,6 +208,10 @@ public:
     HDX_API
     void SetSelectionColor(GfVec4f const& color);
 
+    /// Set the selection locate (over) color.
+    HDX_API
+    void SetSelectionLocateColor(GfVec4f const& color);
+
     /// Set if the selection highlight should be rendered as an outline around
     /// the selected objects or as a solid color overlaid on top of them.
     HDX_API


### PR DESCRIPTION
### Description of Change(s)
Currently Hydra has a notion of two selection types: "selected" and "over".
While the color of "selected" is customizable, the color of "over" is hard-coded and locked to a blueish hue.
We'd like the ability to expose this so applications can customize the color for any style they may be using.

### Fixes Issue(s)
- "over" selected state always being rendered as a blue.

