### PR TITLE
Small fix to GfVec Slerp test

### DIFF
--- a/pxr/base/gf/testenv/testGfVec.py
+++ b/pxr/base/gf/testenv/testGfVec.py
@@ -504,7 +504,7 @@ class TestGfVec(unittest.TestCase):
                 v3 = Gf.Slerp(0.75, v1, v2)
                 self.assertTrue(Gf.IsClose(v3, Vec(-.70711, 0, -.70711), eps))
                 v3 = Gf.Slerp(1, v1, v2)
-                self.assertTrue(Gf.IsClose(v3, v3, eps))
+                self.assertTrue(Gf.IsClose(v3, v2, eps))
 
                 # test Slerp w/ opposing vectors
                 SetVec( v1, [0,1,0] )
@@ -519,7 +519,7 @@ class TestGfVec(unittest.TestCase):
                 v3 = Gf.Slerp(0.75, v1, v2)
                 self.assertTrue(Gf.IsClose(v3, Vec(0, -.70711, .70711), eps))
                 v3 = Gf.Slerp(1, v1, v2)
-                self.assertTrue(Gf.IsClose(v3, v3, eps))
+                self.assertTrue(Gf.IsClose(v3, v2, eps))
 
     def test_Types(self):
         vecTypes = [Gf.Vec2d,


### PR DESCRIPTION
### Description of Change(s)

I was looking at the GfVec tests and noticed that one of the tests compares a vector to itself rather than the expected result of the Slerp call. Heavy stuff here :smile:

