### PR TITLE
[usdAbc] Fixed Windows issue in testUsdAbcIndexedGeomArb

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -216,8 +216,6 @@ pxr_register_test(testUsdAbcIndexedGeomArb
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcIndexedGeomArb"
     DIFF_COMPARE good_primvars_namespace_after_fix.usda
     EXPECTED_RETURN_CODE 0
-    ENV
-        USD_ABC_TESTSUFFIX=def
 )
 
 pxr_register_test(testUsdAbcInstancing

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcIndexedGeomArb.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcIndexedGeomArb.py
@@ -26,13 +26,13 @@ import unittest, os, sys
 
 class TestUsdAbcIndexedGeomArb(unittest.TestCase):
     def test_IndexedGeomArb(self):
-        name = "hasColorSet.abc"
-        abcFile = os.path.join("testUsdAbcIndexedGeomArb", name)
+        usdFile = "good_primvars_namespace_after_fix.usda"
+        abcFile = "hasColorSet.abc"
         cmd = 'usdcat'
         if sys.platform.startswith('win'):
-            cmd = 'usdcat.exe'
+            cmd = 'usdcat.cmd'
             
-        os.system("%s %s" % (cmd, abcFile))
+        os.system("%s -o %s %s" % (cmd, usdFile, abcFile))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)
testUsdAbcIndexedGeomArb.py was calling usdcat.exe which was failing on Windows.
Updated to usdcat.cmd to fix the test and output the results to a test local file for `DIFF_COMPARE`

### Fixes Issue(s)
-

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X] I have submitted a signed Contributor License Agreement
