### PR TITLE
Fix UDIM file resolving when no "1001" file exists

### DIFF
--- a/pxr/usdImaging/usdImaging/materialParamUtils.cpp
+++ b/pxr/usdImaging/usdImaging/materialParamUtils.cpp
@@ -121,7 +121,9 @@ _ResolvedPathForFirstTile(
         // naming pattern but the files that are linked do not. We'll
         // let whoever consumes the pattern determine if they want to
         // resolve symlinks themselves.
-        return resolver.Resolve(path);
+        path = resolver.Resolve(path);
+        if (!path.empty())
+            return path;
     }
     return std::string();
 }


### PR DESCRIPTION
### Description of Change(s)
Correct problem with fix for #1329. When symlink resolution was removed, so
was any testing for whether or not the "Resolve" call succeeded. This change
restores the looping to look for an existing tile file rather than always
returning the attempted resolution of the first tile file.

### Fixes Issue(s)
- #1329 

- [X] I have submitted a signed Contributor License Agreement
