### PR TITLE
Fix MaterialX boolean inputs

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -126,8 +126,8 @@ HdMtlxConvertToString(VtValue const& hdParameterValue)
 {
     std::ostringstream valStream;
     if (hdParameterValue.IsHolding<bool>()) {
-        return (hdParameterValue.UncheckedGet<bool>()) ? "false" 
-                                                                : "true";
+        return (hdParameterValue.UncheckedGet<bool>()) ? "true"
+                                                               : "false";
     }
     else if (hdParameterValue.IsHolding<int>() || 
              hdParameterValue.IsHolding<float>()) {

--- a/pxr/usd/usdMtlx/parser.cpp
+++ b/pxr/usd/usdMtlx/parser.cpp
@@ -140,6 +140,12 @@ ShaderBuilder::AddProperty(
         // Not found.  If an Sdf type exists use that.
         if (converted.valueTypeName) {
             type = converted.valueTypeName.GetAsToken();
+            // Do not use GetAsToken for comparison as recommended in the API
+            if (converted.valueTypeName == SdfValueTypeNames->Bool) {
+                 defaultValue = UsdMtlxGetUsdValue(element, isOutput);
+                 metadata.emplace(SdrPropertyMetadata->SdrUsdDefinitionType,
+                           converted.valueTypeName.GetType().GetTypeName());
+            }
         }
         else {
             type = TfToken(mtlxType);

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.py
@@ -39,7 +39,8 @@ class TestDiscovery(unittest.TestCase):
         names = sorted(registry.GetNodeIdentifiers('UsdMtlxTestNode',
                                                    Ndr.VersionFilterAllVersions))
         self.assertEqual(names,
-            ['pxr_nd_float',
+            ['pxr_nd_boolean',
+             'pxr_nd_float',
              'pxr_nd_integer',
              'pxr_nd_string',
              'pxr_nd_vector',
@@ -50,7 +51,8 @@ class TestDiscovery(unittest.TestCase):
         # Check node names.
         names = sorted(registry.GetNodeNames('UsdMtlxTestNode'))
         self.assertEqual(names,
-            ['pxr_nd_float',
+            ['pxr_nd_boolean',
+             'pxr_nd_float',
              'pxr_nd_integer',
              'pxr_nd_string',
              'pxr_nd_vector'])
@@ -63,7 +65,8 @@ class TestDiscovery(unittest.TestCase):
         nodes = registry.GetNodesByFamily('UsdMtlxTestNode')
         names = sorted([node.GetIdentifier() for node in nodes])
         self.assertEqual(names,
-            ['pxr_nd_float',
+            ['pxr_nd_boolean',
+             'pxr_nd_float',
              'pxr_nd_integer',
              'pxr_nd_string',
              'pxr_nd_vector_2',
@@ -83,6 +86,8 @@ class TestDiscovery(unittest.TestCase):
             [Ndr.Version(),
              Ndr.Version(),
              Ndr.Version(),
+             Ndr.Version(),
+             Ndr.Version(),
              Ndr.Version(1),
              Ndr.Version(2, 0),
              Ndr.Version(2, 1),
@@ -94,7 +99,9 @@ class TestDiscovery(unittest.TestCase):
                         filter=Ndr.VersionFilterDefaultOnly)
                                                 if name.startswith('pxr_')])
         self.assertEqual(names,
-            ['pxr_nd_float',
+            ['pxr_nd_boolean',
+             'pxr_nd_booleanDefaults',
+             'pxr_nd_float',
              'pxr_nd_integer',
              'pxr_nd_string',
              'pxr_nd_vector_2',
@@ -105,8 +112,21 @@ class TestDiscovery(unittest.TestCase):
             [Ndr.Version(),
              Ndr.Version(),
              Ndr.Version(),
+             Ndr.Version(),
+             Ndr.Version(),
              Ndr.Version(2, 0),
              Ndr.Version()])
+
+        # Check default values of boolean inputs:
+        node = registry.GetNodeByIdentifier("pxr_nd_booleanDefaults")
+        self.assertTrue(node)
+        trueInput = node.GetInput("inTrue")
+        self.assertTrue(trueInput.GetDefaultValue())
+        self.assertTrue(trueInput.GetDefaultValueAsSdfType())
+        falseInput = node.GetInput("inFalse")
+        self.assertFalse(falseInput.GetDefaultValue())
+        self.assertFalse(falseInput.GetDefaultValueAsSdfType())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.testenv/test.mtlx
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.testenv/test.mtlx
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
+  <nodedef name="pxr_nd_boolean" node="UsdMtlxTestNode">
+    <input name="in" type="boolean" />
+    <input name="note" type="string" value="" uniform="true" />
+    <output name="out" type="boolean" />
+  </nodedef>
+  <nodedef name="pxr_nd_booleanDefaults" node="UsdMtlxTestNodeWithDefaults">
+    <input name="inTrue" type="boolean" value="true" />
+    <input name="inFalse" type="boolean" value="false" />
+    <output name="out" type="boolean" />
+  </nodedef>
   <nodedef name="pxr_nd_integer" node="UsdMtlxTestNode">
     <input name="in" type="integer" />
     <input name="note" type="string" value="" uniform="true" />
@@ -29,6 +39,8 @@
   <nodedef name="pxr_nd_vector_noversion" node="UsdMtlxTestNode" inherit="pxr_nd_vector">
     <output name="out" type="vector3" />
   </nodedef>
+  <implementation name="im_boolean" nodedef="pxr_nd_boolean" file="mx_boolean.osl" function="mx_boolean" />
+  <implementation name="im_booleanDefaults" nodedef="pxr_nd_booleanDefaults" file="mx_boolean.osl" function="mx_booleanDefaults" />
   <implementation name="im_integer" nodedef="pxr_nd_integer" file="mx_integer.osl" function="mx_integer" />
   <implementation name="im_float" nodedef="pxr_nd_float" file="mx_float.osl" function="mx_float" />
   <implementation name="im_string" nodedef="pxr_nd_string" file="mx_string.osl" function="mx_string" />


### PR DESCRIPTION
### Description of Change(s)
 - Remembers default values of boolean inputs in Sdr
 - Fixes swapped truth values in hdMtlx when creating inputs

### Fixes Issue(s)
- #1784 

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
