### PR TITLE
Taking front of empty vector crashes in debug

### DIFF
--- a/pxr/imaging/hd/dataSourceLegacyPrim.cpp
+++ b/pxr/imaging/hd/dataSourceLegacyPrim.cpp
@@ -2525,12 +2525,12 @@ _ConvertHdMaterialNetworkToHdDataSources(
                 HdMaterialNodeSchema::BuildRetained(
                     HdRetainedContainerDataSource::New(
                         paramsNames.size(), 
-                        &paramsNames.front(), 
-                        &paramsValues.front()), 
+                        paramsNames.data(),
+                        paramsValues.data()),
                     HdRetainedContainerDataSource::New(
                         cNames.size(), 
-                        &cNames.front(), 
-                        &cValues.front()), 
+                        cNames.data(),
+                        cValues.data()),
                     HdRetainedTypedSampledDataSource<TfToken>::New(
                         node.identifier)));
         }
@@ -2547,14 +2547,14 @@ _ConvertHdMaterialNetworkToHdDataSources(
     HdContainerDataSourceHandle nodesDefaultContext = 
         HdRetainedContainerDataSource::New(
             nodeNames.size(), 
-            &nodeNames.front(), 
-            &nodeValues.front());
+            nodeNames.data(),
+            nodeValues.data());
 
     HdContainerDataSourceHandle terminalsDefaultContext = 
         HdRetainedContainerDataSource::New(
             terminalsNames.size(), 
-            &terminalsNames.front(), 
-            &terminalsValues.front());
+            terminalsNames.data(),
+            terminalsValues.data());
 
     // Create the material network, potentially one per network selector
     HdDataSourceBaseHandle network = HdMaterialNetworkSchema::BuildRetained(


### PR DESCRIPTION
### Description of Change(s)
Because MSVC will throw an unstoppable exception of a bad memory access.
Not an issue in release.

### Fixes Issue(s)
- #1733

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
