### PR TITLE
Fix usdview promoting render setting types from float to double

### DIFF
--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -1153,7 +1153,13 @@ UsdImagingGLEngine::SetRendererSetting(TfToken const& id, VtValue const& value)
     }
 
     TF_VERIFY(_renderDelegate);
-    _renderDelegate->SetRenderSetting(id, value);
+    // usdviewq passes a double as VtValue since Python has no 'float' type
+    if (value.IsHolding<double>()) {
+        _renderDelegate->SetRenderSetting(
+            id, VtValue(static_cast<float>(value.UncheckedGet<double>())));
+    } else {
+        _renderDelegate->SetRenderSetting(id, value);
+    }
 }
 
 void


### PR DESCRIPTION
### Description of Change(s)

For render settings of type float, usdview passes a double to the render delegate.
To fix this, the type is corrected in UsdImagingGLEngine before it is passed to the delegate.

### Fixes Issue(s)

This fixes #913.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
