### PR TITLE
[ndr] adds missing functional header

### DIFF
--- a/pxr/usd/ndr/filesystemDiscoveryHelpers.h
+++ b/pxr/usd/ndr/filesystemDiscoveryHelpers.h
@@ -32,6 +32,8 @@
 #include "pxr/usd/ndr/declare.h"
 #include "pxr/usd/ndr/nodeDiscoveryResult.h"
 
+#include <functional>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class NdrDiscoveryPluginContext;


### PR DESCRIPTION
### Description of Change(s)
filesystemDiscoveryHelpers.h was missing an include to functional which caused a build failure.
The build error was the following:

error: "function" in namespace "std" does not name a template type

### Fixes Issue(s)
-

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
