### PR TITLE
Reapply fix from #1465 that was reverted by #1580

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1155,7 +1155,7 @@ typedef struct _REPARSE_DATA_BUFFER {
 std::string ArchReadLink(const char* path)
 {
     HANDLE handle = ::CreateFileW(
-        ArchWindowsUtf8ToUtf16(path).c_str(), GENERIC_READ, 0,
+        ArchWindowsUtf8ToUtf16(path).c_str(), GENERIC_READ, FILE_SHARE_READ,
         NULL, OPEN_EXISTING,
         FILE_FLAG_OPEN_REPARSE_POINT |
         FILE_FLAG_BACKUP_SEMANTICS, NULL);


### PR DESCRIPTION
Reapply fix from #1465 that was reverted by #1580 (presumably by accident).

### Description of Change(s)

Add a FILE_SHARE_READ flag to the CreateFile call that is used to open a symlink location on Windows. This failure was manifesting as a rare intermittent failure to properly resolve a file path inside a symlinked directory on Windows when running many simultaneous processes reading and writing USD files inside this symlinked directory.

- [X] I have submitted a signed Contributor License Agreement
