### PR TITLE
Added missing #include<functional> for std::function.

### DIFF
--- a/pxr/usd/ndr/filesystemDiscoveryHelpers.h
+++ b/pxr/usd/ndr/filesystemDiscoveryHelpers.h
@@ -32,6 +32,8 @@
 #include "pxr/usd/ndr/declare.h"
 #include "pxr/usd/ndr/nodeDiscoveryResult.h"
 
+#include <functional>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class NdrDiscoveryPluginContext;


### PR DESCRIPTION
Added missing include file to be able to use `std::function`.

Fixes issue #1808

- [X ] I have submitted a signed Contributor License Agreement
