### PR TITLE
Add the AppendDiscoveryResult to NdrRegistry

### DIFF
--- a/pxr/usd/ndr/registry.cpp
+++ b/pxr/usd/ndr/registry.cpp
@@ -353,18 +353,18 @@ NdrRegistry::SetExtraDiscoveryPlugins(const std::vector<TfType>& pluginTypes)
     SetExtraDiscoveryPlugins(std::move(discoveryPlugins));
 }
 
-void NdrRegistry::AppendDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult)
+void NdrRegistry::AddDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult)
 {
     std::lock_guard<std::mutex> drLock(_discoveryResultMutex);
     _AddDiscoveryResultNoLock(std::move(discoveryResult));
 }
 
-void NdrRegistry::AppendDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult)
+void NdrRegistry::AddDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult)
 {
     // Explicitly create a copy, otherwise this method will recurse
     // into itself.
     NdrNodeDiscoveryResult result = discoveryResult;
-    AppendDiscoveryResult(std::move(result));
+    AddDiscoveryResult(std::move(result));
 }
 
 void

--- a/pxr/usd/ndr/registry.cpp
+++ b/pxr/usd/ndr/registry.cpp
@@ -353,6 +353,20 @@ NdrRegistry::SetExtraDiscoveryPlugins(const std::vector<TfType>& pluginTypes)
     SetExtraDiscoveryPlugins(std::move(discoveryPlugins));
 }
 
+void NdrRegistry::AppendDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult)
+{
+    std::lock_guard<std::mutex> drLock(_discoveryResultMutex);
+    _AddDiscoveryResultNoLock(std::move(discoveryResult));
+}
+
+void NdrRegistry::AppendDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult)
+{
+    // Explicitly create a copy, otherwise this method will recurse
+    // into itself.
+    NdrNodeDiscoveryResult result = discoveryResult;
+    AppendDiscoveryResult(std::move(result));
+}
+
 void
 NdrRegistry::SetExtraParserPlugins(const std::vector<TfType>& pluginTypes)
 {

--- a/pxr/usd/ndr/registry.h
+++ b/pxr/usd/ndr/registry.h
@@ -94,12 +94,14 @@ public:
     /// This method will not immediately spawn a parse call which will be
     /// deferred until a GetNode*() method is called.
     NDR_API
-    void AppendDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult);
+    void AddDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult);
 
     /// Copy version of the method above.
-    /// For performance reasons, one should prefer to use the move version.
+    /// For performance reasons, one should prefer to use the rvalue reference
+    /// form.
+    /// \overload
     NDR_API
-    void AppendDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult);
+    void AddDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult);
 
     /// Allows the client to set any additional parser plugins that would
     /// otherwise NOT be found through the plugin system.

--- a/pxr/usd/ndr/registry.h
+++ b/pxr/usd/ndr/registry.h
@@ -86,6 +86,21 @@ public:
     NDR_API
     void SetExtraDiscoveryPlugins(const std::vector<TfType>& pluginTypes);
 
+    /// Allows the client to explicitly set additional discovery results that
+    /// would otherwise NOT be found through the plugin system. For example
+    /// to support lazily-loaded plugins which cannot be easily discovered
+    /// in advance.
+    ///
+    /// This method will not immediately spawn a parse call which will be
+    /// deferred until a GetNode*() method is called.
+    NDR_API
+    void AppendDiscoveryResult(NdrNodeDiscoveryResult&& discoveryResult);
+
+    /// Copy version of the method above.
+    /// For performance reasons, one should prefer to use the move version.
+    NDR_API
+    void AppendDiscoveryResult(const NdrNodeDiscoveryResult& discoveryResult);
+
     /// Allows the client to set any additional parser plugins that would
     /// otherwise NOT be found through the plugin system.
     ///


### PR DESCRIPTION
This method allows the client to explicitly set additional discovery
results that would NOT be found through the plugin system. For example
to support lazily-loaded plugins which cannot be easily discovered in
advance.

- [X ] I have submitted a signed Contributor License Agreement
