### PR TITLE
Improve _GatherDependencies performance by pre-caching path lookup in parallel

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -659,7 +659,13 @@ private:
     _DependencyMap _dependencyInfo;
 
     void _GatherDependencies(SdfPath const& subtree,
-                             SdfPathVector *affectedCachePaths);
+                             SdfPathVector& affectedCachePaths);
+
+    typedef TfHashMap<SdfPath, SdfPathVector, SdfPath::Hash> _DependenciesCacheMap;
+    _DependenciesCacheMap _dependenciesCacheMap;
+
+    void _GatherDependenciesCache(SdfPath const &subtree,
+                                  SdfPathVector& affectedCachePaths);
 
     // SdfPath::ReplacePrefix() is used frequently to convert between
     // cache path and Hydra render index path and is a performance bottleneck.

--- a/pxr/usdImaging/usdImaging/delegate.h
+++ b/pxr/usdImaging/usdImaging/delegate.h
@@ -659,13 +659,13 @@ private:
     _DependencyMap _dependencyInfo;
 
     void _GatherDependencies(SdfPath const& subtree,
-                             SdfPathVector& affectedCachePaths);
+                             SdfPathVector *affectedCachePaths);
 
-    typedef TfHashMap<SdfPath, SdfPathVector, SdfPath::Hash> _DependenciesCacheMap;
-    _DependenciesCacheMap _dependenciesCacheMap;
+    typedef TfHashMap<SdfPath, SdfPathVector, SdfPath::Hash> _FlattenedDependenciesCacheMap;
+    _FlattenedDependenciesCacheMap _flattenedDependenciesCacheMap;
 
-    void _GatherDependenciesCache(SdfPath const &subtree,
-                                  SdfPathVector& affectedCachePaths);
+    void _CacheDependencies(SdfPath const &subtree,
+                            SdfPathVector *affectedCachePaths);
 
     // SdfPath::ReplacePrefix() is used frequently to convert between
     // cache path and Hydra render index path and is a performance bottleneck.


### PR DESCRIPTION
### Description of Change(s)

This PR is to improve the performance for `UsdImagingDelegate::SetTime` by pre-caching path dependencies in parallel, in our production shot, the time dropped from 1.2 min to be 10.x second in total.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1813

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x ] I have submitted a signed Contributor License Agreement
