### PR TITLE
Use SdfPathSet instead of StdPathVector for instancePaths in UsdImagingInstanceAdapter::_Populate

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceAdapter.h
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.h
@@ -546,7 +546,7 @@ private:
 
         // Paths to Usd instance prims. Note that this is not necessarily
         // equivalent to all the instances that will be drawn. See below.
-        std::vector<SdfPath> instancePaths;
+        SdfPathSet instancePaths;
 
         // Number of actual instances of this instancer that will be 
         // drawn. See comment on _RunForAllInstancesToDraw.


### PR DESCRIPTION
### Description of Change(s)
When having a high count of instances the runtime of std::vector::insert at 'random' positions in this function can potentially go up to O(N^2) whereas std::set::insert runs with O(N log(N)). I have profilings of scenes with 1M instances where std::vector::insert takes ~100s of total time (25% load time) whereas times for std::set::insert are mostly noise in the profiling.

Also when erasing an prototype avoid a copy by using std::swap to grab the data from the instancerData structure.


### Fixes Issue(s)
-

- [X ] I have submitted a signed Contributor License Agreement
