### PR TITLE
[usdImagingGL] fix thresholds for testUsdImagingGLPurpose

### DIFF
--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -1854,8 +1854,8 @@ pxr_register_test(testUsdImagingGLPurpose
         world_1.png
         world_2.png
         world_3.png
-    FAIL 1
-    FAIL_PERCENT 1
+    FAIL .1
+    FAIL_PERCENT 10
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPurpose


### PR DESCRIPTION
### Description of Change(s)

Currently, testUsdImagingGLPurpose relies solely on perceptual diff,
which fails to detect a change between world_0.png (which shows a
sphere) and world_1.png (which is empty). Changing to a reasonable
default for pixel difference (-fail .1, -failpercent 10) which can
successfully distinguish the two images.

### Fixes Issue(s)
- testUsdImagingGLPurpose fails to detect any changes when purpose is altered

- [X] I have submitted a signed Contributor License Agreement
