### PR TITLE
[build_scripts] update to alembic 1.7.16

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -998,10 +998,12 @@ OPENEXR_URL = "https://github.com/AcademySoftwareFoundation/openexr/archive/v2.3
 
 def InstallOpenEXR(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(OPENEXR_URL, context, force)):
-        RunCMake(context, force, 
-                 ['-DOPENEXR_BUILD_PYTHON_LIBS=OFF',
-                  '-DOPENEXR_PACKAGE_PREFIX="{}"'.format(context.instDir),
-                  '-DOPENEXR_ENABLE_TESTS=OFF'] + buildArgs)
+        extraArgs = ['-DOPENEXR_BUILD_PYTHON_LIBS=OFF',
+                     '-DOPENEXR_PACKAGE_PREFIX="{}"'.format(context.instDir),
+                     '-DOPENEXR_ENABLE_TESTS=OFF']
+
+        extraArgs += buildArgs
+        RunCMake(context, force, extraArgs)
 
 OPENEXR = Dependency("OpenEXR", InstallOpenEXR, "include/OpenEXR/ImfVersion.h")
 
@@ -1317,7 +1319,7 @@ HDF5 = Dependency("HDF5", InstallHDF5, "include/hdf5.h")
 ############################################################
 # Alembic
 
-ALEMBIC_URL = "https://github.com/alembic/alembic/archive/1.7.10.zip"
+ALEMBIC_URL = "https://github.com/alembic/alembic/archive/1.7.16.zip"
 
 def InstallAlembic(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ALEMBIC_URL, context, force)):


### PR DESCRIPTION
### Description of Change(s)
With the current versions of alembic 1.7.10 it was not possible to get a debug build of Usd on Windows through build_usd.py. Alembic 1.7.10 had a bug where it would error from its own warnings.

### Requires:
- https://github.com/PixarAnimationStudios/USD/pull/1844

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1812

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
