### PR TITLE
Allow building against recent glibc with no malloc hooks (>= 2.34)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -413,7 +413,7 @@ There are certain optimizations that can be enabled in the build.
 ##### Malloc Library
 
 We've found that USD performs best with allocators such as [Jemalloc](https://github.com/jemalloc/jemalloc).
-In support of this, you can specify your own allocator through ```PXR_MALLOC_LIBRARY```.
+In support of this, for Linux systems you can specify your own allocator through ```PXR_MALLOC_LIBRARY```.
 This variable should be set to a path to a shared object for the allocator. For example,
 
 ```bash
@@ -422,6 +422,13 @@ This variable should be set to a path to a shared object for the allocator. For 
 
 If none are specified, the default allocator will be used. More information on getting the most out of
 USD can be found [Getting the Best Performance with USD](http://openusd.org/docs/Maximizing-USD-Performance.html).
+
+However glibc 2.34 removed the deprecated memory allocation hooks, preventing USD to correctly build. Custom memory
+allocation code can be compiled out with the ```PXR_ENABLE_MALLOCHOOK_SUPPORT``` option.
+
+```bash
+-DPXR_ENABLE_MALLOCHOOK_SUPPORT=OFF
+```
 
 ## Linker Options
 

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -51,6 +51,7 @@ option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)
 option(PXR_USE_AR_2 "Use Asset Resolver (Ar) 2.0" ON)
+option(PXR_ENABLE_MALLOCHOOK_SUPPORT "Enable Arch malloc hooks" ON)
 
 # Determine GFX api
 # Metal only valid on Apple platforms

--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -59,6 +59,11 @@ pxr_library(arch
     DOXYGEN_FILES
         overview.dox
 )
+if (PXR_ENABLE_MALLOCHOOK_SUPPORT)
+    target_compile_definitions(arch
+        PRIVATE target_compile_definition ARCH_MALLOC_HOOK
+    )
+endif()
 
 pxr_build_test_shared_lib(testArchAbiPlugin
     CPPFILES


### PR DESCRIPTION
### Description of Change(s)

In version [2.34 glibc removed the deprecated](https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html) ```__malloc_hook```, ```__realloc_hook```, ```__memalign_hook``` and ```__free_hook```, preventing ```ArchMallocHook``` to link against glibc. This PR:
- Adds a CMake Option ```PXR_ENABLE_MALLOCHOOK_SUPPORT``` (default: ```ON```). When ```OFF```, the C symbol ```ARCH_MALLOC_HOOK``` is not defined and glibc ```__*_hook``` are not used
- Adds a build script option ```--enable-malloc-hook```
- Mention glibc>=2.34 and the CMake option in the build documentation
- Mention in the build doc that malloc overrides is only available for Linux systems

### Fixes Issue(s)
- #1592

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
