### PR TITLE
Fixed missing material dependency on GeomSubSet

### DIFF
--- a/pxr/usdImaging/usdImaging/meshAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/meshAdapter.cpp
@@ -115,6 +115,11 @@ UsdImagingMeshAdapter::Populate(UsdPrim const& prim,
                 index->GetMaterialAdapter(materialPrim);
             if (materialAdapter) {
                 materialAdapter->Populate(materialPrim, index, nullptr);
+                // We need to register a dependency on the material prim so
+                // that geometry is updated when the material is
+                // (specifically, DirtyMaterialId).
+                // XXX: Eventually, it would be great to push this into hydra.
+                index->AddDependency(cachePath, materialPrim);
             }
         }
     }


### PR DESCRIPTION
### Description of Change(s)
This simple change replicates the logic (and code!) from https://github.com/PixarAnimationStudios/USD/blob/release/pxr/usdImaging/usdImaging/gprimAdapter.cpp#L159 which adds a dependency from the mesh to the material if the material was assigned to a GeomSubset.

### Fixes Issue(s)
- Fixes #1837


- [X] I have submitted a signed Contributor License Agreement
