### PR TITLE
added root selected check to printTreeWidget.py>ExpandItemRecursively()

### DIFF
--- a/pxr/usdImaging/usdviewq/primTreeWidget.py
+++ b/pxr/usdImaging/usdviewq/primTreeWidget.py
@@ -389,11 +389,12 @@ class PrimTreeWidget(QtWidgets.QTreeWidget):
         return col != PrimViewColumnIndex.VIS and col != PrimViewColumnIndex.DRAWMODE
 
     def ExpandItemRecursively(self, item):
-        item = item.parent()
-        while item.parent():
-            if not item.isExpanded():
-                self.expandItem(item)
+        if (item.parent() != None):        
             item = item.parent()
+            while item.parent():
+                if not item.isExpanded():
+                    self.expandItem(item)
+                item = item.parent()
 
     def FrameSelection(self):
         if (self._appController):


### PR DESCRIPTION
### Description of Change(s)
Added a check to see if item.parent() is valid in ExpandItemRecursively in [pxr/usdImaging/usdviewq/primTreeWidget.py](https://github.com/PixarAnimationStudios/USD/blob/release/pxr/usdImaging/usdviewq/primTreeWidget.py#L391)
### Fixes Issue(s)
-#1619 usdview traceback when focusing in tree view with root prim selected

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
