### PR TITLE
[cmake] fix FindOpenEXR.cmake so it can deal with windows debug libs with _d suffix

### DIFF
--- a/cmake/modules/FindOpenEXR.cmake
+++ b/cmake/modules/FindOpenEXR.cmake
@@ -51,25 +51,81 @@ foreach(OPENEXR_LIB
 
     # OpenEXR libraries may be suffixed with the version number, so we search
     # using both versioned and unversioned names.
-    set(DEBUG_POSTFIX )
-    if(DEFINED PXR_USE_DEBUG_BUILD)
-        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${PXR_USE_DEBUG_BUILD} MATCHES ON)
-            set(DEBUG_POSTFIX _d)
-        endif()
-    endif()
-    find_library(OPENEXR_${OPENEXR_LIB}_LIBRARY
+
+    find_library(OPENEXR_${OPENEXR_LIB}_LIBRARY_RELEASE
         NAMES
-            ${OPENEXR_LIB}-${OPENEXR_MAJOR_VERSION}_${OPENEXR_MINOR_VERSION}${DEBUG_POSTFIX}
-            ${OPENEXR_LIB}{DEBUG_POSTFIX}
+            ${OPENEXR_LIB}-${OPENEXR_MAJOR_VERSION}_${OPENEXR_MINOR_VERSION}
+            ${OPENEXR_LIB}
         HINTS
+            "${OPENEXR_RELEASE_LOCATION}"
+            "$ENV{OPENEXR_RELEASE_LOCATION}"
             "${OPENEXR_LOCATION}"
             "$ENV{OPENEXR_LOCATION}"
         PATH_SUFFIXES
             lib/
         DOC
-            "OPENEXR's ${OPENEXR_LIB} library path"
+            "OPENEXR's ${OPENEXR_LIB} release library path"
     )
 
+    # On MacOS and Windows, by default debug libs get a _d suffix
+    find_library(OPENEXR_${OPENEXR_LIB}_LIBRARY_DEBUG
+        NAMES
+            ${OPENEXR_LIB}-${OPENEXR_MAJOR_VERSION}_${OPENEXR_MINOR_VERSION}_d
+            ${OPENEXR_LIB}_d
+        HINTS
+            "${OPENEXR_DEBUG_LOCATION}"
+            "$ENV{OPENEXR_DEBUG_LOCATION}"
+            "${OPENEXR_LOCATION}"
+            "$ENV{OPENEXR_LOCATION}"
+        PATH_SUFFIXES
+            lib/
+        DOC
+            "OPENEXR's ${OPENEXR_LIB} debug library path"
+    )
+
+    # Figure out whether to use debug or release lib as "the" library
+
+    if(OPENEXR_${OPENEXR_LIB}_LIBRARY_RELEASE AND OPENEXR_${OPENEXR_LIB}_LIBRARY_DEBUG)
+        # both were found, decide which to use
+        if(DEFINED PXR_USE_DEBUG_BUILD)
+            if(PXR_USE_DEBUG_BUILD)
+                set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "DEBUG")
+            else()
+                set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "RELEASE")
+            endif()
+        else()
+            string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LOWER)
+            if(CMAKE_BUILD_TYPE_LOWER MATCHES "^(debug|relwithdebinfo)$")
+                set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "DEBUG")
+            else()
+                set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "RELEASE")
+            endif()
+        endif()
+    elseif(OPENEXR_${OPENEXR_LIB}_LIBRARY_RELEASE)
+        set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "RELEASE")
+    elseif(OPENEXR_${OPENEXR_LIB}_LIBRARY_DEBUG)
+        set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "DEBUG")
+    else()
+        set(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE "NOTFOUND")
+    endif()
+
+    if(OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE)
+        set(OPENEXR_${OPENEXR_LIB}_LIBRARY
+            "${OPENEXR_${OPENEXR_LIB}_LIBRARY_${OPENEXR_${OPENEXR_LIB}_LIBRARY_TYPE}}"
+            CACHE
+            FILEPATH
+            "OPENEXR's ${OPENEXR_LIB} library path"
+        )
+    else()
+        set(OPENEXR_${OPENEXR_LIB}_LIBRARY OPENEXR_${OPENEXR_LIB}_LIBRARY-NOTFOUND)
+    endif()
+
+    if(OPENEXR_${OPENEXR_LIB}_LIBRARY_RELEASE)
+        list(APPEND OPENEXR_LIBRARIES_RELEASE ${OPENEXR_${OPENEXR_LIB}_LIBRARY_RELEASE})
+    endif()
+    if(OPENEXR_${OPENEXR_LIB}_LIBRARY_DEBUG)
+        list(APPEND OPENEXR_LIBRARIES_DEBUG ${OPENEXR_${OPENEXR_LIB}_LIBRARY_DEBUG})
+    endif()
     if(OPENEXR_${OPENEXR_LIB}_LIBRARY)
         list(APPEND OPENEXR_LIBRARIES ${OPENEXR_${OPENEXR_LIB}_LIBRARY})
     endif()


### PR DESCRIPTION
### Description of Change(s)

Default debug builds of OpenEXR 2.3.0 on windows create libraries with a "_d" suffix. 

The current FindOpenEXR.cmake included with USD can't deal with this, and will therefore fail to find OpenEXR.  This happens even with the supplied `build_usd.py`, if you try to build in debug mode on windows.  This fix will work both with `build_usd.py`, and with cmake builds with a user supplied OpenEXR.

### Fixes Issue(s)
- USD can't find debug OpenEXR libs on windows

- [X] I have submitted a signed Contributor License Agreement
