### PR TITLE
[arch] remove ArchTestCrash(bool) declaration

### DIFF
--- a/pxr/base/arch/stackTrace.h
+++ b/pxr/base/arch/stackTrace.h
@@ -305,16 +305,6 @@ int ArchCrashHandlerSystemv(const char* pathname, char *const argv[],
 			    int timeout, ArchCrashHandlerSystemCB callback, 
 			    void* userData);
 
-/// Crash, to test crash behavior.
-///
-/// This function causes the calling program to crash by doing bad malloc 
-/// and free things.  If \c spawnthread is true, it spawns a thread which 
-/// remains alive during the crash.  It aborts if it fails to crash.
-///
-/// \private
-ARCH_API
-void ArchTestCrash(bool spawnthread);
-
 #if defined(ARCH_OS_DARWIN)
 // macOS has no ETIME. ECANCELED seems to have about the closest meaning to
 // the actual error here. The operation is timing out, not being explicitly


### PR DESCRIPTION
### Description of Change(s)

From the looks of things, `ArchTestCrash(bool)` was the original signature; then at some point it was changed to `ArchTestCrash(ArchTestCrashMode)` and moved to `testArchUtil`.  However it seems that the old declaration was left dangling (though implementation was removed).

### Fixes Issue(s)
- ArchTestCrash(bool) declared but not implemented

- [x] I have submitted a signed Contributor License Agreement
