### PR TITLE
Allow building usdBakeMtlx on windows.

### DIFF
--- a/pxr/usdImaging/bin/usdBakeMtlx/CMakeLists.txt
+++ b/pxr/usdImaging/bin/usdBakeMtlx/CMakeLists.txt
@@ -1,8 +1,3 @@
-if (WIN32)
-    message(WARNING "UsdBakeMtlx is not supported on Windows")
-    return()
-endif()
-
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdBakeMtlx)
 
@@ -21,6 +16,9 @@ pxr_library(usdBakeMtlx
         ${Boost_INCLUDE_DIRS}
         ${MATERIALX_INCLUDE_DIRS}
         ${PYTHON_INCLUDE_DIRS}
+
+    PUBLIC_HEADERS
+        api.h
 
     PUBLIC_CLASSES
         bakeMaterialX

--- a/pxr/usdImaging/bin/usdBakeMtlx/api.h
+++ b/pxr/usdImaging/bin/usdBakeMtlx/api.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_PLUGIN_USD_BAKEMTLX_API_H
+#define PXR_USD_PLUGIN_USD_BAKEMTLX_API_H
+
+#include "pxr/base/arch/export.h"
+
+#if defined(PXR_STATIC)
+#   define USDBAKEMTLX_API
+#   define USDBAKEMTLX_API_TEMPLATE_CLASS(...)
+#   define USDBAKEMTLX_API_TEMPLATE_STRUCT(...)
+#   define USDBAKEMTLX_LOCAL
+#else
+#   if defined(USDBAKEMTLX_EXPORTS)
+#       define USDBAKEMTLX_API ARCH_EXPORT
+#       define USDBAKEMTLX_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDBAKEMTLX_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#   else
+#       define USDBAKEMTLX_API ARCH_IMPORT
+#       define USDBAKEMTLX_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDBAKEMTLX_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   endif
+#   define USDBAKEMTLX_LOCAL ARCH_HIDDEN
+#endif
+
+#endif

--- a/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.h
+++ b/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.h
@@ -27,6 +27,7 @@
 
 #include "pxr/pxr.h"
 
+#include "pxr/usdImaging/bin/usdBakeMtlx/api.h"
 #include "pxr/imaging/hd/material.h"
 #include "pxr/usd/usdShade/material.h"
 
@@ -44,6 +45,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(UsdStage);
 
 /// Read the MaterialX XML file at \p pathname convert and add to
 /// the given USD \p stage.
+USDBAKEMTLX_API
 UsdStageRefPtr UsdBakeMtlxReadDocToStage(std::string const &pathname,
                                          UsdStageRefPtr stage);
 
@@ -51,6 +53,7 @@ UsdStageRefPtr UsdBakeMtlxReadDocToStage(std::string const &pathname,
 /// MaterialX Document and Bake it using MaterialX::TextureBaker, storing
 /// the resulting mtlx Document at \p bakedMtlxFilename. Any resulting 
 /// textures from the baking process will live in the same directory. 
+USDBAKEMTLX_API
 std::string UsdBakeMtlxBakeMaterial(
     UsdShadeMaterial const& mtlxMaterial,
     std::string const& bakedMtlxDir,


### PR DESCRIPTION
### Description of Change(s)
At the moment building the usdBakeMtlx binary is disabled on Windows. I made a few changes to the CMake file and added an api.h and marked a couple of functions to be exported from the library build in support of the python binary. With these changes I was able to build the library and binary. But I haven't had the chance to really test it, and I build USD in a custom environment, not using build_usd.py. And I was building against Mtls 1.38.4 using #1792.

So I'd really love some confirmation from anyone else building on Windows that this change actually works in isolation...

- [ X ] I have submitted a signed Contributor License Agreement
