### PR TITLE
Register velocities and acclerations on point instancer primitives as primvars

### DIFF
--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -33,6 +33,7 @@
 
 #include "pxr/imaging/hd/perfLog.h"
 #include "pxr/imaging/hd/renderIndex.h"
+#include "pxr/imaging/hd/tokens.h"
 #include "pxr/usd/sdf/schema.h"
 #include "pxr/usd/usd/primRange.h"
 #include "pxr/usd/usdGeom/imageable.h"
@@ -554,6 +555,18 @@ UsdImagingPointInstancerAdapter::TrackVariability(UsdPrim const& prim,
                     HdChangeTracker::DirtyPrimvar,
                     _tokens->instancer,
                     timeVaryingBits,
+                    false) ||
+            _IsVarying(prim,
+                    UsdGeomTokens->velocities,
+                    HdChangeTracker::DirtyPrimvar,
+                    _tokens->instancer,
+                    timeVaryingBits,
+                    false) ||
+            _IsVarying(prim,
+                    UsdGeomTokens->accelerations,
+                    HdChangeTracker::DirtyPrimvar,
+                    _tokens->instancer,
+                    timeVaryingBits,
                     false);
 
         if (!(*timeVaryingBits & HdChangeTracker::DirtyPrimvar)) {
@@ -602,9 +615,9 @@ UsdImagingPointInstancerAdapter::UpdateForTime(UsdPrim const& prim,
                 protoPrim, cachePath, time, requestedBits);
         }
     } else if (_instancerData.find(cachePath) != _instancerData.end()) {
-        // For the instancer itself, we only send translate, rotate and scale
-        // back as primvars, which all fall into the DirtyPrimvar bucket
-        // currently.
+        // For the instancer itself, we only send translate, rotate, scale,
+        // velocities, and accelerations back as primvars, which all fall into
+        // the DirtyPrimvar bucket currently.
         if (requestedBits & HdChangeTracker::DirtyPrimvar) {
             UsdGeomPointInstancer instancer(prim);
 
@@ -639,8 +652,24 @@ UsdImagingPointInstancerAdapter::UpdateForTime(UsdPrim const& prim,
                     HdInterpolationInstance);
             }
 
-            // Convert non-constant primvars on UsdGeomPointInstancer
-            // into instance-rate primvars. Note: this only gets local primvars.
+            VtVec3fArray velocities;
+            if (instancer.GetVelocitiesAttr().Get(&velocities, time)) {
+                _MergePrimvar(
+                    &vPrimvars,
+                    HdTokens->velocities,
+                    HdInterpolationInstance);
+            }
+
+            VtVec3fArray accelerations;
+            if (instancer.GetAccelerationsAttr().Get(&accelerations, time)) {
+                _MergePrimvar(
+                    &vPrimvars,
+                    HdTokens->accelerations,
+                    HdInterpolationInstance);
+            }
+
+            // Convert non-uniform primvars on UsdGeomPointInstancer into
+            // instance-rate primvars. Note: this only gets local primvars.
             // Inherited primvars don't vary per-instance, so we let the
             // prototypes pick them up.
             UsdGeomPrimvarsAPI primvars(instancer);
@@ -701,7 +730,9 @@ UsdImagingPointInstancerAdapter::ProcessPropertyChange(UsdPrim const& prim,
 
     if (propertyName == UsdGeomTokens->positions ||
         propertyName == UsdGeomTokens->orientations ||
-        propertyName == UsdGeomTokens->scales) {
+        propertyName == UsdGeomTokens->scales ||
+        propertyName == UsdGeomTokens->velocities ||
+        propertyName == UsdGeomTokens->accelerations) {
 
         TfToken primvarName = propertyName;
         if (propertyName == UsdGeomTokens->positions) {
@@ -710,6 +741,10 @@ UsdImagingPointInstancerAdapter::ProcessPropertyChange(UsdPrim const& prim,
             primvarName = _tokens->rotate;
         } else if (propertyName == UsdGeomTokens->scales) {
             primvarName = _tokens->scale;
+        } else if (propertyName == UsdGeomTokens->velocities) {
+            primvarName = HdTokens->velocities;
+        } else if (propertyName == UsdGeomTokens->accelerations) {
+            primvarName = HdTokens->accelerations;
         }
 
         return _ProcessNonPrefixedPrimvarPropertyChange(
@@ -1674,6 +1709,10 @@ UsdImagingPointInstancerAdapter::SamplePrimvar(
             usdKey = UsdGeomTokens->scales;
         } else if (key == _tokens->rotate) {
             usdKey = UsdGeomTokens->orientations;
+        } else if (key == HdTokens->velocities) {
+            usdKey = UsdGeomTokens->velocities;
+        } else if (key == HdTokens->accelerations) {
+            usdKey = UsdGeomTokens->accelerations;
         }
         return UsdImagingPrimAdapter::SamplePrimvar(
             usdPrim, cachePath, usdKey, time,
@@ -1906,6 +1945,20 @@ UsdImagingPointInstancerAdapter::Get(UsdPrim const& usdPrim,
             VtVec3fArray scales;
             if (instancer.GetScalesAttr().Get(&scales, time)) {
                 return VtValue(scales);
+            }
+
+        } else if (key == HdTokens->velocities) {
+            UsdGeomPointInstancer instancer(usdPrim);
+            VtVec3fArray velocities;
+            if (instancer.GetVelocitiesAttr().Get(&velocities, time)) {
+                return VtValue(velocities);
+            }
+
+        } else if (key == HdTokens->accelerations) {
+            UsdGeomPointInstancer instancer(usdPrim);
+            VtVec3fArray accelerations;
+            if (instancer.GetAccelerationsAttr().Get(&accelerations, time)) {
+                return VtValue(accelerations);
             }
 
         } else {


### PR DESCRIPTION
### Description of Change(s)

Register velocities and acclerations on point instancer primitives as hydra-accessible primvars.
I have not actually been able to test this change in isolation, other than confirming that it builds (since none of the standard USD render delegates have any interest in these attributes).

This is a trimmed down version of #1734 (which in turn is a trimmed down version of #1731).

- [ X ] I have submitted a signed Contributor License Agreement
