### PR TITLE
[Usdrecord] add aov and shadingMode args to usdrecord

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -99,7 +99,9 @@ def main():
     UsdAppUtils.complexityArgs.AddCmdlineArgs(parser)
     UsdAppUtils.colorArgs.AddCmdlineArgs(parser)
     UsdAppUtils.rendererArgs.AddCmdlineArgs(parser)
-
+    UsdAppUtils.aovArgs.AddCmdlineArgs(parser)
+    UsdAppUtils.shadingModeArgs.AddCmdlineArgs(parser)
+    
     parser.add_argument('--imageWidth', '-w', action='store', type=int,
         default=960,
         help=(
@@ -146,6 +148,8 @@ def main():
                 args.rendererPlugin))
     frameRecorder.SetImageWidth(args.imageWidth)
     frameRecorder.SetComplexity(args.complexity.value)
+    frameRecorder.SetAov(args.aov)
+    frameRecorder.SetShadingMode(args.shadingMode)
     frameRecorder.SetColorCorrectionMode(args.colorCorrectionMode)
     frameRecorder.SetIncludedPurposes(purposes)
 

--- a/pxr/usdImaging/usdAppUtils/CMakeLists.txt
+++ b/pxr/usdImaging/usdAppUtils/CMakeLists.txt
@@ -41,6 +41,8 @@ pxr_library(usdAppUtils
         __init__.py
         cameraArgs.py
         colorArgs.py
+        aovArgs.py
+        shadingModeArgs.py
         complexityArgs.py
         framesArgs.py
         rendererArgs.py

--- a/pxr/usdImaging/usdAppUtils/aovArgs.py
+++ b/pxr/usdImaging/usdAppUtils/aovArgs.py
@@ -22,14 +22,17 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from pxr import Tf
-Tf.PreparePythonModule()
-del Tf
+def AddCmdlineArgs(argsParser, defaultValue='color', altHelpText=''):
+    """
+    Adds output aov command line arguments to argsParser.
 
-from . import cameraArgs
-from . import colorArgs
-from . import aovArgs
-from . import shadingModeArgs
-from . import complexityArgs
-from . import framesArgs
-from . import rendererArgs
+    The resulting 'aov' argument will be a Python string.
+    """
+    helpText = altHelpText
+    if not helpText:
+        helpText = (
+            'the aov mode to use (default=%(default)s)')
+
+    aovChoices = ['color', 'depth', 'primId']
+    argsParser.add_argument('--aov', action='store',
+                            type=str, choices=aovChoices, default=defaultValue, help=helpText)

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -44,7 +44,6 @@
 
 #include <string>
 
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -52,6 +51,8 @@ UsdAppUtilsFrameRecorder::UsdAppUtilsFrameRecorder() :
     _imageWidth(960u),
     _complexity(1.0f),
     _colorCorrectionMode("disabled"),
+    _aov(HdAovTokens->color),
+    _shadingMode(UsdImagingGLDrawMode::DRAW_SHADED_SMOOTH),
     _purposes({UsdGeomTokens->default_, UsdGeomTokens->proxy})
 {
     GarchGLApiLoad();
@@ -82,6 +83,29 @@ UsdAppUtilsFrameRecorder::SetIncludedPurposes(const TfTokenVector& purposes)
                             p.GetText());
         }
     }
+}
+
+void 
+UsdAppUtilsFrameRecorder::SetShadingMode(const TfToken& shadingMode)
+{
+    if (shadingMode == "shaded_smooth")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_SHADED_SMOOTH;
+    else if(shadingMode == "geom_smooth")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_GEOM_SMOOTH;
+    else if(shadingMode == "points")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_POINTS;
+    else if(shadingMode == "wireframe")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_WIREFRAME;
+    else if (shadingMode == "wireframe_on_surface")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_WIREFRAME_ON_SURFACE;
+    else if (shadingMode == "shaded_flat")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_SHADED_FLAT;
+    else if (shadingMode == "geom_only")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_GEOM_ONLY;
+    else if (shadingMode == "geom_flat")
+        _shadingMode = UsdImagingGLDrawMode::DRAW_GEOM_FLAT;
+    else
+        TF_CODING_ERROR("Unrecognized shadingMode value '%s'", shadingMode.GetText());
 }
 
 static GfCamera
@@ -212,7 +236,7 @@ UsdAppUtilsFrameRecorder::Record(
     const GfFrustum frustum = gfCamera.GetFrustum();
     const GfVec3d cameraPos = frustum.GetPosition();
 
-    _imagingEngine.SetRendererAov(HdAovTokens->color);
+    _imagingEngine.SetRendererAov(_aov);
 
     _imagingEngine.SetCameraState(
         frustum.ComputeViewMatrix(),
@@ -247,6 +271,7 @@ UsdAppUtilsFrameRecorder::Record(
     renderParams.showProxy = _HasPurpose(_purposes, UsdGeomTokens->proxy);
     renderParams.showRender = _HasPurpose(_purposes, UsdGeomTokens->render);
     renderParams.showGuides = _HasPurpose(_purposes, UsdGeomTokens->guide);
+    renderParams.drawMode = _shadingMode;
 
     glEnable(GL_DEPTH_TEST);
     glViewport(0, 0, _imageWidth, imageHeight);

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -97,6 +97,20 @@ public:
         _colorCorrectionMode = colorCorrectionMode;
     }
 
+    /// Sets the output aov to be used for recording.
+    ///
+    /// By default, aov is "color"
+    USDAPPUTILS_API
+    void SetAov(const TfToken& aov){
+        _aov = aov;
+    }
+
+    /// Sets the output shadingMode to be used for recording.
+    ///
+    /// By default, shadingMode is "geom_smooth"
+    USDAPPUTILS_API
+    void SetShadingMode(const TfToken& shadingMode);
+
     /// Sets the UsdGeomImageable purposes to be used for rendering
     ///
     /// We will __always__ include "default" purpose, and by default,
@@ -128,6 +142,8 @@ private:
     size_t _imageWidth;
     float _complexity;
     TfToken _colorCorrectionMode;
+    TfToken _aov;
+    UsdImagingGLDrawMode _shadingMode;
     TfTokenVector _purposes;
 };
 

--- a/pxr/usdImaging/usdAppUtils/shadingModeArgs.py
+++ b/pxr/usdImaging/usdAppUtils/shadingModeArgs.py
@@ -22,14 +22,21 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from pxr import Tf
-Tf.PreparePythonModule()
-del Tf
+def AddCmdlineArgs(argsParser, defaultValue='shaded_smooth', altHelpText=''):
+    """
+    Adds output shadingMode command line arguments to argsParser.
 
-from . import cameraArgs
-from . import colorArgs
-from . import aovArgs
-from . import shadingModeArgs
-from . import complexityArgs
-from . import framesArgs
-from . import rendererArgs
+    The resulting 'shadingMode' argument will be a Python string.
+    """
+    helpText = altHelpText
+    if not helpText:
+        helpText = (
+            'the shading mode to use (default=%(default)s)')
+
+    shadingModeChoices = [ 'points', 'wireframe', 'wireframe_on_surface', 
+                        'shaded_flat', 'shaded_smooth', 'geom_only',
+                        'geom_flat', 'geom_smooth']
+    
+    argsParser.add_argument('--shadingMode','-sm', action='store',
+                            type=str, choices=shadingModeChoices, 
+                            default=defaultValue, help=helpText)

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -46,6 +46,8 @@ wrapFrameRecorder()
         .def("SetRendererPlugin", &This::SetRendererPlugin)
         .def("SetImageWidth", &This::SetImageWidth)
         .def("SetComplexity", &This::SetComplexity)
+        .def("SetAov", &This::SetAov)
+        .def("SetShadingMode", &This::SetShadingMode)
         .def("SetColorCorrectionMode", &This::SetColorCorrectionMode)
         .def("SetIncludedPurposes", &This::SetIncludedPurposes,
              (arg("purposes")))


### PR DESCRIPTION
### Description of Change(s)
Add aov, shadingMode args for usdrecord. Below is the help text.
```
  --aov {color,depth,primId}
                        the aov mode to use (default=color)
  --shadingMode {points,wireframe,wireframe_on_surface,shaded_flat,shaded_smooth,geom_only,geom_flat,geom_smooth}, -sm {points,wireframe,wireframe_on_surface,shaded_flat,shaded_smooth,geom_only,geom_flat,geom_smooth}
                        the shading mode to use (default=geom_smooth)
```

And followings are rendered images with new usdrecord.
depth aov
![aov_depth](https://user-images.githubusercontent.com/1808932/167285602-30740a00-bc61-420e-b780-4e490c685be9.jpg)

wireframe_on_surface shadingMode
![mode_wireframe_on_surface](https://user-images.githubusercontent.com/1808932/167285613-d1316f62-b976-4ac9-a894-4b2a7cbdc435.jpg)

geom_only shadingMode
![mode_geomonly](https://user-images.githubusercontent.com/1808932/167285606-fe270cf8-c396-4f38-a133-360284224c14.jpg)

wireframe_shadingMode
![mode_wireframe](https://user-images.githubusercontent.com/1808932/167285610-e9ae1ba6-e9a0-407b-ba3a-0cb29780d788.jpg)


### Fixes Issue(s)
-

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
