### PR TITLE
Return False when image diff file not found

### DIFF
--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -184,7 +184,7 @@ def _diff(fileName, baselineDir, verbose, failuresDir=None):
             "Error: could not files matching {0} to diff".format(fileName))
         return False
 
-    for fileToDiff in glob.glob(fileName):
+    for fileToDiff in filesToDiff:
         baselineFile = _resolvePath(baselineDir, fileToDiff)
         cmd = [diff, baselineFile, fileToDiff]
         if verbose:
@@ -229,7 +229,13 @@ def _imageDiff(fileName, baseLineDir, verbose, env, warn=None, warnpercent=None,
     if perceptual:
         cmdArgs.extend(['-p'])
 
-    for image in glob.glob(fileName):
+    filesToDiff = glob.glob(fileName)
+    if not filesToDiff:
+        sys.stderr.write(
+            "Error: could not files matching {0} to diff".format(fileName))
+        return False
+
+    for image in filesToDiff:
         cmd = [imageDiff]
         cmd.extend(cmdArgs)
         baselineImage = _resolvePath(baseLineDir, image)

--- a/pxr/usdImaging/bin/testusdview/CMakeLists.txt
+++ b/pxr/usdImaging/bin/testusdview/CMakeLists.txt
@@ -819,7 +819,6 @@ pxr_register_test(testUsdviewUpAxis_zUp
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewUpAxis_zUp.py testZUp.usda"
     IMAGE_DIFF_COMPARE
         zUp.png
-        yUp.png
     FAIL 1
     FAIL_PERCENT 0.0002
     PERCEPTUAL


### PR DESCRIPTION
### Description of Change(s)
In testWrapper.py _imageDiff, the test will pass if glob does not find the file. This change would make the test return False (fail) if this happens, so that the problem is not silently passed over. Also, in the _diff function in the same file, there is an unnecessary second call to glob, which this change would remove.

### Fixes Issue(s)
- _imageDiff function in testWrapper.py returns True (passes) when the file cannot be found
- _diff function in testWrapper.py makes an unncessary repeat call to glob.glob
- two tests that reference the wrong images have been fixed
- one test (testUsdImagingGLInstancing_nestedInstance) has been disabled, the test itself is failing

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
