### PR TITLE
APPLE: [HdSt] CPU cull optim, only rebuild batch if visibility changes

### DIFF
--- a/pxr/imaging/hdSt/drawItemInstance.cpp
+++ b/pxr/imaging/hdSt/drawItemInstance.cpp
@@ -43,9 +43,11 @@ HdStDrawItemInstance::~HdStDrawItemInstance()
 void
 HdStDrawItemInstance::SetVisible(bool visible)
 {
-    _visible = visible;
-    if(_batch) {
-        _batch->DrawItemInstanceChanged(this);
+    if (_visible != visible) {
+        _visible = visible;
+        if (_batch) {
+            _batch->DrawItemInstanceChanged(this);
+        }
     }
 }
 


### PR DESCRIPTION
### Description of Change(s)

- Check whether the state of the visible flag has changed before rebuilding the draw batches.

### Fixes Issue(s)
- Performance for CPU culling

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
