### PR TITLE
Avoid python3 warning about not properly closing a file.

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -348,11 +348,11 @@ class AppController(QtCore.QObject):
         smallFontSizeStr = "%spt" % str(smallSize)
 
         # Apply the style sheet to it
-        sheet = open(os.path.join(resourceDir, 'usdviewstyle.qss'), 'r')
-        sheetString = sheet.read() % {
-            'RESOURCE_DIR'  : resourceDir,
-            'BASE_FONT_SZ'  : baseFontSizeStr,
-            'SMALL_FONT_SZ' : smallFontSizeStr}
+        with open(os.path.join(resourceDir, 'usdviewstyle.qss'), 'r') as sheet:
+            sheetString = sheet.read() % {
+                'RESOURCE_DIR'  : resourceDir,
+                'BASE_FONT_SZ'  : baseFontSizeStr,
+                'SMALL_FONT_SZ' : smallFontSizeStr}
 
         app = QtWidgets.QApplication.instance()
         app.setStyleSheet(sheetString)


### PR DESCRIPTION
### Description of Change(s)

When running usdview in a python3 environment, a warning like the following could be output:
```
.....\python39\lib\site-packages\pxr\Usdviewq\appController.py:419: ResourceWarning: unclosed file <_io.TextIOWrapper name='...../python39/lib/site-packages/pxr/Usdviewq/usdviewstyle.q
ss' mode='r' encoding='cp65001'>
  self._setStyleSheetUsingState()
```

This change uses `with open as` to fix this problem.

- [ X ] I have submitted a signed Contributor License Agreement
