### PR TITLE
Fix Storm code generation from USD PreviewSurface for GLSL bindings to primvars

### DIFF
--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -5579,6 +5579,17 @@ HdSt_CodeGen::_GenerateShaderParameters(bool bindlessTextureEnabled)
                 << "\n}\n"
                 << "#define HD_HAS_" << it->second.name << " 1\n";
             
+            // Emit scalar accessors to support shading languages like MSL which
+            // do not support swizzle operators on scalar values.
+            if (_GetNumComponents(it->second.dataType) <= 4) {
+                accessors
+                    << _GetFlatType(it->second.dataType) << " HdGetScalar_"
+                    << it->second.name << "()"
+                    << " { return HdGet_" << it->second.name << "()"
+                    << _GetFlatTypeSwizzleString(it->second.dataType)
+                    << "; }\n";
+            }
+
             if (it->second.name == it->second.inPrimvars[0]) {
                 accessors
                     << "#endif\n";


### PR DESCRIPTION
### Description of Change(s)
Fix code generation for GLSL bindings to primvars. This type of binding was missing the definition of HdGetScalar_name to call HdGet_name.

I'm fairly out of my depth with this change, so I'm not sure if this is the right approach. But in the specific case of opacity reported in issue #1862, this change fixes the code generation and the material works as expected.

### Fixes Issue(s)
- #1862 

- [ X ] I have submitted a signed Contributor License Agreement
