### PR TITLE
Enable FIS lighting for MaterialX 1.38.3 and later

### DIFF
--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -78,8 +78,14 @@ _GenMaterialXShader(mx::GenContext & mxContext, mx::ElementPtr const& mxElem)
         materialContext.getOptions().hwShadowMap && !hasTransparency;
     
     // Use the domeLightPrefilter texture instead of sampling the Environment Map
+#ifdef MATERIALX_MAJOR_VERSION
+    // Enable FIS lighting starting with MaterialX 1.38.3
+    materialContext.getOptions().hwSpecularEnvironmentMethod =
+        mx::HwSpecularEnvironmentMethod::SPECULAR_ENVIRONMENT_FIS;
+#else
     materialContext.getOptions().hwSpecularEnvironmentMethod =
         mx::HwSpecularEnvironmentMethod::SPECULAR_ENVIRONMENT_PREFILTER;
+#endif
 
     return mx::createShader("Shader", materialContext, mxElem);
 }

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -600,6 +600,10 @@ HdStMaterialXShaderGen::_EmitMxInitFunction(
         emitLine("u_envRadiance = HdGetSampler_domeLightPrefilter()", mxStage);
     }
     emitLine("u_envRadianceMips = textureQueryLevels(u_envRadiance)", mxStage);
+#ifdef MATERIALX_MAJOR_VERSION
+    // Enable FIS lighting starting with MaterialX 1.38.3
+    emitLine("u_envRadianceSamples = 64", mxStage);
+#endif
     emitLine("#endif", mxStage, false);
     emitLineBreak(mxStage);
 


### PR DESCRIPTION
### Description of Change(s)
Enable FIS lighting for MaterialX 1.38.3 and later

Please refer to a previous PR #1792 where this fix was discussed and asked to be placed in a separate PR.



<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
