### PR TITLE
Fix Windows file existence check to prevent errors when creating new .usd files

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -88,7 +88,9 @@ Tf_HasAttribute(
     const DWORD attribs =
         GetFileAttributesW(ArchWindowsUtf8ToUtf16(path).c_str());
     if (attribs == INVALID_FILE_ATTRIBUTES) {
-        if (attribute == 0 && GetLastError() == ERROR_FILE_NOT_FOUND) {
+        if (attribute == 0 &&
+            (GetLastError() == ERROR_FILE_NOT_FOUND ||
+             GetLastError() == ERROR_PATH_NOT_FOUND)) {
             // Don't report an error if we're just testing existence.
             SetLastError(ERROR_SUCCESS);
         }


### PR DESCRIPTION
### Description of Change(s)
When testing for the existance of a file on Windows, we want to clear the
error state if the system complains with either ERROR_FILE_NOT_FOUND _or_
ERROR_PATH_NOT_FOUND. These two errors together are equivalent to ENOENT
on Linux, which is the equivalent check that happens on that OS when
calling TfPathExists.

### Fixes Issue(s)
- #1870 

- [ X ] I have submitted a signed Contributor License Agreement
