### PR TITLE
Crash when reporting invalid instance

### DIFF
--- a/pxr/usd/usd/primData.cpp
+++ b/pxr/usd/usd/primData.cpp
@@ -239,7 +239,7 @@ Usd_DescribePrimData(const Usd_PrimData *p, SdfPath const &proxyPrimPath)
         isInstanceProxy ? proxyPrimPath.GetText() : p->_path.GetText(),
         (isInstanceProxy || isInstance) ? TfStringPrintf(
             "with prototype <%s> ", isInstance ?
-            prototypeForInstance->GetPath().GetText() :
+            (prototypeForInstance ? prototypeForInstance->GetPath().GetText() : "unknown prototype") :
             p->_path.GetText()).c_str() : "",
         (isInstanceProxy || isPrototype || isInPrototype) ? TfStringPrintf(
             "using prim index <%s> ",


### PR DESCRIPTION
### Description of Change(s)
When an invalid prim spec is used for an instance on a stage that is no longer
valid, the prototype-for-instance pointer would be null yet would be traversed.
So instead of a an exception being thrown, we would get a crash. The fix checks
the pointer before using it.
### Fixes Issue(s)
Crash when reporting invalid instance

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
