### PR TITLE
Apple Silicon Support

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+import sys
+import locale
+import os
+import shlex
+import subprocess
+
+def GetLocale():
+    return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
+
+def GetCommandOutput(command):
+    """Executes the specified command and returns output or None."""
+    try:
+        return subprocess.check_output(
+            shlex.split(command), 
+            stderr=subprocess.STDOUT).decode(GetLocale(), 'replace').strip()
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+def GetMacArmArch():
+    return os.environ.get('MACOS_ARM_ARCHITECTURE') or "arm64"
+
+def GetMacArch():
+    macArch = GetCommandOutput('arch').strip()
+    if macArch == "i386" or macArch == "x86_64":
+        macArch = "x86_64"
+    else:
+        macArch = GetMacArmArch()
+    return macArch
+
+devout = open(os.devnull, 'w')
+
+def ExtractFilesRecursive(path, cond):
+    files = []
+    for r, d, f in os.walk(path):
+        for file in f:
+            if cond(os.path.join(r,file)):
+                files.append(os.path.join(r, file))
+    return files
+
+def CodesignFiles(files):
+    SDKVersion  = subprocess.check_output(['xcodebuild', '-version']).strip()[6:10]
+    codeSignIDs = subprocess.check_output(['security', 'find-identity', '-vp', 'codesigning'])
+
+    codeSignID = "-"
+    if os.environ.get('CODE_SIGN_ID'):
+        codeSignID = os.environ.get('CODE_SIGN_ID')
+    elif float(SDKVersion) >= 11.0 and codeSignIDs.find(b'Apple Development') != -1:
+        codeSignID = "Apple Development"
+    elif codeSignIDs.find(b'Mac Developer') != -1:
+        codeSignID = "Mac Developer"
+        
+    for f in files:
+        subprocess.call(['codesign', '-f', '-s', '{codesignid}'
+              .format(codesignid=codeSignID), f],
+              stdout=devout, stderr=devout)
+
+def Codesign(install_path, verbose_output=False):
+    if verbose_output:
+        global devout
+        devout = sys.stdout
+
+    files = ExtractFilesRecursive(install_path, 
+                 (lambda file: '.so' in file or '.dylib' in file))
+    CodesignFiles(files)

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -43,6 +43,7 @@ import sys
 import sysconfig
 import tarfile
 import zipfile
+import apple_utils
 
 if sys.version_info.major >= 3:
     from urllib.request import urlopen
@@ -90,8 +91,6 @@ def Linux():
     return platform.system() == "Linux"
 def MacOS():
     return platform.system() == "Darwin"
-def Arm():
-    return platform.processor() == "arm"
 
 def Python3():
     return sys.version_info.major == 3
@@ -887,9 +886,10 @@ def InstallTBB_LinuxOrMacOS(context, force, buildArgs):
         AppendCXX11ABIArg("CXXFLAGS", context, buildArgs)
 
         # Ensure that the tbb build system picks the proper architecture.
-        if MacOS() and Arm():
-            buildArgs.append("arch=arm64")
-
+        if MacOS():
+            if apple_utils.GetMacArch() != "x86_64":
+                buildArgs.append("arch=arm64")
+              
         # TBB does not support out-of-source builds in a custom location.
         Run('make -j{procs} {buildArgs}'
             .format(procs=context.numJobs, 
@@ -983,13 +983,12 @@ TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")
 PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.29.tar.gz"
 
 def InstallPNG(context, force, buildArgs):
-    macArgs = []
-    if MacOS() and Arm():
-        # ensure libpng's build doesn't erroneously activate inappropriate
-        # Neon extensions
-        macArgs = ["-DPNG_HARDWARE_OPTIMIZATIONS=OFF", 
-                   "-DPNG_ARM_NEON=off"] # case is significant
     with CurrentWorkingDirectory(DownloadURL(PNG_URL, context, force)):
+        macArgs = []
+        if MacOS() and apple_utils.GetMacArch() != "x86_64":
+            # Ensure libpng's build doesn't erroneously activate inappropriate
+            # Neon extensions
+            macArgs = ["-DCMAKE_C_FLAGS=\"-DPNG_ARM_NEON_OPT=0\""]
         RunCMake(context, force, buildArgs + macArgs)
 
 PNG = Dependency("PNG", InstallPNG, "include/png.h")
@@ -1080,7 +1079,11 @@ BLOSC_URL = "https://github.com/Blosc/c-blosc/archive/v1.20.1.zip"
 
 def InstallBLOSC(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(BLOSC_URL, context, force)):
-        RunCMake(context, force, buildArgs)
+        macArgs = []
+        if MacOS() and apple_utils.GetMacArch() != "x86_64":
+            # Need to disable SSE for macOS ARM targets.
+            macArgs = ["-DDEACTIVATE_SSE2=ON"]
+        RunCMake(context, force, buildArgs + macArgs)
 
 BLOSC = Dependency("Blosc", InstallBLOSC, "include/blosc.h")
 
@@ -1187,6 +1190,21 @@ def InstallOpenColorIO(context, force, buildArgs):
                       [("IMPORTED_LOCATION_RELEASE", 
                         "IMPORTED_LOCATION_RELWITHDEBINFO")])
 
+        if MacOS():
+            arch = apple_utils.GetMacArch()
+
+            PatchFile("CMakeLists.txt",
+                    [('CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}',
+                    'CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}\n' +
+                    '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
+                    ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=arch)),
+                    ('CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}',
+                    'CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}\n' +
+                    '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
+                    ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=arch)),
+                    ('set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING',
+                     'set(CMAKE_OSX_ARCHITECTURES "{arch}" CACHE STRING'.format(arch=arch))])
+            
         # The OCIO build treats all warnings as errors but several come up
         # on various platforms, including:
         # - On gcc6, v1.1.0 emits many -Wdeprecated-declaration warnings for
@@ -1204,6 +1222,16 @@ def InstallOpenColorIO(context, force, buildArgs):
             pass
         else:
             extraArgs.append('-DCMAKE_CXX_FLAGS=-w')
+		
+        if MacOS():
+            #if using version 2 of OCIO we patch a different config path as it resides elsewere
+            PatchFile("src/core/Config.cpp",
+                       [("cacheidnocontext_ = cacheidnocontext_;", 
+                         "cacheidnocontext_ = rhs.cacheidnocontext_;")])
+
+            extraArgs.append('-DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-unused-const-variable -Wno-unused-private-field"')
+            if (apple_utils.GetMacArch() != "x86_64"):
+                extraArgs.append('-DOCIO_USE_SSE=OFF')
 
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
@@ -1304,16 +1332,26 @@ def GetPySideInstructions():
                 'If PySide is already installed, you may need to '
                 'update your PYTHONPATH to indicate where it is '
                 'located.')
-    else:                       
-        return ('PySide2 is not installed. If you have pip '
+    elif MacOS():
+        # PySide6 is required for Apple Silicon support, so is the default
+        # across all macOS hardware platforms.
+        return ('PySide6 is not installed. If you have pip '
+                'installed, run "pip install PySide6" '
+                'to install it, then re-run this script.\n'
+                'If PySide6 is already installed, you may need to '
+                'update your PYTHONPATH to indicate where it is '
+                'located.')
+    else:
+        return ('PySide2 or PySide6 are not installed. If you have pip '
                 'installed, run "pip install PySide2" '
                 'to install it, then re-run this script.\n'
                 'If PySide2 is already installed, you may need to '
                 'update your PYTHONPATH to indicate where it is '
                 'located.')
 
+
 PYSIDE = PythonDependency("PySide", GetPySideInstructions,
-                          moduleNames=["PySide", "PySide2"])
+                          moduleNames=["PySide", "PySide2", "PySide6"])
 
 ############################################################
 # HDF5
@@ -1336,6 +1374,10 @@ ALEMBIC_URL = "https://github.com/alembic/alembic/archive/1.7.10.zip"
 
 def InstallAlembic(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ALEMBIC_URL, context, force)):
+        if MacOS():
+            PatchFile("CMakeLists.txt", 
+                      [("ADD_DEFINITIONS(-Wall -Werror -Wextra -Wno-unused-parameter)",
+                        "ADD_DEFINITIONS(-Wall -Wextra -Wno-unused-parameter)")])
         cmakeOptions = ['-DUSE_BINARIES=OFF', '-DUSE_TESTS=OFF']
         if context.enableHDF5:
             # HDF5 requires the H5_BUILT_AS_DYNAMIC_LIB macro be defined if
@@ -1389,10 +1431,10 @@ MATERIALX = Dependency("MaterialX", InstallMaterialX, "include/MaterialXCore/Lib
 
 ############################################################
 # Embree
-# For MacOS we use version 3.7.0 to include a fix from Intel
-# to build on Catalina.
+# For MacOS we use version 3.13.3 to include a fix from Intel
+# to build on Apple Silicon.
 if MacOS():
-    EMBREE_URL = "https://github.com/embree/embree/archive/v3.7.0.tar.gz"
+    EMBREE_URL = "https://github.com/embree/embree/archive/v3.13.3.tar.gz"
 else:
     EMBREE_URL = "https://github.com/embree/embree/archive/v3.2.2.tar.gz"
 
@@ -1703,6 +1745,10 @@ group.add_argument("--generator", type=str,
 group.add_argument("--toolset", type=str,
                    help=("CMake toolset to use when building libraries with "
                          "cmake"))
+if MacOS():
+    codesignDefault = False if apple_utils.GetMacArch() == "x64_64" else True
+    group.add_argument("--codesign", dest="macos_codesign", default=codesignDefault,
+                       help=("Use codesigning for macOS builds (defaults to enabled on Apple Silicon)"))
 
 if Linux():
     group.add_argument("--use-cxx11-abi", type=int, choices=[0, 1],
@@ -1953,6 +1999,8 @@ class InstallContext:
         self.useCXX11ABI = \
             (args.use_cxx11_abi if hasattr(args, "use_cxx11_abi") else None)
         self.safetyFirst = args.safety_first
+        self.macOSCodesign = \
+            (args.macos_codesign if hasattr(args, "macos_codesign") else False)
 
         # Dependencies that are forced to be built
         self.forceBuildAll = args.force_all
@@ -2160,11 +2208,13 @@ if PYSIDE in requiredDependencies:
     # The USD build will skip building usdview if pyside2-uic or pyside-uic is
     # not found, so check for it here to avoid confusing users. This list of 
     # PySide executable names comes from cmake/modules/FindPySide.cmake
+    pyside6Uic = ["pyside6-uic", "uic"]
+    found_pyside6Uic = any([which(p) for p in pyside6Uic])
     pyside2Uic = ["pyside2-uic", "python2-pyside2-uic", "pyside2-uic-2.7", "uic"]
     found_pyside2Uic = any([which(p) for p in pyside2Uic])
     pysideUic = ["pyside-uic", "python2-pyside-uic", "pyside-uic-2.7"]
     found_pysideUic = any([which(p) for p in pysideUic])
-    if not given_pysideUic and not found_pyside2Uic and not found_pysideUic:
+    if not given_pysideUic and not found_pyside2Uic and not found_pysideUic and not found_pyside6Uic:
         if Windows():
             # Windows does not support PySide2 with Python2.7
             PrintError("pyside-uic not found -- please install PySide and"
@@ -2172,10 +2222,10 @@ if PYSIDE in requiredDependencies:
                        " {0} depending on your platform)"
                    .format(" or ".join(pysideUic)))
         else:
-            PrintError("pyside2-uic not found -- please install PySide2 and"
+            PrintError("uic not found-- please install PySide2 or PySide6 and"
                        " adjust your PATH. (Note that this program may be"
                        " named {0} depending on your platform)"
-                       .format(" or ".join(pyside2Uic)))
+                       .format(" or ".join(set(pyside2Uic+pyside6Uic))))
         sys.exit(1)
 
 if JPEG in requiredDependencies:
@@ -2266,6 +2316,7 @@ summaryMsg = summaryMsg.format(
                   else "Release w/ Debug Info" if context.buildRelWithDebug
                   else ""),
     buildImaging=("On" if context.buildImaging else "Off"),
+    macOSCodesign=("On" if context.macOSCodesign else "Off"),
     enablePtex=("On" if context.enablePtex else "Off"),
     enableOpenVDB=("On" if context.enableOpenVDB else "Off"),
     buildOIIO=("On" if context.buildOIIO else "Off"),
@@ -2344,6 +2395,10 @@ if Windows():
         os.path.join(context.instDir, "bin"),
         os.path.join(context.instDir, "lib")
     ])
+
+if MacOS():
+    if context.macOSCodesign:
+        apple_utils.Codesign(context.usdInstDir, verbosity > 1)
 
 Print("""
 Success! To use USD, please ensure that you have:""")

--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -26,15 +26,27 @@ if (NOT PYTHON_EXECUTABLE)
     return()
 endif()
 
-# Prefer PySide2 over PySide
+# Prefer PySide6 over PySide2 and PySide
 # Note: Windows does not support PySide2 with Python2.7
 execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" "-c" "import PySide2"
+    COMMAND "${PYTHON_EXECUTABLE}" "-c" "import PySide6"
     RESULT_VARIABLE pySideImportResult 
 )
 if (pySideImportResult EQUAL 0)
-    set(pySideImportResult "PySide2")
-    set(pySideUIC pyside2-uic python2-pyside2-uic pyside2-uic-2.7 uic)
+    set(pySideImportResult "PySide6")
+    set(pySideUIC pyside6-uic python3-pyside6-uic uic)
+endif()
+
+# PySide6 not found
+if (pySideImportResult EQUAL 1)
+    execute_process(
+        COMMAND "${PYTHON_EXECUTABLE}" "-c" "import PySide2"
+        RESULT_VARIABLE pySideImportResult 
+    )
+    if (pySideImportResult EQUAL 0)
+        set(pySideImportResult "PySide2")
+        set(pySideUIC pyside2-uic python2-pyside2-uic pyside2-uic-2.7 uic)
+    endif()
 endif()
 
 # PySide2 not found OR PYSIDE explicitly requested
@@ -66,6 +78,8 @@ if (pySideImportResult)
 else()
     if (PYSIDE_USE_PYSIDE)
         message(STATUS "Did not find PySide with ${PYTHON_EXECUTABLE}")
+    elseif (PYSIDE_USE_PYSIDE6)
+        message(STATUS "Did not find PySide6 with ${PYTHON_EXECUTABLE}")
     else()
         message(STATUS "Did not find PySide2 with ${PYTHON_EXECUTABLE}")
     endif()

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -28,7 +28,7 @@ from __future__ import division
 from __future__ import print_function
 
 # Qt Components
-from .qt import QtCore, QtGui, QtWidgets
+from .qt import QtCore, QtGui, QtWidgets, QtActionWidgets
 
 # Stdlib components
 import re, sys, os, cProfile, pstats, traceback
@@ -616,7 +616,7 @@ class AppController(QtCore.QObject):
             self._ui.frameSlider.setTracking(
                     self._dataModel.viewSettings.redrawOnScrub)
 
-            self._ui.colorGroup = QtWidgets.QActionGroup(self)
+            self._ui.colorGroup = QtActionWidgets.QActionGroup(self)
             self._ui.colorGroup.setExclusive(True)
             self._clearColorActions = (
                 self._ui.actionBlack,
@@ -626,7 +626,7 @@ class AppController(QtCore.QObject):
             for action in self._clearColorActions:
                 self._ui.colorGroup.addAction(action)
 
-            self._ui.renderModeActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.renderModeActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.renderModeActionGroup.setExclusive(True)
             self._renderModeActions = (
                 self._ui.actionWireframe,
@@ -641,7 +641,7 @@ class AppController(QtCore.QObject):
             for action in self._renderModeActions:
                 self._ui.renderModeActionGroup.addAction(action)
 
-            self._ui.colorCorrectionActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.colorCorrectionActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.colorCorrectionActionGroup.setExclusive(True)
             self._colorCorrectionActions = (
                 self._ui.actionNoColorCorrection,
@@ -662,7 +662,7 @@ class AppController(QtCore.QObject):
                             self._dataModel.viewSettings.renderMode, fallback))
                 self._dataModel.viewSettings.renderMode = fallback
 
-            self._ui.pickModeActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.pickModeActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.pickModeActionGroup.setExclusive(True)
             self._pickModeActions = (
                 self._ui.actionPick_Prims,
@@ -679,7 +679,7 @@ class AppController(QtCore.QObject):
                             self._dataModel.viewSettings.pickMode, fallback))
                 self._dataModel.viewSettings.pickMode = fallback
 
-            self._ui.selHighlightModeActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.selHighlightModeActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.selHighlightModeActionGroup.setExclusive(True)
             self._selHighlightActions = (
                 self._ui.actionNever,
@@ -688,7 +688,7 @@ class AppController(QtCore.QObject):
             for action in self._selHighlightActions:
                 self._ui.selHighlightModeActionGroup.addAction(action)
 
-            self._ui.highlightColorActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.highlightColorActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.highlightColorActionGroup.setExclusive(True)
             self._selHighlightColorActions = (
                 self._ui.actionSelYellow,
@@ -697,7 +697,7 @@ class AppController(QtCore.QObject):
             for action in self._selHighlightColorActions:
                 self._ui.highlightColorActionGroup.addAction(action)
 
-            self._ui.interpolationActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.interpolationActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.interpolationActionGroup.setExclusive(True)
             for interpolationType in Usd.InterpolationType.allValues:
                 action = self._ui.menuInterpolation.addAction(interpolationType.displayName)
@@ -706,7 +706,7 @@ class AppController(QtCore.QObject):
                     self._dataModel.stage.GetInterpolationType() == interpolationType)
                 self._ui.interpolationActionGroup.addAction(action)
 
-            self._ui.primViewDepthGroup = QtWidgets.QActionGroup(self)
+            self._ui.primViewDepthGroup = QtActionWidgets.QActionGroup(self)
             for i in range(1, 9):
                 action = getattr(self._ui, "actionLevel_" + str(i))
                 self._ui.primViewDepthGroup.addAction(action)
@@ -880,7 +880,7 @@ class AppController(QtCore.QObject):
 
             self._ui.actionToggle_Framed_View.triggered.connect(self._toggleFramedView)
 
-            self._ui.complexityGroup = QtWidgets.QActionGroup(self._mainWindow)
+            self._ui.complexityGroup = QtActionWidgets.QActionGroup(self._mainWindow)
             self._ui.complexityGroup.setExclusive(True)
             self._complexityActions = (
                 self._ui.actionLow,
@@ -1434,7 +1434,7 @@ class AppController(QtCore.QObject):
 
     def _configureRendererPlugins(self):
         if self._stageView:
-            self._ui.rendererPluginActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.rendererPluginActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.rendererPluginActionGroup.setExclusive(True)
 
             pluginTypes = self._stageView.GetRendererPlugins()
@@ -1478,7 +1478,7 @@ class AppController(QtCore.QObject):
 
     def _configureRendererAovs(self):
         if self._stageView:
-            self._ui.rendererAovActionGroup = QtWidgets.QActionGroup(self)
+            self._ui.rendererAovActionGroup = QtActionWidgets.QActionGroup(self)
             self._ui.rendererAovActionGroup.setExclusive(True)
             self._ui.menuRendererAovs.clear()
 
@@ -1769,7 +1769,7 @@ class AppController(QtCore.QObject):
             addLabelSeparator("<i> Displays </i>", ocioMenu)
             for d in displays:
                 displayMenu = QtWidgets.QMenu(d)
-                group = QtWidgets.QActionGroup(displayMenu)
+                group = QtActionWidgets.QActionGroup(displayMenu)
                 group.setExclusive(True)
 
                 for v in config.getViews(d):
@@ -1784,7 +1784,7 @@ class AppController(QtCore.QObject):
         if colorSpaces:
             ocioMenu.addSeparator()
             addLabelSeparator("<i> Colorspaces </i>", ocioMenu)
-            group = QtWidgets.QActionGroup(ocioMenu)
+            group = QtActionWidgets.QActionGroup(ocioMenu)
             group.setExclusive(True)
             for cs in colorSpaces:
                 colorSpace = cs.getName()

--- a/pxr/usdImaging/usdviewq/qt.py
+++ b/pxr/usdImaging/usdviewq/qt.py
@@ -71,13 +71,101 @@ if PySideModule == 'PySide':
     if not hasattr(QtCore, 'QStringListModel'):
         QtCore.QStringListModel = QtGui.QStringListModel
 
+    def isContextInitialised(self):
+        return self.context().initialized()
+    
+    QGLWidget.isContextInitialised = isContextInitialised
+
+    def bindTexture(self, qimage):
+        from OpenGL import GL
+        tex = self.bindTexture(qimage, GL.GL_TEXTURE_2D, GL.GL_RGBA,
+                               QtOpenGL.QGLContext.NoBindOption)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, tex)
+
+        return tex
+
+    def releaseTexture(self, tex):
+        from OpenGL import GL
+        GL.glDeleteTextures(tex)
+
+    QGLWidget.BindTexture = bindTexture
+    QGLWidget.ReleaseTexture = releaseTexture
+
+    def initQGLWidget(self, glFormat, parent):
+        QGLWidget.__init__(self, glFormat, parent)
+
+    QGLWidget.InitQGLWidget = initQGLWidget
+
 elif PySideModule == 'PySide2':
     from PySide2 import QtCore, QtGui, QtWidgets, QtOpenGL
+    from PySide2.QtOpenGL import QGLWidget as QGLWidget
+    from PySide2.QtOpenGL import QGLFormat as QGLFormat
+    from PySide2 import QtWidgets as QtActionWidgets
     
     # Older versions still have QtGui.QStringListModel - this
     # is apparently a bug:
     #    https://bugreports.qt.io/browse/PYSIDE-614
     if not hasattr(QtCore, 'QStringListModel'):
         QtCore.QStringListModel = QtGui.QStringListModel
+
+    def isContextInitialised(self):
+        return self.context().initialized()
+    
+    QGLWidget.isContextInitialised = isContextInitialised
+
+    def bindTexture(self, qimage):
+        from OpenGL import GL
+        tex = self.bindTexture(qimage, GL.GL_TEXTURE_2D, GL.GL_RGBA,
+                               QtOpenGL.QGLContext.NoBindOption)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, tex)
+
+        return tex
+
+    def releaseTexture(self, tex):
+        from OpenGL import GL
+        GL.glDeleteTextures(tex)
+
+    QGLWidget.BindTexture = bindTexture
+    QGLWidget.ReleaseTexture = releaseTexture
+
+    def initQGLWidget(self, glFormat, parent):
+        QGLWidget.__init__(self, glFormat, parent)
+
+    QGLWidget.InitQGLWidget = initQGLWidget
+
+elif PySideModule == 'PySide6':
+    from PySide6 import QtCore, QtGui, QtWidgets, QtOpenGL
+    from PySide6.QtOpenGLWidgets import QOpenGLWidget as QGLWidget
+    from PySide6.QtGui import QSurfaceFormat as QGLFormat
+    from PySide6 import QtGui as QtActionWidgets
+
+    def isContextInitialised(self):
+        return True
+
+    QGLWidget.isContextInitialised = isContextInitialised
+
+    QGLWidget.updateGL = QGLWidget.update
+
+    def bindTexture(self, qimage):
+        tex = QtOpenGL.QOpenGLTexture(qimage)
+        tex.bind()
+        return tex
+
+    def releaseTexture(self, tex):
+        tex.release()
+        tex.destroy()
+
+    QGLWidget.BindTexture = bindTexture
+    QGLWidget.ReleaseTexture = releaseTexture
+
+    if not hasattr(QGLFormat, 'setSampleBuffers'):
+        QGLFormat.setSampleBuffers = lambda self, _: None
+
+    def initQGLWidget(self, glFormat, parent):
+        QGLWidget.__init__(self)
+        self.setFormat(glFormat)
+
+    QGLWidget.InitQGLWidget = initQGLWidget
+
 else:
     raise ImportError('Unrecognized PySide module "{}"'.format(PySideModule))


### PR DESCRIPTION
### Description of Change(s)

Builds on the work in https://github.com/PixarAnimationStudios/USD/pull/1898 which adds PySide6 support.

Enables native Apple Silicon support for Hydra-Storm.  This includes applications which usd PySide bindings such as usdview as well as applications that link in USD directly.

To build usdview on Apple Silicon it is necessary to install PySide6, the changes for this have now been isolated to https://github.com/PixarAnimationStudios/USD/pull/1898

Embree upgraded to 3.13.2 to support Apple Silicon

Thanks to the rest of the team at Apple for this work.

Tested On:
Built with the following options: `--ptex --openvdb --openimageio --opencolorio --alembic --draco --hdf5 --embree --tests`
- macOS Catalina, Big Sur and Monterey on Intel architecture.  With and without PySide2 installed.
- macOS Big Sur and Monterey on M1 and M1Pro architectures.  With and without PySide2 installed next to PySide6.
- Ubuntu 21.04 with and without PySide2 installed next to PySide6.

Known Limitations:
- No support for cross compilation between Intel and Apple Silicon.
- No support for universal binaries.


### Fixes Issue(s)
- Native Apple Silicon support

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
