### PR TITLE
[HGI] Cleanup of vertex bindings, split off HgiMetal step functions

### DIFF
--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -400,7 +400,7 @@ HdSt_TextureTestDriver::Draw(HgiTextureHandle const &colorDst,
     gfxCmds->PushDebugGroup("Debug HdSt_TextureTestDriver");
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
-    gfxCmds->BindVertexBuffers(0, {_vertexBuffer}, {0});
+    gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
     gfxCmds->SetViewport(viewport);
     gfxCmds->SetConstantValues(_pipeline, HgiShaderStageFragment, 0, 
         _constantsData.size(), _constantsData.data());

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -487,7 +487,7 @@ HdxColorCorrectionTask::_ApplyColorCorrection(
     gfxCmds->PushDebugGroup("ColorCorrection");
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
-    gfxCmds->BindVertexBuffers(0, {_vertexBuffer}, {0});
+    gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
     const GfVec4i vp(0, 0, dimensions[0], dimensions[1]);
     _screenSize[0] = static_cast<float>(dimensions[0]);
     _screenSize[1] = static_cast<float>(dimensions[1]);

--- a/pxr/imaging/hdx/fullscreenShader.cpp
+++ b/pxr/imaging/hdx/fullscreenShader.cpp
@@ -688,7 +688,7 @@ HdxFullscreenShader::_Draw(
     gfxCmds->PushDebugGroup(_debugName.c_str());
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
-    gfxCmds->BindVertexBuffers(0, {_vertexBuffer}, {0});
+    gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
     gfxCmds->SetViewport(viewport);
 
     if (!_constantsData.empty()) {

--- a/pxr/imaging/hdx/visualizeAovTask.cpp
+++ b/pxr/imaging/hdx/visualizeAovTask.cpp
@@ -510,7 +510,7 @@ HdxVisualizeAovTask::_ApplyVisualizationKernel(
     gfxCmds->PushDebugGroup("Visualize AOV");
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
-    gfxCmds->BindVertexBuffers(0, {_vertexBuffer}, {0});
+    gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
     const GfVec4i vp(0, 0, dimensions[0], dimensions[1]);
     _screenSize[0] = static_cast<float>(dimensions[0]);
     _screenSize[1] = static_cast<float>(dimensions[1]);

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -99,14 +99,9 @@ public:
         const void* data) = 0;
 
     /// Binds the vertex buffer(s) that describe the vertex attributes.
-    /// `firstBinding` the first index to which buffers are bound (usually 0).
-    /// `byteOffsets` offset to where the data of each buffer starts, in bytes.
-    /// `strides` the size of a vertex in each of the buffers.
     HGI_API
     virtual void BindVertexBuffers(
-        uint32_t firstBinding,
-        HgiBufferHandleVector const& buffers,
-        std::vector<uint32_t> const& byteOffsets) = 0;
+        HgiVertexBufferBindingVector const &bindings) = 0;
 
     /// Records a draw command that renders one or more instances of primitives
     /// using the number of vertices provided.

--- a/pxr/imaging/hgi/resourceBindings.h
+++ b/pxr/imaging/hgi/resourceBindings.h
@@ -206,6 +206,25 @@ private:
 using HgiResourceBindingsHandle = HgiHandle<HgiResourceBindings>;
 using HgiResourceBindingsHandleVector = std::vector<HgiResourceBindingsHandle>;
 
+struct HgiVertexBufferBinding
+{
+    HGI_API
+    HgiVertexBufferBinding(HgiBufferHandle const &buffer,
+                           uint32_t byteOffset,
+                           uint32_t index)
+        : buffer(buffer)
+        , byteOffset(byteOffset)
+        , index(index)
+    {
+    }
+
+    HgiBufferHandle buffer;
+    uint32_t byteOffset;
+    uint32_t index;
+};
+
+using HgiVertexBufferBindingVector = std::vector<HgiVertexBufferBinding>;
+
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -127,12 +127,10 @@ HgiGLGraphicsCmds::SetConstantValues(
 
 void
 HgiGLGraphicsCmds::BindVertexBuffers(
-    uint32_t firstBinding,
-    HgiBufferHandleVector const& vertexBuffers,
-    std::vector<uint32_t> const& byteOffsets)
+    HgiVertexBufferBindingVector const &bindings)
 {
     _ops.push_back( 
-        HgiGLOps::BindVertexBuffers(firstBinding, vertexBuffers, byteOffsets) );
+        HgiGLOps::BindVertexBuffers(bindings) );
 }
 
 void

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -82,9 +82,7 @@ public:
     
     HGIGL_API
     void BindVertexBuffers(
-        uint32_t firstBinding,
-        HgiBufferHandleVector const& buffers,
-        std::vector<uint32_t> const& byteOffsets) override;
+        HgiVertexBufferBindingVector const &bindings) override;
 
     HGIGL_API
     void Draw(

--- a/pxr/imaging/hgiGL/ops.cpp
+++ b/pxr/imaging/hgiGL/ops.cpp
@@ -580,27 +580,22 @@ HgiGLOps::SetConstantValues(
 
 HgiGLOpsFn
 HgiGLOps::BindVertexBuffers(
-    uint32_t firstBinding,
-    HgiBufferHandleVector const& vertexBuffers,
-    std::vector<uint32_t> const& byteOffsets)
+    HgiVertexBufferBindingVector const &bindings)
 {
-    return [firstBinding, vertexBuffers, byteOffsets] {
+    return [bindings] {
         TRACE_SCOPE("HgiGLOps::BindVertexBuffers");
-        TF_VERIFY(byteOffsets.size() == vertexBuffers.size());
-        TF_VERIFY(byteOffsets.size() == vertexBuffers.size());
 
         // XXX use glBindVertexBuffers to bind all VBs in one go.
-        for (size_t i=0; i<vertexBuffers.size(); i++) {
-            HgiBufferHandle bufHandle = vertexBuffers[i];
-            HgiGLBuffer* buf = static_cast<HgiGLBuffer*>(bufHandle.Get());
+        for (HgiVertexBufferBinding const &binding : bindings) {
+            HgiGLBuffer* buf = static_cast<HgiGLBuffer*>(binding.buffer.Get());
             HgiBufferDesc const& desc = buf->GetDescriptor();
 
             TF_VERIFY(desc.usage & HgiBufferUsageVertex);
 
             glBindVertexBuffer(
-                firstBinding + i,
+                binding.index,
                 buf->GetBufferId(),
-                byteOffsets[i],
+                binding.byteOffset,
                 desc.vertexStride);
         }
 

--- a/pxr/imaging/hgiGL/ops.h
+++ b/pxr/imaging/hgiGL/ops.h
@@ -134,9 +134,7 @@ public:
 
     HGIGL_API
     static HgiGLOpsFn BindVertexBuffers(
-        uint32_t firstBinding,
-        HgiBufferHandleVector const& buffers,
-        std::vector<uint32_t> const& byteOffsets);
+        HgiVertexBufferBindingVector const &bindings);
 
     HGIGL_API
     static HgiGLOpsFn Draw(

--- a/pxr/imaging/hgiMetal/CMakeLists.txt
+++ b/pxr/imaging/hgiMetal/CMakeLists.txt
@@ -21,20 +21,22 @@ pxr_library(hgiMetal
 
     PUBLIC_HEADERS
         api.h
+        blitCmds.h
+        buffer.h
         capabilities.h
         computeCmds.h
         computePipeline.h
         diagnostic.h
-        hgi.h
-        texture.h
-        blitCmds.h
-        buffer.h
         graphicsCmds.h
         graphicsPipeline.h
+        hgi.h
+
         resourceBindings.h
         sampler.h
         shaderFunction.h
         shaderProgram.h
+        stepFunctions.h
+        texture.h
 
     PRIVATE_HEADERS
         conversions.h
@@ -58,6 +60,7 @@ pxr_library(hgiMetal
         shaderGenerator.mm
         shaderProgram.mm
         shaderSection.mm
+        stepFunctions.mm
         texture.mm
 
     RESOURCE_FILES

--- a/pxr/imaging/hgiMetal/resourceBindings.h
+++ b/pxr/imaging/hgiMetal/resourceBindings.h
@@ -40,6 +40,26 @@ enum HgiMetalArgumentIndex {
     HgiMetalArgumentIndexBuffers = 30,
 };
 
+enum HgiMetalArgumentOffset {
+    HgiMetalArgumentOffsetBufferVS = 0,
+    HgiMetalArgumentOffsetBufferFS = 512,
+    HgiMetalArgumentOffsetSamplerVS = 1024,
+    HgiMetalArgumentOffsetSamplerFS = 1536,
+    HgiMetalArgumentOffsetTextureVS = 2048,
+    HgiMetalArgumentOffsetTextureFS = 2560,
+
+    HgiMetalArgumentOffsetBufferCS = 0,
+    HgiMetalArgumentOffsetSamplerCS = 1024,
+    HgiMetalArgumentOffsetTextureCS = 2048,
+    
+    HgiMetalArgumentOffsetConstants = 3072,
+    
+    HgiMetalArgumentOffsetSize = 4096
+};
+
+
+class HgiMetal;
+
 ///
 /// \class HgiMetalResourceBindings
 ///

--- a/pxr/imaging/hgiMetal/resourceBindings.mm
+++ b/pxr/imaging/hgiMetal/resourceBindings.mm
@@ -31,21 +31,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-enum HgiMetalArgmentOffset {
-    HgiMetalArgumentOffsetBufferVS = 0,
-    HgiMetalArgumentOffsetBufferFS = 512,
-    HgiMetalArgumentOffsetSamplerVS = 1024,
-    HgiMetalArgumentOffsetSamplerFS = 1536,
-    HgiMetalArgumentOffsetTextureVS = 2048,
-    HgiMetalArgumentOffsetTextureFS = 2560,
-
-    HgiMetalArgumentOffsetBufferCS = 0,
-    HgiMetalArgumentOffsetSamplerCS = 1024,
-    HgiMetalArgumentOffsetTextureCS = 2048,
-    
-    HgiMetalArgumentOffsetConstants = 3072,
-};
-
 HgiMetalResourceBindings::HgiMetalResourceBindings(
     HgiResourceBindingsDesc const& desc)
     : HgiResourceBindings(desc)

--- a/pxr/imaging/hgiMetal/stepFunctions.h
+++ b/pxr/imaging/hgiMetal/stepFunctions.h
@@ -1,0 +1,132 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_HGI_METAL_STEP_FUNCTIONS_H
+#define PXR_IMAGING_HGI_METAL_STEP_FUNCTIONS_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgi/resourceBindings.h"
+#include "pxr/imaging/hgiMetal/api.h"
+
+#include <cstdint>
+#include <vector>
+
+#include <Metal/Metal.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// We implement multi-draw indirect commands on Metal by encoding
+// separate draw commands for each draw.
+//
+// Some aspects of drawing command primitive input assembly work
+// differently on Metal than other graphics APIs. There are two
+// concerns that we need to account for while processing a buffer
+// with multiple indirect draw commands.
+//
+// 1) Metal does not support a vertex attrib divisor, so in order to
+// have vertex attributes which advance once per draw command we use
+// a constant vertex buffer step function and advance the vertex buffer
+// binding offset explicitly by executing setVertexBufferOffset for
+// the vertex buffers associated with "perDrawCommand" vertex attributes.
+//
+// 2) Metal does not support a base vertex offset for control point
+// vertex attributes when drawing patches. It is inconvenient and
+// expensive to encode a distinct controlPointIndex buffer for each
+// draw that shares a patch topology. Instead, we use a per patch
+// control point vertex buffer step function, and explicitly advance
+// the vertex buffer binding offset by executing setVertexBufferOffset
+// for the vertex buffers associated with "perPatchControlPoint"
+// vertex attributes.
+
+struct HgiGraphicsPipelineDesc;
+
+/// \struct HgiMetalStepFunctionDesc
+///
+/// For passing in vertex buffer step function parameters.
+///
+struct HgiMetalStepFunctionDesc
+{
+    HgiMetalStepFunctionDesc(
+            uint32_t bindingIndex,
+            uint32_t byteOffset,
+            uint32_t vertexStride)
+        : bindingIndex(bindingIndex)
+        , byteOffset(byteOffset)
+        , vertexStride(vertexStride)
+        { }
+    uint32_t bindingIndex;
+    uint32_t byteOffset;
+    uint32_t vertexStride;
+};
+
+using HgiMetalStepFunctionDescVector = std::vector<HgiMetalStepFunctionDesc>;
+
+class HgiMetalStepFunctions
+{
+public:
+    HGIMETAL_API
+    HgiMetalStepFunctions();
+    
+    HGIMETAL_API
+    HgiMetalStepFunctions(
+        HgiGraphicsPipelineDesc const &graphicsDesc,
+        HgiVertexBufferBindingVector const &bindings);
+
+    HGIMETAL_API
+    void Init(HgiGraphicsPipelineDesc const &graphicsDesc);
+    
+    HGIMETAL_API
+    void Bind(HgiVertexBufferBindingVector const &bindings);
+    
+    HGIMETAL_API
+    void SetVertexBufferOffsets(
+        id<MTLRenderCommandEncoder> encoder,
+        uint32_t baseInstance);
+    
+    HGIMETAL_API
+    void SetPatchBaseOffsets(
+        id<MTLRenderCommandEncoder> encoder,
+        uint32_t baseInstance);
+    
+    HGIMETAL_API
+    HgiMetalStepFunctionDescVector const &GetPatchBaseDescs() const
+    {
+        return _patchBaseDescs;
+    }
+    
+    HGIMETAL_API
+    uint32_t GetDrawBufferIndex() const
+    {
+        return _drawBufferIndex;
+    }
+
+private:
+    HgiMetalStepFunctionDescVector _vertexBufferDescs;
+    HgiMetalStepFunctionDescVector _patchBaseDescs;
+    uint32_t _drawBufferIndex;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiMetal/stepFunctions.mm
+++ b/pxr/imaging/hgiMetal/stepFunctions.mm
@@ -1,0 +1,121 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/imaging/hgiMetal/stepFunctions.h"
+
+#include "pxr/imaging/hgi/graphicsPipeline.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HgiMetalStepFunctions::HgiMetalStepFunctions()
+    : _drawBufferIndex(0)
+{
+    static const size_t _maxStepFunctionDescs = 4;
+    _vertexBufferDescs.reserve(_maxStepFunctionDescs);
+    _patchBaseDescs.reserve(_maxStepFunctionDescs);
+}
+
+HgiMetalStepFunctions::HgiMetalStepFunctions(
+    HgiGraphicsPipelineDesc const &graphicsDesc,
+    HgiVertexBufferBindingVector const &bindings)
+{
+    static const size_t _maxStepFunctionDescs = 4;
+    _vertexBufferDescs.reserve(_maxStepFunctionDescs);
+    _patchBaseDescs.reserve(_maxStepFunctionDescs);
+    
+    Init(graphicsDesc);
+    Bind(bindings);
+}
+
+void
+HgiMetalStepFunctions::Init(HgiGraphicsPipelineDesc const &graphicsDesc)
+{
+    _vertexBufferDescs.clear();
+    _patchBaseDescs.clear();
+
+    for (size_t index = 0; index < graphicsDesc.vertexBuffers.size(); index++) {
+        auto const & vbo = graphicsDesc.vertexBuffers[index];
+        if (vbo.vertexStepFunction ==
+                    HgiVertexBufferStepFunctionPerDrawCommand) {
+            _vertexBufferDescs.emplace_back(
+                        index, 0, vbo.vertexStride);
+            _drawBufferIndex = index;
+        } else if (vbo.vertexStepFunction ==
+                    HgiVertexBufferStepFunctionPerPatchControlPoint) {
+            _patchBaseDescs.emplace_back(
+                index, 0, vbo.vertexStride);
+        }
+    }
+}
+    
+void
+HgiMetalStepFunctions::Bind(HgiVertexBufferBindingVector const &bindings)
+{
+    for (HgiVertexBufferBinding const &binding : bindings) {
+        HgiBufferDesc const& desc = binding.buffer->GetDescriptor();
+
+        TF_VERIFY(desc.usage & HgiBufferUsageVertex);
+
+        for (auto & stepFunction : _vertexBufferDescs) {
+            if (stepFunction.bindingIndex == binding.index) {
+                stepFunction.byteOffset = binding.byteOffset;
+            }
+        }
+        for (auto & stepFunction : _patchBaseDescs) {
+            if (stepFunction.bindingIndex == binding.index) {
+                stepFunction.byteOffset = binding.byteOffset;
+            }
+        }
+    }
+}
+
+void
+HgiMetalStepFunctions::SetVertexBufferOffsets(
+    id<MTLRenderCommandEncoder> encoder,
+    uint32_t baseInstance)
+{
+    for (auto const & stepFunction : _vertexBufferDescs) {
+        uint32_t const offset = stepFunction.vertexStride * baseInstance +
+                                stepFunction.byteOffset;
+
+        [encoder setVertexBufferOffset:offset
+                               atIndex:stepFunction.bindingIndex];
+     }
+}
+
+void
+HgiMetalStepFunctions::SetPatchBaseOffsets(
+    id<MTLRenderCommandEncoder> encoder,
+    uint32_t baseVertex)
+{
+    for (auto const & stepFunction : _patchBaseDescs) {
+        uint32_t const offset = stepFunction.vertexStride * baseVertex +
+                                stepFunction.byteOffset;
+
+        [encoder setVertexBufferOffset:offset
+                               atIndex:stepFunction.bindingIndex];
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

General code cleanup around the HgiMetal implementation of graphicsCmds.  The vertex buffer bindings were being passed around as two parallel arrays of buffer handles and byte offsets with a 'firstBinding' parameter too.  Moved this to a new struct `HgiVertexBufferBinding`.

This allows the `HdStPipelineDrawBatch` to be cleaned up too.

There was a lot of logic around the calculation and setting of the vertex buffer step functions in `HgiMetalGraphicsCmd` this has been split out to a separate class `HgiMetalStepFunctions` which can be used by other parts of the engine.

### Fixes Issue(s)
- Code maintainability and clarity

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
