### PR TITLE
Optimize Usd_LinearInterpolator. 

### DIFF
--- a/pxr/usd/usd/interpolators.h
+++ b/pxr/usd/usd/interpolators.h
@@ -291,30 +291,35 @@ private:
             upperValue = lowerValue;
         }
 
-        _result->swap(lowerValue);
 
         // Fall back to held interpolation (_result is set to lowerValue above)
         // if sizes don't match. We don't consider this an error because
         // that would be too restrictive. Consumers will be responsible for
         // implementing their own interpolation in cases where this occurs
         // (e.g. meshes with varying topology)
-        if (_result->size() != upperValue.size()) {
+        if (lowerValue.size() != upperValue.size()) {
+            _result->swap(lowerValue);
             return true;
         }
 
         const double parametricTime = (time - lower) / (upper - lower);
         if (parametricTime == 0.0) {
-            // do nothing.
+            // just swap the lower value in.
+            _result->swap(lowerValue);
         }
         else if (parametricTime == 1.0) {
             // just swap the upper value in.
             _result->swap(upperValue);
         }
         else {
+            _result->resize(lowerValue.size());
+
             // must actually calculate interpolated values.
-            T *rptr = _result->data();
+            const T *lower = lowerValue.cdata();
+            const T* upper=  upperValue.cdata();
+            T* result = _result->data();
             for (size_t i = 0, j = _result->size(); i != j; ++i) {
-                rptr[i] = Usd_Lerp(parametricTime, rptr[i], upperValue[i]);
+                result[i] = Usd_Lerp(parametricTime, lower[i], upper[i]);
             }
         }
 


### PR DESCRIPTION


### Description of Change(s)
Swapping the lowerValue with the _result and calling _result.data() afterwards results in a memmove in the data() function call. Later on the Usd_Lerp loop overwrites the all values which have been copied before with the memmove call making the memmove an expensive nop.

Also using operator[] on each loop iteration on upperValue results in a function call to uperValue.data() on each loop iteration which can easily be avoided by fetching the data pointer once before.

### Fixes Issue(s)
Improves performance of Usd_LinearInterpolator.
-

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
