### PR TITLE
Enable Storm for Apple Intel GPUs

### DIFF
--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -1392,7 +1392,8 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
         capabilities->IsSet(HgiDeviceCapabilitiesBitsShaderDoublePrecision);
     const bool minusOneToOneDepth =
         capabilities->IsSet(HgiDeviceCapabilitiesBitsDepthRangeMinusOnetoOne);
-
+    const bool useTessellationBarycentric =
+        capabilities->IsSet(HgiDeviceCapabilitiesBitsTessellationBarycentric);
     bool const useHgiResourceGeneration =
         IsEnabledHgiResourceGeneration(capabilities);
 
@@ -1662,6 +1663,16 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
         _genFS << "vec3 GetBarycentricCoord() {\n"
                   "  return gl_BaryCoordNoPerspNV;\n"
                   "}\n";
+    } else if (useTessellationBarycentric && _hasPTVS) {
+        if (_geometricShader->IsPrimTypeQuads() || _geometricShader->IsPrimTypeTriQuads()) {
+            _genFS << "vec3 GetBarycentricCoord() {\n"
+                      "  return vec3(0.0, ptvsBarycentricCoord.y, ptvsBarycentricCoord.x);"
+                      "}\n";
+        } else { 
+            _genFS << "vec3 GetBarycentricCoord() {\n"
+                      "  return ptvsBarycentricCoord;\n"
+                      "}\n";
+        }
     } else {
         if (_hasGS) {
             _genGS << "noperspective out vec3 hd_barycentricCoord;\n";
@@ -1738,7 +1749,7 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
             // do nothing. no additional code needs to be generated.
             ;
     }
-    if (!builtinBarycentricsEnabled) {
+    if (!(builtinBarycentricsEnabled || useTessellationBarycentric)) {
         switch(_geometricShader->GetPrimitiveType())
         {
             case HdSt_GeometricShader::PrimitiveType::PRIM_MESH_COARSE_QUADS:
@@ -2299,6 +2310,23 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
         HgiShaderFunctionAddStageInput(
             &fsDesc, "gl_FragCoord", "vec4",
             HgiShaderKeywordTokens->hdPosition);
+        
+        if (_hasPTVS) {
+            std::string vecSize = std::string();
+            if (_geometricShader->IsPrimTypeQuads() || _geometricShader->IsPrimTypeTriQuads()) {
+                vecSize = "vec2";
+            } else {
+                vecSize = "vec3";
+            }
+            HgiShaderFunctionAddStageInput(
+                &fsDesc, "ptvsBarycentricCoord", vecSize,
+                "");
+            
+            HgiShaderFunctionAddStageInput(
+                &fsDesc, "patch_idOut", "uint",
+                "");
+        }
+        
 
         if (!glslProgram->CompileShader(fsDesc)) {
             return nullptr;
@@ -2403,9 +2431,9 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
 
         //Set the patchtype to later decide tessfactor types
         ptvsDesc.tessellationDescriptor.patchType =
-            _geometricShader->IsPrimTypeTriangles() ?
+            (_geometricShader->IsPrimTypeTriangles() ?
             HgiShaderFunctionTessellationDesc::PatchType::Triangle :
-            HgiShaderFunctionTessellationDesc::PatchType::Quad;
+            HgiShaderFunctionTessellationDesc::PatchType::Quad);
 
         resourceGen._GenerateHgiResources(&ptvsDesc,
             HdShaderTokens->postTessVertexShader, _resAttrib, _metaData);
@@ -2438,8 +2466,8 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
             HgiShaderKeywordTokens->hdPatchID);
         
         std::string tessCoordType =
-            _geometricShader->IsPrimTypeTriangles() ?
-            "vec3" : "vec2";
+        (_geometricShader->IsPrimTypeQuads() || _geometricShader->IsPrimTypeTriQuads()) ?
+            "vec2" : "vec3";
         
         HgiShaderFunctionAddStageInput(
             &ptvsDesc, "gl_TessCoord", tessCoordType,
@@ -2452,6 +2480,10 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
         HgiShaderFunctionAddStageOutput(
                 &ptvsDesc, "gl_Position", "vec4",
                 "position");
+        
+        HgiShaderFunctionAddStageOutput(
+                &ptvsDesc, "ptvsBarycentricCoord", tessCoordType,
+                "");
 
         char const* pointRole =
             (_geometricShader->GetPrimitiveType() ==
@@ -2461,6 +2493,9 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
         HgiShaderFunctionAddStageOutput(
             &ptvsDesc, "gl_PointSize", "float",
                 pointRole);
+        HgiShaderFunctionAddStageOutput(
+            &ptvsDesc, "patch_idOut", "uint",
+                "");
 
         if (!glslProgram->CompileShader(ptvsDesc)) {
             return nullptr;
@@ -3720,10 +3755,9 @@ HdSt_CodeGen::_GenerateDrawingCoord(
             primitiveID << "int GetBasePrimitiveOffset() { return 0; }\n";
             _genPTVS    << "int GetBasePrimitiveOffset() { return 0; }\n";
         }
-        if (_geometricShader->GetPrimitiveType() ==
-               HdSt_GeometricShader::PrimitiveType::PRIM_MESH_COARSE_TRIQUADS) {
+        if (HdSt_GeometricShader::IsPrimTypeTriQuads(_geometricShader->GetPrimitiveType())) {
             primitiveID << "int GetPrimitiveID() {\n"
-                        << "  return (gl_PrimitiveID - GetBasePrimitiveOffset()) / 2;\n"
+                        << "  return (gl_PrimitiveID - GetBasePrimitiveOffset());\n"
                         << "}\n"
                         << "int GetTriQuadID() {\n"
                         << "  return (gl_PrimitiveID - GetBasePrimitiveOffset()) & 1;\n"

--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -622,10 +622,14 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
         bool const hasBuiltinBarycentrics =
             resourceRegistry->GetHgi()->GetCapabilities()->
                 IsSet(HgiDeviceCapabilitiesBitsBuiltinBarycentrics);
+        
+        bool const hasTessellationBarycentrics =
+        resourceRegistry->GetHgi()->GetCapabilities()->
+            IsSet(HgiDeviceCapabilitiesBitsTessellationBarycentric);
 
         HdSt_MeshTopologySharedPtr topology =
             HdSt_MeshTopology::New(meshTopology, refineLevel, refineMode,
-                hasBuiltinBarycentrics
+                (hasBuiltinBarycentrics || hasTessellationBarycentrics)
                     ? HdSt_MeshTopology::QuadsTriangulated
                     : HdSt_MeshTopology::QuadsUntriangulated);
         
@@ -2576,6 +2580,10 @@ HdStMesh::_UpdateDrawItemGeometricShader(HdSceneDelegate *sceneDelegate,
     bool const hasMetalTessellation =
         resourceRegistry->GetHgi()->GetCapabilities()->
             IsSet(HgiDeviceCapabilitiesBitsMetalTessellation);
+    
+    bool const hasTessellationBarycentrics =
+         resourceRegistry->GetHgi()->GetCapabilities()->
+             IsSet(HgiDeviceCapabilitiesBitsTessellationBarycentric);
 
     // create a shaderKey and set to the geometric shader.
     HdSt_MeshShaderKey shaderKey(primType,
@@ -2588,6 +2596,7 @@ HdStMesh::_UpdateDrawItemGeometricShader(HdSceneDelegate *sceneDelegate,
                                  desc.lineWidth,
                                  _doubleSided || desc.doubleSided,
                                  hasBuiltinBarycentrics,
+                                 hasTessellationBarycentrics,
                                  hasMetalTessellation,
                                  hasCustomDisplacement,
                                  hasPerFaceInterpolation,

--- a/pxr/imaging/hdSt/meshShaderKey.h
+++ b/pxr/imaging/hdSt/meshShaderKey.h
@@ -56,6 +56,7 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
                        float lineWidth,
                        bool doubleSided,
                        bool hasBuiltinBarycentrics,
+                       bool hasTessellationBarycentrics,
                        bool hasMetalTessellation,
                        bool hasCustomDisplacement,
                        bool hasPerFaceInterpolation,

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -38,6 +38,8 @@
 
 #include "pxr/imaging/hio/glslfx.h"
 #include "pxr/imaging/hgi/hgi.h"
+#include "pxr/imaging/hgi/enums.h"
+#include "pxr/imaging/hgi/capabilities.h"
 
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/hash.h"
@@ -120,9 +122,15 @@ HdStResourceRegistry::HdStResourceRegistry(Hgi * const hgi)
     , _numBufferSourcesToResolve(0)
     // default aggregation strategies for varying (vertex, varying) primvars
     , _nonUniformAggregationStrategy(
-        std::make_unique<HdStVBOMemoryManager>(this))
+       hgi->GetCapabilities()->IsSet(HgiDeviceCapabilitiesBitsPatchVertexOffsetting) ?
+       std::unique_ptr<HdAggregationStrategy>(std::make_unique<
+           HdStVBOSimpleMemoryManager>(this)) :
+           std::make_unique<HdStVBOMemoryManager>(this))
     , _nonUniformImmutableAggregationStrategy(
-        std::make_unique<HdStVBOMemoryManager>(this))
+        hgi->GetCapabilities()->IsSet(HgiDeviceCapabilitiesBitsPatchVertexOffsetting) ?
+        std::unique_ptr<HdAggregationStrategy>(std::make_unique<
+            HdStVBOSimpleMemoryManager>(this)) :
+            std::make_unique<HdStVBOMemoryManager>(this))
     // default aggregation strategy for uniform on UBO (for globals)
     , _uniformUboAggregationStrategy(
         std::make_unique<HdStInterleavedUBOMemoryManager>(this))

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -79,8 +79,7 @@ void main(void)
     ["out block", "VertexData", "outData",
         ["vec4", "Peye"],
         ["vec3", "Neye"]
-    ],
-    ["out", "vec3", "ptvsBarycentricCoord"]
+    ]
 ]
 
 --- --------------------------------------------------------------------------
@@ -137,6 +136,7 @@ void main(void)
 
     gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
     ptvsBarycentricCoord = gl_TessCoord;
+    patch_idOut = patch_id;
     ApplyClipPlanes(outData.Peye);
 
     ProcessPrimvarsOut(basis, 0, 1, 2, 0);
@@ -148,8 +148,7 @@ void main(void)
     ["out block", "VertexData", "outData",
         ["vec4", "Peye"],
         ["vec3", "Neye"]
-    ],
-    ["out", "vec2", "ptvsBarycentricCoord"]
+    ]
 ]
 
 --- --------------------------------------------------------------------------
@@ -216,6 +215,7 @@ void main(void)
 
     gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
     ptvsBarycentricCoord = gl_TessCoord;
+    patch_idOut = patch_id;
     ApplyClipPlanes(outData.Peye);
 
     ProcessPrimvarsOut(basis, 0, 1, 2, 3);
@@ -228,8 +228,7 @@ void main(void)
     ["out block", "VertexData", "outData",
         ["vec4", "Peye"],
         ["vec3", "Neye"]
-    ],
-    ["out", "vec2", "ptvsBarycentricCoord"]
+    ]
 ]
 
 --- --------------------------------------------------------------------------
@@ -296,6 +295,7 @@ void main(void)
 
     gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
     ptvsBarycentricCoord = gl_TessCoord;
+    patch_idOut = patch_id;
     ApplyClipPlanes(outData.Peye);
 
     ProcessPrimvarsOut(basis, 0, 1, 2, 4);
@@ -933,26 +933,12 @@ vec3 GetPatchControlPoint()
 }
 
 --- --------------------------------------------------------------------------
--- layout Mesh.Fragment.PatchCoord.ControlPointTessCoord.Triangle
-
-[
-    ["in", "vec3", "ptvsBarycentricCoord"]
-]
-
---- --------------------------------------------------------------------------
 -- glsl Mesh.Fragment.PatchCoord.ControlPointTessCoord.Triangle
 
 vec3 GetPatchControlPoint()
 {
     return ptvsBarycentricCoord;
 }
-
---- --------------------------------------------------------------------------
--- layout Mesh.Fragment.PatchCoord.ControlPointTessCoord.Quad
-
-[
-    ["in", "vec2", "ptvsBarycentricCoord"]
-]
 
 --- --------------------------------------------------------------------------
 -- glsl Mesh.Fragment.PatchCoord.ControlPointTessCoord.Quad
@@ -1045,12 +1031,6 @@ vec4 GetInterpolatedPatchCoord()
     return OsdInterpolatePatchCoord(GetPatchCoordLocalST(), GetPatchParam());
 }
 
---- --------------------------------------------------------------------------
--- layout Mesh.Fragment.PatchCoord.TriQuadPTVS
-
-[
-    ["in", "vec2", "ptvsBarycentricCoord"]
-]
 
 --- --------------------------------------------------------------------------
 -- glsl Mesh.Fragment.PatchCoord.TriQuadPTVS

--- a/pxr/imaging/hdx/oitBufferAccessor.cpp
+++ b/pxr/imaging/hdx/oitBufferAccessor.cpp
@@ -31,6 +31,9 @@
 #include "pxr/imaging/hgiGL/buffer.h"
 
 #include "pxr/imaging/hdx/tokens.h"
+#include "pxr/imaging/hgi/hgi.h"
+#include "pxr/imaging/hgi/capabilities.h"
+#include "pxr/imaging/hgi/enums.h"
 
 #include "pxr/base/tf/envSetting.h"
 
@@ -41,9 +44,15 @@ TF_DEFINE_ENV_SETTING(HDX_ENABLE_OIT, true,
 
 /* static */
 bool
-HdxOitBufferAccessor::IsOitEnabled()
+HdxOitBufferAccessor::IsOitEnabled(Hgi *hgi)
 {
-    return TfGetEnvSetting(HDX_ENABLE_OIT);
+    //If we don't have HGI, hgi is not authoritive
+    bool hasHgiOIT = true;
+    if (hgi != nullptr) {
+        hasHgiOIT = hgi->GetCapabilities()->IsSet(
+            HgiDeviceCapabilitiesBitsOIT);
+    }
+    return TfGetEnvSetting(HDX_ENABLE_OIT) && hasHgiOIT;
 }
 
 HdxOitBufferAccessor::HdxOitBufferAccessor(HdTaskContext *ctx)

--- a/pxr/imaging/hdx/oitBufferAccessor.h
+++ b/pxr/imaging/hdx/oitBufferAccessor.h
@@ -45,7 +45,7 @@ using HdStRenderPassShaderSharedPtr =
 /// Class for OIT render tasks to access the OIT buffers.
 class HdxOitBufferAccessor {
 public:
-    static bool IsOitEnabled();
+    static bool IsOitEnabled(Hgi *hgi);
 
     HDX_API
     HdxOitBufferAccessor(HdTaskContext *ctx);

--- a/pxr/imaging/hdx/oitRenderTask.cpp
+++ b/pxr/imaging/hdx/oitRenderTask.cpp
@@ -36,6 +36,24 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+static Hgi* TryGetHgi(HdSceneDelegate* delegate) {
+    if (delegate == nullptr) {
+        return nullptr;
+    }
+    HdResourceRegistrySharedPtr resourceRegistry =
+        delegate->GetRenderIndex().GetResourceRegistry();
+    if (resourceRegistry == nullptr) {
+        return nullptr;
+    }
+    std::shared_ptr<HdStResourceRegistry> hdStResourceRegistry =
+        std::static_pointer_cast<HdStResourceRegistry>(
+        resourceRegistry);
+    if (hdStResourceRegistry == nullptr) {
+        return nullptr;
+    }
+    return hdStResourceRegistry->GetHgi();
+}
+
 HdxOitRenderTask::HdxOitRenderTask(HdSceneDelegate* delegate, SdfPath const& id)
     : HdxRenderTask(delegate, id)
     , _oitTranslucentRenderPassShader(
@@ -44,7 +62,7 @@ HdxOitRenderTask::HdxOitRenderTask(HdSceneDelegate* delegate, SdfPath const& id)
     , _oitOpaqueRenderPassShader(
         std::make_shared<HdStRenderPassShader>(
             HdxPackageRenderPassOitOpaqueShader()))
-    , _isOitEnabled(HdxOitBufferAccessor::IsOitEnabled())
+    , _isOitEnabled(TryGetHgi(delegate))
 {
 }
 

--- a/pxr/imaging/hdx/oitVolumeRenderTask.cpp
+++ b/pxr/imaging/hdx/oitVolumeRenderTask.cpp
@@ -39,13 +39,31 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+static Hgi* TryGetHgi(HdSceneDelegate* delegate) {
+    if (delegate == nullptr) {
+        return nullptr;
+    }
+    HdResourceRegistrySharedPtr resourceRegistry =
+        delegate->GetRenderIndex().GetResourceRegistry();
+    if (resourceRegistry == nullptr) {
+        return nullptr;
+    }
+    std::shared_ptr<HdStResourceRegistry> hdStResourceRegistry =
+        std::static_pointer_cast<HdStResourceRegistry>(
+        resourceRegistry);
+    if (hdStResourceRegistry == nullptr) {
+        return nullptr;
+    }
+    return hdStResourceRegistry->GetHgi();
+}
+
 HdxOitVolumeRenderTask::HdxOitVolumeRenderTask(
                 HdSceneDelegate* delegate, SdfPath const& id)
     : HdxRenderTask(delegate, id)
     , _oitVolumeRenderPassShader(
         std::make_shared<HdStRenderPassShader>(
             HdxPackageRenderPassOitVolumeShader()))
-    , _isOitEnabled(HdxOitBufferAccessor::IsOitEnabled())
+    , _isOitEnabled(TryGetHgi(delegate))
 {
 }
 

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -75,6 +75,8 @@ using HgiBits = uint32_t;
 ///   Set if requires ability to migitate patch vertes offset bug on Intel</li>
 /// <li>HgiDeviceCapabilitiesBitsTessellationBarycentric:
 ///   Use the tesscoord/position_in_patch as barycentric</li>
+/// <li>HgiDeviceCapabilitiesBitsOIT:
+///   Is able to perform OIT</li>
 /// </ul>
 ///
 enum HgiDeviceCapabilitiesBits : HgiBits
@@ -96,7 +98,8 @@ enum HgiDeviceCapabilitiesBits : HgiBits
     HgiDeviceCapabilitiesBitsMetalTessellation         = 1 << 14,
     HgiDeviceCapabilitiesBasePrimitiveOffset           = 1 << 15,
     HgiDeviceCapabilitiesBitsPatchVertexOffsetting     = 1 << 16,
-    HgiDeviceCapabilitiesBitsTessellationBarycentric   = 1 << 17
+    HgiDeviceCapabilitiesBitsTessellationBarycentric   = 1 << 17,
+    HgiDeviceCapabilitiesBitsOIT                       = 1 << 18
 };
 
 using HgiDeviceCapabilities = HgiBits;

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -71,26 +71,32 @@ using HgiBits = uint32_t;
 ///   Supports Metal tessellation shaders</li>
 /// <li>HgiDeviceCapabilitiesBitsBasePrimitiveOffset:
 ///   The device requires workaround for base primitive offset</li>
+/// <li>HgiDeviceCapabilitiesPatchVertexOffsetting:
+///   Set if requires ability to migitate patch vertes offset bug on Intel</li>
+/// <li>HgiDeviceCapabilitiesBitsTessellationBarycentric:
+///   Use the tesscoord/position_in_patch as barycentric</li>
 /// </ul>
 ///
 enum HgiDeviceCapabilitiesBits : HgiBits
 {
-    HgiDeviceCapabilitiesBitsPresentation            = 1 << 0,
-    HgiDeviceCapabilitiesBitsBindlessBuffers         = 1 << 1,
-    HgiDeviceCapabilitiesBitsConcurrentDispatch      = 1 << 2,
-    HgiDeviceCapabilitiesBitsUnifiedMemory           = 1 << 3,
-    HgiDeviceCapabilitiesBitsBuiltinBarycentrics     = 1 << 4,
-    HgiDeviceCapabilitiesBitsShaderDrawParameters    = 1 << 5,
-    HgiDeviceCapabilitiesBitsMultiDrawIndirect       = 1 << 6,
-    HgiDeviceCapabilitiesBitsBindlessTextures        = 1 << 7,
-    HgiDeviceCapabilitiesBitsShaderDoublePrecision   = 1 << 8,
-    HgiDeviceCapabilitiesBitsDepthRangeMinusOnetoOne = 1 << 9,
-    HgiDeviceCapabilitiesBitsCppShaderPadding        = 1 << 10,
-    HgiDeviceCapabilitiesBitsConservativeRaster      = 1 << 11,
-    HgiDeviceCapabilitiesBitsStencilReadback         = 1 << 12,
-    HgiDeviceCapabilitiesBitsCustomDepthRange        = 1 << 13,
-    HgiDeviceCapabilitiesBitsMetalTessellation       = 1 << 14,
-    HgiDeviceCapabilitiesBasePrimitiveOffset         = 1 << 15,
+    HgiDeviceCapabilitiesBitsPresentation              = 1 << 0,
+    HgiDeviceCapabilitiesBitsBindlessBuffers           = 1 << 1,
+    HgiDeviceCapabilitiesBitsConcurrentDispatch        = 1 << 2,
+    HgiDeviceCapabilitiesBitsUnifiedMemory             = 1 << 3,
+    HgiDeviceCapabilitiesBitsBuiltinBarycentrics       = 1 << 4,
+    HgiDeviceCapabilitiesBitsShaderDrawParameters      = 1 << 5,
+    HgiDeviceCapabilitiesBitsMultiDrawIndirect         = 1 << 6,
+    HgiDeviceCapabilitiesBitsBindlessTextures          = 1 << 7,
+    HgiDeviceCapabilitiesBitsShaderDoublePrecision     = 1 << 8,
+    HgiDeviceCapabilitiesBitsDepthRangeMinusOnetoOne   = 1 << 9,
+    HgiDeviceCapabilitiesBitsCppShaderPadding          = 1 << 10,
+    HgiDeviceCapabilitiesBitsConservativeRaster        = 1 << 11,
+    HgiDeviceCapabilitiesBitsStencilReadback           = 1 << 12,
+    HgiDeviceCapabilitiesBitsCustomDepthRange          = 1 << 13,
+    HgiDeviceCapabilitiesBitsMetalTessellation         = 1 << 14,
+    HgiDeviceCapabilitiesBasePrimitiveOffset           = 1 << 15,
+    HgiDeviceCapabilitiesBitsPatchVertexOffsetting     = 1 << 16,
+    HgiDeviceCapabilitiesBitsTessellationBarycentric   = 1 << 17
 };
 
 using HgiDeviceCapabilities = HgiBits;

--- a/pxr/imaging/hgiMetal/capabilities.mm
+++ b/pxr/imaging/hgiMetal/capabilities.mm
@@ -43,6 +43,7 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
                   hasIntel);
     _SetFlag(HgiDeviceCapabilitiesBitsPatchVertexOffsetting,
                   hasIntel && !vertexOffsettingFixes);
+    _SetFlag(HgiDeviceCapabilitiesBitsOIT, !hasIntel);
 
     defaultStorageMode = MTLResourceStorageModeShared;
     bool unifiedMemory = false;


### PR DESCRIPTION
Update: Covers primitive ID as well and is everything needed for Intel GPU enablement from only being barycentric and base vertex offset fixes.

Enable Storm for Apple Intel GPUs

### Description of Change(s)
- Use post tessellation vertex shader on Intel in most cases to support hardware barycentric coordinates on Intel Apple machines using metal ( needs hardware barycentric as no geometry shader is presented ). Uses the tessellation coordinate as a barycentric coordinate.
- Use HdStVBOSimpleMemoryManager instead of HdStVBOMemoryManager for nonUniformAggregationStrategy and nonUniformImmutableAggregationStrategy in the resourceRegistry on Apple intel machines to work around a Metal driver bug on Apple Intel Macs which prevents us from emulating base vertex via setVertexoffset. This change has a performance overhead, but correctness can not be achived through simple means otherwise. This change cause the baseVertex to always be 0. This bug has been fixed internally at Apple and is expected to be fixed in MacOS 13.0
- Pass patch_id between stages to work around a driver issue where the hardware primitive id is wrong if patch_id is not passed as an interstage.
- Fix the primitive id calculation for post tessellation vertex shader triquads ( division by two )

### Fixes Issue(s)
- Missing barycentric coordinates on Apple Intel Macs
- Incorrect base vertex workaround for patch drawing on Apple Intel Macs

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x ] I have submitted a signed Contributor License Agreement
