### PR TITLE
APPLE: Upgrade third party packages for Apple Silicon cross compilation

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,7 +20,7 @@ Our test machines have the following software versions installed
 | Boost         | 1.70.0               | 1.76.0                       | 1.70.0                         |
 | Intel TBB     | 2019 Update 6        | 2018 Update 1, 2019 Update 6 | 2019 Update 6                  |
 | OpenSubdiv    | 3.4.4                | 3.4.4                        | 3.4.4                          |
-| OpenImageIO   | 2.1.16.0             | 2.1.16.0                     | 2.1.16.0                       |
+| OpenImageIO   | 2.3.15.0             | 2.3.15.0                     | 2.3.15.0                       |
 | OpenColorIO   | 1.1.0                | 1.1.0                        | 1.1.0                          |
 | OSL           | 1.10.9               |                              |                                |
 | Ptex          | 2.3.2                | 2.1.33                       | 2.1.33                         |
@@ -28,8 +28,8 @@ Our test machines have the following software versions installed
 | PyOpenGL      | 3.1.5                | 3.1.5                        | 3.1.5                          |
 | Embree        | 3.2.2                | 3.13.3                       | 3.2.2                          |
 | RenderMan     | 24.0                 | 24.0                         | 24.0                           |
-| Alembic       | 1.7.10               | 1.7.10                       | 1.7.10                         |
-| OpenEXR       | 2.4.4                | 2.4.4                        | 2.5.2                          |
+| Alembic       | 1.8.3                | 1.8.3                        | 1.8.3                          |
+| OpenEXR       | 2.5.5                | 2.5.5                        | 2.5.5                          |
 | MaterialX     | 1.38.4               | 1.38.4                       | 1.38.4                         |
 | Jinja2        | 2.0                  |                              |                                |
 | Flex          | 2.5.39               |                              |                                |

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+import sys
+import locale
+import os
+import shlex
+import subprocess
+
+def GetLocale():
+    return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
+
+def GetCommandOutput(command):
+    """Executes the specified command and returns output or None."""
+    try:
+        return subprocess.check_output(
+            shlex.split(command), 
+            stderr=subprocess.STDOUT).decode(GetLocale(), 'replace').strip()
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+def GetMacArmArch():
+    return os.environ.get('MACOS_ARM_ARCHITECTURE') or "arm64"
+
+def GetMacArch():
+    macArch = GetCommandOutput('arch').strip()
+    if macArch == "i386" or macArch == "x86_64":
+        macArch = "x86_64"
+    else:
+        macArch = GetMacArmArch()
+    return macArch
+
+devout = open(os.devnull, 'w')
+
+def ExtractFilesRecursive(path, cond):
+    files = []
+    for r, d, f in os.walk(path):
+        for file in f:
+            if cond(os.path.join(r,file)):
+                files.append(os.path.join(r, file))
+    return files
+
+def CodesignFiles(files):
+    SDKVersion  = subprocess.check_output(['xcodebuild', '-version']).strip()[6:10]
+    codeSignIDs = subprocess.check_output(['security', 'find-identity', '-vp', 'codesigning'])
+
+    codeSignID = "-"
+    if os.environ.get('CODE_SIGN_ID'):
+        codeSignID = os.environ.get('CODE_SIGN_ID')
+    elif float(SDKVersion) >= 11.0 and codeSignIDs.find(b'Apple Development') != -1:
+        codeSignID = "Apple Development"
+    elif codeSignIDs.find(b'Mac Developer') != -1:
+        codeSignID = "Mac Developer"
+        
+    for f in files:
+        subprocess.call(['codesign', '-f', '-s', '{codesignid}'
+              .format(codesignid=codeSignID), f],
+              stdout=devout, stderr=devout)
+
+def Codesign(install_path, verbose_output=False):
+    if verbose_output:
+        global devout
+        devout = sys.stdout
+
+    files = ExtractFilesRecursive(install_path, 
+                 (lambda file: '.so' in file or '.dylib' in file))
+    CodesignFiles(files)


### PR DESCRIPTION
### Description of Change(s)

This builds on the changes in https://github.com/PixarAnimationStudios/USD/pull/1875

- Change jpeg over to turboJPEG 2.0.1
- openEXR upgraded to 2.5.5
- openVDB upgraded to 6.2.1
- openImageIO upgraded to 2.3.15
- Alembic upgraded to 1.8.3

### Fixes Issue(s)
- Third party library support for Apple Silicon cross compilation

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
