### PR TITLE
From tbb::atomic to std::atomic

### DIFF
--- a/extras/usd/examples/usdObj/pch.h
+++ b/extras/usd/examples/usdObj/pch.h
@@ -166,7 +166,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/extras/usd/examples/usdSchemaExamples/pch.h
+++ b/extras/usd/examples/usdSchemaExamples/pch.h
@@ -168,7 +168,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/base/plug/pch.h
+++ b/pxr/base/plug/pch.h
@@ -183,7 +183,6 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/base/tf/pch.h
+++ b/pxr/base/tf/pch.h
@@ -243,7 +243,6 @@
 #include <boost/variant.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/base/trace/pch.h
+++ b/pxr/base/trace/pch.h
@@ -178,7 +178,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/base/vt/pch.h
+++ b/pxr/base/vt/pch.h
@@ -171,7 +171,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/base/work/pch.h
+++ b/pxr/base/work/pch.h
@@ -110,7 +110,6 @@
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/imaging/garch/pch.h
+++ b/pxr/imaging/garch/pch.h
@@ -145,7 +145,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/glf/pch.h
+++ b/pxr/imaging/glf/pch.h
@@ -199,7 +199,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hd/pch.h
+++ b/pxr/imaging/hd/pch.h
@@ -152,7 +152,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdMtlx/pch.h
+++ b/pxr/imaging/hdMtlx/pch.h
@@ -139,7 +139,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdSt/pch.h
+++ b/pxr/imaging/hdSt/pch.h
@@ -170,7 +170,6 @@
 #include <opensubdiv/osd/cpuVertexBuffer.h>
 #include <opensubdiv/osd/mesh.h>
 #include <opensubdiv/version.h>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdx/pch.h
+++ b/pxr/imaging/hdx/pch.h
@@ -152,7 +152,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hgiMetal/pch.h
+++ b/pxr/imaging/hgiMetal/pch.h
@@ -141,7 +141,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/spin_mutex.h>

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -154,7 +154,6 @@
 #include <embree3/rtcore.h>
 #include <embree3/rtcore_geometry.h>
 #include <embree3/rtcore_ray.h>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/plugin/hdStorm/pch.h
+++ b/pxr/imaging/plugin/hdStorm/pch.h
@@ -141,7 +141,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/spin_mutex.h>

--- a/pxr/imaging/plugin/hioOiio/pch.h
+++ b/pxr/imaging/plugin/hioOiio/pch.h
@@ -199,7 +199,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/ar/pch.h
+++ b/pxr/usd/ar/pch.h
@@ -166,7 +166,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/usd/ndr/pch.h
+++ b/pxr/usd/ndr/pch.h
@@ -198,7 +198,6 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/usd/pcp/cache.cpp
+++ b/pxr/usd/pcp/cache.cpp
@@ -53,7 +53,6 @@
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/registryManager.h"
 
-#include <tbb/atomic.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/usd/pcp/mapExpression.cpp
+++ b/pxr/usd/pcp/mapExpression.cpp
@@ -238,7 +238,7 @@ PcpMapExpression::_Node::New( _Op op_,
         // Check for existing instance to re-use
         _NodeMap::accessor accessor;
         if (_nodeRegistry->map.insert(accessor, key) ||
-            accessor->second->_refCount.fetch_and_increment() == 0) {
+            accessor->second->_refCount.fetch_add(1) == 0) {
             // Either there was no node in the table, or there was but it had
             // begun dying (another client dropped its refcount to 0).  We have
             // to create a new node in the table.  When the client that is
@@ -387,7 +387,7 @@ intrusive_ptr_add_ref(PcpMapExpression::_Node* p)
 void
 intrusive_ptr_release(PcpMapExpression::_Node* p)
 {
-    if (p->_refCount.fetch_and_decrement() == 1)
+    if (p->_refCount.fetch_sub(1) == 1)
         delete p;
 }
 

--- a/pxr/usd/pcp/mapExpression.h
+++ b/pxr/usd/pcp/mapExpression.h
@@ -30,7 +30,6 @@
 
 #include <boost/intrusive_ptr.hpp>
 
-#include <tbb/atomic.h>
 #include <tbb/spin_mutex.h>
 
 #include <atomic>
@@ -265,7 +264,7 @@ private: // data
         struct _NodeMap;
         static TfStaticData<_NodeMap> _nodeRegistry;
 
-        mutable tbb::atomic<int> _refCount;
+        mutable std::atomic<int> _refCount;
         mutable Value _cachedValue;
         mutable std::set<_Node*> _dependentExpressions;
         Value _valueForVariable;

--- a/pxr/usd/pcp/pch.h
+++ b/pxr/usd/pcp/pch.h
@@ -194,7 +194,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>

--- a/pxr/usd/plugin/usdAbc/pch.h
+++ b/pxr/usd/plugin/usdAbc/pch.h
@@ -206,7 +206,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/plugin/usdDraco/pch.h
+++ b/pxr/usd/plugin/usdDraco/pch.h
@@ -169,7 +169,6 @@
 #include <draco/compression/encode.h>
 #include <draco/mesh/mesh.h>
 #include <draco/mesh/mesh_misc_functions.h>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/sdf/changeManager.cpp
+++ b/pxr/usd/sdf/changeManager.cpp
@@ -34,7 +34,7 @@
 #include "pxr/base/tf/instantiateSingleton.h"
 #include "pxr/base/tf/stackTrace.h"
 
-#include <tbb/atomic.h>
+#include <atomic>
 
 using std::string;
 using std::vector;
@@ -149,9 +149,9 @@ Sdf_ChangeManager::_ProcessRemoveIfInert(_Data *data)
     TF_VERIFY(data->outermostBlock);
 }
 
-static tbb::atomic<size_t> &
+static std::atomic<size_t> &
 _InitChangeSerialNumber() {
-    static tbb::atomic<size_t> value;
+    static std::atomic<size_t> value;
     value = 1;
     return value;
 }
@@ -190,8 +190,8 @@ Sdf_ChangeManager::_SendNotices(_Data *data)
     }
 
     // Obtain a serial number for this round of change processing.
-    static tbb::atomic<size_t> &changeSerialNumber = _InitChangeSerialNumber();
-    size_t serialNumber = changeSerialNumber.fetch_and_increment();
+    static std::atomic<size_t> &changeSerialNumber = _InitChangeSerialNumber();
+    size_t serialNumber = changeSerialNumber.fetch_add(1);
 
     // Send global notice.
     SdfNotice::LayersDidChange(changes, serialNumber).Send();

--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -62,7 +62,7 @@ static_assert(sizeof(Sdf_PrimPropertyPathNode) == 3 * sizeof(void *), "");
 struct Sdf_PathNodePrivateAccess
 {
     template <class Handle>
-    static inline tbb::atomic<unsigned int> &
+    static inline std::atomic<unsigned int> &
     GetRefCount(Handle h) {
         Sdf_PathNode const *p =
             reinterpret_cast<Sdf_PathNode const *>(h.GetPtr());
@@ -265,7 +265,7 @@ _FindOrCreate(Table &table,
     if (iresult.second ||
         (Table::NodeHandle::IsCounted &&
          Access::GetRefCount(
-             iresult.first->second).fetch_and_increment() == 0)) {
+             iresult.first->second).fetch_add(1) == 0)) {
         // There was either no entry, or there was one but it had begun dying
         // (another client dropped its refcount to 0).  We have to create a new
         // entry in the table.  When the client that is deleting the other node

--- a/pxr/usd/sdf/pathNode.h
+++ b/pxr/usd/sdf/pathNode.h
@@ -33,7 +33,7 @@
 #include <boost/noncopyable.hpp>
 #include <boost/intrusive_ptr.hpp>
 
-#include <tbb/atomic.h>
+#include <atomic>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -311,7 +311,7 @@ private:
     // Instance variables.  PathNode's size is important to keep small.  Please
     // be mindful of that when making any changes here.
     const Sdf_PathNodeConstRefPtr _parent;
-    mutable tbb::atomic<unsigned int> _refCount;
+    mutable std::atomic<unsigned int> _refCount;
 
     const short _elementCount;
     const unsigned char _nodeType;
@@ -751,7 +751,7 @@ inline void intrusive_ptr_add_ref(const PXR_NS::Sdf_PathNode* p) {
     ++p->_refCount;
 }
 inline void intrusive_ptr_release(const PXR_NS::Sdf_PathNode* p) {
-    if (p->_refCount.fetch_and_decrement() == 1)
+    if (p->_refCount.fetch_sub(1) == 1)
         p->_Destroy();
 }
 

--- a/pxr/usd/sdf/pch.h
+++ b/pxr/usd/sdf/pch.h
@@ -225,7 +225,6 @@
 #include <boost/variant.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>

--- a/pxr/usd/usd/pch.h
+++ b/pxr/usd/usd/pch.h
@@ -228,7 +228,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/in_place_factory.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>

--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -45,6 +45,7 @@
 
 #include <tbb/enumerable_thread_specific.h>
 #include <algorithm>
+#include <atomic>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -100,11 +101,24 @@ private:
 
     struct _PrototypeTask
     {
-        _PrototypeTask() : numDependencies(0) { }
+        _PrototypeTask() noexcept
+            : numDependencies(0) { }
+
+        _PrototypeTask(const _PrototypeTask &other) noexcept
+            : dependentPrototypes(other.dependentPrototypes)
+        {
+            numDependencies.store(other.numDependencies.load());
+        }
+
+        _PrototypeTask(_PrototypeTask &&other) noexcept
+            : dependentPrototypes(std::move(other.dependentPrototypes))
+        {
+            numDependencies.store(other.numDependencies.load());
+        }
 
         // Number of dependencies -- prototype prims that must be resolved
         // before this prototype can be resolved.
-        tbb::atomic<size_t> numDependencies;
+        std::atomic<size_t> numDependencies;
 
         // List of prototype prims that depend on this prototype.
         std::vector<_PrimContext> dependentPrototypes;
@@ -196,7 +210,7 @@ private:
             _PrototypeTask& dependentPrototypeData =
                 prototypeTasks->find(dependentPrototype)->second;
             if (dependentPrototypeData.numDependencies
-                .fetch_and_decrement() == 1){
+                .fetch_sub(1) == 1){
                 dispatcher->Run(
                     &_PrototypeBBoxResolver::_ExecuteTaskForPrototype,
                     this, dependentPrototype, prototypeTasks, xfCaches,
@@ -1484,4 +1498,3 @@ size_t hash_value(const UsdGeomBBoxCache::_PrimContext &key)
 
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/usd/usdGeom/pch.h
+++ b/pxr/usd/usdGeom/pch.h
@@ -181,7 +181,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdHydra/pch.h
+++ b/pxr/usd/usdHydra/pch.h
@@ -162,7 +162,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdLux/pch.h
+++ b/pxr/usd/usdLux/pch.h
@@ -177,7 +177,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdMedia/pch.h
+++ b/pxr/usd/usdMedia/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdMtlx/pch.h
+++ b/pxr/usd/usdMtlx/pch.h
@@ -193,7 +193,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/usd/usdPhysics/pch.h
+++ b/pxr/usd/usdPhysics/pch.h
@@ -181,7 +181,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdRender/pch.h
+++ b/pxr/usd/usdRender/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdRi/pch.h
+++ b/pxr/usd/usdRi/pch.h
@@ -173,7 +173,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdShade/pch.h
+++ b/pxr/usd/usdShade/pch.h
@@ -179,7 +179,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdSkel/pch.h
+++ b/pxr/usd/usdSkel/pch.h
@@ -180,7 +180,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdUI/pch.h
+++ b/pxr/usd/usdUI/pch.h
@@ -168,7 +168,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdUtils/pch.h
+++ b/pxr/usd/usdUtils/pch.h
@@ -215,7 +215,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdVol/pch.h
+++ b/pxr/usd/usdVol/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usdImaging/plugin/usdShaders/pch.h
+++ b/pxr/usdImaging/plugin/usdShaders/pch.h
@@ -160,7 +160,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usdImaging/usdAppUtils/pch.h
+++ b/pxr/usdImaging/usdAppUtils/pch.h
@@ -173,7 +173,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usdImaging/usdImaging/pch.h
+++ b/pxr/usdImaging/usdImaging/pch.h
@@ -173,7 +173,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
+++ b/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
@@ -286,22 +286,36 @@ private:
     // non-time varying data, entries may exist in the cache with invalid
     // values. The version is used to determine validity.
     struct _Entry {
-        _Entry()
+        _Entry() noexcept
             : value(Strategy::MakeDefault())
             , version(_GetInitialEntryVersion()) 
         { }
 
         _Entry(const query_type & query_,
                const value_type& value_,
-               unsigned version_)
+               unsigned version_) noexcept
             : query(query_)
             , value(value_)
             , version(version_)
         { }
 
+        _Entry(const _Entry &other) noexcept
+            : query(other.query)
+            , value(other.value)
+        {
+            version.store(other.version.load());
+        }
+
+        _Entry(_Entry &&other) noexcept
+            : query(std::move(other.query))
+            , value(std::move(other.value))
+        {
+            version.store(other.version.load());
+        }
+
         query_type query;
         value_type value;
-        tbb::atomic<unsigned> version;
+        std::atomic<unsigned> version;
     };
 
     // Returns the version number for a valid cache entry
@@ -341,7 +355,7 @@ private:
 
     // A serial number indicating the valid state of entries in the cache. When
     // an entry has an equal or greater value, the entry is valid.
-    tbb::atomic<unsigned> _cacheVersion;
+    std::atomic<unsigned> _cacheVersion;
 
     // Value overrides for a set of descendents.
     ValueOverridesMap _valueOverrides;
@@ -359,8 +373,9 @@ UsdImaging_ResolvedAttributeCache<Strategy,ImplData>::_SetCacheEntryForPrim(
 {
     // Note: _cacheVersion is not allowed to change during cache access.
     unsigned v = entry->version;
+    unsigned cv = _cacheVersion.load();
     if (v < _cacheVersion 
-        && entry->version.compare_and_swap(_cacheVersion, v) == v)
+        && entry->version.compare_exchange_strong(cv, v))
     {
         entry->value = value;
         entry->version = _GetValidVersion();

--- a/pxr/usdImaging/usdImagingGL/pch.h
+++ b/pxr/usdImaging/usdImagingGL/pch.h
@@ -186,7 +186,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/usdImaging/usdRiImaging/pch.h
+++ b/pxr/usdImaging/usdRiImaging/pch.h
@@ -169,7 +169,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/usdImaging/usdSkelImaging/pch.h
+++ b/pxr/usdImaging/usdSkelImaging/pch.h
@@ -169,7 +169,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usdImaging/usdVolImaging/pch.h
+++ b/pxr/usdImaging/usdVolImaging/pch.h
@@ -167,7 +167,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/usdImaging/usdviewq/pch.h
+++ b/pxr/usdImaging/usdviewq/pch.h
@@ -167,7 +167,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>


### PR DESCRIPTION
### Description of Change(s)

Swaps out tbb::atomic with std::atomic, with the help of the people in #1471

_PrototypeTask and _Entry structs need defined copy/move constructors to be able to compile (std::atomic has copy deleted and move undefined). The adding into a TfHashMap with a make_pair is considered a move.

### Fixes Issue(s)
- In the process of supporting a later TBB version https://github.com/PixarAnimationStudios/USD/issues/1471 tbb::atomic is considered deprecated in favour of std::atomic.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
