### PR TITLE
tf: account for Python GIL explicit initialization deprecation from Python 3.7 to 3.9

### DIFF
--- a/pxr/base/tf/pyInterpreter.cpp
+++ b/pxr/base/tf/pyInterpreter.cpp
@@ -67,6 +67,9 @@ TfPyInitialize()
 
     if (!Py_IsInitialized()) {
 
+        // Starting with Python 3.7, the GIL is initialized as part of
+        // Py_Initialize(). Python 3.9 deprecated explicit GIL initialization.
+#if PY_MAJOR_VERSION < 3 || PY_MINOR_VERSION < 7
         if (!ArchIsMainThread() && !PyEval_ThreadsInitialized()) {
             // Python claims that PyEval_InitThreads "should be called in the
             // main thread before creating a second thread or engaging in any
@@ -74,6 +77,7 @@ TfPyInitialize()
             TF_WARN("Calling PyEval_InitThreads() for the first time outside "
                     "the 'main thread'.  Python doc says not to do this.");
         }
+#endif
 
         const std::string s = ArchGetExecutablePath();
 
@@ -113,9 +117,10 @@ TfPyInitialize()
         sigaction(SIGINT, &origSigintHandler, NULL);
 #endif
 
-#if PY_MAJOR_VERSION > 2
-        // In python 3 PyEval_InitThreads must be called after Py_Initialize()
-        // see https://docs.python.org/3/c-api/init.html
+#if PY_MAJOR_VERSION > 2 && PY_MINOR_VERSION < 7
+        // In Python 3 (before 3.7), PyEval_InitThreads must be called
+        // after Py_Initialize().
+        // see https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads
         //
         // Initialize Python threading.  This grabs the GIL.  We'll release it
         // at the end of this function.

--- a/pxr/base/tf/pyModule.cpp
+++ b/pxr/base/tf/pyModule.cpp
@@ -399,8 +399,12 @@ void Tf_PyInitWrapModule(
     const char* packageTag,
     const char* packageTag2)
 {
+    // Starting with Python 3.7, the GIL is initialized as part of
+    // Py_Initialize(). Python 3.9 deprecated explicit GIL initialization.
+#if PY_MAJOR_VERSION < 3 || PY_MINOR_VERSION < 7
     // Ensure the python GIL is created.
     PyEval_InitThreads();
+#endif
 
     // Tell the tracing mechanism that python is alive.
     Tf_PyTracingPythonInitialized();


### PR DESCRIPTION
### Description of Change(s)

Starting with Python 3.7, the GIL is initialized as part of Py_Initialize() and PyEval_InitThreads() no longer needs to be called separately. In Python 3.9, PyEval_InitThreads() no longer does anything and was marked deprecated.

See here for more detail:
https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads

This change avoids the use of PyEval_InitThreads() and PyEval_ThreadsInitialized() when building against Python 3.7 or later and cleans up the deprecation warnings that are otherwise issued. Those functions are slated for removal in Python 3.11.

- [ X ] I have submitted a signed Contributor License Agreement
