### PR TITLE
Allow for Metal Storm applications without openGL

### DIFF
--- a/pxr/imaging/glf/contextCaps.cpp
+++ b/pxr/imaging/glf/contextCaps.cpp
@@ -76,7 +76,8 @@ GlfContextCaps::GetInstance()
 {
     GlfContextCaps& caps = TfSingleton<GlfContextCaps>::GetInstance();
 
-    if (caps.glVersion == 0) {
+    if (GlfGLContext::GetCurrentGLContext()->IsValid() &&
+        caps.glVersion == 0) {
         TF_CODING_ERROR("GlfContextCaps has not been initialized");
         // Return the default set
     }


### PR DESCRIPTION
### Description of Change(s)
This PR is provided for reference to anyone that needs a Metal-only application of USD Storm without OpenGL.

It only sets up the openGL state if there is a valid contexts, which removes the need to set up a dummy openGL context for Metal applications.

The behaviour of openGL applications like usdview isn't affected.

### Fixes Issue(s)
- Dummy openGL context in Metal applications.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
