### PR TITLE
APPLE: macOS Cross Compilation

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -20,16 +20,16 @@ Our test machines have the following software versions installed
 | Boost         | 1.70.0               | 1.76.0                       | 1.70.0                         |
 | Intel TBB     | 2019 Update 6        | 2018 Update 1, 2019 Update 6 | 2019 Update 6                  |
 | OpenSubdiv    | 3.4.4                | 3.4.4                        | 3.4.4                          |
-| OpenImageIO   | 2.1.16.0             | 2.1.16.0                     | 2.1.16.0                       |
+| OpenImageIO   | 2.3.15.0             | 2.3.15.0                     | 2.3.15.0                       |
 | OpenColorIO   | 1.1.0                | 1.1.0                        | 1.1.0                          |
 | OSL           | 1.10.9               |                              |                                |
 | Ptex          | 2.3.2                | 2.1.33                       | 2.1.33                         |
 | Qt for Python | PySide2 5.14.1       | PySide6 6.3.1                | PySide2 5.14.1                 |
 | PyOpenGL      | 3.1.5                | 3.1.5                        | 3.1.5                          |
-| Embree        | 3.2.2                | 3.13.3                       | 3.2.2                          |
+| Embree        | 3.2.2                | 3.2.2                        | 3.2.2                          |
 | RenderMan     | 24.0                 | 24.0                         | 24.0                           |
-| Alembic       | 1.7.10               | 1.7.10                       | 1.7.10                         |
-| OpenEXR       | 2.4.4                | 2.4.4                        | 2.5.2                          |
+| Alembic       | 1.8.3                | 1.8.3                        | 1.8.3                          |
+| OpenEXR       | 2.5.5                | 2.5.5                        | 2.5.5                          |
 | MaterialX     | 1.38.4               | 1.38.4                       | 1.38.4                         |
 | Jinja2        | 2.0                  |                              |                                |
 | Flex          | 2.5.39               |                              |                                |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -19,7 +19,7 @@ Our test machines have the following software versions installed
 | Python        | 2.7.16, 3.6.8        | 2.7.10, 3.7.7                | 2.7.12, 3.7.4, 3.8.10          |
 | Boost         | 1.70.0               | 1.76.0                       | 1.70.0                         |
 | Intel TBB     | 2019 Update 6        | 2018 Update 1, 2019 Update 6 | 2019 Update 6                  |
-| OpenSubdiv    | 3.4.4                | 3.4.4                        | 3.4.4                          |
+| OpenSubdiv    | 3.5.0rc              | 3.5.0rc                      | 3.5.0rc                        |
 | OpenImageIO   | 2.3.15.0             | 2.3.15.0                     | 2.3.15.0                       |
 | OpenColorIO   | 1.1.0                | 1.1.0                        | 1.1.0                          |
 | OSL           | 1.10.9               |                              |                                |

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+import sys
+import locale
+import os
+import platform
+import shlex
+import subprocess
+
+TARGET_NATIVE = "native"
+TARGET_X86 = "x86_64"
+TARGET_ARM64 = "arm64"
+
+def MacOS():
+    return platform.system() == "Darwin"
+
+def GetLocale():
+    return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
+
+def GetCommandOutput(command):
+    """Executes the specified command and returns output or None."""
+    try:
+        return subprocess.check_output(
+            shlex.split(command), 
+            stderr=subprocess.STDOUT).decode(GetLocale(), 'replace').strip()
+    except subprocess.CalledProcessError:
+        pass
+    return None
+
+def GetMacArmArch():
+    # Allows the arm architecture string to be overridden by setting MACOS_ARM_ARCHITECTURE
+    return os.environ.get('MACOS_ARM_ARCHITECTURE') or TARGET_ARM64
+
+def GetMacArch():
+    macArch = GetCommandOutput('arch').strip()
+    if macArch == "i386" or macArch == TARGET_X86:
+        macArch = TARGET_X86
+    else:
+        macArch = GetMacArmArch()
+    return macArch
+
+def GetMacTargetArch(context):
+    if context.targetNative:
+        macTargets = GetMacArch()
+    else:
+        if context.targetX86:
+            macTargets = TARGET_X86
+        if context.targetARM64:
+            macTargets = GetMacArmArch()
+    return macTargets
+
+def IsMacTargetIntel(context):
+    return GetMacTargetArch(context) == TARGET_X86
+
+devout = open(os.devnull, 'w')
+
+def ExtractFilesRecursive(path, cond):
+    files = []
+    for r, d, f in os.walk(path):
+        for file in f:
+            if cond(os.path.join(r,file)):
+                files.append(os.path.join(r, file))
+    return files
+
+def CodesignFiles(files):
+    SDKVersion  = subprocess.check_output(['xcodebuild', '-version']).strip()[6:10]
+    codeSignIDs = subprocess.check_output(['security', 'find-identity', '-vp', 'codesigning'])
+
+    codeSignID = "-"
+    if os.environ.get('CODE_SIGN_ID'):
+        codeSignID = os.environ.get('CODE_SIGN_ID')
+    elif float(SDKVersion) >= 11.0 and codeSignIDs.find(b'Apple Development') != -1:
+        codeSignID = "Apple Development"
+    elif codeSignIDs.find(b'Mac Developer') != -1:
+        codeSignID = "Mac Developer"
+        
+    for f in files:
+        subprocess.call(['codesign', '-f', '-s', '{codesignid}'
+              .format(codesignid=codeSignID), f],
+              stdout=devout, stderr=devout)
+
+def Codesign(install_path, verbose_output=False):
+    if not MacOS():
+        return False
+    if verbose_output:
+        global devout
+        devout = sys.stdout
+
+    files = ExtractFilesRecursive(install_path, 
+                 (lambda file: '.so' in file or '.dylib' in file))
+    CodesignFiles(files)
+

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 import argparse
 import codecs
 import contextlib
+import copy
 import ctypes
 import datetime
 import distutils
@@ -43,6 +44,7 @@ import sys
 import sysconfig
 import tarfile
 import zipfile
+import apple_utils
 
 if sys.version_info.major >= 3:
     from urllib.request import urlopen
@@ -90,8 +92,6 @@ def Linux():
     return platform.system() == "Linux"
 def MacOS():
     return platform.system() == "Darwin"
-def Arm():
-    return platform.processor() == "arm"
 
 def Python3():
     return sys.version_info.major == 3
@@ -247,7 +247,7 @@ def GetCPUCount():
     except NotImplementedError:
         return 1
 
-def Run(cmd, logCommandOutput = True):
+def Run(cmd, logCommandOutput = True, envOverride = None):
     """Run the specified command in a subprocess."""
     PrintInfo('Running "{cmd}"'.format(cmd=cmd))
 
@@ -261,7 +261,7 @@ def Run(cmd, logCommandOutput = True):
         # code will handle them.
         if logCommandOutput:
             p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, 
-                                 stderr=subprocess.STDOUT)
+                                 stderr=subprocess.STDOUT, env=envOverride)
             while True:
                 l = p.stdout.readline().decode(GetLocale(), 'replace')
                 if l:
@@ -270,7 +270,7 @@ def Run(cmd, logCommandOutput = True):
                 elif p.poll() is not None:
                     break
         else:
-            p = subprocess.Popen(shlex.split(cmd))
+            p = subprocess.Popen(shlex.split(cmd), env=envOverride)
             p.wait()
 
     if p.returncode != 0:
@@ -355,7 +355,7 @@ def FormatMultiProcs(numJobs, generator):
 
     return "{tag}{procs}".format(tag=tag, procs=numJobs)
 
-def RunCMake(context, force, extraArgs = None):
+def RunCMake(context, force, extraArgs = None, envOverride = None):
     """Invoke CMake to configure, build, and install a library whose 
     source code is located in the current working directory."""
     # Create a directory for out-of-source builds in the build directory
@@ -398,6 +398,16 @@ def RunCMake(context, force, extraArgs = None):
     if MacOS():
         osx_rpath = "-DCMAKE_MACOSX_RPATH=ON"
 
+        # For macOS cross compilation, set the Xcode architecture flags.
+        targetArch = apple_utils.GetMacTargetArch(context)
+
+        if context.targetNative or targetArch == apple_utils.GetMacArch():
+            extraArgs.append('-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=YES')
+        else:
+            extraArgs.append('-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO')
+
+        extraArgs.append('-DCMAKE_OSX_ARCHITECTURES={0}'.format(targetArch))
+
     # We use -DCMAKE_BUILD_TYPE for single-configuration generators 
     # (Ninja, make), and --config for multi-configuration generators 
     # (Visual Studio); technically we don't need BOTH at the same
@@ -430,10 +440,12 @@ def RunCMake(context, force, extraArgs = None):
                     osx_rpath=(osx_rpath or ""),
                     generator=(generator or ""),
                     toolset=(toolset or ""),
-                    extraArgs=(" ".join(extraArgs) if extraArgs else "")))
+                    extraArgs=(" ".join(extraArgs) if extraArgs else "")),
+                    envOverride=envOverride)
         Run("cmake --build . --config {config} --target install -- {multiproc}"
             .format(config=config,
-                    multiproc=FormatMultiProcs(context.numJobs, generator)))
+                    multiproc=FormatMultiProcs(context.numJobs, generator)),
+                    envOverride=envOverride)
 
 def GetCMakeVersion():
     """
@@ -713,8 +725,28 @@ def InstallBoost_Helper(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
                                              dontExtract=dontExtract)):
         bootstrap = "bootstrap.bat" if Windows() else "./bootstrap.sh"
-        Run('{bootstrap} --prefix="{instDir}"'
-            .format(bootstrap=bootstrap, instDir=context.instDir))
+
+        # For cross-compilation on macOS we need to specify the architecture
+        # for both the bootstrap and the b2 phase of building boost.
+        bootstrapCmd = '{bootstrap} --prefix="{instDir}"'.format(
+            bootstrap=bootstrap, instDir=context.instDir)
+
+        macOSArchitecture = ""
+        macOSArch = ""
+
+        if MacOS():
+            if apple_utils.GetMacTargetArch(context) == apple_utils.TARGET_X86:
+                macOSArchitecture = "architecture=x86"
+                macOSArch = "-arch {0}".format(apple_utils.TARGET_X86)
+            elif apple_utils.GetMacTargetArch(context) == apple_utils.GetMacArmArch():
+                macOSArchitecture = "architecture=arm"
+                macOSArch = "-arch {0}".format(apple_utils.GetMacArmArch())
+
+            if macOSArch:
+                bootstrapCmd += " cxxflags=\"{0}\" cflags=\"{0}\" linkflags=\"{0}\"".format(macOSArch)
+            bootstrapCmd += " --with-toolset=clang"
+
+        Run(bootstrapCmd)
 
         # b2 supports at most -j64 and will error if given a higher value.
         num_procs = min(64, context.numJobs)
@@ -818,6 +850,15 @@ def InstallBoost_Helper(context, force, buildArgs):
             # libraries includes @rpath
             b2_settings.append("toolset=clang")
 
+            # Specify target for macOS cross-compilation.
+            if macOSArchitecture:
+                b2_settings.append(macOSArchitecture)
+
+            if macOSArch:
+                b2_settings.append("cxxflags=\"{0}\"".format(macOSArch))
+                b2_settings.append("cflags=\"{0}\"".format(macOSArch))
+                b2_settings.append("linkflags=\"{0}\"".format(macOSArch))
+
         if context.buildDebug:
             b2_settings.append("--debug-configuration")
 
@@ -853,11 +894,6 @@ BOOST = Dependency("boost", InstallBoost, BOOST_VERSION_FILE)
 if Windows():
     TBB_URL = "https://github.com/oneapi-src/oneTBB/releases/download/2019_U6/tbb2019_20190410oss_win.zip"
     TBB_ROOT_DIR_NAME = "tbb2019_20190410oss"
-elif MacOS() and not Arm():
-    # On MacOS Intel systems we experience various crashes in tests during
-    # teardown starting with 2018 Update 2. Until we figure that out, we use
-    # 2018 Update 1 on this platform.
-    TBB_URL = "https://github.com/oneapi-src/oneTBB/archive/refs/tags/2018_U1.tar.gz"
 else:
     TBB_URL = "https://github.com/oneapi-src/oneTBB/archive/refs/tags/2019_U6.tar.gz"
 
@@ -883,18 +919,36 @@ def InstallTBB_Windows(context, force, buildArgs):
         CopyDirectory(context, "include\\tbb", "include\\tbb")
 
 def InstallTBB_LinuxOrMacOS(context, force, buildArgs):
-    with CurrentWorkingDirectory(DownloadURL(TBB_URL, context, force)):
+    tbbURL = TBB_URL
+    if MacOS() and apple_utils.IsMacTargetIntel(context):
+        # On MacOS Intel systems we experience various crashes in tests during
+        # teardown starting with 2018 Update 2. Until we figure that out, we use
+        # 2018 Update 1 on this platform.
+        tbbURL = "https://github.com/oneapi-src/oneTBB/archive/refs/tags/2018_U1.tar.gz"
+    with CurrentWorkingDirectory(DownloadURL(tbbURL, context, force)):
         # Append extra argument controlling libstdc++ ABI if specified.
         AppendCXX11ABIArg("CXXFLAGS", context, buildArgs)
 
-        # Ensure that the tbb build system picks the proper architecture.
-        if MacOS() and Arm():
-            buildArgs.append("arch=arm64")
+        if MacOS():
+            PatchFile("build/macos.clang.inc", 
+                    [("-m64",
+                      "-m64 -arch {0}".format(apple_utils.TARGET_X86)),
+                     ("ifeq ($(arch),$(filter $(arch),armv7 armv7s arm64))",
+                      "ifeq ($(arch),$(filter $(arch),armv7 armv7s {0}))".format(apple_utils.GetMacArmArch()))])
+    
+            targetArch = apple_utils.GetMacTargetArch(context)
 
-        # TBB does not support out-of-source builds in a custom location.
-        Run('make -j{procs} {buildArgs}'
-            .format(procs=context.numJobs, 
-                    buildArgs=" ".join(buildArgs)))
+            if (targetArch == apple_utils.TARGET_X86):
+                targetArch = "intel64"
+
+            Run('make -j{procs} arch={arch} {buildArgs}'.format(
+                arch=targetArch,
+                procs=context.numJobs,
+                buildArgs=" ".join(buildArgs)))
+        else:
+            Run('make -j{procs} {buildArgs}'.format(
+                procs=context.numJobs,
+                buildArgs=" ".join(buildArgs)))
 
         # Install both release and debug builds. USD requires the debug
         # libraries when building in debug mode, and installing both
@@ -921,18 +975,26 @@ TBB = Dependency("TBB", InstallTBB, "include/tbb/tbb.h")
 
 if Windows():
     JPEG_URL = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/1.5.1.zip"
+elif MacOS():
+    JPEG_URL = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/2.0.1.zip"
 else:
     JPEG_URL = "https://www.ijg.org/files/jpegsrc.v9b.tar.gz"
 
 def InstallJPEG(context, force, buildArgs):
-    if Windows():
+    if Windows() or MacOS():
         InstallJPEG_Turbo(context, force, buildArgs)
     else:
         InstallJPEG_Lib(context, force, buildArgs)
 
 def InstallJPEG_Turbo(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(JPEG_URL, context, force)):
-        RunCMake(context, force, buildArgs)
+        extraJPEGArgs = buildArgs
+        if MacOS():
+            extraJPEGArgs.append("-DWITH_SIMD=FALSE")
+
+        RunCMake(context, force, extraJPEGArgs)
+        return os.getcwd()
+
 
 def InstallJPEG_Lib(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(JPEG_URL, context, force)):
@@ -984,13 +1046,14 @@ TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")
 PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.29.tar.gz"
 
 def InstallPNG(context, force, buildArgs):
-    macArgs = []
-    if MacOS() and Arm():
-        # ensure libpng's build doesn't erroneously activate inappropriate
-        # Neon extensions
-        macArgs = ["-DPNG_HARDWARE_OPTIMIZATIONS=OFF", 
-                   "-DPNG_ARM_NEON=off"] # case is significant
     with CurrentWorkingDirectory(DownloadURL(PNG_URL, context, force)):
+        macArgs = []
+        if MacOS() and not apple_utils.IsMacTargetIntel(context):
+            # Ensure libpng's build doesn't erroneously activate inappropriate
+            # Neon extensions
+            macArgs = ["-DCMAKE_C_FLAGS=\"-DPNG_ARM_NEON_OPT=0\""]
+
+
         RunCMake(context, force, buildArgs + macArgs)
 
 PNG = Dependency("PNG", InstallPNG, "include/png.h")
@@ -1092,7 +1155,7 @@ BLOSC_URL = "https://github.com/Blosc/c-blosc/archive/v1.20.1.zip"
 def InstallBLOSC(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(BLOSC_URL, context, force)):
         macArgs = []
-        if MacOS() and Arm():
+        if MacOS() and not apple_utils.IsMacTargetIntel(context):
             # Need to disable SSE for macOS ARM targets.
             macArgs = ["-DDEACTIVATE_SSE2=ON"]
         RunCMake(context, force, buildArgs + macArgs)
@@ -1135,7 +1198,8 @@ OPENVDB = Dependency("OpenVDB", InstallOpenVDB, "include/openvdb/openvdb.h")
 ############################################################
 # OpenImageIO
 
-OIIO_URL = "https://github.com/OpenImageIO/oiio/archive/Release-2.1.16.0.zip"
+# OIIO 2.3.15 adds fixes for Apple Silicon cross compilation.
+OIIO_URL = "https://github.com/OpenImageIO/oiio/archive/refs/tags/v2.3.15.0.zip"
 
 def InstallOpenImageIO(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(OIIO_URL, context, force)):
@@ -1202,23 +1266,21 @@ def InstallOpenColorIO(context, force, buildArgs):
                       [("IMPORTED_LOCATION_RELEASE", 
                         "IMPORTED_LOCATION_RELWITHDEBINFO")])
 
-        # When building for Apple Silicon we need to make sure that
-        # the correct build architecture is specified for OCIO and
-        # and for TinyXML and YAML.
-        if MacOS() and Arm():
-            arch = 'arm64'
+        if MacOS():
+            targetArch = apple_utils.GetMacTargetArch(context)
+
             PatchFile("CMakeLists.txt",
                     [('CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}',
-                    'CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}\n' +
-                    '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
-                    ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=arch)),
-                    ('CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}',
-                    'CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}\n' +
-                    '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
-                    ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=arch)),
-                    ('set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING',
-                     'set(CMAKE_OSX_ARCHITECTURES "{arch}" CACHE STRING'.format(arch=arch))])
-
+                      'CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}\n' +
+                      '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
+                      ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=targetArch)),
+                     ('CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}',
+                      'CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}\n' +
+                      '            CMAKE_CACHE_ARGS -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH:BOOL=TRUE'
+                      ' -DCMAKE_OSX_ARCHITECTURES:STRING="{arch}"'.format(arch=targetArch)),
+                     ('set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING',
+                      'set(CMAKE_OSX_ARCHITECTURES "{arch}" CACHE STRING'.format(arch=targetArch))])
+            
         # The OCIO build treats all warnings as errors but several come up
         # on various platforms, including:
         # - On gcc6, v1.1.0 emits many -Wdeprecated-declaration warnings for
@@ -1236,9 +1298,16 @@ def InstallOpenColorIO(context, force, buildArgs):
             pass
         else:
             extraArgs.append('-DCMAKE_CXX_FLAGS=-w')
+		
+        if MacOS():
+            #if using version 2 of OCIO we patch a different config path as it resides elsewere
+            PatchFile("src/core/Config.cpp",
+                       [("cacheidnocontext_ = cacheidnocontext_;", 
+                         "cacheidnocontext_ = rhs.cacheidnocontext_;")])
 
-        if MacOS() and Arm():
-            extraArgs.append('-DOCIO_USE_SSE=OFF')
+            extraArgs.append('-DCMAKE_CXX_FLAGS="-Wno-unused-function -Wno-unused-const-variable -Wno-unused-private-field"')
+            if not apple_utils.IsMacTargetIntel(context):
+                extraArgs.append('-DOCIO_USE_SSE=OFF')
 
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
@@ -1251,10 +1320,11 @@ OPENCOLORIO = Dependency("OpenColorIO", InstallOpenColorIO,
 ############################################################
 # OpenSubdiv
 
-OPENSUBDIV_URL = "https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_4_4.zip"
+OPENSUBDIV_URL = "https://github.com/PixarAnimationStudios/OpenSubdiv/archive/refs/tags/v3_5_0_RC1.tar.gz"
 
 def InstallOpenSubdiv(context, force, buildArgs):
-    with CurrentWorkingDirectory(DownloadURL(OPENSUBDIV_URL, context, force)):
+    srcOSDDir = DownloadURL(OPENSUBDIV_URL, context, force)
+    with CurrentWorkingDirectory(srcOSDDir):
         extraArgs = [
             '-DNO_EXAMPLES=ON',
             '-DNO_TUTORIALS=ON',
@@ -1298,8 +1368,6 @@ def InstallOpenSubdiv(context, force, buildArgs):
         # just 1 job for now. See:
         # https://github.com/PixarAnimationStudios/OpenSubdiv/issues/1194
         oldNumJobs = context.numJobs
-        if MacOS():
-            context.numJobs = 1
 
         try:
             RunCMake(context, force, extraArgs)
@@ -1356,6 +1424,7 @@ def GetPySideInstructions():
                 'update your PYTHONPATH to indicate where it is '
                 'located.')
 
+
 PYSIDE = PythonDependency("PySide", GetPySideInstructions,
                           moduleNames=["PySide", "PySide2", "PySide6"])
 
@@ -1366,6 +1435,9 @@ HDF5_URL = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.0
 
 def InstallHDF5(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(HDF5_URL, context, force)):
+        if MacOS():
+            PatchFile("config/cmake_ext_mod/ConfigureChecks.cmake", 
+                    [("if (ARCH_LENGTH GREATER 1)", "if (FALSE)")])
         RunCMake(context, force,
                  ['-DBUILD_TESTING=OFF',
                   '-DHDF5_BUILD_TOOLS=OFF',
@@ -1376,10 +1448,14 @@ HDF5 = Dependency("HDF5", InstallHDF5, "include/hdf5.h")
 ############################################################
 # Alembic
 
-ALEMBIC_URL = "https://github.com/alembic/alembic/archive/1.7.10.zip"
+ALEMBIC_URL = "https://github.com/alembic/alembic/archive/1.8.3.zip"
 
 def InstallAlembic(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ALEMBIC_URL, context, force)):
+        if MacOS():
+            PatchFile("CMakeLists.txt", 
+                      [("ADD_DEFINITIONS(-Wall -Werror -Wextra -Wno-unused-parameter)",
+                        "ADD_DEFINITIONS(-Wall -Wextra -Wno-unused-parameter)")])
         cmakeOptions = ['-DUSE_BINARIES=OFF', '-DUSE_TESTS=OFF']
         if context.enableHDF5:
             # HDF5 requires the H5_BUILT_AS_DYNAMIC_LIB macro be defined if
@@ -1725,6 +1801,11 @@ group.add_argument("--build-variant", default=BUILD_RELEASE,
                    help=("Build variant for USD and 3rd-party dependencies. "
                          "(default: {})".format(BUILD_RELEASE)))
 
+group.add_argument("--build-target", default=apple_utils.TARGET_NATIVE,
+                   choices=[apple_utils.TARGET_NATIVE, apple_utils.TARGET_X86, apple_utils.TARGET_ARM64],
+                   help=("Build target for macOS cross compilation. "
+                         "(default: {})".format(apple_utils.TARGET_NATIVE)))
+
 group.add_argument("--build-args", type=str, nargs="*", default=[],
                    help=("Custom arguments to pass to build system when "
                          "building libraries (see docs above)"))
@@ -1743,6 +1824,9 @@ group.add_argument("--generator", type=str,
 group.add_argument("--toolset", type=str,
                    help=("CMake toolset to use when building libraries with "
                          "cmake"))
+if MacOS():
+    group.add_argument("--codesign", dest="macos_codesign", default=False,
+                       help=("Use codesigning for macOS builds, required for Apple Silicon builds"))
 
 if Linux():
     group.add_argument("--use-cxx11-abi", type=int, choices=[0, 1],
@@ -1989,10 +2073,15 @@ class InstallContext:
         self.buildShared = (args.build_type == SHARED_LIBS)
         self.buildMonolithic = (args.build_type == MONOLITHIC_LIB)
 
-        # Build options
+        # Build target options, for macOS
+        self.targetNative = (args.build_target == apple_utils.TARGET_NATIVE)
+        self.targetX86 = (args.build_target == apple_utils.TARGET_X86)
+        self.targetARM64 = (args.build_target == apple_utils.TARGET_ARM64)
         self.useCXX11ABI = \
             (args.use_cxx11_abi if hasattr(args, "use_cxx11_abi") else None)
         self.safetyFirst = args.safety_first
+        self.macOSCodesign = \
+            (args.macos_codesign if hasattr(args, "macos_codesign") else False)
 
         # Dependencies that are forced to be built
         self.forceBuildAll = args.force_all
@@ -2248,6 +2337,7 @@ if context.useCXX11ABI is not None:
 
 summaryMsg += """\
     Variant                     {buildVariant}
+    Target                      {buildTarget}
     Imaging                     {buildImaging}
       Ptex support:             {enablePtex}
       OpenVDB support:          {enableOpenVDB}
@@ -2307,7 +2397,12 @@ summaryMsg = summaryMsg.format(
                   else "Debug" if context.buildDebug
                   else "Release w/ Debug Info" if context.buildRelWithDebug
                   else ""),
+    buildTarget=(apple_utils.TARGET_NATIVE if context.targetNative
+                  else apple_utils.TARGET_X86 if context.targetX86
+                  else apple_utils.GetMacArmArch() if context.targetARM64
+                  else ""),
     buildImaging=("On" if context.buildImaging else "Off"),
+    macOSCodesign=("On" if context.macOSCodesign else "Off"),
     enablePtex=("On" if context.enablePtex else "Off"),
     enableOpenVDB=("On" if context.enableOpenVDB else "Off"),
     buildOIIO=("On" if context.buildOIIO else "Off"),
@@ -2386,6 +2481,10 @@ if Windows():
         os.path.join(context.instDir, "bin"),
         os.path.join(context.instDir, "lib")
     ])
+
+if MacOS():
+    if context.macOSCodesign or context.targetARM64:
+        apple_utils.Codesign(context.usdInstDir, verbosity > 1)
 
 Print("""
 Success! To use USD, please ensure that you have:""")


### PR DESCRIPTION
### Description of Change(s)

This is a smaller change than the full Universal build support put up here: https://github.com/PixarAnimationStudios/USD/pull/1893

Allows for building ARM64 images on x86 machines and x86 ones on Apple Silicon by specifying the `--build-target` option.

It simplifies the changes into build_usd.py, avoiding the complexity of creating two images from TBB.



### Fixes Issue(s)
- Cross compilation on macOS

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
