### PR TITLE
Add support for validating USDZ files referencing textures with .jpeg…

### DIFF
--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -244,7 +244,7 @@ should always have upAxis set to 'Y'"""
 
 class TextureChecker(BaseRuleChecker):
     # The most basic formats are those published in the USDZ spec
-    _basicUSDZImageFormats = ("jpg", "png")
+    _basicUSDZImageFormats = ("jpg", "jpeg", "png")
 
     # In non-consumer-content (arkit) mode, OIIO can allow us to 
     # additionaly read other formats from USDZ packages
@@ -259,7 +259,7 @@ class TextureChecker(BaseRuleChecker):
     @staticmethod
     def GetDescription():
         return """Texture files should be readable by intended client 
-(only .jpg or .png for consumer-level USDZ)."""
+(only .jpg, .jpeg or .png for consumer-level USDZ)."""
 
     def __init__(self, verbose, consumerLevelChecks, assetLevelChecks):
         # Check if the prim has an allowed type.
@@ -466,7 +466,7 @@ Specifically:
         from pxr import Ar
         ext = Ar.GetResolver().GetExtension(asset.resolvedPath)
         # not an exhaustive list, but ones we typically can read
-        return ext in ["bmp", "tga", "jpg", "png", "tif"]
+        return ext in ["bmp", "tga", "jpg", "jpeg", "png", "tif"]
         
     def _GetInputValue(self, shader, inputName):
         from pxr import Usd


### PR DESCRIPTION
Add support for validating USDZ files referencing textures with the `.jpeg` extension

### Description of Change(s)
This prevents usdchecker from throwing a `TextureChecker` error when validating USDZ files referencing textures with the `.jpeg` extension. (usdchecker works fine with USDZ files referencing textures with the `.jpg` extension)

### Fixes Issue(s)
Prevents USDZ referencing textures with the `.jpeg` extension from failing the `TextureChecker` validation check. 

- [X] I have submitted a signed Contributor License Agreement
