### PR TITLE
Perform translations of DirtyCategories dirty bit

### DIFF
--- a/pxr/imaging/hd/dirtyBitsTranslator.cpp
+++ b/pxr/imaging/hd/dirtyBitsTranslator.cpp
@@ -110,6 +110,10 @@ HdDirtyBitsTranslator::RprimDirtyBitsToLocatorSet(TfToken const& primType,
         }
     }
 
+    if (bits & HdChangeTracker::DirtyCategories) {
+        set->append(HdCategoriesSchema::GetDefaultLocator());
+    }
+
     if (primType == HdPrimTypeTokens->cone) {
         if (bits & HdChangeTracker::DirtyPrimvar) {
             set->append(HdConeSchema::GetDefaultLocator());
@@ -466,6 +470,12 @@ HdDirtyBitsTranslator::RprimLocatorSetToDirtyBits(
         if (_FindLocator(HdCapsuleSchema::GetDefaultLocator(), end, &it)) {
             bits |= HdChangeTracker::DirtyPrimvar;
         }
+    }
+
+    // Locator (*): categories
+
+    if (_FindLocator(HdCategoriesSchema::GetDefaultLocator(), end, &it)) {
+        bits |= HdChangeTracker::DirtyCategories;
     }
 
     if (primType == HdPrimTypeTokens->cone) {


### PR DESCRIPTION
Perform dirty bit translations so that changes to rprim category
membership result in sync calls when using the UsdImaging scene delegate
with the scene index emulation layer.

### Description of Change(s)
This is sort of an amendment to #1653. Even after applying that patch, light linker updates didn't work in Houdini using USD 22.05 when a new light linker collection was added to the scene. Tracking this down revealed that the DirtyCategories bit was being set on the right rprims, but the translation of this dirty bit through the emulation scene index was losing this dirty bit. So this change tracks the dirty bit in HdDirtyBitsTranslator.

- [ X ] I have submitted a signed Contributor License Agreement
