### PR TITLE
Fix PointInstancer prototypes example typos

### DIFF
--- a/pxr/usd/usdGeom/generatedSchema.usda
+++ b/pxr/usd/usdGeom/generatedSchema.usda
@@ -3465,7 +3465,7 @@ class PointInstancer "PointInstancer" (
     \\code
     01 def PointInstancer \"Crowd_Mid\"
     02 {
-    03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleTine_Casual> ]
+    03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleThin_Casual> ]
     04     
     05     over \"Prototypes\" 
     06     {

--- a/pxr/usd/usdGeom/pointInstancer.h
+++ b/pxr/usd/usdGeom/pointInstancer.h
@@ -246,7 +246,7 @@ class SdfAssetPath;
 /// \code
 /// 01 def PointInstancer "Crowd_Mid"
 /// 02 {
-/// 03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleTine_Casual> ]
+/// 03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleThin_Casual> ]
 /// 04     
 /// 05     over "Prototypes" 
 /// 06     {

--- a/pxr/usd/usdGeom/schema.usda
+++ b/pxr/usd/usdGeom/schema.usda
@@ -1913,7 +1913,7 @@ class PointInstancer "PointInstancer" (
     \\code
     01 def PointInstancer "Crowd_Mid"
     02 {
-    03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleTine_Casual> ]
+    03     rel prototypes = [ </Crowd_Mid/Prototypes/MaleThin_Business>, </Crowd_Mid/Prototypes/MaleThin_Casual> ]
     04     
     05     over "Prototypes" 
     06     {


### PR DESCRIPTION
### Description of Change(s)
As can be seen in [the USD docs](https://graphics.pixar.com/usd/release/api/class_usd_geom_point_instancer.html#UsdGeomPointInstancer_protoProcessing), the example for a prototypes relationship in the UsdGeomPointInstancer section seems to have a typo. There is a reference to ```</Crowd_Mid/Prototypes/MaleTine_Casual>```, but the prim that this seems to be targeting is named ```</Crowd_Mid/Prototypes/MaleThin_Casual>```.

### Fixes Issue(s)
- Replaced ```</Crowd_Mid/Prototypes/MaleTine_Casual>``` with ```</Crowd_Mid/Prototypes/MaleThin_Casual>``` in the ```pxr/usd/usdGeom/``` folder

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
