### PR TITLE
APPLE: OCIO 2.1.1 with native Metal support

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -21,7 +21,7 @@ Our test machines have the following software versions installed
 | Intel TBB     | 2019 Update 6        | 2018 Update 1, 2019 Update 6 | 2019 Update 6                  |
 | OpenSubdiv    | 3.5.0                | 3.5.0                        | 3.5.0                          |
 | OpenImageIO   | 2.1.16.0             | 2.3.15.0                     | 2.1.16.0                       |
-| OpenColorIO   | 1.1.0                | 1.1.0                        | 1.1.0                          |
+| OpenColorIO   | 1.1.0 (default)      | 2.1.2                        | 2.1.2                          |
 | OSL           | 1.10.9               |                              |                                |
 | Ptex          | 2.3.2                | 2.1.33                       | 2.1.33                         |
 | Qt for Python | PySide2 5.14.1       | PySide6 6.3.1                | PySide2 5.14.1                 |


### PR DESCRIPTION
### Description of Change(s)

Add OCIO 2 with GPU path for openGL and Metal.

Thanks to the team at Apple for the work on implementing this.

### Fixes Issue(s)
- Full OCIO support

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
