### PR TITLE
APPLE: HGI performance metrics for CPU and GPU

### DIFF
--- a/pxr/imaging/hgi/CMakeLists.txt
+++ b/pxr/imaging/hgi/CMakeLists.txt
@@ -21,6 +21,7 @@ pxr_library(hgi
         graphicsPipeline
         hgi
         indirectCommandEncoder
+        metrics
         resourceBindings
         sampler
         shaderFunction

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -49,6 +49,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HgiCapabilities;
 class HgiIndirectCommandEncoder;
+class HgiMetrics;
 
 using HgiUniquePtr = std::unique_ptr<class Hgi>;
 
@@ -301,6 +302,11 @@ public:
     /// Thread safety: This call is thread safe.
     HGI_API
     virtual HgiIndirectCommandEncoder* GetIndirectCommandEncoder() const = 0;
+
+    /// Metrics
+    /// Thread safety: This call is thread safe.
+    HGI_API
+    virtual HgiMetrics * GetMetrics() = 0;
 
     /// Optionally called by client app at the start of a new rendering frame.
     /// We can't rely on StartFrame for anything important, because it is up to

--- a/pxr/imaging/hgi/metrics.cpp
+++ b/pxr/imaging/hgi/metrics.cpp
@@ -1,0 +1,191 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hgi/metrics.h"
+
+#include <iostream>
+#include <iomanip>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+uint64_t
+HgiMetrics::_GetNanoseconds()
+{
+    using namespace std::chrono;
+    auto now = steady_clock::now();
+    // nanoseconds are used for compatibility with OpenGL queries.
+    auto nSec = duration_cast<nanoseconds>(now.time_since_epoch());
+
+    return nSec.count();
+}
+
+HgiMetrics::HgiMetrics()
+    : _activePacketId(0)
+{
+    _log.reserve(128);
+}
+
+HgiMetrics::~HgiMetrics()
+{
+}
+
+void
+HgiMetrics::Reset()
+{
+    _log.clear();
+}
+
+HGI_API
+std::vector<HgiMetrics::Summary>& HgiMetrics::GetLog()
+{
+    return _log;
+}
+
+void
+HgiMetrics::StartPacket()
+{
+    Packet &packet = _GetPacket(_activePacketId);
+    
+    packet.id = _activePacketId;
+    packet.eventsExpected = 0;
+    packet.eventsReceived = 0;
+    packet.timingCompleted = false;
+    packet.cpuStart = _GetNanoseconds();
+    
+    for (uint32_t i = 0; i < NUM_GPU_EVENTS; ++i) {
+        packet.events[i].id = 0;
+        packet.events[i].merged = false;
+    }
+}
+
+void
+HgiMetrics::EndPacket()
+{
+    Packet &packet = _GetPacket(_activePacketId);
+    packet.summary.cpuElapsed = _GetNanoseconds() - packet.cpuStart;
+    packet.timingCompleted = true;
+
+    uint32_t gpuPacketIndex = _ResolveGPUEvents();
+    
+    Packet &gpuPacket = _packets[gpuPacketIndex];
+    
+    static const size_t _maxLogEntries = 128;
+
+    if (_log.size() < _maxLogEntries) {
+        _log.push_back(gpuPacket.summary);
+    } else {
+        size_t index = _activePacketId % _maxLogEntries;
+        _log[index] = gpuPacket.summary;
+    }
+
+    ++_activePacketId;
+}
+
+HgiMetrics::Packet&
+HgiMetrics::_GetPacket(uint64_t packetId)
+{
+    return _packets[packetId % NUM_PACKETS];
+}
+
+uint32_t
+HgiMetrics::_ResolveGPUEvents()
+{
+    Packet *validPacket = nullptr;
+    uint64_t lastPacketId = 0;
+    uint32_t gpuFrameIndex = 0;
+
+    for (int i = 0; i < NUM_PACKETS; i++) {
+        Packet *packet = &_packets[i];
+        // To be a valid time it must have received all timing events back and
+        // have its frame marked as finished.
+        if (packet->id >= lastPacketId && packet->timingCompleted &&
+            packet->eventsExpected == packet->eventsReceived &&
+            packet->eventsExpected > 0) {
+            validPacket = packet;
+            gpuFrameIndex = i;
+            lastPacketId = packet->id;
+        }
+    }
+
+    if (!validPacket) {
+        return 0;
+    }
+
+    _ReadGPUTimers(validPacket);
+
+    GPUEvent* events = validPacket->events;
+
+    // Account for overlaps between the events to work out the total elapsed
+    // time and idle time.
+    for (uint32_t i = 0; i < validPacket->eventsReceived; ++i) {
+        GPUEvent & eventI = events[i];
+
+        if (eventI.merged) {
+            continue;
+        }
+
+        for (uint32_t j = i + 1; j < validPacket->eventsReceived; ++j) {
+            GPUEvent & eventJ = events[j];
+            // Check for overlap between the two events and merge.
+            if ((eventI.t0 < eventJ.t0 && eventI.t1 > eventJ.t0) ||
+                (eventI.t0 < eventJ.t1 && eventI.t1 > eventJ.t1) ||
+                (eventI.t0 > eventJ.t0 && eventI.t1 < eventJ.t1) ||
+                (eventI.t0 < eventJ.t0 && eventI.t1 > eventJ.t1)) {
+                eventI.t0 = std::min(eventI.t0, eventJ.t0);
+                eventI.t1 = std::max(eventI.t1, eventJ.t1);
+                eventJ.merged = true;
+            }
+        }
+    }
+    
+    // With the overlaps resolved, calculate the elapsed time from start of
+    // first command buffer to the end of the last and the occupied GPU time
+    // which excludes idle time.
+    uint64_t minT0 = events[0].t0;
+    uint64_t maxT1 = events[0].t1;
+    validPacket->summary.packetId = validPacket->id;
+    validPacket->summary.gpuOccupied = maxT1 - minT0;
+
+    for (uint32_t i = 1; i < validPacket->eventsReceived; ++i) {
+        GPUEvent const& eventI = events[i];
+
+        if (eventI.merged) {
+            continue;
+        }
+
+        minT0 = std::min(minT0, eventI.t0);
+        maxT1 = std::max(maxT1, eventI.t1);
+        validPacket->summary.gpuOccupied += (eventI.t1 - eventI.t0);
+    }
+
+    validPacket->summary.gpuElapsed = maxT1 - minT0;
+    
+    return gpuFrameIndex;
+}
+
+void
+HgiMetrics::_ReadGPUTimers(Packet* packet)
+{
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgi/metrics.h
+++ b/pxr/imaging/hgi/metrics.h
@@ -1,0 +1,109 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_HGI_METRICS_H
+#define PXR_IMAGING_HGI_METRICS_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgi/api.h"
+
+#include <chrono>
+#include <atomic>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HgiMetrics
+{
+public:
+    struct Summary {
+        uint64_t packetId;
+        uint64_t gpuElapsed;
+        uint64_t gpuOccupied;
+        uint64_t cpuElapsed;
+    };
+    
+    HgiMetrics();
+    
+    virtual ~HgiMetrics();
+
+    HGI_API
+    void Reset();
+    
+    HGI_API
+    std::vector<HgiMetrics::Summary>& GetLog();
+
+    HGI_API
+    void StartPacket();
+
+    HGI_API
+    void EndPacket();
+
+    uint32_t GetActivePacketId() const { return _activePacketId; }
+
+    HGI_API
+    virtual uint64_t StartGPUEvent(uint32_t packetId, uint64_t id) = 0;
+
+    HGI_API
+    virtual void EndGPUEvent(uint32_t packetId, uint64_t id) = 0;
+
+protected:
+    #define NUM_PACKETS 8
+    #define NUM_GPU_EVENTS 8
+    
+    struct GPUEvent {
+        union {
+            uint32_t tokens[2];
+            uint64_t id;
+        };
+        uint64_t t0;
+        uint64_t t1;
+        bool merged;
+    };
+
+    struct Packet {
+        uint32_t id;
+        GPUEvent events[NUM_GPU_EVENTS];
+        std::atomic<int32_t> eventsExpected;
+        std::atomic<int32_t> eventsReceived;
+        uint64_t cpuStart;
+        Summary summary;
+        bool timingCompleted;
+    };
+
+    Packet& _GetPacket(uint64_t packetId);
+    uint32_t _ResolveGPUEvents();
+    virtual void _ReadGPUTimers(Packet* packet);
+
+    static uint64_t
+    _GetNanoseconds();
+
+    uint32_t _activePacketId;
+    Packet _packets[NUM_PACKETS];
+    std::vector<Summary> _log;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiGL/CMakeLists.txt
+++ b/pxr/imaging/hgiGL/CMakeLists.txt
@@ -35,6 +35,7 @@ pxr_library(hgiGL
         graphicsCmds
         graphicsPipeline
         hgi
+        metrics
         ops
         resourceBindings
         sampler

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -251,12 +251,18 @@ HgiGLGraphicsCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
     // not set and restore all relevant gl state.
     HgiGL_ScopedStateHolder openglStateGuard;
 
+    uint64_t packetId = hgi->GetMetrics()->GetActivePacketId();
+    uint64_t eventID = hgi->GetMetrics()->StartGPUEvent(packetId, 0);
+
     // Resolve multisample textures
     HgiGL* hgiGL = static_cast<HgiGL*>(hgi);
     HgiGLDevice* device = hgiGL->GetPrimaryDevice();
     _AddResolveToOps(device);
 
     device->SubmitOps(_ops);
+
+    hgi->GetMetrics()->EndGPUEvent(packetId, eventID);
+
     return true;
 }
 

--- a/pxr/imaging/hgiGL/hgi.cpp
+++ b/pxr/imaging/hgiGL/hgi.cpp
@@ -35,6 +35,7 @@
 #include "pxr/imaging/hgiGL/diagnostic.h"
 #include "pxr/imaging/hgiGL/graphicsCmds.h"
 #include "pxr/imaging/hgiGL/graphicsPipeline.h"
+#include "pxr/imaging/hgiGL/metrics.h"
 #include "pxr/imaging/hgiGL/resourceBindings.h"
 #include "pxr/imaging/hgiGL/sampler.h"
 #include "pxr/imaging/hgiGL/shaderFunction.h"
@@ -80,6 +81,7 @@ HgiGL::HgiGL()
     _device = new HgiGLDevice();
 
     _capabilities.reset(new HgiGLCapabilities());
+    _metrics.reset(new HgiGLMetrics());
 }
 
 HgiGL::~HgiGL()
@@ -266,6 +268,12 @@ HgiGL::GetIndirectCommandEncoder() const
     return nullptr;
 }
 
+HgiGLMetrics *
+HgiGL::GetMetrics()
+{
+    return _metrics.get();
+}
+
 void
 HgiGL::StartFrame()
 {
@@ -342,6 +350,7 @@ HgiGL::_SubmitCmds(HgiCmds* cmds, HgiSubmitWaitType wait)
 
     // If the Hgi client does not call Hgi::EndFrame we garbage collect here.
     if (_frameDepth == 0) {
+        _metrics->EndPacket();
         _garbageCollector.PerformGarbageCollection();
         _device->GarbageCollect();
     }

--- a/pxr/imaging/hgiGL/hgi.h
+++ b/pxr/imaging/hgiGL/hgi.h
@@ -27,6 +27,7 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/hgiGL/api.h"
 #include "pxr/imaging/hgiGL/capabilities.h"
+#include "pxr/imaging/hgiGL/metrics.h"
 #include "pxr/imaging/hgiGL/garbageCollector.h"
 #include "pxr/imaging/hgi/hgi.h"
 #include "pxr/imaging/hgi/tokens.h"
@@ -167,6 +168,9 @@ public:
     HgiIndirectCommandEncoder* GetIndirectCommandEncoder() const override;
 
     HGIGL_API
+    HgiGLMetrics * GetMetrics() override;
+
+    HGIGL_API
     void StartFrame() override;
 
     HGIGL_API
@@ -220,6 +224,7 @@ private:
 
     HgiGLDevice* _device;
     std::unique_ptr<HgiGLCapabilities> _capabilities;
+    std::unique_ptr<HgiGLMetrics> _metrics;
     HgiGLGarbageCollector _garbageCollector;
     int _frameDepth;
 };

--- a/pxr/imaging/hgiGL/metrics.cpp
+++ b/pxr/imaging/hgiGL/metrics.cpp
@@ -1,0 +1,75 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hgiGL/metrics.h"
+#include "pxr/imaging/garch/glApi.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+uint64_t
+HgiGLMetrics::StartGPUEvent(uint32_t packetId, uint64_t id)
+{
+    Packet &packet = _GetPacket(packetId);
+    
+    int32_t index =
+        packet.eventsExpected.fetch_add(1, std::memory_order_relaxed);
+
+    if (index < NUM_GPU_EVENTS) {
+        GPUEvent& event = packet.events[index];
+        glGenQueries(2, event.tokens);
+        glQueryCounter(event.tokens[0], GL_TIMESTAMP);
+        event.t0 = 0;
+        return event.id;
+    }
+
+    return 0;
+}
+
+void
+HgiGLMetrics::EndGPUEvent(uint32_t packetId, uint64_t id)
+{
+    Packet &packet = _GetPacket(packetId);
+
+    for (uint32_t i = 0; i < NUM_GPU_EVENTS; ++i) {
+        GPUEvent& event = packet.events[i];
+        if (event.id == id) {
+            glQueryCounter(event.tokens[1], GL_TIMESTAMP);
+            event.t1 = 0;
+            packet.eventsReceived.fetch_add(1, std::memory_order_relaxed);
+            break;
+        }
+    }
+}
+
+void
+HgiGLMetrics::_ReadGPUTimers(Packet* packet)
+{
+    // Read all of the timestamps
+    for (uint32_t i = 0; i < packet->eventsReceived; ++i) {
+        GPUEvent & eventI = packet->events[i];
+        glGetQueryObjectui64v(eventI.tokens[0], GL_QUERY_RESULT, &eventI.t0);
+        glGetQueryObjectui64v(eventI.tokens[1], GL_QUERY_RESULT, &eventI.t1);
+    }
+}
+    
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiGL/metrics.h
+++ b/pxr/imaging/hgiGL/metrics.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_HGI_GL_METRICS_H
+#define PXR_IMAGING_HGI_GL_METRICS_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgiGL/api.h"
+
+#include "pxr/imaging/hgi/metrics.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HgiGLMetrics : public HgiMetrics
+{
+public:
+    uint64_t StartGPUEvent(uint32_t packetId, uint64_t id) override;
+    void EndGPUEvent(uint32_t packetId, uint64_t id) override;
+
+protected:
+    void _ReadGPUTimers(Packet* packet) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiMetal/CMakeLists.txt
+++ b/pxr/imaging/hgiMetal/CMakeLists.txt
@@ -31,6 +31,7 @@ pxr_library(hgiMetal
         graphicsPipeline.h
         hgi.h
         indirectCommandEncoder.h
+        metrics.h
         resourceBindings.h
         sampler.h
         shaderFunction.h
@@ -55,6 +56,7 @@ pxr_library(hgiMetal
         graphicsPipeline.mm
         hgi.mm
         indirectCommandEncoder.mm
+        metrics.mm
         resourceBindings.mm
         sampler.mm
         shaderFunction.mm

--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -28,6 +28,7 @@
 #include "pxr/imaging/hgiMetal/api.h"
 #include "pxr/imaging/hgiMetal/capabilities.h"
 #include "pxr/imaging/hgiMetal/indirectCommandEncoder.h"
+#include "pxr/imaging/hgiMetal/metrics.h"
 #include "pxr/imaging/hgi/hgi.h"
 #include "pxr/imaging/hgi/tokens.h"
 
@@ -146,6 +147,9 @@ public:
 
     HGIMETAL_API
     HgiMetalIndirectCommandEncoder* GetIndirectCommandEncoder() const override;
+
+    HGIMETAL_API
+    HgiMetalMetrics * GetMetrics() override;
 
     HGIMETAL_API
     void StartFrame() override;

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -33,6 +33,7 @@
 #include "pxr/imaging/hgiMetal/diagnostic.h"
 #include "pxr/imaging/hgiMetal/graphicsCmds.h"
 #include "pxr/imaging/hgiMetal/graphicsPipeline.h"
+#include "pxr/imaging/hgiMetal/metrics.h"
 #include "pxr/imaging/hgiMetal/resourceBindings.h"
 #include "pxr/imaging/hgiMetal/sampler.h"
 #include "pxr/imaging/hgiMetal/shaderFunction.h"
@@ -334,6 +335,20 @@ HgiMetalIndirectCommandEncoder*
 HgiMetal::GetIndirectCommandEncoder() const
 {
     return _indirectCommandEncoder.get();
+}
+
+static HgiMetalMetrics* _GetMetrics()
+{
+    // Because it is accessed in GPU callbacks, the metrics need to be a singleton.
+    static HgiMetalMetrics _metrics;
+    
+    return &_metrics;
+}
+
+HgiMetalMetrics *
+HgiMetal::GetMetrics()
+{
+    return _GetMetrics();
 }
 
 void

--- a/pxr/imaging/hgiMetal/metrics.h
+++ b/pxr/imaging/hgiMetal/metrics.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_HGI_METAL_METRICS_H
+#define PXR_IMAGING_HGI_METAL_METRICS_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgiMetal/api.h"
+
+#include "pxr/imaging/hgi/metrics.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HgiMetalMetrics final : public HgiMetrics
+{
+public:
+    HGIMETAL_API
+    uint64_t StartGPUEvent(uint32_t packetId, uint64_t id) override;
+
+    HGIMETAL_API
+    void EndGPUEvent(uint32_t packetId, uint64_t id) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiMetal/metrics.mm
+++ b/pxr/imaging/hgiMetal/metrics.mm
@@ -1,0 +1,69 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/imaging/hgiMetal/metrics.h"
+
+#include <algorithm>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+uint64_t
+HgiMetalMetrics::StartGPUEvent(uint32_t packetId, uint64_t id)
+{
+    // We should be locking a mutex here, but because of performance concerns
+    // we ignore the possibility of a race condition between this and the
+    // EndGPUEvent.
+    
+    Packet &packet = _GetPacket(packetId);
+    
+    int32_t index =
+        packet.eventsExpected.fetch_add(1, std::memory_order_relaxed);
+
+    if (index < NUM_GPU_EVENTS) {
+        GPUEvent& event = packet.events[index];
+        event.t0 = _GetNanoseconds();
+        event.id = id;
+    }
+
+    return id;
+}
+
+void
+HgiMetalMetrics::EndGPUEvent(uint32_t packetId, uint64_t id)
+{
+    // We should be locking a mutex here, but because of performance concerns
+    // we ignore the possibility of a race condition between this and the
+    // EndGPUEvent.
+    
+    Packet &packet = _GetPacket(packetId);
+
+    for (uint32_t i = 0; i < NUM_GPU_EVENTS; ++i) {
+        if (packet.events[i].id == id) {
+            packet.events[i].t1 = _GetNanoseconds();
+            packet.eventsReceived.fetch_add(1, std::memory_order_relaxed);
+            break;
+        }
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

Provide GPU and CPU metrics for HGI.  The system collects a log of the GPU and CPU counters which can be processed by the client application.  It is enabled by specifying the maximum number of entries in the log with the PXR_HGI_PERF_LOG_CAPACITY environment variable.

Tested on Metal and OpenGL.

### Fixes Issue(s)
- GPU performance analysis.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
