### PR TITLE
add BOOST_ALL_NO_LIB define to prevent boost adding lib names to objects

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -99,6 +99,9 @@ if (NOT Boost_USE_STATIC_LIBS)
     _add_define("BOOST_ALL_DYN_LINK")
 endif()
 
+# Stop Boost trying to be "helpful" and baking lib names in via `#pragma lib`
+_add_define("BOOST_ALL_NO_LIB")
+
 if(${PXR_USE_DEBUG_PYTHON})
     _add_define("BOOST_DEBUG_PYTHON")
     _add_define("BOOST_LINKING_PYTHON")


### PR DESCRIPTION
### Description of Change(s)

This just adds the BOOST_ALL_NO_LIB define to the msvcdefaults

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/1943

- [x] I have submitted a signed Contributor License Agreement
