### PR TITLE
Add missing <algorithm> include for std::find and std::transform

### DIFF
--- a/pxr/usd/sdr/shaderMetadataHelpers.cpp
+++ b/pxr/usd/sdr/shaderMetadataHelpers.cpp
@@ -27,6 +27,7 @@
 #include "pxr/usd/sdr/shaderMetadataHelpers.h"
 #include "pxr/usd/sdr/shaderProperty.h"
 
+#include <algorithm>
 #include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
### Description of Change(s)

Building with clang-13 was failing because of missing <algorithm> include. This PR adds the missing include.

### Fixes Issue(s)
-

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
