### PR TITLE
[tests] fixes for tests if paths have spaces

### DIFF
--- a/extras/imaging/examples/hdTiny/CMakeLists.txt
+++ b/extras/imaging/examples/hdTiny/CMakeLists.txt
@@ -37,7 +37,7 @@ if (APPLE)
         ENV
             DYLD_INSERT_LIBRARIES=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.dylib
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdTiny'" 
         STDOUT_REDIRECT output.txt
         DIFF_COMPARE output.txt
     )
@@ -46,7 +46,7 @@ elseif (UNIX)
         ENV
             LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.so
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdTiny'" 
         STDOUT_REDIRECT output.txt
         DIFF_COMPARE output.txt
     )
@@ -56,7 +56,7 @@ elseif (WIN32)
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdTiny'" 
         STDOUT_REDIRECT output.txt
         DIFF_COMPARE output.txt
     )

--- a/extras/usd/examples/usdDancingCubesExample/CMakeLists.txt
+++ b/extras/usd/examples/usdDancingCubesExample/CMakeLists.txt
@@ -44,7 +44,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND
     "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     pxr_register_test(testUsdDancingCubesExample
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdDancingCubesExample"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdDancingCubesExample'"
         DIFF_COMPARE dynamicContents.usda newDynamicContents.usda
         EXPECTED_RETURN_CODE 0
         ENV
@@ -53,7 +53,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND
 else()
     pxr_register_test(testUsdDancingCubesExample
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdDancingCubesExample"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdDancingCubesExample'"
         EXPECTED_RETURN_CODE 0
         ENV
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/usdDancingCubesExample/resources

--- a/extras/usd/examples/usdRecursivePayloadsExample/CMakeLists.txt
+++ b/extras/usd/examples/usdRecursivePayloadsExample/CMakeLists.txt
@@ -42,7 +42,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND
     "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     pxr_register_test(testUsdRecursivePayloadsExample
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRecursivePayloadsExample"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRecursivePayloadsExample'"
         DIFF_COMPARE flattenedContents.usda newFlattenedContents.usda
         EXPECTED_RETURN_CODE 0
         ENV
@@ -51,7 +51,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND
 else()
     pxr_register_test(testUsdRecursivePayloadsExample
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRecursivePayloadsExample"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRecursivePayloadsExample'"
         EXPECTED_RETURN_CODE 0
         ENV
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/usdRecursivePayloadsExample/resources

--- a/extras/usd/examples/usdResolverExample/CMakeLists.txt
+++ b/extras/usd/examples/usdResolverExample/CMakeLists.txt
@@ -43,7 +43,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdResolverExample
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverExample"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverExample'"
     EXPECTED_RETURN_CODE 0
     ENV
         ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/usdResolverExample/resources

--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -179,41 +179,41 @@ endif()
 
 
 pxr_register_test(testArchAbi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchAbi"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchAbi'"
 )
 pxr_register_test(testArchAttributes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchAttributes"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchAttributes'"
 )
 pxr_register_test(testArchDemangle
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchDemangle"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchDemangle'"
 )
 pxr_register_test(testArchError
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchError"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchError'"
 )
 pxr_register_test(testArchErrno
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchErrno"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchErrno'"
 )
 pxr_register_test(testArchFileSystem
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchFileSystem"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchFileSystem'"
 )
 pxr_register_test(testArchFunction
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchFunction"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchFunction'"
 )
 pxr_register_test(testArchStackTrace
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchStackTrace"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchStackTrace'"
 )
 pxr_register_test(testArchSymbols
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchSymbols"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchSymbols'"
 )
 pxr_register_test(testArchSystemInfo
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchSystemInfo"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchSystemInfo'"
 )
 pxr_register_test(testArchTiming
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchTiming"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchTiming'"
 )
 pxr_register_test(testArchThreads
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchThreads"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchThreads'"
 )
 pxr_register_test(testArchVsnprintf
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArchVsnprintf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArchVsnprintf'"
 )

--- a/pxr/base/gf/CMakeLists.txt
+++ b/pxr/base/gf/CMakeLists.txt
@@ -198,94 +198,94 @@ pxr_test_scripts(
 
 pxr_register_test(testGfBBox3d
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfBBox3d"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfBBox3d'"
 )
 pxr_register_test(testGfDecomposeRotation
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfDecomposeRotation"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfDecomposeRotation'"
 )
 pxr_register_test(testGfDualQuaternion
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfDualQuaternion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfDualQuaternion'"
 )
 if (NOT APPLE)
     pxr_register_test(testGfFrustum
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfFrustum"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfFrustum'"
     )
 endif()
 pxr_register_test(testGfGamma
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfGamma"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfGamma'"
 )
 pxr_register_test(testGfHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfHardToReach"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfHardToReach'"
 )
 pxr_register_test(testGfHomogeneous
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfHomogeneous"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfHomogeneous'"
 )
 pxr_register_test(testGfInterval
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfInterval"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfInterval'"
 )
 pxr_register_test(testGfMultiInterval
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfMultiInterval"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfMultiInterval'"
 )
 pxr_register_test(testGfLine
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfLine"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfLine'"
 )
 pxr_register_test(testGfLineSeg
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfLineSeg"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfLineSeg'"
 )
 pxr_register_test(testGfMath
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfMath"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfMath'"
 )
 pxr_register_test(testGfMatrix
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfMatrix"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfMatrix'"
 )
 pxr_register_test(testGfPlane
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfPlane"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfPlane'"
 )
 pxr_register_test(testGfQuaternion
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfQuaternion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfQuaternion'"
 )
 pxr_register_test(testGfRange
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfRange"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfRange'"
 )
 pxr_register_test(testGfRay
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfRay"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfRay'"
 )
 pxr_register_test(testGfRect2i
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfRect2i"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfRect2i'"
 )
 pxr_register_test(testGfRotation
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfRotation"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfRotation'"
 )
 pxr_register_test(testGfSize
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfSize"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfSize'"
 )
 pxr_register_test(testGfTransform
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfTransform"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfTransform'"
 )
 pxr_register_test(testGfVec
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfVec"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfVec'"
 )
 pxr_register_test(testGfCamera
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testGfCamera"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testGfCamera'"
 )

--- a/pxr/base/plug/CMakeLists.txt
+++ b/pxr/base/plug/CMakeLists.txt
@@ -168,6 +168,6 @@ pxr_create_test_module(TestPlugModuleIncomplete
 
 pxr_register_test(testPlug
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPlug"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPlug'"
 )
 

--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -425,30 +425,30 @@ pxr_install_test_dir(
 )
 
 pxr_register_test(TfAnyUniquePtr
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfAnyUniquePtr"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfAnyUniquePtr"
 )
 pxr_register_test(TfAtomicOfstreamWrapper
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfAtomicOfstreamWrapper"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfAtomicOfstreamWrapper"
 )
 pxr_register_test(TfBitUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfBitUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfBitUtils"
 )
 pxr_register_test(TfDl
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDl"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDl"
 )
 pxr_register_test(TfDebug
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebug"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebug"
 )
 pxr_register_test(TfDebugFatal_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebugFatal_1"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebugFatal_1"
     EXPECTED_RETURN_CODE 134
 )
 pxr_register_test(TfDebugFatal_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebugFatal_2"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebugFatal_2"
     EXPECTED_RETURN_CODE 134
 )
 pxr_register_test(TfDebugFatal_3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebugFatal_3"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebugFatal_3"
     EXPECTED_RETURN_CODE 134
 )
 # These tests will depend on downstream libraries when built monolithic.
@@ -456,7 +456,7 @@ pxr_register_test(TfDebugFatal_3
 # simply disable these tests in that case.
 if(NOT PXR_BUILD_MONOLITHIC)
 pxr_register_test(TfDebugTestEnv
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebugTestEnv"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebugTestEnv"
     ENV TF_DEBUG="FOO* FLAM_* FLAM -FOOFLIMFLAM TF_DISCOVERY_D*"
     STDOUT_REDIRECT debugTestEnv.out
     DIFF_COMPARE debugTestEnv.out
@@ -464,22 +464,22 @@ pxr_register_test(TfDebugTestEnv
 endif()
 pxr_register_test(TfDebugTestEnvHelp
     ENV TF_DEBUG=help
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDebugTestEnvHelp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDebugTestEnvHelp"
 )
 pxr_register_test(TfDenseHashMap
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDenseHashMap"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDenseHashMap"
 )
 pxr_register_test(TfDelegate
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfDelegateAddRemove"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfDelegateAddRemove"
     STDOUT_REDIRECT output.txt 
     DIFF_COMPARE output.txt 
 )
 pxr_register_test(TfError
     ENV TF_FATAL_VERIFY=0
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfError"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfError"
 )
 pxr_register_test(TfErrorThreadTransport
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfErrorThreadTransport"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfErrorThreadTransport"
 )
 pxr_register_test(TfEnvSetting
     ENV
@@ -487,193 +487,193 @@ pxr_register_test(TfEnvSetting
         TF_TEST_INT_ENV_SETTING=123
         TF_TEST_STRING_ENV_SETTING=alpha
         TF_ENV_SETTING_ALERTS_ENABLED=0
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfEnvSetting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfEnvSetting"
     STDERR_REDIRECT debugTfEnvSettingStderr.txt
     DIFF_COMPARE debugTfEnvSettingStderr.txt
 )
 pxr_register_test(TfException
     ENV TF_FATAL_THROW=0
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfException"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfException"
 )
 pxr_register_test(TfFileUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfFileUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfFileUtils"
 )
 pxr_register_test(TfFileUtils_Python
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfFileUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfFileUtils'"
 )
 pxr_register_test(TfFunctionRef
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfFunctionRef"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfFunctionRef"
 )
 pxr_register_test(TfStringUtils_Python
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfStringUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfStringUtils'"
 )
 pxr_register_test(TfGetenv
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfGetenv"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfGetenv"
 )
 pxr_register_test(TfHash
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfHash"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfHash"
 )
 pxr_register_test(TfIterator
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfIterator"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfIterator"
 )
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     pxr_register_test(TfMallocTag
         ENV GLIBCXX_FORCE_NEW=1
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfMallocTag"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfMallocTag"
     )
 endif()
 pxr_register_test(TfRefPtr
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfRefPtr"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfRefPtr"
 )
 pxr_register_test(TfEnum
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfEnum"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfEnum"
     STDOUT_REDIRECT enum.out
     DIFF_COMPARE enum.out
 )
 pxr_register_test(TfNotice
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfNotice"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfNotice"
     STDOUT_REDIRECT notice.out
     DIFF_COMPARE notice.out
 )
 pxr_register_test(TfNamedTemporaryFile
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfNamedTemporaryFile"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfNamedTemporaryFile'"
 )
 pxr_register_test(TfPathUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfPathUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfPathUtils"
 )
 pxr_register_test(TfPathUtils_Python
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPathUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPathUtils'"
 )
 pxr_register_test(TfPatternMatcher
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfPatternMatcher"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfPatternMatcher"
 )
 pxr_register_test(TfPointerAndBits
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfPointerAndBits"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfPointerAndBits"
 )
 pxr_register_test(TfPreprocessorUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfPreprocessorUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfPreprocessorUtils"
 )
 pxr_register_test(TfProbe
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfProbe"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfProbe"
 )
 pxr_register_test(TfRegistryManager
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfRegistryManager"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfRegistryManager"
 )
 pxr_register_test(TfRegistryManagerUnload
     REQUIRES_SHARED_LIBS
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfRegistryManagerUnload"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfRegistryManagerUnload"
 )
 pxr_register_test(TfRegTest
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf'"
     EXPECTED_RETURN_CODE 2
 )
 pxr_register_test(TfRegTest_TfScoped
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfScoped no args expected"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfScoped no args expected"
     EXPECTED_RETURN_CODE 2
 )
 pxr_register_test(TfRegTest_TfUndefinedTest
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfUndefinedTest"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfUndefinedTest"
     EXPECTED_RETURN_CODE 3
 )
 pxr_register_test(TfSafeOutputFile
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfSafeOutputFile"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfSafeOutputFile"
 )
 pxr_register_test(TfScopeDescription
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfScopeDescription"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfScopeDescription"
 )
 pxr_register_test(TfScoped
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfScoped"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfScoped"
 )
 pxr_register_test(TfScopedVar
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfScopedVar"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfScopedVar"
 )
 pxr_register_test(TfSetenv
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfSetenv"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfSetenv"
 )
 pxr_register_test(TfSmallVector
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfSmallVector"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfSmallVector"
 )
 pxr_register_test(TfStacked
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStacked"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStacked"
 )
 pxr_register_test(TfStaticData
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStaticData"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStaticData"
 )
 pxr_register_test(TfStaticTokens
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStaticTokens"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStaticTokens"
 )
 pxr_register_test(TfStl
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStl"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStl"
 )
 pxr_register_test(TfStopwatch
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStopwatch"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStopwatch"
 )
 pxr_register_test(TfStringUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfStringUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfStringUtils"
 )
 pxr_register_test(TfTemplateString
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfTemplateString"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfTemplateString"
 )
 pxr_register_test(testTfTemplateString
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfTemplateString"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfTemplateString'"
 )
 pxr_register_test(TfToken
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfToken"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfToken"
 )
 pxr_register_test(TfType
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfType"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfType"
 )
 pxr_register_test(TfTypeInfoMap
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfTypeInfoMap"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfTypeInfoMap"
 )
 pxr_register_test(TfType_MultipleInheritance
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfType_MultipleInheritance"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfType_MultipleInheritance"
 )
 pxr_register_test(TfWeakPtr
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfWeakPtr"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfWeakPtr"
 )
 pxr_register_test(TfWeakPtrConversion
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfWeakPtrConversion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf' TfWeakPtrConversion"
 )
 
 if(PXR_ENABLE_PYTHON_SUPPORT)
     pxr_register_test(testTfPython
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPython"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPython'"
     )
     pxr_register_test(testTfPyFunction
         REQUIRES_PYTHON_MODULES
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyFunction"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyFunction'"
     )
     pxr_register_test(testTfPyNotice
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyNotice"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyNotice'"
     )
     pxr_register_test(testTfPyInterpreter
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyInterpreter"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyInterpreter'"
     )
     pxr_register_test(testTfPyInvoke
         REQUIRES_PYTHON_MODULES
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyInvoke"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyInvoke'"
     )
     pxr_register_test(testTfPyLock
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyLock"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyLock'"
     )
     pxr_register_test(testTfPyResultConversions
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyResultConversions"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyResultConversions'"
     )
     pxr_register_test(testTfPyScopeDescription
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyScopeDescription"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyScopeDescription'"
     )
     pxr_register_test(testTfScriptModuleLoader
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfScriptModuleLoader"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfScriptModuleLoader'"
         STDOUT_REDIRECT scriptModuleLoader.out
         DIFF_COMPARE scriptModuleLoader.out
     )
@@ -681,31 +681,31 @@ endif()
 
 pxr_register_test(testTfType
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfType"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfType'"
 )
 pxr_register_test(testTfSIGSEGV
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfCrashHandler ${CMAKE_INSTALL_PREFIX}/tests/testTfSIGSEGV SIGSEGV"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfCrashHandler' ${CMAKE_INSTALL_PREFIX}/tests/testTfSIGSEGV SIGSEGV"
 )
 pxr_register_test(testTfSIGFPE
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfCrashHandler ${CMAKE_INSTALL_PREFIX}/tests/testTfSIGFPE SIGFPE"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfCrashHandler' ${CMAKE_INSTALL_PREFIX}/tests/testTfSIGFPE SIGFPE"
 )
 pxr_register_test(testTf_PyContainerConversions
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf_PyContainerConversions"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTf_PyContainerConversions'"
 )
 pxr_register_test(testTf_PyOptional
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyOptional"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyOptional'"
 )
 pxr_register_test(testTf_PyStaticTokens
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfPyStaticTokens"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfPyStaticTokens'"
 )
 pxr_register_test(testTfCxxCast
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfCast"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfCast'"
 )
 pxr_register_test(testTfSpan
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTfSpan"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTfSpan'"
 )

--- a/pxr/base/trace/CMakeLists.txt
+++ b/pxr/base/trace/CMakeLists.txt
@@ -189,98 +189,98 @@ pxr_install_test_dir(
 )
 
 pxr_register_test(testTraceCategory
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceCategory"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceCategory'"
 )
 
 pxr_register_test(testTraceData
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceData"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceData'"
 )
 
 pxr_register_test(testTraceHash
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceHash"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceHash'"
 )
 
 pxr_register_test(testTraceMacros
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceMacros"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceMacros'"
 )
 
 pxr_register_test(testTraceThreading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceThreading"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceThreading'"
 )
 
 pxr_register_test(testTrace
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTrace"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTrace'"
 )
 
 pxr_register_test(testTraceRecursion1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_5begins.out
 )
 
 pxr_register_test(testTraceRecursion2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_typical.out
 )
 
 pxr_register_test(testTraceRecursion3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_newnode.out
 )
 
 pxr_register_test(testTraceRecursion4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_inner.out
 )
 
 pxr_register_test(testTraceRecursion5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_1817.out
 )
 
 pxr_register_test(testTraceRecursion6
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_branch.out
 )
 
 pxr_register_test(testTraceRecursion7
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceRecursion'"
     DIFF_COMPARE recursion_marker_merge.out
 )
 
 pxr_register_test(testTraceReports
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceReports"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceReports'"
 )
 
 pxr_register_test(testTraceReporter
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceReporter"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceReporter'"
 )
 
 pxr_register_test(testTraceSerialization
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceSerialization"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceSerialization'"
 )
 
 pxr_register_test(testTraceCounters
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceCounters"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceCounters'"
 )
 
 pxr_register_test(testTraceMarkers
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceMarkers"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceMarkers'"
 )
 
 pxr_register_test(testTraceReportPerf
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceReportPerf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceReportPerf'"
 )    
 
 pxr_register_test(testTraceEventContainer
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTraceEventContainer"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testTraceEventContainer'"
 )

--- a/pxr/base/vt/CMakeLists.txt
+++ b/pxr/base/vt/CMakeLists.txt
@@ -79,16 +79,16 @@ pxr_test_scripts(
 )
 pxr_register_test(testVtValue
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testVtValue"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testVtValue'"
 )
 pxr_register_test(testVtArray
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testVtArray"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testVtArray'"
 )
 pxr_register_test(testVtFunctions
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testVtFunctions"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testVtFunctions'"
 )
 pxr_register_test(testVtCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testVtCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testVtCpp'"
 )

--- a/pxr/base/work/CMakeLists.txt
+++ b/pxr/base/work/CMakeLists.txt
@@ -62,31 +62,31 @@ pxr_build_test(testWorkThreadLimits
         testenv/testWorkThreadLimits.cpp
 ) 
 pxr_register_test(testWorkDispatcher
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkDispatcher"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkDispatcher'"
 )
 pxr_register_test(testWorkLoops
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkLoops"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkLoops'"
 )
 pxr_register_test(testWorkReduce
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkReduce"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkReduce'"
 )
 pxr_register_test(testWorkThreadLimitsDefault
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits'"
 )
 pxr_register_test(testWorkThreadLimits1
     ENV PXR_WORK_THREAD_LIMIT=1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits'"
 )
 pxr_register_test(testWorkThreadLimits3
     ENV PXR_WORK_THREAD_LIMIT=3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits'"
 )
 pxr_register_test(testWorkThreadLimitsRawTBBMax
     RUN_SERIAL
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits --rawtbb"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits' --rawtbb"
 )
 pxr_register_test(testWorkThreadLimitsRawTBB2
     RUN_SERIAL
     ENV PXR_WORK_THREAD_LIMIT=2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits --rawtbb"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimits' --rawtbb"
 )

--- a/pxr/imaging/cameraUtil/CMakeLists.txt
+++ b/pxr/imaging/cameraUtil/CMakeLists.txt
@@ -33,6 +33,6 @@ pxr_test_scripts(
 
 pxr_register_test(testCameraUtil
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testCameraUtil"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testCameraUtil'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/imaging/hd/CMakeLists.txt
+++ b/pxr/imaging/hd/CMakeLists.txt
@@ -334,63 +334,63 @@ pxr_install_test_dir(
 
 
 pxr_register_test(testHdBufferSourceEmptyVal
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdBufferSourceEmptyVal"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdBufferSourceEmptyVal'"
 )
 
 pxr_register_test(testHdBufferSpec
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdBufferSpec"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdBufferSpec'"
 )
 
 # pxr_register_test(testHdChangeTracker
-#     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdChangeTracker"
+#     COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdChangeTracker'"
 # )
 
 pxr_register_test(testHdCommand
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdCommand"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdCommand'"
 )
 
 pxr_register_test(testHdDataSourceLocator
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdDataSourceLocator"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdDataSourceLocator'"
 )
 
 pxr_register_test(testHdDirtyList
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdDirtyList"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdDirtyList'"
 )
 
 pxr_register_test(testHdExtCompDependencySort
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdExtCompDependencySort"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdExtCompDependencySort'"
 )
 
 pxr_register_test(testHdExtComputationUtils
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdExtComputationUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdExtComputationUtils'"
 )
 
 pxr_register_test(testHdPerfLog
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdPerfLog"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdPerfLog'"
 )
 
 # pxr_register_test(testHdRenderIndex
-#     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdRenderIndex"
+#     COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdRenderIndex'"
 # )
 
 pxr_register_test(testHdDataSource
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdDataSource"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdDataSource'"
 )
 
 pxr_register_test(testHdSceneIndex
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdSceneIndex"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdSceneIndex'"
 )
 
 pxr_register_test(testHdSortedIds
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdSortedIds"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdSortedIds'"
     # XXX Disabling compare for now. testHdSortedId_removeTest.txt differs on Mac and Windows.
     # DIFF_COMPARE testHdSortedId_populateTest.txt testHdSortedId_singleInsertTest.txt testHdSortedId_multiInsertTest.txt testHdSortedId_removeTest.txt testHdSortedId_removeOnlyElementTest.txt testHdSortedId_removeRangeTest.txt testHdSortedId_removeBatchTest.txt testHdSortedId_removeSortedTest.txt testHdSortedId_removeUnsortedTest.txt testHdSortedId_removeAfterInsertNoSyncTest.txt
 )
 
 pxr_register_test(testHdTimeSampleArray
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTimeSampleArray"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdTimeSampleArray'"
 )
 
 pxr_register_test(testHdTypes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTypes"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testHdTypes'"
 )

--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -145,35 +145,35 @@ pxr_install_test_dir(
 
 pxr_register_test(testArOptionalImplementation_1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation _TestResolver"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation' _TestResolver"
     STDOUT_REDIRECT base.txt
     DIFF_COMPARE base.txt
 )
 
 pxr_register_test(testArOptionalImplementation_2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation _TestResolverWithContextMethods"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation' _TestResolverWithContextMethods"
     STDOUT_REDIRECT resolver_with_context.txt
     DIFF_COMPARE resolver_with_context.txt
 )
 
 pxr_register_test(testArOptionalImplementation_3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation _TestDerivedResolverWithContextMethods"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation' _TestDerivedResolverWithContextMethods"
     STDOUT_REDIRECT derived_resolver_with_context.txt
     DIFF_COMPARE derived_resolver_with_context.txt
 )
 
 pxr_register_test(testArOptionalImplementation_4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation _TestResolverWithCacheMethods"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation' _TestResolverWithCacheMethods"
     STDOUT_REDIRECT resolver_with_cache.txt
     DIFF_COMPARE resolver_with_cache.txt
 )
 
 pxr_register_test(testArOptionalImplementation_5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation _TestDerivedResolverWithCacheMethods"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArOptionalImplementation' _TestDerivedResolverWithCacheMethods"
     STDOUT_REDIRECT derived_resolver_with_cache.txt
     DIFF_COMPARE derived_resolver_with_cache.txt
 )
@@ -202,7 +202,7 @@ if (BUILD_SHARED_LIBS)
     )
 
     pxr_register_test(testArURIResolver_CPP
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArURIResolver_CPP"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArURIResolver_CPP'"
     )
 endif()
 
@@ -225,7 +225,7 @@ pxr_build_test(testArNotice_CPP
 ) 
 
 pxr_register_test(testArNotice_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArNotice_CPP"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArNotice_CPP'"
 )
 
 pxr_build_test(testArResolverContext_CPP
@@ -239,38 +239,38 @@ pxr_build_test(testArResolverContext_CPP
 
 pxr_register_test(testArAdvancedAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArAdvancedAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArAdvancedAPI'"
 )
 
 pxr_register_test(testArDefaultResolver
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver'"
 )
 
 pxr_register_test(testArDefaultResolver_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver_CPP"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver_CPP'"
 )
 
 pxr_register_test(testArPackageUtils
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArPackageUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArPackageUtils'"
 )
 
 pxr_register_test(testArResolvedPath
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArResolvedPath"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArResolvedPath'"
 )
 
 pxr_register_test(testArTimestamp
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArTimestamp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArTimestamp'"
 )
 
 pxr_register_test(testArResolverContext
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArResolverContext"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArResolverContext'"
 )
 
 pxr_register_test(testArResolverContext_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArResolverContext_CPP"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testArResolverContext_CPP'"
 )

--- a/pxr/usd/bin/usdcat/CMakeLists.txt
+++ b/pxr/usd/bin/usdcat/CMakeLists.txt
@@ -15,7 +15,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatOutToFile
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat input.usda --out output.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' input.usda --out output.usda"
     DIFF_COMPARE output.usda
     EXPECTED_RETURN_CODE 0
 )
@@ -27,7 +27,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatVariadicCatting
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat a.usd b.usd c.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' a.usd b.usd c.usd"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -38,7 +38,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatMissingOrInvalidFiles1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat hello.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' hello.txt"
     EXPECTED_RETURN_CODE 1 
 )
 
@@ -49,7 +49,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatMissingOrInvalidFiles2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat foo.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' foo.usda"
     EXPECTED_RETURN_CODE 1 
 )
 
@@ -60,14 +60,14 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatMask
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --mask /InsideMask --flatten --skipSourceFileComment input.usda -o output.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' --mask /InsideMask --flatten --skipSourceFileComment input.usda -o output.usda"
     DIFF_COMPARE output.usda
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdCatMask2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --mask /InsideMask input.usda -o output.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' --mask /InsideMask input.usda -o output.usda"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -78,7 +78,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatLoadOnly
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --loadOnly input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' --loadOnly input.usda"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -89,7 +89,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatLayerMetadata
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --layerMetadata input.usda -o output.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' --layerMetadata input.usda -o output.usda"
     DIFF_COMPARE output.usda
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/bin/usdchecker/CMakeLists.txt
+++ b/pxr/usd/bin/usdchecker/CMakeLists.txt
@@ -29,26 +29,26 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdChecker1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/clean.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' clean/clean.usd"
     EXPECTED_RETURN_CODE 0
 )
 
 
 pxr_register_test(testUsdChecker2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/clean_flat.usdc"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' clean/clean_flat.usdc"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdChecker3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/clean.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' clean/clean.usdz"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdChecker4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/clean_flat.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' clean/clean_flat.usdz"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -75,26 +75,26 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdChecker5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit clean/clean_arkit.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit clean/clean_arkit.usdz"
     EXPECTED_RETURN_CODE 0
 )
 
 
 pxr_register_test(testUsdChecker6
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit clean/clean_flat.usdc"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit clean/clean_flat.usdc"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdChecker7
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit --rootPackageOnly clean/clean_flat.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit --rootPackageOnly clean/clean_flat.usdz"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdChecker8
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit clean/clean_flat.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit clean/clean_flat.usdz"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -120,27 +120,27 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdChecker9
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker bad/badUsdz.usdz"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' bad/badUsdz.usdz"
     EXPECTED_RETURN_CODE 1
 )
 
 
 pxr_register_test(testUsdChecker10
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit --dumpRules bad/variants.usdc -o variants_failedChecks.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit --dumpRules bad/variants.usdc -o variants_failedChecks.txt"
     DIFF_COMPARE variants_failedChecks.txt
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdChecker11
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker bad/brokenRef.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' bad/brokenRef.usd"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdChecker12
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker --arkit bad/badShaderUnsupportedTexture.usdc"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdchecker' --arkit bad/badShaderUnsupportedTexture.usdc"
     EXPECTED_RETURN_CODE 1
 )
 

--- a/pxr/usd/bin/usdcompress/CMakeLists.txt
+++ b/pxr/usd/bin/usdcompress/CMakeLists.txt
@@ -19,7 +19,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressExitCodeSuccess
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress a.usda -o out.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' a.usda -o out.usda"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -33,7 +33,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressExitCodeBadInputFileName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress bad.usda -o out.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' bad.usda -o out.usda"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -47,7 +47,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressExitCodeBadArgumentName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress a.usda --bad -o out.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' a.usda --bad -o out.usda"
     EXPECTED_RETURN_CODE 2
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -61,7 +61,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressPropertyOpinionsOneCustom
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeOneCustomOpinion.usda -o out.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeOneCustomOpinion.usda -o out.usda"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -75,7 +75,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressPropertyOpinionsMultiple
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeMultipleOpinions.usda -o out.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeMultipleOpinions.usda -o out.usda"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -89,7 +89,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressPropertyOpinionsIgnoreErrors
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeMultipleOpinions.usda -o CubeMultipleOpinionsCompressed.usda --ignore_opinion_errors"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeMultipleOpinions.usda -o CubeMultipleOpinionsCompressed.usda --ignore_opinion_errors"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeMultipleOpinionsCompressed.usda
     DIFF_COMPARE CubeMultipleOpinionsCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -105,7 +105,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressComplexSet
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress ComplexSet.usda -o ComplexSetCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' ComplexSet.usda -o ComplexSetCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE ComplexSetCompressed.usda
     DIFF_COMPARE ComplexSetCompressed.usda.draco/ComplexSet_Geom_CubesFill_CubesFillGeom101.drc
@@ -130,7 +130,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressTriangles
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithTriangles.usda -o CubeWithTrianglesCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithTriangles.usda -o CubeWithTrianglesCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithTrianglesCompressed.usda
     DIFF_COMPARE CubeWithTrianglesCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -146,7 +146,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressQuads
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithQuads.usda -o CubeWithQuadsCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithQuads.usda -o CubeWithQuadsCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithQuadsCompressed.usda
     DIFF_COMPARE CubeWithQuadsCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -162,7 +162,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressDiscardQuads
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithQuads.usda -o CubeWithQuadsCompressedDiscarded.usda --preserve_polygons 0"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithQuads.usda -o CubeWithQuadsCompressedDiscarded.usda --preserve_polygons 0"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithQuadsCompressedDiscarded.usda
     DIFF_COMPARE CubeWithQuadsCompressedDiscarded.usda.draco/Cube_Geom_Cube.drc
@@ -179,7 +179,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressGenericPrimvars
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithGenericPrimvars.usda -o CubeWithGenericPrimvarsCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithGenericPrimvars.usda -o CubeWithGenericPrimvarsCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithGenericPrimvarsCompressed.usda
     DIFF_COMPARE CubeWithGenericPrimvarsCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -196,7 +196,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressVertexColor
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithVertexColor.usda -o CubeWithVertexColorCompressed.usda --discard_subdivision 1"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithVertexColor.usda -o CubeWithVertexColorCompressed.usda --discard_subdivision 1"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithVertexColorCompressed.usda
     DIFF_COMPARE CubeWithVertexColorCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -213,7 +213,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressVertexColorPreservePositionOrder
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithVertexColor.usda -o CubeWithVertexColorCompressedWithPositionOrder.usda --discard_subdivision 0"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithVertexColor.usda -o CubeWithVertexColorCompressedWithPositionOrder.usda --discard_subdivision 0"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithVertexColorCompressedWithPositionOrder.usda
     DIFF_COMPARE CubeWithVertexColorCompressedWithPositionOrder.usda.draco/Cube_Geom_Cube.drc
@@ -230,7 +230,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressCornerColor
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithCornerColor.usda -o CubeWithCornerColorCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithCornerColor.usda -o CubeWithCornerColorCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithCornerColorCompressed.usda
     DIFF_COMPARE CubeWithCornerColorCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -247,7 +247,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressCornerColorPreservePositionOrder
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithCornerColor.usda -o CubeWithCornerColorCompressedWithPositionOrder.usda --discard_subdivision 0"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithCornerColor.usda -o CubeWithCornerColorCompressedWithPositionOrder.usda --discard_subdivision 0"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithCornerColorCompressedWithPositionOrder.usda
     DIFF_COMPARE CubeWithCornerColorCompressedWithPositionOrder.usda.draco/Cube_Geom_Cube.drc
@@ -263,7 +263,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressHoles
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithHoles.usda -o CubeWithHolesCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithHoles.usda -o CubeWithHolesCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithHolesCompressed.usda
     DIFF_COMPARE CubeWithHolesCompressed.usda.draco/Cube_Geom_Cube.drc
@@ -279,7 +279,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressDiscardHoles
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithHoles.usda -o CubeWithHolesCompressedDiscarded.usda --discard_subdivision 1"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithHoles.usda -o CubeWithHolesCompressedDiscarded.usda --discard_subdivision 1"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithHolesCompressedDiscarded.usda
     DIFF_COMPARE CubeWithHolesCompressedDiscarded.usda.draco/Cube_Geom_Cube.drc
@@ -295,7 +295,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressCreases
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress MeshWithCreases.usda -o MeshWithCreasesCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' MeshWithCreases.usda -o MeshWithCreasesCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE MeshWithCreasesCompressed.usda
     DIFF_COMPARE MeshWithCreasesCompressed.usda.draco/xform_bottomPanel.drc
@@ -311,7 +311,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressDiscardCreases
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress MeshWithCreases.usda -o MeshWithCreasesCompressedDiscarded.usda --discard_subdivision 1"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' MeshWithCreases.usda -o MeshWithCreasesCompressedDiscarded.usda --discard_subdivision 1"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE MeshWithCreasesCompressedDiscarded.usda
     DIFF_COMPARE MeshWithCreasesCompressedDiscarded.usda.draco/xform_bottomPanel.drc
@@ -327,7 +327,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCompressTimeSample
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcompress CubeWithTimeSample.usda -o CubeWithTimeSampleCompressed.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcompress' CubeWithTimeSample.usda -o CubeWithTimeSampleCompressed.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE CubeWithTimeSampleCompressed.usda
     DIFF_COMPARE CubeWithTimeSampleCompressed.usda.draco/Cube_Geom_Cube.drc

--- a/pxr/usd/bin/usddiff/CMakeLists.txt
+++ b/pxr/usd/bin/usddiff/CMakeLists.txt
@@ -14,7 +14,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffExitCodesForDiff1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usda a.usda --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usda a.usda --noeffect"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -27,7 +27,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffExitCodesForDiff2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usda b.usda --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usda b.usda --noeffect"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -40,7 +40,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffToolSelectionDefault
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usda b.usda --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usda b.usda --noeffect"
     STDOUT_REDIRECT out.txt
     DIFF_COMPARE out.txt
     EXPECTED_RETURN_CODE 1
@@ -55,7 +55,7 @@ pxr_install_test_dir(
  
 pxr_register_test(testUsdDiffToolVariousFormats1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usda a.usd --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usda a.usd --noeffect"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -68,7 +68,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffToolVariousFormats2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usdc a.usd --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usdc a.usd --noeffect"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -126,7 +126,7 @@ if (PXR_BUILD_DRACO_PLUGIN)
 
     pxr_register_test(testUsdDiffWithDracoFiles
     PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect CubeWithGenericPrimvars.drc CubeWithGenericPrimvars.drc"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect CubeWithGenericPrimvars.drc CubeWithGenericPrimvars.drc"
         EXPECTED_RETURN_CODE 0
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
@@ -141,7 +141,7 @@ if (PXR_BUILD_DRACO_PLUGIN)
 
     pxr_register_test(testUsdDiffWithUsdaAndDracoFiles
     PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect CubeWithGenericPrimvars.drc CubeWithGenericPrimvars.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect CubeWithGenericPrimvars.drc CubeWithGenericPrimvars.usda"
         EXPECTED_RETURN_CODE 0
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
@@ -157,7 +157,7 @@ if (PXR_BUILD_DRACO_PLUGIN)
 
     pxr_register_test(testUsdDiffWithReferredDracoFiles
     PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect --flatten CubeWithGenericPrimvarsCompressed.usda CubeWithGenericPrimvarsCompressed.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect --flatten CubeWithGenericPrimvarsCompressed.usda CubeWithGenericPrimvarsCompressed.usda"
         EXPECTED_RETURN_CODE 0
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
@@ -173,7 +173,7 @@ if (PXR_BUILD_DRACO_PLUGIN)
 
     pxr_register_test(testUsdDiffWithDracoUsdz
     PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect --flatten ComplexSetCompressed.usdz ComplexSetCompressed.usdz"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect --flatten ComplexSetCompressed.usdz ComplexSetCompressed.usdz"
         EXPECTED_RETURN_CODE 0
         PRE_PATH
             ${CMAKE_INSTALL_PREFIX}/bin
@@ -189,7 +189,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffComposedResults1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usd b.usd --noeffect"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usd b.usd --noeffect"
     EXPECTED_RETURN_CODE 1 
     STDOUT_REDIRECT layer_diff.txt
     DIFF_COMPARE layer_diff.txt
@@ -204,7 +204,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffComposedResults2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff a.usd b.usd --noeffect --flatten"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' a.usd b.usd --noeffect --flatten"
     EXPECTED_RETURN_CODE 1 
     STDOUT_REDIRECT composed_diff.txt
     DIFF_COMPARE composed_diff.txt
@@ -220,7 +220,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect a/ a/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect a/ a/"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -233,7 +233,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect a/ b/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect a/ b/"
     EXPECTED_RETURN_CODE 1 
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -246,7 +246,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect . a/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect . a/"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -259,7 +259,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect a.usda a/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect a.usda a/"
     EXPECTED_RETURN_CODE 0
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -272,7 +272,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect a.usda b/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect a.usda b/"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -285,7 +285,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories6
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect b/ a.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect b/ a.usda"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -298,7 +298,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories7
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect a.usda b.usda b/"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect a.usda b.usda b/"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin
@@ -311,7 +311,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdDiffWithDirectories8
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usddiff --noeffect b/ a.usda b.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usddiff' --noeffect b/ a.usda b.usda"
     EXPECTED_RETURN_CODE 1
     PRE_PATH
         ${CMAKE_INSTALL_PREFIX}/bin

--- a/pxr/usd/bin/usdedit/CMakeLists.txt
+++ b/pxr/usd/bin/usdedit/CMakeLists.txt
@@ -34,8 +34,8 @@ else()
 
     pxr_register_test(testUsdEditFilePermissions1
         PYTHON
-        PRE_COMMAND "${CHMODBIN} -w write_protected.usda"
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit write_protected.usda"
+        PRE_COMMAND "'${CHMODBIN}' -w write_protected.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' write_protected.usda"
         EXPECTED_RETURN_CODE 1 
         ENV
           USD_EDITOR="${HEADBIN}"
@@ -50,8 +50,8 @@ else()
 
     pxr_register_test(testUsdEditFilePermissions2
         PYTHON
-        PRE_COMMAND "${CHMODBIN} -w write_protected.usda"
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit -n write_protected.usda"
+        PRE_COMMAND "'${CHMODBIN}' -w write_protected.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' -n write_protected.usda"
         EXPECTED_RETURN_CODE 0
         ENV
           USD_EDITOR="${HEADBIN}"
@@ -66,8 +66,8 @@ else()
 
     pxr_register_test(testUsdEditFilePermissions3
         PYTHON
-        PRE_COMMAND "${CHMODBIN} -w write_protected.usda"
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit -f write_protected.usda"
+        PRE_COMMAND "'${CHMODBIN}' -w write_protected.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' -f write_protected.usda"
         EXPECTED_RETURN_CODE 0
         ENV
           USD_EDITOR="${HEADBIN}"
@@ -82,8 +82,8 @@ else()
 
     pxr_register_test(testUsdEditRespectFileFormat1
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit hello_ascii.usd"
-        POST_COMMAND "${HEADBIN} -c9 hello_ascii.usd"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' hello_ascii.usd"
+        POST_COMMAND "'${HEADBIN}' -c9 hello_ascii.usd"
         POST_COMMAND_STDOUT_REDIRECT ascii_output.txt
         EXPECTED_RETURN_CODE 0
         DIFF_COMPARE ascii_output.txt
@@ -100,8 +100,8 @@ else()
 
     pxr_register_test(testUsdEditRespectFileFormat2
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit hello_crate.usd"
-        POST_COMMAND "${HEADBIN} -c8 hello_crate.usd"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' hello_crate.usd"
+        POST_COMMAND "'${HEADBIN}' -c8 hello_crate.usd"
         POST_COMMAND_STDOUT_REDIRECT crate_output.txt   
         EXPECTED_RETURN_CODE 0
         DIFF_COMPARE crate_output.txt
@@ -118,7 +118,7 @@ else()
 
     pxr_register_test(testUsdEditPackageFile1
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit test.usdz"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' test.usdz"
         EXPECTED_RETURN_CODE 0
         ENV
           USD_EDITOR="sed -i 's/Sphere/Sphere2/g'"
@@ -133,7 +133,7 @@ else()
 
     pxr_register_test(testUsdEditPackageFile2
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdedit test.usdz[test.usda]"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdedit' test.usdz[test.usda]"
         EXPECTED_RETURN_CODE 0
         ENV
           USD_EDITOR="sed -i 's/Sphere/Sphere2/g'"

--- a/pxr/usd/bin/usdresolve/CMakeLists.txt
+++ b/pxr/usd/bin/usdresolve/CMakeLists.txt
@@ -20,7 +20,7 @@ if (NOT WIN32)
 
     pxr_register_test(testResolveRelPath
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdresolve input.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdresolve' input.usda"
         STDOUT_REDIRECT output.txt
         DIFF_COMPARE output.txt
         CLEAN_OUTPUT "(?:[A-Za-z]:)?\\/.*\\/"

--- a/pxr/usd/bin/usdstitchclips/CMakeLists.txt
+++ b/pxr/usd/bin/usdstitchclips/CMakeLists.txt
@@ -15,7 +15,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsInvalidClipPaths1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips a.usd b.usd --clipPath /World/fx/Particles_Splash --out test1.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' a.usd b.usd --clipPath /World/fx/Particles_Splash --out test1.usd"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -26,7 +26,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsInvalidClipPaths2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips a.usd b.usd --clipPath /World/f_x --out test2.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' a.usd b.usd --clipPath /World/f_x --out test2.usd"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -37,7 +37,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsFileCleanup1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --clipPath /Wrong/Clip/Path --out result.usd a.usd b.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --clipPath /Wrong/Clip/Path --out result.usd a.usd b.usd"
     EXPECTED_RETURN_CODE 1
     FILES_DONT_EXIST result.usd result.topology.usd
 )
@@ -49,7 +49,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsFileCleanup2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --clipPath /Wrong/Clip/Path --out preexisting.usd a.usd b.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --clipPath /Wrong/Clip/Path --out preexisting.usd a.usd b.usd"
     EXPECTED_RETURN_CODE 1
     FILES_EXIST preexisting.topology.usd
     FILES_DONT_EXIST preexisting.usd
@@ -62,7 +62,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsFileCleanup3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --clipPath /Wrong/Clip/Path --out nonexistant.usd a.usd b.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --clipPath /Wrong/Clip/Path --out nonexistant.usd a.usd b.usd"
     EXPECTED_RETURN_CODE 1
     FILES_DONT_EXIST nonexistant.usd nonexistant.topology.usd 
 )
@@ -74,7 +74,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClips
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --clipPath
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --clipPath
     /World/fx/Particles_Splash --out result.usda Particles_Splash.101.usd Particles_Splash.102.usd Particles_Splash.103.usd Particles_Splash.104.usd Particles_Splash.105.usd Particles_Splash.106.usd Particles_Splash.107.usd Particles_Splash.108.usd Particles_Splash.109.usd "
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE result.usda result.topology.usda
@@ -87,7 +87,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --activeOffset 0.3 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash/points --out result.usda p.101.usda p.102.usda p.103.usda p.104.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --activeOffset 0.3 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash/points --out result.usda p.101.usda p.102.usda p.103.usda p.104.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE result.usda result.topology.usda
 )
@@ -99,7 +99,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --endTimeCode 104 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --endTimeCode 104 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
     EXPECTED_RETURN_CODE 1 
 )
 
@@ -110,7 +110,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --startTimeCode 101 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --startTimeCode 101 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -121,7 +121,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash p.*.usda"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -132,7 +132,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --clipPath /World/fx/Particles_Splash p.*.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --clipPath /World/fx/Particles_Splash p.*.usda"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -143,7 +143,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplate6
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --templatePath p.#.usd p.*.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --templatePath p.#.usd p.*.usda"
     EXPECTED_RETURN_CODE 1
 )
 
@@ -154,7 +154,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsCustomSetName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --clipSet bob --clipPath /World/fx/Particles_Splash --out result_customSetName.usda Particles_Splash.101.usd Particles_Splash.102.usd Particles_Splash.103.usd Particles_Splash.104.usd Particles_Splash.105.usd Particles_Splash.106.usd Particles_Splash.107.usd Particles_Splash.108.usd Particles_Splash.109.usd "
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --clipSet bob --clipPath /World/fx/Particles_Splash --out result_customSetName.usda Particles_Splash.101.usd Particles_Splash.102.usd Particles_Splash.103.usd Particles_Splash.104.usd Particles_Splash.105.usd Particles_Splash.106.usd Particles_Splash.107.usd Particles_Splash.108.usd Particles_Splash.109.usd "
     EXPECTED_RETURN_CODE 0 
     DIFF_COMPARE result_customSetName.usda result_customSetName.topology.usda
 )
@@ -166,7 +166,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdStitchClipsTemplateCustomSetName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips --noComment --clipSet bob --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash/points --out result_customSetName.usda p.101.usda p.102.usda p.103.usda p.104.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdstitchclips' --noComment --clipSet bob --templateMetadata --startTimeCode 101 --endTimeCode 104 --stride 1 --templatePath p.#.usd --clipPath /World/fx/Particles_Splash/points --out result_customSetName.usda p.101.usda p.102.usda p.103.usda p.104.usda"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE result_customSetName.usda result_customSetName.topology.usda
 )

--- a/pxr/usd/bin/usdtree/CMakeLists.txt
+++ b/pxr/usd/bin/usdtree/CMakeLists.txt
@@ -15,7 +15,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTree
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flatten input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flatten input.usda"
     STDOUT_REDIRECT output.txt
     DIFF_COMPARE output.txt
     EXPECTED_RETURN_CODE 0
@@ -28,7 +28,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeLoaded
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flatten input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flatten input.usda"
     STDOUT_REDIRECT output.txt
     DIFF_COMPARE output.txt
     EXPECTED_RETURN_CODE 0
@@ -41,7 +41,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeUnloaded
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flatten --unloaded input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flatten --unloaded input.usda"
     STDOUT_REDIRECT output_unloaded.txt
     DIFF_COMPARE output_unloaded.txt
     EXPECTED_RETURN_CODE 0
@@ -55,7 +55,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeAttributes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flatten --attributes --metadata input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flatten --attributes --metadata input.usda"
     STDOUT_REDIRECT output_attributes.txt
     DIFF_COMPARE output_attributes.txt
     EXPECTED_RETURN_CODE 0
@@ -69,7 +69,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeNotFlattened
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --unloaded --attributes --metadata input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --unloaded --attributes --metadata input.usda"
     STDOUT_REDIRECT output_notflattened.txt
     DIFF_COMPARE output_notflattened.txt
     EXPECTED_RETURN_CODE 0
@@ -83,7 +83,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeMasked
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flatten --attributes --metadata --mask /root/child1 input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flatten --attributes --metadata --mask /root/child1 input.usda"
     STDOUT_REDIRECT output_masked.txt
     DIFF_COMPARE output_masked.txt
     EXPECTED_RETURN_CODE 0
@@ -97,7 +97,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeFlattenLayerStack
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --flattenLayerStack input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --flattenLayerStack input.usda"
     STDOUT_REDIRECT output_fls.txt
     DIFF_COMPARE output_fls.txt
     EXPECTED_RETURN_CODE 0
@@ -111,7 +111,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdTreeSimple
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdtree --simple input.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdtree' --simple input.usda"
     STDOUT_REDIRECT output_simple.txt
     DIFF_COMPARE output_simple.txt
     EXPECTED_RETURN_CODE 0

--- a/pxr/usd/bin/usdzip/CMakeLists.txt
+++ b/pxr/usd/bin/usdzip/CMakeLists.txt
@@ -23,7 +23,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdZipInputFiles
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip flat.usdz src -l flat.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' flat.usdz src -l flat.txt"
     DIFF_COMPARE flat.txt
     EXPECTED_RETURN_CODE 0
 )
@@ -35,7 +35,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdZipInputFiles2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip -r recursive.usdz src -l recursive.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' -r recursive.usdz src -l recursive.txt"
     DIFF_COMPARE recursive.txt
     EXPECTED_RETURN_CODE 0
 )
@@ -47,7 +47,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdZipInputFiles3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip flat_inputs.usdz src/a.txt src/b.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' flat_inputs.usdz src/a.txt src/b.png"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -58,26 +58,26 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdZipInputFiles4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip recursive_inputs.usdz src/a.txt src/b.png src/sub"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' recursive_inputs.usdz src/a.txt src/b.png src/sub"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdZipMissingInput
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip nonexistent.usdz nonexistent.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' nonexistent.usdz nonexistent.usd"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdZipAsset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip -a root.usd package.usdz -l contents.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' -a root.usd package.usdz -l contents.txt"
     DIFF_COMPARE contents.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdZipARKitAsset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdzip --arkitAsset root.usd package.usdz -l contents_arkit.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdzip' --arkitAsset root.usd package.usdz -l contents_arkit.txt"
     DIFF_COMPARE contents_arkit.txt
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/kind/CMakeLists.txt
+++ b/pxr/usd/kind/CMakeLists.txt
@@ -38,6 +38,6 @@ pxr_install_test_dir(
 
 pxr_register_test(testKindRegistry
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testKindRegistry"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testKindRegistry'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/ndr/CMakeLists.txt
+++ b/pxr/usd/ndr/CMakeLists.txt
@@ -65,12 +65,12 @@ pxr_install_test_dir(
 
 pxr_register_test(testNdrFilesystemDiscovery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testNdrFilesystemDiscovery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testNdrFilesystemDiscovery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testNdrVersion
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testNdrVersion"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testNdrVersion'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/pcp/CMakeLists.txt
+++ b/pxr/usd/pcp/CMakeLists.txt
@@ -882,7 +882,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testPcpMuseum_BasicInstancing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicInstancing/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicInstancing/root.sdf"
     STDOUT_REDIRECT compositionResults_BasicInstancing.txt
     DIFF_COMPARE compositionResults_BasicInstancing.txt 
     ENV 
@@ -891,7 +891,7 @@ pxr_register_test(testPcpMuseum_BasicInstancing
 
 pxr_register_test(testPcpMuseum_BasicInstancingAndNestedInstances
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicInstancingAndNestedInstances/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicInstancingAndNestedInstances/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicInstancingAndNestedInstances.txt
     DIFF_COMPARE compositionResults_BasicInstancingAndNestedInstances.txt 
     ENV 
@@ -900,7 +900,7 @@ pxr_register_test(testPcpMuseum_BasicInstancingAndNestedInstances
 
 pxr_register_test(testPcpMuseum_BasicInstancingAndVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicInstancingAndVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicInstancingAndVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicInstancingAndVariants.txt
     DIFF_COMPARE compositionResults_BasicInstancingAndVariants.txt 
     ENV 
@@ -909,7 +909,7 @@ pxr_register_test(testPcpMuseum_BasicInstancingAndVariants
 
 pxr_register_test(testPcpMuseum_BasicPayloadDiamond
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --payloads ^(?!/RootUnloaded) BasicPayloadDiamond/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --payloads ^(?!/RootUnloaded) BasicPayloadDiamond/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicPayloadDiamond.txt
     DIFF_COMPARE compositionResults_BasicPayloadDiamond.txt 
     ENV 
@@ -918,161 +918,161 @@ pxr_register_test(testPcpMuseum_BasicPayloadDiamond
 
 pxr_register_test(testPcpMuseum_BasicReference
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicReference/root.sdf --session BasicReference/session.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicReference/root.sdf --session BasicReference/session.sdf" 
     STDOUT_REDIRECT compositionResults_BasicReference.txt
     DIFF_COMPARE compositionResults_BasicReference.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicReferenceAndClass
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicReferenceAndClass/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicReferenceAndClass/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicReferenceAndClass.txt
     DIFF_COMPARE compositionResults_BasicReferenceAndClass.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicReferenceAndClassDiamond
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicReferenceAndClassDiamond/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicReferenceAndClassDiamond/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicReferenceAndClassDiamond.txt
     DIFF_COMPARE compositionResults_BasicReferenceAndClassDiamond.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicAncestralReference
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicAncestralReference/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicAncestralReference/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicAncestralReference.txt
     DIFF_COMPARE compositionResults_BasicAncestralReference.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicReferenceDiamond
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicReferenceDiamond/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicReferenceDiamond/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicReferenceDiamond_pcp.txt
     DIFF_COMPARE compositionResults_BasicReferenceDiamond_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicRelocateToAnimInterface
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicRelocateToAnimInterface/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicRelocateToAnimInterface/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicRelocateToAnimInterface.txt
     DIFF_COMPARE compositionResults_BasicRelocateToAnimInterface.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicInherits.txt
     DIFF_COMPARE compositionResults_BasicInherits.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicLocalAndGlobalClassCombination
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicLocalAndGlobalClassCombination/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicLocalAndGlobalClassCombination/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicLocalAndGlobalClassCombination.txt
     DIFF_COMPARE compositionResults_BasicLocalAndGlobalClassCombination.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicListEditing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicListEditing/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicListEditing/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicListEditing.txt
     DIFF_COMPARE compositionResults_BasicListEditing.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicListEditingWithInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicListEditingWithInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicListEditingWithInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicListEditingWithInherits_pcp.txt
     DIFF_COMPARE compositionResults_BasicListEditingWithInherits_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicDuplicateSublayer
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicDuplicateSublayer/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicDuplicateSublayer/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicDuplicateSublayer.txt
     DIFF_COMPARE compositionResults_BasicDuplicateSublayer.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicTimeOffset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicTimeOffset/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicTimeOffset/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicTimeOffset.txt
     DIFF_COMPARE compositionResults_BasicTimeOffset.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicNestedPayload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicNestedPayload/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicNestedPayload/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicNestedPayload.txt
     DIFF_COMPARE compositionResults_BasicNestedPayload.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicNestedVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicNestedVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicNestedVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicNestedVariants_pcp.txt
     DIFF_COMPARE compositionResults_BasicNestedVariants_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicNestedVariantsWithSameName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicNestedVariantsWithSameName/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicNestedVariantsWithSameName/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicNestedVariantsWithSameName.txt
     DIFF_COMPARE compositionResults_BasicNestedVariantsWithSameName.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicVariantWithConnections
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicVariantWithConnections/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicVariantWithConnections/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicVariantWithConnections.txt
     DIFF_COMPARE compositionResults_BasicVariantWithConnections.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicOwner
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --session BasicOwner/session.sdf BasicOwner/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --session BasicOwner/session.sdf BasicOwner/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicOwner.txt
     DIFF_COMPARE compositionResults_BasicOwner.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicPayload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --session BasicPayload/session.sdf --errorFile compositionErrors_BasicPayload_pcp.txt BasicPayload/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --session BasicPayload/session.sdf --errorFile compositionErrors_BasicPayload_pcp.txt BasicPayload/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicPayload_pcp.txt
     DIFF_COMPARE compositionResults_BasicPayload_pcp.txt compositionErrors_BasicPayload_pcp.txt
 )
 
 pxr_register_test(testPcpMuseum_BasicSpecializes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicSpecializes/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicSpecializes/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicSpecializes.txt
     DIFF_COMPARE compositionResults_BasicSpecializes.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicSpecializesAndInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicSpecializesAndInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicSpecializesAndInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicSpecializesAndInherits.txt
     DIFF_COMPARE compositionResults_BasicSpecializesAndInherits.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicSpecializesAndReferences
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicSpecializesAndReferences/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicSpecializesAndReferences/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicSpecializesAndReferences.txt
     DIFF_COMPARE compositionResults_BasicSpecializesAndReferences.txt 
 )
 
 pxr_register_test(testPcpMuseum_BasicSpecializesAndVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults BasicSpecializesAndVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' BasicSpecializesAndVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_BasicSpecializesAndVariants.txt
     DIFF_COMPARE compositionResults_BasicSpecializesAndVariants.txt 
 )
 
 pxr_register_test(testPcpMuseum_ImpliedAndAncestralInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults ImpliedAndAncestralInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' ImpliedAndAncestralInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_ImpliedAndAncestralInherits.txt
     DIFF_COMPARE compositionResults_ImpliedAndAncestralInherits.txt
 )
@@ -1080,7 +1080,7 @@ pxr_register_test(testPcpMuseum_ImpliedAndAncestralInherits
 pxr_register_test(testPcpMuseum_ImpliedAndAncestralInherits_graph
     PYTHON
     TESTENV testPcpMuseum_ImpliedAndAncestralInherits
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --dumpPath /World/CharGroup/Sim/includes/Hand/Geom --dumpMaps ImpliedAndAncestralInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --dumpPath /World/CharGroup/Sim/includes/Hand/Geom --dumpMaps ImpliedAndAncestralInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_ImpliedAndAncestralInherits_graph.txt
     CLEAN_OUTPUT "[^@]*/ImpliedAndAncestralInherits/"
     DIFF_COMPARE compositionResults_ImpliedAndAncestralInherits_graph.txt 
@@ -1088,91 +1088,91 @@ pxr_register_test(testPcpMuseum_ImpliedAndAncestralInherits_graph
 
 pxr_register_test(testPcpMuseum_ImpliedAndAncestralInherits_ComplexEvaluation
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults ImpliedAndAncestralInherits_ComplexEvaluation/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' ImpliedAndAncestralInherits_ComplexEvaluation/root.sdf" 
     STDOUT_REDIRECT compositionResults_ImpliedAndAncestralInherits_ComplexEvaluation.txt
     DIFF_COMPARE compositionResults_ImpliedAndAncestralInherits_ComplexEvaluation.txt
 )
 
 pxr_register_test(testPcpMuseum_PayloadsAndAncestralArcs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --payloads ^(?!/Root/UnloadedInheritedPayload) PayloadsAndAncestralArcs/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --payloads ^(?!/Root/UnloadedInheritedPayload) PayloadsAndAncestralArcs/root.sdf" 
     STDOUT_REDIRECT compositionResults_PayloadsAndAncestralArcs.txt
     DIFF_COMPARE compositionResults_PayloadsAndAncestralArcs.txt 
 )
 
 pxr_register_test(testPcpMuseum_ReferenceListOpsWithOffsets
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults ReferenceListOpsWithOffsets/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' ReferenceListOpsWithOffsets/root.sdf" 
     STDOUT_REDIRECT compositionResults_ReferenceListOpsWithOffsets.txt
     DIFF_COMPARE compositionResults_ReferenceListOpsWithOffsets.txt 
 )
 
 pxr_register_test(testPcpMuseum_RelativePathPayloads
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults RelativePathPayloads/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' RelativePathPayloads/root.sdf" 
     STDOUT_REDIRECT compositionResults_RelativePathPayloads.txt
     DIFF_COMPARE compositionResults_RelativePathPayloads.txt 
 )
 
 pxr_register_test(testPcpMuseum_RelativePathReferences
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults RelativePathReferences/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' RelativePathReferences/root.sdf" 
     STDOUT_REDIRECT compositionResults_RelativePathReferences.txt
     DIFF_COMPARE compositionResults_RelativePathReferences.txt 
 )
 
 pxr_register_test(testPcpMuseum_RelocatePrimsWithSameName
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults RelocatePrimsWithSameName/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' RelocatePrimsWithSameName/root.sdf" 
     STDOUT_REDIRECT compositionResults_RelocatePrimsWithSameName.txt
     DIFF_COMPARE compositionResults_RelocatePrimsWithSameName.txt 
 )
 
 pxr_register_test(testPcpMuseum_SpecializesAndAncestralArcs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SpecializesAndAncestralArcs/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SpecializesAndAncestralArcs/root.sdf" 
     STDOUT_REDIRECT compositionResults_SpecializesAndAncestralArcs.txt
     DIFF_COMPARE compositionResults_SpecializesAndAncestralArcs.txt 
 )
 
 pxr_register_test(testPcpMuseum_SpecializesAndAncestralArcs2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SpecializesAndAncestralArcs2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SpecializesAndAncestralArcs2/root.sdf" 
     STDOUT_REDIRECT compositionResults_SpecializesAndAncestralArcs2.txt
     DIFF_COMPARE compositionResults_SpecializesAndAncestralArcs2.txt 
 )
 
 pxr_register_test(testPcpMuseum_SubrootInheritsAndVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SubrootInheritsAndVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SubrootInheritsAndVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_SubrootInheritsAndVariants.txt
     DIFF_COMPARE compositionResults_SubrootInheritsAndVariants.txt 
 )
 
 pxr_register_test(testPcpMuseum_SubrootReferenceAndClasses
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SubrootReferenceAndClasses/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SubrootReferenceAndClasses/root.sdf" 
     STDOUT_REDIRECT compositionResults_SubrootReferenceAndClasses.txt
     DIFF_COMPARE compositionResults_SubrootReferenceAndClasses.txt 
 )
 
 pxr_register_test(testPcpMuseum_SubrootReferenceAndRelocates
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SubrootReferenceAndRelocates/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SubrootReferenceAndRelocates/root.sdf" 
     STDOUT_REDIRECT compositionResults_SubrootReferenceAndRelocates.txt
     DIFF_COMPARE compositionResults_SubrootReferenceAndRelocates.txt 
 )
 
 pxr_register_test(testPcpMuseum_SubrootReferenceAndVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults SubrootReferenceAndVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' SubrootReferenceAndVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_SubrootReferenceAndVariants.txt
     DIFF_COMPARE compositionResults_SubrootReferenceAndVariants.txt 
 )
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond1.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond1.txt 
     ENV 
@@ -1181,7 +1181,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond1
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_48tcps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_48tcps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond2.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond2.txt 
     ENV 
@@ -1190,7 +1190,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond2
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_24tcps_12fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_24tcps_12fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond3.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond3.txt 
     ENV 
@@ -1199,7 +1199,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond3
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_12fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_12fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond4.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond4.txt 
     ENV 
@@ -1208,7 +1208,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond4
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond1_Legacy.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond1_Legacy.txt 
     ENV 
@@ -1217,7 +1217,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy1
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_48tcps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_48tcps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond2_Legacy.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond2_Legacy.txt 
     ENV 
@@ -1226,7 +1226,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy2
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_24tcps_12fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_24tcps_12fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond3_Legacy.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond3_Legacy.txt 
     ENV 
@@ -1235,7 +1235,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy3
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_12fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_12fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecond4_Legacy.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecond4_Legacy.txt 
     ENV 
@@ -1244,7 +1244,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecond_Legacy4
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_24tcps_12fps.sdf --session TimeCodesPerSecond/session_48tcps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_24tcps_12fps.sdf --session TimeCodesPerSecond/session_48tcps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecondWithSessionLayer1.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecondWithSessionLayer1.txt 
     ENV 
@@ -1253,7 +1253,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer1
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_48tcps.sdf --session TimeCodesPerSecond/session_24fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_48tcps.sdf --session TimeCodesPerSecond/session_24fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecondWithSessionLayer2.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecondWithSessionLayer2.txt 
     ENV 
@@ -1262,7 +1262,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer2
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_12fps.sdf --session TimeCodesPerSecond/session_24fps.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_12fps.sdf --session TimeCodesPerSecond/session_24fps.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecondWithSessionLayer3.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecondWithSessionLayer3.txt 
     ENV 
@@ -1271,7 +1271,7 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer3
 
 pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TimeCodesPerSecond/root_12fps.sdf --session TimeCodesPerSecond/session.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TimeCodesPerSecond/root_12fps.sdf --session TimeCodesPerSecond/session.sdf" 
     STDOUT_REDIRECT compositionResults_TimeCodesPerSecondWithSessionLayer4.txt
     DIFF_COMPARE compositionResults_TimeCodesPerSecondWithSessionLayer4.txt 
     ENV 
@@ -1280,394 +1280,394 @@ pxr_register_test(testPcpMuseum_TimeCodesPerSecondWithSessionLayer4
 
 pxr_register_test(testPcpMuseum_TypicalReferenceToRiggedModel
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TypicalReferenceToRiggedModel/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TypicalReferenceToRiggedModel/root.sdf" 
     STDOUT_REDIRECT compositionResults_TypicalReferenceToRiggedModel.txt
     DIFF_COMPARE compositionResults_TypicalReferenceToRiggedModel.txt 
 )
 
 pxr_register_test(testPcpMuseum_TypicalReferenceToChargroup
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TypicalReferenceToChargroup/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TypicalReferenceToChargroup/root.sdf" 
     STDOUT_REDIRECT compositionResults_TypicalReferenceToChargroup_pcp.txt
     DIFF_COMPARE compositionResults_TypicalReferenceToChargroup_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TypicalReferenceToChargroupWithRename
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TypicalReferenceToChargroupWithRename/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TypicalReferenceToChargroupWithRename/root.sdf" 
     STDOUT_REDIRECT compositionResults_TypicalReferenceToChargroupWithRename.txt
     DIFF_COMPARE compositionResults_TypicalReferenceToChargroupWithRename.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyListEditedTargetPaths
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyListEditedTargetPaths/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyListEditedTargetPaths/root.sdf"
     STDOUT_REDIRECT compositionResults_TrickyListEditedTargetPaths.txt
     DIFF_COMPARE compositionResults_TrickyListEditedTargetPaths.txt
 )
 
 pxr_register_test(testPcpMuseum_TrickySpookyInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpookyInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpookyInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpookyInherits_pcp.txt
     DIFF_COMPARE compositionResults_TrickySpookyInherits_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpookyInheritsInSymmetricArmRig
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpookyInheritsInSymmetricArmRig/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpookyInheritsInSymmetricArmRig/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpookyInheritsInSymmetricArmRig.txt
     DIFF_COMPARE compositionResults_TrickySpookyInheritsInSymmetricArmRig.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpookyInheritsInSymmetricBrowRig
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpookyInheritsInSymmetricBrowRig/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpookyInheritsInSymmetricBrowRig/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpookyInheritsInSymmetricBrowRig.txt
     DIFF_COMPARE compositionResults_TrickySpookyInheritsInSymmetricBrowRig.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsAndRelocates2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsAndRelocates2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsAndRelocates2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsAndRelocates2.txt
     DIFF_COMPARE compositionResults_TrickyInheritsAndRelocates2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsAndRelocates3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsAndRelocates3/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsAndRelocates3/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsAndRelocates3.txt
     DIFF_COMPARE compositionResults_TrickyInheritsAndRelocates3.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsAndRelocates4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsAndRelocates4/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsAndRelocates4/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsAndRelocates4.txt
     DIFF_COMPARE compositionResults_TrickyInheritsAndRelocates4.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsAndRelocates5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsAndRelocates5/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsAndRelocates5/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsAndRelocates5.txt
     DIFF_COMPARE compositionResults_TrickyInheritsAndRelocates5.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsInVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsInVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsInVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsInVariants.txt
     DIFF_COMPARE compositionResults_TrickyInheritsInVariants.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyInheritsInVariants2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyInheritsInVariants2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyInheritsInVariants2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyInheritsInVariants2.txt
     DIFF_COMPARE compositionResults_TrickyInheritsInVariants2.txt 
 )
 
 pxr_register_test(testPcpMuseum_SubrootReferenceNonCycle
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --errorFile compositionErrors_SubrootReferenceNonCycle.txt SubrootReferenceNonCycle/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --errorFile compositionErrors_SubrootReferenceNonCycle.txt SubrootReferenceNonCycle/root.sdf" 
     STDOUT_REDIRECT compositionResults_SubrootReferenceNonCycle.txt
     DIFF_COMPARE compositionResults_SubrootReferenceNonCycle.txt compositionErrors_SubrootReferenceNonCycle.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantAncestralSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantAncestralSelection/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantAncestralSelection/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantAncestralSelection_pcp.txt
     DIFF_COMPARE compositionResults_TrickyVariantAncestralSelection_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantIndependentSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantIndependentSelection/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantIndependentSelection/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantIndependentSelection_pcp.txt
     DIFF_COMPARE compositionResults_TrickyVariantIndependentSelection_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantInPayload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantInPayload/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantInPayload/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantInPayload.txt
     DIFF_COMPARE compositionResults_TrickyVariantInPayload.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantOverrideOfLocalClass
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantOverrideOfLocalClass/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantOverrideOfLocalClass/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantOverrideOfLocalClass.txt
     DIFF_COMPARE compositionResults_TrickyVariantOverrideOfLocalClass.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantOverrideOfRelocatedPrim
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantOverrideOfRelocatedPrim/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantOverrideOfRelocatedPrim/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantOverrideOfRelocatedPrim.txt
     DIFF_COMPARE compositionResults_TrickyVariantOverrideOfRelocatedPrim.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantSelectionInVariant
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantSelectionInVariant/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantSelectionInVariant/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantSelectionInVariant_pcp.txt
     DIFF_COMPARE compositionResults_TrickyVariantSelectionInVariant_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantWeakerSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantWeakerSelection/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantWeakerSelection/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantWeakerSelection_pcp.txt
     DIFF_COMPARE compositionResults_TrickyVariantWeakerSelection_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantWeakerSelection2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantWeakerSelection2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantWeakerSelection2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantWeakerSelection2.txt
     DIFF_COMPARE compositionResults_TrickyVariantWeakerSelection2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyVariantWeakerSelection3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyVariantWeakerSelection3/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyVariantWeakerSelection3/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyVariantWeakerSelection3.txt
     DIFF_COMPARE compositionResults_TrickyVariantWeakerSelection3.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyClassHierarchy
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyClassHierarchy/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyClassHierarchy/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyClassHierarchy.txt
     DIFF_COMPARE compositionResults_TrickyClassHierarchy.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyLocalClassHierarchyWithRelocates
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyLocalClassHierarchyWithRelocates/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyLocalClassHierarchyWithRelocates/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyLocalClassHierarchyWithRelocates.txt
     DIFF_COMPARE compositionResults_TrickyLocalClassHierarchyWithRelocates.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedClasses
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedClasses/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedClasses/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedClasses.txt
     DIFF_COMPARE compositionResults_TrickyNestedClasses.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedClasses2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedClasses2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedClasses2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedClasses2.txt
     DIFF_COMPARE compositionResults_TrickyNestedClasses2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedClasses3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedClasses3/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedClasses3/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedClasses3.txt
     DIFF_COMPARE compositionResults_TrickyNestedClasses3.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedSpecializes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedSpecializes/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedSpecializes/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedSpecializes.txt
     DIFF_COMPARE compositionResults_TrickyNestedSpecializes.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedSpecializes2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedSpecializes2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedSpecializes2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedSpecializes2.txt
     DIFF_COMPARE compositionResults_TrickyNestedSpecializes2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedClasses4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedClasses4/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedClasses4/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedClasses4.txt
     DIFF_COMPARE compositionResults_TrickyNestedClasses4.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNestedVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNestedVariants/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNestedVariants/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNestedVariants.txt
     DIFF_COMPARE compositionResults_TrickyNestedVariants.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpecializesAndInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpecializesAndInherits/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpecializesAndInherits/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpecializesAndInherits.txt
     DIFF_COMPARE compositionResults_TrickySpecializesAndInherits.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpecializesAndInherits2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpecializesAndInherits2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpecializesAndInherits2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpecializesAndInherits2.txt
     DIFF_COMPARE compositionResults_TrickySpecializesAndInherits2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpecializesAndInherits3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpecializesAndInherits3/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpecializesAndInherits3/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpecializesAndInherits3.txt
     DIFF_COMPARE compositionResults_TrickySpecializesAndInherits3.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpecializesAndRelocates
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpecializesAndRelocates/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpecializesAndRelocates/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpecializesAndRelocates.txt
     DIFF_COMPARE compositionResults_TrickySpecializesAndRelocates.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpookyVariantSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpookyVariantSelection/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpookyVariantSelection/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpookyVariantSelection_pcp.txt
     DIFF_COMPARE compositionResults_TrickySpookyVariantSelection_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickySpookyVariantSelectionInClass
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickySpookyVariantSelectionInClass/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickySpookyVariantSelectionInClass/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickySpookyVariantSelectionInClass_pcp.txt
     DIFF_COMPARE compositionResults_TrickySpookyVariantSelectionInClass_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyConnectionToRelocatedAttribute
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyConnectionToRelocatedAttribute/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyConnectionToRelocatedAttribute/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyConnectionToRelocatedAttribute.txt
     DIFF_COMPARE compositionResults_TrickyConnectionToRelocatedAttribute.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyRelocatedTargetInVariant
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyRelocatedTargetInVariant/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyRelocatedTargetInVariant/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyRelocatedTargetInVariant.txt
     DIFF_COMPARE compositionResults_TrickyRelocatedTargetInVariant.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyRelocationOfPrimFromPayload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyRelocationOfPrimFromPayload/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyRelocationOfPrimFromPayload/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyRelocationOfPrimFromPayload_pcp.txt
     DIFF_COMPARE compositionResults_TrickyRelocationOfPrimFromPayload_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyRelocationOfPrimFromVariant
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyRelocationOfPrimFromVariant/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyRelocationOfPrimFromVariant/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyRelocationOfPrimFromVariant_pcp.txt
     DIFF_COMPARE compositionResults_TrickyRelocationOfPrimFromVariant_pcp.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyRelocationSquatter
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyRelocationSquatter/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyRelocationSquatter/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyRelocationSquatter.txt
     DIFF_COMPARE compositionResults_TrickyRelocationSquatter.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocations
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyMultipleRelocations/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyMultipleRelocations/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocations.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocations.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocations2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyMultipleRelocations2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyMultipleRelocations2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocations2.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocations2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocations3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyMultipleRelocations3/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyMultipleRelocations3/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocations3.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocations3.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocations4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --errorFile compositionErrors_TrickyMultipleRelocations4.txt TrickyMultipleRelocations4/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --errorFile compositionErrors_TrickyMultipleRelocations4.txt TrickyMultipleRelocations4/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocations4.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocations4.txt compositionErrors_TrickyMultipleRelocations4.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocationsAndClasses
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyMultipleRelocationsAndClasses/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyMultipleRelocationsAndClasses/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocationsAndClasses.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocationsAndClasses.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyMultipleRelocationsAndClasses2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyMultipleRelocationsAndClasses2/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyMultipleRelocationsAndClasses2/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyMultipleRelocationsAndClasses2.txt
     DIFF_COMPARE compositionResults_TrickyMultipleRelocationsAndClasses2.txt 
 )
 
 pxr_register_test(testPcpMuseum_TrickyNonLocalVariantSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults TrickyNonLocalVariantSelection/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' TrickyNonLocalVariantSelection/root.sdf" 
     STDOUT_REDIRECT compositionResults_TrickyNonLocalVariantSelection.txt
     DIFF_COMPARE compositionResults_TrickyNonLocalVariantSelection.txt 
 )
 
 pxr_register_test(testPcpMuseum_ErrorOpinionAtRelocationSource
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --errorFile compositionErrors_ErrorOpinionAtRelocationSource_pcp.txt ErrorOpinionAtRelocationSource/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --errorFile compositionErrors_ErrorOpinionAtRelocationSource_pcp.txt ErrorOpinionAtRelocationSource/root.sdf" 
     STDOUT_REDIRECT compositionResults_ErrorOpinionAtRelocationSource.txt
     DIFF_COMPARE compositionResults_ErrorOpinionAtRelocationSource.txt
 )
 
 pxr_register_test(testPcpMuseum_ErrorRelocateToSelf
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --errorFile compositionErrors_ErrorRelocateToSelf_pcp.txt ErrorRelocateToSelf/root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --errorFile compositionErrors_ErrorRelocateToSelf_pcp.txt ErrorRelocateToSelf/root.sdf" 
     STDOUT_REDIRECT compositionResults_ErrorRelocateToSelf_pcp.txt
     DIFF_COMPARE compositionResults_ErrorRelocateToSelf_pcp.txt compositionErrors_ErrorRelocateToSelf_pcp.txt
 )
 
 
 pxr_register_test(testPcpIterator
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpIterator"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpIterator'"
     DIFF_COMPARE iteration_results.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpMapExpression
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpMapExpression"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpMapExpression'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpPathTranslation_HardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation_HardToReach"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation_HardToReach'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpCache
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCache'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpChanges
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpChanges"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpChanges'"
     EXPECTED_RETURN_CODE 0
     ENV
         PCP_DISABLE_TIME_SCALING_BY_LAYER_TCPS=0
@@ -1675,30 +1675,30 @@ pxr_register_test(testPcpChanges
 
 pxr_register_test(testPcpDependencies
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpDependencies"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpDependencies'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpHardToReach"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpHardToReach'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpInstanceKey
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpInstanceKey"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpInstanceKey'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpLayerMuting
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpLayerMuting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpLayerMuting'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug69932
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults bug69932/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' bug69932/root.sdf"
     STDOUT_REDIRECT compositionResults_bug69932.txt
     DIFF_COMPARE compositionResults_bug69932.txt
     EXPECTED_RETURN_CODE 0
@@ -1706,13 +1706,13 @@ pxr_register_test(testPcpRegressionBugs_bug69932
 
 pxr_register_test(testPcpRegressionBugs_bug70951
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug70951"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug70951'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug74847
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults bug74847/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' bug74847/root.sdf"
     STDOUT_REDIRECT compositionResults_bug74847.txt
     DIFF_COMPARE compositionResults_bug74847.txt
     EXPECTED_RETURN_CODE 0
@@ -1720,31 +1720,31 @@ pxr_register_test(testPcpRegressionBugs_bug74847
 
 pxr_register_test(testPcpRegressionBugs_bug82180
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug82180" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug82180'" 
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug90508
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug90508" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug90508'" 
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug90706
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug90706" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug90706'" 
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug92955
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug92955" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug92955'" 
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_bug92827
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults bug92827/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' bug92827/root.sdf"
     STDOUT_REDIRECT compositionResults_bug92827.txt
     DIFF_COMPARE compositionResults_bug92827.txt
     EXPECTED_RETURN_CODE 0
@@ -1752,13 +1752,13 @@ pxr_register_test(testPcpRegressionBugs_bug92827
 
 pxr_register_test(testPcpRegressionBugs_bug101300
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug101300" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpRegressionBugs_bug101300'" 
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpRegressionBugs_USD-6755
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults --errorFile compositionErrors.txt root.sdf" 
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' --errorFile compositionErrors.txt root.sdf" 
     STDOUT_REDIRECT compositionResults.txt
     DIFF_COMPARE compositionResults.txt compositionErrors.txt
     EXPECTED_RETURN_CODE 0
@@ -1766,7 +1766,7 @@ pxr_register_test(testPcpRegressionBugs_USD-6755
 
 pxr_register_test(testPcpRegressionBugs_case1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults case1/root.sdf"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpCompositionResults' case1/root.sdf"
     STDOUT_REDIRECT compositionResults_case1.txt
     DIFF_COMPARE  compositionResults_case1.txt
     EXPECTED_RETURN_CODE 0
@@ -1774,36 +1774,36 @@ pxr_register_test(testPcpRegressionBugs_case1
 
 pxr_register_test(testPcpResolvedPathChange
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpResolvedPathChange"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpResolvedPathChange'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpMapFunction
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpMapFunction"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpMapFunction'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpPathTranslation
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testPcpDynamicFileFormatPlugin
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpDynamicFileFormatPlugin"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpDynamicFileFormatPlugin'"
     EXPECTED_RETURN_CODE 0  
 )
 
 pxr_register_test(testPcpStreamingLayerReload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpStreamingLayerReload"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpStreamingLayerReload'"
     EXPECTED_RETURN_CODE 0  
 )
 
 pxr_register_test(testPcpOwner
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpOwner"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testPcpOwner'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -52,6 +52,6 @@ pxr_install_test_dir(
 
 pxr_register_test(testOslParser
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testOslParser"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testOslParser'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -165,7 +165,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdAbcAlembicData
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcAlembicData"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcAlembicData'"
     EXPECTED_RETURN_CODE 0
     ENV 
         USD_ABC_NUM_OGAWA_STREAMS=2
@@ -173,37 +173,37 @@ pxr_register_test(testUsdAbcAlembicData
 
 pxr_register_test(testUsdAbcBugs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcBugs"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcBugs'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcCamera
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcCamera"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcCamera'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcConversionSubdiv
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionSubdiv"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionSubdiv'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcConversionBasisCurves
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionBasisCurves"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcConversionBasisCurves'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcFaceset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcFaceset"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcFaceset'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcIndexedProperties
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcIndexedProperties"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcIndexedProperties'"
     DIFF_COMPARE indexedTextureCoordinates.def.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -212,7 +212,7 @@ pxr_register_test(testUsdAbcIndexedProperties
 
 pxr_register_test(testUsdAbcIndexedGeomArb
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat hasColorSet.abc --out good_primvars_namespace_after_fix.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdcat' hasColorSet.abc --out good_primvars_namespace_after_fix.usda"
     DIFF_COMPARE good_primvars_namespace_after_fix.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -221,7 +221,7 @@ pxr_register_test(testUsdAbcIndexedGeomArb
 
 pxr_register_test(testUsdAbcInstancing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing'"
     DIFF_COMPARE nestedInstancing.def.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -230,7 +230,7 @@ pxr_register_test(testUsdAbcInstancing
 
 pxr_register_test(testUsdAbcInstancingXinst
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing'"
     DIFF_COMPARE nestedInstancing.xinst.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -240,7 +240,7 @@ pxr_register_test(testUsdAbcInstancingXinst
 
 pxr_register_test(testUsdAbcInstancingPinst
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing'"
     DIFF_COMPARE nestedInstancing.pinst.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -250,7 +250,7 @@ pxr_register_test(testUsdAbcInstancingPinst
 
 pxr_register_test(testUsdAbcInstancingNinst
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcInstancing'"
     DIFF_COMPARE nestedInstancing.ninst.usda
     EXPECTED_RETURN_CODE 0
     ENV
@@ -260,19 +260,19 @@ pxr_register_test(testUsdAbcInstancingNinst
 
 pxr_register_test(testUsdAbcIsConstant
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcIsConstant"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcIsConstant'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcP_OldEncoding
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcP_OldEncoding"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcP_OldEncoding'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcUvReadWrite
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcUvReadWrite"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcUvReadWrite'"
     EXPECTED_RETURN_CODE 0
     ENV
         USD_ABC_WRITE_UV_AS_ST_TEXCOORD2FARRAY=1
@@ -280,7 +280,7 @@ pxr_register_test(testUsdAbcUvReadWrite
 
 pxr_register_test(testUsdAbcUvReadWrite_OldEncoding
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcUvReadWrite_OldEncoding"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcUvReadWrite_OldEncoding'"
     EXPECTED_RETURN_CODE 0
     ENV
         USD_ABC_WRITE_UV_AS_ST_TEXCOORD2FARRAY=0
@@ -288,6 +288,6 @@ pxr_register_test(testUsdAbcUvReadWrite_OldEncoding
 
 pxr_register_test(testUsdAbcSDFArguments
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcSDFArguments"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcSDFArguments'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -318,121 +318,121 @@ pxr_install_test_dir(
 
 pxr_register_test(testSdfAttribute
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttribute"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfAttribute'"
 )
 
 pxr_register_test(testSdfAttributeBlocking
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking'"
 )
 
 pxr_register_test(testSdfAttributeBlocking_Cpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking_Cpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking_Cpp'"
 )
 
 pxr_register_test(testSdfBatchNamespaceEdit
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfBatchNamespaceEdit"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfBatchNamespaceEdit'"
 )
 
 pxr_register_test(testSdfCopyUtils
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfCopyUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfCopyUtils'"
 )
 
 pxr_register_test(testSdfCustomLayerData
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfCustomLayerData"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfCustomLayerData'"
 )
 
 pxr_register_test(testSdfHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfHardToReach"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfHardToReach'"
 )
 
 pxr_register_test(testSdfFileFormat
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfFileFormat"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfFileFormat'"
 )
 
 pxr_register_test(testSdfLayer
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayer"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfLayer'"
 )
 
 pxr_register_test(testSdfLayerHints
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerHints"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerHints'"
 )
 
 pxr_register_test(testSdfLayerMuting
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerMuting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerMuting'"
 )
 
 pxr_register_test(testSdfListOp
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfListOp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfListOp'"
 )
 
 pxr_register_test(testSdfMetaDataPlugInfo
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfMetaDataPlugInfo"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfMetaDataPlugInfo'"
 )
 
 pxr_register_test(testSdfParsing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfParsing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfParsing'"
 )
 
 pxr_register_test(testSdfParsingOld
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfParsing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfParsing'"
 )
 
 pxr_register_test(testSdfPath
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPath"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPath'"
 )
 
 pxr_register_test(testSdfPath2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPath2"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPath2'"
 )
 pxr_register_test(testSdfPath2Construct
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPath2Construct"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPath2Construct'"
 )
 
 pxr_register_test(testSdfPathParser
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPathParser"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPathParser'"
 )
 
 pxr_register_test(testSdfPathTable
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPathTable"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPathTable'"
 )
 
 pxr_register_test(testSdfPathThreading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPathThreading"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPathThreading'"
 )
 pxr_register_test(testSdfPayload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPayload"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPayload'"
 )
 pxr_register_test(testSdfPrim
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPrim"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfPrim'"
 )
 pxr_register_test(testSdfReference
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfReference"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfReference'"
 )
 pxr_register_test(testSdfSpecHash
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfSpecHash"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfSpecHash'"
 )
 pxr_register_test(testSdfTimeCode
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTimeCode"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfTimeCode'"
 )
 pxr_register_test(testSdfTypes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTypes"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdfTypes'"
 )

--- a/pxr/usd/sdr/CMakeLists.txt
+++ b/pxr/usd/sdr/CMakeLists.txt
@@ -60,7 +60,7 @@ pxr_build_test_shared_lib(TestSdrRegistry
 
 pxr_register_test(testSdrRegistry
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdrRegistry"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testSdrRegistry'"
     ENV
         PXR_NDR_SKIP_DISCOVERY_PLUGIN_DISCOVERY=1
         PXR_NDR_SKIP_PARSER_PLUGIN_DISCOVERY=1

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -664,13 +664,13 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdAppliedAPISchemas
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppliedAPISchemas"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppliedAPISchemas'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAppliedAPISchemas_AutoApplyDisabled
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppliedAPISchemas"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppliedAPISchemas'"
     EXPECTED_RETURN_CODE 0
     ENV
         USD_DISABLE_AUTO_APPLY_API_SCHEMAS=1
@@ -678,187 +678,187 @@ pxr_register_test(testUsdAppliedAPISchemas_AutoApplyDisabled
 
 pxr_register_test(testUsdAttributeBlocking
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlocking"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlocking'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAttributeBlockingCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlockingCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlockingCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAttributeConnections
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeConnections"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeConnections'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAttributeQuery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeQuery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeQuery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdErrors
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdErrors"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdErrors'"
     ENV TF_FATAL_THROW=0
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdValueClips
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValueClips"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdValueClips'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdVariantEditing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdVariantEditing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdVariantEditing'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdVariantFallbacks
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdVariantFallbacks"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdVariantFallbacks'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdVariants
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdVariants"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdVariants'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAttributeInterpolationCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeInterpolationCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeInterpolationCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdBugs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdBugs"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdBugs'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdBug119633
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdBug119633"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdBug119633'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdBug141491
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdBug141491"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdBug141491'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdChangeProcessing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdChangeProcessing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdChangeProcessing'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdCollectionAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCollectionAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdCollectionAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdClasses
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdClasses"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdClasses'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdCreateProperties
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateProperties"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateProperties'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdCreateAttributeCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateAttributeCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateAttributeCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdExternalAssetDependencies
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdExternalAssetDependencies"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdExternalAssetDependencies'"
     EXPECTED_RETURN_CODE 0  
 )
 
 pxr_register_test(testUsdFallbackPrimTypes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFallbackPrimTypes"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFallbackPrimTypes'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdHardToReach"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdHardToReach'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdInstancing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancing'"
     ENV
         USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY=1
 )
 
 pxr_register_test(testUsdInstanceProxy
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstanceProxy"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdInstanceProxy'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdIntegerCoding
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdIntegerCoding"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdIntegerCoding'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdDataFormats
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdDataFormats"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdDataFormats'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdLoadUnloadDeepNestedInstancing
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdLoadUnloadDeepNestedInstancing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdLoadUnloadDeepNestedInstancing'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdTimeSamples
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeSamples"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeSamples'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdReferences
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdReferences"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdReferences'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdTemplatedIO
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTemplatedIO"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTemplatedIO'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdPrimCompositionQuery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimCompositionQuery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimCompositionQuery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdPrimGetDescendants
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimGetDescendants"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimGetDescendants'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdInstancingCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancingCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancingCpp'"
     EXPECTED_RETURN_CODE 0
     ENV
         USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY=1
@@ -866,13 +866,13 @@ pxr_register_test(testUsdInstancingCpp
 
 pxr_register_test(testUsdPrims
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrims"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPrims'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdFileFormats
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -882,7 +882,7 @@ pxr_register_test(testUsdFileFormats
 if (NOT WIN32)
     pxr_register_test(testUsdFileFormats_asset
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats'"
         ENV
             USDC_USE_ASSET=1
         EXPECTED_RETURN_CODE 0
@@ -891,14 +891,14 @@ endif()
 
 pxr_register_test(testUsdFileFormats_pread
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFileFormats'"
     ENV
         USDC_USE_PREAD=1
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdMetadataCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -907,59 +907,59 @@ pxr_register_test(testUsdMetadataCpp
 # builds, so we only enable this test on shared library builds.
 if (BUILD_SHARED_LIBS)
     pxr_register_test(testUsdResolverChanged
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverChanged"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverChanged'"
         EXPECTED_RETURN_CODE 0
     )
 endif()
 
 pxr_register_test(testUsdStageNoPython
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNoPython"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNoPython'"
     EXPECTED_RETURN_CODE 0
 )
 pxr_register_test(testUsdStageNotification
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNotification"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNotification'"
     EXPECTED_RETURN_CODE 0
 )
 pxr_register_test(testUsdStageThreading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageThreading"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStageThreading'"
     EXPECTED_RETURN_CODE 0
 )
 pxr_register_test(testUsdThreadedAuthoring
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdThreadedAuthoring"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdThreadedAuthoring'"
     EXPECTED_RETURN_CODE 0
 )
 pxr_register_test(testUsdTimeCodeStream
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeCodeStream"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeCodeStream'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdStage
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStage"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStage'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdStageCache
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStageCache'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdStagePopulationMasks
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStagePopulationMasks"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStagePopulationMasks'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdTimeCodeRepr
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeCodeRepr"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeCodeRepr'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdTimeOffsets
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeOffsets"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeOffsets'"
     EXPECTED_RETURN_CODE 0
     ENV
         PCP_DISABLE_TIME_SCALING_BY_LAYER_TCPS=0
@@ -967,61 +967,61 @@ pxr_register_test(testUsdTimeOffsets
 
 pxr_register_test(testUsdPrimRange
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimRange"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimRange'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdStageLoadUnload
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageLoadUnload"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdStageLoadUnload'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdPayloads
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPayloads"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPayloads'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdCratePayloadConversionFromVersion07
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCratePayloadConversionFromVersion07"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdCratePayloadConversionFromVersion07'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdInherits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInherits"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdInherits'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdModel
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdModel"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdModel'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSpecializes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSpecializes"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSpecializes'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdMetadata
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadata"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadata'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdFlatten
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdFlatten2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2 BasicInstancingAndVariants/root.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2' BasicInstancingAndVariants/root.usda"
     STDOUT_REDIRECT flat_BasicInstancingAndVariants.usda
     DIFF_COMPARE flat_BasicInstancingAndVariants.usda
     EXPECTED_RETURN_CODE 0
@@ -1031,7 +1031,7 @@ pxr_register_test(testUsdFlatten2
 
 pxr_register_test(testUsdFlatten3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2 BasicInstancing/root.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2' BasicInstancing/root.usda"
     STDOUT_REDIRECT flat_BasicInstancing.usda
     DIFF_COMPARE flat_BasicInstancing.usda
     EXPECTED_RETURN_CODE 0
@@ -1041,7 +1041,7 @@ pxr_register_test(testUsdFlatten3
 
 pxr_register_test(testUsdFlatten4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2 BasicInstancingAndNestedInstances/root.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFlatten2' BasicInstancingAndNestedInstances/root.usda"
     STDOUT_REDIRECT flat_BasicInstancingAndNestedInstances.usda
     DIFF_COMPARE flat_BasicInstancingAndNestedInstances.usda
     EXPECTED_RETURN_CODE 0
@@ -1051,49 +1051,49 @@ pxr_register_test(testUsdFlatten4
 
 pxr_register_test(testUsdFlattenLayerStack
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdFlattenLayerStack"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdFlattenLayerStack'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdNotices
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdNotices"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdNotices'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdRelationships
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRelationships"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRelationships'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSchemaBase
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBase"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBase'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSchemaBasePy
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBasePy"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBasePy'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSchemaRegistry
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaRegistry"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaRegistry'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdTimeValueAuthoring
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoring"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoring'"
     EXPECTED_RETURN_CODE 0
     ENV
         PCP_DISABLE_TIME_SCALING_BY_LAYER_TCPS=0
 )
 
 pxr_register_test(testUsdTimeValueAuthoringCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoringCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoringCpp'"
     EXPECTED_RETURN_CODE 0
     ENV
         PCP_DISABLE_TIME_SCALING_BY_LAYER_TCPS=0
@@ -1101,13 +1101,13 @@ pxr_register_test(testUsdTimeValueAuthoringCpp
 
 pxr_register_test(testUsdUsdzFileFormat
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUsdzFileFormat_asset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat'"
     ENV
         USDC_USE_ASSET=1
     EXPECTED_RETURN_CODE 0
@@ -1115,7 +1115,7 @@ pxr_register_test(testUsdUsdzFileFormat_asset
 
 pxr_register_test(testUsdUsdzFileFormat_pread
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzFileFormat'"
     ENV
         USDC_USE_PREAD=1
     EXPECTED_RETURN_CODE 0
@@ -1123,16 +1123,16 @@ pxr_register_test(testUsdUsdzFileFormat_pread
 
 pxr_register_test(testUsdZipFile
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdZipFile"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdZipFile'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdZipFile_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdZipFile_CPP"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdZipFile_CPP'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUsdzResolver
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzResolver"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzResolver'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -237,13 +237,13 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdGeomBasisCurves
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomBasisCurves"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomBasisCurves'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomBBoxCache
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomBBoxCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomBBoxCache'"
     EXPECTED_RETURN_CODE 0
     ENV 
         TF_DEBUG=USDGEOM_BBOX
@@ -252,59 +252,59 @@ pxr_register_test(testUsdGeomBBoxCache
 
 pxr_register_test(testUsdGeomCamera
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCamera"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCamera'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomConstraintTarget
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomConstraintTarget"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomConstraintTarget'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomConsts
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomConsts"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomConsts'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomCreateAttribute
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCreateAttribute"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCreateAttribute'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomCurves
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCurves"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCurves'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomMesh
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomMesh"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomMesh'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomMetrics
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomMetrics"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomMetrics'"
     EXPECTED_RETURN_CODE 0
 )
 
 
 pxr_register_test(testUsdGeomSubset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSubset"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSubset'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomIsA
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomIsA"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomIsA'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomHasAPI
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomHasAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomHasAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -313,73 +313,73 @@ pxr_register_test(testUsdGeomHasAPI
 if(NOT PXR_BUILD_MONOLITHIC)
 pxr_register_test(testUsdGeomNoPlugLoad
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomNoPlugLoad"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomNoPlugLoad'"
     EXPECTED_RETURN_CODE 0
 )
 endif()
 
 pxr_register_test(testUsdGeomPrimvar
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPrimvar"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPrimvar'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomPointInstancer
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPointInstancer"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPointInstancer'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomPurposeVisibility
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPurposeVisibility"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomPurposeVisibility'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomSchemata
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSchemata"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSchemata'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomXformable
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformable"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformable'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomXformCache
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCache'"
     EXPECTED_RETURN_CODE 0 
 )
 
 pxr_register_test(testUsdGeomXformCommonAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCommonAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCommonAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomExtentFromPlugins
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentFromPlugins"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentFromPlugins'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomExtentTransform
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentTransform"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentTransform'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomComputeAtTime
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomComputeAtTime"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomComputeAtTime'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdGeomImageable
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomImageable"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomImageable'"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdLux/CMakeLists.txt
+++ b/pxr/usd/usdLux/CMakeLists.txt
@@ -89,7 +89,7 @@ pxr_test_scripts(
 
 pxr_register_test(testUsdLuxLight
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLight"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLight'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -100,7 +100,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdLuxLinkingAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLinkingAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLinkingAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -111,7 +111,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdLuxLightListAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLightListAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdLuxLightListAPI'"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdMedia/CMakeLists.txt
+++ b/pxr/usd/usdMedia/CMakeLists.txt
@@ -42,6 +42,6 @@ pxr_test_scripts(
 
 pxr_register_test(testUsdMediaSpatialAudio
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMediaSpatialAudio"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMediaSpatialAudio'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdMtlx/CMakeLists.txt
+++ b/pxr/usd/usdMtlx/CMakeLists.txt
@@ -81,19 +81,19 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdMtlxDiscovery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxDiscovery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxDiscovery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdMtlxFileFormat
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxFileFormat"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxFileFormat'"
     DIFF_COMPARE Looks.usda NodeGraphs.usda usd_preview_surface_gold.usda Include.usda Include_From_Usdz.usda
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdMtlxParser
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxParser"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdMtlxParser'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdPhysics/CMakeLists.txt
+++ b/pxr/usd/usdPhysics/CMakeLists.txt
@@ -95,13 +95,13 @@ pxr_test_scripts(
 
 pxr_register_test(testUsdPhysicsMetrics
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPhysicsMetrics"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPhysicsMetrics'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdPhysicsRigidBodyAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPhysicsRigidBodyAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdPhysicsRigidBodyAPI'"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdRi/CMakeLists.txt
+++ b/pxr/usd/usdRi/CMakeLists.txt
@@ -60,18 +60,18 @@ pxr_test_scripts(
 
 pxr_register_test(testUsdRiSchemata
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRiSchemata"  
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRiSchemata'"  
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdRiSplineAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRiSplineAPI"  
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRiSplineAPI'"  
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdRiUtilities
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdRiUtilities"  
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdRiUtilities'"  
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdShade/CMakeLists.txt
+++ b/pxr/usd/usdShade/CMakeLists.txt
@@ -138,104 +138,104 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdShadeBinding
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeBinding"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeBinding'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeConnectableAPIBehavior
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectableAPIBehavior"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectableAPIBehavior'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeCoordSysAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeCoordSysAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeCoordSysAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeGetValueProducingAttribute
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeGetValueProducingAttribute"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeGetValueProducingAttribute'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeMaterialAuthoring
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialAuthoring"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialAuthoring'"
     DIFF_COMPARE char_shading.usda char_shading_compact.usda
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeMaterialBinding
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBinding"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBinding'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeMaterialOutputs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialOutputs"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialOutputs'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeMaterialBindFaceSubset
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBindFaceSubset"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBindFaceSubset'"
     DIFF_COMPARE SphereWithMaterialBind.usda
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeShaders
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeShaders"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeShaders'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeShaderDef
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeShaderDef"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeShaderDef'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeNodeGraphs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeNodeGraphs"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeNodeGraphs'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeMaterialBaseMaterial
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBaseMaterial"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialBaseMaterial'"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE test_base_material_specializes.usda
 )
 
 pxr_register_test(testUsdShadeMaterialSpecializesBaseComposition
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialSpecializesBaseComposition"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeMaterialSpecializesBaseComposition'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeInterfaceInputConsumers
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeInterfaceInputConsumers"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeInterfaceInputConsumers'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeConnectability
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectability"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectability'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeHasConnectableAPI
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeHasConnectableAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeHasConnectableAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdShadeConnectability_OldEncoding
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectability"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeConnectability'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdSkel/CMakeLists.txt
+++ b/pxr/usd/usdSkel/CMakeLists.txt
@@ -132,62 +132,62 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdSkelAnimMapper
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelAnimMapper"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelAnimMapper'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelAnimQuery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelAnimQuery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelAnimQuery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelBakeSkinning
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBakeSkinning"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBakeSkinning'"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE blendshapes.baked.usda blendshapesWithNormals.baked.usda lbs.baked.usda lbs.bakedInterval.usda
 )
 
 pxr_register_test(testUsdSkelBindingAPI
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBindingAPI"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBindingAPI'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelCache
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelCache'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelRoot
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelRoot"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelRoot'"
     EXPECTED_RETURN_CODE 0
     DIFF_COMPARE root.computedExtents.usda
 )
 
 pxr_register_test(testUsdSkelSkeletonQuery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelSkeletonQuery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelSkeletonQuery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelSkinningQuery
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelSkinningQuery"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelSkinningQuery'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelTopology
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelTopology"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelTopology'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdSkelUtils
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelUtils"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelUtils'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdUI/CMakeLists.txt
+++ b/pxr/usd/usdUI/CMakeLists.txt
@@ -55,9 +55,9 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdUINodeGraphNode
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUINodeGraphNode"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUINodeGraphNode'"
 )
 pxr_register_test(testUsdUISceneGraphPrim
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUISceneGraphPrim"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUISceneGraphPrim'"
 )

--- a/pxr/usd/usdUtils/CMakeLists.txt
+++ b/pxr/usd/usdUtils/CMakeLists.txt
@@ -119,7 +119,7 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdUtilsConstantsGroup
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsConstantsGroup"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsConstantsGroup'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -200,13 +200,13 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdUtilsAuthoring
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsAuthoring"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsAuthoring'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsCoalescingDiagnosticDelegate
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCoalescingDiagnosticDelegate"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCoalescingDiagnosticDelegate'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -372,109 +372,109 @@ pxr_register_test(testUsdUtilsConditionalAbortDiagnosticDelegateCase16
 )
 
 pxr_register_test(testUsdUtilsCoalescingDiagnosticDelegateCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCoalescingDiagnosticDelegateCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCoalescingDiagnosticDelegateCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsCreateNewARKitUsdzPackage
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCreateNewUsdzPackage --check --arkit -l contents_arkit.txt package.usdz root.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCreateNewUsdzPackage' --check --arkit -l contents_arkit.txt package.usdz root.usd"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsCreateNewUsdzPackage
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCreateNewUsdzPackage --check -l contents.txt package.usdz root.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsCreateNewUsdzPackage' --check -l contents.txt package.usdz root.usd"
     DIFF_COMPARE contents.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsDependencies
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencies"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencies'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsDependencyExtractor1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor ascii.usda ascii-usda.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor' ascii.usda ascii-usda.txt"
     DIFF_COMPARE ascii-usda.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsDependencyExtractor2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor ascii.usd ascii-usd.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor' ascii.usd ascii-usd.txt"
     DIFF_COMPARE ascii-usd.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsDependencyExtractor3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor crate.usdc crate-usdc.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor' crate.usdc crate-usdc.txt"
     DIFF_COMPARE crate-usdc.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsDependencyExtractor4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor crate.usd crate-usd.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsDependencyExtractor' crate.usd crate-usd.txt"
     DIFF_COMPARE crate-usd.txt
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsFlattenLayerStack
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsFlattenLayerStack"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsFlattenLayerStack'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsIntrospection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsIntrospection"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsIntrospection'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsModifyAssetPaths
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsModifyAssetPaths layer.usda modified.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsModifyAssetPaths' layer.usda modified.usda"
     DIFF_COMPARE modified.usda
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsPipeline
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsPipeline"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsPipeline'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsSparseValueWriter
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsSparseValueWriter"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsSparseValueWriter'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsStageCache
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStageCache"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStageCache'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsStitch
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitch"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitch'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsStitchClips
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchClips"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchClips'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsUpdateSchemaWithSdrNode
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsUpdateSchemaWithSdrNode"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsUpdateSchemaWithSdrNode'"
     DIFF_COMPARE resultAPISchema.usda
     DIFF_COMPARE resultAPIIdentifierMissing.usda
     DIFF_COMPARE result_override.usda
@@ -490,28 +490,28 @@ pxr_register_test(testUsdUtilsUpdateSchemaWithSdrNode
 
 pxr_register_test(testUsdUtilsUpdateSchemaWithSdrNodeError
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsUpdateSchemaWithSdrNode TestUsdUpdateSchemaWithSdrNode True"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsUpdateSchemaWithSdrNode' TestUsdUpdateSchemaWithSdrNode True"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdUtilsStitchCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsTimeCodeRange
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsTimeCodeRange"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsTimeCodeRange'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsTimeCodeRangeCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsTimeCodeRangeCpp"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsTimeCodeRangeCpp'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdUtilsVarSelsSessionLayer
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsVarSelsSessionLayer"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsVarSelsSessionLayer'"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usdVol/CMakeLists.txt
+++ b/pxr/usd/usdVol/CMakeLists.txt
@@ -49,7 +49,7 @@ pxr_test_scripts(
 
 pxr_register_test(testUsdVolVolume
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdVolVolume"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdVolVolume'"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usdImaging/bin/testusdview/CMakeLists.txt
+++ b/pxr/usdImaging/bin/testusdview/CMakeLists.txt
@@ -340,33 +340,33 @@ pxr_install_test_dir(
 
 
 pxr_register_test(testUsdviewAlive
-    PRE_COMMAND "${PYTHON_EXECUTABLE} testUsdviewAliveSetup.py"
+    PRE_COMMAND "'${PYTHON_EXECUTABLE}' testUsdviewAliveSetup.py"
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testAlive.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testAlive.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewFileArguments1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testValidFileArg.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testValidFileArg.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewFileArguments2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testValidFileArg.py test.usd"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testValidFileArg.py test.usd"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewFileArguments3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testValidFileArg.py test.usdc"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testValidFileArg.py test.usdc"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewFileArguments4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py test.py"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testInvalidFileArg.py test.py"
     STDERR_REDIRECT py_test_out
     DIFF_COMPARE py_test_out
     EXPECTED_RETURN_CODE 1
@@ -374,7 +374,7 @@ pxr_register_test(testUsdviewFileArguments4
 
 pxr_register_test(testUsdviewFileArguments5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py invalidSyntax.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testInvalidFileArg.py invalidSyntax.usda"
     CLEAN_OUTPUT "(?:[A-Za-z]:)?/(?!refSphere2).*/"
     STDERR_REDIRECT invalidSyntax_test_out
     DIFF_COMPARE invalidSyntax_test_out
@@ -383,7 +383,7 @@ pxr_register_test(testUsdviewFileArguments5
 
 pxr_register_test(testUsdviewFileArguments6
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py test.txt"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testInvalidFileArg.py test.txt"
     STDERR_REDIRECT txt_test_out
     DIFF_COMPARE txt_test_out
     EXPECTED_RETURN_CODE 1
@@ -391,7 +391,7 @@ pxr_register_test(testUsdviewFileArguments6
 
 pxr_register_test(testUsdviewFileArguments7
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py missing"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testInvalidFileArg.py missing"
     STDERR_REDIRECT missing_test_out
     DIFF_COMPARE missing_test_out
     EXPECTED_RETURN_CODE 1
@@ -399,146 +399,146 @@ pxr_register_test(testUsdviewFileArguments7
 
 pxr_register_test(testUsdviewWrapper1
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testCallback.py"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testCallback.py"
     EXPECTED_RETURN_CODE 2
 )
 
 pxr_register_test(testUsdviewWrapper2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testCallback_Invalid_1.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testCallback_Invalid_1.py test.usda"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdviewWrapper3
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testCallback_Invalid_2.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testCallback_Invalid_2.py test.usda"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdviewWrapper4
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testCallback_Invalid_3.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testCallback_Invalid_3.py test.usda"
     EXPECTED_RETURN_CODE 1
 )
 
 pxr_register_test(testUsdviewWrapper5
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' test.usda"
     EXPECTED_RETURN_CODE 2
 )
 
 pxr_register_test(testUsdviewPrimPathBar
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPrimPathBar.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPrimPathBar.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewPrimSearch
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPrimSearch.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPrimSearch.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewPropertySearch
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPropertySearch.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPropertySearch.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewMetadatatabSelect
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewMetadatatabSelect.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewMetadatatabSelect.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewTimeSamples
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewTimeSamples.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewTimeSamples.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewNavigationKeys
     RUN_SERIAL
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewNavigationKeys.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewNavigationKeys.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewNoPlugins
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewNoPlugins.py --noplugins test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewNoPlugins.py --noplugins test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewInterpreterNoRender
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInterpreterNoRender.py --norender test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewInterpreterNoRender.py --norender test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewLoadPlugins_alive
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLoadPlugins_alive.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLoadPlugins_alive.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewLoadPlugins_multipleContainers
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLoadPlugins_multipleContainers.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLoadPlugins_multipleContainers.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewLoadPlugins_missingContainer
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLoadPlugins_missingContainer.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLoadPlugins_missingContainer.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewLoadPlugins_duplicateCommand
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLoadPlugins_duplicateCommand.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLoadPlugins_duplicateCommand.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewLoadPlugins_chained
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLoadPlugins_chained.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLoadPlugins_chained.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewUpAxis_yUp
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewUpAxis_yUp.py testYUp.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewUpAxis_yUp.py testYUp.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewDefaultFontFamily
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewDefaultFontFamily.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewDefaultFontFamily.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewInstancingEdits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInstancingEdits.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewInstancingEdits.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewPrimTreeExpansion
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPrimTreeExpansion.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPrimTreeExpansion.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewAnimatedBounds
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewAnimatedBounds.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewAnimatedBounds.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewMeshBounds
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewMeshBounds.py meshBounds.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewMeshBounds.py meshBounds.usda"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -554,7 +554,7 @@ endif()
 
 pxr_register_test(testUsdviewFreeCamera
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewFreeCamera.py Block.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewFreeCamera.py Block.usda"
     IMAGE_DIFF_COMPARE
         start.png
         block_F.png
@@ -576,7 +576,7 @@ pxr_register_test(testUsdviewFreeCamera
 
 pxr_register_test(testUsdviewFreeCameraAspect
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewFreeCameraAspect.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewFreeCameraAspect.py test.usda"
     IMAGE_DIFF_COMPARE
         aspect185.png
         aspect239.png
@@ -589,7 +589,7 @@ pxr_register_test(testUsdviewFreeCameraAspect
 
 pxr_register_test(testUsdviewSelectionHighlighting
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewSelectionHighlighting.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewSelectionHighlighting.py test.usda"
     IMAGE_DIFF_COMPARE
         sel_highlight.png
         sel_highlight_none.png
@@ -604,7 +604,7 @@ pxr_register_test(testUsdviewSelectionHighlighting
 
 pxr_register_test(testUsdviewRenderMode
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewRenderMode.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewRenderMode.py test.usda"
     IMAGE_DIFF_COMPARE
         render_mode_wireframe.png
         render_mode_wireframe_on_surface.png
@@ -623,7 +623,7 @@ pxr_register_test(testUsdviewRenderMode
 
 pxr_register_test(testUsdviewLights
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLights.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLights.py test.usda"
     IMAGE_DIFF_COMPARE
         camera.png
         noLights.png
@@ -637,7 +637,7 @@ pxr_register_test(testUsdviewLights
 
 pxr_register_test(testUsdviewLights_yup
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLightsYup.py testYup.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLightsYup.py testYup.usda"
     IMAGE_DIFF_COMPARE
         domeYup.png
         bothLightsYup.png
@@ -649,7 +649,7 @@ pxr_register_test(testUsdviewLights_yup
 
 pxr_register_test(testUsdviewLightVisibility
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLightVisibility.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLightVisibility.py test.usda"
     IMAGE_DIFF_COMPARE
         singleInvisible1.png
         singleInvisible2.png
@@ -663,7 +663,7 @@ pxr_register_test(testUsdviewLightVisibility
 
 pxr_register_test(testUsdviewLightVisibility_varying
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewVaryLightVisibility.py testVarying.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewVaryLightVisibility.py testVarying.usda"
     IMAGE_DIFF_COMPARE
         visible.png
         invisible.png
@@ -675,7 +675,7 @@ pxr_register_test(testUsdviewLightVisibility_varying
 
 pxr_register_test(testUsdviewBackgroundColor
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewBackgroundColor.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewBackgroundColor.py test.usda"
     IMAGE_DIFF_COMPARE
         black.png
         grey_dark.png
@@ -689,7 +689,7 @@ pxr_register_test(testUsdviewBackgroundColor
 
 pxr_register_test(testUsdviewComplexity
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewComplexity.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewComplexity.py test.usda"
     IMAGE_DIFF_COMPARE
         low.png
         medium.png
@@ -703,7 +703,7 @@ pxr_register_test(testUsdviewComplexity
 
 pxr_register_test(testUsdviewFieldOfView
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewFieldOfView.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewFieldOfView.py test.usda"
     IMAGE_DIFF_COMPARE
         fov45.png
         fov60.png
@@ -716,7 +716,7 @@ pxr_register_test(testUsdviewFieldOfView
 
 pxr_register_test(testUsdviewClippingPlanes
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewClippingPlanes.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewClippingPlanes.py test.usda"
     IMAGE_DIFF_COMPARE
         no_override.png
         override_near.png
@@ -732,7 +732,7 @@ pxr_register_test(testUsdviewClippingPlanes
 
 pxr_register_test(testUsdviewDefaultMaterial
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewDefaultMaterial.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewDefaultMaterial.py test.usda"
     IMAGE_DIFF_COMPARE
         none.png
         ambient.png
@@ -746,7 +746,7 @@ pxr_register_test(testUsdviewDefaultMaterial
 
 pxr_register_test(testUsdviewCameraMaskMode
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --camera /camera --renderer GL --testScript testUsdviewCameraMaskMode.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --camera /camera --renderer GL --testScript testUsdviewCameraMaskMode.py test.usda"
     IMAGE_DIFF_COMPARE
         none_gl.png
         outline_gl.png
@@ -761,7 +761,7 @@ pxr_register_test(testUsdviewCameraMaskMode
 if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     pxr_register_test(testUsdviewCameraMaskMode_Embree
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --camera /camera --renderer Embree --testScript testUsdviewCameraMaskMode.py test.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --camera /camera --renderer Embree --testScript testUsdviewCameraMaskMode.py test.usda"
         IMAGE_DIFF_COMPARE
             none_embree.png
             outline_embree.png
@@ -777,7 +777,7 @@ endif()
 
 pxr_register_test(testUsdviewFrameSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewFrameSelection.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewFrameSelection.py test.usda"
     IMAGE_DIFF_COMPARE
         framed.png
         toggleToStart.png
@@ -791,7 +791,7 @@ pxr_register_test(testUsdviewFrameSelection
 
 pxr_register_test(testUsdviewReloadReopen
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewReloadReopen.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewReloadReopen.py test.usda"
     IMAGE_DIFF_COMPARE
         coloredAndFramed.png
         reloaded.png
@@ -804,7 +804,7 @@ pxr_register_test(testUsdviewReloadReopen
 
 pxr_register_test(testUsdviewMaterialEdits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewMaterialEdits.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewMaterialEdits.py test.usda"
     IMAGE_DIFF_COMPARE
         1.png
         2.png
@@ -816,7 +816,7 @@ pxr_register_test(testUsdviewMaterialEdits
 
 pxr_register_test(testUsdviewUpAxis_zUp
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewUpAxis_zUp.py testZUp.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewUpAxis_zUp.py testZUp.usda"
     IMAGE_DIFF_COMPARE
         zUp.png
         yUp.png
@@ -828,7 +828,7 @@ pxr_register_test(testUsdviewUpAxis_zUp
 
 pxr_register_test(testUsdviewDeactivate
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewDeactivate.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewDeactivate.py test.usda"
     IMAGE_DIFF_COMPARE
         singleDeactivate.png
         parentDeactivate.png
@@ -842,7 +842,7 @@ pxr_register_test(testUsdviewDeactivate
 
 pxr_register_test(testUsdviewCPUSkinning
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewSkinning.py arm.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewSkinning.py arm.usda"
     IMAGE_DIFF_COMPARE
         change_complexity.png
         vis_frame_4.png
@@ -861,7 +861,7 @@ pxr_register_test(testUsdviewCPUSkinning
 
 pxr_register_test(testUsdviewGPUSkinning
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewSkinning.py arm.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewSkinning.py arm.usda"
     IMAGE_DIFF_COMPARE
         change_complexity.png
         vis_frame_4.png
@@ -880,7 +880,7 @@ pxr_register_test(testUsdviewGPUSkinning
 
 pxr_register_test(testUsdviewInfGeom
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewInfGeom.py infGeom.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewInfGeom.py infGeom.usda"
     IMAGE_DIFF_COMPARE
         infGeom.png
         fixedGeom.png
@@ -894,7 +894,7 @@ pxr_register_test(testUsdviewInfGeom
 # the original testSpecs.xml
 #pxr_register_test(testUsdviewShaderEdits
 #    PYTHON
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewShaderEdits.py test.usda"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewShaderEdits.py test.usda"
 #    IMAGE_DIFF_COMPARE
 #        0.png
 #    FAIL 1
@@ -905,7 +905,7 @@ pxr_register_test(testUsdviewInfGeom
 
 pxr_register_test(testUsdviewPrimvarEdits
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPrimvarEdits.py primvars.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPrimvarEdits.py primvars.usda"
     IMAGE_DIFF_COMPARE
         start.png
         add_fallback_primvar_smooth.png
@@ -922,7 +922,7 @@ pxr_register_test(testUsdviewPrimvarEdits
 
 pxr_register_test(testUsdviewOIT
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewOIT.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewOIT.py test.usda"
     IMAGE_DIFF_COMPARE
         oit.png
     FAIL 1
@@ -933,7 +933,7 @@ pxr_register_test(testUsdviewOIT
 
 pxr_register_test(testUsdviewAdditive
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewAdditive.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewAdditive.py test.usda"
     IMAGE_DIFF_COMPARE
         additive.png
     FAIL 1
@@ -946,7 +946,7 @@ pxr_register_test(testUsdviewAdditive
 #
 # pxr_register_test(testUsdviewLegacyImpl
 #     PYTHON
-#     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewLegacyImpl.py test.usda"
+#     COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewLegacyImpl.py test.usda"
 #     IMAGE_DIFF_COMPARE
 #         perspective.png
 #         ortho.png
@@ -958,7 +958,7 @@ pxr_register_test(testUsdviewAdditive
 
 pxr_register_test(testUsdviewVariantSelection
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewVariantSelection.py test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewVariantSelection.py test.usda"
     IMAGE_DIFF_COMPARE
         capsule1.png
         cone1.png
@@ -976,7 +976,7 @@ pxr_register_test(testUsdviewVariantSelection
 
 pxr_register_test(testUsdviewPointWidths
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewPointWidths.py points.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewPointWidths.py points.usda"
     IMAGE_DIFF_COMPARE
         start.png
         set_point_widths_025.png
@@ -992,7 +992,7 @@ pxr_register_test(testUsdviewPointWidths
 if(OPENCOLORIO_FOUND AND ${PXR_BUILD_OPENCOLORIO_PLUGIN})
     pxr_register_test(testUsdviewColorManagement
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewColorManagement.py test.usda"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/testusdview' --testScript testUsdviewColorManagement.py test.usda"
         IMAGE_DIFF_COMPARE
             colorCorrectionOCIO_g22.png
             colorCorrectionOCIO_linear.png

--- a/pxr/usdImaging/bin/usdrecord/CMakeLists.txt
+++ b/pxr/usdImaging/bin/usdrecord/CMakeLists.txt
@@ -20,13 +20,13 @@ if (NOT PXR_HEADLESS_TEST_MODE)
 
     pxr_register_test(testUsdRecordSingleFrame
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdrecord AnimCube.usda AnimCube.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdrecord' AnimCube.usda AnimCube.png"
         EXPECTED_RETURN_CODE 0
     )
 
     pxr_register_test(testUsdRecordMultipleFrames
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdrecord AnimCube.usda AnimCube.#.png --frames 1,5,10"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/bin/usdrecord' AnimCube.usda AnimCube.#.png --frames 1,5,10"
         EXPECTED_RETURN_CODE 0
     )
 

--- a/pxr/usdImaging/usdAppUtils/CMakeLists.txt
+++ b/pxr/usdImaging/usdAppUtils/CMakeLists.txt
@@ -62,19 +62,19 @@ pxr_install_test_dir(
 )
 pxr_register_test(testUsdAppUtilsCamera
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsCamera"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsCamera'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAppUtilsCmdlineArgs
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsCmdlineArgs"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsCmdlineArgs'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAppUtilsComplexity
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsComplexity"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsComplexity'"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -85,7 +85,7 @@ pxr_install_test_dir(
 if (NOT PXR_HEADLESS_TEST_MODE)
     pxr_register_test(testUsdAppUtilsFrameRecorder
         PYTHON
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsFrameRecorder"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdAppUtilsFrameRecorder'"
         EXPECTED_RETURN_CODE 0
     )
 endif()

--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -587,7 +587,7 @@ pxr_install_test_dir(
 #
 
 pxr_register_test(testUsdImagingGLBasicDrawing
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage basicDrawing/basicDrawing.usda -write testUsdImagingGLBasicDrawing.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage basicDrawing/basicDrawing.usda -write testUsdImagingGLBasicDrawing.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing.png
     FAIL 1
@@ -599,7 +599,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -complexity 1.1 -stage basicDrawing/basicDrawing.usda -write testUsdImagingGLBasicDrawing_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -complexity 1.1 -stage basicDrawing/basicDrawing.usda -write testUsdImagingGLBasicDrawing_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_refined.png
     FAIL 1
@@ -612,7 +612,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_refined
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_leftHanded
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wireOnSurface -stage basicDrawing/leftHanded.usda -write testUsdImagingGLBasicDrawing_leftHanded.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wireOnSurface -stage basicDrawing/leftHanded.usda -write testUsdImagingGLBasicDrawing_leftHanded.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_leftHanded.png
     FAIL 1
@@ -625,7 +625,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_leftHanded
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_points
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage points.usda -frameAll -write testUsdImagingGLBasicDrawing_points.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage points.usda -frameAll -write testUsdImagingGLBasicDrawing_points.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_points.png
     FAIL 1
@@ -638,7 +638,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_points
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_clipped
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage basicDrawing/basicDrawing.usda -clipPlane 1 0 0 0 -frameAll -write testUsdImagingGLBasicDrawing_clipped.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage basicDrawing/basicDrawing.usda -clipPlane 1 0 0 0 -frameAll -write testUsdImagingGLBasicDrawing_clipped.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_clipped.png
     FAIL 1
@@ -651,7 +651,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_clipped
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_points_clipped
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage points.usda -clipPlane -1 0 0 0 -frameAll -write testUsdImagingGLBasicDrawing_points_clipped.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage points.usda -clipPlane -1 0 0 0 -frameAll -write testUsdImagingGLBasicDrawing_points_clipped.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_points_clipped.png
     FAIL 1
@@ -664,7 +664,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_points_clipped
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_id
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -idRender -stage basicDrawing/shaders.usd -frameAll -write testUsdImagingGLBasicDrawing_id.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -idRender -stage basicDrawing/shaders.usd -frameAll -write testUsdImagingGLBasicDrawing_id.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_id.png
     FAIL 1
@@ -677,7 +677,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_id
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_subdivTags
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage subdivTags.usda -frameAll -lighting -write testUsdImagingGLBasicDrawing_subdivTags.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage subdivTags.usda -frameAll -lighting -write testUsdImagingGLBasicDrawing_subdivTags.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_subdivTags.png
     FAIL 1
@@ -690,7 +690,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_subdivTags
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_subdivTagsRefined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage subdivTags.usda -frameAll -lighting -complexity 1.4 -write testUsdImagingGLBasicDrawing_subdivTagsRefined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage subdivTags.usda -frameAll -lighting -complexity 1.4 -write testUsdImagingGLBasicDrawing_subdivTagsRefined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_subdivTagsRefined.png
     FAIL 1
@@ -703,7 +703,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_subdivTagsRefined
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_inputShaderEncoding
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage basicDrawing/newInputShaderEncoding.usd -frameAll -lighting -write testUsdImagingGLBasicDrawing_inputShaderEncoding.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage basicDrawing/newInputShaderEncoding.usd -frameAll -lighting -write testUsdImagingGLBasicDrawing_inputShaderEncoding.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_inputShaderEncoding.png
     FAIL 1
@@ -716,7 +716,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_inputShaderEncoding
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawing_textureChannels
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage basicDrawing/textureChannels.usd -frameAll -lighting -write testUsdImagingGLBasicDrawing_textureChannels.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage basicDrawing/textureChannels.usd -frameAll -lighting -write testUsdImagingGLBasicDrawing_textureChannels.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_textureChannels.png
     FAIL 0.01
@@ -731,7 +731,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_textureChannels
 )
 
 pxr_register_test(testUsdImagingGLBasicDrawingNonBindless_batch
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage shaders.usda -frameAll -write testUsdImagingGLBasicDrawingNonBindless_batch.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage shaders.usda -frameAll -write testUsdImagingGLBasicDrawingNonBindless_batch.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawingNonBindless_batch.png
     FAIL 1
@@ -744,7 +744,7 @@ pxr_register_test(testUsdImagingGLBasicDrawingNonBindless_batch
 )
 
 pxr_register_test(testUsdImagingGLBasicLighting
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -stage basicDrawing.usda -write testUsdImagingGLBasicLighting.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -stage basicDrawing.usda -write testUsdImagingGLBasicLighting.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicLighting.png
     FAIL 1
@@ -755,7 +755,7 @@ pxr_register_test(testUsdImagingGLBasicLighting
 )
 
 pxr_register_test(testUsdImagingGLBasicLighting_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -complexity 1.1 -lighting -stage basicDrawing.usda -write testUsdImagingGLBasicLighting_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -complexity 1.1 -lighting -stage basicDrawing.usda -write testUsdImagingGLBasicLighting_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicLighting_refined.png
     FAIL 1
@@ -766,7 +766,7 @@ pxr_register_test(testUsdImagingGLBasicLighting_refined
 )
 
 pxr_register_test(testUsdImagingGLCurves
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage basicCurves.usda -write testUsdImagingGLCurves.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage basicCurves.usda -write testUsdImagingGLCurves.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLCurves.png
     FAIL 1
@@ -777,7 +777,7 @@ pxr_register_test(testUsdImagingGLCurves
 )
 
 pxr_register_test(testUsdImagingGLCurves_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.1 -stage basicCurves.usda -write testUsdImagingGLCurves_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.1 -stage basicCurves.usda -write testUsdImagingGLCurves_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLCurves_refined.png
     FAIL 1
@@ -788,7 +788,7 @@ pxr_register_test(testUsdImagingGLCurves_refined
 )
 
 pxr_register_test(testUsdImagingGL_moreCurves
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves.png
     FAIL 1
@@ -799,7 +799,7 @@ pxr_register_test(testUsdImagingGL_moreCurves
 )
 
 pxr_register_test(testUsdImagingGL_moreCurves_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.1 -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.1 -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_refined.png
     FAIL 1
@@ -810,7 +810,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_refined
 )
 
 pxr_register_test(testUsdImagingGL_moreCurves_faketubes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.2 -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves_faketubes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.2 -stage moreCurves.usda -camlight -shading smooth -write testUsdImagingGL_moreCurves_faketubes.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_faketubes.png
     FAIL 1
@@ -821,7 +821,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_faketubes
 )
 
 pxr_register_test(testUsdImagingGL_moreCurves_tubes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.3 -stage moreCurves.usda -camlight  -shading smooth -write testUsdImagingGL_moreCurves_tubes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.3 -stage moreCurves.usda -camlight  -shading smooth -write testUsdImagingGL_moreCurves_tubes.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_tubes.png
     FAIL 1
@@ -832,7 +832,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_tubes
 )
 
 pxr_register_test(testUsdImagingGL_pinnedCurves
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.3 -stage pinnedCurves.usda -camlight  -shading smooth -write testUsdImagingGL_pinnedCurves.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.3 -stage pinnedCurves.usda -camlight  -shading smooth -write testUsdImagingGL_pinnedCurves.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_pinnedCurves.png
     FAIL 1
@@ -843,7 +843,7 @@ pxr_register_test(testUsdImagingGL_pinnedCurves
 )
 
 pxr_register_test(testUsdImagingGLPoints
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage basicPoints.usda -write testUsdImagingGLPoints.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage basicPoints.usda -write testUsdImagingGLPoints.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPoints.png
     FAIL 1
@@ -854,7 +854,7 @@ pxr_register_test(testUsdImagingGLPoints
 )
 
 pxr_register_test(testUsdImagingGLPoints_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -complexity 1.1 -stage basicPoints.usda -write testUsdImagingGLPoints_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -complexity 1.1 -stage basicPoints.usda -write testUsdImagingGLPoints_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPoints_refined.png
     FAIL 1
@@ -865,7 +865,7 @@ pxr_register_test(testUsdImagingGLPoints_refined
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_ZupFront
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/FrontCamera -stage domeLightZup.usda -write testUsdImagingGLDomeLight_ZupFront.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/FrontCamera -stage domeLightZup.usda -write testUsdImagingGLDomeLight_ZupFront.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_ZupFront.png
     FAIL 1
@@ -876,7 +876,7 @@ pxr_register_test(testUsdImagingGLDomeLight_ZupFront
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_ZupBack
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/BackCamera -stage domeLightZup.usda -write testUsdImagingGLDomeLight_ZupBack.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/BackCamera -stage domeLightZup.usda -write testUsdImagingGLDomeLight_ZupBack.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_ZupBack.png
     FAIL 1
@@ -887,7 +887,7 @@ pxr_register_test(testUsdImagingGLDomeLight_ZupBack
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_YupFront
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/FrontCamera -stage domeLightYup.usda -write testUsdImagingGLDomeLight_YupFront.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/FrontCamera -stage domeLightYup.usda -write testUsdImagingGLDomeLight_YupFront.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_YupFront.png
     FAIL 1
@@ -898,7 +898,7 @@ pxr_register_test(testUsdImagingGLDomeLight_YupFront
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_YupBack
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/BackCamera -stage domeLightYup.usda -write testUsdImagingGLDomeLight_YupBack.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -camera /Scene/BackCamera -stage domeLightYup.usda -write testUsdImagingGLDomeLight_YupBack.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_YupBack.png
     FAIL 1
@@ -909,7 +909,7 @@ pxr_register_test(testUsdImagingGLDomeLight_YupBack
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_multi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage multiDomeLights.usda -write testUsdImagingGLDomeLight_multi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage multiDomeLights.usda -write testUsdImagingGLDomeLight_multi.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_multi.png
     FAIL 1
@@ -920,7 +920,7 @@ pxr_register_test(testUsdImagingGLDomeLight_multi
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_metallic
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereMetallic.usda -write testUsdImagingGLDomeLight_metallic.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereMetallic.usda -write testUsdImagingGLDomeLight_metallic.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_metallic.png
     FAIL 1
@@ -931,7 +931,7 @@ pxr_register_test(testUsdImagingGLDomeLight_metallic
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_rough
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereRough.usda -write testUsdImagingGLDomeLight_rough.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereRough.usda -write testUsdImagingGLDomeLight_rough.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_rough.png
     FAIL 1
@@ -942,7 +942,7 @@ pxr_register_test(testUsdImagingGLDomeLight_rough
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_grid
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereGrid.usda -write testUsdImagingGLDomeLight_grid.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereGrid.usda -write testUsdImagingGLDomeLight_grid.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_grid.png
     FAIL 1
@@ -953,7 +953,7 @@ pxr_register_test(testUsdImagingGLDomeLight_grid
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_metallic_specwf
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereMetallic_specwf.usda -write testUsdImagingGLDomeLight_metallic_specwf.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereMetallic_specwf.usda -write testUsdImagingGLDomeLight_metallic_specwf.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_metallic_specwf.png
     FAIL 1
@@ -964,7 +964,7 @@ pxr_register_test(testUsdImagingGLDomeLight_metallic_specwf
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_grid_specwf
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereGrid_specwf.usda -write testUsdImagingGLDomeLight_grid_specwf.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage sphereGrid_specwf.usda -write testUsdImagingGLDomeLight_grid_specwf.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_grid_specwf.png
     FAIL 1
@@ -975,7 +975,7 @@ pxr_register_test(testUsdImagingGLDomeLight_grid_specwf
 )
 
 pxr_register_test(testUsdImagingGLDomeLight_invis
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage invisDome.usda -write testUsdImagingGLDomeLight_invis.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -sceneLights -shading smooth -complexity 1.3 -stage invisDome.usda -write testUsdImagingGLDomeLight_invis.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDomeLight_invis.png
     FAIL 0.01
@@ -987,7 +987,7 @@ pxr_register_test(testUsdImagingGLDomeLight_invis
 )
 
 pxr_register_test(testUsdImagingGLDoubleSided
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -stage doubleSided2.usda -write testUsdImagingGLDoubleSided.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -stage doubleSided2.usda -write testUsdImagingGLDoubleSided.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDoubleSided.png
     FAIL 1
@@ -996,7 +996,7 @@ pxr_register_test(testUsdImagingGLDoubleSided
 )
 
 pxr_register_test(testUsdImagingGLExtents
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -stage testExtents.usda -write testUsdImagingGLExtents.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -stage testExtents.usda -write testUsdImagingGLExtents.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLExtents.png
     FAIL 1
@@ -1007,7 +1007,7 @@ pxr_register_test(testUsdImagingGLExtents
 )
 
 pxr_register_test(testUsdImagingGLImplicits
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wireOnSurface -frameAll -stage implicits.usda -write testUsdImagingGLImplicits.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wireOnSurface -frameAll -stage implicits.usda -write testUsdImagingGLImplicits.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLImplicits.png
     FAIL 1
@@ -1018,7 +1018,7 @@ pxr_register_test(testUsdImagingGLImplicits
 )
 
 pxr_register_test(testUsdImagingGLImplicits_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wireOnSurface -complexity 1.1 -frameAll -stage implicits.usda -write testUsdImagingGLImplicits_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wireOnSurface -complexity 1.1 -frameAll -stage implicits.usda -write testUsdImagingGLImplicits_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLImplicits_refined.png
     FAIL 1
@@ -1029,7 +1029,7 @@ pxr_register_test(testUsdImagingGLImplicits_refined
 )
 
 pxr_register_test(testUsdImagingGLHoleFaces
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -stage holeFaces.usda -write testUsdImagingGLHoleFaces.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -stage holeFaces.usda -write testUsdImagingGLHoleFaces.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLHoleFaces.png
     FAIL 1
@@ -1040,7 +1040,7 @@ pxr_register_test(testUsdImagingGLHoleFaces
 )
 
 pxr_register_test(testUsdImagingGLSubdivision_1_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivision_1_1.png
     FAIL 1
@@ -1051,7 +1051,7 @@ pxr_register_test(testUsdImagingGLSubdivision_1_1
 )
 
 pxr_register_test(testUsdImagingGLSubdivision_1_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivision_1_2.png
     FAIL 1
@@ -1062,7 +1062,7 @@ pxr_register_test(testUsdImagingGLSubdivision_1_2
 )
 
 pxr_register_test(testUsdImagingGLSubdivision_1_3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.3 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_3.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.3 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLSubdivision_1_3.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivision_1_3.png
     FAIL 1
@@ -1073,7 +1073,7 @@ pxr_register_test(testUsdImagingGLSubdivision_1_3
 )
 
 pxr_register_test(testUsdImagingGLSubdivision_lefthanded_1_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -frameAll -cullStyle back -offscreen -lighting -stage lefthandedMesh.usda -write testUsdImagingGLSubdivision_lefthanded_1_1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -frameAll -cullStyle back -offscreen -lighting -stage lefthandedMesh.usda -write testUsdImagingGLSubdivision_lefthanded_1_1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivision_lefthanded_1_1.png
     FAIL 1
@@ -1084,7 +1084,7 @@ pxr_register_test(testUsdImagingGLSubdivision_lefthanded_1_1
 )
 
 pxr_register_test(testUsdImagingGLSubdivision_lefthanded_1_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -frameAll -cullStyle back -offscreen -lighting -stage lefthandedMesh.usda -write testUsdImagingGLSubdivision_lefthanded_1_2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -frameAll -cullStyle back -offscreen -lighting -stage lefthandedMesh.usda -write testUsdImagingGLSubdivision_lefthanded_1_2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivision_lefthanded_1_2.png
     FAIL 1
@@ -1095,7 +1095,7 @@ pxr_register_test(testUsdImagingGLSubdivision_lefthanded_1_2
 )
 
 pxr_register_test(testUsdImagingGLComplexityOsd3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexities 1.0 1.1 1.2 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLComplexity.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexities 1.0 1.1 1.2 -offscreen -lighting -stage subdivMesh.usda -write testUsdImagingGLComplexity.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLComplexity_1.png
         testUsdImagingGLComplexity_1.1.png
@@ -1108,7 +1108,7 @@ pxr_register_test(testUsdImagingGLComplexityOsd3
 )
 
 pxr_register_test(testUsdImagingGLBasisCurvesWithColor
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexities 1.0 1.1 1.2 1.3 -offscreen -frameAll -stage curveWithVertexColor.usda -write testUsdImagingGLBasisCurvesWithColor.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexities 1.0 1.1 1.2 1.3 -offscreen -frameAll -stage curveWithVertexColor.usda -write testUsdImagingGLBasisCurvesWithColor.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasisCurvesWithColor_1.png
         testUsdImagingGLBasisCurvesWithColor_1.1.png
@@ -1121,7 +1121,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesWithColor
 )
 
 pxr_register_test(testUsdImagingGLBasisCurvesWithScale
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexities 1.1 -offscreen -lighting -stage curve-scales-flat.usd -write testUsdImagingGLBasisCurvesWithScale.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexities 1.1 -offscreen -lighting -stage curve-scales-flat.usd -write testUsdImagingGLBasisCurvesWithScale.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasisCurvesWithScale_1.1.png
     FAIL_PERCENT 30
@@ -1131,7 +1131,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesWithScale
 )
 
 pxr_register_test(testUsdImagingGLBasisCurvesWithNormals
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexities 1.1 -frameAll -offscreen -lighting -stage curve-authored-normals.usd -write testUsdImagingGLBasisCurvesWithNormals.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexities 1.1 -frameAll -offscreen -lighting -stage curve-authored-normals.usd -write testUsdImagingGLBasisCurvesWithNormals.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasisCurvesWithNormals_1.1.png
     FAIL_PERCENT 3
@@ -1141,7 +1141,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesWithNormals
 )
 
 pxr_register_test(testUsdImagingGLSubdivisionSchemeNone
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -complexities 1.0 1.3 -offscreen -lighting -stage ring.usda -write testUsdImagingGLSubdivisionSchemeNone.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -complexities 1.0 1.3 -offscreen -lighting -stage ring.usda -write testUsdImagingGLSubdivisionSchemeNone.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivisionSchemeNone_1.png
         testUsdImagingGLSubdivisionSchemeNone_1.3.png
@@ -1153,7 +1153,7 @@ pxr_register_test(testUsdImagingGLSubdivisionSchemeNone
 )
 
 pxr_register_test(testUsdImagingGLSubdivisionSchemeNone_NoLights
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -complexities 1.0 1.3 -offscreen -shading wireOnSurface -stage ring.usda -write testUsdImagingGLSubdivisionSchemeNone_NoLights.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -complexities 1.0 1.3 -offscreen -shading wireOnSurface -stage ring.usda -write testUsdImagingGLSubdivisionSchemeNone_NoLights.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivisionSchemeNone_NoLights_1.png
         testUsdImagingGLSubdivisionSchemeNone_NoLights_1.3.png
@@ -1165,7 +1165,7 @@ pxr_register_test(testUsdImagingGLSubdivisionSchemeNone_NoLights
 )
 
 pxr_register_test(testUsdImagingGLVaryingTopology
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -times 1 2 3 -stage varying.usda -write testUsdImagingGLVaryingTopology.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -times 1 2 3 -stage varying.usda -write testUsdImagingGLVaryingTopology.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLVaryingTopology_001.png
         testUsdImagingGLVaryingTopology_002.png
@@ -1178,7 +1178,7 @@ pxr_register_test(testUsdImagingGLVaryingTopology
 )
 
 pxr_register_test(testUsdImagingGLVaryingSharedMeshTopology
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -camlight -times 1 2 3 1 2 3 -stage meshVaryingTopologyWithSharing.usda -camera /MainCamera -write testUsdImagingGLVaryingSharedMeshTopology.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -camlight -times 1 2 3 1 2 3 -stage meshVaryingTopologyWithSharing.usda -camera /MainCamera -write testUsdImagingGLVaryingSharedMeshTopology.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLVaryingSharedMeshTopology_001.png
         testUsdImagingGLVaryingSharedMeshTopology_002.png
@@ -1191,7 +1191,7 @@ pxr_register_test(testUsdImagingGLVaryingSharedMeshTopology
 )
 
 pxr_register_test(testUsdImagingGLEmptyMesh
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -times 1 5 3 7 -stage test.usda -write testUsdImagingGLEmptyMesh.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -times 1 5 3 7 -stage test.usda -write testUsdImagingGLEmptyMesh.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLEmptyMesh_001.png
         testUsdImagingGLEmptyMesh_005.png
@@ -1205,7 +1205,7 @@ pxr_register_test(testUsdImagingGLEmptyMesh
 )
 
 pxr_register_test(testUsdImagingGLPrimitiveDrawing
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLPrimitiveDrawing.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLPrimitiveDrawing.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimitiveDrawing.png
     FAIL 1
@@ -1216,7 +1216,7 @@ pxr_register_test(testUsdImagingGLPrimitiveDrawing
 )
 
 pxr_register_test(testUsdImagingGLPrimitiveDrawingRef
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLPrimitiveDrawingRef.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLPrimitiveDrawingRef.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimitiveDrawingRef.png
     FAIL 1
@@ -1229,7 +1229,7 @@ pxr_register_test(testUsdImagingGLPrimitiveDrawingRef
 )
 
 pxr_register_test(testUsdImagingGLFlatShading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -shading flat -stage primitives.usda -write testUsdImagingGLFlatShading.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -shading flat -stage primitives.usda -write testUsdImagingGLFlatShading.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFlatShading.png
     FAIL 1
@@ -1240,7 +1240,7 @@ pxr_register_test(testUsdImagingGLFlatShading
 )
 
 pxr_register_test(testUsdImagingGLFlatShadingRef
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -shading flat -stage primitives.usda -write testUsdImagingGLFlatShadingRef.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -shading flat -stage primitives.usda -write testUsdImagingGLFlatShadingRef.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFlatShadingRef.png
     FAIL 1
@@ -1253,7 +1253,7 @@ pxr_register_test(testUsdImagingGLFlatShadingRef
 )
 
 pxr_register_test(testUsdImagingGLShadeMaterial
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage coloredCubes.usda -write testUsdImagingGLShadeMaterial.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage coloredCubes.usda -write testUsdImagingGLShadeMaterial.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLShadeMaterial.png
     FAIL 1
@@ -1264,7 +1264,7 @@ pxr_register_test(testUsdImagingGLShadeMaterial
 )
 
 pxr_register_test(testUsdImagingGLShadeMaterialRef
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage coloredCubes.usda -write testUsdImagingGLShadeMaterialRef.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage coloredCubes.usda -write testUsdImagingGLShadeMaterialRef.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLShadeMaterialRef.png
     FAIL 1
@@ -1275,7 +1275,7 @@ pxr_register_test(testUsdImagingGLShadeMaterialRef
 )
 
 pxr_register_test(testUsdImagingGLSphere
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage sphere.usda -times 1 10 -write testUsdImagingGLSphere.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage sphere.usda -times 1 10 -write testUsdImagingGLSphere.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSphere_001.png
         testUsdImagingGLSphere_010.png
@@ -1287,7 +1287,7 @@ pxr_register_test(testUsdImagingGLSphere
 )
 
 pxr_register_test(testUsdImagingGLNurbsCurves
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -times 0 50 150 -stage testCurves.usda -write testUsdImagingGLNurbsCurves.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -times 0 50 150 -stage testCurves.usda -write testUsdImagingGLNurbsCurves.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLNurbsCurves_000.png
         testUsdImagingGLNurbsCurves_050.png
@@ -1300,7 +1300,7 @@ pxr_register_test(testUsdImagingGLNurbsCurves
 )
 
 pxr_register_test(testUsdImagingGLNurbsCurves_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -times 0 50 150 -complexity 1.1 -stage testCurves.usda -write testUsdImagingGLNurbsCurves_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -times 0 50 150 -complexity 1.1 -stage testCurves.usda -write testUsdImagingGLNurbsCurves_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLNurbsCurves_refined_000.png
         testUsdImagingGLNurbsCurves_refined_050.png
@@ -1313,7 +1313,7 @@ pxr_register_test(testUsdImagingGLNurbsCurves_refined
 )
 
 pxr_register_test(testUsdImagingGLNurbsPatch
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -stage bendyNurbs.usda -camera /main_cam -times 1 5 10 -write testUsdImagingGLNurbsPatch.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -stage bendyNurbs.usda -camera /main_cam -times 1 5 10 -write testUsdImagingGLNurbsPatch.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLNurbsPatch_001.png
         testUsdImagingGLNurbsPatch_005.png
@@ -1326,7 +1326,7 @@ pxr_register_test(testUsdImagingGLNurbsPatch
 )
 
 pxr_register_test(testUsdImagingGLNurbsPatchRef
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -stage bendyNurbs.usda -camera /main_cam -times 1 5 10 -write testUsdImagingGLNurbsPatchRef.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -stage bendyNurbs.usda -camera /main_cam -times 1 5 10 -write testUsdImagingGLNurbsPatchRef.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLNurbsPatchRef_001.png
         testUsdImagingGLNurbsPatchRef_005.png
@@ -1341,7 +1341,7 @@ pxr_register_test(testUsdImagingGLNurbsPatchRef
 )
 
 pxr_register_test(testUsdImagingGLFramingBBox_proxy
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage framing.usda -write testUsdImagingGLFramingBBox_proxy.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage framing.usda -write testUsdImagingGLFramingBBox_proxy.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFramingBBox_proxy.png
     FAIL 1
@@ -1352,7 +1352,7 @@ pxr_register_test(testUsdImagingGLFramingBBox_proxy
 )
 
 pxr_register_test(testUsdImagingGLFramingBBox_proxy_render
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage framing.usda -renderPurpose show -write testUsdImagingGLFramingBBox_proxy_render.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage framing.usda -renderPurpose show -write testUsdImagingGLFramingBBox_proxy_render.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFramingBBox_proxy_render.png
     FAIL 1
@@ -1363,7 +1363,7 @@ pxr_register_test(testUsdImagingGLFramingBBox_proxy_render
 )
 
 pxr_register_test(testUsdImagingGLInstancing_instancedCubes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage instancedCubes.usda -write testUsdImagingGLInstancing_instancedCubes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage instancedCubes.usda -write testUsdImagingGLInstancing_instancedCubes.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_instancedCubes.png
     FAIL 0.01
@@ -1375,7 +1375,7 @@ pxr_register_test(testUsdImagingGLInstancing_instancedCubes
 )
 
 pxr_register_test(testUsdImagingGLInstancing_instancedCubes2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage instancedCubes2.usda -write testUsdImagingGLInstancing_instancedCubes2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage instancedCubes2.usda -write testUsdImagingGLInstancing_instancedCubes2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_instancedCubes2.png
     FAIL 0.01
@@ -1387,7 +1387,7 @@ pxr_register_test(testUsdImagingGLInstancing_instancedCubes2
 )
 
 pxr_register_test(testUsdImagingGLInstancing_instancedCubes2NoInstancing
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage instancedCubes2NoInstancing.usda -write testUsdImagingGLInstancing_instancedCubes2NoInstancing.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage instancedCubes2NoInstancing.usda -write testUsdImagingGLInstancing_instancedCubes2NoInstancing.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_instancedCubes2NoInstancing.png
     FAIL 0.01
@@ -1399,7 +1399,7 @@ pxr_register_test(testUsdImagingGLInstancing_instancedCubes2NoInstancing
 )
 
 pxr_register_test(testUsdImagingGLInstancing_nestedInstancedCubes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage nestedInstancedCubes.usda -write testUsdImagingGLInstancing_nestedInstancedCubes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage nestedInstancedCubes.usda -write testUsdImagingGLInstancing_nestedInstancedCubes.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_nestedInstancedCubes.png
     FAIL 0.01
@@ -1411,7 +1411,7 @@ pxr_register_test(testUsdImagingGLInstancing_nestedInstancedCubes
 )
 
 pxr_register_test(testUsdImagingGLInstancing_nestedInstance
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage nestedInstance.usda -write testUsdImagingGLInstancing_nestedInstance.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage nestedInstance.usda -write testUsdImagingGLInstancing_nestedInstance.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_instance3.png
     FAIL 0.02
@@ -1423,7 +1423,7 @@ pxr_register_test(testUsdImagingGLInstancing_nestedInstance
 )
 
 pxr_register_test(testUsdImagingGLInstancing_ni_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage ni_pi.usda -write testUsdImagingGLInstancing_ni_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage ni_pi.usda -write testUsdImagingGLInstancing_ni_pi.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_ni_pi.png
     FAIL 0.01
@@ -1435,7 +1435,7 @@ pxr_register_test(testUsdImagingGLInstancing_ni_pi
 )
 
 pxr_register_test(testUsdImagingGLInstancing_internal_ni
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage internal_ni.usda -write testUsdImagingGLInstancing_internal_ni.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage internal_ni.usda -write testUsdImagingGLInstancing_internal_ni.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancing_internal_ni.png
     FAIL 0.01
@@ -1447,7 +1447,7 @@ pxr_register_test(testUsdImagingGLInstancing_internal_ni
 )
 
 pxr_register_test(testUsdImagingGLPickAndHighlight
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPickAndHighlight -offscreen -frameAll -stage instance.usda -write testUsdImagingGLPickAndHighlight.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPickAndHighlight' -offscreen -frameAll -stage instance.usda -write testUsdImagingGLPickAndHighlight.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPickAndHighlight_000.png
         testUsdImagingGLPickAndHighlight_001.png
@@ -1462,7 +1462,7 @@ pxr_register_test(testUsdImagingGLPickAndHighlight
 )
 
 pxr_register_test(testUsdImagingGLHighlight
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight -offscreen -frameAll -stage instance.usda -write testUsdImagingGLHighlight.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight' -offscreen -frameAll -stage instance.usda -write testUsdImagingGLHighlight.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLHighlight_000.png
         testUsdImagingGLHighlight_001.png
@@ -1475,7 +1475,7 @@ pxr_register_test(testUsdImagingGLHighlight
 )
 
 pxr_register_test(testUsdImagingGLHighlight_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight -offscreen -frameAll -stage pi.usda -write testUsdImagingGLHighlight_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight' -offscreen -frameAll -stage pi.usda -write testUsdImagingGLHighlight_pi.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLHighlight_pi_000.png
         testUsdImagingGLHighlight_pi_001.png
@@ -1491,7 +1491,7 @@ pxr_register_test(testUsdImagingGLHighlight_pi
 )
 
 pxr_register_test(testUsdImagingGLHighlight_pi_ni
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight -offscreen -frameAll -stage pi_ni.usda -write testUsdImagingGLHighlight_pi_ni.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLHighlight' -offscreen -frameAll -stage pi_ni.usda -write testUsdImagingGLHighlight_pi_ni.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLHighlight_pi_ni_000.png
         testUsdImagingGLHighlight_pi_ni_001.png
@@ -1521,7 +1521,7 @@ pxr_register_test(testUsdImagingGLHighlight_pi_ni
 )
 
 pxr_register_test(testUsdImagingGLSurfaceShader_1_2_5
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader -offscreen -frameAll -stage shader_change.usda -lighting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader' -offscreen -frameAll -stage shader_change.usda -lighting"
     IMAGE_DIFF_COMPARE
         out1.png
         out2.png
@@ -1534,7 +1534,7 @@ pxr_register_test(testUsdImagingGLSurfaceShader_1_2_5
 )
 
 pxr_register_test(testUsdImagingGLSurfaceShader_3_4
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader -offscreen -frameAll -stage shader_change.usda -lighting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader' -offscreen -frameAll -stage shader_change.usda -lighting"
     IMAGE_DIFF_COMPARE
         out3.png
         out4.png
@@ -1547,7 +1547,7 @@ pxr_register_test(testUsdImagingGLSurfaceShader_3_4
 )
 
 pxr_register_test(testUsdImagingGLShadeBadTexture
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader -offscreen -frameAll -stage shader_change.usda -lighting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader' -offscreen -frameAll -stage shader_change.usda -lighting"
     IMAGE_DIFF_COMPARE
         out1.png
         out2.png
@@ -1562,7 +1562,7 @@ pxr_register_test(testUsdImagingGLShadeBadTexture
 )
 
 pxr_register_test(testUsdImagingGLShadeBool
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader -offscreen -frameAll -stage shadebool.usda -lighting"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLSurfaceShader' -offscreen -frameAll -stage shadebool.usda -lighting"
     IMAGE_DIFF_COMPARE
         out1.png
         out2.png
@@ -1577,7 +1577,7 @@ pxr_register_test(testUsdImagingGLShadeBool
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_basic
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_basic.usda -times 1 2 -write pi_basic.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_basic.usda -times 1 2 -write pi_basic.png"
     IMAGE_DIFF_COMPARE
         pi_basic_001.png
         pi_basic_002.png
@@ -1589,7 +1589,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_basic
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi.usda -write pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi.usda -write pi.png"
     IMAGE_DIFF_COMPARE
         pi.png
     FAIL 1
@@ -1600,7 +1600,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_pi.usda -write pi_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_pi.usda -write pi_pi.png"
     IMAGE_DIFF_COMPARE
         pi_pi.png
     FAIL 1
@@ -1611,7 +1611,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_pi
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_pi2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_pi2.usda -write pi_pi2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_pi2.usda -write pi_pi2.png"
     IMAGE_DIFF_COMPARE
         pi_pi2.png
     FAIL 1
@@ -1622,7 +1622,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_pi2
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_ni_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage ni_pi.usda -write ni_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage ni_pi.usda -write ni_pi.png"
     IMAGE_DIFF_COMPARE
         ni_pi.png
     FAIL 1
@@ -1633,7 +1633,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_ni_pi
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_ni
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_ni.usda -write pi_ni.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_ni.usda -write pi_ni.png"
     IMAGE_DIFF_COMPARE
         pi_ni.png
     FAIL 1
@@ -1644,7 +1644,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_ni
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_ni2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_ni2.usda -write pi_ni2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_ni2.usda -write pi_ni2.png"
     IMAGE_DIFF_COMPARE
         pi_ni2.png
     FAIL 1
@@ -1655,7 +1655,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_ni2
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_ni_pi.usda -write pi_ni_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_ni_pi.usda -write pi_ni_pi.png"
     IMAGE_DIFF_COMPARE
         pi_ni_pi.png
     FAIL 1
@@ -1666,7 +1666,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_pi
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_root_prototype
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_root_prototype.usda -write pi_root_prototype.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_root_prototype.usda -write pi_root_prototype.png"
     IMAGE_DIFF_COMPARE
         pi_root_prototype.png
     FAIL 1
@@ -1677,7 +1677,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_root_prototype
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_sibling_prototype
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_sibling_prototype.usda -write pi_sibling_prototype.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_sibling_prototype.usda -write pi_sibling_prototype.png"
     IMAGE_DIFF_COMPARE
         pi_sibling_prototype.png
     FAIL 1
@@ -1688,7 +1688,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_sibling_prototype
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_sibling_pi
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_sibling_pi.usda -write pi_sibling_pi.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_sibling_pi.usda -write pi_sibling_pi.png"
     IMAGE_DIFF_COMPARE
         pi_sibling_pi.png
     FAIL 1
@@ -1699,7 +1699,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_sibling_pi
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_varying
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_varying.usda -times 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 18 19 20 21 22 23 24 25 26 27 28 29 30 -write pi_varying.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_varying.usda -times 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 18 19 20 21 22 23 24 25 26 27 28 29 30 -write pi_varying.png"
     IMAGE_DIFF_COMPARE
         pi_varying_000.png
         pi_varying_001.png
@@ -1736,7 +1736,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_varying
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_pi_varying
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_pi_varying.usda -times 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 -write pi_pi_varying.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_pi_varying.usda -times 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 -write pi_pi_varying.png"
     IMAGE_DIFF_COMPARE
         pi_pi_varying_000.png
         pi_pi_varying_001.png
@@ -1764,7 +1764,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_pi_varying
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_pi_time
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_pi_time.usda -times 0 1 2 -write pi_pi_time.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -translate 0 -10 -40 -clear 0.2 0.2 0.2 1 -stage pi_pi_time.usda -times 0 1 2 -write pi_pi_time.png"
     IMAGE_DIFF_COMPARE
         pi_pi_time_000.png
         pi_pi_time_001.png
@@ -1777,7 +1777,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_pi_time
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_masking
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_masking.usda -times 0 1 2 3 4 -write pi_masking.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_masking.usda -times 0 1 2 3 4 -write pi_masking.png"
     IMAGE_DIFF_COMPARE
         pi_masking_000.png
         pi_masking_001.png
@@ -1792,7 +1792,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_masking
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_bad_schema_input
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_bad_schema_input.usda -write pi_bad_schema_input.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_bad_schema_input.usda -write pi_bad_schema_input.png"
     IMAGE_DIFF_COMPARE
         pi_bad_schema_input.png
     FAIL 1
@@ -1803,7 +1803,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_bad_schema_input
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_material
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_ni_material.usda -write pi_ni_material.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_ni_material.usda -write pi_ni_material.png"
     IMAGE_DIFF_COMPARE
         pi_ni_material.png
     FAIL 1
@@ -1814,7 +1814,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_material
 )
 
 pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_material2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -stage pi_ni_material2.usda -write pi_ni_material2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -stage pi_ni_material2.usda -write pi_ni_material2.png"
     IMAGE_DIFF_COMPARE
         pi_ni_material2.png
     FAIL 1
@@ -1825,7 +1825,7 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_ni_material2
 )
 
 pxr_register_test(testUsdImagingGLResync
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLResync --stage world.usda --unload /World/Model --write world.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLResync' --stage world.usda --unload /World/Model --write world.png"
     IMAGE_DIFF_COMPARE
         world_0.png
         world_1.png
@@ -1838,7 +1838,7 @@ pxr_register_test(testUsdImagingGLResync
 )
 
 pxr_register_test(testUsdImagingGLResync_instancer
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLResync --stage instancer.usda --unload /Root/PI/prototypes/proto1 --write instancer.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLResync' --stage instancer.usda --unload /Root/PI/prototypes/proto1 --write instancer.png"
     IMAGE_DIFF_COMPARE
         instancer_0.png
         instancer_1.png
@@ -1851,7 +1851,7 @@ pxr_register_test(testUsdImagingGLResync_instancer
 )
 
 pxr_register_test(testUsdImagingGLPurpose
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPurpose --stage world.usda --purpose /World/Model --write world.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPurpose' --stage world.usda --purpose /World/Model --write world.png"
     IMAGE_DIFF_COMPARE
         world_0.png
         world_1.png
@@ -1865,7 +1865,7 @@ pxr_register_test(testUsdImagingGLPurpose
 )
 
 pxr_register_test(testUsdImagingGLPrimvarSharing
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -frameAll -stage primvar_sharing.usda -times 0 1 2 -write default.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -frameAll -stage primvar_sharing.usda -times 0 1 2 -write default.png"
     IMAGE_DIFF_COMPARE
         default_000.png
         default_001.png
@@ -1880,7 +1880,7 @@ pxr_register_test(testUsdImagingGLPrimvarSharing
 )
 
 pxr_register_test(testUsdImagingGLPrimvarSharing_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -complexity 1.1 -lighting -camlight -frameAll -stage primvar_sharing.usda -times 0 1 2 -write refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -complexity 1.1 -lighting -camlight -frameAll -stage primvar_sharing.usda -times 0 1 2 -write refined.png"
     IMAGE_DIFF_COMPARE
         refined_000.png
         refined_001.png
@@ -1895,7 +1895,7 @@ pxr_register_test(testUsdImagingGLPrimvarSharing_refined
 )
 
 pxr_register_test(testUsdImagingGLPrimvarSharing_colors
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage primvar_sharing_colors.usda -times 0 1 2 -write default_colors.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage primvar_sharing_colors.usda -times 0 1 2 -write default_colors.png"
     IMAGE_DIFF_COMPARE
         default_colors_000.png
         default_colors_001.png
@@ -1910,7 +1910,7 @@ pxr_register_test(testUsdImagingGLPrimvarSharing_colors
 )
 
 pxr_register_test(testUsdImagingGLPrimvarSharing_refined_colors
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -complexity 1.1 -frameAll -stage primvar_sharing_colors.usda -times 0 1 2 -write refined_colors.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -complexity 1.1 -frameAll -stage primvar_sharing_colors.usda -times 0 1 2 -write refined_colors.png"
     IMAGE_DIFF_COMPARE
         refined_colors_000.png
         refined_colors_001.png
@@ -1925,7 +1925,7 @@ pxr_register_test(testUsdImagingGLPrimvarSharing_refined_colors
 )
 
 pxr_register_test(testUsdImagingGLColorOpacityPrimvar
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -translate -5 -2 -25 -times 0 1 -stage color_opacity_primvar.usda -write color_opacity_primvar.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -translate -5 -2 -25 -times 0 1 -stage color_opacity_primvar.usda -write color_opacity_primvar.png"
     IMAGE_DIFF_COMPARE
         color_opacity_primvar_000.png
         color_opacity_primvar_001.png
@@ -1937,7 +1937,7 @@ pxr_register_test(testUsdImagingGLColorOpacityPrimvar
 )
 
 pxr_register_test(testUsdImagingGLTriangleSubdivisionRuleOsd3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -complexity 1.5 -stage catmark_and_smooth_tris.usda -write testUsdImagingGLTriangleSubdivisionRuleOsd3.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -complexity 1.5 -stage catmark_and_smooth_tris.usda -write testUsdImagingGLTriangleSubdivisionRuleOsd3.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLTriangleSubdivisionRuleOsd3.png
     FAIL 1
@@ -1948,7 +1948,7 @@ pxr_register_test(testUsdImagingGLTriangleSubdivisionRuleOsd3
 )
 
 pxr_register_test(testUsdImagingGLWireframeOpacity
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wire -frameAll -complexity 1 -stage wireframe_opacity.usda -write testUsdImagingGLWireframeOpacity.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wire -frameAll -complexity 1 -stage wireframe_opacity.usda -write testUsdImagingGLWireframeOpacity.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLWireframeOpacity.png
     FAIL 1
@@ -1959,7 +1959,7 @@ pxr_register_test(testUsdImagingGLWireframeOpacity
 )
 
 pxr_register_test(testUsdImagingGLCards
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testCards.usda -write testCards.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testCards.usda -write testCards.png"
     IMAGE_DIFF_COMPARE
         testCards.png
     FAIL 0.01
@@ -1971,7 +1971,7 @@ pxr_register_test(testUsdImagingGLCards
 )
 
 pxr_register_test(testUsdImagingGLCards_anim
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testAnim.usda -times 1 2 -write testAnim.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testAnim.usda -times 1 2 -write testAnim.png"
     IMAGE_DIFF_COMPARE
         testAnim_001.png
         testAnim_002.png
@@ -1984,7 +1984,7 @@ pxr_register_test(testUsdImagingGLCards_anim
 )
 
 pxr_register_test(testUsdImagingGLCards_bounds
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -unloadedAsBounds -offscreen -lighting -shading smooth -frameAll -stage testUnloadedAsBounds.usda -write testUnloadedAsBounds.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -unloadedAsBounds -offscreen -lighting -shading smooth -frameAll -stage testUnloadedAsBounds.usda -write testUnloadedAsBounds.png"
     IMAGE_DIFF_COMPARE
         testUnloadedAsBounds.png
     FAIL 0.01
@@ -1996,7 +1996,7 @@ pxr_register_test(testUsdImagingGLCards_bounds
 )
 
 pxr_register_test(testUsdImagingGLMeshQuadrangulation
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wireOnSurface -frameAll -stage meshQuadrangulation.usda -write testUsdImagingGLMeshQuadrangulation_default.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wireOnSurface -frameAll -stage meshQuadrangulation.usda -write testUsdImagingGLMeshQuadrangulation_default.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLMeshQuadrangulation_default.png
     FAIL 1
@@ -2009,7 +2009,7 @@ pxr_register_test(testUsdImagingGLMeshQuadrangulation
 )
 
 pxr_register_test(testUsdImagingGLMeshQuadrangulation_refined
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -shading wireOnSurface -frameAll -stage meshQuadrangulation.usda -complexity 1.1 -write testUsdImagingGLMeshQuadrangulation_refined.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -shading wireOnSurface -frameAll -stage meshQuadrangulation.usda -complexity 1.1 -write testUsdImagingGLMeshQuadrangulation_refined.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLMeshQuadrangulation_refined.png
     FAIL 1
@@ -2022,7 +2022,7 @@ pxr_register_test(testUsdImagingGLMeshQuadrangulation_refined
 )
 
 pxr_register_test(testUsdImagingGLSkeleton
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -shading wire -stage skeleton.usda -times 1 2 3 -write skeleton.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -shading wire -stage skeleton.usda -times 1 2 3 -write skeleton.png"
     IMAGE_DIFF_COMPARE
         skeleton_001.png
         skeleton_002.png
@@ -2035,7 +2035,7 @@ pxr_register_test(testUsdImagingGLSkeleton
 )
 
 pxr_register_test(testUsdImagingGLSkelBlendShapes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage blendshapes.usda -times 1 2 3 -write blendshapes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage blendshapes.usda -times 1 2 3 -write blendshapes.png"
     IMAGE_DIFF_COMPARE
         blendshapes_001.png
         blendshapes_002.png
@@ -2048,7 +2048,7 @@ pxr_register_test(testUsdImagingGLSkelBlendShapes
 )
 
 pxr_register_test(testUsdImagingGLNormals
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testNormals.usda -write testNormals.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testNormals.usda -write testNormals.png"
     IMAGE_DIFF_COMPARE
         testNormals.png
     FAIL 1
@@ -2059,7 +2059,7 @@ pxr_register_test(testUsdImagingGLNormals
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Fallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallback.usda -write testPreviewSurfaceFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallback.usda -write testPreviewSurfaceFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallback.png
     FAIL 1
@@ -2073,7 +2073,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Fallback
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Primvars
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvars.usda -write testPreviewSurfacePrimvars.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvars.usda -write testPreviewSurfacePrimvars.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfacePrimvars.png
     FAIL 1
@@ -2087,7 +2087,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Primvars
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_PrimvarReaderOpacity
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarReaderOpacity.usda -write testPreviewSurfacePrimvarReaderOpacity.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarReaderOpacity.usda -write testPreviewSurfacePrimvarReaderOpacity.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfacePrimvarReaderOpacity.png
     FAIL 0.05
@@ -2101,7 +2101,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_PrimvarReaderOpacity
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Specular
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSpecular.usda -write testPreviewSurfaceSpecular.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSpecular.usda -write testPreviewSurfaceSpecular.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSpecular.png
     FAIL 1
@@ -2115,7 +2115,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Specular
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_MaterialInterface
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceMaterialInterface.usda -write testPreviewSurfaceMaterialInterface.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceMaterialInterface.usda -write testPreviewSurfaceMaterialInterface.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceMaterialInterface.png
     FAIL 1
@@ -2129,7 +2129,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_MaterialInterface
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Texture
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTexture.png
     FAIL 1
@@ -2143,7 +2143,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Texture
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Translucent
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -cullStyle back -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTranslucent.usda -write testPreviewSurfaceTranslucent.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -cullStyle back -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTranslucent.usda -write testPreviewSurfaceTranslucent.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTranslucent.png
     FAIL 1
@@ -2157,7 +2157,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Translucent
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Displacement
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -complexity 1.4 -stage testPreviewSurfaceDisplacement.usda -write testPreviewSurfaceDisplacement.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -complexity 1.4 -stage testPreviewSurfaceDisplacement.usda -write testPreviewSurfaceDisplacement.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 1
@@ -2171,7 +2171,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Displacement
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_TextureOpacity
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureOpacity.png
     FAIL 0.05
@@ -2186,7 +2186,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureOpacity
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_TextureScaleAndBias
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureScaleAndBias.usda -write testPreviewSurfaceTextureScaleAndBias.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureScaleAndBias.usda -write testPreviewSurfaceTextureScaleAndBias.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureScaleAndBias.png
     FAIL 1
@@ -2200,7 +2200,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureScaleAndBias
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Transform2d
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTransform2d.png
     FAIL 0.01
@@ -2215,7 +2215,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Transform2d
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_SourceColorSpace
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSourceColorSpace.png
     FAIL 0.005
@@ -2230,7 +2230,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_SourceColorSpace
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_NormalMap
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceNormalMap.png
     FAIL 0.01
@@ -2245,7 +2245,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_NormalMap
 
 
 pxr_register_test(testUsdImagingGLPreviewSurface_OpacityThreshold
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceOpacityThreshold.usda -write testPreviewSurfaceOpacityThreshold.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceOpacityThreshold.usda -write testPreviewSurfaceOpacityThreshold.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceOpacityThreshold.png
     FAIL 0.005
@@ -2259,7 +2259,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_OpacityThreshold
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_Animated
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -times 1 2 3 4 -shading smooth -frameAll -stage testPreviewSurfaceAnimated.usda -write testPreviewSurfaceAnimated.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -times 1 2 3 4 -shading smooth -frameAll -stage testPreviewSurfaceAnimated.usda -write testPreviewSurfaceAnimated.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceAnimated_001.png
         testPreviewSurfaceAnimated_002.png
@@ -2275,7 +2275,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Animated
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_FallbackPrimvar
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackPrimvar.usda -write testPreviewSurfaceFallbackPrimvar.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackPrimvar.usda -write testPreviewSurfaceFallbackPrimvar.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallbackPrimvar.png
     FAIL 1
@@ -2288,7 +2288,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_FallbackPrimvar
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_FallbackTexture
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackTexture.usda -write testPreviewSurfaceFallbackTexture.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackTexture.usda -write testPreviewSurfaceFallbackTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallbackTexture.png
     FAIL 1
@@ -2301,7 +2301,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_FallbackTexture
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_PrimvarFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarFallback.usda -write testPreviewSurfacePrimvarFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarFallback.usda -write testPreviewSurfacePrimvarFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfacePrimvarFallback.png
     FAIL 1
@@ -2314,7 +2314,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_PrimvarFallback
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_TextureFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureFallback.usda -write testPreviewSurfaceTextureFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureFallback.usda -write testPreviewSurfaceTextureFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureFallback.png
     FAIL 1
@@ -2327,7 +2327,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureFallback
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_TextureNoFile
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureNoFile.usda -write testPreviewSurfaceTextureNoFile.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureNoFile.usda -write testPreviewSurfaceTextureNoFile.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureNoFile.png
     FAIL 1
@@ -2340,7 +2340,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureNoFile
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurface_TextureWithToken
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureWithToken.usda -write testPreviewSurfaceTextureWithToken.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureWithToken.usda -write testPreviewSurfaceTextureWithToken.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureWithToken.png
     FAIL 1
@@ -2353,7 +2353,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureWithToken
 )
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Fallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallback.usda -write testPreviewSurfaceFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallback.usda -write testPreviewSurfaceFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallback.png
     FAIL 1
@@ -2367,7 +2367,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Fallback
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Primvars
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvars.usda -write testPreviewSurfacePrimvars.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvars.usda -write testPreviewSurfacePrimvars.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfacePrimvars.png
     FAIL 1
@@ -2381,7 +2381,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Primvars
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Specular
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSpecular.usda -write testPreviewSurfaceSpecular.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSpecular.usda -write testPreviewSurfaceSpecular.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSpecular.png
     FAIL 1
@@ -2395,7 +2395,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Specular
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_MaterialInterface
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceMaterialInterface.usda -write testPreviewSurfaceMaterialInterface.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceMaterialInterface.usda -write testPreviewSurfaceMaterialInterface.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceMaterialInterface.png
     FAIL 1
@@ -2409,7 +2409,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_MaterialInterface
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Texture
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTexture.png
     FAIL 1
@@ -2423,7 +2423,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Texture
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Translucent
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -cullStyle back -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTranslucent.usda -write testPreviewSurfaceTranslucent.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -cullStyle back -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTranslucent.usda -write testPreviewSurfaceTranslucent.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTranslucent.png
     FAIL 1
@@ -2437,7 +2437,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Translucent
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Displacement
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -complexity 1.4 -stage testPreviewSurfaceDisplacement.usda -write testPreviewSurfaceDisplacement.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -complexity 1.4 -stage testPreviewSurfaceDisplacement.usda -write testPreviewSurfaceDisplacement.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 1
@@ -2451,7 +2451,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Displacement
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureOpacity
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureOpacity.png
     FAIL 0.05
@@ -2466,7 +2466,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureOpacity
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureScaleAndBias
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureScaleAndBias.usda -write testPreviewSurfaceTextureScaleAndBias.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureScaleAndBias.usda -write testPreviewSurfaceTextureScaleAndBias.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureScaleAndBias.png
     FAIL 1
@@ -2480,7 +2480,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureScaleAndBias
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Transform2d
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTransform2d.png
     FAIL 0.01
@@ -2495,7 +2495,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Transform2d
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_SourceColorSpace
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSourceColorSpace.png
     FAIL 0.005
@@ -2510,7 +2510,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_SourceColorSpace
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_NormalMap
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceNormalMap.png
     FAIL 0.01
@@ -2525,7 +2525,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_NormalMap
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_OpacityThreshold
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceOpacityThreshold.usda -write testPreviewSurfaceOpacityThreshold.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceOpacityThreshold.usda -write testPreviewSurfaceOpacityThreshold.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceOpacityThreshold.png
     FAIL 0.005
@@ -2540,7 +2540,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_OpacityThreshold
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Animated
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -times 1 2 3 4 -shading smooth -frameAll -stage testPreviewSurfaceAnimated.usda -write testPreviewSurfaceAnimated.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -times 1 2 3 4 -shading smooth -frameAll -stage testPreviewSurfaceAnimated.usda -write testPreviewSurfaceAnimated.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceAnimated_001.png
         testPreviewSurfaceAnimated_002.png
@@ -2557,7 +2557,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Animated
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_FallbackPrimvar
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackPrimvar.usda -write testPreviewSurfaceFallbackPrimvar.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackPrimvar.usda -write testPreviewSurfaceFallbackPrimvar.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallbackPrimvar.png
     FAIL 1
@@ -2571,7 +2571,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_FallbackPrimvar
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_FallbackTexture
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackTexture.usda -write testPreviewSurfaceFallbackTexture.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceFallbackTexture.usda -write testPreviewSurfaceFallbackTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceFallbackTexture.png
     FAIL 1
@@ -2585,7 +2585,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_FallbackTexture
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_PrimvarFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarFallback.usda -write testPreviewSurfacePrimvarFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfacePrimvarFallback.usda -write testPreviewSurfacePrimvarFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfacePrimvarFallback.png
     FAIL 1
@@ -2599,7 +2599,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_PrimvarFallback
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureFallback.usda -write testPreviewSurfaceTextureFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureFallback.usda -write testPreviewSurfaceTextureFallback.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureFallback.png
     FAIL 1
@@ -2613,7 +2613,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureFallback
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureNoFile
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureNoFile.usda -write testPreviewSurfaceTextureNoFile.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureNoFile.usda -write testPreviewSurfaceTextureNoFile.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureNoFile.png
     FAIL 1
@@ -2627,7 +2627,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureNoFile
 
 
 pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureWithToken
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureWithToken.usda -write testPreviewSurfaceTextureWithToken.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureWithToken.usda -write testPreviewSurfaceTextureWithToken.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureWithToken.png
     FAIL 1
@@ -2640,7 +2640,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureWithToken
 )
 
 pxr_register_test(testUsdImagingGLPremultiplyAlpha
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPremultiplyAlpha.usda -write testPremultiplyAlpha.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPremultiplyAlpha.usda -write testPremultiplyAlpha.png"
     IMAGE_DIFF_COMPARE
         testPremultiplyAlpha.png
     FAIL 0.01
@@ -2652,7 +2652,7 @@ pxr_register_test(testUsdImagingGLPremultiplyAlpha
 )
 
 pxr_register_test(testUsdImagingGLPremultiplyAlpha_udims
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPremultiplyAlphaUdims.usda -write testPremultiplyAlphaUdims.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPremultiplyAlphaUdims.usda -write testPremultiplyAlphaUdims.png"
     IMAGE_DIFF_COMPARE
         testPremultiplyAlphaUdims.png
     FAIL 0.01
@@ -2664,7 +2664,7 @@ pxr_register_test(testUsdImagingGLPremultiplyAlpha_udims
 )
 
 pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage ni_2instances.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage ni_2instances.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancingWithMaterials_ni_2instances.png
     FAIL 0.01
@@ -2677,7 +2677,7 @@ pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances
 
 
 pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_per_instance_overrides_noshading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_per_instance_overrides_noshading.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_per_instance_overrides_noshading.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_per_instance_overrides_noshading.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_per_instance_overrides_noshading.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancingWithMaterials_ni_2instances_per_instance_overrides_noshading.png
     FAIL 0.01
@@ -2690,7 +2690,7 @@ pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_per_inst
 
 
 pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded.png
     FAIL 0.01
@@ -2703,7 +2703,7 @@ pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded
 
 
 pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded_overrides.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded_overrides.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides.png
     FAIL 0.01
@@ -2716,7 +2716,7 @@ pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_o
 
 
 pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides_noshading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded_overrides_noshading.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides_noshading.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage ni_2instances_shaded_overrides_noshading.usda -write testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides_noshading.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_overrides_noshading.png
     FAIL 0.01
@@ -2728,7 +2728,7 @@ pxr_register_test(testUsdImagingGLInstancingWithMaterials_ni_2instances_shaded_o
 )
 
 pxr_register_test(testUsdImagingGLFaceVarying_Uniform_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Uniform_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Uniform_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVarying_Uniform_Low.png
     FAIL 1
@@ -2740,7 +2740,7 @@ pxr_register_test(testUsdImagingGLFaceVarying_Uniform_Low
 
 
 pxr_register_test(testUsdImagingGLFaceVarying_Uniform_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Uniform_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Uniform_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVarying_Uniform_Medium.png
     FAIL 1
@@ -2752,7 +2752,7 @@ pxr_register_test(testUsdImagingGLFaceVarying_Uniform_Medium
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low.png
     FAIL 1
@@ -2764,7 +2764,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium.png
     FAIL 1
@@ -2776,7 +2776,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Uniform_None
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.0 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Uniform_None.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.0 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Uniform_None.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLeftHanded_Uniform_None.png
     FAIL 1
@@ -2788,7 +2788,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Uniform_None
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Uniform_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Uniform_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Uniform_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLeftHanded_Uniform_Low.png
     FAIL 1
@@ -2799,7 +2799,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Uniform_Low
 )
 
 pxr_register_test(testUsdImagingGLFaceVarying_Adaptive_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Adaptive_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Adaptive_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVarying_Adaptive_Low.png
     FAIL 1
@@ -2813,7 +2813,7 @@ pxr_register_test(testUsdImagingGLFaceVarying_Adaptive_Low
 
 
 pxr_register_test(testUsdImagingGLFaceVarying_Adaptive_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Adaptive_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVarying.usda -write testUsdImagingGLFaceVarying_Adaptive_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVarying_Adaptive_Medium.png
     FAIL 1
@@ -2827,7 +2827,7 @@ pxr_register_test(testUsdImagingGLFaceVarying_Adaptive_Medium
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Low.png
     FAIL 1
@@ -2841,7 +2841,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Low
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLinearInterp.usda -write testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Medium.png
     FAIL 1
@@ -2855,7 +2855,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Adaptive_Medium
 
 
 pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLFaceVaryingLeftHanded.usda -write testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low.png
     FAIL 1
@@ -2868,7 +2868,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low
 )
 
 pxr_register_test(testUsdImagingGLShadingPrimvars
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPrimvarNameHandlingInGL.usda -write testUsdImagingGLShadingPrimvars.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage testPrimvarNameHandlingInGL.usda -write testUsdImagingGLShadingPrimvars.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLShadingPrimvars.png
     FAIL 1
@@ -2885,7 +2885,7 @@ pxr_register_test(testUsdImagingGLShadingPrimvars
 # been able to get that too work. I did try to convert these images through OIIO's iconvert tool
 # but it also fails trying to open the .tx files
 #pxr_register_test(testUsdImagingGLTextureWrap
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage textureWrap.usda -write textureWrap.png"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage textureWrap.usda -write textureWrap.png"
 #    IMAGE_DIFF_COMPARE
 #        textureWrap.png
 #    FAIL 1
@@ -2898,7 +2898,7 @@ pxr_register_test(testUsdImagingGLShadingPrimvars
 #)
 #
 #pxr_register_test(testUsdImagingGLTextureWrapNonBindless
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage textureWrap.usda -write textureWrap.png"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage textureWrap.usda -write textureWrap.png"
 #    IMAGE_DIFF_COMPARE
 #        textureWrap.png
 #    FAIL 1
@@ -2911,7 +2911,7 @@ pxr_register_test(testUsdImagingGLShadingPrimvars
 #)
 
 pxr_register_test(testUsdImagingGLUsdLux
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdLux.usda -write usdLux.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdLux.usda -write usdLux.png"
     IMAGE_DIFF_COMPARE
         usdLux.png
     FAIL 1
@@ -2923,7 +2923,7 @@ pxr_register_test(testUsdImagingGLUsdLux
 
 # TODO: Requires create_symlinks.py to run properly
 #pxr_register_test(testUsdImagingGLUsdUdims_Symlinked
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsSymlinked.usda -write usdUdimsSymlinked.png"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsSymlinked.usda -write usdUdimsSymlinked.png"
 #    IMAGE_DIFF_COMPARE
 #        usdUdimsSymlinked.png
 #    FAIL_PERCENT 1
@@ -2935,7 +2935,7 @@ pxr_register_test(testUsdImagingGLUsdLux
 #)
 
 pxr_register_test(testUsdImagingGLUsdUdims
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usda -write usdUdims.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usda -write usdUdims.png"
     IMAGE_DIFF_COMPARE
         usdUdims.png
     FAIL 1
@@ -2948,7 +2948,7 @@ pxr_register_test(testUsdImagingGLUsdUdims
 )
 
 pxr_register_test(testUsdImagingGLUsdUdims_Usdz
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usdz -write usdUdimsUsdz.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usdz -write usdUdimsUsdz.png"
     IMAGE_DIFF_COMPARE
         usdUdimsUsdz.png
     FAIL 1
@@ -2961,7 +2961,7 @@ pxr_register_test(testUsdImagingGLUsdUdims_Usdz
 )
 
 pxr_register_test(testUsdImagingGLUsdUdims_ScaleAndBias
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsScaleAndBias.usda -write usdUdimsScaleAndBias.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsScaleAndBias.usda -write usdUdimsScaleAndBias.png"
     IMAGE_DIFF_COMPARE
         usdUdimsScaleAndBias.png
     FAIL 1
@@ -2974,7 +2974,7 @@ pxr_register_test(testUsdImagingGLUsdUdims_ScaleAndBias
 )
 
 pxr_register_test(testUsdImagingGLUsdUdims_TextureFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsTextureFallback.usda -write usdUdimsTextureFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsTextureFallback.usda -write usdUdimsTextureFallback.png"
     IMAGE_DIFF_COMPARE
         usdUdimsTextureFallback.png
     FAIL 1
@@ -2988,7 +2988,7 @@ pxr_register_test(testUsdImagingGLUsdUdims_TextureFallback
 
 # TODO: Requires create_symlinks.py to run properly
 #pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_Symlinked
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsSymlinked.usda -write usdUdimsSymlinked.png"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsSymlinked.usda -write usdUdimsSymlinked.png"
 #    IMAGE_DIFF_COMPARE
 #        usdUdimsSymlinked.png
 #    FAIL_PERCENT 1
@@ -3000,7 +3000,7 @@ pxr_register_test(testUsdImagingGLUsdUdims_TextureFallback
 #)
 
 pxr_register_test(testUsdImagingGLUsdUdimsNonBindless
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usda -write usdUdims.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdims.usda -write usdUdims.png"
     IMAGE_DIFF_COMPARE
         usdUdims.png
     FAIL 1
@@ -3013,7 +3013,7 @@ pxr_register_test(testUsdImagingGLUsdUdimsNonBindless
 )
 
 pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_ScaleAndBias
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsScaleAndBias.usda -write usdUdimsScaleAndBias.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsScaleAndBias.usda -write usdUdimsScaleAndBias.png"
     IMAGE_DIFF_COMPARE
         usdUdimsScaleAndBias.png
     FAIL 1
@@ -3026,7 +3026,7 @@ pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_ScaleAndBias
 )
 
 pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_TextureFallback
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdUdimsTextureFallback.usda -write usdUdimsTextureFallback.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -stage usdUdimsTextureFallback.usda -write usdUdimsTextureFallback.png"
     IMAGE_DIFF_COMPARE
         usdUdimsTextureFallback.png
     FAIL 1
@@ -3039,7 +3039,7 @@ pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_TextureFallback
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm_baked
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm_baked.usda -times 1 3 7 -write usdSkel_arm_baked.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm_baked.usda -times 1 3 7 -write usdSkel_arm_baked.png"
     IMAGE_DIFF_COMPARE
         usdSkel_arm_baked_001.png
         usdSkel_arm_baked_003.png
@@ -3054,7 +3054,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm_baked
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm.usda -times 1 3 7 -write usdSkel_arm_extComp_CPU.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm.usda -times 1 3 7 -write usdSkel_arm_extComp_CPU.png"
     IMAGE_DIFF_COMPARE
         usdSkel_arm_extComp_CPU_001.png
         usdSkel_arm_extComp_CPU_003.png
@@ -3069,7 +3069,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_twoBends
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage twoBends.usda -write usdSkel_twoBends_extComp_CPU.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage twoBends.usda -write usdSkel_twoBends_extComp_CPU.png"
     IMAGE_DIFF_COMPARE
         usdSkel_twoBends_extComp_CPU.png
     FAIL 1
@@ -3082,7 +3082,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_twoBends
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_arm_baked
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm_baked.usda -times 1 3 7 -write usdSkel_arm_baked.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm_baked.usda -times 1 3 7 -write usdSkel_arm_baked.png"
     IMAGE_DIFF_COMPARE
         usdSkel_arm_baked_001.png
         usdSkel_arm_baked_003.png
@@ -3097,7 +3097,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_arm_baked
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_arm
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm.usda -times 1 3 7 -write usdSkel_arm_extComp_GPU.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage arm.usda -times 1 3 7 -write usdSkel_arm_extComp_GPU.png"
     IMAGE_DIFF_COMPARE
         usdSkel_arm_extComp_GPU_001.png
         usdSkel_arm_extComp_GPU_003.png
@@ -3112,7 +3112,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_arm
 )
 
 pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_twoBends
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage twoBends.usda -write usdSkel_twoBends_extComp_GPU.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage twoBends.usda -write usdSkel_twoBends_extComp_GPU.png"
     IMAGE_DIFF_COMPARE
         usdSkel_twoBends_extComp_GPU.png
     FAIL 1
@@ -3125,7 +3125,7 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_twoBends
 )
 
 pxr_register_test(testUsdImagingGLPopOut
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test test.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut' --output test test.usda"
     IMAGE_DIFF_COMPARE
         test_0.png
         test_1.png
@@ -3144,7 +3144,7 @@ pxr_register_test(testUsdImagingGLPopOut
 )
 
 pxr_register_test(testUsdImagingGLPopOut_instance
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance test_instance.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut' --output test_instance test_instance.usda"
     IMAGE_DIFF_COMPARE
         test_instance_0.png
         test_instance_1.png
@@ -3163,13 +3163,13 @@ pxr_register_test(testUsdImagingGLPopOut_instance
 )
 
 pxr_register_test(testUsdImagingGLPopOut_instance_empty
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance_empty test_instance_empty.usda"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut' --output test_instance_empty test_instance_empty.usda"
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPopOut
 )
 
 pxr_register_test(testUsdImagingGLMaterialTag
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -cullStyle back -offscreen -frameAll -stage materialTag.usda -write testUsdImagingGLMaterialTag.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -cullStyle back -offscreen -frameAll -stage materialTag.usda -write testUsdImagingGLMaterialTag.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLMaterialTag.png
     FAIL 1
@@ -3186,7 +3186,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLMaterialX_mxSimple
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxSimple.usda -write mxSimple.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxSimple.usda -write mxSimple.png"
         IMAGE_DIFF_COMPARE
             mxSimple.png
         FAIL 0.5
@@ -3198,7 +3198,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLMaterialX_standardSurface
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage standardSurface.usda -write standardSurface.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage standardSurface.usda -write standardSurface.png"
         IMAGE_DIFF_COMPARE
             standardSurface.png
         FAIL 0.5
@@ -3211,7 +3211,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_standardSurfaceMarble
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage standardSurfaceMarble.usda -write standardSurfaceMarble.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage standardSurfaceMarble.usda -write standardSurfaceMarble.png"
         IMAGE_DIFF_COMPARE
             standardSurfaceMarble.png
         FAIL 0.5
@@ -3224,7 +3224,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_usdPreviewSurface
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage usdPreviewSurface.usda -write usdPreviewSurface.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage usdPreviewSurface.usda -write usdPreviewSurface.png"
         IMAGE_DIFF_COMPARE
             usdPreviewSurface.png
         FAIL 0.5
@@ -3237,7 +3237,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxPreviewSurfaceVsNative_Default
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxPreviewSurfaceVsNative_Default.usda -write mxPreviewSurfaceVsNative_Default.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxPreviewSurfaceVsNative_Default.usda -write mxPreviewSurfaceVsNative_Default.png"
         IMAGE_DIFF_COMPARE
             mxPreviewSurfaceVsNative_Default.png
         FAIL 0.5
@@ -3250,7 +3250,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxPreviewSurfaceVsNative_Gold
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxPreviewSurfaceVsNative_Gold.usda -write mxPreviewSurfaceVsNative_Gold.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxPreviewSurfaceVsNative_Gold.usda -write mxPreviewSurfaceVsNative_Gold.png"
         IMAGE_DIFF_COMPARE
             mxPreviewSurfaceVsNative_Gold.png
         FAIL 0.5
@@ -3263,7 +3263,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_basicMxYup
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -stage basicMxYup.usda -camera /FrontCamera -write basicMxYup.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -stage basicMxYup.usda -camera /FrontCamera -write basicMxYup.png"
         IMAGE_DIFF_COMPARE
             basicMxYup.png
         FAIL 0.5
@@ -3276,7 +3276,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_basicMxZup
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -stage basicMxZup.usda -camera /FrontCamera -write basicMxZup.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -stage basicMxZup.usda -camera /FrontCamera -write basicMxZup.png"
         IMAGE_DIFF_COMPARE
             basicMxZup.png
         FAIL 0.5
@@ -3289,7 +3289,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxDirectLights
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxDirectLights.usda -write mxDirectLights.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxDirectLights.usda -write mxDirectLights.png"
         IMAGE_DIFF_COMPARE
             mxDirectLights.png
         FAIL 0.5
@@ -3302,7 +3302,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxDirectLightsCameraLight
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -camlight -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxDirectLights.usda -write mxDirectLightsCameraLight.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -camlight -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxDirectLights.usda -write mxDirectLightsCameraLight.png"
         IMAGE_DIFF_COMPARE
             mxDirectLightsCameraLight.png
         FAIL 0.5
@@ -3315,7 +3315,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxTextured
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxTextured.usda -write mxTextured.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxTextured.usda -write mxTextured.png"
         IMAGE_DIFF_COMPARE
             mxTextured.png
         FAIL 0.5
@@ -3328,7 +3328,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxTextured2
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxTextured2.usda -write mxTextured2.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxTextured2.usda -write mxTextured2.png"
         IMAGE_DIFF_COMPARE
             mxTextured2.png
         FAIL 0.5
@@ -3341,7 +3341,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxGlass
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxGlass.usda -write mxGlass.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxGlass.usda -write mxGlass.png"
         IMAGE_DIFF_COMPARE
             mxGlass.png
         FAIL 0.5
@@ -3354,7 +3354,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLMaterialX_mxGeomprop
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxGeomprop.usda -write mxGeomprop.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxGeomprop.usda -write mxGeomprop.png"
         IMAGE_DIFF_COMPARE
             mxGeomprop.png
         FAIL 0.5
@@ -3367,7 +3367,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 endif()
 
 pxr_register_test(testUsdImagingGLInstancePrimvars
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage test.usda -write testUsdImagingGLInstancePrimvars.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage test.usda -write testUsdImagingGLInstancePrimvars.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancePrimvars.png
     FAIL 1
@@ -3378,7 +3378,7 @@ pxr_register_test(testUsdImagingGLInstancePrimvars
 )
 
 pxr_register_test(testUsdImagingGLInstancePrimvars_Filtering
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage testFiltering.usda -write testUsdImagingGLInstancePrimvarsFiltering.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage testFiltering.usda -write testUsdImagingGLInstancePrimvarsFiltering.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancePrimvarsFiltering.png
     FAIL 1
@@ -3389,7 +3389,7 @@ pxr_register_test(testUsdImagingGLInstancePrimvars_Filtering
 )
 
 pxr_register_test(testUsdImagingGLInstancePrimvars_Animated
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -times 1 2 3 -stage testAnimated.usda -write testUsdImagingGLInstancePrimvarsAnimated.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -times 1 2 3 -stage testAnimated.usda -write testUsdImagingGLInstancePrimvarsAnimated.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInstancePrimvarsAnimated_001.png
         testUsdImagingGLInstancePrimvarsAnimated_002.png
@@ -3402,7 +3402,7 @@ pxr_register_test(testUsdImagingGLInstancePrimvars_Animated
 )
 
 pxr_register_test(testUsdImagingGLSimpleVolumes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage simpleVolumes.usda -write testUsdImagingGLSimpleVolumes.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.04 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage simpleVolumes.usda -write testUsdImagingGLSimpleVolumes.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.04 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSimpleVolumes.png
     FAIL 1
@@ -3413,7 +3413,7 @@ pxr_register_test(testUsdImagingGLSimpleVolumes
 )
 
 pxr_register_test(testUsdImagingGLSimpleVolumes_Glow
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage simpleVolumeGlow.usda -write testUsdImagingGLSimpleVolumeGlow.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.05 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage simpleVolumeGlow.usda -write testUsdImagingGLSimpleVolumeGlow.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.05 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSimpleVolumeGlow.png
     FAIL 1
@@ -3424,7 +3424,7 @@ pxr_register_test(testUsdImagingGLSimpleVolumes_Glow
 )
 
 pxr_register_test(testUsdImagingGLVolumeMaterial
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage volumeMaterial.usda -write testUsdImagingGLVolumeMaterial.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.05 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage volumeMaterial.usda -write testUsdImagingGLVolumeMaterial.png -clear 0 0 0 1 -lighting -camera /main_cam -renderSetting volumeRaymarchingStepSize float 0.05 -renderSetting volumeRaymarchingStepSizeLighting float 0.05"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLVolumeMaterial.png
     FAIL 1
@@ -3435,7 +3435,7 @@ pxr_register_test(testUsdImagingGLVolumeMaterial
 )
 
 pxr_register_test(testUsdImagingGLBasisCurvesVaryingTopology
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -frameAll -offscreen -lighting -times 1 3 4 5 4 -stage bunnyCurves.usda -write testUsdImagingGLBasisCurvesVaryingTopology.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -frameAll -offscreen -lighting -times 1 3 4 5 4 -stage bunnyCurves.usda -write testUsdImagingGLBasisCurvesVaryingTopology.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasisCurvesVaryingTopology_003.png
         testUsdImagingGLBasisCurvesVaryingTopology_004.png
@@ -3449,7 +3449,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesVaryingTopology
 
 # Disable this test temporarily due to issue where test runs forever
 pxr_register_test(testUsdImagingGLClippingPlanes
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -camera /World/main_cam -times 1 2 -stage clippingPlanes.usda -write testUsdImagingGLClippingPlanes.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -camera /World/main_cam -times 1 2 -stage clippingPlanes.usda -write testUsdImagingGLClippingPlanes.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLClippingPlanes_001.png
         testUsdImagingGLClippingPlanes_002.png
@@ -3462,7 +3462,7 @@ pxr_register_test(testUsdImagingGLClippingPlanes
 )
 
 pxr_register_test(testUsdImagingGLAnimatedCamera
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -camera /World/main_cam -times 1 2 3 -stage cameraMoving.usda -write testUsdImagingGLAnimatedCamera.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -camera /World/main_cam -times 1 2 3 -stage cameraMoving.usda -write testUsdImagingGLAnimatedCamera.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLAnimatedCamera_001.png
         testUsdImagingGLAnimatedCamera_002.png
@@ -3475,7 +3475,7 @@ pxr_register_test(testUsdImagingGLAnimatedCamera
 )
 
 pxr_register_test(testUsdImagingGLAnimatedLights
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -times 1 2 3 -stage lightMoving.usda -write testUsdImagingGLAnimatedLights.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -times 1 2 3 -stage lightMoving.usda -write testUsdImagingGLAnimatedLights.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLAnimatedLights_001.png
         testUsdImagingGLAnimatedLights_002.png
@@ -3488,7 +3488,7 @@ pxr_register_test(testUsdImagingGLAnimatedLights
 )
 
 pxr_register_test(testUsdImagingGLSdr_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage object.usda -write testUsdImagingGLSdr1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage object.usda -write testUsdImagingGLSdr1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSdr1.png
     FAIL 1
@@ -3499,7 +3499,7 @@ pxr_register_test(testUsdImagingGLSdr_1
 )
 
 pxr_register_test(testUsdImagingGLSdr_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage usdGlslfxEmbedded.usda -write testUsdImagingGLSdr2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage usdGlslfxEmbedded.usda -write testUsdImagingGLSdr2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSdr2.png
     FAIL 1
@@ -3510,7 +3510,7 @@ pxr_register_test(testUsdImagingGLSdr_2
 )
 
 pxr_register_test(testUsdImagingGLInvalidInfoId
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage invalid_infoid.usda -write testUsdImagingGLInvalidInfoId1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage invalid_infoid.usda -write testUsdImagingGLInvalidInfoId1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInvalidInfoId1.png
     FAIL 1
@@ -3521,7 +3521,7 @@ pxr_register_test(testUsdImagingGLInvalidInfoId
 )
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_none
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_none.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_none.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_none.png
     FAIL 1
@@ -3533,7 +3533,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_none
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_guides
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_guides.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_guides.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_guides.png
     FAIL 1
@@ -3545,7 +3545,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_guides
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_render
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_render.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_render.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_render.png
     FAIL 1
@@ -3557,7 +3557,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_render
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_proxy
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_proxy.png
     FAIL 1
@@ -3569,7 +3569,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_proxy
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_all
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_all.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_all.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_all.png
     FAIL 1
@@ -3583,7 +3583,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_all
 # the FAIL_PERCENT. From the testSpecs.xml these thresholds are set to 1
 # so there might be some differences between idiff -p vs perceptualdiff
 pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_none
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_none.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_none.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_none.png
     FAIL 1
@@ -3595,7 +3595,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_none
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_guides
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_guides.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_guides.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_guides.png
     FAIL 1
@@ -3607,7 +3607,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_guides
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_render
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_render.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_render.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_render.png
     FAIL 1
@@ -3619,7 +3619,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_render
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_proxy
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_proxy.png
     FAIL 1
@@ -3631,7 +3631,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_proxy
 
 
 pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_all
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_all.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_all.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_all.png
     FAIL 1
@@ -3642,7 +3642,7 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_all
 )
 
 pxr_register_test(testUsdImagingGLInvalidUniversalSurface
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -frameAll -stage invalid_universal_surface.usda -write testUsdImagingGLInvalidUniversalSurface.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -frameAll -stage invalid_universal_surface.usda -write testUsdImagingGLInvalidUniversalSurface.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInvalidUniversalSurface.png
     FAIL 1
@@ -3653,7 +3653,7 @@ pxr_register_test(testUsdImagingGLInvalidUniversalSurface
 )
 
 pxr_register_test(testUsdImagingGLNoFallbacks
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLNoFallbacks.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage primitives.usda -write testUsdImagingGLNoFallbacks.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLNoFallbacks.png
     FAIL 1
@@ -3665,7 +3665,7 @@ pxr_register_test(testUsdImagingGLNoFallbacks
 
 
 pxr_register_test(testUsdImagingGLFallbacks_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage fallbacks1.usda -write testUsdImagingGLFallbacks_1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage fallbacks1.usda -write testUsdImagingGLFallbacks_1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFallbacks_1.png
     FAIL 1
@@ -3677,7 +3677,7 @@ pxr_register_test(testUsdImagingGLFallbacks_1
 
 
 pxr_register_test(testUsdImagingGLFallbacks_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage fallbacks2.usda -write testUsdImagingGLFallbacks_2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage fallbacks2.usda -write testUsdImagingGLFallbacks_2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFallbacks_2.png
     FAIL 1
@@ -3689,7 +3689,7 @@ pxr_register_test(testUsdImagingGLFallbacks_2
 
 
 pxr_register_test(testUsdImagingGLFallbacks_3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage fallbacks3.usda -write testUsdImagingGLFallbacks_3.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -stage fallbacks3.usda -write testUsdImagingGLFallbacks_3.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFallbacks_3.png
     FAIL 1
@@ -3700,7 +3700,7 @@ pxr_register_test(testUsdImagingGLFallbacks_3
 )
 
 pxr_register_test(testUsdImagingGLPrimvarProcessing
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -times 0 1 2 3   -stage points_widths.usda -write testUsdImagingGLPrimvarProcessing_points_widths.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -times 0 1 2 3   -stage points_widths.usda -write testUsdImagingGLPrimvarProcessing_points_widths.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimvarProcessing_points_widths_000.png
         testUsdImagingGLPrimvarProcessing_points_widths_001.png
@@ -3714,7 +3714,7 @@ pxr_register_test(testUsdImagingGLPrimvarProcessing
 )
 
 pxr_register_test(testUsdImagingGLComposite
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -times 0 1 2 -stage moving_cubes.usda -camera /main_cam -clearOnce -rendererAov color -write testUsdImagingGLComposite.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -times 0 1 2 -stage moving_cubes.usda -camera /main_cam -clearOnce -rendererAov color -write testUsdImagingGLComposite.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLComposite_000.png
         testUsdImagingGLComposite_001.png
@@ -3727,7 +3727,7 @@ pxr_register_test(testUsdImagingGLComposite
 )
 
 pxr_register_test(testUsdImagingGLPresentDisabled
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -presentDisabled -offscreen -lighting -frameAll -stage sphere.usda -rendererAov color -write testUsdImagingGLPresentDisabled.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -presentDisabled -offscreen -lighting -frameAll -stage sphere.usda -rendererAov color -write testUsdImagingGLPresentDisabled.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPresentDisabled.png
     FAIL 1
@@ -3738,7 +3738,7 @@ pxr_register_test(testUsdImagingGLPresentDisabled
 )
 
 pxr_register_test(testUsdImagingGLFraming_1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 640 480 -write testUsdImagingGLFraming1.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 640 480 -write testUsdImagingGLFraming1.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming1.png
     FAIL 0.01
@@ -3751,7 +3751,7 @@ pxr_register_test(testUsdImagingGLFraming_1
 
 
 pxr_register_test(testUsdImagingGLFraming_2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 40 640 430 -displayWindow 0 0 1280 960 -write testUsdImagingGLFraming2.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 40 640 430 -displayWindow 0 0 1280 960 -write testUsdImagingGLFraming2.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming2.png
     FAIL 0.01
@@ -3764,7 +3764,7 @@ pxr_register_test(testUsdImagingGLFraming_2
 
 
 pxr_register_test(testUsdImagingGLFraming_3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -write testUsdImagingGLFraming3.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -write testUsdImagingGLFraming3.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming3.png
     FAIL 0.01
@@ -3777,7 +3777,7 @@ pxr_register_test(testUsdImagingGLFraming_3
 
 
 pxr_register_test(testUsdImagingGLFraming_4
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -pixelAspectRatio 1.5 -write testUsdImagingGLFraming4.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -pixelAspectRatio 1.5 -write testUsdImagingGLFraming4.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming4.png
     FAIL 0.01
@@ -3790,7 +3790,7 @@ pxr_register_test(testUsdImagingGLFraming_4
 
 
 pxr_register_test(testUsdImagingGLFraming_5
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFraming5.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFraming5.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming5.png
     FAIL 0.01
@@ -3803,7 +3803,7 @@ pxr_register_test(testUsdImagingGLFraming_5
 
 
 pxr_register_test(testUsdImagingGLFraming_6
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /OrthoCam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFraming6.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /OrthoCam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFraming6.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFraming6.png
     FAIL 0.01
@@ -3815,7 +3815,7 @@ pxr_register_test(testUsdImagingGLFraming_6
 )
 
 pxr_register_test(testUsdImagingGLHWFaceCulling
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -times 0 1 2 -cullStyle backUnlessDoubleSided -shading smooth -frameAll -stage testHWFaceCulling.usda -write testHWFaceCulling.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -times 0 1 2 -cullStyle backUnlessDoubleSided -shading smooth -frameAll -stage testHWFaceCulling.usda -write testHWFaceCulling.png"
     IMAGE_DIFF_COMPARE
         testHWFaceCulling_000.png
         testHWFaceCulling_001.png
@@ -3833,7 +3833,7 @@ pxr_register_test(testUsdImagingGLHWFaceCulling
 # been able to get that too work. I did try to convert these images through OIIO's iconvert tool
 # but it also fails trying to open the .tx files
 #pxr_register_test(testUsdImagingGLMipmap
-#    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage testUsdImagingGLMipmap.usda -write testUsdImagingGLMipmap.png -times 3 6 10 14 17 -clear 0 0 0 1 -lighting -camera /main_cam"
+#    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage testUsdImagingGLMipmap.usda -write testUsdImagingGLMipmap.png -times 3 6 10 14 17 -clear 0 0 0 1 -lighting -camera /main_cam"
 #    IMAGE_DIFF_COMPARE
 #        testUsdImagingGLMipmap_003.png
 #        testUsdImagingGLMipmap_006.png
@@ -3849,7 +3849,7 @@ pxr_register_test(testUsdImagingGLHWFaceCulling
 #)
 
 pxr_register_test(testUsdImagingGLPrimvarRefinement_Uniform_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Uniform_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Uniform_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimvarRefinement_Uniform_Low.png
     FAIL 1
@@ -3861,7 +3861,7 @@ pxr_register_test(testUsdImagingGLPrimvarRefinement_Uniform_Low
 
 
 pxr_register_test(testUsdImagingGLPrimvarRefinement_Uniform_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Uniform_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Uniform_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimvarRefinement_Uniform_Medium.png
     FAIL 1
@@ -3872,7 +3872,7 @@ pxr_register_test(testUsdImagingGLPrimvarRefinement_Uniform_Medium
 )
 
 pxr_register_test(testUsdImagingGLDisplacement_Uniform_VeryHigh
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.4 -offscreen -lighting -sceneLights -shading wireOnSurface -camera /Camera -stage testUsdImagingGLDisplacement.usda -write testUsdImagingGLDisplacement_Uniform_VeryHigh.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.4 -offscreen -lighting -sceneLights -shading wireOnSurface -camera /Camera -stage testUsdImagingGLDisplacement.usda -write testUsdImagingGLDisplacement_Uniform_VeryHigh.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDisplacement_Uniform_VeryHigh.png
     FAIL 1
@@ -3883,7 +3883,7 @@ pxr_register_test(testUsdImagingGLDisplacement_Uniform_VeryHigh
 )
 
 pxr_register_test(testUsdImagingGLPrimvarRefinement_Adaptive_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Adaptive_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Adaptive_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimvarRefinement_Adaptive_Low.png
     FAIL 1
@@ -3897,7 +3897,7 @@ pxr_register_test(testUsdImagingGLPrimvarRefinement_Adaptive_Low
 
 
 pxr_register_test(testUsdImagingGLPrimvarRefinement_Adaptive_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Adaptive_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLPrimvarRefinement.usda -write testUsdImagingGLPrimvarRefinement_Adaptive_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPrimvarRefinement_Adaptive_Medium.png
     FAIL 1
@@ -3910,7 +3910,7 @@ pxr_register_test(testUsdImagingGLPrimvarRefinement_Adaptive_Medium
 )
 
 pxr_register_test(testUsdImagingGLDisplacement_Adaptive_VeryHigh
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.4 -offscreen -lighting -sceneLights -shading wireOnSurface -camera /Camera -stage testUsdImagingGLDisplacement.usda -write testUsdImagingGLDisplacement_Adaptive_VeryHigh.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.4 -offscreen -lighting -sceneLights -shading wireOnSurface -camera /Camera -stage testUsdImagingGLDisplacement.usda -write testUsdImagingGLDisplacement_Adaptive_VeryHigh.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLDisplacement_Adaptive_VeryHigh.png
     FAIL 1
@@ -3923,7 +3923,7 @@ pxr_register_test(testUsdImagingGLDisplacement_Adaptive_VeryHigh
 )
 
 pxr_register_test(testUsdImagingGLGeomSubsets_Low
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.0 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Low.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.0 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Low.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLGeomSubsets_Low.png
     FAIL_PERCENT 2
@@ -3934,7 +3934,7 @@ pxr_register_test(testUsdImagingGLGeomSubsets_Low
 
 
 pxr_register_test(testUsdImagingGLGeomSubsets_Medium
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Medium.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Medium.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLGeomSubsets_Medium.png
     FAIL_PERCENT 2
@@ -3944,7 +3944,7 @@ pxr_register_test(testUsdImagingGLGeomSubsets_Medium
 )
 
 pxr_register_test(testUsdImagingGLGeomSubsets_Points
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -shading points -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Points.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -shading points -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Points.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLGeomSubsets_Points.png
     FAIL 1
@@ -3955,7 +3955,7 @@ pxr_register_test(testUsdImagingGLGeomSubsets_Points
 )
 
 pxr_register_test(testUsdImagingGLGeomSubsets_Quadrangulated
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Quadrangulated.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Quadrangulated.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLGeomSubsets_Quadrangulated.png
     FAIL_PERCENT 2
@@ -3968,7 +3968,7 @@ pxr_register_test(testUsdImagingGLGeomSubsets_Quadrangulated
 
 
 pxr_register_test(testUsdImagingGLGeomSubsets_QuadrangulatedPoints
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -camlight -shading points -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_QuadrangulatedPoints.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -camlight -shading points -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_QuadrangulatedPoints.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLGeomSubsets_QuadrangulatedPoints.png
     FAIL 1
@@ -3981,7 +3981,7 @@ pxr_register_test(testUsdImagingGLGeomSubsets_QuadrangulatedPoints
 )
 
 pxr_register_test(testUsdImagingGLAovVisualization_Storm_depth
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage viz_aov.usda -rendererAov depth -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Storm_depth.png"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage viz_aov.usda -rendererAov depth -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Storm_depth.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLAovVisualization_Storm_depth.png
     FAIL 0.05
@@ -4005,7 +4005,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     )
 
     pxr_register_test(testUsdImagingGLHdEmbreePickAndHighlight
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPickAndHighlight -renderer HdEmbreeRendererPlugin -offscreen -frameAll -stage test.usda -write testUsdImagingGLHdEmbreePickAndHighlight.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPickAndHighlight' -renderer HdEmbreeRendererPlugin -offscreen -frameAll -stage test.usda -write testUsdImagingGLHdEmbreePickAndHighlight.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLHdEmbreePickAndHighlight_000.png
             testUsdImagingGLHdEmbreePickAndHighlight_001.png
@@ -4023,7 +4023,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     )
 
     pxr_register_test(testUsdImagingGLHdEmbree
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -renderer HdEmbreeRendererPlugin -stage primitives.usda -write default.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -renderer HdEmbreeRendererPlugin -stage primitives.usda -write default.png"
         IMAGE_DIFF_COMPARE
             default.png
         FAIL_PERCENT 1
@@ -4037,7 +4037,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     )
 
     pxr_register_test(testUsdImagingGLHdEmbree_refined
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -complexity 1.1 -renderer HdEmbreeRendererPlugin -stage primitives.usda -write refined.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -lighting -shading smooth -frameAll -complexity 1.1 -renderer HdEmbreeRendererPlugin -stage primitives.usda -write refined.png"
         IMAGE_DIFF_COMPARE
             refined.png
         FAIL_PERCENT 1
@@ -4051,7 +4051,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     )
 
     pxr_register_test(testUsdImagingGLFramingEmbree_1
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 640 480 -write testUsdImagingGLFramingEmbree1.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 640 480 -write testUsdImagingGLFramingEmbree1.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree1.png
         FAIL 1
@@ -4069,7 +4069,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLFramingEmbree_2
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 40 640 430 -displayWindow 0 0 1280 960 -write testUsdImagingGLFramingEmbree2.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 40 640 430 -displayWindow 0 0 1280 960 -write testUsdImagingGLFramingEmbree2.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree2.png
         FAIL 1
@@ -4087,7 +4087,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLFramingEmbree_3
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -write testUsdImagingGLFramingEmbree3.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -write testUsdImagingGLFramingEmbree3.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree3.png
         FAIL 1
@@ -4105,7 +4105,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLFramingEmbree_4
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -pixelAspectRatio 1.5 -write testUsdImagingGLFramingEmbree4.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 0 0 640 480 -displayWindow 0 0 320 480 -pixelAspectRatio 1.5 -write testUsdImagingGLFramingEmbree4.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree4.png
         FAIL 1
@@ -4123,7 +4123,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLFramingEmbree_5
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFramingEmbree5.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /main_cam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFramingEmbree5.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree5.png
         FAIL 1
@@ -4141,7 +4141,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLFramingEmbree_6
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /OrthoCam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFramingEmbree6.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -renderer HdEmbreeRendererPlugin -rendererAov color -offscreen -stage framing.usda -clear 0 0 0 1 -lighting -camera /OrthoCam -dataWindow 25 136 367 298 -displayWindow 50 80 320 400 -write testUsdImagingGLFramingEmbree6.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLFramingEmbree6.png
         FAIL 1
@@ -4158,7 +4158,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
     )
 
     pxr_register_test(testUsdImagingGLAovVisualization_Embree_depth
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov depth -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_depth.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov depth -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_depth.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLAovVisualization_Embree_depth.png
         FAIL 0.05
@@ -4176,7 +4176,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLAovVisualization_Embree_primId
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov primId -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_primId.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov primId -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_primId.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLAovVisualization_Embree_primId.png
         FAIL 0.05
@@ -4193,7 +4193,7 @@ if (EMBREE_FOUND AND ${PXR_BUILD_EMBREE_PLUGIN})
 
 
     pxr_register_test(testUsdImagingGLAovVisualization_Embree_normal
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov normal -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_normal.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -stage viz_aov.usda -renderer HdEmbreeRendererPlugin -rendererAov normal -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Embree_normal.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLAovVisualization_Embree_normal.png
         FAIL 0.05
@@ -4212,7 +4212,7 @@ endif()
 # Register tests that rely on PTEX
 if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     pxr_register_test(testUsdImagingGLBasicDrawing_shaders
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage basicDrawing/shaders.usd -frameAll -write testUsdImagingGLBasicDrawing_shaders.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage basicDrawing/shaders.usd -frameAll -write testUsdImagingGLBasicDrawing_shaders.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawing_shaders.png
         FAIL_PERCENT 1
@@ -4224,7 +4224,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLBasicDrawing_shadersBindings
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage basicDrawing/shaders_bindings.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersBindings.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage basicDrawing/shaders_bindings.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersBindings.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawing_shadersBindings.png
         FAIL_PERCENT 1
@@ -4236,7 +4236,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLBasicDrawing_shadersRelative
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage basicDrawing/shaders-relative.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersRelative.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage basicDrawing/shaders-relative.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersRelative.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawing_shadersRelative.png
         FAIL_PERCENT 1
@@ -4248,7 +4248,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLBasicDrawing_shadersAnim
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -times 1 2 3 -stage basicDrawing/shaders_anim.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersAnim.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -times 1 2 3 -stage basicDrawing/shaders_anim.usd -frameAll -write testUsdImagingGLBasicDrawing_shadersAnim.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawing_shadersAnim_001.png
             testUsdImagingGLBasicDrawing_shadersAnim_002.png
@@ -4262,7 +4262,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLGeomSubsets_Adaptive
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Adaptive.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.1 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_Adaptive.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLGeomSubsets_Adaptive.png
         FAIL_PERCENT 1
@@ -4274,7 +4274,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLGeomSubsets_High
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_High.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.2 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_High.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLGeomSubsets_High.png
         FAIL_PERCENT 1
@@ -4285,7 +4285,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLGeomSubsets_VeryHigh
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -complexity 1.3 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_VeryHigh.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -complexity 1.3 -offscreen -lighting -camlight -shading wireOnSurface -frameAll -stage testUsdImagingGLGeomSubsets.usda -write testUsdImagingGLGeomSubsets_VeryHigh.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLGeomSubsets_VeryHigh.png
         FAIL_PERCENT 1
@@ -4295,7 +4295,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLInstancing_instance
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage instance.usda -write testUsdImagingGLInstancing_instance.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage instance.usda -write testUsdImagingGLInstancing_instance.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLInstancing_instance.png
         FAIL 0.01
@@ -4307,7 +4307,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLInstancing_instance2
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage instance2.usda -write testUsdImagingGLInstancing_instance2.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage instance2.usda -write testUsdImagingGLInstancing_instance2.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLInstancing_instance2.png
         FAIL 0.01
@@ -4319,7 +4319,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLInstancing_instance3
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -stage instance3.usda -write testUsdImagingGLInstancing_instance3.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -offscreen -frameAll -lighting -stage instance3.usda -write testUsdImagingGLInstancing_instance3.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLInstancing_instance3.png
         FAIL 0.01
@@ -4331,7 +4331,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLBasicDrawingNonBindless_shaders
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage shaders.usd -frameAll -write testUsdImagingGLBasicDrawingNonBindless_shaders.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage shaders.usd -frameAll -write testUsdImagingGLBasicDrawingNonBindless_shaders.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawingNonBindless_shaders.png
         FAIL 1
@@ -4344,7 +4344,7 @@ if (PTEX_FOUND AND ${PXR_ENABLE_PTEX_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLBasicDrawingNonBindless_shadersRelative
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -offscreen -stage shaders-relative.usd -frameAll -write testUsdImagingGLBasicDrawingNonBindless_shadersRelative.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -lighting -offscreen -stage shaders-relative.usd -frameAll -write testUsdImagingGLBasicDrawingNonBindless_shadersRelative.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLBasicDrawingNonBindless_shadersRelative.png
         FAIL 1
@@ -4365,7 +4365,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
     )
     
     pxr_register_test(testUsdImagingGLVdbVolume
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolume.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolume.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolume.png
         FAIL 1
@@ -4379,7 +4379,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_DisableSceneMaterials
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -disableSceneMaterials -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeDisableSceneMaterials.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -disableSceneMaterials -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeDisableSceneMaterials.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeDisableSceneMaterials.png
         FAIL 1
@@ -4393,7 +4393,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_Large
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeLarge.usda -clear 0 0 0 1 -lighting -camera /World/main_cam -write testUsdImagingGLVdbVolumeLarge.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeLarge.usda -clear 0 0 0 1 -lighting -camera /World/main_cam -write testUsdImagingGLVdbVolumeLarge.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeLarge.png
         FAIL 1
@@ -4407,7 +4407,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_Flipped
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeFlipped.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFlipped.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeFlipped.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFlipped.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeFlipped.png
         FAIL 1
@@ -4421,7 +4421,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_FallbackMaterial
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeFallbackMaterial.usda -times 1 2 3 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFallbackMaterial.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeFallbackMaterial.usda -times 1 2 3 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFallbackMaterial.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeFallbackMaterial_001.png
             testUsdImagingGLVdbVolumeFallbackMaterial_002.png
@@ -4437,7 +4437,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_Inside
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeInside.usda -times 1 13 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeInside.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeInside.usda -times 1 13 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeInside.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeInside_001.png
             testUsdImagingGLVdbVolumeInside_013.png
@@ -4453,7 +4453,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_Ortho
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeOrtho.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeOrtho.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeOrtho.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeOrtho.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeOrtho.png
         FAIL_PERCENT 2
@@ -4466,7 +4466,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_TwoFields
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeTwoFields.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTwoFields.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeTwoFields.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTwoFields.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeTwoFields.png
         FAIL_PERCENT 2
@@ -4479,7 +4479,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolume_TargetMemory
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeTargetMemory.usda -times 2 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTargetMemory.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeTargetMemory.usda -times 2 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTargetMemory.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeTargetMemory.png
         FAIL 1
@@ -4492,7 +4492,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
     )
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolume.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolume.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolume.png
         FAIL 1
@@ -4506,7 +4506,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_DisableSceneMaterials
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -disableSceneMaterials -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeDisableSceneMaterials.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -disableSceneMaterials -rendererAov color -offscreen -stage vdbVolume.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeDisableSceneMaterials.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeDisableSceneMaterials.png
         FAIL 1
@@ -4520,7 +4520,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_Large
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeLarge.usda -clear 0 0 0 1 -lighting -camera /World/main_cam -write testUsdImagingGLVdbVolumeLarge.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeLarge.usda -clear 0 0 0 1 -lighting -camera /World/main_cam -write testUsdImagingGLVdbVolumeLarge.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeLarge.png
         FAIL 1
@@ -4534,7 +4534,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_Flipped
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeFlipped.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFlipped.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeFlipped.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFlipped.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeFlipped.png
         FAIL 1
@@ -4548,7 +4548,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_FallbackMaterial
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeFallbackMaterial.usda -times 1 2 3 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFallbackMaterial.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeFallbackMaterial.usda -times 1 2 3 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeFallbackMaterial.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeFallbackMaterial_001.png
             testUsdImagingGLVdbVolumeFallbackMaterial_002.png
@@ -4564,7 +4564,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_Inside
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeInside.usda -times 1 13 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeInside.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeInside.usda -times 1 13 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeInside.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeInside_001.png
             testUsdImagingGLVdbVolumeInside_013.png
@@ -4580,7 +4580,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_Ortho
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeOrtho.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeOrtho.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeOrtho.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeOrtho.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeOrtho.png
         FAIL_PERCENT 2
@@ -4593,7 +4593,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_TwoFields
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeTwoFields.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTwoFields.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeTwoFields.usda -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTwoFields.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeTwoFields.png
         FAIL_PERCENT 2
@@ -4606,7 +4606,7 @@ if (OPENVDB_FOUND AND ${PXR_ENABLE_OPENVDB_SUPPORT})
 
 
     pxr_register_test(testUsdImagingGLVdbVolumeNonBindless_TargetMemory
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -rendererAov color -offscreen -stage vdbVolumeTargetMemory.usda -times 2 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTargetMemory.png"
+        COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing' -rendererAov color -offscreen -stage vdbVolumeTargetMemory.usda -times 2 -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLVdbVolumeTargetMemory.png"
         IMAGE_DIFF_COMPARE
             testUsdImagingGLVdbVolumeTargetMemory.png
         FAIL 1

--- a/pxr/usdImaging/usdviewq/CMakeLists.txt
+++ b/pxr/usdImaging/usdviewq/CMakeLists.txt
@@ -108,31 +108,31 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdviewqSettings2
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqSettings2"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqSettings2'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewqRootDataModel
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqRootDataModel"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqRootDataModel'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewqSelectionDataModel
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqSelectionDataModel"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqSelectionDataModel'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewqLauncher
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqLauncher"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqLauncher'"
     EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdviewqViewSettingsDataModel
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqViewSettingsDataModel"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testUsdviewqViewSettingsDataModel'"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/third_party/renderman-24/plugin/rmanOslParser/CMakeLists.txt
+++ b/third_party/renderman-24/plugin/rmanOslParser/CMakeLists.txt
@@ -43,7 +43,7 @@ pxr_test_scripts(
 
 pxr_register_test(testRmanOslParser
     PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testRmanOslParser"
+    COMMAND "'${CMAKE_INSTALL_PREFIX}/tests/testRmanOslParser'"
     EXPECTED_RETURN_CODE 0
     ENV
       RMANTREE=${RMANTREE_PATH}


### PR DESCRIPTION
### Description of Change(s)

pxr_register_test command takes (PRE_/POST_)COMMAND strings, which are
parsed into arguments via shlex.split.  However, path variables (which)
might contain spaces) were not quoted in these commands.

For references, all the changes in this commit were made via this regex
(executed in VSCode):

Find:
```regex
^((?: *#)?( *)pxr_register_test\((?:.|\n(?!\2\)))*?(?:PRE_|POST_)?COMMAND ")\$([^ "]*)
```
Replace:
```regex
$1'$$$3'
```

### Fixes Issue(s)
- Fixes test failures for usdedit if the path to `chmod` or `head` have a space in them

Note that the majority of the changes here are to fix issues with spaces in `CMAKE_INSTALL_PREFIX`.  While this PR may not completely resolve all build issues for spaces in `CMAKE_INSTALL_PREFIX` (in my test, boost had problems... hopefully fixed in newer releases?), it is least a step in the right direction, and a better example to folow in future.

- [X] I have submitted a signed Contributor License Agreement
