### PR TITLE
APPLE: Fix CPU culling in PipelineDrawBatch

### DIFF
--- a/pxr/imaging/hdSt/renderPass.cpp
+++ b/pxr/imaging/hdSt/renderPass.cpp
@@ -26,6 +26,7 @@
 #include "pxr/imaging/hdSt/debugCodes.h"
 #include "pxr/imaging/hdSt/drawItemsCache.h"
 #include "pxr/imaging/hdSt/indirectDrawBatch.h"
+#include "pxr/imaging/hdSt/pipelineDrawBatch.h"
 #include "pxr/imaging/hdSt/resourceRegistry.h"
 #include "pxr/imaging/hdSt/renderParam.h"
 #include "pxr/imaging/hdSt/renderPassState.h"
@@ -384,14 +385,19 @@ HdSt_RenderPass::_FrustumCullCPU(
     // to be consistent with GPU culling.
 
     HdChangeTracker const &tracker = GetRenderIndex()->GetChangeTracker();
+    HgiCapabilities const *capabilities = _hgi->GetCapabilities();
 
-    const bool multiDrawIndirectEnabled = _hgi->
-        GetCapabilities()->IsSet(HgiDeviceCapabilitiesBitsMultiDrawIndirect);
+    const bool multiDrawIndirectEnabled =
+        capabilities->IsSet(HgiDeviceCapabilitiesBitsMultiDrawIndirect);
+
+    const bool gpuFrustumCullingEnabled =
+        HdSt_PipelineDrawBatch::IsEnabled(capabilities) ?
+            HdSt_PipelineDrawBatch::IsEnabledGPUFrustumCulling() :
+            HdSt_IndirectDrawBatch::IsEnabledGPUFrustumCulling();
 
     const bool
        skipCulling = TfDebug::IsEnabled(HDST_DISABLE_FRUSTUM_CULLING) ||
-           (multiDrawIndirectEnabled
-               && HdSt_IndirectDrawBatch::IsEnabledGPUFrustumCulling());
+           (multiDrawIndirectEnabled && gpuFrustumCullingEnabled);
     bool freezeCulling = TfDebug::IsEnabled(HD_FREEZE_CULL_FRUSTUM);
 
     if(skipCulling) {


### PR DESCRIPTION
### Description of Change(s)

When using `HdSt_PipelineDrawBatch`, the logic in `HdSt_RenderPass` was not checking that it had GPU culling disabled and therefore the CPU frustum culling was not being used.

We now check the flag for both `HdSt_IndirectDrawBatch` and `HdSt_PipelineDrawBatch` depending on what is enabled.

### Fixes Issue(s)
- There was no frustum culling on the HdSt_PipelineDrawBatch, since the GPU culling isn't implemented yet.  CPU culling was not being enabled in its place.
- Tested by loading KitchenSet, moving camera into the scene and then using the `HD_FREEZE_CULL_FRUSTUM` debug option in usdView.  Trucking the camera back should show that only the primitives within the frozen frustum are visible.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
