### PR TITLE
[cmake] remove unused PXR_PYTHON_ENABLED and PXR_PYTHON_MODULES_ENABLED

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1306,13 +1306,8 @@ function(_pxr_library NAME)
             PUBLIC_HEADER "${args_PUBLIC_HEADERS}"
     )
 
-    set(pythonEnabled "PXR_PYTHON_ENABLED=1")
-    if(TARGET shared_libs)
-        set(pythonModulesEnabled "PXR_PYTHON_MODULES_ENABLED=1")
-    endif()
     target_compile_definitions(${NAME}
         PUBLIC
-            ${pythonEnabled}
             ${apiPublic}
         PRIVATE
             MFB_PACKAGE_NAME=${PXR_PACKAGE}
@@ -1321,7 +1316,6 @@ function(_pxr_library NAME)
             PXR_BUILD_LOCATION=usd
             PXR_PLUGIN_BUILD_LOCATION=../plugin/usd
             ${pxrInstallLocation}
-            ${pythonModulesEnabled}
             ${apiPrivate}
     )
 


### PR DESCRIPTION
### Description of Change(s)

these are compile definitions set by the _pxr_library cmake function;
however, they are:

- never used anywhere
- set unconditionally (ie, regardless of PXR_ENABLE_PYTHON_SUPPORT)
- unneeded, as c++ code can include `pxr.h`, and use `#ifdef PXR_PYTHON_SUPPORT_ENABLED`

- [X] I have submitted a signed Contributor License Agreement
