### PR TITLE
APPLE: Fixes for Xcode builds and debugging

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1106,7 +1106,7 @@ TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")
 ############################################################
 # PNG
 
-PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.29.zip"
+PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.38.zip"
 
 def InstallPNG(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(PNG_URL, context, force)):


### PR DESCRIPTION
### Description of Change(s)

This PR combines the work in the following two PRs:

https://github.com/PixarAnimationStudios/USD/pull/1937
https://github.com/PixarAnimationStudios/USD/pull/1946

In addition, Xcode builds require code signing.  This has been added as a separate python file, apple_utils.py

Debugging usdview or usdrecord in Xcode requires using the python executable.  However this is does not have the necessary entitlements for debugging, so Xcode will not connect.  To fix this, it is necessary to disable System Integrity Protection (SIP) in the Recovery OS.  You should only disable SIP temporarily to perform the debugging, and reenable it as soon as possible. Failure to reenable SIP when you are done testing leaves your computer vulnerable to malicious code.

More information and instructions on how to disable SIP can be found here:

https://developer.apple.com/documentation/security/disabling_and_enabling_system_integrity_protection

### Fixes Issue(s)
- Building and debugging in Xcode

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
