### PR TITLE
APPLE: Fix spelling of resourceBindingsPtr

### DIFF
--- a/pxr/imaging/hdSt/extCompGpuComputation.cpp
+++ b/pxr/imaging/hdSt/extCompGpuComputation.cpp
@@ -265,9 +265,9 @@ HdStExtCompGpuComputation::Execute(
         resourceBindingsInstance.SetValue(rb);
     }
 
-    HgiResourceBindingsSharedPtr const& resourceBindindsPtr =
+    HgiResourceBindingsSharedPtr const& resourceBindingsPtr =
         resourceBindingsInstance.GetValue();
-    HgiResourceBindingsHandle resourceBindings = *resourceBindindsPtr.get();
+    HgiResourceBindingsHandle resourceBindings = *resourceBindingsPtr.get();
 
     HgiComputeCmds* computeCmds = hdStResourceRegistry->GetGlobalComputeCmds();
 

--- a/pxr/imaging/hdSt/flatNormals.cpp
+++ b/pxr/imaging/hdSt/flatNormals.cpp
@@ -374,9 +374,9 @@ HdSt_FlatNormalsComputationGPU::Execute(
         resourceBindingsInstance.SetValue(rb);
     }
 
-    HgiResourceBindingsSharedPtr const& resourceBindindsPtr =
+    HgiResourceBindingsSharedPtr const& resourceBindingsPtr =
         resourceBindingsInstance.GetValue();
-    HgiResourceBindingsHandle resourceBindings = *resourceBindindsPtr.get();
+    HgiResourceBindingsHandle resourceBindings = *resourceBindingsPtr.get();
 
     // Get or add pipeline in registry.
     HdInstance<HgiComputePipelineSharedPtr> computePipelineInstance =

--- a/pxr/imaging/hdSt/quadrangulate.cpp
+++ b/pxr/imaging/hdSt/quadrangulate.cpp
@@ -626,9 +626,9 @@ HdSt_QuadrangulateComputationGPU::Execute(
         resourceBindingsInstance.SetValue(rb);
     }
 
-    HgiResourceBindingsSharedPtr const& resourceBindindsPtr =
+    HgiResourceBindingsSharedPtr const& resourceBindingsPtr =
         resourceBindingsInstance.GetValue();
-    HgiResourceBindingsHandle resourceBindings = *resourceBindindsPtr.get();
+    HgiResourceBindingsHandle resourceBindings = *resourceBindingsPtr.get();
 
     // Get or add pipeline in registry.
     HdInstance<HgiComputePipelineSharedPtr> computePipelineInstance =

--- a/pxr/imaging/hdSt/smoothNormals.cpp
+++ b/pxr/imaging/hdSt/smoothNormals.cpp
@@ -307,9 +307,9 @@ HdSt_SmoothNormalsComputationGPU::Execute(
         resourceBindingsInstance.SetValue(rb);
     }
 
-    HgiResourceBindingsSharedPtr const& resourceBindindsPtr =
+    HgiResourceBindingsSharedPtr const& resourceBindingsPtr =
         resourceBindingsInstance.GetValue();
-    HgiResourceBindingsHandle resourceBindings = *resourceBindindsPtr.get();
+    HgiResourceBindingsHandle resourceBindings = *resourceBindingsPtr.get();
 
     // Get or add pipeline in registry.
     HdInstance<HgiComputePipelineSharedPtr> computePipelineInstance =

--- a/pxr/imaging/hdSt/subdivision.cpp
+++ b/pxr/imaging/hdSt/subdivision.cpp
@@ -1943,9 +1943,9 @@ _EvalStencilsGPU(
         resourceBindingsInstance.SetValue(rb);
     }
 
-    HgiResourceBindingsSharedPtr const & resourceBindindsPtr =
+    HgiResourceBindingsSharedPtr const & resourceBindingsPtr =
         resourceBindingsInstance.GetValue();
-    HgiResourceBindingsHandle resourceBindings = *resourceBindindsPtr.get();
+    HgiResourceBindingsHandle resourceBindings = *resourceBindingsPtr.get();
 
     // Get or add pipeline in registry.
     HdInstance<HgiComputePipelineSharedPtr> computePipelineInstance =


### PR DESCRIPTION
### Description of Change(s)

It was tweaking my OCD.  Fix the occurrences of `resourceBindindsPtr` to be `resourceBindingsPtr`

### Fixes Issue(s)
- Spelling

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
