### PR TITLE
APPLE: usdrecord: check makeCurrent has initialized frame buffer

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -74,6 +74,19 @@ def _SetupOpenGLContext(width=100, height=100):
     # ready for gl operations.
     glWidget.makeCurrent()
 
+    # check if the frame buffer was initialized by makeCurrent() above
+    # if not, force a show/hide of the glWidget to force initializtion
+    if PySideModule == 'PySide6':
+        if glWidget.defaultFramebufferObject() == 0:
+            glWidget.show()
+            glWidget.hide()
+            counter = 0
+            while glWidget.defaultFramebufferObject() == 0:
+                application.processEvents()
+                counter += 1
+                if counter > 100:
+                    break
+
     return glWidget
 
 def main():


### PR DESCRIPTION
### Steps to Reproduce

download example file: https://developer.apple.com/augmented-reality/quick-look/models/biplane/toy_biplane.usdz
compile dev branch with appropriate dependencies (arm64 or x86_64)
run command: usdrecord -f 1:59 ~/Downloads/toy_biplane.usdz toy_biplane_animation.####.png
results in Segmentation fault: 11

### Description of Change(s)

added a check of the default frame buffer to see if it was initialized by makeCurrent
added a show/hide call to force the initialization if needed.

Found and fixed by Zach Cole

### Fixes Issue(s)

usdrecord would segfault if the frame buffer was not initialized.
makeCurrent was not reliably initializing the frame buffer.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
