### PR TITLE
Update to MaterialX v1.38.5

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1415,7 +1415,7 @@ DRACO = Dependency("Draco", InstallDraco, "include/draco/compression/decode.h")
 ############################################################
 # MaterialX
 
-MATERIALX_URL = "https://github.com/materialx/MaterialX/archive/v1.38.4.zip"
+MATERIALX_URL = "https://github.com/materialx/MaterialX/archive/v1.38.5.zip"
 
 def InstallMaterialX(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(MATERIALX_URL, context, force)):

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -136,8 +136,7 @@ HdStMaterialXShaderGen::HdStMaterialXShaderGen(
                             "st" : mxHdInfo.defaultTexcoordName;
 
     // Register the customized version of the Surface node generator
-    registerImplementation("IM_surface_" + GlslShaderGenerator::TARGET, 
-        HdStMaterialXSurfaceNodeGen::create);
+    registerImplementation("IM_surface_genglsl", HdStMaterialXSurfaceNodeGen::create);
 }
 
 // Based on GlslShaderGenerator::generate()
@@ -273,8 +272,7 @@ HdStMaterialXShaderGen::_EmitMxFunctions(
     mx::ShaderStage& mxStage) const
 {
     // Add global constants and type definitions
-    emitLibraryInclude("stdlib/" + mx::GlslShaderGenerator::TARGET
-                       + "/lib/mx_math.glsl", mxContext, mxStage);
+    emitLibraryInclude("stdlib/genglsl/lib/mx_math.glsl", mxContext, mxStage);
     emitLine("#if NUM_LIGHTS > 0", mxStage, false);
     emitLine("#define MAX_LIGHT_SOURCES NUM_LIGHTS", mxStage, false);
     emitLine("#else", mxStage, false);
@@ -394,16 +392,24 @@ HdStMaterialXShaderGen::_EmitMxFunctions(
         emitSpecularEnvironment(mxContext, mxStage);
     }
     if (shadowing) {
-        emitLibraryInclude("pbrlib/" + mx::GlslShaderGenerator::TARGET
-                           + "/lib/mx_shadow.glsl", mxContext, mxStage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_shadow.glsl", mxContext, mxStage);
     }
+
+#if MATERIALX_MAJOR_VERSION > 1 || \
+    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION > 38) || \
+    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 38 && MATERIALX_BUILD_VERSION > 4)
+    // MaterialX 1.38.5 changes the default transmission method to "refraction".
+    mxContext.getOptions().hwTransmissionRenderMethod = mx::TRANSMISSION_OPACITY;
+
+    // Emit transmission code
+    emitTransmissionRender(mxContext, mxStage);
+#endif
 
     // Emit directional albedo table code.
     if (mxContext.getOptions().hwDirectionalAlbedoMethod == 
             mx::HwDirectionalAlbedoMethod::DIRECTIONAL_ALBEDO_TABLE ||
         mxContext.getOptions().hwWriteAlbedoTable) {
-        emitLibraryInclude("pbrlib/" + mx::GlslShaderGenerator::TARGET
-                           + "/lib/mx_table.glsl", mxContext, mxStage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_table.glsl", mxContext, mxStage);
         emitLineBreak(mxStage);
     }
 
@@ -421,7 +427,7 @@ HdStMaterialXShaderGen::_EmitMxFunctions(
     // Emit uv transform code globally if needed.
     if (mxContext.getOptions().hwAmbientOcclusion) {
         emitLibraryInclude(
-            "stdlib/" + mx::GlslShaderGenerator::TARGET + "/lib/" +
+            "stdlib/genglsl/lib/" +
             _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV],
             mxContext, mxStage);
     }
@@ -490,10 +496,30 @@ HdStMaterialXShaderGen::_EmitMxSurfaceShader(
             // closure/shader nodes and need to be emitted first.
             emitFunctionCalls(mxGraph, mxContext, mxStage, mx::ShaderNode::Classification::TEXTURE);
 
+#if MATERIALX_MAJOR_VERSION == 1 &&  \
+    MATERIALX_MINOR_VERSION == 38 && \
+    MATERIALX_BUILD_VERSION <= 4
             // Emit function calls for all surface shader nodes.
             // These will internally emit their closure function calls.
             emitFunctionCalls(mxGraph, mxContext, mxStage, mx::ShaderNode::Classification::SHADER | 
                                                            mx::ShaderNode::Classification::SURFACE);
+#else
+            // Emit function calls for "root" closure/shader nodes.
+            // These will internally emit function calls for any dependent closure nodes upstream.
+            for (mx::ShaderGraphOutputSocket* socket : mxGraph.getOutputSockets())
+            {
+                if (socket->getConnection())
+                {
+                    const mx::ShaderNode* upstream = socket->getConnection()->getNode();
+                    if (upstream->getParent() == &mxGraph &&
+                        (upstream->hasClassification(mx::ShaderNode::Classification::CLOSURE) ||
+                            upstream->hasClassification(mx::ShaderNode::Classification::SHADER)))
+                    {
+                        emitFunctionCall(*upstream, mxContext, mxStage);
+                    }
+                }
+            }
+#endif
         }
         else
         {


### PR DESCRIPTION
### Description of Change(s)

This PR makes USD (specifically hdStorm) MaterialX 1.38.5-ready.

The changes [between 1.38.4 and 1.38.5](https://github.com/AcademySoftwareFoundation/MaterialX/compare/v1.38.4..v1.38.5#diff-558b484ee6c60c822af7f8d2365b3842d2518b1b75398165ec0e1f31988b40e9) are addressed as following:
- the new transmission handling option is set to `TRANSMISSION_OPACITY` for tests to pass as suggested by @JGamache-autodesk ([#929]( https://github.com/AcademySoftwareFoundation/MaterialX/pull/928))
- addition of the emission call for said option ([#994](https://github.com/AcademySoftwareFoundation/MaterialX/pull/994/files#diff-558b484ee6c60c822af7f8d2365b3842d2518b1b75398165ec0e1f31988b40e9))
- changes for code generation from material nodes ([#981](https://github.com/AcademySoftwareFoundation/MaterialX/commit/39cec2221dacbe3d1d229cd50e2406e0959d3965#diff-558b484ee6c60c822af7f8d2365b3842d2518b1b75398165ec0e1f31988b40e9))
- lastly, Jonathan inlined the `GlslShaderGenerator::TARGET` constant in [#926](https://github.com/AcademySoftwareFoundation/MaterialX/commit/a345d134b865a6cdaf63e10cfc870df49ed841be#diff-558b484ee6c60c822af7f8d2365b3842d2518b1b75398165ec0e1f31988b40e9), which doesn't need an #ifguard because the value is the same in both 1.38.3 and 1.38.4

- [x] I have submitted a signed Contributor License Agreement
