### PR TITLE
APPLE: glslfx metadata extensions

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -185,6 +185,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define HD_SHADER_TOKENS                        \
     (alphaThreshold)                            \
+    (centroid)                                  \
     (clipPlanes)                                \
     (commonShaderSource)                        \
     (computeShader)                             \
@@ -214,6 +215,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (wireframeColor)                            \
     (worldToViewMatrix)                         \
     (worldToViewInverseMatrix)                  \
+    (sample)                                    \
     (stepSize)                                  \
     (stepSizeLighting)
 

--- a/pxr/imaging/hdSt/codeGen.h
+++ b/pxr/imaging/hdSt/codeGen.h
@@ -175,6 +175,7 @@ private:
 
     // resource buckets
     using ElementVector = HdSt_ResourceLayout::ElementVector;
+    using TfTokenVector = HdSt_ResourceLayout::TfTokenVector;
     ElementVector _resVS;
     ElementVector _resTCS;
     ElementVector _resTES;

--- a/pxr/imaging/hdSt/resourceLayout.cpp
+++ b/pxr/imaging/hdSt/resourceLayout.cpp
@@ -82,6 +82,17 @@ _ParseMembers(InputValueVector const & input, int fromElement)
     return result;
 }
 
+TfTokenVector split(const std::string &text, char sep) {
+    TfTokenVector tokens;
+    std::size_t start = 0, end = 0;
+    while ((end = text.find(sep, start)) != std::string::npos) {
+        tokens.push_back(TfToken(text.substr(start, end - start)));
+        start = end + 1;
+    }
+    tokens.push_back(TfToken(text.substr(start)));
+    return tokens;
+}
+
 // e.g. ["in", "vec3", "color"]
 // e.g. ["in", "int", "pointId", "flat"]
 bool
@@ -93,7 +104,9 @@ _ParseValue(InputValueVector const & input, Element *element)
                            /*dataType=*/_Token(input[1]),
                            /*name=*/_Token(input[2]));
         if (input.size() == 4) {
-            element->qualifiers = _Token(input[3]);
+            std::string qualString = input[3].GetWithDefault(
+                    HdStResourceLayoutTokens->unknown.GetString());
+            element->qualifiers = split(qualString, ' ');
         }
         return true;
     } else if (_Token(input[0]) == HdStResourceLayoutTokens->outValue) {
@@ -101,7 +114,9 @@ _ParseValue(InputValueVector const & input, Element *element)
                            /*dataType=*/_Token(input[1]),
                            /*name=*/_Token(input[2]));
         if (input.size() == 4) {
-            element->qualifiers = _Token(input[3]);
+            std::string qualString = input[3].GetWithDefault(
+                    HdStResourceLayoutTokens->unknown.GetString());
+            element->qualifiers = split(qualString, ' ');
         }
         return true;
     }
@@ -190,11 +205,15 @@ _ParseQualifier(InputValueVector const & input, Element *element)
     if (input.size() != 2) return false;
     if (_Token(input[0]) == HdStResourceLayoutTokens->inValue) {
         *element = Element(InOut::STAGE_IN, Kind::QUALIFIER);
-        element->qualifiers = _Token(input[1]);
+        std::string qualString = input[1].GetWithDefault(
+                HdStResourceLayoutTokens->unknown.GetString());
+        element->qualifiers = split(qualString, ' ');
         return true;
     } else if (_Token(input[0]) == HdStResourceLayoutTokens->outValue) {
         *element = Element(InOut::STAGE_OUT, Kind::QUALIFIER);
-        element->qualifiers = _Token(input[1]);
+        std::string qualString = input[1].GetWithDefault(
+                HdStResourceLayoutTokens->unknown.GetString());
+        element->qualifiers = split(qualString, ' ');
         return true;
     }
 

--- a/pxr/imaging/hdSt/resourceLayout.h
+++ b/pxr/imaging/hdSt/resourceLayout.h
@@ -125,7 +125,7 @@ public:
                 TfToken dataType = HdStResourceLayoutTokens->unknown,
                 TfToken name = HdStResourceLayoutTokens->unknown,
                 TfToken arraySize = TfToken(),
-                TfToken qualifiers = TfToken())
+                TfTokenVector qualifiers = TfTokenVector())
             : inOut(inOut)
             , kind(kind)
             , location(-1)
@@ -141,7 +141,7 @@ public:
         int location;
         TfToken dataType;
         TfToken name;
-        TfToken qualifiers;
+        TfTokenVector qualifiers;
         TfToken arraySize;
         TfToken aggregateName;
         MemberVector members;
@@ -178,6 +178,7 @@ public:
         int arraySize;
     };
     using TextureElementVector = std::vector<TextureElement>;
+    using TfTokenVector = std::vector<TfToken>;
 
     HdSt_ResourceLayout();
     ~HdSt_ResourceLayout();

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -757,6 +757,29 @@ enum HgiShaderTextureType
     HgiShaderTextureTypeArrayTexture
 };
 
+/// \enum HgiTessellationSpacing
+///
+/// Describes the type of shader tessellation spacing to use
+///
+/// <ul>
+/// <li>None:
+///   No tessellation spacing
+/// <li>Even:
+///   Even spacing. Only whole integers are considered for spacing
+/// <li>FractionalOdd:
+///   Fractional odd tessellation spacing
+/// <li>FractionalEven:
+///   Fractional even tessellation spacing
+/// </ul>
+///
+enum HgiTessellationSpacing
+{
+    HgiTessellationSpacingNone = 0,
+    HgiTessellationSpacingEven,
+    HgiTessellationSpacingFractionalOdd,
+    HgiTessellationSpacingFractionalEven
+};
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -155,6 +155,11 @@ bool operator!=(
 ///
 struct HgiShaderFunctionParamDesc
 {
+    enum SamplingFlag: uint32_t {
+        Centroid = 1,
+        Sample = 2
+    };
+
     HGI_API
     HgiShaderFunctionParamDesc();
 
@@ -163,6 +168,7 @@ struct HgiShaderFunctionParamDesc
     int32_t location;
     int32_t interstageSlot;
     HgiInterpolationType interpolation;
+    SamplingFlag samplingFlag;
     std::string role;
     std::string arraySize;
 };
@@ -280,6 +286,8 @@ bool operator!=(
 /// <ul>
 /// <li>patchType:
 ///   The type of patch</li>
+/// <li>spacing
+///   The spacing mode of tessellation</li>
 /// <li>numVertsInPerPatch:
 ///   The number of vertices in per patch</li>
 /// <li>numVertsOutPerPatch:
@@ -293,6 +301,7 @@ struct HgiShaderFunctionTessellationDesc
     HgiShaderFunctionTessellationDesc();
 
     PatchType patchType = PatchType::Triangle;
+    HgiTessellationSpacing spacing;
     uint32_t numVertsPerPatchIn = 3;
     uint32_t numVertsPerPatchOut = 3;
 };

--- a/pxr/imaging/hgiGL/shaderGenerator.cpp
+++ b/pxr/imaging/hgiGL/shaderGenerator.cpp
@@ -371,14 +371,17 @@ HgiGLShaderGenerator::_WriteInOuts(
             attrs.push_back({"location", std::to_string(param.interstageSlot)});
         }
 
-        CreateShaderSection<HgiGLMemberShaderSection>(
-            paramName,
-            param.type,
-            param.interpolation,
-            attrs,
-            qualifier,
-            std::string(),
-            param.arraySize);
+        std::unique_ptr<HgiGLMemberShaderSection> p =
+                std::make_unique<HgiGLMemberShaderSection>(paramName,
+                                                           param.type,
+                                                           param.interpolation,
+                                                           attrs,
+                                                           qualifier,
+                                                           std::string(),
+                                                           param.arraySize);
+        HgiGLMemberShaderSection * const result = p.get();
+        result->SetSamplingFlags(param.samplingFlag);
+        GetShaderSections()->push_back(std::move(p));
     }
 }
 

--- a/pxr/imaging/hgiGL/shaderSection.cpp
+++ b/pxr/imaging/hgiGL/shaderSection.cpp
@@ -170,6 +170,15 @@ HgiGLMemberShaderSection::VisitGlobalMemberDeclarations(std::ostream &ss)
         ss << "noperspective ";
         break;
     }
+
+    if ((_samplingFlags & HgiShaderFunctionParamDesc::Centroid) != 0) {
+        ss << "centroid ";
+    }
+
+    if ((_samplingFlags & HgiShaderFunctionParamDesc::Sample) != 0) {
+        ss << "sample ";
+    }
+
     WriteDeclaration(ss);
     return true;
 }
@@ -178,6 +187,11 @@ void
 HgiGLMemberShaderSection::WriteType(std::ostream& ss) const
 {
     ss << _typeName;
+}
+
+void HgiGLMemberShaderSection::SetSamplingFlags(
+        HgiShaderFunctionParamDesc::SamplingFlag samplingFlags) {
+    _samplingFlags = samplingFlags;
 }
 
 HgiGLBlockShaderSection::HgiGLBlockShaderSection(

--- a/pxr/imaging/hgiGL/shaderSection.h
+++ b/pxr/imaging/hgiGL/shaderSection.h
@@ -137,6 +137,9 @@ public:
     HGIGL_API
     void WriteType(std::ostream& ss) const override;
 
+    HGIGL_API
+    void SetSamplingFlags(HgiShaderFunctionParamDesc::SamplingFlag samplingFlags);
+
 private:
     HgiGLMemberShaderSection() = delete;
     HgiGLMemberShaderSection & operator=(
@@ -145,6 +148,7 @@ private:
 
     std::string _typeName;
     HgiInterpolationType _interpolation;
+    HgiShaderFunctionParamDesc::SamplingFlag _samplingFlags;
 };
 
 /// \class HgiGLBlockShaderSection


### PR DESCRIPTION
### Description of Change(s)
- Extend glslfx to support
  - Able to express "centroid" and "sample" for shader data
  - Able to express spacings for tessellation. This is important so that we can express that for Metal in the future inside of the glslfx file instead of expressing it on the host code side.
  - Consume the parsed centroid and sample qualifiers for shaders in the shader generator and write out to the shader
- Introduce HgiTessellationSpacing which will be used in post tessellation control and basis curve Metal support

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
