### PR TITLE
Replace CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
-                      ${CMAKE_SOURCE_DIR}/cmake/defaults
-                      ${CMAKE_SOURCE_DIR}/cmake/modules
-                      ${CMAKE_SOURCE_DIR}/cmake/macros)
+                      ${PROJECT_SOURCE_DIR}/cmake/defaults
+                      ${PROJECT_SOURCE_DIR}/cmake/modules
+                      ${PROJECT_SOURCE_DIR}/cmake/macros)
 
 include(Options)
 include(ProjectDefaults)

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -43,9 +43,9 @@ function(_copy_headers LIBRARY_NAME)
     set(hpath "${_args_PREFIX}/${LIBRARY_NAME}")
     if ("${CMAKE_CURRENT_SOURCE_DIR}" MATCHES ".*/pxr/.*")
         # Include paths under pxr/ match the source path.
-        file(RELATIVE_PATH hpath "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+        file(RELATIVE_PATH hpath "${PROJECT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
-    set(header_dest_dir "${CMAKE_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include/${hpath}")
+    set(header_dest_dir "${PROJECT_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include/${hpath}")
     if( NOT "${_args_FILES}" STREQUAL "")
         set(files_copied "")
         foreach (f ${_args_FILES})
@@ -479,8 +479,8 @@ function(_pxr_enable_precompiled_header TARGET_NAME)
 
     # Headers live in subdirectories.
     set(rel_output_header_path "${PXR_PREFIX}/${TARGET_NAME}/${output_header_name}")
-    set(abs_output_header_path "${CMAKE_BINARY_DIR}/include/${rel_output_header_path}")
-    set(abs_precompiled_path ${CMAKE_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${precompiled_name})
+    set(abs_output_header_path "${PROJECT_BINARY_DIR}/include/${rel_output_header_path}")
+    set(abs_precompiled_path ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${precompiled_name})
 
     # Additional compile flags to use precompiled header.  This will be
     set(compile_flags "")
@@ -1022,13 +1022,13 @@ function(_pxr_python_module NAME)
     # Include headers from the build directory.
     get_filename_component(
         PRIVATE_INC_DIR
-        "${CMAKE_BINARY_DIR}/include"
+        "${PROJECT_BINARY_DIR}/include"
         ABSOLUTE
     )
     if (PXR_INSTALL_SUBDIR)
         get_filename_component(
             SUBDIR_INC_DIR
-            "${CMAKE_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include"
+            "${PROJECT_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include"
             ABSOLUTE
         )
     endif()
@@ -1337,8 +1337,8 @@ function(_pxr_library NAME)
 
     target_include_directories(${NAME}
         PRIVATE
-            "${CMAKE_BINARY_DIR}/include"
-            "${CMAKE_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include"
+            "${PROJECT_BINARY_DIR}/include"
+            "${PROJECT_BINARY_DIR}/${PXR_INSTALL_SUBDIR}/include"
         INTERFACE
             $<INSTALL_INTERFACE:${headerInstallDir}>
     )
@@ -1359,7 +1359,7 @@ function(_pxr_library NAME)
     # Doxygen will be run on these files during the install step ---
     # see pxr_build_documentation().
     if(PXR_BUILD_DOCUMENTATION)
-        set(docBuildDir ${CMAKE_BINARY_DIR}/docs/${headerInstallPrefix})
+        set(docBuildDir ${PROJECT_BINARY_DIR}/docs/${headerInstallPrefix})
         set(doxygenFiles "${args_PUBLIC_HEADERS};${args_DOXYGEN_FILES}")
 
         set(files_copied "")

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -24,8 +24,8 @@
 include(Private)
 
 function(pxr_build_documentation)
-    configure_file(${CMAKE_SOURCE_DIR}/docs/doxygen/Doxyfile.in
-                   ${CMAKE_BINARY_DIR}/Doxyfile)
+    configure_file(${PROJECT_SOURCE_DIR}/docs/doxygen/Doxyfile.in
+                   ${PROJECT_BINARY_DIR}/Doxyfile)
 
     add_custom_target(
         documentation
@@ -34,34 +34,34 @@ function(pxr_build_documentation)
         # since it's generated outside of the libraries.
         COMMAND
             ${CMAKE_COMMAND} -E copy
-            "${CMAKE_BINARY_DIR}/include/pxr/pxr.h"
-            "${CMAKE_BINARY_DIR}/docs/include/pxr/pxr.h"
+            "${PROJECT_BINARY_DIR}/include/pxr/pxr.h"
+            "${PROJECT_BINARY_DIR}/docs/include/pxr/pxr.h"
         COMMAND 
             ${CMAKE_COMMAND} -E copy_directory
-            "${CMAKE_SOURCE_DIR}/docs"
-            "${CMAKE_BINARY_DIR}/docs"
+            "${PROJECT_SOURCE_DIR}/docs"
+            "${PROJECT_BINARY_DIR}/docs"
     )
 
     # Execute doxygen during the install step. All of the files we want
     # doxygen to process should already have been copied to the docs
     # directory during the build step
-    install(CODE "execute_process(COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile)")
+    install(CODE "execute_process(COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile)")
 
     set(INST_DOCS_ROOT  "${CMAKE_INSTALL_PREFIX}/docs")
 
-    set(BUILT_DOCS_TAG_FILE "${CMAKE_BINARY_DIR}/docs/USD.tag")
+    set(BUILT_DOCS_TAG_FILE "${PROJECT_BINARY_DIR}/docs/USD.tag")
     install(
         FILES ${BUILT_DOCS_TAG_FILE}
         DESTINATION ${INST_DOCS_ROOT}
     )
 
-    set(BUILT_HTML_DOCS "${CMAKE_BINARY_DIR}/docs/doxy_html")
+    set(BUILT_HTML_DOCS "${PROJECT_BINARY_DIR}/docs/doxy_html")
     install(
         DIRECTORY ${BUILT_HTML_DOCS}
         DESTINATION ${INST_DOCS_ROOT}
     )
 
-    set(BUILT_XML_DOCS "${CMAKE_BINARY_DIR}/docs/doxy_xml")
+    set(BUILT_XML_DOCS "${PROJECT_BINARY_DIR}/docs/doxy_xml")
     install(
         DIRECTORY ${BUILT_XML_DOCS}
         DESTINATION ${INST_DOCS_ROOT}
@@ -186,7 +186,7 @@ function(pxr_cpp_bin BIN_NAME)
     # Install and include headers from the build directory.
     get_filename_component(
         PRIVATE_INC_DIR
-        "${CMAKE_BINARY_DIR}/include"
+        "${PROJECT_BINARY_DIR}/include"
         ABSOLUTE
     )
 
@@ -491,7 +491,7 @@ function(pxr_build_test_shared_lib LIBRARY_NAME)
 
         set(testPlugInfoLibDir "tests/${bt_INSTALL_PREFIX}/lib/${LIBRARY_NAME}")
         set(testPlugInfoResourceDir "${testPlugInfoLibDir}/${TEST_PLUG_INFO_RESOURCE_PATH}")
-        set(testPlugInfoPath "${CMAKE_BINARY_DIR}/${testPlugInfoResourceDir}/plugInfo.json")
+        set(testPlugInfoPath "${PROJECT_BINARY_DIR}/${testPlugInfoResourceDir}/plugInfo.json")
 
         file(RELATIVE_PATH 
             TEST_PLUG_INFO_LIBRARY_PATH
@@ -777,7 +777,7 @@ function(pxr_register_test TEST_NAME)
 
         # <PXR_CTEST_RUN_ID> will be set by CTestCustom.cmake, and then
         # expanded by testWrapper.py
-        set(failuresDir ${CMAKE_BINARY_DIR}/Testing/Failed-Diffs/<PXR_CTEST_RUN_ID>/${TEST_NAME})
+        set(failuresDir ${PROJECT_BINARY_DIR}/Testing/Failed-Diffs/<PXR_CTEST_RUN_ID>/${TEST_NAME})
         set(testWrapperCmd ${testWrapperCmd} --failures-dir=${failuresDir})
     endif()
 
@@ -929,11 +929,11 @@ endfunction() # pxr_setup_third_plugins
 function(pxr_toplevel_prologue)
     # Generate a namespace declaration header, pxr.h, at the top level of
     # pxr at configuration time.
-    configure_file(${CMAKE_SOURCE_DIR}/pxr/pxr.h.in
-        ${CMAKE_BINARY_DIR}/include/pxr/pxr.h     
+    configure_file(${PROJECT_SOURCE_DIR}/pxr/pxr.h.in
+        ${PROJECT_BINARY_DIR}/include/pxr/pxr.h     
     )  
     install(
-        FILES ${CMAKE_BINARY_DIR}/include/pxr/pxr.h
+        FILES ${PROJECT_BINARY_DIR}/include/pxr/pxr.h
         DESTINATION include/pxr
     )
 
@@ -1210,12 +1210,12 @@ function(pxr_monolithic_epilogue)
             usd_m
         COMMAND ${CMAKE_COMMAND} -E copy
             "${CMAKE_CURRENT_BINARY_DIR}/usd-targets-$<CONFIG>.cmake"
-            "${CMAKE_BINARY_DIR}/usd-targets-$<CONFIG>.cmake"
+            "${PROJECT_BINARY_DIR}/usd-targets-$<CONFIG>.cmake"
         COMMAND ${CMAKE_COMMAND} -E copy
             "${CMAKE_CURRENT_BINARY_DIR}/usd-imports-$<CONFIG>.cmake"
-            "${CMAKE_BINARY_DIR}/usd-imports-$<CONFIG>.cmake"
-        COMMAND ${CMAKE_COMMAND} -E echo Export file: ${CMAKE_BINARY_DIR}/usd-targets-$<CONFIG>.cmake
-        COMMAND ${CMAKE_COMMAND} -E echo Import file: ${CMAKE_BINARY_DIR}/usd-imports-$<CONFIG>.cmake
+            "${PROJECT_BINARY_DIR}/usd-imports-$<CONFIG>.cmake"
+        COMMAND ${CMAKE_COMMAND} -E echo Export file: ${PROJECT_BINARY_DIR}/usd-targets-$<CONFIG>.cmake
+        COMMAND ${CMAKE_COMMAND} -E echo Import file: ${PROJECT_BINARY_DIR}/usd-imports-$<CONFIG>.cmake
     )
 endfunction() # pxr_monolithic_epilogue
 
@@ -1243,13 +1243,13 @@ function(pxr_tests_prologue)
     add_custom_target(
         test_setup
         ALL
-        DEPENDS "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
+        DEPENDS "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
     )
     add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
+        OUTPUT "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
         COMMAND ${CMAKE_COMMAND} -E copy
             "${CMAKE_CURRENT_SOURCE_DIR}/cmake/defaults/CTestCustom.cmake"
-            "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
+            "${PROJECT_BINARY_DIR}/CTestCustom.cmake"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/defaults/CTestCustom.cmake"
         COMMENT "Copying CTestCustom.cmake"
     )

--- a/third_party/renderman-24/plugin/hdPrman/CMakeLists.txt
+++ b/third_party/renderman-24/plugin/hdPrman/CMakeLists.txt
@@ -133,13 +133,13 @@ pxr_plugin(${PXR_PACKAGE}
 
 # Include paths to hdPrman headers within hdPrman itself look like
 # #include "hdPrman/...", so we need to add include/pxr/imaging
-# to the include paths for this library. We use CMAKE_BINARY_DIR
+# to the include paths for this library. We use PROJECT_BINARY_DIR
 # to include headers out of the build directory, which is what
 # normally happens in the USD build.
 if(TARGET hdPrman)
     target_include_directories(${PXR_PACKAGE}
         PRIVATE
-            "${CMAKE_BINARY_DIR}/include/pxr/imaging"
+            "${PROJECT_BINARY_DIR}/include/pxr/imaging"
     )
 endif()
 


### PR DESCRIPTION
### Description of Change(s)

In order to allow building USD as a subdirectory with CMake, it is necessary to change all `CMAKE_SOURCE_DIR --> PROJECT_SOURCE_DIR`, and `CMAKE_BINARY_DIR --> PROJECT_BINARY_DIR` .

- [x] I have submitted a signed Contributor License Agreement (corporate CLA via Adobe).