### PR TITLE
GetShaderFunction for ShaderProgram

### DIFF
--- a/pxr/imaging/hgi/shaderProgram.h
+++ b/pxr/imaging/hgi/shaderProgram.h
@@ -99,6 +99,11 @@ public:
     HGI_API
     virtual HgiShaderFunctionHandleVector const& GetShaderFunctions() const = 0;
 
+    /// Returns the shader based on shaderStage if it exists
+    HGI_API
+    virtual HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const = 0;
+
     /// Returns the byte size of the GPU shader program.
     /// APIs that do not have programs can return the combined byte size of the
     /// shader functions used by the program.

--- a/pxr/imaging/hgiGL/shaderProgram.cpp
+++ b/pxr/imaging/hgiGL/shaderProgram.cpp
@@ -90,6 +90,17 @@ HgiGLShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiGLShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    return HgiShaderFunctionHandle();
+}
+
 bool
 HgiGLShaderProgram::IsValid() const
 {

--- a/pxr/imaging/hgiGL/shaderProgram.h
+++ b/pxr/imaging/hgiGL/shaderProgram.h
@@ -55,6 +55,10 @@ public:
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const override;
 
     HGIGL_API
+    HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const override;
+
+    HGIGL_API
     size_t GetByteSizeOfResource() const override;
 
     HGIGL_API

--- a/pxr/imaging/hgiMetal/shaderProgram.h
+++ b/pxr/imaging/hgiMetal/shaderProgram.h
@@ -56,6 +56,10 @@ public:
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const override;
 
     HGIMETAL_API
+    HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const override;
+
+    HGIMETAL_API
     size_t GetByteSizeOfResource() const override;
 
     HGIMETAL_API

--- a/pxr/imaging/hgiMetal/shaderProgram.mm
+++ b/pxr/imaging/hgiMetal/shaderProgram.mm
@@ -67,6 +67,17 @@ HgiMetalShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiMetalShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    return HgiShaderFunctionHandle();
+}
+
 bool
 HgiMetalShaderProgram::IsValid() const
 {

--- a/pxr/imaging/hgiVulkan/shaderProgram.cpp
+++ b/pxr/imaging/hgiVulkan/shaderProgram.cpp
@@ -71,6 +71,17 @@ HgiVulkanShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiVulkanShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    return HgiShaderFunctionHandle();
+}
+
 HgiVulkanDevice*
 HgiVulkanShaderProgram::GetDevice() const
 {

--- a/pxr/imaging/hgiVulkan/shaderProgram.h
+++ b/pxr/imaging/hgiVulkan/shaderProgram.h
@@ -63,6 +63,10 @@ public:
     HGIVULKAN_API
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const;
 
+    HGIVULKAN_API
+    HgiShaderFunctionHandle const
+    GetShaderFunction(HgiShaderStage shaderStage) const override;
+
     /// Returns the device used to create this object.
     HGIVULKAN_API
     HgiVulkanDevice* GetDevice() const;


### PR DESCRIPTION
### Description of Change(s)
Adds a convenient GetShaderFunction for ShaderProgram.
Found it justified as it landed itself well as a member function and it could prevent repetition from users of the class

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
