### PR TITLE
APPLE: Fix crash in skinned animation on Metal

### DIFF
--- a/pxr/imaging/hdSt/copyComputation.cpp
+++ b/pxr/imaging/hdSt/copyComputation.cpp
@@ -21,8 +21,6 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/imaging/glf/diagnostic.h"
-
 #include "pxr/imaging/hdSt/copyComputation.h"
 #include "pxr/imaging/hdSt/bufferArrayRange.h"
 #include "pxr/imaging/hdSt/bufferResource.h"
@@ -118,8 +116,6 @@ HdStCopyComputationGPU::Execute(HdBufferArrayRangeSharedPtr const &range_,
         HgiBlitCmds* blitCmds = hdStResourceRegistry->GetGlobalBlitCmds();
         blitCmds->CopyBufferGpuToGpu(blitOp);
     }
-
-    GLF_POST_PENDING_GL_ERRORS();
 }
 
 int

--- a/pxr/imaging/hdSt/extCompGpuComputation.cpp
+++ b/pxr/imaging/hdSt/extCompGpuComputation.cpp
@@ -40,7 +40,6 @@
 #include "pxr/imaging/hgi/computePipeline.h"
 #include "pxr/imaging/hgi/shaderProgram.h"
 #include "pxr/imaging/hgi/tokens.h"
-#include "pxr/imaging/glf/diagnostic.h"
 #include "pxr/base/tf/hash.h"
 
 #include <limits>


### PR DESCRIPTION
### Description of Change(s)

The function `HdStCopyComputationGPU::Execute()` had a call to `GLF_POST_PENDING_GL_ERRORS` in it.  This macro expands out to include openGL-specific calls such as `glGetError()` etc.  On Metal applications these cause an exception if the GL context wasn't initialised.

This crash was found when performing skinning calculations.  See the HumanFemale test model for a reproduction, running in the Apple HydraPlayer sample application from WWDC 2022.

Also removed the include to `pxr/imaging/glf/diagnostic.h` in `pxr/imaging/hdSt/extCompGpuComputation.cpp` where it isn't needed.

Suggestion: The file `pxr/imaging/glf/diagnostic.h` is included in various other places in HdSt files, but it is only used for the `GLF_GROUP_FUNCTION` macro.  I think we should move this macro to the Hd library to remove the dependancy from HdSt onto Glf entirely.  It's dangerous to have the glf code included, even if it isn't used.  I'm happy to make this change but it should be in a separate PR.

### Fixes Issue(s)
- Crash in macOS applications

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
