### PR TITLE
Build resources with the folder structure to avoid install() step

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -327,6 +327,15 @@ function(_install_resource_files NAME pluginInstallPrefix pluginToLibraryPath)
             DESTINATION ${resourcesPath}/${dirPath}
             RENAME ${destFileName}
         )
+        file(GENERATE
+            OUTPUT "${PROJECT_BINARY_DIR}/install/$<CONFIG>/${resourcesPath}/${dirPath}/${destFileName}"
+            INPUT "${resourceFile}"
+        )
+        get_filename_component(absResourceFile ${resourceFile} ABSOLUTE)
+        set_property(TARGET ${NAME}
+            PROPERTY USD_RESOURCES "${absResourceFile}@${resourcesPath}/${dirPath}/${destFileName}"
+            APPEND
+        )
     endforeach()
 endfunction() # _install_resource_files
 
@@ -1370,6 +1379,9 @@ function(_pxr_library NAME)
             IMPORT_PREFIX "${args_PREFIX}"            
             PREFIX "${args_PREFIX}"
             SUFFIX "${args_SUFFIX}"
+            ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/install/$<CONFIG>/lib"
+            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/install/$<CONFIG>/lib"
+            RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/install/$<CONFIG>/bin"
     )
 
     target_compile_definitions(${NAME}

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -961,6 +961,10 @@ function(pxr_setup_plugins)
     set(plugInfoContents "{\n    \"Includes\": [\n        \"*/${resourcesDir}/\"${extraIncludes}\n    ]\n}\n")
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plugins_plugInfo.json"
          "${plugInfoContents}")
+    file(GENERATE
+        OUTPUT "${PROJECT_BINARY_DIR}/install/$<CONFIG>/lib/usd/plugInfo.json"
+        CONTENT "${plugInfoContents}"
+    )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/plugins_plugInfo.json"
         DESTINATION lib/usd
@@ -970,6 +974,10 @@ function(pxr_setup_plugins)
     set(plugInfoContents "{\n    \"Includes\": [ \"*/${resourcesDir}/\" ]\n}\n")
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/usd_plugInfo.json"
          "${plugInfoContents}")
+    file(GENERATE
+         OUTPUT "${PROJECT_BINARY_DIR}/install/$<CONFIG>/plugin/usd/plugInfo.json"
+         CONTENT "${plugInfoContents}"
+    )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/usd_plugInfo.json"
         DESTINATION plugin/usd


### PR DESCRIPTION
### Description of Change(s)

- Set LIBRARY_OUTPUT_DIRECTORY on USD CMake targets
- Add `configure_file()` to copy `plugInfo.json` and other resources to the correct location in the build folder

The proposed changes do no affect the install structure of USD, but allow running USD from the build folder without installing the files. See #1983 for more explanations.

### Fixes Issue(s)
- #1983

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
