### PR TITLE
[arch, plug] fix paths that contain unicode char for plugInfo.json

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -97,6 +97,19 @@ def Python3():
     return sys.version_info.major == 3
 
 def GetLocale():
+    if Windows():
+        # Windows handles encoding a little differently then Linux / Mac
+        # For interactive streams (isatty() == True) it will use the
+        # console codepage, otherwise it will return an ANSI codepage.
+        # To keep things consistent we'll force UTF-8 for non-interactive
+        # streams (which is recommended by Microsoft). See:
+        # https://docs.python.org/3.6/library/sys.html#sys.stdout
+        # https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+        if sys.stdout.isatty():
+            return sys.stdout.encoding
+        else:
+            return "UTF-8"
+
     return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
 
 def GetCommandOutput(command):

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -408,10 +408,14 @@ function (pxr_create_test_module MODULE_NAME)
         return()
     endif()
 
-    cmake_parse_arguments(tm "" "INSTALL_PREFIX;SOURCE_DIR" "" ${ARGN})
+    cmake_parse_arguments(tm "" "INSTALL_PREFIX;SOURCE_DIR;DEST_DIR" "" ${ARGN})
 
     if (NOT tm_SOURCE_DIR)
         set(tm_SOURCE_DIR testenv)
+    endif()
+
+    if (NOT tm_DEST_DIR)
+        set(tm_DEST_DIR ${MODULE_NAME})
     endif()
 
     # Look specifically for an __init__.py and a plugInfo.json prefixed by the
@@ -427,7 +431,7 @@ function (pxr_create_test_module MODULE_NAME)
             RENAME 
                 __init__.py
             DESTINATION 
-                tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
+                tests/${tm_INSTALL_PREFIX}/lib/python/${tm_DEST_DIR}
         )
     endif()
     if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${plugInfoFile}")
@@ -437,7 +441,7 @@ function (pxr_create_test_module MODULE_NAME)
             RENAME 
                 plugInfo.json
             DESTINATION 
-                tests/${tm_INSTALL_PREFIX}/lib/python/${MODULE_NAME}
+                tests/${tm_INSTALL_PREFIX}/lib/python/${tm_DEST_DIR}
         )
     endif()
 endfunction() # pxr_create_test_module

--- a/pxr/base/arch/symbols.cpp
+++ b/pxr/base/arch/symbols.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/arch/symbols.h"
 #include "pxr/base/arch/defines.h"
+
 #if defined(ARCH_OS_LINUX)
 #include <dlfcn.h>
 #elif defined(ARCH_OS_DARWIN)
@@ -87,9 +88,9 @@ ArchGetAddressInfo(
     }
 
     if (objectPath) {
-        char modName[MAX_PATH] = {0};
-        if (GetModuleFileName(module, modName, MAX_PATH)) {
-            objectPath->assign(modName);
+        wchar_t modName[ARCH_PATH_MAX] = {0};
+        if (GetModuleFileNameW(module, modName, ARCH_PATH_MAX)) {
+            objectPath->assign(ArchWindowsUtf16ToUtf8(modName));
         }
     }
 

--- a/pxr/base/plug/CMakeLists.txt
+++ b/pxr/base/plug/CMakeLists.txt
@@ -166,6 +166,21 @@ pxr_create_test_module(TestPlugModuleIncomplete
     INSTALL_PREFIX PlugPlugins
 )
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Create a test module that has a unicode character in it's path
+    # for Windows
+    pxr_create_test_module(TestPlugModuleUnicode
+        INSTALL_PREFIX PlugPlugins
+        DEST_DIR TestPlugMödüleÜnicöde
+    )
+else()
+    # Create a test module without a unicode character in the path
+    # to make this test consistent on other OSes
+    pxr_create_test_module(TestPlugModuleUnicode
+        INSTALL_PREFIX PlugPlugins
+    )
+endif()
+
 pxr_register_test(testPlug
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPlug"

--- a/pxr/base/plug/info.cpp
+++ b/pxr/base/plug/info.cpp
@@ -150,7 +150,17 @@ _ReadPlugInfoObject(const std::string& pathname, JsObject* result)
 
     // The file may not exist or be readable.
     std::ifstream ifs;
+#if defined(ARCH_OS_WINDOWS)
+    // XXX: This is a MSVC specific overload to std::ifstream::open which
+    // supports std::wstring as an argument.
+    // Other compilers on Windows may fail here since it's not
+    // enforced by the C++ standard. If another compiler for Windows is needed
+    // we could use ArchOpenFile / ArchGetFileLength / ArchPRead instead
+    // of std::ifstream
+    ifs.open(ArchWindowsUtf8ToUtf16(pathname).c_str());
+#else
     ifs.open(pathname.c_str());
+#endif
     if (!ifs.is_open()) {
         TF_DEBUG(PLUG_INFO_SEARCH).
             Msg("Failed to open plugin info %s\n", pathname.c_str());

--- a/pxr/base/plug/testPlug.py
+++ b/pxr/base/plug/testPlug.py
@@ -108,7 +108,7 @@ class TestPlug(unittest.TestCase):
                         'TestPlugModuleDepBadDep2', 'TestPlugModuleDepBadLoad',
                         'TestPlugModuleDepCycle', 
                         'TestPlugModuleLoaded', 'TestPlugModuleLoadedBadBase',
-                        'TestPlugModuleUnloadable']))
+                        'TestPlugModuleUnloadable', 'TestPlugModuleUnicode']))
 
         # Check available subclasses of TestPlugBase<1>
         base1Subclasses = Tf.Type.FindByName('_TestPlugBase<1>').GetAllDerivedTypes()
@@ -117,7 +117,8 @@ class TestPlug(unittest.TestCase):
             'TestPlugModule1.TestPlugPythonDerived1',
             'TestPlugModuleLoaded.TestPlugPythonLoaded',
             'TestPlugModuleLoadedBadBase.TestPlugPythonLoadedBadBase',
-            'TestPlugUnloadable', 'TestPlugPythonUnloadable')
+            'TestPlugUnloadable', 'TestPlugPythonUnloadable',
+            'TestPlugModuleUnicode.TestPlugPythonUnicode')
         for sc in base1SubclassesExpected:
             self.assertIn(sc, base1Subclasses)
         self.assertEqual(len(base1Subclasses), len(base1SubclassesExpected))

--- a/pxr/base/plug/testenv/TestPlugModuleUnicode__init__.py
+++ b/pxr/base/plug/testenv/TestPlugModuleUnicode__init__.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2016 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+from pxr import Plug
+
+# This plugin is coded correctly, but will have a pluginfo.json in a
+# unicode path
+class TestPlugPythonUnicode(Plug._TestPlugBase1):
+    def GetTypeName(self):
+        return 'TestPlugPythonUnicode'
+

--- a/pxr/base/plug/testenv/TestPlugModuleUnicode_plugInfo.json
+++ b/pxr/base/plug/testenv/TestPlugModuleUnicode_plugInfo.json
@@ -1,0 +1,15 @@
+{
+    "Plugins": [
+        {
+            "Type": "python",
+            "Name": "TestPlugModuleUnicode",
+            "Info": {
+                "Types": {
+                    "TestPlugModuleUnicode.TestPlugPythonUnicode": {
+                        "bases": ["_TestPlugBase<1>"]
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### Description of Change(s)
arch: ArchGetAddressInfo was using GetModuleFileName instead of GetModuleFileNameW on Windows. This prevented the objectPath to be correctly returned should the module found at the address containing a unicode character.

plug: _ReadPlugInfoObject did not properly handle the case of a UTF-8 encoded string on Windows. This would result in the plugInfo.json file not being loaded if it resided at a path containing a unicode character

### Fixes Issue(s)

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
