### PR TITLE
[ar] Allow a plugin resolver to declare itself as primary

### DIFF
--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -204,6 +204,19 @@ if (BUILD_SHARED_LIBS)
     pxr_register_test(testArURIResolver_CPP
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArURIResolver_CPP"
     )
+
+    pxr_build_test(testArPrimaryResolver_CPP
+        LIBRARIES
+            arch
+            tf
+            ar
+        CPPFILES
+            testenv/testArPrimaryResolver.cpp
+    )
+
+    pxr_register_test(testArPrimaryResolver_CPP
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArPrimaryResolver_CPP"
+    )
 endif()
 
 pxr_build_test(testArDefaultResolver_CPP

--- a/pxr/usd/ar/testenv/TestArURIResolver_plugInfo.json
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugInfo.json
@@ -19,6 +19,11 @@
                     "_TestOtherURIResolver": {
                         "bases": ["_TestURIResolverBase"],
                         "uriSchemes": ["test_other"]
+                    },
+                    "_TestOtherPrimaryResolver": {
+                        "bases": ["_TestURIResolverBase"],
+                        "uriSchemes": ["test_primary"],
+                        "primary": true
                     }
                 }
             }

--- a/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
@@ -155,6 +155,18 @@ public:
     }
 };
 
+// Test resolver that can be used as a primary resolver but handles asset paths of the form "test_primary://..."
+class _TestOtherPrimaryResolver
+        : public _TestURIResolverBase
+{
+public:
+    _TestOtherPrimaryResolver()
+        : _TestURIResolverBase("test_primary")
+    {
+
+    }
+};
+
 // XXX: Should have a AR_DEFINE_ABSTRACT_RESOLVER macro like
 // AR_DEFINE_ABSTRACT_RESOLVER(_TestURIResolverBase, ArResolver)
 // to take care of this registration.
@@ -165,3 +177,4 @@ TF_REGISTRY_FUNCTION(TfType)
 
 AR_DEFINE_RESOLVER(_TestURIResolver, _TestURIResolverBase);
 AR_DEFINE_RESOLVER(_TestOtherURIResolver, _TestURIResolverBase);
+AR_DEFINE_RESOLVER(_TestOtherPrimaryResolver, _TestURIResolverBase);

--- a/pxr/usd/ar/testenv/testArPrimaryResolver.cpp
+++ b/pxr/usd/ar/testenv/testArPrimaryResolver.cpp
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/pxr.h"
+
+#include "TestArURIResolver_plugin.h"
+
+#include "pxr/usd/ar/defaultResolverContext.h"
+#include "pxr/usd/ar/defineResolverContext.h"
+#include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/resolverContext.h"
+#include "pxr/usd/ar/resolverContextBinder.h"
+
+#include "pxr/base/arch/systemInfo.h"
+#include "pxr/base/plug/plugin.h"
+#include "pxr/base/plug/registry.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/tf/token.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE;
+
+static void
+SetupPlugins()
+{
+    // Register TestArURIResolver plugin. We assume the build system will
+    // install it to the ArPlugins subdirectory in the same location as
+    // this test.
+    const std::string uriResolverPluginPath =
+        TfStringCatPaths(
+            TfGetPathName(ArchGetExecutablePath()),
+            "ArPlugins/lib/TestArURIResolver*/Resources/") + "/";
+
+    PlugPluginPtrVector plugins =
+        PlugRegistry::GetInstance().RegisterPlugins(uriResolverPluginPath);
+    
+    TF_AXIOM(plugins.size() == 1);
+    TF_AXIOM(plugins[0]->GetName() == "TestArURIResolver");
+
+    // Set the preferred resolver to a resolver marked as primary but also specifies uriSchemes
+    // before running any test cases.
+    ArSetPreferredResolver("_TestOtherPrimaryResolver");
+}
+
+static void
+TestResolveWithContext()
+{
+    ArResolver& resolver = ArGetResolver();
+
+    // Verify that the context object is getting bound in the _TestURIResolver.
+    // The test resolver simply appends the string in the context object
+    // to the end of the given path when resolving.
+    ArResolverContext ctx(_TestURIResolverContext("context"));
+    ArResolverContextBinder binder(ctx);
+    TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo?context");
+
+    // Verify that binding another context overrides the previously-bound
+    // context until the new binding is dropped.
+    {
+        ArResolverContext ctx2(_TestURIResolverContext("context2"));
+        ArResolverContextBinder binder2(ctx2);
+        TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo?context2");
+    }
+    TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo?context");
+
+    // Verify that binding an unrelated context blocks the previously-bound
+    // context.
+    {
+        ArResolverContext ctx3(ArDefaultResolverContext{});
+        ArResolverContextBinder binder3(ctx3);
+        TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo");
+    }
+    TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo?context");
+
+    // Verify that another URI resolver that is not primary can still resolve
+    ArResolverContext ctx4(_TestURIResolverContext("context4"));
+    ArResolverContextBinder binder4(ctx4);
+    TF_AXIOM(resolver.Resolve("test://foo") == "test://foo?context4");
+}
+
+int main(int argc, char** argv)
+{
+    SetupPlugins();
+
+    printf("TestResolveWithContext ...\n");
+    TestResolveWithContext();
+
+    printf("Test PASSED\n");
+    return 0;
+}

--- a/pxr/usd/ar/testenv/testArURIResolver.cpp
+++ b/pxr/usd/ar/testenv/testArURIResolver.cpp
@@ -94,6 +94,11 @@ TestResolveWithContext()
         TF_AXIOM(resolver.Resolve("test://foo") == "test://foo");
     }
     TF_AXIOM(resolver.Resolve("test://foo") == "test://foo?context");
+
+    // Verify that another primary resolver with uriSchemes can still resolve
+    ArResolverContext ctx4(_TestURIResolverContext("context4"));
+    ArResolverContextBinder binder4(ctx4);
+    TF_AXIOM(resolver.Resolve("test_primary://foo") == "test_primary://foo?context4");
 }
 
 static void

--- a/pxr/usd/ar/testenv/testArURIResolver.py
+++ b/pxr/usd/ar/testenv/testArURIResolver.py
@@ -55,6 +55,7 @@ class TestArURIResolver(unittest.TestCase):
         self.assertTrue(pr.GetPluginWithName('TestArURIResolver'))
         self.assertTrue(Tf.Type.FindByName('_TestURIResolver'))
         self.assertTrue(Tf.Type.FindByName('_TestOtherURIResolver'))
+        self.assetTrue(Tf.Type.FindByName('_TestOtherPrimaryResolver'))
 
         self.assertTrue(pr.GetPluginWithName('TestArPackageResolver'))
         self.assertTrue(Tf.Type.FindByName('_TestPackageResolver'))
@@ -85,6 +86,12 @@ class TestArURIResolver(unittest.TestCase):
             resolver.Resolve("test_other://foo.package[bar.file]"), 
             "test_other://foo.package[bar.file]")
 
+        self.assertEqual(resolver.Resolve("test_primary://foo"),
+                         "test_primary://foo")
+        self.assertEqual(
+            resolver.Resolve("test_primary://foo.package[bar.file]"),
+            "test_primary://foo.package[bar.file]")
+
         # These calls should hit the URI resolver since schemes are
         # case-insensitive.
         self.assertEqual(resolver.Resolve("TEST://foo"), 
@@ -97,6 +104,12 @@ class TestArURIResolver(unittest.TestCase):
         self.assertEqual(
             resolver.Resolve("TEST_OTHER://foo.package[bar.file]"), 
             "TEST_OTHER://foo.package[bar.file]")
+
+        self.assertEqual(resolver.Resolve("TEST_PRIMARY://foo"),
+                         "TEST_PRIMARY://foo")
+        self.assertEqual(
+            resolver.Resolve("TEST_PRIMARY://foo.package[bar.file]"),
+            "TEST_PRIMARY://foo.package[bar.file]")
 
     def test_ResolveForNewAsset(self):
         resolver = Ar.GetResolver()


### PR DESCRIPTION
### Description of Change(s)

A plugin resolver could only be considered a primary resolver if it does not specify uriSchemes in plugInfo.json. This prevents a "fallback" sort of behavior when multiple plugin resolvers that support URI schemes need to live in the same environment but one is intended to be the primary resolver

This change adds a "primary" flag for a plugin resolver in plugInfo.json to explicitly set. The "primary" flag indicates that the plugin resolver could be a primary resolver but also supports specific URI schemes

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/1989

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
