### PR TITLE
Use literal `true` instead of `1` for bools.

### DIFF
--- a/pxr/base/tf/pxrLZ4/lz4.cpp
+++ b/pxr/base/tf/pxrLZ4/lz4.cpp
@@ -956,7 +956,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic(
                     break;   /* match found */
                 }
 
-            } while(1);
+            } while(true);
         }
 
         /* Catch up */
@@ -1717,7 +1717,7 @@ LZ4_decompress_generic(
         }
 
         /* Fast loop : decode sequences as long as output < iend-FASTLOOP_SAFE_DISTANCE */
-        while (1) {
+        while (true) {
             /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
             assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
             if (endOnInput) { assert(ip < iend); }
@@ -1848,7 +1848,7 @@ LZ4_decompress_generic(
 #endif
 
         /* Main Loop : decode remaining sequences where output < FASTLOOP_SAFE_DISTANCE */
-        while (1) {
+        while (true) {
             token = *ip++;
             length = token >> ML_BITS;  /* literal length */
 

--- a/pxr/base/tf/testenv/getenv.cpp
+++ b/pxr/base/tf/testenv/getenv.cpp
@@ -34,51 +34,51 @@ Test_TfGetenv()
 {
     bool status = true;
     std::string testVar = "GetEnvTestsuiteTestVar";
-    ArchSetEnv(testVar.c_str(), "testing", 1);
+    ArchSetEnv(testVar.c_str(), "testing", true);
     status &= ( TfGetenv(testVar, "bogusValue") == "testing" );
     ArchRemoveEnv(testVar.c_str());
     status &= ( TfGetenv(testVar, "bogusValue") == "bogusValue" );
 
-    ArchSetEnv(testVar.c_str(), "42", 1);
+    ArchSetEnv(testVar.c_str(), "42", true);
     status &= ( TfGetenvInt(testVar, 99) == 42 );
     ArchRemoveEnv(testVar.c_str());
     status &= ( TfGetenvInt(testVar, 99) == 99 );
 
-    ArchSetEnv(testVar.c_str(), "true", 1);
+    ArchSetEnv(testVar.c_str(), "true", true);
     status &= ( TfGetenvBool(testVar, false) == true );
     ArchRemoveEnv(testVar.c_str());
     status &= ( TfGetenvBool(testVar, false) == false );
 
-    ArchSetEnv(testVar.c_str(), "TRUE", 1);
+    ArchSetEnv(testVar.c_str(), "TRUE", true);
     status &= ( TfGetenvBool(testVar, false) == true );
     ArchRemoveEnv(testVar.c_str());
     status &= ( TfGetenvBool(testVar, false) == false );
 
-    ArchSetEnv(testVar.c_str(), "yes", 1);
+    ArchSetEnv(testVar.c_str(), "yes", true);
     status &= ( TfGetenvBool(testVar, false) == true );
 
-    ArchSetEnv(testVar.c_str(), "YES", 1);
+    ArchSetEnv(testVar.c_str(), "YES", true);
     status &= ( TfGetenvBool(testVar, false) == true );
 
-    ArchSetEnv(testVar.c_str(), "1", 1);
+    ArchSetEnv(testVar.c_str(), "1", true);
     status &= ( TfGetenvBool(testVar, false) == true );
 
-    ArchSetEnv(testVar.c_str(), "ON", 1);
+    ArchSetEnv(testVar.c_str(), "ON", true);
     status &= ( TfGetenvBool(testVar, false) == true );
 
-    ArchSetEnv(testVar.c_str(), "on", 1);
+    ArchSetEnv(testVar.c_str(), "on", true);
     status &= ( TfGetenvBool(testVar, false) == true );
 
-    ArchSetEnv(testVar.c_str(), "false", 1);
+    ArchSetEnv(testVar.c_str(), "false", true);
     status &= ( TfGetenvBool(testVar, false) == false );
 
-    ArchSetEnv(testVar.c_str(), "false", 1);
+    ArchSetEnv(testVar.c_str(), "false", true);
     status &= ( TfGetenvBool(testVar, true) == false );
 
-    ArchSetEnv(testVar.c_str(), "someothercrap", 1);
+    ArchSetEnv(testVar.c_str(), "someothercrap", true);
     status &= ( TfGetenvBool(testVar, false) == false );
 
-    ArchSetEnv(testVar.c_str(), "someothercrap", 1);
+    ArchSetEnv(testVar.c_str(), "someothercrap", true);
     status &= ( TfGetenvBool(testVar, true) == false );
 
     return status;


### PR DESCRIPTION
This fixes one class of warnings for the `pxr/base` code from clang-tidy.

- [x] I have submitted a signed Contributor License Agreement
