### PR TITLE
Remove macOS experimental warning

### DIFF
--- a/cmake/defaults/ProjectDefaults.cmake
+++ b/cmake/defaults/ProjectDefaults.cmake
@@ -28,7 +28,6 @@ if(APPLE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
     set(CMAKE_DYLIB_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE STRING "install_name path for dylib.")
     list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-    message(WARNING "Building USD on Mac OSX is currently experimental.")
 elseif(WIN32)
     # Windows specific set up
     message(WARNING "Building USD on Windows is currently experimental.")


### PR DESCRIPTION
### Description of Change(s)
This PR just removes the CMake warning that states the macOS build is experimental. Since USD Metal is now part of the repo, and we regularly build USD for macOS with the regular components, I think it's safe to remove the disclaimer.

- [X] I have submitted a signed Contributor License Agreement
