### PR TITLE
Record the absolute path to the clip file when constructing a Usd_Clip

### DIFF
--- a/pxr/usd/usd/clip.cpp
+++ b/pxr/usd/usd/clip.cpp
@@ -122,9 +122,14 @@ Usd_Clip::Usd_Clip(
     if (TF_VERIFY(sourceLayerIndex < sourceLayerStack->GetLayers().size())) {
         const ArResolverContextBinder binder(
             sourceLayerStack->GetIdentifier().pathResolverContext);
-        _layer = SdfLayer::FindRelativeToLayer(
-            sourceLayerStack->GetLayers()[sourceLayerIndex],
-            assetPath.GetAssetPath());
+        if (sourceLayerStack->GetLayers()[sourceLayerIndex] &&
+            !assetPath.GetAssetPath().empty())
+        {
+            anchoredAssetPath = SdfComputeAssetPathRelativeToLayer(
+                sourceLayerStack->GetLayers()[sourceLayerIndex],
+                assetPath.GetAssetPath());
+            _layer = SdfLayer::Find(anchoredAssetPath);
+        }
     }
 
     _hasLayer = (bool)_layer;
@@ -737,12 +742,10 @@ Usd_Clip::_GetLayerForClip() const
 
     SdfLayerRefPtr layer;
 
-    if (TF_VERIFY(sourceLayerIndex < sourceLayerStack->GetLayers().size())) {
+    if (TF_VERIFY(!anchoredAssetPath.empty())) {
         const ArResolverContextBinder binder(
             sourceLayerStack->GetIdentifier().pathResolverContext);
-        layer = SdfLayer::FindOrOpenRelativeToLayer(
-            sourceLayerStack->GetLayers()[sourceLayerIndex],
-            assetPath.GetAssetPath());
+        layer = SdfLayer::FindOrOpen(anchoredAssetPath);
     }
 
     if (!layer) {

--- a/pxr/usd/usd/clip.h
+++ b/pxr/usd/usd/clip.h
@@ -35,6 +35,7 @@
 #include <iosfwd>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -201,6 +202,7 @@ public:
     /// Asset path for the clip and the path to the prim in the clip
     /// that provides data.
     SdfAssetPath assetPath;
+    std::string anchoredAssetPath;
     SdfPath primPath;
 
     /// The authored start time for this clip. This generally is equivalent


### PR DESCRIPTION
### Description of Change(s)
Record the absolute path to the clip file when constructing the Usd_Clip
object, rather than re-calculating the clip file path when data is first
requested from the clip file. This prevents incorrect clip file path
calculations if the layer stack has been modified since the Usd_Clip
object was created.

I'm not sure if this is the correct way to fix this (the other thought I had was responding to change notifications affecting the layer stack, but that seemed like it would be far more complicated, with no real benefit.

### Fixes Issue(s)
- #2014

- [ X ] I have submitted a signed Contributor License Agreement
