### PR TITLE
[sdf, usd] Fix crash when URL-encoded characters are used to generate session layer identifiers

### DIFF
--- a/pxr/usd/sdf/assetPathResolver.cpp
+++ b/pxr/usd/sdf/assetPathResolver.cpp
@@ -258,6 +258,12 @@ Sdf_GetAnonLayerIdentifierTemplate(
     const string& tag)
 {
     string idTag = tag.empty() ? tag : TfStringTrim(tag);
+
+    // Ensure that URL-encoded characters are not misinterpreted as
+    // format strings to TfStringPrintf in Sdf_ComputeAnonLayerIdentifier.
+    // See discussion in https://github.com/PixarAnimationStudios/USD/pull/2022
+    idTag = TfStringReplace(idTag, "%", "%%");
+
     return _Tokens->AnonLayerPrefix.GetString() + "%p" +
         (idTag.empty() ? idTag : ":" + idTag);
 }

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -458,6 +458,11 @@ pxr_install_test_dir(
 )
 
 pxr_install_test_dir(
+    SRC testenv/testUsdStage
+    DEST testUsdStage
+)
+
+pxr_install_test_dir(
     SRC testenv/testUsdAppliedAPISchemas
     DEST testUsdAppliedAPISchemas_AutoApplyDisabled
 )

--- a/pxr/usd/usd/testenv/testUsdStage.py
+++ b/pxr/usd/usd/testenv/testUsdStage.py
@@ -29,6 +29,10 @@ from pxr import Sdf,Usd,Tf
 allFormats = ['usd' + c for c in 'ac']
 
 class TestUsdStage(unittest.TestCase):
+    def test_URLEncodedIdentifiers(self):
+        stage = Usd.Stage.Open("Libeccio%20LowFBX.usda")
+        assert stage
+
     def test_Repr(self):
         stage = Usd.Stage.CreateInMemory()
 

--- a/pxr/usd/usd/testenv/testUsdStage/Libeccio%20LowFBX.usda
+++ b/pxr/usd/usd/testenv/testUsdStage/Libeccio%20LowFBX.usda
@@ -1,0 +1,17 @@
+#usda 1.0
+(
+    defaultPrim = "hello"
+)
+
+def Xform "hello"
+{
+    custom double3 xformOp:translate = (4, 5, 6)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Sphere "world"
+    {
+        float3[] extent = [(-2, -2, -2), (2, 2, 2)]
+        color3f[] primvars:displayColor = [(0, 0, 1)]
+        double radius = 2
+    }
+}


### PR DESCRIPTION
[sdf, usd] Fix crash when URL-encoded characters are used to generate session layer identifiers

When opening a stage whose root layer has URL-encoded characters, sequences such as %20 for spaces could get misinterpreted as format strings when generating session layer identifiers on the fly via TfStringPrintf. This change uses stringstreams to ensure that URL-encoded characters never get misinterpreted on this codepath, which was previously leading to crashes such as the one in the testUsdStage case added here.

Thanks to Seema Kulkarni and Edward Slavin for earlier work on this PR.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
