### PR TITLE
Prevent invalid binding relationship access in UsdShadeMaterialBindingAPI

### DIFF
--- a/pxr/usd/usdShade/materialBindingAPI.cpp
+++ b/pxr/usd/usdShade/materialBindingAPI.cpp
@@ -252,7 +252,7 @@ UsdShadeMaterialBindingAPI::DirectBinding::DirectBinding(
 UsdShadeMaterial
 UsdShadeMaterialBindingAPI::DirectBinding::GetMaterial() const
 {
-    if (_bindingRel && !_materialPath.IsEmpty()) {
+    if (_bindingRel.GetPrim() && !_materialPath.IsEmpty()) {
         return UsdShadeMaterial(_bindingRel.GetStage()->GetPrimAtPath(
                 _materialPath));
     }
@@ -311,7 +311,7 @@ UsdShadeMaterialBindingAPI::CollectionBinding::CollectionBinding(
 UsdShadeMaterial
 UsdShadeMaterialBindingAPI::CollectionBinding::GetMaterial() const
 {
-    if (_bindingRel && !_materialPath.IsEmpty()) {
+    if (_bindingRel.GetPrim() && !_materialPath.IsEmpty()) {
         return UsdShadeMaterial(_bindingRel.GetStage()->GetPrimAtPath(
                 _materialPath));
     }
@@ -321,7 +321,7 @@ UsdShadeMaterialBindingAPI::CollectionBinding::GetMaterial() const
 UsdCollectionAPI
 UsdShadeMaterialBindingAPI::CollectionBinding::GetCollection() const
 {
-    if (_bindingRel && !_collectionPath.IsEmpty()) {
+    if (_bindingRel.GetPrim() && !_collectionPath.IsEmpty()) {
         return UsdCollectionAPI::GetCollection(_bindingRel.GetStage(),
                                                _collectionPath);
     }

--- a/pxr/usd/usdShade/materialBindingAPI.cpp
+++ b/pxr/usd/usdShade/materialBindingAPI.cpp
@@ -252,7 +252,7 @@ UsdShadeMaterialBindingAPI::DirectBinding::DirectBinding(
 UsdShadeMaterial
 UsdShadeMaterialBindingAPI::DirectBinding::GetMaterial() const
 {
-    if (!_materialPath.IsEmpty()) {
+    if (_bindingRel && !_materialPath.IsEmpty()) {
         return UsdShadeMaterial(_bindingRel.GetStage()->GetPrimAtPath(
                 _materialPath));
     }
@@ -311,7 +311,7 @@ UsdShadeMaterialBindingAPI::CollectionBinding::CollectionBinding(
 UsdShadeMaterial
 UsdShadeMaterialBindingAPI::CollectionBinding::GetMaterial() const
 {
-    if (!_materialPath.IsEmpty()) {
+    if (_bindingRel && !_materialPath.IsEmpty()) {
         return UsdShadeMaterial(_bindingRel.GetStage()->GetPrimAtPath(
                 _materialPath));
     }
@@ -321,7 +321,7 @@ UsdShadeMaterialBindingAPI::CollectionBinding::GetMaterial() const
 UsdCollectionAPI
 UsdShadeMaterialBindingAPI::CollectionBinding::GetCollection() const
 {
-    if (!_collectionPath.IsEmpty()) {
+    if (_bindingRel && !_collectionPath.IsEmpty()) {
         return UsdCollectionAPI::GetCollection(_bindingRel.GetStage(),
                                                _collectionPath);
     }


### PR DESCRIPTION
### Description of Change(s)
The validity of the binding relationship is not verified before accessing the stage, which then throws a `Usd_ThrowExpiredPrimAccessError` while dereferencing the prim data handle. Adding an extra check in the if-condition prevents such invalid access and returns an empty material if the binding relationship is invalid.
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
