### PR TITLE
APPLE: Basis curves on Metal - Updated mega PR

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -185,6 +185,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define HD_SHADER_TOKENS                        \
     (alphaThreshold)                            \
+    (centroid)                                  \
     (clipPlanes)                                \
     (commonShaderSource)                        \
     (computeShader)                             \
@@ -214,6 +215,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (wireframeColor)                            \
     (worldToViewMatrix)                         \
     (worldToViewInverseMatrix)                  \
+    (sample)                                    \
     (stepSize)                                  \
     (stepSizeLighting)
 

--- a/pxr/imaging/hdSt/basisCurves.cpp
+++ b/pxr/imaging/hdSt/basisCurves.cpp
@@ -289,16 +289,9 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
         std::static_pointer_cast<HdStResourceRegistry>(
             renderIndex.GetResourceRegistry());
     
-    // For the time being, don't use complex curves on Metal. Support for this
-    // is planned for the future.
-    const bool hasMetalTessellation =
-        resourceRegistry->GetHgi()->GetCapabilities()->
-        IsSet(HgiDeviceCapabilitiesBitsMetalTessellation);
-    
     TfToken curveType = _topology->GetCurveType();
     TfToken curveBasis = _topology->GetCurveBasis();
-    bool supportsRefinement = _SupportsRefinement(_refineLevel) &&
-        !hasMetalTessellation;
+    bool supportsRefinement = _SupportsRefinement(_refineLevel);
     if (!supportsRefinement) {
         // XXX: Rendering non-linear (i.e., cubic) curves as linear segments
         // when unrefined can be confusing. Should we continue to do this?
@@ -329,8 +322,7 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
     case HdBasisCurvesGeomStylePatch:
     {
         if (_SupportsRefinement(_refineLevel) &&
-            _SupportsUserWidths(drawItem) &&
-            !hasMetalTessellation) {
+            _SupportsUserWidths(drawItem)) {
             if (_SupportsUserNormals(drawItem)){
                 drawStyle = HdSt_BasisCurvesShaderKey::RIBBON;
                 normalStyle = HdSt_BasisCurvesShaderKey::ORIENTED;
@@ -380,6 +372,9 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
             shadingTerminal = HdBasisCurvesReprDescTokens->surfaceShaderUnlit;
         }
     }
+     bool hasPostTessVertexSupport = resourceRegistry->GetHgi()
+        ->GetCapabilities()->IsSet(HgiDeviceCapabilitiesBitsMetalTessellation);
+
 
     HdSt_BasisCurvesShaderKey shaderKey(curveType,
                                         curveBasis,
@@ -389,7 +384,8 @@ HdStBasisCurves::_UpdateDrawItemGeometricShader(
                                         _basisNormalInterpolation,
                                         shadingTerminal,
                                         hasAuthoredTopologicalVisiblity,
-                                        _pointsShadingEnabled);
+                                        _pointsShadingEnabled,
+                                        hasPostTessVertexSupport);
 
     TF_DEBUG(HD_RPRIM_UPDATED).
             Msg("HdStBasisCurves(%s) - Shader Key PrimType: %s\n ",

--- a/pxr/imaging/hdSt/basisCurvesComputations.h
+++ b/pxr/imaging/hdSt/basisCurvesComputations.h
@@ -61,16 +61,21 @@ protected:
     virtual bool _CheckValid() const override;
 
 public:
-    // For building index and primitive index arrays
+    // For building index, primitive index and tessFactor arrays
     struct IndexAndPrimIndex {
         // default constructor results in empty VtValue's
         IndexAndPrimIndex() {}
 
-        IndexAndPrimIndex(VtValue indices, VtValue primIndices) :
-            _indices(indices), _primIndices(primIndices) {}
+        IndexAndPrimIndex(VtValue indices,
+                          VtValue primIndices,
+                          VtValue tessFactors) :
+                     _indices(indices),
+                     _primIndices(primIndices),
+                     _tessFactors(tessFactors) {}
 
         VtValue _indices;
         VtValue _primIndices;
+        VtValue _tessFactors;
     };
 private:
     IndexAndPrimIndex _BuildLinesIndexArray();
@@ -80,7 +85,8 @@ private:
     HdBasisCurvesTopology *_topology;
     bool _forceLines;
 
-    HdBufferSourceSharedPtr _primitiveParam;    
+    HdBufferSourceSharedPtr _primitiveParam;
+    HdBufferSourceSharedPtr _tessFactorsParam;
 };
 
 

--- a/pxr/imaging/hdSt/basisCurvesShaderKey.h
+++ b/pxr/imaging/hdSt/basisCurvesShaderKey.h
@@ -74,24 +74,35 @@ struct HdSt_BasisCurvesShaderKey : public HdSt_ShaderKey
                               bool basisNormalInterpolation,
                               TfToken shadingTerminal,
                               bool hasAuthoredTopologicalVisibility,
-                              bool pointsShadingEnabled);
+                              bool pointsShadingEnabled,
+                              bool hasPostTessVertexSupport);
+
     ~HdSt_BasisCurvesShaderKey();
 
     TfToken const &GetGlslfxFilename() const override { return glslfx; }
     TfToken const *GetVS() const override  { return VS; }
     TfToken const *GetTCS() const override { return TCS; }
     TfToken const *GetTES() const override { return TES; }
+    TfToken const *GetPTCS() const override { return PTCS; }
+    TfToken const *GetPTVS() const override { return PTVS; }
     TfToken const *GetFS() const override { return FS; }
 
     HdSt_GeometricShader::PrimitiveType GetPrimitiveType() const override { 
         return primType; 
     }
 
+    bool UseMetalTessellation() const override {
+        return useMetalTessellation;
+    }
+
     HdSt_GeometricShader::PrimitiveType primType;
+    bool useMetalTessellation;
     TfToken glslfx;
     TfToken VS[7];
-    TfToken TCS[4];
-    TfToken TES[9];
+    TfToken TCS[7];
+    TfToken PTCS[10];
+    TfToken TES[10];
+    TfToken PTVS[17];
     TfToken FS[8];
 };
 

--- a/pxr/imaging/hdSt/codeGen.h
+++ b/pxr/imaging/hdSt/codeGen.h
@@ -170,11 +170,13 @@ private:
     std::stringstream _genPTCS, _genPTVS;
     std::stringstream _genGS, _genFS, _genCS;
     std::stringstream _procVS, _procTCS, _procTES, _procGS;
-    std::stringstream _procPTCS, _procPTVSDecl, _procPTVSIn, _procPTVSOut;
+    std::stringstream _procPTCSIn, _procPTCSDecl;
+    std::stringstream _procPTVSDecl, _procPTVSIn, _procPTVSOut;
     std::stringstream _osdFS, _osdPTCS, _osdPTVS;
 
     // resource buckets
     using ElementVector = HdSt_ResourceLayout::ElementVector;
+    using TfTokenVector = HdSt_ResourceLayout::TfTokenVector;
     ElementVector _resVS;
     ElementVector _resTCS;
     ElementVector _resTES;

--- a/pxr/imaging/hdSt/geometricShader.cpp
+++ b/pxr/imaging/hdSt/geometricShader.cpp
@@ -156,6 +156,7 @@ HdSt_GeometricShader::GetPrimitiveIndexSize() const
             primIndexSize = 3;
             break;
         case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES:
+        case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES:
         case PrimitiveType::PRIM_MESH_COARSE_QUADS:
         case PrimitiveType::PRIM_MESH_REFINED_QUADS:
             primIndexSize = 4;
@@ -186,6 +187,7 @@ HdSt_GeometricShader::GetNumPatchEvalVerts() const
             numPatchEvalVerts = 2;
             break;
         case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES:
+        case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES:
             numPatchEvalVerts = 4;
             break;
         case PrimitiveType::PRIM_MESH_BSPLINE:
@@ -213,6 +215,7 @@ HdSt_GeometricShader::GetNumPrimitiveVertsForGeometryShader() const
             numPrimVerts = 1;
             break;
         case PrimitiveType::PRIM_BASIS_CURVES_LINES:
+        case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES:
             numPrimVerts = 2;
             break;
         case PrimitiveType::PRIM_MESH_COARSE_TRIANGLES:
@@ -249,6 +252,7 @@ HdSt_GeometricShader::GetHgiPrimitiveType() const
         case PrimitiveType::PRIM_BASIS_CURVES_LINES:
             primitiveType = HgiPrimitiveTypeLineList;
             break;
+        case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES:
         case PrimitiveType::PRIM_MESH_COARSE_TRIANGLES:
         case PrimitiveType::PRIM_MESH_REFINED_TRIANGLES:
         case PrimitiveType::PRIM_MESH_COARSE_TRIQUADS:

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -65,6 +65,7 @@ public:
         PRIM_BASIS_CURVES_LINES,     // when linear (or) non-refined cubic
         PRIM_BASIS_CURVES_LINEAR_PATCHES,  // refined linear curves
         PRIM_BASIS_CURVES_CUBIC_PATCHES,   // refined cubic curves
+        PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES,
         PRIM_MESH_COARSE_TRIANGLES,
         PRIM_MESH_REFINED_TRIANGLES, // e.g: loop subdiv
         PRIM_MESH_COARSE_QUADS,      // e.g: quadrangulation for ptex
@@ -85,6 +86,7 @@ public:
     static inline bool IsPrimTypeBasisCurves(PrimitiveType primType) {
         return (primType == PrimitiveType::PRIM_BASIS_CURVES_LINES ||
                 primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES ||
+                primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES ||
                 primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES);
     }
 
@@ -127,7 +129,9 @@ public:
         return primType == PrimitiveType::PRIM_MESH_BSPLINE ||
                primType == PrimitiveType::PRIM_MESH_BOXSPLINETRIANGLE ||
                primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES ||
-               primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES;
+               primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES ||
+               primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES ||
+            primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES;
     }
 
     // Face-varying patch type
@@ -269,6 +273,7 @@ public:
 
 private:
     PrimitiveType _primType;
+    HgiTessellationSpacing _tessellationSpacing;
     HdCullStyle _cullStyle;
     bool _useHardwareFaceCulling;
     bool _hasMirroredTransform;

--- a/pxr/imaging/hdSt/glConversions.cpp
+++ b/pxr/imaging/hdSt/glConversions.cpp
@@ -212,6 +212,7 @@ HdStGLConversions::GetPrimitiveMode(
             primMode = GL_LINES_ADJACENCY;
             break;
         case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES:
+        case PrimitiveType::PRIM_BASIS_CURVES_CUBIC_WIRE_PATCHES:
         case PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES:
         case PrimitiveType::PRIM_MESH_BSPLINE:
         case PrimitiveType::PRIM_MESH_BOXSPLINETRIANGLE:

--- a/pxr/imaging/hdSt/indirectDrawBatch.cpp
+++ b/pxr/imaging/hdSt/indirectDrawBatch.cpp
@@ -893,7 +893,7 @@ HdSt_IndirectDrawBatch::_HasNothingToDraw() const
 
 void
 HdSt_IndirectDrawBatch::PrepareDraw(
-    HgiGraphicsCmds *,
+    HgiGraphicsCmds *cmds,
     HdStRenderPassStateSharedPtr const & renderPassState,
     HdStResourceRegistrySharedPtr const & resourceRegistry)
 {
@@ -919,7 +919,7 @@ HdSt_IndirectDrawBatch::PrepareDraw(
     if (_useGpuCulling) {
         // Ignore passed in gfxCmds for now since GPU frustum culling
         // may still require multiple command buffer submissions.
-        _ExecuteFrustumCull(updateBufferData,
+        _ExecuteFrustumCull(cmds, updateBufferData,
                             renderPassState, resourceRegistry);
     }
 }
@@ -1311,6 +1311,7 @@ _GetCullPipeline(
 
 void
 HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
+    HgiGraphicsCmds * cullGfxCmds,
     bool const updateBufferData,
     HdStRenderPassStateSharedPtr const & renderPassState,
     HdStResourceRegistrySharedPtr const & resourceRegistry)
@@ -1374,7 +1375,6 @@ HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
 
     // GfxCmds has no attachment since it is a vertex only shader.
     HgiGraphicsCmdsDesc gfxDesc;
-    HgiGraphicsCmdsUniquePtr cullGfxCmds = hgi->CreateGraphicsCmds(gfxDesc);
     if (_useInstanceCulling) {
         cullGfxCmds->PushDebugGroup("GPU frustum culling (instanced)");
     } else {
@@ -1459,7 +1459,7 @@ HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
     }
 
     cullGfxCmds->PopDebugGroup();
-    hgi->SubmitCmds(cullGfxCmds.get());
+    hgi->SubmitCmds(cullGfxCmds);
 
     state.UnbindResourcesForViewTransformation();
 

--- a/pxr/imaging/hdSt/indirectDrawBatch.h
+++ b/pxr/imaging/hdSt/indirectDrawBatch.h
@@ -152,6 +152,7 @@ private:
                 HdStBufferArrayRangeSharedPtr const & indexBar);
 
     void _ExecuteFrustumCull(
+                HgiGraphicsCmds * cullGfxCmds,
                 bool updateDispatchBuffer,
                 HdStRenderPassStateSharedPtr const & renderPassState,
                 HdStResourceRegistrySharedPtr const & resourceRegistry);

--- a/pxr/imaging/hdSt/meshShaderKey.cpp
+++ b/pxr/imaging/hdSt/meshShaderKey.cpp
@@ -291,6 +291,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     uint8_t ptcsIndex = 0;
     if (useMetalTessellation) {
         PTVS[ptvsIndex++] = _tokens->instancing;
+        PTVS[ptvsIndex++] = _tokens->mainVaryingInterpPTVS;
 
         // PTVS handles both usual "vs" normals and then later it may also 
         // handle a separate fallback calculation.

--- a/pxr/imaging/hdSt/meshShaderKey.h
+++ b/pxr/imaging/hdSt/meshShaderKey.h
@@ -120,7 +120,7 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
     TfToken TCS[3];
     TfToken TES[4];
     TfToken PTCS[3];
-    TfToken PTVS[11];
+    TfToken PTVS[12];
     TfToken GS[10];
     TfToken FS[22];
 };

--- a/pxr/imaging/hdSt/pipelineDrawBatch.h
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.h
@@ -140,9 +140,16 @@ private:
                 HdStBufferArrayRangeSharedPtr const & indexBar);
 
     void _ExecuteFrustumCull(
+                HgiGraphicsCmds * cullGfxCmds,
                 bool updateDispatchBuffer,
                 HdStRenderPassStateSharedPtr const & renderPassState,
                 HdStResourceRegistrySharedPtr const & resourceRegistry);
+
+    void _ExecutePostTesselation(
+            HgiGraphicsCmds *ptcsGfxCmds,
+            bool const updateBufferData,
+            HdStRenderPassStateSharedPtr const & renderPassState,
+            HdStResourceRegistrySharedPtr const & resourceRegistry);
 
     void _BeginGPUCountVisibleInstances(
         HdStResourceRegistrySharedPtr const & resourceRegistry);

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -1071,7 +1071,7 @@ HdStRenderPassState::GetClipPlanes() const
 }
 
 void
-HdStRenderPassState::_InitPrimitiveState(
+HdStRenderPassState::InitPrimitiveState(
     HgiGraphicsPipelineDesc * pipeDesc,
     HdSt_GeometricShaderSharedPtr const & geometricShader) const
 {
@@ -1086,6 +1086,16 @@ HdStRenderPassState::_InitPrimitiveState(
                 geometricShader->IsPrimTypeTriangles()
                     ? HgiTessellationState::PatchType::Triangle
                     : HgiTessellationState::PatchType::Quad;
+            if (geometricShader->GetHgiPrimitiveType() ==
+                HgiPrimitiveTypePointList) {
+                pipeDesc->tessellationState.patchType = HgiTessellationState::Isoline;
+            }
+        }
+    }
+    if (geometricShader->GetUseMetalTessellation()) {
+        if (geometricShader->GetHgiPrimitiveType() ==
+            HgiPrimitiveTypePointList) {
+            pipeDesc->tessellationState.patchType = HgiTessellationState::Isoline;
         }
     }
 }
@@ -1219,7 +1229,7 @@ HdStRenderPassState::InitGraphicsPipelineDesc(
     HgiGraphicsPipelineDesc * pipeDesc,
     HdSt_GeometricShaderSharedPtr const & geometricShader) const
 {
-    _InitPrimitiveState(pipeDesc, geometricShader);
+    InitPrimitiveState(pipeDesc, geometricShader);
     _InitDepthStencilState(&pipeDesc->depthState);
     _InitMultiSampleState(&pipeDesc->multiSampleState);
     _InitRasterizationState(&pipeDesc->rasterizationState, geometricShader);

--- a/pxr/imaging/hdSt/renderPassState.h
+++ b/pxr/imaging/hdSt/renderPassState.h
@@ -200,6 +200,12 @@ public:
     /// Generates the hash for the settings used to init the graphics pipeline.
     HDST_API
     uint64_t GetGraphicsPipelineHash() const;
+    
+    /// Initializes the primitive state
+    HDST_API
+    void InitPrimitiveState(
+                HgiGraphicsPipelineDesc * pipeDesc,
+                HdSt_GeometricShaderSharedPtr const & geometricShader) const;
 
 private:
     bool _UseAlphaMask() const;
@@ -210,9 +216,6 @@ private:
     void _InitAttachmentDesc(HgiAttachmentDesc &attachmentDesc,
                              int aovIndex = -1) const;
 
-    void _InitPrimitiveState(
-                HgiGraphicsPipelineDesc * pipeDesc,
-                HdSt_GeometricShaderSharedPtr const & geometricShader) const;
     void _InitAttachmentState(HgiGraphicsPipelineDesc * pipeDesc) const;
     void _InitDepthStencilState(HgiDepthStencilState * depthState) const;
     void _InitMultiSampleState(HgiMultiSampleState * multisampleState) const;

--- a/pxr/imaging/hdSt/resourceBinder.cpp
+++ b/pxr/imaging/hdSt/resourceBinder.cpp
@@ -70,6 +70,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (ivec4)
     (constantPrimvars)
     (primitiveParam)
+    (tessFactors)
     (topologyVisibility)
 );
 
@@ -413,6 +414,9 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
                 } else if (_TokenContainsString(name, 
                            HdStTokens->fvarPatchParam.GetString())) {
                     metaDataOut->fvarPatchParamBindings.push_back(bindingDecl);
+                } else if (_TokenContainsString(name,
+                           HdStTokens->tessFactors.GetString())) {
+                    metaDataOut->tessFactorsBinding = bindingDecl;
                 } else {
                     TF_WARN("Unexpected topological resource '%s'\n",
                     name.GetText());
@@ -600,7 +604,7 @@ HdSt_ResourceBinder::ResolveBindings(HdStDrawItem const *drawItem,
                     /*name=*/HdInstancerTokens->culledInstanceIndices,
                     /*type=*/glType,
                     /*binding=*/culledInstanceIndexArrayBinding,
-                    /*isWritable=*/true);
+                    /*writable=*/true);
         }
     }
 
@@ -992,7 +996,8 @@ HdSt_ResourceBinder::GetBufferBindingDesc(
 
     HgiShaderStage stageUsage =
         HgiShaderStageVertex | HgiShaderStageFragment |
-        HgiShaderStagePostTessellationVertex;
+        HgiShaderStagePostTessellationVertex |
+        HgiShaderStagePostTessellationControl;
     HgiBufferBindDesc desc;
 
     switch (binding.GetType()) {
@@ -1615,6 +1620,7 @@ HdSt_ResourceBinder::MetaData::ComputeHash() const
     boost::hash_combine(hash, instanceIndexBaseBinding.dataType);
     boost::hash_combine(hash, primitiveParamBinding.binding.GetValue());
     boost::hash_combine(hash, primitiveParamBinding.dataType);
+    boost::hash_combine(hash, tessFactorsBinding.binding.GetValue());
     boost::hash_combine(hash, edgeIndexBinding.binding.GetValue());
     boost::hash_combine(hash, edgeIndexBinding.dataType);
     boost::hash_combine(hash, coarseFaceIndexBinding.binding.GetValue());

--- a/pxr/imaging/hdSt/resourceBinder.h
+++ b/pxr/imaging/hdSt/resourceBinder.h
@@ -309,6 +309,7 @@ public:
         BindingDeclaration culledInstanceIndexArrayBinding;
         BindingDeclaration instanceIndexBaseBinding;
         BindingDeclaration primitiveParamBinding;
+        BindingDeclaration tessFactorsBinding;
         BindingDeclaration edgeIndexBinding;
         BindingDeclaration coarseFaceIndexBinding;
         std::vector<BindingDeclaration> fvarPatchParamBindings;

--- a/pxr/imaging/hdSt/resourceLayout.cpp
+++ b/pxr/imaging/hdSt/resourceLayout.cpp
@@ -82,6 +82,17 @@ _ParseMembers(InputValueVector const & input, int fromElement)
     return result;
 }
 
+TfTokenVector split(const std::string &text, char sep) {
+  TfTokenVector tokens;
+  std::size_t start = 0, end = 0;
+  while ((end = text.find(sep, start)) != std::string::npos) {
+    tokens.push_back(TfToken(text.substr(start, end - start)));
+    start = end + 1;
+  }
+  tokens.push_back(TfToken(text.substr(start)));
+  return tokens;
+}
+
 // e.g. ["in", "vec3", "color"]
 // e.g. ["in", "int", "pointId", "flat"]
 bool
@@ -93,7 +104,9 @@ _ParseValue(InputValueVector const & input, Element *element)
                            /*dataType=*/_Token(input[1]),
                            /*name=*/_Token(input[2]));
         if (input.size() == 4) {
-            element->qualifiers = _Token(input[3]);
+            std::string qualString = input[3].GetWithDefault(
+                 HdStResourceLayoutTokens->unknown.GetString());
+            element->qualifiers = split(qualString, ' ');
         }
         return true;
     } else if (_Token(input[0]) == HdStResourceLayoutTokens->outValue) {
@@ -101,7 +114,9 @@ _ParseValue(InputValueVector const & input, Element *element)
                            /*dataType=*/_Token(input[1]),
                            /*name=*/_Token(input[2]));
         if (input.size() == 4) {
-            element->qualifiers = _Token(input[3]);
+            std::string qualString = input[3].GetWithDefault(
+                 HdStResourceLayoutTokens->unknown.GetString());
+            element->qualifiers = split(qualString, ' ');
         }
         return true;
     }
@@ -190,11 +205,15 @@ _ParseQualifier(InputValueVector const & input, Element *element)
     if (input.size() != 2) return false;
     if (_Token(input[0]) == HdStResourceLayoutTokens->inValue) {
         *element = Element(InOut::STAGE_IN, Kind::QUALIFIER);
-        element->qualifiers = _Token(input[1]);
+        std::string qualString = input[1].GetWithDefault(
+             HdStResourceLayoutTokens->unknown.GetString());
+        element->qualifiers = split(qualString, ' ');
         return true;
     } else if (_Token(input[0]) == HdStResourceLayoutTokens->outValue) {
         *element = Element(InOut::STAGE_OUT, Kind::QUALIFIER);
-        element->qualifiers = _Token(input[1]);
+        std::string qualString = input[1].GetWithDefault(
+             HdStResourceLayoutTokens->unknown.GetString());
+        element->qualifiers = split(qualString, ' ');
         return true;
     }
 

--- a/pxr/imaging/hdSt/resourceLayout.h
+++ b/pxr/imaging/hdSt/resourceLayout.h
@@ -117,6 +117,7 @@ public:
         TfToken arraySize;
     };
     using MemberVector = std::vector<Member>;
+    using TfTokenVector = std::vector<TfToken>;
 
     /// Specifies a resource element.
     struct Element {
@@ -125,7 +126,7 @@ public:
                 TfToken dataType = HdStResourceLayoutTokens->unknown,
                 TfToken name = HdStResourceLayoutTokens->unknown,
                 TfToken arraySize = TfToken(),
-                TfToken qualifiers = TfToken())
+                TfTokenVector qualifiers = TfTokenVector())
             : inOut(inOut)
             , kind(kind)
             , location(-1)
@@ -141,7 +142,7 @@ public:
         int location;
         TfToken dataType;
         TfToken name;
-        TfToken qualifiers;
+        TfTokenVector qualifiers;
         TfToken arraySize;
         TfToken aggregateName;
         MemberVector members;

--- a/pxr/imaging/hdSt/shaderKey.h
+++ b/pxr/imaging/hdSt/shaderKey.h
@@ -29,6 +29,7 @@
 #include "pxr/imaging/hdSt/geometricShader.h" // XXX: for PrimitiveType
 #include "pxr/imaging/hd/version.h"
 #include "pxr/imaging/hd/enums.h"
+#include "pxr/imaging/hgi/enums.h"
 #include "pxr/base/tf/token.h"
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -33,9 +33,9 @@
 #import $TOOLS/hdSt/shaders/visibility.glslfx
 
 // Known issues:
-// * The direction of the 'v' post tessellation is inconsistent between 
+// * The direction of the 'v' post tessellation is inconsistent between
 // curve representations with regards to whether it increases from left to right
-// or right to left. If we start using materials that require 'v', we should fix 
+// or right to left. If we start using materials that require 'v', we should fix
 // this to be both consistent and match the RenderMan default orientation.
 //
 // * RenderMan uses 'u' describe the parameter along curve profile and 'v' to
@@ -49,6 +49,91 @@
 //   have updated many of the functions to use
 //   mix(endPointValue, startPointValue, u) when intuitively it should be
 //   the other way around.
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.JointTessControl.SetTessFactorGLSL
+
+void SetTessFactors(float out0, float out1, float out2, float out3, float in0, float in1)
+{
+    gl_TessLevelOuter[0] = out0;
+    gl_TessLevelOuter[1] = out1;
+    gl_TessLevelOuter[2] = out2;
+    gl_TessLevelOuter[3] = out3;
+
+    gl_TessLevelInner[0] = in0;
+    gl_TessLevelInner[1] = in1;
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.JointTessControl.SetTessFactorMSL
+
+void SetTessFactors(float out0, float out1, float out2, float out3, float in0, float in1)
+{
+    device half* tessAsHalf = (device half*)tessFactors + patch_id * 6;
+
+    tessAsHalf[0] = half(out0);
+    tessAsHalf[1] = half(out3);
+    tessAsHalf[2] = half(out2);
+    tessAsHalf[3] = half(out1);
+
+    tessAsHalf[4] = half(in1);
+    tessAsHalf[5] = half(in0);
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTessellation.Shared
+
+//TODO make this avail in glsl, move tocoeffs and move them up.
+struct FlatCurveVertexData
+{
+    float4 Peye[4];
+    float3 Neye[4];
+};
+
+FlatCurveVertexData PopulatePeyeAndNeye()
+{
+    MAT4 projMat = HdGet_projectionMatrix();
+    vec4 viewport = HdGet_viewport();
+    vec2 screen_size = vec2(viewport.z, viewport.w);
+    MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
+    MAT4 transformInv = ApplyInstanceTransformInverse(HdGet_transformInverse());
+
+    FlatCurveVertexData vertexData;
+    for (int i = 0; i < HD_NUM_PATCH_EVAL_VERTS; i++) {
+        vertexData.Peye[i] = vec4(GetWorldToViewMatrix() * transform *
+                       vec4(points[i], 1.0));
+        vertexData.Neye[i] = getNormal(transpose(transformInv *
+                     GetWorldToViewInverseMatrix()), i);
+    }
+    return vertexData;
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.InvertNormal
+
+vec3 InvertNormalIfNeeded(vec3 normal)
+{
+    return -normal;
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.NoInvertNormal
+
+vec3 InvertNormalIfNeeded(vec3 normal)
+{
+    return normal;
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.Coeffs
+
+//TODO move this somewhere else
+
+ struct Coeffs
+ {
+   vec4 basis;
+   vec4 tangent_basis;
+ };
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.Vertex.Patch
@@ -102,6 +187,24 @@ vec3 getNormal(MAT4 transform)
 }
 
 --- --------------------------------------------------------------------------
+-- glsl Curves.PostTess.Normal.Implicit
+
+ vec3 getNormal(MAT4 transform, int index)
+ {
+     // Generate a camera-facing normal in camera/eye space, designed to match
+     // RenderMan.
+     return vec3(0, 0, 1);
+ }
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTess.Normal.Oriented
+
+vec3 getNormal(MAT4 transform, int index)
+{
+    return (transform * vec4(HdGet_normals(), index)).xyz;
+}
+
+--- --------------------------------------------------------------------------
 -- glsl Curves.Vertex.Normal.Oriented
 
 vec3 getNormal(MAT4 transform)
@@ -148,7 +251,7 @@ void main(void)
     ProcessPointId(pointId);}
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessControl.Shared
+-- glsl Curves.Shared
 
 float GetMaxTess()
 {
@@ -162,11 +265,11 @@ float GetPixelToTessRatio()
     return 20.0;
 }
 
-vec2 projectToScreen(MAT4 projMat, vec4 vertex, vec2 screen_size)
+vec2 projectToScreen(MAT4 projMat, vec4 vert, vec2 screen_size)
 {
-    vec4 res = vec4(projMat * vertex);
+    vec4 res = vec4(projMat * vert);
     res /= res.w;
-    return (clamp(res.xy, -1.3, 1.3) + 1) * (screen_size * 0.5);
+    return (clamp(res.xy, -1.3f, 1.3f) + 1.0f) * (screen_size * 0.5f);
 }
 
 --- --------------------------------------------------------------------------
@@ -186,54 +289,60 @@ out CurveVertexData
     vec3 Neye;
 } outData[HD_NUM_PATCH_EVAL_VERTS];
 
-void determineLODSettings();
+void determineLODSettings(FlatCurveVertexData vertexData);
 void main(void)
 {
     if(gl_InvocationID == 0) {
-       determineLODSettings();
+       FlatCurveVertexData vertexData;
+       for (int i = 0; i < gl_MaxPatchVertices) {
+           vertexData.Peye[i] = inData[i].Peye;
+           vertexData.Neye[i] = inData[i].Neye;
+       }
+       determineLODSettings(vertexData);
     }
 
     outData[gl_InvocationID].Peye = inData[gl_InvocationID].Peye;
     outData[gl_InvocationID].Neye = inData[gl_InvocationID].Neye;
-
-    ProcessPrimvarsOut();
+    ProcessPrimvars();
 }
 
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTessControl.Linear.Patch
+
+ void main(void)
+ {
+     FlatCurveVertexData vertexData = PopulatePeyeAndNeye();
+     determineLODSettings(vertexData);
+ }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessControl.Linear.Ribbon
+-- glsl Curves.JointTessControl.Linear.Ribbon
 
-// Use the length of the control points in screen space to determine how many 
+// Use the length of the control points in screen space to determine how many
 // times to subdivide the curve.
-void determineLODSettings()
+void determineLODSettings(FlatCurveVertexData vertexData)
 {
-    gl_TessLevelOuter[0] = 1;
-    gl_TessLevelOuter[1] = 1;
-    gl_TessLevelOuter[2] = 1;
-    gl_TessLevelOuter[3] = 1;
-
-    gl_TessLevelInner[0] = 1;
-    gl_TessLevelInner[1] = 1;
+    SetTessFactors(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessControl.Linear.HalfTube
+-- glsl Curves.JointTessControl.Linear.HalfTube
 
-// Use the width of the control points in screen space to determine how 
+// Use the width of the control points in screen space to determine how
 // many times to subdivide the curve.  NOTE.  As a quick hack, we leverage the
-// fact that the normal isn't normalized at this point in the pipeline to 
+// fact that the normal isn't normalized at this point in the pipeline to
 // provide a quick estimate of width in eye space.  If that becomes a bad
 // assumption in the future, this needs to be reworked.
-void determineLODSettings()
+void determineLODSettings(FlatCurveVertexData vertexData)
 {
     MAT4 projMat = GetProjectionMatrix();
     vec4 viewport = GetViewport();
     vec2 screen_size = vec2(viewport.z, viewport.w);
 
-    // NOTE. We've observed that outData.Neye is not normalized, and 
+    // NOTE. We've observed that outData.Neye is not normalized, and
     // we're using its length as an estimator of the accumulated transform
-    float wEye0 = HdGet_widths(0) * length(inData[0].Neye);
-    float wEye1 = HdGet_widths(1) * length(inData[1].Neye);
+    float wEye0 = HdGet_widths(0) * length(vertexData.Neye[0]);
+    float wEye1 = HdGet_widths(1) * length(vertexData.Neye[1]);
 
     // project a point that is 'w' units away from the origin
     vec2 v_w0 = projectToScreen(projMat, vec4(wEye0, 0, 0, 1), screen_size);
@@ -245,16 +354,10 @@ void determineLODSettings()
 
     float maxWidthScreenSpace = max(length(v_w0), length(v_w1));
 
-    float level_w = clamp(maxWidthScreenSpace / GetPixelToTessRatio() / widthDecimation, 1, maxTess);
-
-    gl_TessLevelOuter[0] = 1;
-    gl_TessLevelOuter[1] = level_w;
-    gl_TessLevelOuter[2] = 1;
-    gl_TessLevelOuter[3] = level_w;
-
-    gl_TessLevelInner[0] = level_w;
-    gl_TessLevelInner[1] = 1;
+    float level_w = clamp(maxWidthScreenSpace / GetPixelToTessRatio() / widthDecimation, 1.0f, maxTess);
+    SetTessFactors(1.0f, level_w, 1.0f, level_w, level_w, 1.0);
 }
+
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.TessControl.Cubic.Wire
@@ -271,39 +374,66 @@ out CurveVertexData
     vec4 Peye;
 } outData[HD_NUM_PATCH_EVAL_VERTS];
 
-void determineLODSettings();
+void determineLODSettings(FlatCurveVertexData vertexData);
 void main(void)
 {
     if(gl_InvocationID == 0) {
-       determineLODSettings();
+        FlatCurveVertexData vertexData;
+        for (int i = 0; i < gl_MaxPatchVertices) {
+            vertexData.Peye[i] = inData[i].Peye;
+        }
+        determineLODSettings(vertexData);
     }
 
     outData[gl_InvocationID].Peye = inData[gl_InvocationID].Peye;
 
-    ProcessPrimvarsOut();
+    ProcessPrimvarsIn();
 }
 
-// Use the length of the control points in screen space to determine how many 
+// Use the length of the control points in screen space to determine how many
 // times to subdivide the curve.
-void determineLODSettings()
+void determineLODSettings(FlatCurveVertexData vertexData)
 {
     MAT4 projMat = GetProjectionMatrix();
     vec4 viewport = GetViewport();
     vec2 screen_size = vec2(viewport.z, viewport.w);
-    vec2 v0 = projectToScreen(projMat, inData[0].Peye, screen_size);
-    vec2 v1 = projectToScreen(projMat, inData[1].Peye, screen_size);
-    vec2 v2 = projectToScreen(projMat, inData[2].Peye, screen_size);
-    vec2 v3 = projectToScreen(projMat, inData[3].Peye, screen_size);
+    vec2 v0 = projectToScreen(projMat, peye[0], screen_size);
+    vec2 v1 = projectToScreen(projMat, peye[1], screen_size);
+    vec2 v2 = projectToScreen(projMat, peye[2], screen_size);
+    vec2 v3 = projectToScreen(projMat, peye[3], screen_size);
 
     float maxTess = GetMaxTess();
 
     // Need to handle off screen
     float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
-    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+    float level = clamp(dist / GetPixelToTessRatio(), 0.0, maxTess);
 
-    gl_TessLevelOuter[0] = 1;
-    gl_TessLevelOuter[1] = level;
+    SetTessFactors(0.0, 0.0, 0.0, 0.0, 1.0, level);
 }
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTessControl.Cubic.Wire
+//This is a bit weird and questionable
+ void main(void)
+ {
+     MAT4 projMat = HdGet_projectionMatrix();
+     vec4 viewport = HdGet_viewport();
+     vec2 screen_size = vec2(viewport.z, viewport.w);
+     MAT4 transform = HdGet_transform();
+
+     FlatCurveVertexData vertexData = PopulatePeyeAndNeye(Peye, Neye);
+     vec2 v0 = projectToScreen(projMat, vertexData.Peye[0], screen_size);
+     vec2 v1 = projectToScreen(projMat, vertexData.Peye[1], screen_size);
+     vec2 v2 = projectToScreen(projMat, vertexData.Peye[2], screen_size);
+     vec2 v3 = projectToScreen(projMat, vertexData.Peye[3], screen_size);
+
+     float maxTess = GetMaxTess();
+
+     // Need to handle off screen
+     float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
+     float level = clamp(dist / GetPixelToTessRatio(), 0.0f, maxTess);
+     SetTessFactors(1.0, 1.0, 1.0, 1.0, 1.0, level);
+ }
 
 
 --- --------------------------------------------------------------------------
@@ -323,73 +453,83 @@ out CurveVertexData
     vec3 Neye;
 } outData[HD_NUM_PATCH_EVAL_VERTS];
 
-void determineLODSettings();
+void determineLODSettings(FlatCurveVertexData vertexData);
 void main(void)
 {
-    if(gl_InvocationID == 0) {
-	     determineLODSettings();
+    ProcessPrimvarsIn();
+    if (gl_InvocationID == 0) {
+        FlatCurveVertexData vertexData;
+        for (int i = 0; i < gl_MaxPatchVertices; i++) {
+            vertexData.Peye[i] = inData[i].Peye;
+            vertexData.Neye[i] = inData[i].Neye;
+        }
+        determineLODSettings(vertexData);
     }
 
     outData[gl_InvocationID].Peye = inData[gl_InvocationID].Peye;
     outData[gl_InvocationID].Neye = inData[gl_InvocationID].Neye;
 
-    ProcessPrimvarsOut();
+    vec2 coord = gl_TessCoord.xy;
+    vec4 basis = vec4(coord.x, coord.y, 1.0f-coord.x-coord.y, 0.0f);
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessControl.Cubic.Ribbon
+-- glsl Curves.PostTessControl.Cubic.Patch
 
-// Use the length of the control points in screen space to determine how many 
+ void main(void)
+ {
+     FlatCurveVertexData vertexData = PopulatePeyeAndNeye();
+     determineLODSettings(vertexData);
+ }
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.JointTessControl.Cubic.Ribbon
+
+// Use the length of the control points in screen space to determine how many
 // times to subdivide the curve.
-void determineLODSettings()
+void determineLODSettings(FlatCurveVertexData vertexData)
 {
     MAT4 projMat = GetProjectionMatrix();
     vec4 viewport = GetViewport();
     vec2 screen_size = vec2(viewport.z, viewport.w);
-    vec2 v0 = projectToScreen(projMat, inData[0].Peye, screen_size);
-    vec2 v1 = projectToScreen(projMat, inData[1].Peye, screen_size);
-    vec2 v2 = projectToScreen(projMat, inData[2].Peye, screen_size);
-    vec2 v3 = projectToScreen(projMat, inData[3].Peye, screen_size);
+    vec2 v0 = projectToScreen(projMat, vertexData.Peye[0], screen_size);
+    vec2 v1 = projectToScreen(projMat, vertexData.Peye[1], screen_size);
+    vec2 v2 = projectToScreen(projMat, vertexData.Peye[2], screen_size);
+    vec2 v3 = projectToScreen(projMat, vertexData.Peye[3], screen_size);
 
     float maxTess = GetMaxTess();
 
     // Need to handle off screen
     float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
-    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+    float level = clamp(dist / GetPixelToTessRatio(), 0.0f, maxTess);
 
-    gl_TessLevelOuter[0] = level;
-    gl_TessLevelOuter[1] = 1;
-    gl_TessLevelOuter[2] = level;
-    gl_TessLevelOuter[3] = 1;
-
-    gl_TessLevelInner[0] = 1;
-    gl_TessLevelInner[1] = level;
+    SetTessFactors(level, 1.0f, level, 1.0f, 1.0f, level);
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessControl.Cubic.HalfTube
+-- glsl Curves.JointTessControl.Cubic.HalfTube
 
-// Use the width & length of the control points in screen space to determine how 
+// Use the width & length of the control points in screen space to determine how
 // many times to subdivide the curve.  NOTE.  As a quick hack, we leverage the
-// fact that the normal isn't normalized at this point in the pipeline to 
+// fact that the normal isn't normalized at this point in the pipeline to
 // provide a quick estimate of width in eye space.  If that becomes a bad
 // assumption in the future, this needs to be reworked.
-void determineLODSettings()
+void determineLODSettings(FlatCurveVertexData vertexData)
 {
     MAT4 projMat = GetProjectionMatrix();
     vec4 viewport = GetViewport();
     vec2 screen_size = vec2(viewport.z, viewport.w);
-    vec2 v0 = projectToScreen(projMat, inData[0].Peye, screen_size);
-    vec2 v1 = projectToScreen(projMat, inData[1].Peye, screen_size);
-    vec2 v2 = projectToScreen(projMat, inData[2].Peye, screen_size);
-    vec2 v3 = projectToScreen(projMat, inData[3].Peye, screen_size);
+    vec2 v0 = projectToScreen(projMat, vertexData.Peye[0], screen_size);
+    vec2 v1 = projectToScreen(projMat, vertexData.Peye[1], screen_size);
+    vec2 v2 = projectToScreen(projMat, vertexData.Peye[2], screen_size);
+    vec2 v3 = projectToScreen(projMat, vertexData.Peye[3], screen_size);
 
-    // NOTE. We've observed that outData.Neye is not normalized, and 
+    // NOTE. We've observed that outData.Neye is not normalized, and
     // we're using its length as an estimator of the accumulated transform
-    float wEye0 = HdGet_widths(0) * length(inData[0].Neye);
-    float wEye1 = HdGet_widths(1) * length(inData[1].Neye);
-    float wEye2 = HdGet_widths(2) * length(inData[2].Neye);
-    float wEye3 = HdGet_widths(3) * length(inData[3].Neye);
+    float wEye0 = HdGet_widths(0) * length(vertexData.Neye[0]);
+    float wEye1 = HdGet_widths(1) * length(vertexData.Neye[1]);
+    float wEye2 = HdGet_widths(2) * length(vertexData.Neye[2]);
+    float wEye3 = HdGet_widths(3) * length(vertexData.Neye[3]);
 
     // project a point that is 'w' units away from the origin
     vec2 v_w0 = projectToScreen(projMat, vec4(wEye0, 0, 0, 1), screen_size);
@@ -403,20 +543,14 @@ void determineLODSettings()
 
     // Need to handle off screen
     float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
-    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+    float level = clamp(dist / GetPixelToTessRatio(), 0.0f, maxTess);
 
-    float maxWidthScreenSpace = 
+    float maxWidthScreenSpace =
       max(max(max(length(v_w0), length(v_w1)), length(v_w2)), length(v_w3));
 
-    float level_w = clamp(maxWidthScreenSpace / GetPixelToTessRatio() / widthDecimation, 1, maxTess);
+    float level_w = clamp(maxWidthScreenSpace / GetPixelToTessRatio() / widthDecimation, 1.0f, maxTess);
 
-    gl_TessLevelOuter[0] = level;
-    gl_TessLevelOuter[1] = level_w;
-    gl_TessLevelOuter[2] = level;
-    gl_TessLevelOuter[3] = level_w;
-
-    gl_TessLevelInner[0] = level_w;
-    gl_TessLevelInner[1] = level;
+    SetTessFactors(level, level_w, level, level_w, level_w, level);
 }
 
 --- --------------------------------------------------------------------------
@@ -454,10 +588,10 @@ void main()
 
     Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
     vec4 basis = coeffs.basis;
-    vec4 pos = basis[0] * cv0 + 
-         basis[1] * cv1 + 
-         basis[2] * cv2 + 
-         basis[3] * cv3; 
+    vec4 pos = basis[0] * cv0 +
+         basis[1] * cv1 +
+         basis[2] * cv2 +
+         basis[3] * cv3;
 
     outData.Peye = pos;
     gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
@@ -466,6 +600,58 @@ void main()
 
     ProcessPrimvarsOut(basis, 0, 1, 2, 3, vec2(u, v)); // interpolate varying primvars
 }
+
+--- --------------------------------------------------------------------------
+-- layout Curves.PostTessVertex.Cubic.Wire
+
+[
+    ["in", "fractional_odd"],
+    ["out block", "CurveVertexData", "outData",
+        ["vec4", "Peye"],
+        ["vec3", "Neye"]
+    ]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTessVertex.Cubic.Wire
+template <typename T>
+T InterpolatePrimvar(
+        T inPv0, T inPv1, T inPv2, T inPv3, vec4 basis) {
+    return
+            inPv0 * basis[0] +
+            inPv1 * basis[1] +
+            inPv2 * basis[2] +
+            inPv3 * basis[3];
+}
+
+ void main(void)
+ {
+     ProcessPrimvarsIn();
+     MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
+
+     float u = gl_TessCoord.x;
+     float v = .5;
+
+     FlatCurveVertexData vertexData = PopulatePeyeAndNeye();
+     vec4 cv0 = vertexData.Peye[0];
+     vec4 cv1 = vertexData.Peye[1];
+     vec4 cv2 = vertexData.Peye[2];
+     vec4 cv3 = vertexData.Peye[3];
+
+     Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+     vec4 basis = coeffs.basis;
+     vec4 pos = basis[0] * cv0 +
+                basis[1] * cv1 +
+                basis[2] * cv2 +
+                basis[3] * cv3;
+
+     outData.Peye = pos;
+     gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
+
+     ApplyClipPlanes(outData.Peye);
+
+     ProcessPrimvarsOut(basis, 0, 1, 2, 3, vec2(u, v)); // interpolate varying primvars
+ }
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.TessEval.Patch
@@ -499,7 +685,7 @@ out float v;
 FORWARD_DECL(
     void evaluate(float u, float v, REF(thread, vec4) position,
                   REF(thread, vec4) tangent, REF(thread, float) width,
-                  REF(thread, vec3) normal));
+                  REF(thread, vec3) normal), FlatCurveVertexData vertexData);
 FORWARD_DECL(Coeffs evaluateBasis(float u, float u2, float u3));
 
 // it's the responsibility of orient to store Neye, usually with either
@@ -519,7 +705,12 @@ void main()
     float rawWidth;
     vec3 normal;
 
-    evaluate(u, v, position, tangent, rawWidth, normal);
+    FlatCurveVertexData vertexData;
+    for (int i = 0; i < gl_MaxPatchVertices; i++) {
+        vertexData.Peye[i] = inData[i].Peye;
+        vertexData.Neye[i] = inData[i].Neye;
+    }
+    evaluate(u, v, position, tangent, rawWidth, normal, vertexData);
     vec3 direction = orient(v, position, tangent, normal);
     MAT4 transform = ApplyInstanceTransform(HdGet_transform());
 
@@ -530,16 +721,16 @@ void main()
 
 #if defined(HD_HAS_screenSpaceWidths) || defined(HD_HAS_minScreenSpaceWidths)
 
-    // If any screen space width operations are required, compute the 
+    // If any screen space width operations are required, compute the
     // conversion factor from world units to screen pixels at this curve tess
     // position. Critically, this procedure does not rely on the thickening
-    // 'direction' vector, which may point out of the image plane and have 
+    // 'direction' vector, which may point out of the image plane and have
     // zero apparent screen-space length in some circumstances.
     //
     // This procedure is correct for both perspective and ortho cameras. It is a
     // boiled-down x-only expression of the projected pixel length of a
     // hypothetical unit X vector in eye space, and can be derived by writing a
-    // projection matrix transforming (1,0,0,1) and performing the usual 
+    // projection matrix transforming (1,0,0,1) and performing the usual
     // division by w. Since the viewport is 2 NDC units across, we take half the
     // viewportSizeX. The division is by -position.z for perspective projections
     // and by 1 for ortho projections, using entries 2,3 and 3,3 to select
@@ -559,14 +750,14 @@ void main()
 #endif
 
 #ifdef HD_HAS_minScreenSpaceWidths
-    // Compute a world space width that yields, at minimum, the given 
+    // Compute a world space width that yields, at minimum, the given
     // minScreenSpaceWidth interpreted in screen space pixels.
     float minScreenSpaceWidth = HdGet_minScreenSpaceWidths();
     float screenSpaceWidth = worldSpaceWidth * worldToPixelWidth;
     if (screenSpaceWidth < minScreenSpaceWidth) {
         worldSpaceWidth *= minScreenSpaceWidth / screenSpaceWidth;
     }
-#endif 
+#endif
 
 #endif // end screen space operations
 
@@ -583,66 +774,132 @@ void main()
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessEval.Linear.Patch
+-- layout Curves.PostTessVertex.Patch
 
-vec3 evaluateNormal(float u)
+[
+     ["in", "fractional_odd"],
+     ["out block", "CurveVertexData", "outData",
+        ["vec4", "Peye"],
+        ["vec3", "Neye"]
+     ],
+     ["out", "float", "u"],
+     ["out", "float", "v"]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.PostTessVertex.Patch
+
+template <typename T>
+T InterpolatePrimvar(
+        T inPv0, T inPv1, T inPv2, T inPv3, vec4 basis) {
+    return
+            inPv0 * basis[0] +
+            inPv1 * basis[1] +
+            inPv2 * basis[2] +
+            inPv3 * basis[3];
+}
+// Predefine so that we can later swap in the correct one depending
+// on what type of curve we have
+
+template <typename T>
+T bilerp(T c00, T c01, T c10, T c11, float2 uv) {
+ T c0 = mix(c00, c01, T(uv[0]));
+ T c1 = mix(c10, c11, T(uv[0]));
+ return mix(c0, c1, T(uv[1]));
+}
+
+void main(void)
 {
-    // XXX: This clamp is a hack to mask some odd orientation flipping issues 
-    u = clamp(u, 1e-3, 1.0 - 1e-3);
-    return mix(inData[1].Neye, inData[0].Neye, u);
+    u = gl_TessCoord.y;
+    v = gl_TessCoord.x;
+    ProcessPrimvarsIn();
+    MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    vec4 basis = coeffs.basis;
+
+    vec4 position;
+    vec4 tangent;
+    float width;
+    vec3 normal;
+    FlatCurveVertexData vertexData = PopulatePeyeAndNeye();
+    evaluate(u, v, position, tangent, width, normal, vertexData);
+    vec3 direction = orient(v, position, tangent, normal);
+    vec4 scaledDirection = GetWorldToViewMatrix() * transform
+        * vec4(direction, 0);
+    vec3 offset = direction * length(scaledDirection.xyz) * width * 0.5;
+    position.xyz = position.xyz + offset;
+    position.w = 1;
+
+    outData.Peye = position;
+    //TODO verify if this normal population is needed
+    outData.Neye = basis[0] * vertexData.Neye[0] +
+        basis[1] * vertexData.Neye[1] +
+        basis[2] * vertexData.Neye[2] +
+        basis[3] * vertexData.Neye[3];
+
+
+    gl_Position = vec4(GetProjectionMatrix() * outData.Peye);
+    ApplyClipPlanes(outData.Peye);
+
+    int pointId = GetPointId();
+    gl_PointSize = GetPointRasterSize(pointId);
+    ProcessPointId(pointId);
+
+    ProcessPrimvarsOut(basis, 0, 1, 2, 3, vec2(u, v)); // interpolate varying primvars
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Curves.JointTessEval.Linear.Patch
+
+vec3 evaluateNormal(float u, FlatCurveVertexData vertexData)
+{
+    // XXX: This clamp is a hack to mask some odd orientation flipping issues
+    u = clamp(u, 1e-3, 1.0f - 1e-3);
+    return mix(vertexData.Neye[1], vertexData.Neye[0], u);
 }
 
 void evaluate(float u, float v, REF(thread, vec4) position,
-              REF(thread, vec4) tangent, REF(thread, float) width, 
-              REF(thread, vec3) normal) {
-    vec4 p0 = inData[0].Peye;
-    vec4 p1 = inData[1].Peye;
+              REF(thread, vec4) tangent, REF(thread, float) width,
+              REF(thread, vec3) normal, FlatCurveVertexData vertexData) {
 
     float w0 = HdGet_widths(0);
     float w1 = HdGet_widths(1);
 
-    position = mix(p1, p0, u);
-    tangent = normalize(p1 - p0);
+    position = mix(vertexData.Peye[1], vertexData.Peye[0], u);
+    tangent = normalize(vertexData.Peye[1] - vertexData.Peye[0]);
     width = mix(w1, w0, u);
-    normal = normalize(evaluateNormal(u));
+    normal = normalize(evaluateNormal(u, vertexData));
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessEval.Cubic.Patch
-struct Coeffs
-{
-  vec4 basis;
-  vec4 tangent_basis;
-};
+-- glsl Curves.JointTessEval.Cubic.Patch
 
 FORWARD_DECL(Coeffs evaluateBasis(float u, float u2, float u3));
 FORWARD_DECL(float evaluateWidths(vec4 basis, float u));
-FORWARD_DECL(vec3 evaluateNormal(vec4 basis, float u));
+FORWARD_DECL(vec3 evaluateNormal(vec4 basis, float u, FlatCurveVertexData vertexData));
 
 void evaluate(float u, float v, REF(thread, vec4) position,
               REF(thread, vec4) tangent, REF(thread, float) width,
-              REF(thread, vec3) normal) {
-    vec4 p0 = inData[0].Peye;
-    vec4 p1 = inData[1].Peye;
-    vec4 p2 = inData[2].Peye;
-    vec4 p3 = inData[3].Peye;
+              REF(thread, vec3) normal, FlatCurveVertexData vertexData) {
 
     Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
 
-    position = coeffs.basis[0] * p0 +
-               coeffs.basis[1] * p1 +
-               coeffs.basis[2] * p2 +
-               coeffs.basis[3] * p3;
+    position = coeffs.basis[0] * vertexData.Peye[0] +
+               coeffs.basis[1] * vertexData.Peye[1] +
+               coeffs.basis[2] * vertexData.Peye[2] +
+               coeffs.basis[3] * vertexData.Peye[3];
 
-    tangent = coeffs.tangent_basis[0] * p0 + 
-              coeffs.tangent_basis[1] * p1 +
-              coeffs.tangent_basis[2] * p2 + 
-              coeffs.tangent_basis[3] * p3;
+    tangent = coeffs.tangent_basis[0] * vertexData.Peye[0] +
+              coeffs.tangent_basis[1] * vertexData.Peye[1] +
+              coeffs.tangent_basis[2] * vertexData.Peye[2] +
+              coeffs.tangent_basis[3] * vertexData.Peye[3];
 
     width = evaluateWidths(coeffs.basis, u);
-    normal = normalize(evaluateNormal(coeffs.basis, u));
+    normal = normalize(evaluateNormal(coeffs.basis, u, vertexData));
     tangent = normalize(tangent);
 }
+
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.TessEval.HalfTube
@@ -659,55 +916,54 @@ vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal){
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessEval.Ribbon.Oriented
+-- glsl Curves.Ribbon.Oriented
 
 vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal){
     outData.Neye = normal;
-    return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
+    return InvertNormalIfNeeded(normalize(cross(tangent.xyz, normal)  * (v - 0.5)));
 }
 
 --- --------------------------------------------------------------------------
--- glsl Curves.TessEval.Ribbon.Implicit
+-- glsl Curves.Ribbon.Implicit
 
 vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal){
     outData.Neye = tangent.xyz;
     // NOTE: lava/lib/basisCurves currently uses tangent X position instead of
     // tangent X normal. We should do a more thorough evaluation to see which
-    // is better but to minimize regressions, we're going to keep this as 
+    // is better but to minimize regressions, we're going to keep this as
     // tangent X normal for now.
     return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
 }
 
-
 --- --------------------------------------------------------------------------
 -- glsl Curves.Cubic.Normals.Basis
 
-vec3 evaluateNormal(vec4 basis, float u)
-{   
-    vec3 n0 = inData[0].Neye;
-    vec3 n1 = inData[1].Neye;
-    vec3 n2 = inData[2].Neye;
-    vec3 n3 = inData[3].Neye;
-    return n0 * basis.x 
+vec3 evaluateNormal(vec4 basis, float u, FlatCurveVertexData vertexData)
+{
+    vec3 n0 = vertexData.Neye[0];
+    vec3 n1 = vertexData.Neye[1];
+    vec3 n2 = vertexData.Neye[2];
+    vec3 n3 = vertexData.Neye[3];
+    return n0 * basis.x
          + n1 * basis.y
-         + n2 * basis.z 
+         + n2 * basis.z
          + n3 * basis.w;
 }
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.Cubic.Normals.Linear
 
-// HdSt only supports vertex (cubic) primvar indexes and expands varying 
+// HdSt only supports vertex (cubic) primvar indexes and expands varying
 // (linear) primvars so we pull the data out of only the two interior indices.
-// This may not be valid for all potential basis, but works well for curves with 
+// This may not be valid for all potential basis, but works well for curves with
 // vstep = 1 and bezier, the only supported cubic curves in HdSt.
 
-vec3 evaluateNormal(vec4 basis, float u)
-{   
-    // XXX: This clamp is a hack to mask some odd orientation flipping issues 
+vec3 evaluateNormal(vec4 basis, float u, FlatCurveVertexData vertexData)
+{
+    // XXX: This clamp is a hack to mask some odd orientation flipping issues
     // for oriented bezier curves.
-    u = clamp(u, 1e-3, 1.0 - 1e-3);
-    return mix(inData[2].Neye, inData[1].Neye, u);
+    u = clamp(u, 1e-3, 1.0f - 1e-3);
+    return mix(vertexData.Neye[2], vertexData.Neye[1], u);
 }
 
 --- --------------------------------------------------------------------------
@@ -719,19 +975,19 @@ float evaluateWidths(vec4 basis, float u)
     float w1 = HdGet_widths(1);
     float w2 = HdGet_widths(2);
     float w3 = HdGet_widths(3);
-    return w0 * basis.x 
+    return w0 * basis.x
          + w1 * basis.y
-         + w2 * basis.z 
+         + w2 * basis.z
          + w3 * basis.w;
 }
 
 --- --------------------------------------------------------------------------
 -- glsl Curves.Cubic.Widths.Linear
 
-// HdSt only supports vertex (cubic) primvar indexes and expands varying 
+// HdSt only supports vertex (cubic) primvar indexes and expands varying
 // (linear) primvars so we pull the data out of only the two interior indices.
 // (ie. w0 -> widths[1], w1 -> widths[2])
-// This may not be valid for all potential basis, but works well for curves with 
+// This may not be valid for all potential basis, but works well for curves with
 // vstep = 1 and bezier, the only supported cubic curves in HdSt.
 float evaluateWidths(vec4 basis, float u)
 {
@@ -743,37 +999,37 @@ float evaluateWidths(vec4 basis, float u)
 --- --------------------------------------------------------------------------
 -- glsl Curves.Linear.VaryingInterpolation
 
-float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3, 
+float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3,
                          vec4 basis, vec2 uv)
-{   
-    return inPv0 * basis.x + 
+{
+    return inPv0 * basis.x +
            inPv1 * basis.y +
            inPv2 * basis.z +
            inPv3 * basis.w;
 }
 
-vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3, 
+vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return inPv0 * basis.x + 
+{
+    return inPv0 * basis.x +
            inPv1 * basis.y +
            inPv2 * basis.z +
            inPv3 * basis.w;
 }
 
-vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3, 
+vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return inPv0 * basis.x + 
+{
+    return inPv0 * basis.x +
            inPv1 * basis.y +
            inPv2 * basis.z +
            inPv3 * basis.w;
 }
 
-vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3, 
+vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return inPv0 * basis.x + 
+{
+    return inPv0 * basis.x +
            inPv1 * basis.y +
            inPv2 * basis.z +
            inPv3 * basis.w;
@@ -782,27 +1038,27 @@ vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3,
 --- --------------------------------------------------------------------------
 -- glsl Curves.Cubic.VaryingInterpolation
 
-float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3, 
+float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3,
                          vec4 basis, vec2 uv)
-{   
+{
     return mix(inPv2, inPv1, uv.x);
 }
 
-vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3, 
+vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3,
                         vec4 basis, vec2 uv)
-{   
+{
     return mix(inPv2, inPv1, uv.x);
 }
 
-vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3, 
+vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3,
                         vec4 basis, vec2 uv)
-{   
+{
     return mix(inPv2, inPv1, uv.x);
 }
 
-vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3, 
+vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3,
                         vec4 basis, vec2 uv)
-{   
+{
     return mix(inPv2, inPv1, uv.x);
 }
 
@@ -821,7 +1077,8 @@ Coeffs evaluateBasis(float u, float u2, float u3)
   tangent_basis[1] = -9.0*u2 + 6.0*u;
   tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
   tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
-  return Coeffs(basis, tangent_basis);
+  Coeffs coeffs = {basis, tangent_basis};
+  return coeffs;
 }
 
 --- --------------------------------------------------------------------------
@@ -839,7 +1096,8 @@ Coeffs evaluateBasis(float u, float u2, float u3)
   tangent_basis[1] = -1;
   tangent_basis[2] = 0;
   tangent_basis[3] = 0;
-  return Coeffs(basis, tangent_basis);
+  Coeffs coeffs = {basis, tangent_basis};
+  return coeffs;
 }
 
 --- --------------------------------------------------------------------------
@@ -857,7 +1115,8 @@ Coeffs evaluateBasis(float u, float u2, float u3)
   tangent_basis[1] = -4.5*u2 + 4.0*u + 0.5;
   tangent_basis[2] = 4.5*u2 - 5.0*u;
   tangent_basis[3] = -1.5*u2 + 2.0*u - 0.5;
-  return Coeffs(basis, tangent_basis);
+  Coeffs coeffs = {basis, tangent_basis};
+  return coeffs;
 }
 
 --- --------------------------------------------------------------------------
@@ -875,7 +1134,8 @@ Coeffs evaluateBasis(float u, float u2, float u3)
   tangent_basis[1] = -1.5*u2 + u + 0.5;
   tangent_basis[2] = 1.5*u2 - 2.0*u;
   tangent_basis[3] = -0.5*u2 + u - 0.5;
-  return Coeffs(basis, tangent_basis);
+  Coeffs coeffs = {basis, tangent_basis};
+  return coeffs;
 }
 
 --- --------------------------------------------------------------------------
@@ -893,7 +1153,7 @@ Coeffs evaluateBasis(float u, float u2, float u3)
 void main(void)
 {
     DiscardBasedOnTopologicalVisibility();
-    
+
     vec4 color = vec4(0.5, 0.5, 0.5, 1);
 #ifdef HD_HAS_displayColor
     color.rgb = HdGet_displayColor().rgb;
@@ -915,7 +1175,7 @@ void main(void)
                     ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord).rgb,
                     GetLightingBlendAmount());
 
-#ifdef HD_MATERIAL_TAG_MASKED   
+#ifdef HD_MATERIAL_TAG_MASKED
     if (ShouldDiscardByAlpha(color)) {
         discard;
     }
@@ -925,18 +1185,19 @@ void main(void)
 }
 
 --- --------------------------------------------------------------------------
+-- layout Curves.Fragment.Patch
+
+[
+    ["in block", "CurveVertexData", "inData",
+        ["vec4", "Peye"],
+        ["vec3", "Neye"]
+    ],
+    ["in","float", "u"],
+    ["in","float", "v"]
+]
+
+--- --------------------------------------------------------------------------
 -- glsl Curves.Fragment.Patch
-
-/// In the previous stage, we may have stored the tangent in Neye from which
-/// we plan to compute a normal in the fragment shader.
-in CurveVertexData
-{
-    vec4 Peye;
-    vec3 Neye;
-} inData;
-
-centroid in float u;
-centroid in float v;
 
 FORWARD_DECL(vec3 fragmentNormal(vec3 position, vec3 normal, float v));
 void main(void)
@@ -957,16 +1218,15 @@ void main(void)
     vec3 Neye = fragmentNormal(Peye, inData.Neye, v);
 
     vec4 patchCoord = vec4(0);
-    color.rgb = mix(color.rgb, 
+    color.rgb = mix(color.rgb,
                     ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord).rgb,
                     GetLightingBlendAmount());
 
-#ifdef HD_MATERIAL_TAG_MASKED   
+#ifdef HD_MATERIAL_TAG_MASKED
     if (ShouldDiscardByAlpha(color)) {
         discard;
     }
 #endif
-
     RenderOutput(vec4(Peye, 1), Neye, color, patchCoord);
 }
 
@@ -986,15 +1246,15 @@ vec3 fragmentNormal(in vec3 position, in vec3 tangent, in float v)
 -- glsl Curves.Fragment.Ribbon.Round
 
 float remapFragmentV(float v){
-    // As we are using a plane to approximate a tube, we don't want to shade 
+    // As we are using a plane to approximate a tube, we don't want to shade
     // based on v but rather the projection of the tube's v onto the plane
-    return clamp((asin(v * 2.0 - 1.0) / (3.146 / 2.0) + 1.0) / 2.0, 0.0, 1.0);
+    return clamp((asin(v * 2.0f - 1.0f) / (3.146 / 2.0f) + 1.0f) / 2.0f, 0.0f, 1.0f);
 }
 
 vec3 fragmentNormal(vec3 position, in vec3 tangent, float v)
 {
 
-    // we slightly bias v towards 0.5 based on filterwidth as a hack to 
+    // we slightly bias v towards 0.5 based on filterwidth as a hack to
     // minimize aliasing
     v = mix(remapFragmentV(v), 0.5, min(fwidth(v), .2));
 

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -603,6 +603,19 @@ void main(void)
 }
 
 --- --------------------------------------------------------------------------
+-- glsl Mesh.PostTessVertex.VaryingInterpolation
+
+template <typename T>
+T InterpolatePrimvar(
+T inPv0, T inPv1, T inPv2, T inPv3, vec4 basis, vec2 uv = vec2()) {
+    return
+    inPv0 * basis[0] +
+    inPv1 * basis[1] +
+    inPv2 * basis[2] +
+    inPv3 * basis[3];
+}
+
+--- --------------------------------------------------------------------------
 -- glsl Mesh.TessEval.VaryingInterpolation
 
 float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3, 

--- a/pxr/imaging/hdSt/shaders/renderPassShader.glslfx
+++ b/pxr/imaging/hdSt/shaders/renderPassShader.glslfx
@@ -41,6 +41,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader": {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdSt/tokens.h
+++ b/pxr/imaging/hdSt/tokens.h
@@ -69,6 +69,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (fvarIndices)                               \
     (fvarPatchParam)                            \
     (coarseFaceIndex)                           \
+    (tessFactors)                               \
     (processedFaceCounts)                       \
     (processedFaceIndices)                      \
     (geomSubsetFaceIndices)                     \

--- a/pxr/imaging/hdx/shaders/renderPassColorAndSelectionShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorAndSelectionShader.glslfx
@@ -45,6 +45,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassColorShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorShader.glslfx
@@ -43,6 +43,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassColorWithOccludedSelectionShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorWithOccludedSelectionShader.glslfx
@@ -45,6 +45,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassIdShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassIdShader.glslfx
@@ -42,6 +42,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassOitOpaqueShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitOpaqueShader.glslfx
@@ -43,6 +43,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassOitShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitShader.glslfx
@@ -43,6 +43,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassOitVolumeShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitVolumeShader.glslfx
@@ -43,6 +43,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
@@ -42,6 +42,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hdx/shaders/renderPassShadowShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassShadowShader.glslfx
@@ -42,6 +42,10 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera",
+                    "RenderPass.ApplyClipPlanes" ]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -395,6 +395,7 @@ enum HgiBindResourceType
     HgiBindResourceTypeStorageImage,
     HgiBindResourceTypeUniformBuffer,
     HgiBindResourceTypeStorageBuffer,
+    HgiBindResourceTypeTessFactors,
 
     HgiBindResourceTypeCount
 };
@@ -756,6 +757,31 @@ enum HgiShaderTextureType
     HgiShaderTextureTypeShadowTexture,
     HgiShaderTextureTypeArrayTexture
 };
+
+ /// \enum HgiTessellationSpacing
+ ///
+ /// Describes the type of shader tessellation spacing to use
+ ///
+ /// <ul>
+ /// <li>None:
+ ///   No tessellation spacing</li>
+ /// <li>Even:
+ ///   Even spacing. Only whole integers are considered for spacing</li>
+ /// <li>FractionalOdd:
+ ///   Fractional odd tessellation spacing</li>
+ /// <li>FractionalEven:
+ ///   Fractional even tessellation spacing</li>
+ /// </ul>
+ ///
+ enum HgiTessellationSpacing
+ {
+     HgiTessellationSpacingNone = 0,
+     HgiTessellationSpacingEven,
+     HgiTessellationSpacingFractionalOdd,
+     HgiTessellationSpacingFractionalEven
+ };
+
+typedef bool HgiState;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hgi/graphicsPipeline.h
+++ b/pxr/imaging/hgi/graphicsPipeline.h
@@ -358,6 +358,10 @@ struct HgiTessellationLevel
 ///   The type of tessellation patch.</li>
 /// <li>primitiveIndexSize:
 ///   The number of control indices per patch.</li>
+/// <li>useConstantTessFactors:
+///   Indicates if we are using constant tess factors</li>
+/// <li>isPostTessControl:
+///   Indicates that we are going to execute a post tess control tessellation phase in this pipeline</li>
 /// <li>tessellationLevel:
 ///   The fallback tessellation levels.</li>
 /// </ul>
@@ -366,7 +370,8 @@ struct HgiTessellationState
 {
     enum PatchType {
         Triangle,
-        Quad
+        Quad,
+        Isoline
     };
 
     HGI_API
@@ -374,6 +379,8 @@ struct HgiTessellationState
 
     PatchType patchType;
     int primitiveIndexSize;
+    bool useConstantTessFactors;
+    bool isPostTessControl = false;
     HgiTessellationLevel tessellationLevel;
 };
 

--- a/pxr/imaging/hgi/resourceBindings.cpp
+++ b/pxr/imaging/hgi/resourceBindings.cpp
@@ -40,7 +40,8 @@ HgiResourceBindings::GetDescriptor() const
 
 HgiBufferBindDesc::HgiBufferBindDesc()
     : bindingIndex(0)
-    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex)
+    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex |
+        HgiShaderStagePostTessellationControl)
 {
 }
 

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -147,6 +147,8 @@ bool operator!=(
 ///   Optionally specify an index for interstage parameters.</li>
 /// <li>interpolation:
 ///   Optionally specify the interpolation: Default, Flat or NoPerspective.</li>
+/// <li>samplingFlag:
+///   Optionally specify multiple sampling flags, centroid and or sample </li>
 /// <li>role:
 ///   Optionally a role can be specified, like position, uv, color.</li>
 /// <li>arraySize:
@@ -155,6 +157,11 @@ bool operator!=(
 ///
 struct HgiShaderFunctionParamDesc
 {
+    enum SamplingFlag: uint32_t {
+        Centroid = 1,
+        Sample = 2
+    };
+    
     HGI_API
     HgiShaderFunctionParamDesc();
 
@@ -163,6 +170,7 @@ struct HgiShaderFunctionParamDesc
     int32_t location;
     int32_t interstageSlot;
     HgiInterpolationType interpolation;
+    SamplingFlag samplingFlag;
     std::string role;
     std::string arraySize;
 };
@@ -280,6 +288,8 @@ bool operator!=(
 /// <ul>
 /// <li>patchType:
 ///   The type of patch</li>
+/// <li>spacing
+///   The spacing mode of tessellation</li>
 /// <li>numVertsInPerPatch:
 ///   The number of vertices in per patch</li>
 /// <li>numVertsOutPerPatch:
@@ -288,11 +298,12 @@ bool operator!=(
 ///
 struct HgiShaderFunctionTessellationDesc
 {
-    enum class PatchType { Quad, Triangle };
+    enum class PatchType { Quad, Triangle, Isoline };
     HGI_API
     HgiShaderFunctionTessellationDesc();
 
     PatchType patchType = PatchType::Triangle;
+    HgiTessellationSpacing spacing;
     uint32_t numVertsPerPatchIn = 3;
     uint32_t numVertsPerPatchOut = 3;
 };

--- a/pxr/imaging/hgi/shaderGenerator.cpp
+++ b/pxr/imaging/hgi/shaderGenerator.cpp
@@ -31,7 +31,8 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 HgiShaderGenerator::HgiShaderGenerator(const HgiShaderFunctionDesc &descriptor)
-    : _descriptor(descriptor)
+    : _descriptor(descriptor),
+      _stage(descriptor.shaderStage)
 {
 }
 

--- a/pxr/imaging/hgi/shaderGenerator.h
+++ b/pxr/imaging/hgi/shaderGenerator.h
@@ -74,6 +74,9 @@ protected:
     HGI_API
     HgiShaderStage _GetShaderStage() const;
 
+protected:
+    const HgiShaderStage _stage;
+
 private:
     const HgiShaderFunctionDesc &_descriptor;
 

--- a/pxr/imaging/hgi/shaderProgram.h
+++ b/pxr/imaging/hgi/shaderProgram.h
@@ -98,6 +98,11 @@ public:
     /// Returns the shader functions that are part of this program.
     HGI_API
     virtual HgiShaderFunctionHandleVector const& GetShaderFunctions() const = 0;
+    
+    /// Returns the shader based on shaderStage if it exists
+    HGI_API
+    virtual HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const = 0;
 
     /// Returns the byte size of the GPU shader program.
     /// APIs that do not have programs can return the combined byte size of the

--- a/pxr/imaging/hgiGL/shaderGenerator.cpp
+++ b/pxr/imaging/hgiGL/shaderGenerator.cpp
@@ -370,15 +370,18 @@ HgiGLShaderGenerator::_WriteInOuts(
             // For interstage parameters use the interstageSlot for location.
             attrs.push_back({"location", std::to_string(param.interstageSlot)});
         }
-
-        CreateShaderSection<HgiGLMemberShaderSection>(
-            paramName,
-            param.type,
-            param.interpolation,
-            attrs,
-            qualifier,
-            std::string(),
-            param.arraySize);
+        
+        std::unique_ptr<HgiGLMemberShaderSection> p =
+            std::make_unique<HgiGLMemberShaderSection>(paramName,
+                                          param.type,
+                                          param.interpolation,
+                                          attrs,
+                                          qualifier,
+                                          std::string(),
+                                          param.arraySize);
+        HgiGLMemberShaderSection * const result = p.get();
+        result->SetSamplingFlags(param.samplingFlag);
+        GetShaderSections()->push_back(std::move(p));
     }
 }
 

--- a/pxr/imaging/hgiGL/shaderProgram.cpp
+++ b/pxr/imaging/hgiGL/shaderProgram.cpp
@@ -90,6 +90,18 @@ HgiGLShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiGLShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    const HgiShaderFunctionHandle handle = HgiShaderFunctionHandle();
+    return handle;
+}
+
 bool
 HgiGLShaderProgram::IsValid() const
 {

--- a/pxr/imaging/hgiGL/shaderProgram.h
+++ b/pxr/imaging/hgiGL/shaderProgram.h
@@ -55,6 +55,10 @@ public:
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const override;
 
     HGIGL_API
+    HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const override;
+
+    HGIGL_API
     size_t GetByteSizeOfResource() const override;
 
     HGIGL_API

--- a/pxr/imaging/hgiGL/shaderSection.cpp
+++ b/pxr/imaging/hgiGL/shaderSection.cpp
@@ -170,6 +170,15 @@ HgiGLMemberShaderSection::VisitGlobalMemberDeclarations(std::ostream &ss)
         ss << "noperspective ";
         break;
     }
+    
+    if ((_samplingFlags & HgiShaderFunctionParamDesc::Centroid) != 0) {
+        ss << "centroid ";
+    }
+    
+    if ((_samplingFlags & HgiShaderFunctionParamDesc::Sample) != 0) {
+        ss << "sample ";
+    }
+    
     WriteDeclaration(ss);
     return true;
 }
@@ -178,6 +187,11 @@ void
 HgiGLMemberShaderSection::WriteType(std::ostream& ss) const
 {
     ss << _typeName;
+}
+
+void HgiGLMemberShaderSection::SetSamplingFlags(
+    HgiShaderFunctionParamDesc::SamplingFlag samplingFlags) {
+    _samplingFlags = samplingFlags;
 }
 
 HgiGLBlockShaderSection::HgiGLBlockShaderSection(

--- a/pxr/imaging/hgiGL/shaderSection.h
+++ b/pxr/imaging/hgiGL/shaderSection.h
@@ -136,6 +136,9 @@ public:
 
     HGIGL_API
     void WriteType(std::ostream& ss) const override;
+    
+    HGIGL_API
+    void SetSamplingFlags(HgiShaderFunctionParamDesc::SamplingFlag samplingFlags);
 
 private:
     HgiGLMemberShaderSection() = delete;
@@ -145,6 +148,7 @@ private:
 
     std::string _typeName;
     HgiInterpolationType _interpolation;
+    HgiShaderFunctionParamDesc::SamplingFlag _samplingFlags;
 };
 
 /// \class HgiGLBlockShaderSection

--- a/pxr/imaging/hgiMetal/conversions.mm
+++ b/pxr/imaging/hgiMetal/conversions.mm
@@ -425,9 +425,9 @@ struct {
     {HgiPrimitiveTypeLineList,     MTLPrimitiveTopologyClassLine},
     {HgiPrimitiveTypeLineStrip,    MTLPrimitiveTopologyClassLine},
     {HgiPrimitiveTypeTriangleList, MTLPrimitiveTopologyClassTriangle},
-    {HgiPrimitiveTypePatchList,    MTLPrimitiveTopologyClassUnspecified},
+    {HgiPrimitiveTypePatchList,    MTLPrimitiveTopologyClassTriangle},
     {HgiPrimitiveTypeLineListWithAdjacency,
-                                MTLPrimitiveTopologyClassUnspecified}
+                                   MTLPrimitiveTopologyClassTriangle}
 };
 
 struct {
@@ -441,7 +441,7 @@ struct {
     {HgiPrimitiveTypeTriangleList, MTLPrimitiveTypeTriangle},
     {HgiPrimitiveTypePatchList,    MTLPrimitiveTypeTriangle /*Invalid*/},
     {HgiPrimitiveTypeLineListWithAdjacency,
-                                MTLPrimitiveTypeTriangle /*Invalid*/}
+                                   MTLPrimitiveTypeTriangle /*Invalid*/}
 };
 
 MTLPixelFormat

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -157,6 +157,10 @@ private:
         HgiMetalGraphicsPipeline* graphicsPipeline;
         id<MTLBuffer> argumentBuffer;
         HgiVertexBufferBindingVector vertexBindings;
+        bool bindPTCS = false;
+        HgiBufferHandle tessFactorBuffer;
+        uint32_t tessFactorOffset = 0;
+        uint32_t tessFactorStride = 0;
     } _CachedEncState;
     
     HgiMetal* _hgi;
@@ -173,6 +177,7 @@ private:
     bool _scissorRectSet;
     bool _enableParallelEncoder;
     bool _primitiveTypeChanged;
+    bool _bindPTCS;
     uint32 _maxNumEncoders;
     HgiMetalStepFunctions _stepFunctions;
 };

--- a/pxr/imaging/hgiMetal/graphicsPipeline.mm
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.mm
@@ -23,6 +23,7 @@
 //
 
 #include "pxr/imaging/hgiMetal/hgi.h"
+#include "pxr/imaging/hgiMetal/buffer.h"
 #include "pxr/imaging/hgiMetal/conversions.h"
 #include "pxr/imaging/hgiMetal/diagnostic.h"
 #include "pxr/imaging/hgiMetal/graphicsPipeline.h"
@@ -43,8 +44,7 @@ HgiMetalGraphicsPipeline::HgiMetalGraphicsPipeline(
     , _vertexDescriptor(nil)
     , _depthStencilState(nil)
     , _renderPipelineState(nil)
-    , _constantTessFactors(nil)
-{
+    , _constantTessFactors(nil) {
     _CreateVertexDescriptor();
     _CreateDepthStencilState(hgi);
     _CreateRenderPipelineState(hgi);
@@ -123,17 +123,25 @@ HgiMetalGraphicsPipeline::_CreateRenderPipelineState(HgiMetal *hgi)
 
     // Create a new render pipeline state object
     HGIMETAL_DEBUG_LABEL(stateDesc, _descriptor.debugName.c_str());
-    stateDesc.rasterSampleCount = _descriptor.multiSampleState.sampleCount;
 
     stateDesc.inputPrimitiveTopology =
         HgiMetalConversions::GetPrimitiveClass(_descriptor.primitiveType);
 
+
+
     HgiMetalShaderProgram const *metalProgram =
         static_cast<HgiMetalShaderProgram*>(_descriptor.shaderProgram.Get());
-
-    if (_descriptor.primitiveType == HgiPrimitiveTypePatchList) {
-        stateDesc.vertexFunction = metalProgram->GetPostTessVertexFunction();
-
+    auto tessVertexFunc = metalProgram->GetPostTessVertexFunction();
+    if (_descriptor.primitiveType == HgiPrimitiveTypePatchList
+        || tessVertexFunc != nullptr
+        || _descriptor.tessellationState.isPostTessControl) {
+        stateDesc.vertexFunction = _descriptor.tessellationState.isPostTessControl ?
+            metalProgram->GetPostTessControlFunction() :
+            metalProgram->GetPostTessVertexFunction();
+        if (stateDesc.inputPrimitiveTopology
+                == MTLPrimitiveTopologyClassLine) {
+            stateDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassTriangle;
+        }
         MTLWinding winding = HgiMetalConversions::GetWinding(
             _descriptor.rasterizationState.winding);
         //flip the tess winding
@@ -143,10 +151,53 @@ HgiMetalGraphicsPipeline::_CreateRenderPipelineState(HgiMetal *hgi)
 
         stateDesc.tessellationControlPointIndexType =
             MTLTessellationControlPointIndexTypeUInt32;
+        bool useConstantStepFunction =
+            (static_cast<HgiMetalShaderProgram*>(
+            _descriptor.shaderProgram.Get())
+            ->GetPostTessControlFunction() == nullptr) ||
+        _descriptor.tessellationState.isPostTessControl;
+        stateDesc.tessellationFactorStepFunction =
+            useConstantStepFunction ?
+            MTLTessellationFactorStepFunctionConstant :
+            MTLTessellationFactorStepFunctionPerPatch;
+        stateDesc.tessellationFactorScaleEnabled = NO;
+        HgiShaderFunctionHandle tessFunc =
+            metalProgram->GetShaderFunction(
+                HgiShaderStagePostTessellationVertex);
+        if (tessFunc) {
+            switch (tessFunc->GetDescriptor().tessellationDescriptor.spacing) {
+                 //default to integer
+               case HgiTessellationSpacingNone:
+               case HgiTessellationSpacingEven:
+                   stateDesc.tessellationPartitionMode =
+                       MTLTessellationPartitionModeInteger;
+                   break;
+               case HgiTessellationSpacingFractionalOdd:
+                   stateDesc.tessellationPartitionMode =
+                       MTLTessellationPartitionModeFractionalOdd;
+                 break;
+               case HgiTessellationSpacingFractionalEven:
+                   stateDesc.tessellationPartitionMode =
+                       MTLTessellationPartitionModeFractionalEven;
+                 break;
+               default:
+                   stateDesc.tessellationPartitionMode =
+                       MTLTessellationPartitionModeInteger;
+                 break;
+            }
+        }
+        if (_descriptor.tessellationState.isPostTessControl) {
+            stateDesc.tessellationPartitionMode = MTLTessellationPartitionModePow2;
+        }
+        if (_descriptor.tessellationState.patchType == HgiTessellationState::Isoline) {
+             _descriptor.rasterizationState.polygonMode = HgiPolygonModeLine;
+         }
     } else {
         stateDesc.vertexFunction = metalProgram->GetVertexFunction();
     }
     
+    stateDesc.rasterSampleCount = _descriptor.multiSampleState.sampleCount;
+    stateDesc.sampleCount = _descriptor.multiSampleState.sampleCount;
     id<MTLFunction> fragFunction = metalProgram->GetFragmentFunction();
     if (fragFunction && _descriptor.rasterizationState.rasterizerEnabled) {
         stateDesc.fragmentFunction = fragFunction;
@@ -211,7 +262,6 @@ HgiMetalGraphicsPipeline::_CreateRenderPipelineState(HgiMetal *hgi)
         stateDesc.stencilAttachmentPixelFormat = depthPixelFormat;
     }
 
-    stateDesc.sampleCount = _descriptor.multiSampleState.sampleCount;
     if (_descriptor.multiSampleState.alphaToCoverageEnable) {
         stateDesc.alphaToCoverageEnabled = YES;
     } else {
@@ -238,6 +288,7 @@ HgiMetalGraphicsPipeline::_CreateRenderPipelineState(HgiMetal *hgi)
             [err UTF8String]);
     }
 }
+
 
 static MTLStencilDescriptor *
 _CreateStencilDescriptor(HgiStencilState const & stencilState)
@@ -343,9 +394,11 @@ HgiMetalGraphicsPipeline::BindPipeline(id<MTLRenderCommandEncoder> renderEncoder
                                    options:MTLResourceStorageModeShared];
             }
         }
+
         [renderEncoder setTessellationFactorBuffer:_constantTessFactors
                                             offset: 0
                                     instanceStride: 0];
+
     }
 
     //

--- a/pxr/imaging/hgiMetal/resourceBindings.mm
+++ b/pxr/imaging/hgiMetal/resourceBindings.mm
@@ -151,26 +151,31 @@ HgiMetalResourceBindings::BindResources(
         
         id<MTLBuffer> bufferId = metalbuffer->GetBufferId();
         NSUInteger offset = bufDesc.offsets.front();
-
-        if ((bufDesc.stageUsage & HgiShaderStageVertex) ||
-            (bufDesc.stageUsage & HgiShaderStagePostTessellationVertex)) {
-            NSUInteger argBufferOffset = HgiMetalArgumentOffsetBufferVS
-                                       + bufDesc.bindingIndex * sizeof(void*);
-            [argEncoderBuffer setArgumentBuffer:argBuffer
-                                         offset:argBufferOffset];
-            [argEncoderBuffer setBuffer:bufferId offset:offset atIndex:0];
-        }
         
-        if (bufDesc.stageUsage & HgiShaderStageFragment) {
-            NSUInteger argBufferOffset = HgiMetalArgumentOffsetBufferFS
-                                       + bufDesc.bindingIndex * sizeof(void*);
-            [argEncoderBuffer setArgumentBuffer:argBuffer
-                                         offset:argBufferOffset];
-            [argEncoderBuffer setBuffer:bufferId offset:offset atIndex:0];
-        }
+        if (bufDesc.resourceType == HgiBindResourceTypeTessFactors) {
+            [renderEncoder setTessellationFactorBuffer:bufferId offset:offset instanceStride:0];
+        } else {
+            if ((bufDesc.stageUsage & HgiShaderStageVertex) ||
+                (bufDesc.stageUsage & HgiShaderStagePostTessellationVertex) ||
+                (bufDesc.stageUsage & HgiShaderStagePostTessellationControl)) {
+                NSUInteger argBufferOffset = HgiMetalArgumentOffsetBufferVS
+                                           + bufDesc.bindingIndex * sizeof(void*);
+                [argEncoderBuffer setArgumentBuffer:argBuffer
+                                             offset:argBufferOffset];
+                [argEncoderBuffer setBuffer:bufferId offset:offset atIndex:0];
+            }
+            
+            if (bufDesc.stageUsage & HgiShaderStageFragment) {
+                NSUInteger argBufferOffset = HgiMetalArgumentOffsetBufferFS
+                                           + bufDesc.bindingIndex * sizeof(void*);
+                [argEncoderBuffer setArgumentBuffer:argBuffer
+                                             offset:argBufferOffset];
+                [argEncoderBuffer setBuffer:bufferId offset:offset atIndex:0];
+            }
 
-        [renderEncoder useResource:bufferId
-                             usage:(MTLResourceUsageRead | MTLResourceUsageWrite)];
+            [renderEncoder useResource:bufferId
+                                 usage:(MTLResourceUsageRead | MTLResourceUsageWrite)];
+        }
     }
     
 

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -69,6 +69,8 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         NSString *entryPoint = nullptr;
         switch (_descriptor.shaderStage) {
             case HgiShaderStageVertex:
+            case HgiShaderStagePostTessellationVertex:
+            case HgiShaderStagePostTessellationControl:
                 entryPoint = @"vertexEntryPoint";
                 break;
             case HgiShaderStageFragment:
@@ -77,15 +79,13 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             case HgiShaderStageCompute:
                 entryPoint = @"computeEntryPoint";
                 break;
-            case HgiShaderStagePostTessellationVertex:
-                entryPoint = @"vertexEntryPoint";
-                break;
             case HgiShaderStageTessellationControl:
             case HgiShaderStageTessellationEval:
             case HgiShaderStageGeometry:
                 TF_CODING_ERROR("Todo: Unsupported shader stage");
                 break;
         }
+
 
         // Load the function into the library
         _shaderId = [library newFunctionWithName:entryPoint];

--- a/pxr/imaging/hgiMetal/shaderProgram.h
+++ b/pxr/imaging/hgiMetal/shaderProgram.h
@@ -56,6 +56,10 @@ public:
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const override;
 
     HGIMETAL_API
+    HgiShaderFunctionHandle const
+        GetShaderFunction(HgiShaderStage shaderStage) const override;
+
+    HGIMETAL_API
     size_t GetByteSizeOfResource() const override;
 
     HGIMETAL_API

--- a/pxr/imaging/hgiMetal/shaderProgram.mm
+++ b/pxr/imaging/hgiMetal/shaderProgram.mm
@@ -67,6 +67,18 @@ HgiMetalShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiMetalShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    const HgiShaderFunctionHandle handle = HgiShaderFunctionHandle();
+    return handle;
+}
+
 bool
 HgiMetalShaderProgram::IsValid() const
 {

--- a/pxr/imaging/hgiVulkan/shaderProgram.cpp
+++ b/pxr/imaging/hgiVulkan/shaderProgram.cpp
@@ -71,6 +71,18 @@ HgiVulkanShaderProgram::GetShaderFunctions() const
     return _descriptor.shaderFunctions;
 }
 
+HgiShaderFunctionHandle const
+HgiVulkanShaderProgram::GetShaderFunction(HgiShaderStage shaderStage) const
+{
+    for (const HgiShaderFunctionHandle &handle : _descriptor.shaderFunctions) {
+        if (handle->GetDescriptor().shaderStage == shaderStage) {
+            return handle;
+        }
+    }
+    const HgiShaderFunctionHandle handle = HgiShaderFunctionHandle();
+    return handle;
+}
+
 HgiVulkanDevice*
 HgiVulkanShaderProgram::GetDevice() const
 {

--- a/pxr/imaging/hgiVulkan/shaderProgram.h
+++ b/pxr/imaging/hgiVulkan/shaderProgram.h
@@ -63,6 +63,10 @@ public:
     HGIVULKAN_API
     HgiShaderFunctionHandleVector const& GetShaderFunctions() const;
 
+    HGIVULKAN_API
+    HgiShaderFunctionHandle const
+    GetShaderFunction(HgiShaderStage shaderStage) const override;
+
     /// Returns the device used to create this object.
     HGIVULKAN_API
     HgiVulkanDevice* GetDevice() const;


### PR DESCRIPTION
### Description of Change(s)
- Adds the PTCS stage
- Adds shaders and handling of basis curves shader keys - attempts to join as much functionality with gl as possible
- Passing of Tess factor buffers, and their pickup
- Dispatch of PTCS stage and Tess factors in prepare with a new graphics pipeline
- Addition of centroid / sampler handling for interstage interpolation
- Vast Codegen changes to handle PTCS stage

Some of these changes are already split up and some are in flight of being merged in and changes from an earlier PR are already in to start supporting the PTCS stage - This one is a "mega PR" where everything can be looked at together and all latest feedback has been adhered to.
Incoming will be an updated split of the rest of the PTCS stage addition from this PR. With the outstanding changes to glslfx and shader function interface already split, that hopefully makes the change granular enough, to get it all in.


### Fixes Issue(s)
- Complex basis curves on Metal render

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
