### PR TITLE
Fix CHANGELOG date for 22.03 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -717,7 +717,7 @@ this happen!
 - Deprecated UsdImagingGLEngine::_GetDelegate. This API will be removed in the 
   next release.
 
-## [22.03] - 2021-02-18
+## [22.03] - 2022-02-18
 
 ### Build
 - boost::program_options is now required only if PXR_BUILD_USD_TOOLS or


### PR DESCRIPTION
### Description of Change(s)

Silly typo fix I happened to notice for release date of 22.03 in the changelog (2022, not 2021)

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
