### PR TITLE
Thor/dev/openxr debugging apple

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1009,7 +1009,15 @@ else:
     OPENEXR_URL = "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v2.4.3.zip"
 
 def InstallOpenEXR(context, force, buildArgs):
-    with CurrentWorkingDirectory(DownloadURL(OPENEXR_URL, context, force)):
+    srcDir = DownloadURL(OPENEXR_URL, context, force)
+    #This patch lets us debug in Xcode on Mac
+    with CurrentWorkingDirectory(srcDir):
+        if MacOS():
+            PatchFile(srcDir + "/OpenEXR/CMakeLists.txt",
+                [("SET (OPENEXR_LIBSUFFIX \"\")",
+                  "SET (OPENEXR_LIBSUFFIX \"\")\n"
+                  "FILE ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/config/OpenEXRConfig.h \"\n")])
+
         RunCMake(context, force, 
                  ['-DPYILMBASE_ENABLE=OFF',
                   '-DOPENEXR_VIEWERS_ENABLE=OFF',


### PR DESCRIPTION
### Description of Change(s)
Currently building and debugging opener and thus also openimageio using generator Xcode and debug is not possible due to the USD findopenexr cmake stage can't find openexr due to the openexrconfig.h is not referenced in the openexr cmakelist. This patch fixes that. For full debugging support using openimageio, also requires a PR outstanding for libpng and improvement to AR to find shared debug libraries.

### Fixes Issue(s)
- Can't build USD with openexr/openimageio because findopenxr won't find openexr on Generator Xcode

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
