### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,6 +3,7 @@ Advanced Build Configuration
 
 ## Table of Contents
 - [Building With Build Script](#building-with-build-script)
+- [Building With VCPKG](#building-with-vcpkg)
 - [Building With CMake](#building-with-cmake)
 - [Optional Components](#optional-components)
 - [Imaging Plugins](#imaging-plugins)
@@ -21,6 +22,18 @@ script. This script will download required dependencies and build
 and install them along with USD in a given directory. 
 
 See instructions and examples in [README.md](README.md#getting-and-building-the-code).
+
+## Building With VCPKG
+
+You can download and install USD using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```sh
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
+  ./vcpkg integrate install
+  ./vcpkg install usd
+```
+The USD port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Building With CMake
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,7 +31,7 @@ You can download and install USD using the [vcpkg](https://github.com/Microsoft/
   cd vcpkg
   ./bootstrap-vcpkg.sh #.\bootstrap-vcpkg.bat(for windows)
   ./vcpkg integrate install
-  ./vcpkg install usd
+  ./vcpkg install usd:x64-windows
 ```
 The USD port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -33,7 +33,7 @@ You can download and install USD using the [vcpkg](https://github.com/Microsoft/
   ./vcpkg integrate install
   ./vcpkg install usd
 ```
-The USD port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull   request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The USD port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Building With CMake
 


### PR DESCRIPTION
`USD` available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `USD` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `USD`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/usd/portfile.cmake). We try to keep the library maintained as close as possible to the original library.