### PR TITLE
APPLE: Texture and buffer writability in Metal/HGI along with settings where appropriate

### DIFF
--- a/pxr/imaging/hdSt/domeLightComputations.cpp
+++ b/pxr/imaging/hdSt/domeLightComputations.cpp
@@ -238,6 +238,7 @@ HdSt_DomeLightComputationGPU::Execute(
     HgiTextureBindDesc texBind0;
     texBind0.bindingIndex = 0;
     texBind0.stageUsage = HgiShaderStageCompute;
+    texBind0.writable = false;
     texBind0.textures.push_back(srcTextureName);
     texBind0.samplers.push_back(srcSamplerName);
     texBind0.resourceType = HgiBindResourceTypeCombinedSamplerImage;
@@ -246,6 +247,7 @@ HdSt_DomeLightComputationGPU::Execute(
     HgiTextureBindDesc texBind1;
     texBind1.bindingIndex = 1;
     texBind1.stageUsage = HgiShaderStageCompute;
+    texBind1.writable = true;
     texBind1.textures.push_back(dstTextureView->GetViewTexture());
     texBind1.samplers.push_back(srcSamplerName);
     texBind1.resourceType = HgiBindResourceTypeStorageImage;

--- a/pxr/imaging/hdSt/extCompGpuComputation.cpp
+++ b/pxr/imaging/hdSt/extCompGpuComputation.cpp
@@ -56,6 +56,7 @@ _AppendResourceBindings(
     bufBind.bindingIndex = location;
     bufBind.resourceType = HgiBindResourceTypeStorageBuffer;
     bufBind.stageUsage = HgiShaderStageCompute;
+    bufBind.writable = true;
     bufBind.offsets.push_back(0);
     bufBind.buffers.push_back(buffer);
     resourceDesc->buffers.push_back(std::move(bufBind));

--- a/pxr/imaging/hdSt/flatNormals.cpp
+++ b/pxr/imaging/hdSt/flatNormals.cpp
@@ -75,6 +75,7 @@ _CreateResourceBindings(
         bufBind0.bindingIndex = BufferBinding_Points;
         bufBind0.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind0.stageUsage = HgiShaderStageCompute;
+        bufBind0.writable = false;
         bufBind0.offsets.push_back(0);
         bufBind0.buffers.push_back(points);
         resourceDesc.buffers.push_back(std::move(bufBind0));
@@ -85,6 +86,7 @@ _CreateResourceBindings(
         bufBind1.bindingIndex = BufferBinding_Normals;
         bufBind1.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind1.stageUsage = HgiShaderStageCompute;
+        bufBind1.writable = true;
         bufBind1.offsets.push_back(0);
         bufBind1.buffers.push_back(normals);
         resourceDesc.buffers.push_back(std::move(bufBind1));
@@ -95,6 +97,7 @@ _CreateResourceBindings(
         bufBind2.bindingIndex = BufferBinding_Indices;
         bufBind2.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind2.stageUsage = HgiShaderStageCompute;
+        bufBind2.writable = false;
         bufBind2.offsets.push_back(0);
         bufBind2.buffers.push_back(indices);
         resourceDesc.buffers.push_back(std::move(bufBind2));
@@ -105,6 +108,7 @@ _CreateResourceBindings(
         bufBind3.bindingIndex = BufferBinding_PrimitiveParam;
         bufBind3.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind3.stageUsage = HgiShaderStageCompute;
+        bufBind3.writable = false;
         bufBind3.offsets.push_back(0);
         bufBind3.buffers.push_back(primitiveParam);
         resourceDesc.buffers.push_back(std::move(bufBind3));

--- a/pxr/imaging/hdSt/quadrangulate.cpp
+++ b/pxr/imaging/hdSt/quadrangulate.cpp
@@ -73,6 +73,7 @@ _CreateResourceBindings(
         bufBind0.bindingIndex = BufferBinding_Primvar;
         bufBind0.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind0.stageUsage = HgiShaderStageCompute;
+        bufBind0.writable = true;
         bufBind0.offsets.push_back(0);
         bufBind0.buffers.push_back(primvar);
         resourceDesc.buffers.push_back(std::move(bufBind0));
@@ -83,6 +84,7 @@ _CreateResourceBindings(
         bufBind1.bindingIndex = BufferBinding_Quadinfo;
         bufBind1.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind1.stageUsage = HgiShaderStageCompute;
+        bufBind1.writable = true;
         bufBind1.offsets.push_back(0);
         bufBind1.buffers.push_back(quadrangulateTable);
         resourceDesc.buffers.push_back(std::move(bufBind1));

--- a/pxr/imaging/hdSt/resourceBinder.cpp
+++ b/pxr/imaging/hdSt/resourceBinder.cpp
@@ -994,6 +994,7 @@ HdSt_ResourceBinder::GetBufferBindingDesc(
         HgiShaderStageVertex | HgiShaderStageFragment |
         HgiShaderStagePostTessellationVertex;
     HgiBufferBindDesc desc;
+    desc.writable = true;
 
     switch (binding.GetType()) {
     case HdBinding::SSBO:
@@ -1004,6 +1005,7 @@ HdSt_ResourceBinder::GetBufferBindingDesc(
         desc.bindingIndex = static_cast<uint32_t>(binding.GetLocation());
         desc.resourceType = HgiBindResourceTypeStorageBuffer;
         desc.stageUsage = stageUsage;
+        desc.writable = false;
         bindingsDesc->buffers.push_back(desc);
         break;
     case HdBinding::UBO:
@@ -1123,6 +1125,7 @@ HdSt_ResourceBinder::GetTextureBindingDesc(
     texelDesc.samplers = { texelSampler };
     texelDesc.resourceType = HgiBindResourceTypeSampledImage;
     texelDesc.bindingIndex = binding.GetTextureUnit();
+    texelDesc.writable = false;
     bindingsDesc->textures.push_back(std::move(texelDesc));
 }
 
@@ -1146,6 +1149,7 @@ HdSt_ResourceBinder::GetTextureWithLayoutBindingDesc(
     layoutDesc.samplers = { };
     layoutDesc.resourceType = HgiBindResourceTypeSampledImage;
     layoutDesc.bindingIndex = layoutBinding.GetTextureUnit();
+    layoutDesc.writable = false;
     bindingsDesc->textures.push_back(std::move(layoutDesc));
 }
 

--- a/pxr/imaging/hdSt/smoothNormals.cpp
+++ b/pxr/imaging/hdSt/smoothNormals.cpp
@@ -74,6 +74,7 @@ _CreateResourceBindings(
         bufBind0.bindingIndex = BufferBinding_Points;
         bufBind0.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind0.stageUsage = HgiShaderStageCompute;
+        bufBind0.writable = false;
         bufBind0.offsets.push_back(0);
         bufBind0.buffers.push_back(points);
         resourceDesc.buffers.push_back(std::move(bufBind0));
@@ -84,6 +85,7 @@ _CreateResourceBindings(
         bufBind1.bindingIndex = BufferBinding_Normals;
         bufBind1.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind1.stageUsage = HgiShaderStageCompute;
+        bufBind1.writable = true;
         bufBind1.offsets.push_back(0);
         bufBind1.buffers.push_back(normals);
         resourceDesc.buffers.push_back(std::move(bufBind1));
@@ -94,6 +96,7 @@ _CreateResourceBindings(
         bufBind2.bindingIndex = BufferBinding_Adjacency;
         bufBind2.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind2.stageUsage = HgiShaderStageCompute;
+        bufBind2.writable = false;
         bufBind2.offsets.push_back(0);
         bufBind2.buffers.push_back(adjacency);
         resourceDesc.buffers.push_back(std::move(bufBind2));

--- a/pxr/imaging/hdSt/subdivision.cpp
+++ b/pxr/imaging/hdSt/subdivision.cpp
@@ -1729,6 +1729,7 @@ _CreateResourceBindings(
         bufBind0.bindingIndex = BufferBinding_Sizes;
         bufBind0.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind0.stageUsage = HgiShaderStageCompute;
+        bufBind0.writable = false;
         bufBind0.offsets.push_back(0);
         bufBind0.buffers.push_back(sizes);
         resourceDesc.buffers.push_back(std::move(bufBind0));
@@ -1739,6 +1740,7 @@ _CreateResourceBindings(
         bufBind1.bindingIndex = BufferBinding_Offsets;
         bufBind1.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind1.stageUsage = HgiShaderStageCompute;
+        bufBind1.writable = false;
         bufBind1.offsets.push_back(0);
         bufBind1.buffers.push_back(offsets);
         resourceDesc.buffers.push_back(std::move(bufBind1));
@@ -1749,6 +1751,7 @@ _CreateResourceBindings(
         bufBind2.bindingIndex = BufferBinding_Indices;
         bufBind2.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind2.stageUsage = HgiShaderStageCompute;
+        bufBind2.writable = false;
         bufBind2.offsets.push_back(0);
         bufBind2.buffers.push_back(indices);
         resourceDesc.buffers.push_back(std::move(bufBind2));
@@ -1759,6 +1762,7 @@ _CreateResourceBindings(
         bufBind3.bindingIndex = BufferBinding_Weights;
         bufBind3.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind3.stageUsage = HgiShaderStageCompute;
+        bufBind3.writable = false;
         bufBind3.offsets.push_back(0);
         bufBind3.buffers.push_back(weights);
         resourceDesc.buffers.push_back(std::move(bufBind3));
@@ -1769,6 +1773,7 @@ _CreateResourceBindings(
         bufBind4.bindingIndex = BufferBinding_Primvar;
         bufBind4.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind4.stageUsage = HgiShaderStageCompute;
+        bufBind4.writable = true;
         bufBind4.offsets.push_back(0);
         bufBind4.buffers.push_back(primvar);
         resourceDesc.buffers.push_back(std::move(bufBind4));

--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -604,6 +604,7 @@ HdSt_TextureTestDriver::_CreateTextureBindings(
         HgiTextureBindDesc texBindDesc;
         texBindDesc.bindingIndex = 0;
         texBindDesc.stageUsage = HgiShaderStageFragment;
+        texBindDesc.writable = true;
         texBindDesc.textures.push_back(textureHandle);
         if (samplerHandle) {
             texBindDesc.samplers.push_back(samplerHandle);

--- a/pxr/imaging/hdx/boundingBoxTask.cpp
+++ b/pxr/imaging/hdx/boundingBoxTask.cpp
@@ -260,6 +260,7 @@ HdxBoundingBoxTask::_CreateResourceBindings()
     bufBind1.offsets.push_back(0);
     bufBind1.sizes.push_back(0);
     bufBind1.buffers.push_back(_transformsBuffer);
+    bufBind1.writable = false;
     resourceDesc.buffers.push_back(std::move(bufBind1));
 
     _resourceBindings = _GetHgi()->CreateResourceBindings(resourceDesc);

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -348,6 +348,7 @@ HdxColorCorrectionTask::_CreateResourceBindings(
     HgiTextureBindDesc texBind0;
     texBind0.bindingIndex = 0;
     texBind0.stageUsage = HgiShaderStageFragment;
+    texBind0.writable = false;
     texBind0.textures.push_back(aovTexture);
     texBind0.samplers.push_back(_sampler);
     resourceDesc.textures.push_back(std::move(texBind0));
@@ -356,6 +357,7 @@ HdxColorCorrectionTask::_CreateResourceBindings(
         HgiTextureBindDesc texBind1;
         texBind1.bindingIndex = 1;
         texBind1.stageUsage = HgiShaderStageFragment;
+        texBind1.writable = false;
         texBind1.textures.push_back(_texture3dLUT);
         texBind1.samplers.push_back(_sampler);
         resourceDesc.textures.push_back(std::move(texBind1));

--- a/pxr/imaging/hdx/fullscreenShader.cpp
+++ b/pxr/imaging/hdx/fullscreenShader.cpp
@@ -360,6 +360,7 @@ HdxFullscreenShader::_CreateResourceBindings(TextureMap const& textures)
         HgiTextureBindDesc texBind;
         texBind.bindingIndex = bindSlots++;
         texBind.stageUsage = HgiShaderStageFragment;
+        texBind.writable = false;
         texBind.textures.push_back(texHandle);
         texBind.samplers.push_back(_sampler);
         resourceDesc.textures.push_back(std::move(texBind));
@@ -372,6 +373,7 @@ HdxFullscreenShader::_CreateResourceBindings(TextureMap const& textures)
         bufBind.bindingIndex = buffer.first;
         bufBind.resourceType = HgiBindResourceTypeStorageBuffer;
         bufBind.stageUsage = HgiShaderStageFragment;
+        bufBind.writable = false;
         bufBind.offsets.push_back(0);
         bufBind.buffers.push_back(bufferHandle);
         resourceDesc.buffers.push_back(std::move(bufBind));

--- a/pxr/imaging/hdx/visualizeAovTask.cpp
+++ b/pxr/imaging/hdx/visualizeAovTask.cpp
@@ -298,6 +298,7 @@ HdxVisualizeAovTask::_CreateResourceBindings(
     HgiTextureBindDesc texBind0;
     texBind0.bindingIndex = 0;
     texBind0.stageUsage = HgiShaderStageFragment;
+    texBind0.writable = false;
     texBind0.textures.push_back(inputAovTexture);
     texBind0.samplers.push_back(_sampler);
     resourceDesc.textures.push_back(std::move(texBind0));

--- a/pxr/imaging/hgi/resourceBindings.cpp
+++ b/pxr/imaging/hgi/resourceBindings.cpp
@@ -53,7 +53,8 @@ bool operator==(
            lhs.offsets == rhs.offsets &&
            lhs.sizes == rhs.sizes &&
            lhs.bindingIndex == rhs.bindingIndex &&
-           lhs.stageUsage == rhs.stageUsage;
+           lhs.stageUsage == rhs.stageUsage &&
+           lhs.writable == rhs.writable;
 }
 
 bool operator!=(
@@ -78,7 +79,8 @@ bool operator==(
            lhs.resourceType == rhs.resourceType &&
            lhs.bindingIndex == rhs.bindingIndex &&
            lhs.stageUsage == rhs.stageUsage &&
-           lhs.samplers == rhs.samplers;
+           lhs.samplers == rhs.samplers &&
+           lhs.writable == rhs.writable;
 }
 
 bool operator!=(

--- a/pxr/imaging/hgi/resourceBindings.h
+++ b/pxr/imaging/hgi/resourceBindings.h
@@ -85,6 +85,7 @@ struct HgiBufferBindDesc
     HgiBindResourceType resourceType;
     uint32_t bindingIndex;
     HgiShaderStage stageUsage;
+    bool writable;
 };
 using HgiBufferBindDescVector = std::vector<HgiBufferBindDesc>;
 
@@ -130,6 +131,7 @@ struct HgiTextureBindDesc
     HgiBindResourceType resourceType;
     uint32_t bindingIndex;
     HgiShaderStage stageUsage;
+    bool writable;
 };
 using HgiTextureBindDescVector = std::vector<HgiTextureBindDesc>;
 

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -676,8 +676,10 @@ HgiMetalBufferShaderSection::WriteParameter(std::ostream& ss) const
 {
     if (!_writable) {
         ss << "const ";
+        ss << "constant ";
+    } else {
+        ss << "device ";
     }
-    ss << "device ";
     WriteType(ss);
     
     switch (_binding) {
@@ -702,8 +704,10 @@ HgiMetalBufferShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
 
     if (!_writable) {
         ss << "const ";
+        ss << "constant ";
+    } else {
+        ss << "device ";
     }
-    ss << "device ";
     WriteType(ss);
 
     switch (_binding) {
@@ -731,8 +735,10 @@ HgiMetalBufferShaderSection::VisitScopeConstructorDeclarations(
 
     if (!_writable) {
         ss << "const ";
+        ss << "constant ";
+    } else {
+        ss << "device ";
     }
-    ss << "device ";
     WriteType(ss);
     ss << "* _";
     WriteIdentifier(ss);


### PR DESCRIPTION
### Description of Change(s)
Allows HGI to define readonly buffers and textures
Allow HGIMetal to consume readonly buffers and textures
Take advantage of that in the resource binder and as well in hdx where we manually set up resources
Sets buffers we don't index into to live in constant space, and pass them as const reference instead of as a pointer in device space on Metal

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
