### PR TITLE
APPLE: Single GPU callback for freeing all argument buffers on a command buffer

### DIFF
--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -227,7 +227,11 @@ private:
     id<MTLArgumentEncoder> _argEncoderBuffer;
     id<MTLArgumentEncoder> _argEncoderSampler;
     id<MTLArgumentEncoder> _argEncoderTexture;
-    std::stack<id<MTLBuffer>> _freeArgBuffers;
+    
+    using FreeArgStack = std::stack<id<MTLBuffer>>;
+    using ActiveArgBuffers = std::vector<id<MTLBuffer>>;
+    FreeArgStack _freeArgBuffers;
+    std::shared_ptr<ActiveArgBuffers> _activeArgBuffers;
     std::mutex _freeArgMutex;
 
     HgiCmds* _currentCmds;


### PR DESCRIPTION
### Description of Change(s)

Previously, when each argument buffer was created there would be a callback added to the command buffer to return it to the free list once it was used.  This requires a mutex to be locked for each callback, since the free list is read on the CPU thread.

For complicated scenes this could result in hundreds of callbacks and mutex locks, which makes the debugger hard to follow and introduces the possibility of stalls between the CPU and GPU.

### Fixes Issue(s)
- Performance instability.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
