### PR TITLE
APPLE: GPU frustum culling

### DIFF
--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -133,7 +133,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (early_fragment_tests)
 );
 
-TF_DEFINE_ENV_SETTING(HDST_ENABLE_HGI_RESOURCE_GENERATION, false,
+TF_DEFINE_ENV_SETTING(HDST_ENABLE_HGI_RESOURCE_GENERATION, true,
                       "Enable Hgi resource generation for codeGen");
 
 /* static */
@@ -1344,6 +1344,7 @@ HdSt_CodeGen::_GetShaderResourceLayouts(
         HdShaderTokens->geometryShader,
         HdShaderTokens->fragmentShader,
         HdShaderTokens->postTessVertexShader,
+        HdShaderTokens->computeShader,
     };
 
     for (auto const &shader : shaders) {
@@ -1366,6 +1367,9 @@ HdSt_CodeGen::_GetShaderResourceLayouts(
 
         HdSt_ResourceLayout::ParseLayout(
                 &_resPTVS, HdShaderTokens->postTessVertexShader, layoutDict);
+
+        HdSt_ResourceLayout::ParseLayout(
+                &_resCS, HdShaderTokens->computeShader, layoutDict);
     }
 }
 
@@ -1525,6 +1529,8 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
         _geometricShader->GetSource(HdShaderTokens->geometryShader);
     std::string fragmentShader =
         _geometricShader->GetSource(HdShaderTokens->fragmentShader);
+    std::string computeShader =
+        _geometricShader->GetSource(HdShaderTokens->computeShader);
 
     _hasVS  = (!vertexShader.empty());
     _hasTCS = (!tessControlShader.empty());
@@ -1533,6 +1539,7 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
     _hasPTVS = (!postTessVertexShader.empty()) && metalTessellationEnabled;
     _hasGS  = (!geometryShader.empty()) && !metalTessellationEnabled;
     _hasFS  = (!fragmentShader.empty());
+    _hasCS  = (!computeShader.empty());
 
     // Initialize source buckets
     _genDefines.str(""); _genDecl.str(""); _genAccessors.str("");
@@ -2014,6 +2021,7 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
     _genPTVS << postTessVertexShader;
     _genGS  << geometryShader;
     _genFS  << fragmentShader;
+    _genCS  << computeShader;
 
     // Sanity check that if you provide a control shader, you have also provided
     // an evaluation shader (and vice versa)
@@ -2645,6 +2653,8 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
             HdShaderTokens->computeShader, _resAttrib, _metaData);
         resourceGen._GenerateHgiResources(&csDesc,
             HdShaderTokens->computeShader, _resCommon, _metaData);
+        resourceGen._GenerateHgiResources(&csDesc,
+            HdShaderTokens->computeShader, _resCS, _metaData);
 
         std::string const declarations = _genDefines.str() + _genDecl.str();
         std::string const source = _genAccessors.str() + _genCS.str();
@@ -3830,13 +3840,16 @@ HdSt_CodeGen::_GenerateDrawingCoord(
     //   layout (location=y) in ivec4 drawingCoord1
     //   layout (location=z) in ivec2 drawingCoord2
     //   layout (location=w) in int   drawingCoordI[N]
-    _EmitDeclaration(&_resAttrib, _metaData.drawingCoord0Binding);
-    _EmitDeclaration(&_resAttrib, _metaData.drawingCoord1Binding);
-    _EmitDeclaration(&_resAttrib, _metaData.drawingCoord2Binding);
+    if (!_hasCS) {
+        _EmitDeclaration(&_resAttrib, _metaData.drawingCoord0Binding);
+        _EmitDeclaration(&_resAttrib, _metaData.drawingCoord1Binding);
+        _EmitDeclaration(&_resAttrib, _metaData.drawingCoord2Binding);
 
-    if (_metaData.drawingCoordIBinding.binding.IsValid()) {
-        _EmitDeclaration(&_resAttrib, _metaData.drawingCoordIBinding,
-            /*arraySize=*/std::max(1, _metaData.instancerNumLevels));
+
+        if (_metaData.drawingCoordIBinding.binding.IsValid()) {
+            _EmitDeclaration(&_resAttrib, _metaData.drawingCoordIBinding,
+                /*arraySize=*/std::max(1, _metaData.instancerNumLevels));
+        }
     }
 
     std::stringstream primitiveID;
@@ -3940,6 +3953,12 @@ HdSt_CodeGen::_GenerateDrawingCoord(
                << "  return drawingCoord1[0].y + (int(hd_InstanceID) - "
                << "gl_BaseInstance) * HD_INSTANCE_INDEX_WIDTH; \n"
                << "}\n";
+        
+        _genCS << "int g_instanceID;          // Set from calling code.\n"
+               << "FORWARD_DECL(int GetDrawingCoordField(uint coordIndex, uint fieldIndex));\n"
+               << "int GetInstanceIndexCoord() {\n"
+               << "return GetDrawingCoordField(1, 1) + g_instanceID * HD_INSTANCE_INDEX_WIDTH;\n"
+               << "}\n";
 
         if (_geometricShader->IsFrustumCullingPass()) {
             // for frustum culling:  use instanceIndices.
@@ -3957,6 +3976,23 @@ HdSt_CodeGen::_GenerateDrawingCoord(
                     << "        = instanceIndices[drawingCoord1.y + "
                     << "hd_InstanceID*HD_INSTANCE_INDEX_WIDTH+i];\n"
                     << "}\n";
+            
+            if (_hasCS) {
+                _genCS << "hd_instanceIndex GetInstanceIndex() {\n"
+                       << "  int offset = GetInstanceIndexCoord();\n"
+                       << "  hd_instanceIndex r;\n"
+                       << "  for (int i = 0; i < HD_INSTANCE_INDEX_WIDTH; ++i)\n"
+                       << "    r.indices[i] = instanceIndices[offset+i];\n"
+                       << "    return r;\n"
+                       << "}\n";
+                _genCS << "void SetCulledInstanceIndex(uint instanceID) {\n"
+                       << "  int instanceIndex = GetDrawingCoordField(1, 1);\n"
+                       << "  for (int i = 0; i < HD_INSTANCE_INDEX_WIDTH; ++i) {\n"
+                       << "    culledInstanceIndices[instanceIndex + instanceID * HD_INSTANCE_INDEX_WIDTH+i]\n"
+                       << "        = instanceIndices[instanceIndex + g_instanceID * HD_INSTANCE_INDEX_WIDTH+i];\n"
+                       << "  }\n"
+                       << "}\n";
+            }
         } else {
             // for drawing:  use culledInstanceIndices.
             _EmitAccessor(_genVS, _metaData.culledInstanceIndexArrayBinding.name,
@@ -3983,28 +4019,33 @@ HdSt_CodeGen::_GenerateDrawingCoord(
             genAttr << "void SetCulledInstanceIndex(uint instance) "
                     "{ /*no-op*/ }\n";
         }
+
+        _genCS << "hd_instanceIndex GetInstanceIndex() {"
+               << "  hd_instanceIndex r; r.indices[0] = 0; return r; }\n";
     }
 
-    for (std::string const & param : drawingCoordParams) {
-        TfToken const drawingCoordParamName("dc_" + param);
-        _AddInterstageElement(&_resInterstage,
-                              HdSt_ResourceLayout::InOut::NONE,
-                              /*name=*/drawingCoordParamName,
-                              /*dataType=*/_tokens->_int);
-    }
-    for (int i = 0; i < instanceIndexWidth; ++i) {
-        TfToken const name(TfStringPrintf("dc_instanceIndexI%d", i));
-        _AddInterstageElement(&_resInterstage,
-                              HdSt_ResourceLayout::InOut::NONE,
-                              /*name=*/name,
-                              /*dataType=*/_tokens->_int);
-    }
-    for (int i = 0; i < instanceIndexWidth; ++i) {
-        TfToken const name(TfStringPrintf("dc_instanceCoordsI%d", i));
-        _AddInterstageElement(&_resInterstage,
-                              HdSt_ResourceLayout::InOut::NONE,
-                              /*name=*/name,
-                              /*dataType=*/_tokens->_int);
+    if (!_hasCS) {
+        for (std::string const & param : drawingCoordParams) {
+            TfToken const drawingCoordParamName("dc_" + param);
+            _AddInterstageElement(&_resInterstage,
+                                  HdSt_ResourceLayout::InOut::NONE,
+                                  /*name=*/drawingCoordParamName,
+                                  /*dataType=*/_tokens->_int);
+        }
+        for (int i = 0; i < instanceIndexWidth; ++i) {
+            TfToken const name(TfStringPrintf("dc_instanceIndexI%d", i));
+            _AddInterstageElement(&_resInterstage,
+                                  HdSt_ResourceLayout::InOut::NONE,
+                                  /*name=*/name,
+                                  /*dataType=*/_tokens->_int);
+        }
+        for (int i = 0; i < instanceIndexWidth; ++i) {
+            TfToken const name(TfStringPrintf("dc_instanceCoordsI%d", i));
+            _AddInterstageElement(&_resInterstage,
+                                  HdSt_ResourceLayout::InOut::NONE,
+                                  /*name=*/name,
+                                  /*dataType=*/_tokens->_int);
+        }
     }
 
     _genVS   << genAttr.str();
@@ -4034,11 +4075,30 @@ HdSt_CodeGen::_GenerateDrawingCoord(
              << "  dc.varyingCoord            = drawingCoord2[0].y;\n"
              << "  hd_instanceIndex r = GetInstanceIndex();\n";
 
+    _genCS   << "// Compute shaders read the drawCommands buffer directly.\n"
+             << "// GetDrawingCoordField() needs to be implemented by the\n"
+             << "// kernel by offsetting by the thread ID.\n"
+             << "FORWARD_DECL(int GetDrawingCoordField(uint coordIndex, uint fieldIndex));\n"
+             << "hd_drawingCoord GetDrawingCoord() {\n"
+             << "  hd_drawingCoord dc;\n"
+             << "  dc.modelCoord              = GetDrawingCoordField(0, 0);\n"
+             << "  dc.constantCoord           = GetDrawingCoordField(0, 1);\n"
+             << "  dc.elementCoord            = GetDrawingCoordField(0, 2);\n"
+             << "  dc.primitiveCoord          = GetDrawingCoordField(0, 3);\n"
+             << "  dc.fvarCoord               = GetDrawingCoordField(1, 0);\n"
+             << "  dc.shaderCoord             = GetDrawingCoordField(1, 1);\n"
+             << "  dc.vertexCoord             = GetDrawingCoordField(1, 2);\n"
+             << "  dc.topologyVisibilityCoord = GetDrawingCoordField(2, 0);\n"
+             << "  dc.varyingCoord            = GetDrawingCoordField(2, 1);\n"
+             << "  hd_instanceIndex r = GetInstanceIndex();\n";
+
     for(int i = 0; i < instanceIndexWidth; ++i) {
         std::string const index = std::to_string(i);
         _genVS   << "  dc.instanceIndex[" << index << "]"
                  << " = r.indices[" << index << "];\n";
         _genPTVS << "  dc.instanceIndex[" << index << "]"
+                 << " = r.indices[" << index << "];\n";
+        _genCS   << "  dc.instanceIndex[" << index << "]"
                  << " = r.indices[" << index << "];\n";
     }
     for(int i = 0; i < instanceIndexWidth-1; ++i) {
@@ -4049,11 +4109,16 @@ HdSt_CodeGen::_GenerateDrawingCoord(
         _genPTVS << "  dc.instanceCoords[" << index << "]"
                  << " = drawingCoordI" << index << "[0]"
                  << " + dc.instanceIndex[" << std::to_string(i+1) << "];\n";
+        _genCS   << "  dc.instanceCoords[" << index << "]"
+                 << " = GetDrawingCoordField(3," << index << ")"
+                 << " + dc.instanceIndex[" << std::to_string(i+1) << "];\n";
     }
 
     _genVS   << "  return dc;\n"
              << "}\n";
     _genPTVS << "  return dc;\n"
+             << "}\n";
+    _genCS   << "  return dc;\n"
              << "}\n";
 
     // note: GL spec says tessellation input array size must be equal to
@@ -4551,6 +4616,9 @@ HdSt_CodeGen::_GenerateElementPrimvar()
                 << "  return GetElementID()\n"
                 << "  + GetDrawingCoord().elementCoord;\n"
                 << "}\n";
+        }
+        else if (_geometricShader->IsPrimTypeCompute()) {
+            // do nothing.
         }
         else {
             TF_CODING_ERROR("HdSt_GeometricShader::PrimitiveType %d is "

--- a/pxr/imaging/hdSt/codeGen.h
+++ b/pxr/imaging/hdSt/codeGen.h
@@ -183,6 +183,7 @@ private:
     ElementVector _resFS;
     ElementVector _resPTCS;
     ElementVector _resPTVS;
+    ElementVector _resCS;
 
     ElementVector _resInterstage;
 

--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -22,13 +22,6 @@
 // language governing permissions and limitations under the Apache License.
 //
 
-#if defined(ARCH_OS_WINDOWS)
-// On Windows, MemoryBarrier is defined to __faststorefence, so we have to
-// remove it here so that it can be called on HgiComputeCmds.
-// https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-memorybarrier
-#undef MemoryBarrier
-#endif
-
 #include "pxr/imaging/hdSt/commandBuffer.h"
 #include "pxr/imaging/hdSt/debugCodes.h"
 #include "pxr/imaging/hdSt/geometricShader.h"
@@ -60,8 +53,14 @@
 #include <functional>
 #include <unordered_map>
 
-PXR_NAMESPACE_OPEN_SCOPE
+#if defined(ARCH_OS_WINDOWS)
+// On Windows, MemoryBarrier is defined to __faststorefence, so we have to
+// remove it here so that it can be called on HgiComputeCmds.
+// https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-memorybarrier
+#undef MemoryBarrier
+#endif
 
+PXR_NAMESPACE_OPEN_SCOPE
 
 HdStCommandBuffer::HdStCommandBuffer()
     : _visibleSize(0)

--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -60,6 +60,7 @@
 #undef MemoryBarrier
 #endif
 
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 HdStCommandBuffer::HdStCommandBuffer()

--- a/pxr/imaging/hdSt/commandBuffer.h
+++ b/pxr/imaging/hdSt/commandBuffer.h
@@ -38,7 +38,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
+class HdRenderIndex;
 class HdStDrawItem;
 class HdStDrawItemInstance;
 class HgiCapabilities;
@@ -74,17 +74,13 @@ public:
     HDST_API
     void PrepareDraw(HgiGraphicsCmds *gfxCmds,
                      HdStRenderPassStateSharedPtr const &renderPassState,
-                     HdStResourceRegistrySharedPtr const &resourceRegistry);
+                     HdRenderIndex *renderIndex);
 
     /// Execute the command buffer
     HDST_API
     void ExecuteDraw(HgiGraphicsCmds *gfxCmds,
                      HdStRenderPassStateSharedPtr const &renderPassState,
                      HdStResourceRegistrySharedPtr const &resourceRegistry);
-
-    /// Cull drawItemInstances based on passed in combined view and projection matrix
-    HDST_API
-    void FrustumCull(GfMatrix4d const &cullMatrix);
 
     /// Sync visibility state from RprimSharedState to DrawItemInstances.
     HDST_API
@@ -125,6 +121,12 @@ public:
 
 private:
     void _RebuildDrawBatches(HgiCapabilities const *hgiCapabilities);
+    
+    /// Cull drawItemInstances based on renderPassState view and projection matrix
+    void _FrustumCull(HdStRenderPassStateSharedPtr const &renderPassState,
+                      HdRenderIndex const *renderIndex);
+
+    void _FrustumCullCPU(GfMatrix4d const &cullMatrix);
 
     HdDrawItemConstPtrVectorSharedPtr _drawItems;
     std::vector<HdStDrawItemInstance> _drawItemInstances;

--- a/pxr/imaging/hdSt/cullingShaderKey.cpp
+++ b/pxr/imaging/hdSt/cullingShaderKey.cpp
@@ -38,6 +38,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((isVisible,        "ViewFrustumCull.IsVisible"))
     ((mainInstancingVS, "ViewFrustumCull.VertexInstancing"))
     ((mainVS,           "ViewFrustumCull.Vertex"))
+    ((mainInstancingCS, "ViewFrustumCull.ComputeInstancing"))
+    ((mainCS,           "ViewFrustumCull.Compute"))
 );
 
 HdSt_CullingShaderKey::HdSt_CullingShaderKey(
@@ -54,6 +56,23 @@ HdSt_CullingShaderKey::HdSt_CullingShaderKey(
 }
 
 HdSt_CullingShaderKey::~HdSt_CullingShaderKey()
+{
+}
+
+HdSt_CullingComputeShaderKey::HdSt_CullingComputeShaderKey(
+    bool instancing, bool tinyCull, bool counting)
+    : glslfx(_tokens->baseGLSLFX)
+{
+
+    CS[0] = _tokens->instancing;
+    CS[1] = counting ? _tokens->counting : _tokens->noCounting;
+    CS[2] = tinyCull ? _tokens->tinyCull : _tokens->noTinyCull;
+    CS[3] = _tokens->isVisible;
+    CS[4] = instancing ? _tokens->mainInstancingCS : _tokens->mainCS;
+    CS[5] = TfToken();
+}
+
+HdSt_CullingComputeShaderKey::~HdSt_CullingComputeShaderKey()
 {
 }
 

--- a/pxr/imaging/hdSt/cullingShaderKey.h
+++ b/pxr/imaging/hdSt/cullingShaderKey.h
@@ -51,6 +51,23 @@ struct HdSt_CullingShaderKey : public HdSt_ShaderKey
     TfToken VS[6];
 };
 
+struct HdSt_CullingComputeShaderKey : public HdSt_ShaderKey
+{
+    HdSt_CullingComputeShaderKey(bool instancing, bool tinyCull, bool counting);
+    ~HdSt_CullingComputeShaderKey();
+
+    TfToken const &GetGlslfxFilename() const override { return glslfx; }
+    TfToken const *GetCS() const override { return CS; }
+
+    bool IsFrustumCullingPass() const override { return true; }
+    HdSt_GeometricShader::PrimitiveType GetPrimitiveType() const override {
+        return HdSt_GeometricShader::PrimitiveType::PRIM_COMPUTE;
+    }
+
+    TfToken glslfx;
+    TfToken CS[6];
+};
+
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hdSt/drawBatch.h
+++ b/pxr/imaging/hdSt/drawBatch.h
@@ -95,6 +95,11 @@ public:
         HdStRenderPassStateSharedPtr const &renderPassState,
         HdStResourceRegistrySharedPtr const &resourceRegistry) = 0;
 
+    /// Do the final preparation before the draw.
+    virtual void BeforeDraw(
+        HdStRenderPassStateSharedPtr const & renderPassState,
+        HdStResourceRegistrySharedPtr const & resourceRegistry) = 0;
+
     /// Executes the drawing commands for this batch.
     virtual void ExecuteDraw(
         HgiGraphicsCmds *gfxCmds,

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -73,8 +73,8 @@ public:
         PRIM_MESH_REFINED_TRIQUADS,  // e.g: triangulated catmark/bilinear
         PRIM_MESH_BSPLINE,           // e.g. catmark limit surface patches
         PRIM_MESH_BOXSPLINETRIANGLE, // e.g. loop limit surface patches
-        PRIM_VOLUME                  // Simply draws triangles of bounding
-                                     // box of a volume.
+        PRIM_VOLUME,                 // Triangles of bounding box of a volume.
+        PRIM_COMPUTE                 // A compute shader, e.g frustum culling
     };
 
     /// static query functions for PrimitiveType
@@ -128,6 +128,10 @@ public:
                primType == PrimitiveType::PRIM_MESH_BOXSPLINETRIANGLE ||
                primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES ||
                primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES;
+    }
+    
+    static inline bool IsPrimTypeCompute(PrimitiveType primType) {
+        return primType == PrimitiveType::PRIM_COMPUTE;
     }
 
     // Face-varying patch type
@@ -237,6 +241,10 @@ public:
 
     bool IsPrimTypePatches() const {
         return IsPrimTypePatches(_primType);
+    }
+
+    bool IsPrimTypeCompute() const {
+        return IsPrimTypeCompute(_primType);
     }
 
     FvarPatchType GetFvarPatchType() const {

--- a/pxr/imaging/hdSt/indirectDrawBatch.cpp
+++ b/pxr/imaging/hdSt/indirectDrawBatch.cpp
@@ -924,6 +924,14 @@ HdSt_IndirectDrawBatch::PrepareDraw(
     }
 }
 
+void
+HdSt_IndirectDrawBatch::BeforeDraw(
+    HdStRenderPassStateSharedPtr const & renderPassState,
+    HdStResourceRegistrySharedPtr const & resourceRegistry)
+{
+    // No implementation.    
+}
+
 ////////////////////////////////////////////////////////////
 // GPU Resource Binding
 ////////////////////////////////////////////////////////////

--- a/pxr/imaging/hdSt/indirectDrawBatch.h
+++ b/pxr/imaging/hdSt/indirectDrawBatch.h
@@ -65,6 +65,12 @@ public:
         HdStRenderPassStateSharedPtr const &renderPassState,
         HdStResourceRegistrySharedPtr const &resourceRegistry) override;
 
+    /// Do the final preparation before the draw.
+    HDST_API
+    void BeforeDraw(
+        HdStRenderPassStateSharedPtr const & renderPassState,
+        HdStResourceRegistrySharedPtr const & resourceRegistry) override;
+
     /// Executes the drawing commands for this batch.
     HDST_API
     void ExecuteDraw(

--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -66,19 +66,17 @@ TF_DEFINE_PRIVATE_TOKENS(
     (constantPrimvars)
 
     (dispatchBuffer)
+    (drawCullInput)
 
-    (drawCommandIndex)
     (drawIndirect)
     (drawIndirectCull)
     (drawIndirectResult)
-
-    (instanceCountInput)
 
     (ulocCullParams)
 );
 
 
-TF_DEFINE_ENV_SETTING(HDST_ENABLE_PIPELINE_DRAW_BATCH_GPU_FRUSTUM_CULLING,false,
+TF_DEFINE_ENV_SETTING(HDST_ENABLE_PIPELINE_DRAW_BATCH_GPU_FRUSTUM_CULLING, true,
                       "Enable pipeline draw batching GPU frustum culling");
 
 HdSt_PipelineDrawBatch::HdSt_PipelineDrawBatch(
@@ -106,6 +104,10 @@ HdSt_PipelineDrawBatch::HdSt_PipelineDrawBatch(
     , _instanceCountOffset(0)
     , _cullInstanceCountOffset(0)
     , _patchBaseVertexByteOffset(0)
+    , _drawCoord0Offset(0)
+    , _drawCoord1Offset(0)
+    , _drawCoord2Offset(0)
+    , _drawCoordIOffset(0)
 {
     _Init(drawItemInstance);
 }
@@ -487,57 +489,6 @@ _AddDrawResourceViews(HdStDispatchBufferSharedPtr const & dispatchBuffer,
     }
 }
 
-void
-_AddInstanceCullResourceViews(HdStDispatchBufferSharedPtr const & cullInput,
-                              _DrawCommandTraits const & traits)
-{
-    // cull indirect command
-    cullInput->AddBufferResourceView(
-        HdTokens->drawDispatch, {HdTypeInt32, 1},
-        traits.cullCount_offset);
-    // cull drawing coord 0
-    cullInput->AddBufferResourceView(
-        HdTokens->drawingCoord0, {HdTypeInt32Vec4, 1},
-        traits.drawingCoord0_offset);
-    // cull drawing coord 1
-    cullInput->AddBufferResourceView(
-        // see the comment above
-        HdTokens->drawingCoord1, {HdTypeInt32Vec2, 1},
-        traits.drawingCoord1_offset);
-    // cull instance drawing coord
-    if (traits.instancerNumLevels > 0) {
-        cullInput->AddBufferResourceView(
-            HdTokens->drawingCoordI, {HdTypeInt32, traits.instancerNumLevels},
-            traits.drawingCoordI_offset);
-    }
-    // cull draw index
-    cullInput->AddBufferResourceView(
-        _tokens->drawCommandIndex, {HdTypeInt32, 1},
-        traits.baseInstance_offset);
-}
-
-void
-_AddNonInstanceCullResourceViews(HdStDispatchBufferSharedPtr const & cullInput,
-                                 _DrawCommandTraits const & traits)
-{
-    // cull indirect command
-    cullInput->AddBufferResourceView(
-        HdTokens->drawDispatch, {HdTypeInt32, 1},
-        traits.count_offset);
-    // cull drawing coord 0
-    cullInput->AddBufferResourceView(
-        HdTokens->drawingCoord0, {HdTypeInt32Vec4, 1},
-        traits.drawingCoord0_offset);
-    // cull draw index
-    cullInput->AddBufferResourceView(
-        _tokens->drawCommandIndex, {HdTypeInt32, 1},
-        traits.baseInstance_offset);
-    // cull instance count input
-    cullInput->AddBufferResourceView(
-        _tokens->instanceCountInput, {HdTypeInt32, 1},
-        traits.instanceCount_offset);
-}
-
 HdBufferArrayRangeSharedPtr
 _GetShaderBar(HdSt_MaterialNetworkShaderSharedPtr const & shader)
 {
@@ -848,6 +799,12 @@ HdSt_PipelineDrawBatch::_CompileBatch(
     _instanceCountOffset = traits.instanceCount_offset/sizeof(uint32_t);
     _cullInstanceCountOffset = traits.cullInstanceCount_offset/sizeof(uint32_t);
 
+    // cache the offset needed for compute culling.
+    _drawCoord0Offset = traits.drawingCoord0_offset / sizeof(uint32_t);
+    _drawCoord1Offset = traits.drawingCoord1_offset / sizeof(uint32_t);
+    _drawCoord2Offset = traits.drawingCoord2_offset / sizeof(uint32_t);
+    _drawCoordIOffset = traits.drawingCoordI_offset / sizeof(uint32_t);
+
     // cache the location of patchBaseVertex for tessellated patch drawing.
     _patchBaseVertexByteOffset = traits.patchBaseVertex_offset;
 
@@ -873,13 +830,6 @@ HdSt_PipelineDrawBatch::_CompileBatch(
             resourceRegistry->RegisterDispatchBuffer(_tokens->drawIndirectCull,
                                                      numDrawItemInstances,
                                                      traits.numUInt32);
-
-        // add culling resource views
-        if (_useInstanceCulling) {
-            _AddInstanceCullResourceViews(_dispatchBufferCullInput, traits);
-        } else {
-            _AddNonInstanceCullResourceViews(_dispatchBufferCullInput, traits);
-        }
 
         // copy data
         _dispatchBufferCullInput->CopyData(_drawCommandBuffer);
@@ -986,7 +936,22 @@ HdSt_PipelineDrawBatch::PrepareDraw(
         _dispatchBuffer->CopyData(_drawCommandBuffer);
         _drawCommandBufferDirty = false;
     }
-    
+
+
+    if (_useGpuCulling) {
+        // Ignore passed in gfxCmds for now since GPU frustum culling
+        // may still require multiple command buffer submissions.
+        _ExecuteFrustumCull(updateBufferData,
+                            renderPassState, resourceRegistry);
+    }
+ 
+}
+
+void
+HdSt_PipelineDrawBatch::BeforeDraw(
+    HdStRenderPassStateSharedPtr const & renderPassState,
+    HdStResourceRegistrySharedPtr const & resourceRegistry)
+{   
     Hgi *hgi = resourceRegistry->GetHgi();
     HgiCapabilities const *capabilities = hgi->GetCapabilities();
 
@@ -1000,13 +965,6 @@ HdSt_PipelineDrawBatch::PrepareDraw(
     _indirectCommands.reset();
     if (drawICB) {
         _PrepareIndirectCommandBuffer(renderPassState, resourceRegistry);
-    }
-
-    if (_useGpuCulling) {
-        // Ignore passed in gfxCmds for now since GPU frustum culling
-        // may still require multiple command buffer submissions.
-        _ExecuteFrustumCull(updateBufferData,
-                            renderPassState, resourceRegistry);
     }
 }
 
@@ -1452,7 +1410,7 @@ HdSt_PipelineDrawBatch::_ExecuteDrawImmediate(
 ////////////////////////////////////////////////////////////
 
 static
-HgiGraphicsPipelineSharedPtr
+HgiComputePipelineSharedPtr
 _GetCullPipeline(
     HdStResourceRegistrySharedPtr const & resourceRegistry,
     _BindingState const & state,
@@ -1463,28 +1421,23 @@ _GetCullPipeline(
                                         state.glslProgram->GetProgram();
     uint64_t const hash = reinterpret_cast<uint64_t>(programHandle.Get());
 
-    HdInstance<HgiGraphicsPipelineSharedPtr> pipelineInstance =
-        resourceRegistry->RegisterGraphicsPipeline(hash);
+    HdInstance<HgiComputePipelineSharedPtr> pipelineInstance =
+        resourceRegistry->RegisterComputePipeline(hash);
 
     if (pipelineInstance.IsFirstInstance()) {
         // Create a points primitive, vertex shader only pipeline that uses
         // a uniform block data for the 'cullParams' in the shader.
-        HgiGraphicsPipelineDesc pipeDesc;
-        pipeDesc.shaderConstantsDesc.stageUsage = HgiShaderStageVertex;
+        HgiComputePipelineDesc pipeDesc;
+        pipeDesc.debugName = "FrustumCulling";
+        pipeDesc.shaderProgram = programHandle;
         pipeDesc.shaderConstantsDesc.byteSize = byteSizeUniforms;
-        pipeDesc.depthState.depthTestEnabled = false;
-        pipeDesc.depthState.depthWriteEnabled = false;
-        pipeDesc.primitiveType = HgiPrimitiveTypePointList;
-        pipeDesc.shaderProgram = state.glslProgram->GetProgram();
-        pipeDesc.rasterizationState.rasterizerEnabled = false;
-
-        pipeDesc.vertexBuffers = _GetVertexBuffersForViewTransformation(state);
 
         Hgi* hgi = resourceRegistry->GetHgi();
-        HgiGraphicsPipelineHandle pso = hgi->CreateGraphicsPipeline(pipeDesc);
+        HgiComputePipelineSharedPtr pipe =
+            std::make_shared<HgiComputePipelineHandle>(
+                hgi->CreateComputePipeline(pipeDesc));
 
-        pipelineInstance.SetValue(
-            std::make_shared<HgiGraphicsPipelineHandle>(pso));
+        pipelineInstance.SetValue(pipe);
     }
 
     return pipelineInstance.GetValue();
@@ -1529,7 +1482,8 @@ HdSt_PipelineDrawBatch::_PrepareIndirectCommandBuffer(
         GetBufferArrayRange()->GetResource(HdTokens->drawDispatch);
     
     HgiIndirectCommandEncoder *encoder = hgi->GetIndirectCommandEncoder();
-    HgiComputeCmds *computeCmds = resourceRegistry->GetGlobalComputeCmds();
+    HgiComputeCmds *computeCmds = resourceRegistry->GetGlobalComputeCmds(
+        HgiComputeDispatchConcurrent);
 
     if (!_useDrawIndexed) {
         _indirectCommands = encoder->EncodeDraw(
@@ -1579,58 +1533,43 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
         _dispatchBufferCullInput->CopyData(_drawCommandBuffer);
     }
 
-    _CullingProgram cullingProgram = _GetCullingProgram(resourceRegistry);
-    if (!TF_VERIFY(cullingProgram.IsValid())) return;
-
-    HdStBufferResourceSharedPtr cullCommandBuffer =
-        _dispatchBufferCullInput->GetResource(HdTokens->drawDispatch);
-    if (!TF_VERIFY(cullCommandBuffer)) return;
+    _CreateCullingProgram(resourceRegistry);
+    if (!TF_VERIFY(_cullingProgram.IsValid())) return;
 
     struct Uniforms {
+        GfVec4i dummyVertexOffset; // See codeGen.cpp _GenerateComputeParameters
         GfMatrix4f cullMatrix;
         GfVec2f drawRangeNDC;
         uint32_t drawCommandNumUints;
+        uint32_t drawCoord0Offset;
+        uint32_t drawCoord1Offset;
+        uint32_t drawCoord2Offset;
+        uint32_t drawCoordIOffset;      // Unused in non-instanced culling.
     };
 
-    struct UniformsInstanced {
-        GfMatrix4f cullMatrix;
-        GfVec2f drawRangeNDC;
-        uint32_t drawCommandNumUints;
-        int32_t resetPass;
-    };
-
-    // We perform frustum culling on the GPU with the rasterizer disabled,
-    // stomping the instanceCount of each drawing command in the
-    // dispatch buffer to 0 for primitives that are culled, skipping
-    // over other elements.
+    // We perform frustum culling in a compute shader, stomping the
+    // instanceCount of each drawing command in the dispatch buffer to 0 for
+    // primitives that are culled, skipping over other elements.
 
     _BindingState state(
             _drawItemInstances.front()->GetDrawItem(),
             _dispatchBufferCullInput,
-            cullingProgram.GetBinder(),
-            cullingProgram.GetGLSLProgram(),
-            cullingProgram.GetComposedShaders(),
-            cullingProgram.GetGeometricShader());
+            _cullingProgram.GetBinder(),
+            _cullingProgram.GetGLSLProgram(),
+            _cullingProgram.GetComposedShaders(),
+            _cullingProgram.GetGeometricShader());
 
     Hgi * hgi = resourceRegistry->GetHgi();
 
-    HgiGraphicsPipelineSharedPtr const & pso =
+    HgiComputePipelineSharedPtr const & pso =
         _GetCullPipeline(resourceRegistry,
                          state,
-                         _useInstanceCulling
-                             ? sizeof(UniformsInstanced)
-                             : sizeof(Uniforms));
-    HgiGraphicsPipelineHandle psoHandle = *pso.get();
+                         sizeof(Uniforms));
+    HgiComputePipelineHandle psoHandle = *pso.get();
 
-    // GfxCmds has no attachment since it is a vertex only shader.
-    HgiGraphicsCmdsDesc gfxDesc;
-    HgiGraphicsCmdsUniquePtr cullGfxCmds = hgi->CreateGraphicsCmds(gfxDesc);
-    if (_useInstanceCulling) {
-        cullGfxCmds->PushDebugGroup("GPU frustum culling (instanced)");
-    } else {
-        cullGfxCmds->PushDebugGroup("GPU frustum culling (non-instanced)");
-    }
-    cullGfxCmds->BindPipeline(psoHandle);
+    HgiComputeCmds* computeCmds =
+        resourceRegistry->GetGlobalComputeCmds(HgiComputeDispatchConcurrent);
+    computeCmds->PushDebugGroup("FrustumCulling Cmds");
 
     HgiResourceBindingsDesc bindingsDesc;
     state.GetBindingsForViewTransformation(&bindingsDesc);
@@ -1642,7 +1581,6 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
                 _tokens->drawIndirectResult,
                 _resultBuffer,
                 _resultBuffer->GetOffset());
-                
     }
 
     // bind destination buffer
@@ -1652,81 +1590,52 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
             _tokens->dispatchBuffer,
             _dispatchBuffer->GetEntireResource(),
             _dispatchBuffer->GetEntireResource()->GetOffset());
-
+    
+    // bind the read-only copy of the destination buffer for input.
+    state.binder.GetBufferBindingDesc(
+            &bindingsDesc,
+            _tokens->drawCullInput,
+            _dispatchBufferCullInput->GetEntireResource(),
+            _dispatchBufferCullInput->GetEntireResource()->GetOffset());
+    
+    // HdSt_ResourceBinder::GetBufferBindingDesc() sets everything to
+    // (VS | FS | TS), so we have to set all the buffer stage usage to Compute
+    TF_FOR_ALL(iter, bindingsDesc.buffers) {
+        iter->stageUsage = HgiShaderStageCompute;
+        iter->writable = true;
+    }
+    
     HgiResourceBindingsHandle resourceBindings =
             hgi->CreateResourceBindings(bindingsDesc);
-    cullGfxCmds->BindResources(resourceBindings);
 
-    HgiVertexBufferBindingVector bindings;
-    _GetVertexBufferBindingsForViewTransformation(&bindings, state);
-    cullGfxCmds->BindVertexBuffers(bindings);
+    computeCmds->BindResources(resourceBindings);
+    computeCmds->BindPipeline(psoHandle);
 
     GfMatrix4f const &cullMatrix = GfMatrix4f(renderPassState->GetCullMatrix());
     GfVec2f const &drawRangeNdc = renderPassState->GetDrawingRangeNDC();
+    
+    HdStBufferResourceSharedPtr paramBuffer = _dispatchBuffer->
+        GetBufferArrayRange()->GetResource(HdTokens->drawDispatch);
+    
+    // set instanced cull parameters
+    Uniforms cullParams;
+    cullParams.dummyVertexOffset = GfVec4i(0);
+    cullParams.drawCommandNumUints =
+            _dispatchBuffer->GetCommandNumUints();
+    cullParams.cullMatrix = cullMatrix;
+    cullParams.drawRangeNDC = drawRangeNdc;
+    cullParams.drawCoord0Offset = uint32_t(_drawCoord0Offset);
+    cullParams.drawCoord1Offset = uint32_t(_drawCoord1Offset);
+    cullParams.drawCoord2Offset = uint32_t(_drawCoord2Offset);
+    cullParams.drawCoordIOffset = uint32_t(_drawCoordIOffset);
 
-    // Get the bind index for the 'cullParams' uniform block
-    HdBinding binding = state.binder.GetBinding(_tokens->ulocCullParams);
-    int bindLoc = binding.GetLocation();
-
-    if (_useInstanceCulling) {
-        // set instanced cull parameters
-        UniformsInstanced cullParamsInstanced;
-        cullParamsInstanced.drawCommandNumUints =
-                _dispatchBuffer->GetCommandNumUints();
-        cullParamsInstanced.cullMatrix = cullMatrix;
-        cullParamsInstanced.drawRangeNDC = drawRangeNdc;
-
-        // Reset Pass
-        cullParamsInstanced.resetPass = 1;
-        cullGfxCmds->SetConstantValues(
-            psoHandle, HgiShaderStageVertex,
-            bindLoc, sizeof(UniformsInstanced), &cullParamsInstanced);
-
-        cullGfxCmds->DrawIndirect(
-            cullCommandBuffer->GetHandle(),
-            cullCommandBuffer->GetOffset(),
-            _dispatchBufferCullInput->GetCount(),
-            cullCommandBuffer->GetStride());
-
-        // Make sure the reset-pass memory writes
-        // are visible to the culling shader pass.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
-
-        // Perform Culling Pass
-        cullParamsInstanced.resetPass = 0;
-        cullGfxCmds->SetConstantValues(
-            psoHandle, HgiShaderStageVertex,
-            bindLoc, sizeof(UniformsInstanced), &cullParamsInstanced);
-
-        cullGfxCmds->DrawIndirect(
-            cullCommandBuffer->GetHandle(),
-            cullCommandBuffer->GetOffset(),
-            _dispatchBufferCullInput->GetCount(),
-            cullCommandBuffer->GetStride());
-
-        // Make sure culling memory writes are
-        // visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
-    } else {
-        // set cull parameters
-        Uniforms cullParams;
-        cullParams.drawCommandNumUints = _dispatchBuffer->GetCommandNumUints();
-        cullParams.cullMatrix = cullMatrix;
-        cullParams.drawRangeNDC = drawRangeNdc;
-
-        // Perform Culling
-        cullGfxCmds->SetConstantValues(
-            psoHandle, HgiShaderStageVertex,
-            bindLoc, sizeof(Uniforms), &cullParams);
-
-        cullGfxCmds->Draw(_dispatchBufferCullInput->GetCount(), 0, 1, 0);
-
-        // Make sure culling memory writes are visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
-    }
-
-    cullGfxCmds->PopDebugGroup();
-    hgi->SubmitCmds(cullGfxCmds.get());
+    computeCmds->SetConstantValues(
+        psoHandle, 0,
+        sizeof(Uniforms), &cullParams);
+    
+    int inputCount = _dispatchBufferCullInput->GetCount();
+    computeCmds->Dispatch(inputCount, 1);
+    computeCmds->PopDebugGroup();
 
     if (IsEnabledGPUCountVisibleInstances()) {
         _EndGPUCountVisibleInstances(resourceRegistry, &_numVisibleItems);
@@ -1838,13 +1747,13 @@ HdSt_PipelineDrawBatch::_EndGPUCountVisibleInstances(
     *result = count;
 }
 
-HdSt_PipelineDrawBatch::_CullingProgram &
-HdSt_PipelineDrawBatch::_GetCullingProgram(
+void
+HdSt_PipelineDrawBatch::_CreateCullingProgram(
     HdStResourceRegistrySharedPtr const & resourceRegistry)
 {
     if (!_cullingProgram.GetGLSLProgram() || _dirtyCullingProgram) {
-        // create a culling shader key
-        HdSt_CullingShaderKey shaderKey(_useInstanceCulling,
+        // Create a culling compute shader key
+        HdSt_CullingComputeShaderKey shaderKey(_useInstanceCulling,
             _useTinyPrimCulling,
             IsEnabledGPUCountVisibleInstances());
 
@@ -1852,13 +1761,11 @@ HdSt_PipelineDrawBatch::_GetCullingProgram(
         HdSt_GeometricShaderSharedPtr cullShader =
             HdSt_GeometricShader::Create(shaderKey, resourceRegistry);
         _cullingProgram.SetGeometricShader(cullShader);
-
         _cullingProgram.CompileShader(_drawItemInstances.front()->GetDrawItem(),
                                        resourceRegistry);
 
         _dirtyCullingProgram = false;
     }
-    return _cullingProgram;
 }
 
 void
@@ -1894,20 +1801,8 @@ HdSt_PipelineDrawBatch::_CullingProgram::_GetCustomBindings(
                                   _tokens->dispatchBuffer));
     customBindings->push_back(HdBindingRequest(HdBinding::UBO,
                                   _tokens->ulocCullParams));
-
-    if (_useInstanceCulling) {
-        customBindings->push_back(
-            HdBindingRequest(HdBinding::DRAW_INDEX_INSTANCE,
-                _tokens->drawCommandIndex));
-    } else {
-        // non-instance culling
-        customBindings->push_back(
-            HdBindingRequest(HdBinding::DRAW_INDEX,
-                _tokens->drawCommandIndex));
-        customBindings->push_back(
-            HdBindingRequest(HdBinding::DRAW_INDEX,
-                _tokens->instanceCountInput));
-    }
+    customBindings->push_back(HdBindingRequest(HdBinding::SSBO,
+                                  _tokens->drawCullInput));
 
     // set instanceDraw true if instanceCulling is enabled.
     // this value will be used to determine if glVertexAttribDivisor needs to

--- a/pxr/imaging/hdSt/pipelineDrawBatch.h
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.h
@@ -68,6 +68,12 @@ public:
         HdStRenderPassStateSharedPtr const & renderPassState,
         HdStResourceRegistrySharedPtr const & resourceRegistry) override;
 
+    /// Do the final preparation before the draw.
+    HDST_API
+    void BeforeDraw(
+        HdStRenderPassStateSharedPtr const & renderPassState,
+        HdStResourceRegistrySharedPtr const & resourceRegistry) override;
+
     /// Executes the drawing commands for this batch.
     HDST_API
     void ExecuteDraw(
@@ -126,7 +132,7 @@ private:
         size_t _bufferArrayHash;
     };
 
-    _CullingProgram &_GetCullingProgram(
+    void _CreateCullingProgram(
         HdStResourceRegistrySharedPtr const & resourceRegistry);
 
     void _CompileBatch(HdStResourceRegistrySharedPtr const & resourceRegistry);
@@ -186,6 +192,10 @@ private:
     size_t _instanceCountOffset;
     size_t _cullInstanceCountOffset;
     size_t _patchBaseVertexByteOffset;
+    size_t _drawCoord0Offset;
+    size_t _drawCoord1Offset;
+    size_t _drawCoord2Offset;
+    size_t _drawCoordIOffset;
     
     std::unique_ptr<HgiIndirectCommands> _indirectCommands;
 };

--- a/pxr/imaging/hdSt/renderPass.cpp
+++ b/pxr/imaging/hdSt/renderPass.cpp
@@ -141,9 +141,6 @@ HdSt_RenderPass::_Execute(HdRenderPassStateSharedPtr const &renderPassState,
     // Validate and update draw batches.
     _UpdateCommandBuffer(renderTags);
 
-    // CPU frustum culling (if chosen)
-    _FrustumCullCPU(stRenderPassState);
-
     // Downcast the resource registry
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
         std::dynamic_pointer_cast<HdStResourceRegistry>(
@@ -165,7 +162,7 @@ HdSt_RenderPass::_Execute(HdRenderPassStateSharedPtr const &renderPassState,
     prepareGfxCmds->PushDebugGroup(prepareName.c_str());
 
     _cmdBuffer.PrepareDraw(prepareGfxCmds.get(),
-                           stRenderPassState, resourceRegistry);
+                           stRenderPassState, GetRenderIndex());
 
     prepareGfxCmds->PopDebugGroup();
     _hgi->SubmitCmds(prepareGfxCmds.get());
@@ -371,49 +368,6 @@ HdSt_RenderPass::_UpdateCommandBuffer(TfTokenVector const& renderTags)
     }
 
     _cmdBuffer.SetEnableTinyPrimCulling(_useTinyPrimCulling);
-}
-
-void
-HdSt_RenderPass::_FrustumCullCPU(
-    HdStRenderPassStateSharedPtr const &renderPassState)
-{
-    // This process should be moved to HdSt_DrawBatch::PrepareDraw
-    // to be consistent with GPU culling.
-
-    HdChangeTracker const &tracker = GetRenderIndex()->GetChangeTracker();
-    HgiCapabilities const *capabilities = _hgi->GetCapabilities();
-
-    const bool multiDrawIndirectEnabled =
-        capabilities->IsSet(HgiDeviceCapabilitiesBitsMultiDrawIndirect);
-
-    const bool gpuFrustumCullingEnabled =
-        HdSt_PipelineDrawBatch::IsEnabled(capabilities) ?
-            HdSt_PipelineDrawBatch::IsEnabledGPUFrustumCulling() :
-            HdSt_IndirectDrawBatch::IsEnabledGPUFrustumCulling();
-
-    const bool
-       skipCulling = TfDebug::IsEnabled(HDST_DISABLE_FRUSTUM_CULLING) ||
-           (multiDrawIndirectEnabled && gpuFrustumCullingEnabled);
-    bool freezeCulling = TfDebug::IsEnabled(HD_FREEZE_CULL_FRUSTUM);
-
-    if(skipCulling) {
-        // Since culling state is stored across renders,
-        // we need to update all items visible state
-        _cmdBuffer.SyncDrawItemVisibility(tracker.GetVisibilityChangeCount());
-
-        TF_DEBUG(HD_DRAWITEMS_CULLED).Msg("CULLED: skipped\n");
-    }
-    else {
-        if (!freezeCulling) {
-            // Re-cull the command buffer.
-            _cmdBuffer.FrustumCull(renderPassState->GetCullMatrix());
-        }
-
-        if (TfDebug::IsEnabled(HD_DRAWITEMS_CULLED)) {
-            TF_DEBUG(HD_DRAWITEMS_CULLED).Msg("CULLED: %zu drawItems\n",
-                                              _cmdBuffer.GetCulledSize());
-        }
-    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/renderPass.h
+++ b/pxr/imaging/hdSt/renderPass.h
@@ -64,9 +64,6 @@ private:
     void _UpdateDrawItems(TfTokenVector const& renderTags);
     void _UpdateCommandBuffer(TfTokenVector const& renderTags);
 
-    // XXX: This should really be in HdSt_DrawBatch::PrepareDraw.
-    void _FrustumCullCPU(HdStRenderPassStateSharedPtr const &renderPassState);
-
     // -----------------------------------------------------------------------
     // Drawing state
     HdStCommandBuffer _cmdBuffer;

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -456,7 +456,8 @@ public:
     /// The returned pointer should not be held onto by the client as it is
     /// only valid until the HgiComputeCmds has been submitted.
     HDST_API
-    HgiComputeCmds* GetGlobalComputeCmds();
+    HgiComputeCmds* GetGlobalComputeCmds(
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial);
 
     /// Submits blit work queued in global blit cmds for GPU execution.
     /// We can call this when we want to submit some work to the GPU.

--- a/pxr/imaging/hdSt/shaderKey.cpp
+++ b/pxr/imaging/hdSt/shaderKey.cpp
@@ -48,6 +48,7 @@ HdSt_ShaderKey::ComputeHash() const
     TfToken const *PTVS = GetPTVS();
     TfToken const *GS = GetGS();
     TfToken const *FS = GetFS();
+    TfToken const *CS = GetCS();
 
     while (VS && (!VS->IsEmpty())) {
         boost::hash_combine(hash, VS->Hash());
@@ -76,6 +77,10 @@ HdSt_ShaderKey::ComputeHash() const
     while (FS && (!FS->IsEmpty())) {
         boost::hash_combine(hash, FS->Hash());
         ++FS;
+    }
+    while (CS && (!CS->IsEmpty())) {
+        boost::hash_combine(hash, CS->Hash());
+        ++CS;
     }
     
     // During batching, we rely on geometric shader equality, and thus the
@@ -140,6 +145,7 @@ HdSt_ShaderKey::GetGlslfxString() const
        << "{\"techniques\": {\"default\": {\n";
 
     bool firstStage = true;
+    ss << _JoinTokens("computeShader",     GetCS(),  &firstStage);
     ss << _JoinTokens("vertexShader",      GetVS(),  &firstStage);
     ss << _JoinTokens("tessControlShader", GetTCS(), &firstStage);
     ss << _JoinTokens("tessEvalShader",    GetTES(), &firstStage);
@@ -197,6 +203,13 @@ HdSt_ShaderKey::GetGS() const
 /*virtual*/
 TfToken const*
 HdSt_ShaderKey::GetFS() const
+{
+    return nullptr;
+}
+    
+/*virtual*/
+TfToken const*
+HdSt_ShaderKey::GetCS() const
 {
     return nullptr;
 }

--- a/pxr/imaging/hdSt/shaderKey.h
+++ b/pxr/imaging/hdSt/shaderKey.h
@@ -78,7 +78,9 @@ struct HdSt_ShaderKey {
     HDST_API
     virtual TfToken const *GetGS() const;
     HDST_API
-    virtual TfToken const *GetFS() const; 
+    virtual TfToken const *GetFS() const;
+    HDST_API
+    virtual TfToken const *GetCS() const;
 
     // An implementation detail of code gen, which generates slightly
     // different code for the VS stage for the frustum culling pass.

--- a/pxr/imaging/hdSt/shaders/frustumCull.glslfx
+++ b/pxr/imaging/hdSt/shaders/frustumCull.glslfx
@@ -301,3 +301,159 @@ void main()
         FrustumCullCountVisibleInstances(1);
     }
 }
+
+
+--- --------------------------------------------------------------------------
+-- layout ViewFrustumCull.Compute
+
+[
+    ["uniform block", "Uniforms", "ulocCullParams",
+        ["mat4", "cullMatrix"],
+        ["vec2", "drawRangeNDC"],
+        ["uint", "drawCommandNumUints"],
+        ["uint", "drawCoord0Offset"],
+        ["uint", "drawCoord1Offset"],
+        ["uint", "drawCoord2Offset"],
+        ["uint", "drawCoordIOffset"]
+    ],
+    ["buffer readOnly", "DrawCullInput", "drawCullInput",
+        ["uint", "drawCullInput", "[]"]
+    ],
+    ["buffer readWrite", "DispatchBuffer", "dispatchBuffer",
+        ["uint", "drawCommands", "[]"]
+    ]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl ViewFrustumCull.Compute
+
+MAT4 GetCullMatrix()
+{
+    return MAT4(cullMatrix);
+}
+
+uint g_drawCommandIndex;
+
+int GetDrawingCoordField(uint coordIndex, uint fieldIndex)
+{   
+    uint offset = g_drawCommandIndex * drawCommandNumUints;
+
+    offset += (coordIndex == 0) ? drawCoord0Offset : 
+              (coordIndex == 1) ? drawCoord1Offset : drawCoord2Offset;
+
+    return int(drawCullInput[offset + fieldIndex]);
+}
+
+void compute(int drawCommandIndex)
+{
+    g_drawCommandIndex = drawCommandIndex;
+
+    // instanceCountOffset is a relative offset in drawcommand struct.
+    // it's a second entry in both DrawArraysCommand and DrawElementsCommand.
+    const uint instanceCountOffset = 1;
+
+    MAT4 transform = HdGet_transform();
+    MAT4 toClip = GetCullMatrix() * transform;
+
+    vec4 localMin = HdGet_bboxLocalMin();
+    vec4 localMax = HdGet_bboxLocalMax();
+
+    bool isVisible = FrustumCullIsVisible(
+        toClip, localMin, localMax, drawRangeNDC);
+
+    // Compute the index to the 'instanceCount' struct member in drawCommands.
+    uint instanceIndex = uint(drawCommandIndex) * 
+        drawCommandNumUints + instanceCountOffset;
+
+    // Set the resulting instance count to 0 if the primitive is culled
+    // otherwise pass through the original incoming instance count.
+    uint resultInstanceCount = drawCullInput[instanceIndex] * uint(isVisible);
+    drawCommands[instanceIndex] = resultInstanceCount;
+
+    FrustumCullCountVisibleInstances(int(resultInstanceCount));
+}
+
+--- --------------------------------------------------------------------------
+-- layout ViewFrustumCull.ComputeInstancing
+
+[
+    ["uniform block", "Uniforms", "ulocCullParams",
+        ["mat4", "cullMatrix"],
+        ["vec2", "drawRangeNDC"],
+        ["uint", "drawCommandNumUints"],
+        ["uint", "drawCoord0Offset"],
+        ["uint", "drawCoord1Offset"],
+        ["uint", "drawCoord2Offset"],
+        ["uint", "drawCoordIOffset"]
+    ],
+    ["buffer readOnly", "DrawCullInput", "drawCullInput",
+        ["uint", "drawCullInput", "[]"]
+    ],
+    ["buffer readWrite", "DispatchBuffer", "dispatchBuffer",
+        ["uint", "drawCommands", "[]"]
+    ]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl ViewFrustumCull.ComputeInstancing
+
+MAT4 GetCullMatrix()
+{
+    return MAT4(cullMatrix);
+}
+
+uint g_drawCommandIndex;
+
+// drawCoordI is coordIndex 3
+int GetDrawingCoordField(uint coordIndex, uint fieldIndex)
+{   
+    uint offset = g_drawCommandIndex * drawCommandNumUints;
+
+    offset += (coordIndex == 0) ? drawCoord0Offset : 
+              (coordIndex == 1) ? drawCoord1Offset :
+              (coordIndex == 2) ? drawCoord2Offset : drawCoordIOffset;
+
+    return int(drawCullInput[offset + fieldIndex]);
+}
+
+
+void compute(int drawCommandIndex)
+{
+    g_drawCommandIndex = uint(drawCommandIndex);
+
+    // instanceCountOffset is a relative offset in drawcommand struct.
+    // it's a second entry in both DrawArraysCommand and DrawElementsCommand.
+    const uint instanceCountOffset = 1;
+
+    uint offset = drawCommandIndex * drawCommandNumUints;
+
+    const uint instanceCount = drawCullInput[offset + instanceCountOffset];
+ 
+    vec4 localMin = HdGet_bboxLocalMin();
+    vec4 localMax = HdGet_bboxLocalMax();
+    MAT4 transform = HdGet_transform();
+
+    // Reset the instance count.
+    drawCommands[offset + instanceCountOffset] = 0;
+
+    for (int i = 0; i < instanceCount; ++i)
+    {
+        g_instanceID = i;
+
+        MAT4 toClip = GetCullMatrix() * ApplyInstanceTransform(transform);
+
+        bool isVisible = FrustumCullIsVisible(
+            toClip, localMin, localMax, drawRangeNDC);
+
+        if (isVisible) {
+            // Increment the instance count and store instanceIndex to
+            // culledInstanceIndices.
+            uint id = drawCommands[offset + instanceCountOffset];
+            
+            drawCommands[offset + instanceCountOffset] += 1;
+
+            SetCulledInstanceIndex(id);
+            FrustumCullCountVisibleInstances(1);
+        }
+    }
+}

--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -596,6 +596,9 @@ HdxPickTask::Execute(HdTaskContext* ctx)
 {
     GLF_GROUP_FUNCTION();
 
+    // This is important for Hgi garbage collection to run.
+    _hgi->StartFrame();
+
     GfVec2i dimensions = _contextParams.resolution;
     GfVec4i viewport(0, 0, dimensions[0], dimensions[1]);
 
@@ -692,6 +695,9 @@ HdxPickTask::Execute(HdTaskContext* ctx)
         TF_CODING_ERROR("Unrecognized interesection mode '%s'",
             _contextParams.resolveMode.GetText());
     }
+
+    // This is important for Hgi garbage collection to run.
+    _hgi->EndFrame();
 }
 
 const TfTokenVector &

--- a/pxr/imaging/hgi/computeCmds.h
+++ b/pxr/imaging/hgi/computeCmds.h
@@ -33,6 +33,23 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+/// \enum HgiComputeDispatch
+///
+/// Specifies the dispatch method for compute encoders.
+///
+/// <ul>
+/// <li>HgiComputeDispatchSerial:
+///   Kernels are dispatched serially.</li>
+/// <li>HgiComputeDispatchConcurrent:
+///   Kernels are dispatched concurrently, if supported by the API</li>
+/// </ul>
+///
+enum HgiComputeDispatch
+{
+    HgiComputeDispatchSerial = 0,
+    HgiComputeDispatchConcurrent
+};
+
 using HgiComputeCmdsUniquePtr = std::unique_ptr<class HgiComputeCmds>;
 
 
@@ -93,6 +110,10 @@ public:
     /// the barrier is available to commands after the barrier.
     HGI_API
     virtual void MemoryBarrier(HgiMemoryBarrier barrier) = 0;
+
+    /// Returns the dispatch method for this encoder.
+    HGI_API
+    virtual HgiComputeDispatch GetDispatchMethod() const = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -177,7 +177,8 @@ public:
     /// created on the main thread, recorded into (exclusively) by one secondary
     /// thread and be submitted on the main thread. See notes above.
     HGI_API
-    virtual HgiComputeCmdsUniquePtr CreateComputeCmds() = 0;
+    virtual HgiComputeCmdsUniquePtr CreateComputeCmds(
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial) = 0;
 
     /// Create a texture in rendering backend.
     /// Thread safety: Creation must happen on main thread. See notes above.

--- a/pxr/imaging/hgiGL/computeCmds.cpp
+++ b/pxr/imaging/hgiGL/computeCmds.cpp
@@ -140,6 +140,12 @@ HgiGLComputeCmds::MemoryBarrier(HgiMemoryBarrier barrier)
     _ops.push_back( HgiGLOps::MemoryBarrier(barrier) );
 }
 
+HgiComputeDispatch
+HgiGLComputeCmds::GetDispatchMethod() const
+{
+    return HgiComputeDispatchSerial;
+}
+
 bool
 HgiGLComputeCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
 {

--- a/pxr/imaging/hgiGL/computeCmds.h
+++ b/pxr/imaging/hgiGL/computeCmds.h
@@ -68,6 +68,9 @@ public:
     HGIGL_API
     void MemoryBarrier(HgiMemoryBarrier barrier) override;
 
+    HGIGL_API
+    HgiComputeDispatch GetDispatchMethod() const override;
+
 protected:
     friend class HgiGL;
 

--- a/pxr/imaging/hgiGL/hgi.cpp
+++ b/pxr/imaging/hgiGL/hgi.cpp
@@ -116,7 +116,7 @@ HgiGL::CreateBlitCmds()
 }
 
 HgiComputeCmdsUniquePtr
-HgiGL::CreateComputeCmds()
+HgiGL::CreateComputeCmds(HgiComputeDispatch dispatchMethod)
 {
     HgiGLComputeCmds* cmds(new HgiGLComputeCmds(_device));
     return HgiComputeCmdsUniquePtr(cmds);

--- a/pxr/imaging/hgiGL/hgi.h
+++ b/pxr/imaging/hgiGL/hgi.h
@@ -92,7 +92,8 @@ public:
     HgiBlitCmdsUniquePtr CreateBlitCmds() override;
 
     HGIGL_API
-    HgiComputeCmdsUniquePtr CreateComputeCmds() override;
+    HgiComputeCmdsUniquePtr CreateComputeCmds(
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial) override;
 
     HGIGL_API
     HgiTextureHandle CreateTexture(HgiTextureDesc const & desc) override;

--- a/pxr/imaging/hgiMetal/computeCmds.h
+++ b/pxr/imaging/hgiMetal/computeCmds.h
@@ -72,13 +72,16 @@ public:
     void MemoryBarrier(HgiMemoryBarrier barrier) override;
 
     HGIMETAL_API
+    HgiComputeDispatch GetDispatchMethod() const override;
+
+    HGIMETAL_API
     id<MTLComputeCommandEncoder> GetEncoder();
 
 protected:
     friend class HgiMetal;
 
     HGIMETAL_API
-    HgiMetalComputeCmds(HgiMetal* hgi);
+    HgiMetalComputeCmds(HgiMetal* hgi, HgiComputeDispatch dispatchMethod);
 
     HGIMETAL_API
     bool _Submit(Hgi* hgi, HgiSubmitWaitType wait) override;
@@ -98,6 +101,7 @@ private:
     id<MTLComputeCommandEncoder> _encoder;
     bool _secondaryCommandBuffer;
     bool _hasWork;
+    HgiComputeDispatch _dispatchMethod;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -70,7 +70,8 @@ public:
         HgiGraphicsCmdsDesc const& desc) override;
     
     HGIMETAL_API
-    HgiComputeCmdsUniquePtr CreateComputeCmds() override;
+    HgiComputeCmdsUniquePtr CreateComputeCmds(
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial) override;
 
     HGIMETAL_API
     HgiBlitCmdsUniquePtr CreateBlitCmds() override;

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -168,9 +168,9 @@ HgiMetal::CreateGraphicsCmds(
 }
 
 HgiComputeCmdsUniquePtr
-HgiMetal::CreateComputeCmds()
+HgiMetal::CreateComputeCmds(HgiComputeDispatch dispatchMethod)
 {
-    HgiComputeCmds* computeCmds = new HgiMetalComputeCmds(this);
+    HgiComputeCmds* computeCmds = new HgiMetalComputeCmds(this, dispatchMethod);
     if (!_currentCmds) {
         _currentCmds = computeCmds;
     }

--- a/pxr/imaging/hgiMetal/resourceBindings.mm
+++ b/pxr/imaging/hgiMetal/resourceBindings.mm
@@ -300,7 +300,7 @@ HgiMetalResourceBindings::BindResources(
     [computeEncoder setBuffer:argBuffer
                        offset:HgiMetalArgumentOffsetConstants
                       atIndex:HgiMetalArgumentIndexConstants];
-  }
+}
 
 void HgiMetalResourceBindings::SetConstantValues(
     id<MTLBuffer> argumentBuffer,

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -732,7 +732,6 @@ HgiMetalBufferShaderSection::VisitScopeConstructorDeclarations(
     if (_unused) return false;
 
     if (!_writable) {
-        ss << "const ";
         ss << "constant ";
     } else {
         ss << "device ";

--- a/pxr/imaging/hgiVulkan/hgi.cpp
+++ b/pxr/imaging/hgiVulkan/hgi.cpp
@@ -108,7 +108,7 @@ HgiVulkan::CreateBlitCmds()
 }
 
 HgiComputeCmdsUniquePtr
-HgiVulkan::CreateComputeCmds()
+HgiVulkan::CreateComputeCmds(HgiComputeDispatch dispatchMethod)
 {
     HgiVulkanComputeCmds* cmds(new HgiVulkanComputeCmds(this));
     return HgiComputeCmdsUniquePtr(cmds);

--- a/pxr/imaging/hgiVulkan/hgi.h
+++ b/pxr/imaging/hgiVulkan/hgi.h
@@ -67,7 +67,8 @@ public:
     HgiBlitCmdsUniquePtr CreateBlitCmds() override;
 
     HGIVULKAN_API
-    HgiComputeCmdsUniquePtr CreateComputeCmds() override;
+    HgiComputeCmdsUniquePtr CreateComputeCmds(
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial) override;
 
     HGIVULKAN_API
     HgiTextureHandle CreateTexture(HgiTextureDesc const & desc) override;


### PR DESCRIPTION
### Description of Change(s)

Implementation of GPU culling using compute shaders in the PipelineDrawBatch. The vertex-shader transform feedback approach that was used previously in the IndirectDrawBatch has not been supported in HGI since it would require multiple command buffers for synchronisation of the stages. The compute shader approach does not require a separate reset pass for instance culling since it can expand out the instances in a loop within the compute shader and populate the drawCommand buffers directly.

Indexing into the drawCommands in the shader is done through a small emulation function in the codegen, `GetDrawingCoordField()`, which has to be implemented in the kernel. This uses the thread ID to offset into the drawCommand buffer and access the encoded instance count, transform etc directly.

Also, the `g_instanceID` parameter needs to be set in the culling kernel so that the codegen can access it in `GetInstanceIndexCoord()`.

For performance reasons, I've added a flag to specify that the compute encoder is created with concurrent dispatch.

To use the PipelineDrawBatch on OpenGL the option `HDST_ENABLE_HGI_RESOURCE_GENERATION` has been changed to default `true`

There was also an issue around how the garbage collector was releasing resources outside of the HGI BeginFrame::EndFrame pair. This was causing a crash on OpenGL when picking a prim in the viewport. I've put a potential fix for this in `HdxPickTask`.

Since the ICB changes have been merged into dev, this PR has been rebased on top of this.  ICBs need to run in a separate batch, so they have been moved to the new `Hd_DrawBatch::BeforeDraw` method.

Fixed the Windows build by using an `#undef` on the `MemoryBarrier` define.  I suggest we change the name of this function to avoid future issues.

### Fixes Issue(s)

Culling on instanced and non-instanced primitives on the GPU.

### Tested on:

MacBook Pro M1 Max, with macOS Ventura
MacBook Pro i7 Radeon 560, with macOS Ventura
HP Xeon nVidia 3080, with Ubuntu 20.02

### Update

This was originally submitted as PR: https://github.com/PixarAnimationStudios/USD/pull/2045
but was accidentally closed with a force-push.  Reopened.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement