### PR TITLE
APPLE: Fix for Alembic HDF5 on universal builds

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1538,6 +1538,11 @@ def InstallHDF5(context, force, buildArgs):
         if MacOS():
             PatchFile("config/cmake_ext_mod/ConfigureChecks.cmake",
                     [("if (ARCH_LENGTH GREATER 1)", "if (FALSE)")])
+            if context.targetUniversal:
+                PatchFile("config/cmake/H5pubconf.h.in",
+                        [(" #define H5_SIZEOF_LONG_LONG 8",
+                        " #define H5_SIZEOF_LONG_LONG 8\n" +
+                        " #define H5_SIZEOF_LONG_DOUBLE 16")])
         RunCMake(context, force,
                  ['-DBUILD_TESTING=OFF',
                   '-DHDF5_BUILD_TOOLS=OFF',


### PR DESCRIPTION
### Description of Change(s)

HDF5 needs to set the size of a long double based on architecture, but the cmake logic doesn't support multiple targets.  For x64 and arm64 this is 16 bytes so we can force it.

### Fixes Issue(s)
- HDF5 not building when `--build-target universal` defined.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
