### PR TITLE
Fix bug in HdExtComputationUtils::_GenerateDependencyMap() with multiple input computations

### DIFF
--- a/pxr/imaging/hd/extComputationUtils.cpp
+++ b/pxr/imaging/hd/extComputationUtils.cpp
@@ -68,7 +68,7 @@ HdExtComputationUtils::_GenerateDependencyMap(
     HdExtComputationUtils::ComputationDependencyMap cdm;
     while (!computations.empty()) {
         // Pop head entry and skip if already processed.
-        HdExtComputation const * curComp = computations.back();
+        HdExtComputation const * curComp = computations.front();
         computations.pop_front();
         if (cdm.find(curComp) != cdm.end()) {
             continue;

--- a/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
+++ b/pxr/imaging/hd/testenv/testHdExtComputationUtils.cpp
@@ -36,13 +36,20 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 static const SdfPath pathA("/path/to/A");
-static const SdfPath compA("/path/to/A/computation");
+static const SdfPath compA("/path/to/A/computationA");
+static const SdfPath compB("/path/to/A/computationB");
+static const SdfPath compC("/path/to/A/computationC");
 static const TfToken input1("input1");
 static const TfToken input2("input2");
 static const TfToken primvarName("outputPV");
 static const TfToken compOutputName("compOutput");
 
-// Delegate that implements a simple computation (adding together two inputs).
+// Delegate that implements a simple computation, which adds together inputs
+// from two aggregate computations:
+//
+// computationA -> computationB -> input1
+//             \-> computationC -> input2
+//
 class ExtComputationTestDelegate : public HdUnitTestDelegate {
 public:
     ExtComputationTestDelegate(HdRenderIndex *parentIndex)
@@ -71,11 +78,24 @@ public:
 
     virtual TfTokenVector
     GetExtComputationSceneInputNames(SdfPath const& computationId) override {
-        if (computationId == compA) {
-            return {input1, input2};
+        if (computationId == compB) {
+            return {input1};
+        } else if (computationId == compC) {
+            return {input2};
         }
 
         return {};
+    }
+
+    virtual HdExtComputationInputDescriptorVector
+    GetExtComputationInputDescriptors(SdfPath const& computationId) override {
+        HdExtComputationInputDescriptorVector inputs;
+        if (computationId == compA) {
+            inputs.emplace_back(input1, compB, input1);
+            inputs.emplace_back(input2, compC, input2);
+        }
+
+        return inputs;
     }
 
     virtual HdExtComputationOutputDescriptorVector
@@ -96,21 +116,17 @@ public:
                                              size_t maxSampleCount,
                                              float *sampleTimes,
                                              VtValue *sampleValues) override {
-        if (computationId != compA) {
-            return 0;
-        }
-
         const size_t numSamples = std::min(size_t(4), maxSampleCount);
 
         // The two inputs have different sample times (0,1,2,3 and 0,2,4,6).
-        if (input == input1) {
+        if (computationId == compB && input == input1) {
             for (size_t i = 0; i < numSamples; ++i) {
                 sampleTimes[i] = i;
                 sampleValues[i] = VtValue(double(i));
             }
             return numSamples;
         }
-        else if (input == input2) {
+        else if (computationId == compC && input == input2) {
             for (size_t i = 0; i < numSamples; ++i) {
                 sampleTimes[i] = i * 2;
                 sampleValues[i] = VtValue(double(i));
@@ -218,11 +234,13 @@ void RunTest()
         HdRenderIndex::New(&renderDelegate, {}));
     ExtComputationTestDelegate delegate(index.get());
 
-    // Create an sprim for the computation.
-    index->InsertSprim(HdPrimTypeTokens->extComputation, &delegate, compA);
-    auto sprim = index->GetSprim(HdPrimTypeTokens->extComputation, compA);
-    HdDirtyBits dirty = HdExtComputation::DirtyBits::AllDirty;
-    sprim->Sync(&delegate, nullptr, &dirty);
+    // Create an sprim for each computation.
+    for (const SdfPath &comp : {compA, compB, compC}) {
+        index->InsertSprim(HdPrimTypeTokens->extComputation, &delegate, comp);
+        auto sprim = index->GetSprim(HdPrimTypeTokens->extComputation, comp);
+        HdDirtyBits dirty = HdExtComputation::DirtyBits::AllDirty;
+        sprim->Sync(&delegate, nullptr, &dirty);
+    }
 
     auto compPrimvars = delegate.GetExtComputationPrimvarDescriptors(
         pathA, HdInterpolationConstant);


### PR DESCRIPTION
### Description of Change(s)

The last element in the queue was used instead of the front element that is subsequently popped from the queue, which caused some input computations to be skipped if the queue ever has multiple entries.

Extended testHdExtComputationUtils to add code coverage for this by using multiple input computations (the skinning computation only has a single input aggregator computation, so it didn't encounter this bug).

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
