### PR TITLE
[gf] make vec*.h use GfSqrt instead of sqrt

### DIFF
--- a/pxr/base/gf/vec.template.h
+++ b/pxr/base/gf/vec.template.h
@@ -252,8 +252,7 @@ public:
 {% if IS_FLOATING_POINT(SCL) %}
     /// Length
     {{ SCL }} GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec2d.h
+++ b/pxr/base/gf/vec2d.h
@@ -248,8 +248,7 @@ public:
 
     /// Length
     double GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec2f.h
+++ b/pxr/base/gf/vec2f.h
@@ -248,8 +248,7 @@ public:
 
     /// Length
     float GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec2h.h
+++ b/pxr/base/gf/vec2h.h
@@ -249,8 +249,7 @@ public:
 
     /// Length
     GfHalf GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec3d.h
+++ b/pxr/base/gf/vec3d.h
@@ -260,8 +260,7 @@ public:
 
     /// Length
     double GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec3f.h
+++ b/pxr/base/gf/vec3f.h
@@ -260,8 +260,7 @@ public:
 
     /// Length
     float GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec3h.h
+++ b/pxr/base/gf/vec3h.h
@@ -261,8 +261,7 @@ public:
 
     /// Length
     GfHalf GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec4d.h
+++ b/pxr/base/gf/vec4d.h
@@ -272,8 +272,7 @@ public:
 
     /// Length
     double GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec4f.h
+++ b/pxr/base/gf/vec4f.h
@@ -272,8 +272,7 @@ public:
 
     /// Length
     float GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the

--- a/pxr/base/gf/vec4h.h
+++ b/pxr/base/gf/vec4h.h
@@ -273,8 +273,7 @@ public:
 
     /// Length
     GfHalf GetLength() const {
-        // TODO should use GfSqrt.
-        return sqrt(GetLengthSq());
+        return GfSqrt(GetLengthSq());
     }
 
     /// Normalizes the vector in place to unit length, returning the


### PR DESCRIPTION
### Description of Change(s)

with gcc, at least, this avoids using a double for vec3f::GetLength, which avoids a compiler warning when using -Wconversion



### Fixes Issue(s)
- warning when using -Wconversion flag on gcc

- [X] I have submitted a signed Contributor License Agreement
