### PR TITLE
[vt] fix for crash when creating VtArray from large python buffer

### DIFF
--- a/pxr/base/vt/arrayPyBuffer.cpp
+++ b/pxr/base/vt/arrayPyBuffer.cpp
@@ -416,12 +416,12 @@ Vt_ArrayFromBuffer(TfPyObjWrapper const &obj,
     // Check that the number of elements matches.
     auto multiply = [](Py_ssize_t x, Py_ssize_t y) { return x * y; };
     auto numItems = std::accumulate(
-        view.shape, view.shape + view.ndim, 1, multiply);
+        view.shape, view.shape + view.ndim, (Py_ssize_t)1, multiply);
 
     // Compute the total # of items in one element.
     auto elemShape = Vt_GetElementShape<T>();
     auto elemSize = std::accumulate(
-        elemShape.begin(), elemShape.end(), 1, multiply);
+        elemShape.begin(), elemShape.end(), (Py_ssize_t)1, multiply);
 
     // Sanity check data sizes.
     auto arraySize = numItems / elemSize;

--- a/pxr/base/vt/testenv/testVtArray.py
+++ b/pxr/base/vt/testenv/testVtArray.py
@@ -25,6 +25,8 @@
 # pylint: disable=range-builtin-not-iterating
 #
 from __future__ import division
+
+import array
 import unittest
 import sys, math
 from pxr import Gf, Vt
@@ -157,10 +159,10 @@ class TestVtArray(unittest.TestCase):
         for arrayType, (x0, x1) in overflows:
             for x in (x0, x1):
                 with self.assertRaises(OverflowError):
-                    array = arrayType((x,))
+                    arrayT = arrayType((x,))
             for x in (x0+1, x1-1):
-                array = arrayType((x,))
-                self.assertEqual(array, eval(repr(array)))
+                arrayT = arrayType((x,))
+                self.assertEqual(arrayT, eval(repr(arrayT)))
 
     def test_ParallelizedOps(self):
         m0 = Vt.Matrix4dArray((Gf.Matrix4d(1),Gf.Matrix4d(2)))
@@ -356,6 +358,14 @@ class TestVtArray(unittest.TestCase):
         _TestDivision(Vt.QuatfArray, Gf.Quatf, Gf.Vec3f)
         _TestDivision(Vt.QuatdArray, Gf.Quatd, Gf.Vec3d)
         _TestDivision(Vt.QuaternionArray, Gf.Quaternion, Gf.Vec3d)
+
+    def test_LargeBuffer(self):
+        '''VtArray can be created from a buffer with item count
+           greater than maxint'''
+        largePyBuffer = array.array('B', (0,)) * 2500000000
+        vtArrayFromBuffer = Vt.UCharArray.FromBuffer(largePyBuffer)
+        self.assertEqual(len(vtArrayFromBuffer), 2500000000)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)

The third parameter of `std::accumulate` will determine the return type for `std::accumulate`. If the type is not explicit, then the compiler will infer it. More info here:

https://en.cppreference.com/w/cpp/algorithm/accumulate

The `Vt_ArrayFromBuffer` helper uses `std::accumulate` to determine the number of items to be created in the `VtArray`. Because the third parameter given here is just `1`, the compiler assumes this is an `int` and uses that for the return type from `std::accumulate`. This is fine for most sane uses of `VtArray` that are initialized from a Python buffer with less than 2 billion-ish items. But if your Python buffer has more than maxint items, then the `int` return type overflows, and the process usually crashes.

This change makes the third parameter explicitly `Py_ssize_t`, which is the type of the other inputs to `std::accumulate` and was likely the intended output type all along.

### Fixes Issue(s)

Crash or incorrect behavior when creating a `VtArray` from a python buffer with more than maxint elements.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
