### PR TITLE
Make timing tests compare to upper / lower bounds

### DIFF
--- a/pxr/base/trace/testenv/testTrace.py
+++ b/pxr/base/trace/testenv/testTrace.py
@@ -204,22 +204,28 @@ class TestTrace(unittest.TestCase):
 
         gc.enabled = True
         sleepTime = 1.0
+        pre_begin = time.time()
         b = gc.BeginEvent("Test tuple")
-        b2 = time.time()
+        post_begin = time.time()
         time.sleep(sleepTime)
+        pre_end = time.time()
         e = gc.EndEvent("Test tuple")
-        e2 = time.time()
+        post_end = time.time()
 
         elapsedSeconds = Trace.GetElapsedSeconds(b, e)
-        expectedElapsedSeconds = e2 - b2
+        expectedMinSeconds = pre_end - post_begin
+        expectedMaxSeconds = post_end - pre_begin
         gr.Report()
 
-        elapsedDiff = abs(elapsedSeconds - expectedElapsedSeconds)
-        self.assertTrue(elapsedDiff < 0.005,
-                        "Elapsed: {} Expected: {} Diff: {}".format(
-                            elapsedSeconds, expectedElapsedSeconds, 
-                            elapsedDiff))
-
+        epsilon = 0.005
+        self.assertGreater(elapsedSeconds, expectedMinSeconds - epsilon,
+                        "Elapsed: {} Expected Min: {} Diff: {}".format(
+                            elapsedSeconds, expectedMinSeconds,
+                            expectedMinSeconds - elapsedSeconds))
+        self.assertLess(elapsedSeconds, expectedMaxSeconds + epsilon,
+                        "Elapsed: {} Expected Max: {} Diff: {}".format(
+                            elapsedSeconds, expectedMaxSeconds,
+                            elapsedSeconds - expectedMaxSeconds))
         print("")
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description of Change(s)

When running tests in parallel, we get intermittent failures of
timing related tests due to the elapsed time being outstide of the
allowed range.

However, this could just be due to thread scheduling issues, as
an indeterminate amount of time could pass between the recorded trace
and the standard library call which was used as "ground truth".

Now, I bracket the trace records on both sides with standard library
timing calls, to provide expected upper and lower bounds, which should
be more forgiving of randomness from thread scheduling.

A follow up to changes in:

cadce6fff973a97d2c83f1a8609a3baa85720b7b - Avoid hard-coded comparisons for timing tests


### Fixes Issue(s)
- Intermittent failures of testTrace and TfStopwatch tests when running tests with many processes

- [X] I have submitted a signed Contributor License Agreement
