### PR TITLE
APPLE: Enable ICB on Intel

### DIFF
--- a/pxr/imaging/hgiMetal/capabilities.mm
+++ b/pxr/imaging/hgiMetal/capabilities.mm
@@ -75,7 +75,7 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
         }
     } else if (hasIntelGPU) {
         // Indirect command buffers not currently supported on Intel GPUs.
-        icbSupported = false;
+        icbSupported = true;
     }
 
     if (!TfGetEnvSetting(HGIMETAL_ENABLE_INDIRECT_COMMAND_BUFFER)) {


### PR DESCRIPTION
### Description of Change(s)
Enable Indirect draw command buffers on Intel as they are working with all latest changes to dev and run through Apple's tests now


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
