### PR TITLE
APPLE: Fix OpenImageIO and OpenEXR debug libraries not found

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1702,8 +1702,10 @@ def InstallUSD(context, force, buildArgs):
 
         if context.buildDebug:
             extraArgs.append('-DTBB_USE_DEBUG_BUILD=ON')
+            extraArgs.append('-DPXR_USE_DEBUG_BUILD=ON')
         else:
             extraArgs.append('-DTBB_USE_DEBUG_BUILD=OFF')
+            extraArgs.append('-DPXR_USE_DEBUG_BUILD=OFF')
 
         if context.buildDocs:
             extraArgs.append('-DPXR_BUILD_DOCUMENTATION=ON')

--- a/cmake/modules/FindOpenEXR.cmake
+++ b/cmake/modules/FindOpenEXR.cmake
@@ -68,10 +68,16 @@ foreach(OPENEXR_LIB
 
     # OpenEXR libraries may be suffixed with the version number, so we search
     # using both versioned and unversioned names.
+    set(DEBUG_POSTFIX )
+    if(DEFINED PXR_USE_DEBUG_BUILD)
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${PXR_USE_DEBUG_BUILD} MATCHES ON)
+            set(DEBUG_POSTFIX _d)
+        endif()
+    endif()
     find_library(OPENEXR_${OPENEXR_LIB}_LIBRARY
         NAMES
-            ${OPENEXR_LIB}-${OPENEXR_MAJOR_VERSION}_${OPENEXR_MINOR_VERSION}
-            ${OPENEXR_LIB}
+            ${OPENEXR_LIB}-${OPENEXR_MAJOR_VERSION}_${OPENEXR_MINOR_VERSION}${DEBUG_POSTFIX}
+            ${OPENEXR_LIB}{DEBUG_POSTFIX}
         HINTS
             "${OPENEXR_LOCATION}"
             "$ENV{OPENEXR_LOCATION}"

--- a/cmake/modules/FindOpenImageIO.cmake
+++ b/cmake/modules/FindOpenImageIO.cmake
@@ -30,8 +30,14 @@ if(UNIX)
             "$ENV{OIIO_LOCATION}"
             "/opt/oiio"
     )
+    set(LIBNAME libOpenImageIO.so)
+    if(if DEFINED PXR_USE_DEBUG_BUILD)
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${PXR_USE_DEBUG_BUILD} MATCHES ON)
+            set(LIBNAME libOpenImageIO_d.dylib)
+        endif()
+    endif()
     find_path(OIIO_LIBRARY_DIR
-            libOpenImageIO.so
+            ${LIBNAME}
         HINTS
             "${OIIO_LOCATION}"
             "$ENV{OIIO_LOCATION}"
@@ -74,10 +80,15 @@ find_path(OIIO_INCLUDE_DIR
 )
 
 list(APPEND OIIO_INCLUDE_DIRS ${OIIO_INCLUDE_DIR})
-
+set(DEBUG_POSTFIX )
+if(if DEFINED PXR_USE_DEBUG_BUILD)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${PXR_USE_DEBUG_BUILD} MATCHES ON)
+      set(DEBUG_POSTFIX _d)
+    endif()
+endif()
 foreach(OIIO_LIB
-    OpenImageIO
-    OpenImageIO_Util
+    OpenImageIO${DEBUG_POSTFIX}
+    OpenImageIO_Util${DEBUG_POSTFIX}
     )
 
     find_library(OIIO_${OIIO_LIB}_LIBRARY


### PR DESCRIPTION
### Description of Change(s)
Modify build script to indicate to CMAKE we are building a debug build
If we are doing a debug build and we are doing a Mac build, append a postfix to correctly find the debug library files.

### Fixes Issue(s)
Debug OpenImageIO / OpenEXR builds cannot be made on Apple platforms

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
