### PR TITLE
USD-6554 - add in shebang and cmd controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,21 @@ include(Packages)
 
 # This has to be defined after Packages is included, because it relies on the
 # discovered path to the python executable.
-set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}" 
-    CACHE 
-    STRING
-    "Replacement path for Python #! line."
-)
+if (NOT PXR_PYTHON_SHEBANG)
+    set(PXR_PYTHON_SHEBANG "${PYTHON_EXECUTABLE}"
+        CACHE
+        STRING
+        "Replacement path for Python #! line."
+    )
+endif()
+
+if (NOT PYTHON_COMMAND_NAME)
+    set(PYTHON_COMMAND_NAME "${PYTHON_EXECUTABLE}"
+        CACHE
+        STRING
+        "Python command to launch usd tools (e.g. usdview) with."
+    )
+endif()
 
 # CXXDefaults will set a variety of variables for the project.
 # Consume them here. This is an effort to keep the most common

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if (NOT PXR_PYTHON_SHEBANG)
 endif()
 
 if (NOT PYTHON_COMMAND_NAME)
-    set(PYTHON_COMMAND_NAME "${PYTHON_EXECUTABLE}"
+    set(PYTHON_COMMAND_NAME  "python"
         CACHE
         STRING
         "Python command to launch usd tools (e.g. usdview) with."

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -131,7 +131,8 @@ function(pxr_python_bin BIN_NAME)
             COMMENT "Creating Python cmd wrapper"
             COMMAND
                 ${PYTHON_EXECUTABLE}
-                ${PROJECT_SOURCE_DIR}/cmake/macros/shebang.py
+                ${PROJECT_SOURCE_DIR}/cmake/macros/wincmd.py
+                ${PYTHON_COMMAND_NAME}
                 ${BIN_NAME}
                 ${outfile}.cmd
         )

--- a/cmake/macros/shebang.py
+++ b/cmake/macros/shebang.py
@@ -24,25 +24,16 @@
 #
 # Usage:
 #   shebang shebang-str source.py dest.py
-#   shebang file output.cmd
 #
-# The former substitutes '/pxrpythonsubst' in <source.py> with <shebang-str>
-# and writes the result to <dest.py>.  The latter generates a file named
-# <output.cmd> with the contents '@python "%~dp0<file>"';  this is a
-# Windows command script to execute "python <file>" where <file> is in
-# the same directory as the command script.
+# This substitutes '/pxrpythonsubst' in <source.py> with <shebang-str>
+# and writes the result to <dest.py>. 
 
 from __future__ import print_function
 import sys
 
-if len(sys.argv) < 3 or len(sys.argv) > 4:
-    print("Usage: %s {shebang-str source.py dest|file output.cmd}" % sys.argv[0])
+if len(sys.argv) != 4:
+    print("Usage: %s {shebang-str source.py dest}" % sys.argv[0])
     sys.exit(1)
-
-if len(sys.argv) == 3:
-    with open(sys.argv[2], 'w') as f:
-        print('@python "%%~dp0%s" %%*' % (sys.argv[1], ), file=f)
-
 else:
     with open(sys.argv[2], 'r') as s:
         with open(sys.argv[3], 'w') as d:

--- a/cmake/macros/wincmd.py
+++ b/cmake/macros/wincmd.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2022 Anthony Tan
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License").
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+#
+# Usage:
+#   wincmd file output.cmd
+#   wincmd python_interp file output.cmd
+#
+# Both generate a file named <output.cmd>, in the first form, this mimics
+# the old behaviour of shebang.py and generates the file with the contents 
+# '@python "%~dp0<file>"'; this is a Windows command script to execute 
+# "python <file>" where <file> is in the same directory as the command script.
+# The second form instead uses the name supplied as the python interpreter and 
+# is intended to allow the windows command to invoke things like mayapy.exe
+
+from __future__ import print_function
+import sys
+
+if len(sys.argv) < 3 or len(sys.argv) > 4:
+    print("Usage: %s {python-interpreter file output.cmd|file output.cmd}" % sys.argv[0])
+    sys.exit(1)
+
+if len(sys.argv) == 3:
+    with open(sys.argv[2], 'w') as f:
+        print('@python "%%~dp0%s" %%*' % (sys.argv[1], ), file=f)
+
+if len(sys.argv) == 4:
+    with open(sys.argv[3], 'w') as f:
+        print('@%s "%%~dp0%s" %%*' % (sys.argv[1], sys.argv[2], ), file=f)
+


### PR DESCRIPTION
### Description of Change(s)
This change defines a new variable - `PYTHON_COMMAND_NAME` - which can be used to specifically target the windows .cmd wrappers, and exposes `PXR_PYTHON_SHEBANG` to allow build time override (e.g. if you're using a wrapped python instance to build, and that's meant to be build-time only or similar.)

Both will fall back to `${PYTHON_EXECUTABLE}` matching current behaviour.

This follows on from the discussion in #1438, I've just extend the closed/unmerged PR (#1445) so it's an explicit selection rather than guessing on the interpreter name (i.e. if you're doing this, you're in control of your build environment so you probably know what to specify). 

Split out to a new file instead of creating a complex arg-counting-flag-whatevering-signature for `shebang.py`

**Note:** I wasn't 100% sure what license to apply for the new `wincmd.py` file so have tagged it with the unmodified Apache 2.0 lisc. 

### Fixes Issue(s)
#1438

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement