### PR TITLE
Use System fonts for sphinx documentation

### DIFF
--- a/docs/_static/css/pxr_custom.css
+++ b/docs/_static/css/pxr_custom.css
@@ -13,7 +13,9 @@ body, .rst-content {
     font-family: var(--serif);
 }
 
-
+h4 {
+    font-weight: 650;
+}
 
 .bolditalic {
   font-weight: bold;

--- a/docs/_static/css/pxr_custom.css
+++ b/docs/_static/css/pxr_custom.css
@@ -1,3 +1,20 @@
+:root {
+    --san-serif: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Lato", "proxima-nova", "Helvetica Neue", Arial, "Segoe UI", Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    --san-serif2: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, "Segoe UI", Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    --serif: ui-serif, -apple-system-ui-serif, 'Georgia', serif;
+    --monospace: ui-monospace, -apple-system-ui-serif, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, 'Andale Mono', 'Ubuntu Mono', monospace;
+}
+
+body, .rst-content {
+    font-family: var(--san-serif);
+}
+
+.rst-content .toctree-wrapper>p.caption, h1, h2, h3, h4, h5, h6, legend {
+    font-family: var(--serif);
+}
+
+
+
 .bolditalic {
   font-weight: bold;
   font-style: italic;
@@ -18,8 +35,8 @@
   text-decoration: underline;
 }
 
-.mono {
-  font-family: monospace
+.mono, .rst-content .linenodiv pre, .rst-content div[class^=highlight] pre, .rst-content pre.literal-block {
+  font-family: var(--monospace)
 }
 
 .underline {
@@ -49,7 +66,7 @@ img.usd-logo-image {
 }
 
 .usd-title-image-outer {
-    --title-image-width: calc
+    --title-image-width: calc;
     position: relative;
     float: left;
 }
@@ -65,7 +82,7 @@ img.usd-logo-image {
     left: 0;
     bottom: 0;
     width: 100%;
-    font-family: Roboto Slab,ff-tisa-web-pro,Georgia,Arial,sans-serif;
+    font-family: var(--san-serif);
     font-weight: 700;
     font-size: 3vw;
 }


### PR DESCRIPTION
### Description of Change(s)

This PR changes the sphinx font choices to use the system fonts where possible.

This used to not be supported well, but has recently become supported well enough that various frameworks and sites like [Bootstrap](https://github.com/phorgeit/phorge/commit/f8ffa393c4427f8b9026075e6dc490990a12df12#diff-0449f1a620b6418ecfcef758578731fc62f1dde6c292c76ef0ca531d44c35d45) have adopted it. 

For the most part, this lets the user+OS vendor have more control over the legibility of the text, allowing for better variable weights and respects any legibility choices the user may have made.

If those are not specified, or supported, they fall back to the previous font choices that Read the Docs used.

### Fixes Issue(s)

This fixes a few minor issues I was seeing:

* Certain font sizes and weights weren't rendering differently enough than other fonts. e.g the H3 and H4 styling had very similar visual weights due to the font being picked up.

* The USD header image text was rendering as serif for me, even though the CSS expected san-serif. This fixes that

* Missing semicolon after calc in `.usd-title-image-outer` . I'm not sure what was meant to be calc'd here...but this at least fixes the syntax error.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
