### PR TITLE
USD Crate format Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 .AppleDouble
 
+cmake-build-*
+.idea
+__pycache__

--- a/docs/_ext/usddoc.py
+++ b/docs/_ext/usddoc.py
@@ -1,0 +1,369 @@
+import re
+
+import docutils.parsers.rst
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+import os
+
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+
+
+class Parser(object):
+    tokens = ("usddoc", "usdbytelayout")
+    cache = {}
+    inline_layout_pattern = re.compile(r"<(\w+) (\w+)>")
+    byte_layout_pattern = re.compile(r"([\w0-9-]+) ([0-9]+|\?)")
+
+    def __init__(self, element, identifier, source_file):
+        super(Parser, self).__init__()
+        self.element = element
+        self.identifier = identifier
+        self.source_file = source_file
+        self.contents = []
+
+    @classmethod
+    def parse_cpp(cls, filepath, force=False):
+        filepath = os.path.abspath(os.path.join(repo_root, filepath))
+        base, ext = os.path.splitext(filepath)
+        if ext == ".h":
+            header = filepath
+            filepath = base + ".cpp"
+        else:
+            header = base + ".h"
+
+        if filepath in cls.cache and not force:
+            return cls.cache[filepath]
+
+        for path in (filepath, header):
+            if not os.path.exists(path):
+                raise IOError("Could not find {}".format(path))
+
+            with open(path, "r") as fh:
+                current = None
+                for line in fh.readlines():
+                    line = line.strip()
+                    if not current and line.startswith("/*"):
+                        line = line[2:].strip().split()
+                        if len(line) < 2:
+                            continue
+
+                        if line[0].lower() not in cls.tokens:
+                            continue
+
+                        current = cls(line[0], line[1], path)
+                        continue
+
+                    if current and line.startswith("* "):
+                        line = line[2:]
+
+                    if current and line == "*":
+                        line = "\n"
+
+                    if current and line.startswith("*/"):
+                        line = line[:-2].strip()
+                        if line:
+                            current.contents.append(line)
+                        cls.cache.setdefault(filepath, {}).setdefault(current.element, {})[current.identifier] = current
+                        current = None
+                        continue
+
+                    if not current:
+                        continue
+
+                    current.contents.append(line)
+
+        results = cls.cache.get(filepath)
+        if not results:
+            raise IOError("Could not find any compatible docs in {}".format(path))
+
+        return results
+
+    @classmethod
+    def fetch_cpp_doc(cls, src, docid):
+        return cls.get_cached(src, "usddoc", docid).parse()
+
+    @classmethod
+    def fetch_cpp_byte_layout(cls, src, docid):
+        return cls.get_cached(src, "usdbytelayout", docid).parse()
+
+    @classmethod
+    def get_cached(cls, src_file, doc_type, doc_id):
+        found = cls.parse_cpp(src_file)
+        if not found:
+            raise RuntimeError(f"Could not parse {src_file}")
+
+        parsed_doc_objects = found.get(doc_type)
+        if not parsed_doc_objects:
+            raise RuntimeError(f"Could not find any {doc_type} elements in {src_file}")
+
+        doc_object = parsed_doc_objects.get(doc_id)
+        if not doc_object:
+            raise  RuntimeError(f"Could not find {doc_type} with id {doc_id} in {src_file}")
+
+        return doc_object
+
+
+    def parse(self):
+        if self.element == "usddoc":
+            return self._parse_usddoc()
+        elif self.element == "usdbytelayout":
+            return self._parse_usdbytelayout()
+        else:
+            raise RuntimeError("Unknown element type: {}".format(self.element))
+
+    def format_paragraph(self, contents):
+        parser = docutils.parsers.rst.Parser()
+        settings = docutils.frontend.OptionParser(
+            components=(docutils.parsers.rst.Parser,)
+        ).get_default_values()
+        document = docutils.utils.new_document(self.identifier, settings)
+        parser.parse(contents, document)
+
+        nodes = document.children
+
+        return nodes
+
+    def _parse_usddoc(self):
+        _nodes = []
+        contents = ""
+        for line in self.contents:
+            match = self.inline_layout_pattern.match(line)
+            if match:
+                groups = match.groups()
+                if groups[0] in self.tokens:
+                    if contents:
+                        _nodes.extend(self.format_paragraph(contents))
+                        contents = ""
+
+                    _nodes.extend(Parser.get_cached(self.source_file, groups[0], groups[1]).parse())
+                    continue
+
+
+            contents += line + "\n"
+
+        if contents:
+            _nodes.extend(self.format_paragraph(contents))
+
+
+
+
+
+
+        return _nodes
+
+    def _parse_usdbytelayout(self):
+        rows = []
+        current = []
+        current_size = 0
+        for line in self.contents:
+            match = self.byte_layout_pattern.match(line.strip())
+            if not match:
+                continue
+
+            key, size = match.groups()
+
+            if size == "?":
+                if current:
+                    rows.append(current)
+                    current_size = 0
+                    current = []
+
+                rows.append([(key, 16)])
+                continue
+
+            size = int(size)
+
+            # if we still have space in this row
+            if current_size < 16 and current_size + size > 16:
+                use = 16 - current_size
+                current.append((key, use))
+                size -= use
+                current_size += use
+
+            # if we're at 16
+            if current_size >= 16:
+                current_size = 0
+                rows.append(current)
+                current = []
+
+            current.append((key, size))
+            current_size += size
+
+        if current_size:
+            rows.append(current)
+
+
+        content = """<table class="byte-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>0x0</th>
+                        <th>0x1</th>
+                        <th>0x2</th>
+                        <th>0x3</th>
+                        <th>0x4</th>
+                        <th>0x5</th>
+                        <th>0x6</th>
+                        <th>0x7</th>
+                        <th>0x8</th>
+                        <th>0x9</th>
+                        <th>0xa</th>
+                        <th>0xb</th>
+                        <th>0xc</th>
+                        <th>0xd</th>
+                        <th>0xe</th>
+                        <th>0xf</th>
+                    </tr>
+                </thead>
+                <tbody>"""
+
+        for i, row in enumerate(rows):
+            label = "{0:#0{1}x}".format(i * 16, 6)
+            content += f"\n<tr>\n\t<th>{label}</th>"
+            total = 0
+
+            for item, length in row:
+                total += length
+                content += f"\n\t<td colspan=\"{length}\">{item}</td>"
+
+            if total < 16:
+                try:
+                    item = rows[i+1][0][0]
+                except IndexError:
+                    item = ""
+                content += f"\n\t<td colspan=\"{16-total}\">{item}</td>"
+            content += "\n</tr>"
+
+
+        _nodes = []
+        content += """</tbody>
+            </table>"""
+
+        _nodes.append(nodes.raw('', content, format='html'))
+        return _nodes
+
+    def __repr__(self):
+        return "{}::({},{} in {})".format(super(Parser, self).__repr__(), self.element, self.identifier, self.source_file)
+
+
+class UsdCppDoc(SphinxDirective):
+    has_content = True
+
+    def run(self):
+        src, docid = self.content[0].split()
+        return Parser.fetch_cpp_doc(src, docid)
+
+
+class UsdCppByteLayout(SphinxDirective):
+    has_content = True
+
+    def run(self):
+        src, docid = self.content[0].split()
+        return Parser.fetch_cpp_byte_layout(src, docid)
+
+class UsdCrateTypes(SphinxDirective):
+    has_content = True
+
+    def run(self):
+        crate_data_types_file = os.path.join(repo_root, "pxr/usd/usd/crateDataTypes.h")
+        types_file = os.path.join(repo_root, "pxr/usd/sdf/types.h")
+
+        with open(types_file) as fp:
+            scalar_types = set()
+            dimensioned_types = {}
+            add_to_scalar = False
+            add_to_dimensional = False
+            for line in fp.readlines():
+                if "_SDF_SCALAR_VALUE_TYPES" in line:
+                    if add_to_scalar or add_to_dimensional:
+                        break
+
+                    add_to_scalar = True
+                    add_to_dimensional = False
+                elif "_SDF_DIMENSIONED_VALUE_TYPES" in line:
+                    add_to_scalar = False
+                    add_to_dimensional = True
+
+                if not (add_to_scalar or add_to_dimensional):
+                    continue
+
+                line = line.strip()
+                if not line.startswith("(("):
+                    continue
+
+                token, _, cpp_type, dimensions =  line.split(",  ")
+                token = token[2:]
+
+                if add_to_scalar:
+                    scalar_types.add(token)
+                    continue
+
+                dimensions = dimensions.strip().split()[0]
+                dimensioned_types[cpp_type.strip()] = dimensions[1:-1]
+
+
+
+        table = nodes.table(cols=5)
+        group = nodes.tgroup()
+        head = nodes.thead()
+        body = nodes.tbody()
+
+        table += group
+        group += nodes.colspec(colwidth=4)
+        group += nodes.colspec(colwidth=2)
+        group += nodes.colspec(colwidth=4)
+        group += nodes.colspec(colwidth=3)
+        group += nodes.colspec(colwidth=3)
+        group += head
+        group += body
+
+        row = nodes.row()
+        row += nodes.entry('', nodes.paragraph('', nodes.Text('Name')))
+        row += nodes.entry('', nodes.paragraph('', nodes.Text('ID')))
+        row += nodes.entry('', nodes.paragraph('', nodes.Text('C++ Type')))
+        row += nodes.entry('', nodes.paragraph('', nodes.Text('Supports Array')))
+        row += nodes.entry('', nodes.paragraph('', nodes.Text('Dimensions')))
+        head += row
+
+
+        data = [("Invalid", 0, "", False, None)]
+
+        with open(crate_data_types_file, "r") as fp:
+            for line in fp.readlines():
+                if not line.startswith("xx("):
+                    continue
+
+                line = line.strip()[3:-1]
+                name, enum_index, cpp_type, array_type = line.split(",")
+
+                enum_index = int(enum_index.strip())
+                array_type = array_type.strip() == "true"
+                cpp_type = cpp_type.strip()
+
+                data.append([name.strip(), enum_index, cpp_type, array_type, dimensioned_types.get(cpp_type)])
+
+        data.append(["NumTypes", enum_index+1, '', False, None])
+
+
+        for item in data:
+            row = nodes.row()
+            row += nodes.entry('', nodes.paragraph('', nodes.Text(item[0])))
+            row += nodes.entry('', nodes.paragraph('', nodes.Text(str(item[1]))))
+            row += nodes.entry('', nodes.paragraph('', nodes.Text(item[2])))
+            row += nodes.entry('', nodes.paragraph('', nodes.Text("✓" if item[3] else "")))
+            row += nodes.entry('', nodes.paragraph('', nodes.Text(item[4] or "")))
+            body += row
+
+        return [table]
+
+def setup(app):
+    app.add_directive('usdcppdoc', UsdCppDoc)
+    app.add_directive('usdcppbytelayout', UsdCppByteLayout)
+    app.add_directive('usdcratetypes', UsdCrateTypes)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/_static/css/pxr_custom.css
+++ b/docs/_static/css/pxr_custom.css
@@ -1,3 +1,69 @@
+:root {
+    --dotted-border-color: lightsteelblue;
+    --san-serif: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Lato", "proxima-nova", "Helvetica Neue", Arial, "Segoe UI", Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    --san-serif2: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, "Segoe UI", Roboto, Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    --serif: ui-serif, -apple-system-ui-serif, 'Georgia', serif;
+    --monospace: ui-monospace, -apple-system-ui-serif, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, 'Andale Mono', 'Ubuntu Mono', monospace;
+}
+
+body, .rst-content {
+    font-family: var(--san-serif);
+}
+
+.rst-content .toctree-wrapper>p.caption, h1, h2, h3, h4, h5, h6, legend {
+    font-family: var(--serif);
+}
+
+h4 {
+    font-weight: 600;
+}
+
+
+.byte-table {
+    background:
+        /* TODO: Find a better way to set the table splitters...in the meantime these are hardcoded values */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 5.75% / 1px 100% no-repeat,   /* Left of 0x0 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 11.72% / 1px 100% no-repeat,  /* Left of 0x1 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 17.6% / 1px 100% no-repeat,   /* Left of 0x2 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 23.46% / 1px 100% no-repeat,  /* Left of 0x3 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 29.4% / 1px 100% no-repeat,  /* Left of 0x4 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 35.3% / 1px 100% no-repeat,  /* Left of 0x5 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 41.2% / 1px 100% no-repeat, /* Left of 0x6 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 47.2% / 1px 100% no-repeat,  /* Left of 0x7 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 53% / 1px 100% no-repeat, /* Left of 0x8 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 58.8% / 1px 100% no-repeat,  /* Left of 0x9 */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 64.75% / 1px 100% no-repeat,  /* Left of 0xA */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 70.6% / 1px 100% no-repeat,  /* Left of 0xB */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 76.5% / 1px 100% no-repeat,  /* Left of 0xC */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 82.5% / 1px 100% no-repeat,  /* Left of 0xD */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 88.25% / 1px 100% no-repeat,  /* Left of 0xE */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 94.3% / 1px 100% no-repeat,  /* Left of 0xF */
+            repeating-linear-gradient(to bottom, transparent 0 1px, var(--dotted-border-color) 1px 2px) 100% / 1px 100% no-repeat;  /* End  */
+    border-collapse: collapse;
+    max-width: 1200px;
+    min-width: 650px;
+    padding: 0;
+    margin-bottom: 2rem;
+    table-layout: fixed;
+    width: 100%;
+}
+
+
+.byte-table th {
+    font-size: 0.75rem;
+    color: #888;
+}
+
+.byte-table th,
+.byte-table td {
+    background: transparent;
+    padding: 4px 8px;
+}
+.byte-table td {
+    border: solid 1px grey;
+    text-align: center;
+}
+
 .bolditalic {
   font-weight: bold;
   font-style: italic;
@@ -18,8 +84,8 @@
   text-decoration: underline;
 }
 
-.mono {
-  font-family: monospace
+.mono, .rst-content .linenodiv pre, .rst-content div[class^=highlight] pre, .rst-content pre.literal-block {
+  font-family: var(--monospace)
 }
 
 .underline {
@@ -49,7 +115,7 @@ img.usd-logo-image {
 }
 
 .usd-title-image-outer {
-    --title-image-width: calc
+    --title-image-width: calc;
     position: relative;
     float: left;
 }
@@ -65,7 +131,7 @@ img.usd-logo-image {
     left: 0;
     bottom: 0;
     width: 100%;
-    font-family: Roboto Slab,ff-tisa-web-pro,Georgia,Arial,sans-serif;
+    font-family: var(--san-serif);
     font-weight: 700;
     font-size: 3vw;
 }
@@ -118,7 +184,7 @@ div.usd-tutorial-admonition > p {
 }
 
 .version_warning {
-  padding: .5em; 
+  padding: .5em;
   text-align: center;
   background-color: #FFBABA;
   color: #6A0E0E;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,6 @@ import sys
 sys.path.append(os.path.abspath("./_ext"))
 # sys.path.insert(0, os.path.abspath('.'))
 
-# -- Dev Configure -----------------------------------
-
 # -- Utilities ---------------------------------------------------------------
 
 def GetUSDVersion():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,22 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
+import sys
+
+sys.path.append(os.path.abspath("./_ext"))
 # sys.path.insert(0, os.path.abspath('.'))
+
+# -- Dev Configure -----------------------------------
+
+import subprocess
+files = ["spec_usdc"]
+for f in files:
+    f = os.path.join(os.path.dirname(__file__), f+".rst")
+    if not os.path.exists(f):
+        raise IOError("Path does not exist: "+f)
+
+    subprocess.call(["touch", f])
+
 
 # -- Utilities ---------------------------------------------------------------
 
@@ -77,7 +91,8 @@ release = version
 extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinxcontrib.doxylink',
-    'sphinx_panels'
+    'sphinx_panels',
+    "usddoc"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,16 +18,6 @@ sys.path.append(os.path.abspath("./_ext"))
 
 # -- Dev Configure -----------------------------------
 
-import subprocess
-files = ["spec_usdc"]
-for f in files:
-    f = os.path.join(os.path.dirname(__file__), f+".rst")
-    if not os.path.exists(f):
-        raise IOError("Path does not exist: "+f)
-
-    subprocess.call(["touch", f])
-
-
 # -- Utilities ---------------------------------------------------------------
 
 def GetUSDVersion():

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -7,5 +7,5 @@ Specifications
    :titlesonly:
 
    spec_usdpreviewsurface
-   spec_usdz
+   spec_fileformats
 

--- a/docs/spec_fileformats.rst
+++ b/docs/spec_fileformats.rst
@@ -1,0 +1,10 @@
+##############
+File Formats
+##############
+
+.. toctree::
+   :caption: File Format Specifications
+   :titlesonly:
+
+   spec_usdz
+   spec_usdc

--- a/docs/spec_usdc.rst
+++ b/docs/spec_usdc.rst
@@ -386,6 +386,8 @@ Bool
 
 The **Bool** type is a basic Binary boolean that can be checked by taking any non-zero number as True, and 0 as False.
 
+Booleans in an array are stored as an array of bytes (8 bits per entry).
+
 UChar
 ^^^^^
 

--- a/docs/spec_usdc.rst
+++ b/docs/spec_usdc.rst
@@ -1,0 +1,757 @@
+==============================
+USDC File Format Specification
+==============================
+
+.. include:: rolesAndUtils.rst
+.. include:: <isonum.txt>
+
+Copyright |copy| 2022, Pixar Animation Studios,  *version 0.9.0*
+
+.. contents:: :local:
+
+Introduction
+=============
+
+The **USD Crate** format is binary encoding of the USD scene graph.
+This document aims to document the layout of the this format.
+
+.. warning::
+    This is a Work in Progress documentation of the USD Crate format. It is not guaranteed to
+    be an exact description of the format right now. Contributions to improve accuracy are welcome.
+
+    If areas are unspecified, or if a discrepancy occurs, the implementation in the official USD library
+    should always take precedence as being the canonical implementation of the format.
+
+    It is **NOT** yet recommended to make your own implementation based on this document
+    , and we encourage developers to use the official implementation.
+
+    This document does not describe the composition elements of USD. Implementing this document
+    will only allow for reading a single USD layer.
+
+
+Versions
+---------
+
+This document only aims to document version `0.9.0` of the Crate format and higher.
+For older versions of the Crate format, please refer to the USD code implementations.
+
+These older crate files are exceedingly rare outside of Pixar and very early USD adopters.
+
+Version History
+^^^^^^^^^^^^^^^
+
+Even though the spec only starts with 0.9.0, it is useful to understand the high level history of versions
+
+
+* 0.9.0: Added support for the timecode and timecode[] value types.
+* 0.8.0: Added support for SdfPayloadListOp values and SdfPayload values with layer offsets.
+* 0.7.0: Array sizes written as 64 bit ints.
+* 0.6.0: Compressed (scalar) floating point arrays that are either all ints or can be represented efficiently with a lookup table.
+* 0.5.0: Compressed (u)int & (u)int64 arrays, arrays no longer store '1' rank.
+* 0.4.0: Compressed structural sections.
+* 0.3.0: (broken, unused)
+* 0.2.0: Added support for prepend and append fields of SdfListOp.
+* 0.1.0: Fixed structure layout issue encountered in Windows port.
+* 0.0.1: Initial release.
+
+
+Order of Reads
+--------------
+
+The Crate format is designed for minimal parsing on file load.
+
+To achieve this, the general structure of the file is set up in the preamble section below that must be read first.
+
+Value types are parsed on demand from there on out.
+
+Integers
+--------
+
+Integers are stored with the least significant bit first to allow for fast loading on `Little Endian <https://en.wikipedia.org/wiki/Endianness>`_ systems.
+
+Index
+-----
+
+Many fields reference into an another section to get their value. USD uses unsigned 32 bit integers as an index unless
+otherwise specified.
+
+
+Compression
+===========
+
+LZ4 Compression
+----------------
+
+Various section and data blocks use `LZ4 Compression <https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md>`_.
+
+USD vendors the LZ4 library with modifications and can be found `here <https://github.com/PixarAnimationStudios/USD/tree/release/pxr/base/tf/pxrLZ4>`_.
+It is currently using `version 1.9.2 <https://github.com/lz4/lz4/releases/tag/v1.9.2>`_ of the library.
+
+.. usdcppdoc:: pxr/base/tf/fastCompression.cpp lz4
+
+Integer Compression
+-------------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp compressed_int
+
+
+Preamble
+========
+
+The Crate format has a preamble that must be read prior to parsing the rest of the file.
+
+This contains all the structural information that is required to identify Prim specifications and
+their resulting attributes.
+
+
+Bootstrap
+---------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp bootstrap
+
+Table of Contents
+-----------------
+
+The Table of Contents are found at the byte offset given by the bootstrap above.
+
+It consist of named sections , as documented below.
+
+Sections
+--------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp section
+
+There are several sections with their own specific internal structures.
+
+Sections should be parsed in the order below since many sections depend on their predecessors.
+
+Tokens
+^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp tokens_section
+
+Strings
+^^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp strings_section
+
+Fields
+^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp fields_section
+
+Field Sets
+^^^^^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp field_sets_section
+
+Paths
+^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp paths_section
+
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp build_compressed_paths
+
+Specs
+^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp specs_section
+
+Spec Types are integer backed enums.
+
+Certain types are marked as being **Internal to Pixar**. These are implementations
+of Pixar's internal software and are therefore reserved for use. Though they are documented
+below for completeness, they should not be used for other purposes.
+
+==================   ===  ========================
+Spec Type            Key  Description
+==================   ===  ========================
+Unknown               0    An unknown type
+Attribute             1    Attributes under a Prim Spec
+Connection            2    Connections between rel attributes
+Expression            3    Scripted Expressions or named plugin expressions (Internal to Pixar)
+Mapper                4    Used to modify the value flowing through a connection (Internal to Pixar)
+MapperArg             5    Arguments for a mapper (Internal to Pixar)
+Prim                  6    A Prim specifier
+PseudoRoot            7    The Pseudo Root that exists for all Sdf Layers
+Relationship          8    A relationship description
+RelationshipTarget    9    The Relationship target
+Variant               10   A definition of a specific variant
+VariantSet            11   A group of variants]
+NumSpecTypes          12   A sentinel to represent the number of types
+==================   ===  ========================
+
+Constructing the Layer
+======================
+
+Once you have read the Preamble, you can then start constructing the prim hierarchy of this
+individual USD Crate file that can act as a layer within a USD composition.
+
+.. warning::
+
+    As noted above, implementation of this document only allows for reading a single USD
+    file layer. It does not describe composition however as that is a higher level functionality
+    of the USD library.
+
+You should now have a mapping of:
+
+* Prim and Property Paths from the Paths section
+* Fields consisting of their associated Token and Value Representation.
+* Field Sets consisting of groups of Fields
+* Specs that associate paths with Field Sets and a Spec Type
+
+Therefore each node consists of:
+
+* A Path
+* A SpecType
+* A Field Set
+
+Fields are made up of Value Representations that are deferred for parsing.
+See the section below on how to parse the range of Value Representations.
+
+Layer Metadata
+--------------
+
+Layer Metadata is derived from the Field Sets on the PseudoRoot.
+
+Common metadata in layers are, but not limited to:
+
++--------------------+------------+----------------------------------------------------+
+| Name               | Type       | Description                                        |
++====================+============+====================================================+
+| comment            | string     | Top level comment for this layer                   |
++--------------------+------------+----------------------------------------------------+
+| customLayerData    | dictionary | Custom user specified data                         |
++--------------------+------------+----------------------------------------------------+
+| defaultPrim        | token      | The prim to use when this layer is referenced      |
++--------------------+------------+----------------------------------------------------+
+| documentation      | string     | Top level documentation for this layer             |
++--------------------+------------+----------------------------------------------------+
+| metersPerUnit      | double     | The scale unit for this layer                      |
++--------------------+------------+----------------------------------------------------+
+| primChildren       | token[]    | A list of top level children to limit the layer to |
++--------------------+------------+----------------------------------------------------+
+| timeCodesPerSecond | double     | The time unit used                                 |
++--------------------+------------+----------------------------------------------------+
+| upAxis             | token      | The Up Axis of the scene                           |
++--------------------+------------+----------------------------------------------------+
+
+Prims
+-----
+
+Prims have the spec type of Prim.
+
+Prims are defined by the field set as below. However prims may have many more fields than this, especially
+depending on the schema type of the prim.
+
++------------------+---------------------+----------------------------------------------------------+
+| Name             | Type                | Description                                              |
++==================+=====================+==========================================================+
+| specifier        | SdfSpecifier        | Whether this is a def, over or class                     |
++------------------+---------------------+----------------------------------------------------------+
+| typeName         | token               | The optional prim Type                                   |
++------------------+---------------------+----------------------------------------------------------+
+| kind             | token               | The kind of this prim (component, assembly etc)          |
++------------------+---------------------+----------------------------------------------------------+
+| active           | bool                | Whether this prim is active or not                       |
++------------------+---------------------+----------------------------------------------------------+
+| apiSchems        | TokenListOp         | The API schemas to apply to this prim                    |
++------------------+---------------------+----------------------------------------------------------+
+| variantSelection | VariantSelectionMap | The variants selected for this prim spec                 |
++------------------+---------------------+----------------------------------------------------------+
+| references       | ReferencesListOp    | A list of references this prim should use in composition |
++------------------+---------------------+----------------------------------------------------------+
+| inherits         | PathListOp          | A list of prims this inherits from                       |
++------------------+---------------------+----------------------------------------------------------+
+| properties       | token[]             | List of name of prim properties                          |
++------------------+---------------------+----------------------------------------------------------+
+| primChildren     | token[]             | List of child prims to limit to                          |
++------------------+---------------------+----------------------------------------------------------+
+| comment          | string              | The comment for this prim                                |
++------------------+---------------------+----------------------------------------------------------+
+| documentation    | string              | The documentation for this prim                          |
++------------------+---------------------+----------------------------------------------------------+
+
+
+Variant Sets
+------------
+
+Variant Sets have the VariantSet spec type, and the following fields
+
++-----------------+---------+-------------------------------------------------+
+| Name            | Type    | Description                                     |
++=================+=========+=================================================+
+| variantChildren | token[] | A list of the names of the variants in this set |
++-----------------+---------+-------------------------------------------------+
+
+Variants
+--------
+
+Variants have the Variant Spec Type. They have the following fields.
+
+Variants encapsulate their own hierarchy for use in composition later.
+
+Properties (Attribute)
+----------------------
+
+Properties are of the Attribute SpecType.
+They are the individual data members of each composed prim.
+
+The fields for properties are, but are not limited to:
+
++-----------------+-------------+------------------------------------------+
+| Name            | Type        | Description                              |
++=================+=============+==========================================+
+| typeName        | token       | The name of the type                     |
++-----------------+-------------+------------------------------------------+
+| custom          | bool        | Whether or not this is a custom property |
++-----------------+-------------+------------------------------------------+
+| variability     | variability | See the Variability section below        |
++-----------------+-------------+------------------------------------------+
+| default         | Value       | The static value                         |
++-----------------+-------------+------------------------------------------+
+| timeSamples     | TimeSamples | The TimeSampled animated values          |
++-----------------+-------------+------------------------------------------+
+| connectionPaths | PathListOp  | The list of paths this is connected to   |
++-----------------+-------------+------------------------------------------+
+
+
+
+
+
+
+
+Value Representations
+=====================
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.h value_rep
+
+Refer to the **Value Types** section below for documentation on different value types.
+
+Inlined Types
+-------------
+
+Inlined types are stored directly in the payload of the value representation.
+
+They cannot have the compressed or array bits set.
+
+For types of a single dimension, you can simply cast the data bytes to the given type.
+
+For single dimensioned types like **Vec2i** , elements are stored as signed 8 bit integers and cast to the native type
+of the container.
+
+For multidimensional type like **Matrix2D**, the data is stored as the diagonal signed 8 bit integers and then cast to
+the native type of the type.
+
+E.g a **Matrix3D** is stored as ::
+
+    1 - -
+    - 1 -
+    - - 1
+
+Singular Offset Types
+---------------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp unpack_value
+
+Array Offset Types
+------------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp unpack_array_value
+
+
+Value Types
+===========
+
+The following types are valid Value Representation types in USD.
+
+Type Table
+----------
+
+The following section enumerates the USD type table used to identify value types.
+
+All type values are documented below the table.
+
+.. usdcratetypes::
+
+Base Types
+----------
+
+The following types are foundational types that are used to compose other types.
+
+Bool
+^^^^
+
+The **Bool** type is a basic Binary boolean that can be checked by taking any non-zero number as True.
+
+UChar
+^^^^^
+
+An unsigned character bit , represented by a single unsigned 8-bit integer.
+
+Int
+^^^
+
+A signed 32-bit integer
+
+Uint
+^^^^
+
+An unsigned 32-bit integer
+
+Int64
+^^^^^
+
+A signed 64-bit integer
+
+UInt64
+^^^^^^
+
+An unsigned 64-bit integer
+
+Half
+^^^^
+
+A 16-bit floating point data type
+
+Float
+^^^^^
+
+A 32-bit floating point data type
+
+Double
+^^^^^^
+
+A 64-bit floating point data type
+
+String
+^^^^^^
+
+Strings are stored in the file as an index to a token in the Token section.
+
+Token
+^^^^^
+
+Tokens are stored in the file as an index to a token in the Token section.
+
+AssetPath
+^^^^^^^^^
+
+AssetPaths are stored in the file as an index to a token in the Token section.
+
+Payload
+^^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp payload
+
+ValueBlock
+^^^^^^^^^^
+
+A special value type that can be used to explicitly author an
+opinion for an attribute's default value or time sample value
+that represents having no value. Note that this is different
+from not having a value authored.
+
+Value
+^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp vtvalue
+
+UnregisteredValue
+^^^^^^^^^^^^^^^^^
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp unregistered_value
+
+TimeCode
+^^^^^^^^
+
+A single Double that represents an SdfTimeCode
+
+
+Other Types
+===========
+
+When traversing a USD crate file, other data types used by SDF are involved, and described
+here. These are not directly referencable as Value Representations but are used by other
+container types below.
+
+
+References
+----------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp reference_type
+
+Layer Offset
+------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp layer_offset
+
+Quaternions
+-----------
+
+Quaternions are represented by four contiguous elements of a given type.
+
+The first three make up the imaginary coefficient.
+The last the element is the real coefficient.
+
+QuatD
+^^^^^
+
+A Quaternion using doubles as the core type.
+
+QuatF
+^^^^^
+
+A Quaternion using floats as the core type.
+
+QuatH
+^^^^^
+
+A Quaternion using halfs as the core type.
+
+Vectors (Mathematical)
+----------------------
+
+Vectors are fixed length contiguous arrays of a given type.
+
+Vec2d
+^^^^^
+
+A vector with 2 doubles.
+
+Vec2f
+^^^^^
+
+A vector with 2 floats.
+
+Vec2h
+^^^^^
+
+A vector with 2 halfs.
+
+Vec2i
+^^^^^
+
+A vector with 2 32-bit integers.
+
+Vec3d
+^^^^^
+
+A vector with 3 doubles.
+
+Vec3f
+^^^^^
+
+A vector with 2 floats.
+
+Vec3h
+^^^^^
+
+A vector with 3 halfs.
+
+Vec3i
+^^^^^
+
+A vector with 3 32-bit integers.
+
+Vec4d
+^^^^^
+
+A vector with 4 doubles.
+
+Vec4f
+^^^^^
+
+A vector with 4 floats.
+
+Vec4h
+^^^^^
+
+A vector with 4 halfs.
+
+Vec4i
+^^^^^
+
+A vector with 4 32-bit integers.
+
+
+Matrix
+------
+
+Matrix types are NxN dimensional groups of Doubles. They are defined in a contiguous
+row-major order so `matrix[i][j]` refers to row **i** and column **j**.
+
+
+Identity Matrix values have all cells zeroed out, except for the diagonal from top left ( 0,0 )
+to bottom right (N,N) which are set to 1.
+
+Matrix2d
+^^^^^^^^
+
+A 2x2 matrix
+
+Matrix3d
+^^^^^^^^
+
+A 3x3 matrix
+
+Matrix4d
+^^^^^^^^
+
+A 4x4 matrix
+
+Dictionary
+----------
+
+A Dictionary is a key:value map of data.
+
+The Value Representation starts with an unsigned 64-bit integer representing the number of elements in the
+dictionary.
+
+Keys are strings, stored as an index to a token in the Token section.
+
+Values are a 64-bit unsigned integer representing the offset from the start of the file to a value representation.
+
+List Operations
+---------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp listop
+
+TokenListOp
+^^^^^^^^^^^
+
+A ListOp made of Tokens, stored as an array of Indexes referencing the Tokens section.
+
+StringListOp
+^^^^^^^^^^^^
+
+A ListOp made of Strings, stored as an array of Indexes referencing the Tokens section.
+
+ReferenceListOp
+^^^^^^^^^^^^^^^
+
+A ListOp consisting of References. See the References section below.
+
+IntListOp
+^^^^^^^^^
+
+A ListOp consisting of signed 32-bit Integers
+
+Int64ListOp
+^^^^^^^^^^^
+
+A ListOp consisting of signed 64-bit Integers
+
+UIntListOp
+^^^^^^^^^^
+
+A ListOp consisting of unsigned 32-bit Integers
+
+UInt64ListOp
+^^^^^^^^^^^^
+
+A ListOp consisting of unsigned 64-bit Integers
+
+PayloadListOp
+^^^^^^^^^^^^^
+
+A ListOp consisting of a Payload. See the Payload section above.
+
+UnregisteredValueListOp
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A ListOp consisting of Unregistered Values. See the UnregisteredValue section above.
+
+Vectors (Arrays)
+----------------
+
+Vectors are arrays of a given type stored contiguously. These are different in intent from
+the mathematical vectors listed above, and their naming reflects the container type in programming
+languages like C++.
+
+They always start with a 64-bit unsigned integer reflecting the number of elements,
+which is followed by a contiguous array of the specific data type.
+
+PathVector
+^^^^^^^^^^
+
+Consists of Index signed integers referencing the Paths section
+
+TokenVector
+^^^^^^^^^^^
+
+Consists of Index signed integers referencing the Tokens section
+
+DoubleVector
+^^^^^^^^^^^^
+
+Consists of Doubles
+
+LayerOffsetVector
+^^^^^^^^^^^^^^^^^
+
+Consists of Layer Offsets
+
+StringVector
+^^^^^^^^^^^^
+
+Consists of Index signed integers referencing the Tokens section
+
+
+Specifier
+---------
+
+A 32-bit integer backed enum that defines the possible specifiers for a prim.
+These are representations of SdfSpecifier.
+
+==================   ===  ========================
+Spec Type            Key  Description
+==================   ===  ========================
+Def                   0    Defines a concrete prim
+Over                  1    Overrides an existing prim
+Class                 2    Defines an abstract prim
+NumSpecifiers         3    The number of possible specifiers
+==================   ===  ========================
+
+Permission
+----------
+
+A 32-bit integer backed enum that defines permissions.
+Permissions control which layers may refer to or express opinions about a prim.
+
+These are representations of SdfPermission.
+
+==================   ===  ========================
+Spec Type            Key  Description
+==================   ===  ========================
+Public                0    Public prims can be referred to by anything
+Private               1    Private prims can only be referred within the local layer stack
+NumPermissions        2    The number of possible permissions
+==================   ===  ========================
+
+Variability
+-----------
+
+A 32-bit integer backed enum that defines variability for an attribute.
+Variability indicates whether an attribute is uniform or time varying.
+
+These are representations of SdfVariability.
+
+==================   ===  ========================
+Spec Type            Key  Description
+==================   ===  ========================
+Varying               0    Can be animated
+Uniform               1    Can only be static
+NumVariability        2    The number of possible variability types
+==================   ===  ========================
+
+Variant Selection Map
+---------------------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp variant_selection_map
+
+TimeSamples
+-----------
+
+.. usdcppdoc:: pxr/usd/usd/crateFile.cpp timesamples

--- a/docs/spec_usdc.rst
+++ b/docs/spec_usdc.rst
@@ -67,7 +67,7 @@ Value types are parsed on demand from there on out.
 Integers
 --------
 
-Integers are stored with the least significant bit first to allow for fast loading on `Little Endian <https://en.wikipedia.org/wiki/Endianness>`_ systems.
+Integers are stored with the least significant byte first to allow for fast loading on `Little Endian <https://en.wikipedia.org/wiki/Endianness>`_ systems.
 
 Index
 -----
@@ -170,9 +170,9 @@ Spec Type            Key  Description
 Unknown               0    An unknown type
 Attribute             1    Attributes under a Prim Spec
 Connection            2    Connections between rel attributes
-Expression            3    Scripted Expressions or named plugin expressions (Internal to Pixar)
-Mapper                4    Used to modify the value flowing through a connection (Internal to Pixar)
-MapperArg             5    Arguments for a mapper (Internal to Pixar)
+Expression            3    **(Internal to Pixar)** Scripted Expressions or named plugin expressions
+Mapper                4    **(Internal to Pixar)** Used to modify the value flowing through a connection
+MapperArg             5    **(Internal to Pixar)** Arguments for a mapper
 Prim                  6    A Prim specifier
 PseudoRoot            7    The Pseudo Root that exists for all Sdf Layers
 Relationship          8    A relationship description
@@ -341,10 +341,11 @@ For types of a single dimension, you can simply cast the data bytes to the given
 For single dimensioned types like **Vec2i** , elements are stored as signed 8 bit integers and cast to the native type
 of the container.
 
-For multidimensional type like **Matrix2D**, the data is stored as the diagonal signed 8 bit integers and then cast to
-the native type of the type.
+For multidimensional inlined type like **Matrix2D**, the data is contiguously stored as signed 8 bit integers
+that make up the diagonal values of the matrix, and then cast to the native type of the type.
 
-E.g a **Matrix3D** is stored as ::
+
+E.g a **Matrix3D** is stored as the following row major matrix::
 
     1 - -
     - 1 -
@@ -383,7 +384,7 @@ The following types are foundational types that are used to compose other types.
 Bool
 ^^^^
 
-The **Bool** type is a basic Binary boolean that can be checked by taking any non-zero number as True.
+The **Bool** type is a basic Binary boolean that can be checked by taking any non-zero number as True, and 0 as False.
 
 UChar
 ^^^^^

--- a/pxr/base/tf/fastCompression.cpp
+++ b/pxr/base/tf/fastCompression.cpp
@@ -101,6 +101,24 @@ TfFastCompression::CompressToBuffer(
     return compressed - origCompressed;
 }    
 
+/* usddoc lz4
+ * The first byte of any buffer passed to be decrypted stores the number of chunks used.
+ *
+ * If the number of chunks is 0, then the buffer is decompressed as a whole.
+ *
+ * If the number of chunks is specified as higher than zero, then the first byte of each chunk
+ * represent the size of the chunk, followed by the chunk data which can be decompressed.
+ *
+ * In the table below, chunkSize is not provided if numChunks is zero
+ *
+ * <usdbytelayout lz4_chunks_layout>
+ */
+/* usdbytelayout lz4_chunks_layout
+ *  numChunks 8
+ *  chunkSize 8
+ *  data ?
+ */
+
 size_t
 TfFastCompression::DecompressFromBuffer(
     char const *compressed, char *output,

--- a/pxr/base/tf/fastCompression.cpp
+++ b/pxr/base/tf/fastCompression.cpp
@@ -102,7 +102,7 @@ TfFastCompression::CompressToBuffer(
 }    
 
 /* usddoc lz4
- * The first byte of any buffer passed to be decrypted stores the number of chunks used.
+ * The first byte of any buffer passed to be decompressed stores the number of chunks used.
  *
  * If the number of chunks is 0, then the buffer is decompressed as a whole.
  *

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -437,7 +437,7 @@ struct _IsBitwiseReadWrite<_PathItemHeader> : std::true_type {};
  * In order, from least to most significant bit:
  *
  *  * **IsExplicit** : Removes all items and changes the list to be explicit
- *  * **HasExcplicitItems** : Fills the list with the items included in this ListOp
+ *  * **HasExplicitItems** : Fills the list with the items included in this ListOp
  *  * **HasAddedItems** : Adds the items included in this ListOp
  *  * **HasDeletedItems** : Removes the items specified in this ListOp
  *  * **HasOrderedItems** : Reorder the list based on the item order in this ListOp
@@ -1228,7 +1228,7 @@ public:
      * A layer offset represents a time offset and scale between layers.
      * It is represented by two doubles.
      *
-     * The first represents the time offset to be used , and the second the scale.
+     * The first represents the time offset to be used, and the second the scale.
      * Scale should always be applied before the offset.
      *
      * <usdbytelayout layer_offset_layout>
@@ -2015,7 +2015,7 @@ _ReadPossiblyCompressedArray(
 struct _CompressedIntsReader
 {
     /* usddoc compressed_int
-     *  Compressed integers are stored as a contiguous , homogenous array of
+     *  Compressed integers are stored as a contiguous, homogenous array of
      *  either 32-bit or 64-bit integers.
      *
      *  Once read, the array of integers can be decompressed using the LZ4 algorithm.
@@ -2117,7 +2117,7 @@ _ReadPossiblyCompressedArray(
  * * **i** for integer compression (follow the compressed integer array logic)
  * * **t** for lookup tables (described below)
  *
- * The size of the lookup table (LUT) is a 32bit unsigned integer.
+ * The size of the lookup table (LUT) is a 32 bit unsigned integer.
  * The LUT data is read as a contiguous array of the given type.
  * Following that is a compressed array of integers representing the indexes that should be used
  * to populate the output array by looking up the LUT indices in order.
@@ -3454,7 +3454,7 @@ CrateFile::_ReadStructuralSections(Reader reader, int64_t fileSize)
  * Files must start with an identifier (PXR-USDC), the version number and the offset to the Table of Contents.
  * There is additional reserved space at the end of the bootstrap for future use.
  *
- * Version numbers are stored as Major , Minor and Patch followed by unused bytes.
+ * Version numbers are stored as 3 unsigned 8-bit integers denoting Major, Minor and Patch followed by 5 unused bytes.
  *
  * <usdbytelayout bootstrap>
  */

--- a/pxr/usd/usd/crateFile.h
+++ b/pxr/usd/usd/crateFile.h
@@ -81,10 +81,10 @@ enum class TypeEnum : int32_t;
 
 /* usddoc value_rep
  * Crate stores Value Representations as data blobs that are read on demand.
- * This allows large USD scenes to be read incredibly quickly by deferring all
+ * This allows large USD scenes to be read as quickly as possible by deferring all
  * data reads to the latest point possible.
  *
- * Value reps are stored as an unsigned 64 bit integer.
+ * Value representations are stored as an unsigned 64 bit integer.
  *
  * The first byte refers to the type enum value.
  * The second byte has bit flags to represent characteristics of the type:


### PR DESCRIPTION
### Description of Change(s)

This PR adds an initial pass of the Crate format specification. Where possible it tries to describe things at a byte or bit level.
This is a fairly large undertaking to reverse out the code into natural language, so requires extra scrutiny.

This adds a few features:

* Custom sphinx directive to read marked comments within the C++ source code. This allows the majority of the documentation to live beside the implementation. It also allows for ordering to change as needed which is handy. 
This enables Alex's request to have something akin to literate programming approach within the code.
* Custom sphinx directive to generate byte layouts, inspired by the [PKZip documentation.](https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html)

Sphinx was chosen to include this documentation because:

* The other specifications are in Sphinx already
* Doxygen has limited support for custom documentation extensions

The document includes some warnings for now. I think it would be best to leave the warnings in place till we are certain that the descriptions are accurate. Beyond that, it might be good to take a leaf out of other project specifications books where the official implementation is the gold truth and warnings explicitly state that.


Please note that this PR also includes https://github.com/PixarAnimationStudios/USD/pull/2084 because it's easier on my eyes than the default RTD theme, and provides better visual sectioning differences as well, which are necessary for how deep the nesting levels get.

A PDF preview is attached but the PDF formatting gets messed up so it's still recommended to sphinx-build the docs and view it that way. 
[USDC File Format Specification — Universal Scene Description 22.11 documentation.pdf](https://github.com/PixarAnimationStudios/USD/files/9984656/USDC.File.Format.Specification.Universal.Scene.Description.22.11.documentation.pdf)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
