### PR TITLE
Fix for Windows to replace backslashes in paths

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1673,13 +1673,13 @@ def InstallUSD(context, force, buildArgs):
                 prefix = "Python3" if Python3() else "Python2"
                 extraArgs.append('-D{prefix}_EXECUTABLE="{pyExecPath}"'
                                  .format(prefix=prefix, 
-                                         pyExecPath=pythonInfo[0]))
+                                         pyExecPath=pythonInfo[0].replace('\\', '/')))
                 extraArgs.append('-D{prefix}_LIBRARY="{pyLibPath}"'
                                  .format(prefix=prefix,
-                                         pyLibPath=pythonInfo[1]))
+                                         pyLibPath=pythonInfo[1].replace('\\', '/')))
                 extraArgs.append('-D{prefix}_INCLUDE_DIR="{pyIncPath}"'
                                  .format(prefix=prefix,
-                                         pyIncPath=pythonInfo[2]))
+                                         pyIncPath=pythonInfo[2].replace('\\', '/')))
         else:
             extraArgs.append('-DPXR_ENABLE_PYTHON_SUPPORT=OFF')
 

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -240,6 +240,13 @@ def GetPythonInfo(context):
     else:
         raise RuntimeError("Platform not supported")
 
+    if Windows():
+        # Replace backslashes with forward slashes in paths. CMake could
+        # fail to parse the strings otherwise.
+        pythonExecPath = pythonExecPath.replace('\\', '/')
+        pythonLibPath = pythonLibPath.replace('\\', '/')
+        pythonIncludeDir = pythonIncludeDir.replace('\\', '/')
+
     return (pythonExecPath, pythonLibPath, pythonIncludeDir, pythonVersion)
 
 def GetCPUCount():
@@ -794,14 +801,12 @@ def InstallBoost_Helper(context, force, buildArgs):
             # take the following approach:
             projectPath = 'python-config.jam'
             with open(projectPath, 'w') as projectFile:
-                # Note that we must escape any special characters, like 
-                # backslashes for jam, hence the mods below for the path 
-                # arguments. Also, if the path contains spaces jam will not
-                # handle them well. Surround the path parameters in quotes.
+                # If the path contains spaces jam will not handle them well.
+                # Surround the path parameters in quotes.
                 projectFile.write('using python : %s\n' % pythonInfo[3])
-                projectFile.write('  : "%s"\n' % pythonInfo[0].replace("\\","/"))
-                projectFile.write('  : "%s"\n' % pythonInfo[2].replace("\\","/"))
-                projectFile.write('  : "%s"\n' % os.path.dirname(pythonInfo[1]).replace("\\","/"))
+                projectFile.write('  : "%s"\n' % pythonInfo[0])
+                projectFile.write('  : "%s"\n' % pythonInfo[2])
+                projectFile.write('  : "%s"\n' % os.path.dirname(pythonInfo[1]))
                 if context.buildDebug and context.debugPython:
                     projectFile.write('  : <python-debugging>on\n')
                 projectFile.write('  ;\n')
@@ -1673,13 +1678,13 @@ def InstallUSD(context, force, buildArgs):
                 prefix = "Python3" if Python3() else "Python2"
                 extraArgs.append('-D{prefix}_EXECUTABLE="{pyExecPath}"'
                                  .format(prefix=prefix, 
-                                         pyExecPath=pythonInfo[0].replace('\\', '/')))
+                                         pyExecPath=pythonInfo[0]))
                 extraArgs.append('-D{prefix}_LIBRARY="{pyLibPath}"'
                                  .format(prefix=prefix,
-                                         pyLibPath=pythonInfo[1].replace('\\', '/')))
+                                         pyLibPath=pythonInfo[1]))
                 extraArgs.append('-D{prefix}_INCLUDE_DIR="{pyIncPath}"'
                                  .format(prefix=prefix,
-                                         pyIncPath=pythonInfo[2].replace('\\', '/')))
+                                         pyIncPath=pythonInfo[2]))
         else:
             extraArgs.append('-DPXR_ENABLE_PYTHON_SUPPORT=OFF')
 


### PR DESCRIPTION
### Description of Change(s)
In the build script, replace backslashes in filepaths with forward slashes, before evoking `cmake` with `-D` argument. 
### Fixes Issue(s)
- On Windows, downstream projects (i.e. those with `find_package(pxr CONFIG REQUIRED)` calls in their `CMakeLists.txt` files) could fail to build with the following error:
```
>  cmake -DCMAKE_PREFIX_PATH="C:\Users\nicolas.popravka\AppData\Local\Programs\USD" ...
...
CMake Error at C:/Users/nicolas.popravka/AppData/Local/Programs/USD/pxrConfig.cmake:26 (if):
  Syntax error in cmake code at

    C:/Users/nicolas.popravka/AppData/Local/Programs/USD/pxrConfig.cmake:26

  when parsing string

    C:\Users\nicolas.popravka\AppData\Local\Programs\Python\Python39\python.exe

  Invalid character escape '\U'.
Call Stack (most recent call first):
  CMakeLists.txt:17 (find_package)


-- Configuring incomplete, errors occurred!
```
This is fixed with the proposed change.
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
