### PR TITLE
Two small improvements to the OBJ plugin

### DIFF
--- a/extras/usd/examples/usdObj/stream.cpp
+++ b/extras/usd/examples/usdObj/stream.cpp
@@ -186,7 +186,7 @@ UsdObjStream::AddFace(Face const &face)
 {
     // If there aren't any groups, add one first.
     if (_groups.empty()) {
-        AddGroup(string());
+        AddGroup(string("default"));
     }
     _groups.back().faces.push_back(face);
 }

--- a/extras/usd/examples/usdObj/streamIO.cpp
+++ b/extras/usd/examples/usdObj/streamIO.cpp
@@ -133,7 +133,7 @@ UsdObjReadDataFromStream(std::istream &input,
             // Create new group.
             string groupName;
             lineStream >> groupName;
-            stream->AddGroup(groupName);
+            stream->AddGroup(groupName.size() ? groupName : "default");
         } else {
             // Add arbitrary text (or comment).
             stream->AppendArbitraryText(line);


### PR DESCRIPTION
### Description of Change(s)
The proposed changes slightly improve the example plugin to convert between the OBJ file format and USD, and hopefully make it even more useful ;-)

### Fixes Issue(s)
- OBJ files with no `g` statements, or a `g` statement not followed by a group name, could not be referenced in. With this change, one is now able to do so, like this:
```
def Mesh "default" (
    prepend references = @mesh.obj@</default>
 )
 {
 }
```
- OBJ files with `vt` statements could not be rendered with textures when referenced in. This is fixed.
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
