### PR TITLE
Compare HdPrimvarDesrciptor equality by name and role

### DIFF
--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -191,8 +191,7 @@ struct HdPrimvarDescriptor {
         : name(name_), interpolation(interp_), role(role_), indexed(indexed_)
     { }
     bool operator==(HdPrimvarDescriptor const& rhs) const {
-        return name == rhs.name && role == rhs.role
-            && interpolation == rhs.interpolation;
+        return name == rhs.name && role == rhs.role;
     }
     bool operator!=(HdPrimvarDescriptor const& rhs) const {
         return !(*this == rhs);

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -191,7 +191,8 @@ struct HdPrimvarDescriptor {
         : name(name_), interpolation(interp_), role(role_), indexed(indexed_)
     { }
     bool operator==(HdPrimvarDescriptor const& rhs) const {
-        return name == rhs.name && role == rhs.role;
+        return name == rhs.name && role == rhs.role
+            && interpolation == rhs.interpolation;
     }
     bool operator!=(HdPrimvarDescriptor const& rhs) const {
         return !(*this == rhs);

--- a/pxr/usdImaging/usdImaging/primAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/primAdapter.cpp
@@ -768,12 +768,16 @@ UsdImagingPrimAdapter::_MergePrimvar(
     bool indexed) const
 {
     HdPrimvarDescriptor primvar(name, interp, role, indexed);
-    HdPrimvarDescriptorVector::iterator it =
-        std::find(vec->begin(), vec->end(), primvar);
-    if (it == vec->end())
-        vec->push_back(primvar);
-    else
-        *it = primvar;
+
+    for (HdPrimvarDescriptorVector::iterator it = vec->begin();
+        it != vec->end(); ++it) {
+        if (it->name == name) {
+            *it =  primvar;
+            return;
+        }
+    }
+
+    vec->push_back(primvar);
 }
 
 void


### PR DESCRIPTION
### Description of Change(s)
Removes interpolation from the `HdPrimvarDescriptor` `==` overload.
### Fixes Issue(s)
Fixes an issue where `UsdImagingPrimAdapter::_MergePrimvar` will insert a duplicate descriptor into the vector if the interpolation is changed.

We observe this issue when calling `SetWidthsInterpolation` on basis curves after the widths attribute has been created. The equality check always returns false because the interpolation was changed, so it inserts a duplicate. Our delegate queries each interpolation type, and the last one found wins. This often results in the wrong type, and we can't proceed with some logic.

I tried to write tests for this, but could not reproduce with testusdview. The shader used for curves requires the primvar to be defined, it emits a shader compilation error if only the WidthsAttr is present. And it will render in some invalid states, but error in others, like this:

Initial render state:
- widths value [3, 3, 5]
- widths interp varying

Storm renders the expected image


Second render state:
- widths value [1]
- widths interpolation varying

Storm renders the expected image despite not changing interpolation.

If you reverse that order, so that it starts with a valid constant state and change to varying, it will fail with a shader error. Even with the operations in a changeblock.


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
