### PR TITLE
Apple: Convert UsdZip to C++

### DIFF
--- a/pxr/usd/bin/usdzip/CMakeLists.txt
+++ b/pxr/usd/bin/usdzip/CMakeLists.txt
@@ -1,9 +1,12 @@
 set(PXR_PREFIX pxr/usd)
 set(PXR_PACKAGE usd)
 
-pxr_python_bin(usdzip
-    DEPENDENCIES
+pxr_cpp_bin(usdzip
+        LIBRARIES
+        tf
+        sdf
         usd
+        usdUtils
 )
 
 pxr_install_test_dir(

--- a/pxr/usd/bin/usdzip/CMakeLists.txt
+++ b/pxr/usd/bin/usdzip/CMakeLists.txt
@@ -3,10 +3,14 @@ set(PXR_PACKAGE usd)
 
 pxr_cpp_bin(usdzip
         LIBRARIES
+        ar
         tf
         sdf
         usd
         usdUtils
+        ${Boost_PYTHON_LIBRARY}
+        INCLUDE_DIRS
+        ${Boost_INCLUDE_DIRS}
 )
 
 pxr_install_test_dir(

--- a/pxr/usd/bin/usdzip/CMakeLists.txt
+++ b/pxr/usd/bin/usdzip/CMakeLists.txt
@@ -8,9 +8,6 @@ pxr_cpp_bin(usdzip
         sdf
         usd
         usdUtils
-        ${Boost_PYTHON_LIBRARY}
-        INCLUDE_DIRS
-        ${Boost_INCLUDE_DIRS}
 )
 
 pxr_install_test_dir(

--- a/pxr/usd/bin/usdzip/usdzip.cpp
+++ b/pxr/usd/bin/usdzip/usdzip.cpp
@@ -1,0 +1,368 @@
+//
+// Copyright 2022 Apple
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+
+#include <pxr/pxr.h>
+#include "pxr/base/tf/pxrCLI11/CLI11.h"
+#include <pxr/usd/ar/resolver.h>
+#include <pxr/usd/ar/resolverContextBinder.h>
+#include <pxr/base/arch/fileSystem.h>
+#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/base/tf/pathUtils.h>
+#include <pxr/base/tf/fileUtils.h>
+#include <pxr/usd/usd/zipFile.h>
+#include <pxr/base/tf/debug.h>
+#include <pxr/usd/usdUtils/dependencies.h>
+
+
+PXR_NAMESPACE_USING_DIRECTIVE
+using namespace pxr_CLI;
+
+struct Args {
+    std::string usdzFile;
+    std::vector<std::string> inputFiles = {};
+    bool recurse = false;
+    std::string asset;
+    std::string arkitAsset;
+    bool checkCompliance = false;
+    std::string listTarget;
+    std::string dumpTarget;
+    bool verbose = false;
+};
+
+void Configure(CLI::App *app, Args &args) {
+    app->add_option("usdzFile", args.usdzFile,
+                    "Name of the .usdz file to create or to inspect the contents of.");
+    app->add_option("inputFiles", args.inputFiles,
+                    "Files to include in the .usdz files");
+    app->add_flag("-r,--recurse", args.recurse,
+                  "If specified, files in sub-directories are recursively added to the package");
+    app->add_option("-a,--asset", args.asset,
+                    "Resolvable asset path pointing to the root layer" \
+                  "of the asset to be isolated and copied into the package.");
+    app->add_option("--arkitAsset", args.arkitAsset,
+                    "Similar to the --asset option, the --arkitAsset "\
+                  "option packages all of the dependencies of the named scene file.\n"\
+                  "Assets targeted at the initial usdz " \
+                  "implementation in ARKit operate under greater " \
+                  "constraints than usdz files for more general 'in " \
+                  "house' uses, and this option attempts to ensure that " \
+                  "these constraints are honored; this may involve more " \
+                  "transformations to the data, which may cause loss of " \
+                  "features such as VariantSets."
+    );
+
+    app->add_flag("-c,--checkCompliance", args.checkCompliance,
+                  "(Currently does nothing)"
+                  "Perform compliance checking of the input files."
+                  "If the input asset or \"root\" layer fails any of the compliance checks,"
+                  "the package is not created and the program fails."
+    );
+    app->add_option("-l,--list", args.listTarget,
+                    "List contents of the specified usdz file. If "
+                    "a file-path argument is provided, the list is output "
+                    "to a file at the given path. If no argument is "
+                    "provided or if '-' is specified as the argument, the "
+                    "list is output to stdout"
+    );
+    app->add_option("-d,--dump", args.dumpTarget,
+                    "Dump contents of the specified usdz file. If "
+                    "a file-path argument is provided, the contents are "
+                    "output to a file at the given path. If no argument is "
+                    "provided or if '-' is specified as the argument, the "
+                    "contents are output to stdout."
+    );
+    app->add_flag("-v,--verbose", args.verbose,
+                  "Enable verbose mode, which causes messages "
+                  "regarding files being added to the package to be"
+                  " output to stdout");
+}
+
+bool CheckCompliance(const std::string &rootLayer, bool arkit = false) {
+    std::cerr << "Compliance checking is not implemented yet." << std::endl;
+    return false;
+}
+
+bool CreateUsdzPackage(const std::string &usdzFile, const std::vector<std::string> &filesToAdd, bool recurse,
+                       bool checkCompliance, bool verbose) {
+    std::vector<std::string> fileList;
+    for (auto &path: filesToAdd) {
+        if (TfIsDir(path)) {
+            auto paths = TfListDir(path, recurse);
+            for (auto &p: paths) {
+                if (!TfIsDir(p) && ArchGetFileLength(p.c_str()) > 0) {
+                    if (verbose) {
+                        std::cout << ".. adding: " << p << std::endl;
+                    }
+                    fileList.emplace_back(p);
+                }
+            }
+        } else {
+            if (ArchGetFileLength(path.c_str()) > 0) {
+                if (verbose) {
+                    std::cout << ".. adding: " << path << std::endl;
+                }
+                fileList.emplace_back(path);
+            }
+        }
+    }
+
+    if (fileList.empty()) {
+        std::cerr << "No files to package" << std::endl;
+        return false;
+    }
+
+    if (checkCompliance) {
+        if (!CheckCompliance(fileList[0])) {
+            return false;
+        }
+    }
+
+
+    auto writer = UsdZipFileWriter::CreateNew(usdzFile);
+    for (auto &f: fileList) {
+        if (writer.AddFile(f).empty()) {
+            std::cerr << "Failed to add file " << f << " to package. Discarding package" << std::endl;
+            writer.Discard();
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void ListContents(const std::string &path, UsdZipFile &zipfile) {
+    std::ostream *out = &std::cout;
+    bool closeAfterUse = false;
+    if (path != "-") {
+        closeAfterUse = true;
+        out = new std::ofstream(path);
+    }
+
+    std::vector<std::string> filenames(zipfile.begin(), zipfile.end());
+    for (auto &fn: filenames) {
+        *out << fn << std::endl;
+    }
+
+    if (closeAfterUse) {
+        static_cast<std::ofstream *>(out)->close();
+        delete out;
+    }
+
+}
+
+std::string padded(const size_t data, const size_t padding, const char spacer = ' ') {
+    auto str = std::to_string(data);
+    if (padding > str.size())
+        str.insert(0, padding - str.size(), spacer);
+
+    return str;
+}
+
+void DumpContents(const std::string &path, UsdZipFile &zipfile) {
+    std::ostream *out = &std::cout;
+    bool closeAfterUse = false;
+    if (path != "-") {
+        closeAfterUse = true;
+        out = new std::ofstream(path);
+    }
+    std::vector<std::string> filenames(zipfile.begin(), zipfile.end());
+
+    *out << "    Offset\t      Comp\t    Uncomp\tName" << std::endl;
+    *out << "    ------\t      ----\t    ------\t----" << std::endl;
+
+    for (auto &fn: filenames) {
+        // Copying the logic from Python, instead of trying to be fast
+        auto info = zipfile.Find(fn).GetFileInfo();
+        *out << padded(info.dataOffset, 10) << "\t"
+             << padded(info.size, 10) << "\t"
+             << padded(info.uncompressedSize, 10) << "\t"
+             << fn << std::endl;
+
+    }
+
+    *out << "----------\n" << std::to_string(filenames.size()) << " files total" << std::endl;
+
+    if (closeAfterUse) {
+        static_cast<std::ofstream *>(out)->close();
+        delete out;
+    }
+}
+
+int USDZip(Args &args) {
+    if (!args.asset.empty() and !args.arkitAsset.empty()) {
+        std::cerr << "Specify either --asset or --arkitAsset, not both." << std::endl;
+        return 1;
+    }
+
+    if (args.inputFiles.size() > 0 && (!args.asset.empty() || !args.arkitAsset.empty())) {
+        std::cerr << "Specify either inputFiles or an asset (via --asset or "
+                  << "--arKitAsset, not both" << std::endl;
+        return 1;
+    }
+
+    // If usdzFile is not specified directly as an argument, check if it has been
+    // specified as an argument to the --list or --dump options. In these cases,
+    // output the list or the contents to stdout.
+    std::string listTarget = args.listTarget;
+    std::string dumpTarget = args.dumpTarget;
+    std::string usdzFile = args.usdzFile;
+    if (usdzFile.empty()) {
+        if (!listTarget.empty() && listTarget != "-"
+            && TfGetExtension(listTarget) != "usdz"
+            && TfPathExists(listTarget)) {
+            usdzFile = listTarget;
+            listTarget = "-";
+        } else if (!dumpTarget.empty() && dumpTarget != "-"
+                   && TfGetExtension(dumpTarget) != "usdz"
+                   && TfPathExists(dumpTarget)) {
+            usdzFile = dumpTarget;
+            dumpTarget = "-";
+        } else {
+            std::cerr << "No usdz file specified." << std::endl;
+            return 1;
+        }
+
+    }
+
+    // Check if we're in package creation mode and verbose mode is enabled
+    // print some useful information
+    if (!args.asset.empty() || !args.arkitAsset.empty() || args.inputFiles.size() > 0) {
+        if (TfGetExtension(usdzFile) != "usdz") {
+            usdzFile += ".usdz";
+        }
+
+        if (args.verbose) {
+            if (TfPathExists(usdzFile)) {
+                std::cout << "File at path " << usdzFile << " already exists. "
+                          << "Overwriting file." << std::endl;
+            }
+
+            if (args.inputFiles.size() > 0) {
+                std::cout << "Creating package " << usdzFile << "with files ";
+                for (auto &i: args.inputFiles) {
+                    std::cout << i << ", ";
+                }
+                std::cout << std::endl;
+            }
+
+            if (!args.asset.empty() || !args.arkitAsset.empty()) {
+                TfDebug::SetDebugSymbolsByName("USDUTILS_CREATE_USDZ_PACKAGE", 1);
+            }
+
+            if (!args.recurse) {
+                std::cout << "Not recursing into sub-directories." << std::endl;
+            }
+        }
+    } else {
+        if (args.checkCompliance) {
+            std::cerr << "--checkCompliance should only be specified when "
+                      << "creating a usdz package. Please use 'usdchecker' to check "
+                      << "compliance of an existing .usdz file." << std::endl;
+            return 1;
+        }
+    }
+
+    bool success = true;
+    if (args.inputFiles.size() > 0) {
+        success = CreateUsdzPackage(usdzFile, args.inputFiles, args.recurse,
+                                    args.checkCompliance, args.verbose) && success;
+    } else if (!args.asset.empty()) {
+        ArResolver &resolver = ArGetResolver();
+        auto resolvedAsset = resolver.Resolve(args.asset);
+        if (args.checkCompliance) {
+            success = CheckCompliance(resolvedAsset, false) && success;
+        }
+
+        auto context = resolver.CreateDefaultContextForAsset(resolvedAsset);
+        auto binder = ArResolverContextBinder(context);
+        // Create the package only if the compliance check was passed.
+        success = success && UsdUtilsCreateNewUsdzPackage(SdfAssetPath(args.asset), args.usdzFile);
+    } else if (!args.arkitAsset.empty()) {
+        ArResolver &resolver = ArGetResolver();
+        auto resolvedAsset = resolver.Resolve(args.arkitAsset);
+        if (args.checkCompliance) {
+            success = CheckCompliance(resolvedAsset, true) && success;
+        }
+
+        auto context = resolver.CreateDefaultContextForAsset(resolvedAsset);
+        auto binder = ArResolverContextBinder(context);
+        // Create the package only if the compliance check was passed.
+
+        success = success && UsdUtilsCreateNewARKitUsdzPackage(SdfAssetPath(args.arkitAsset), args.usdzFile);
+    }
+
+    if (!success) {
+        return 1;
+    }
+
+    if (!listTarget.empty() || !dumpTarget.empty()) {
+        if (TfPathExists(usdzFile)) {
+            auto zipfile = UsdZipFile::Open(usdzFile);
+            if (zipfile) {
+                if (!dumpTarget.empty()) {
+                    if (dumpTarget == usdzFile) {
+                        std::cerr << "The file into which the contents will be dumped "
+                                  << usdzFile << " must be different from the file itself." << std::endl;
+                        return 1;
+                    }
+                    DumpContents(dumpTarget, zipfile);
+                }
+                if (!listTarget.empty()) {
+                    if (listTarget == usdzFile) {
+                        std::cerr << "The file into which the contents will be listed "
+                                  << usdzFile << " must be different from the file itself." << std::endl;
+                        return 1;
+                    }
+                    ListContents(listTarget, zipfile);
+                }
+            } else {
+                std::cerr << "Failed to open usdz file at path " << usdzFile << std::endl;
+                return 1;
+            }
+        } else {
+            std::cerr << "Can't find usdz file at path " << usdzFile << std::endl;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+std::string GetVersionString() {
+    return std::to_string(PXR_MAJOR_VERSION) + "." + std::to_string(PXR_MINOR_VERSION) + "." +
+           std::to_string(PXR_PATCH_VERSION);
+}
+
+int main(int argc, char const *argv[]) {
+    auto description = "usdzip " + GetVersionString()
+                       + " : Utility for creating a .usdz file containing USD assets and for "
+                       + "inspecting existing .usdz files.";
+    CLI::App app(description, "usdzip");
+    Args args;
+    Configure(&app, args);
+    CLI11_PARSE(app, argc, argv);
+
+    return USDZip(args);
+}

--- a/pxr/usd/bin/usdzip/usdzip.cpp
+++ b/pxr/usd/bin/usdzip/usdzip.cpp
@@ -423,11 +423,6 @@ int USDZip(Args &args) {
     return 0;
 }
 
-std::string GetVersionString() {
-    return std::to_string(PXR_MAJOR_VERSION) + "." + std::to_string(PXR_MINOR_VERSION) + "." +
-           std::to_string(PXR_PATCH_VERSION);
-}
-
 int main(int argc, char const *argv[]) {
     CLI::App app("Utility for creating a .usdz file containing USD assets and for "
                  "inspecting existing .usdz files.", "usdzip");

--- a/pxr/usd/bin/usdzip/usdzip.cpp
+++ b/pxr/usd/bin/usdzip/usdzip.cpp
@@ -37,10 +37,7 @@
 #include <pxr/usd/usdUtils/dependencies.h>
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-
 #include <Python.h>
-
-using namespace boost::python;
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 

--- a/pxr/usd/bin/usdzip/usdzip.cpp
+++ b/pxr/usd/bin/usdzip/usdzip.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Apple
+// Copyright 2023 Apple
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -283,7 +283,7 @@ void DumpContents(const std::string &path, UsdZipFile &zipfile) {
 }
 
 int USDZip(Args &args) {
-    if (!args.asset.empty() and !args.arkitAsset.empty()) {
+    if (!args.asset.empty() && !args.arkitAsset.empty()) {
         std::cerr << "Specify either --asset or --arkitAsset, not both." << std::endl;
         return 1;
     }

--- a/pxr/usd/bin/usdzip/usdzip.cpp
+++ b/pxr/usd/bin/usdzip/usdzip.cpp
@@ -1,44 +1,27 @@
 //
-// Copyright 2023 Apple
+// Copyright 2025 Apple
 //
-// Licensed under the Apache License, Version 2.0 (the "Apache License")
-// with the following modification; you may not use this file except in
-// compliance with the Apache License and the following modification to it:
-// Section 6. Trademarks. is deleted and replaced with:
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
 //
-// 6. Trademarks. This License does not grant permission to use the trade
-//    names, trademarks, service marks, or product names of the Licensor
-//    and its affiliates, except as required to comply with Section 4(c) of
-//    the License and to reproduce the content of the NOTICE file.
-//
-// You may obtain a copy of the Apache License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the Apache License with the above modification is
-// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied. See the Apache License for the specific
-// language governing permissions and limitations under the Apache License.
-//
-
 
 #include <pxr/pxr.h>
-#include "pxr/base/tf/pxrCLI11/CLI11.h"
+
+#include <pxr/base/tf/pxrCLI11/CLI11.h>
 #include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/ar/resolverContextBinder.h>
 #include <pxr/base/arch/fileSystem.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/base/tf/pathUtils.h>
 #include <pxr/base/tf/fileUtils.h>
-#include "pxr/base/tf/stringUtils.h"
-#include <pxr/usd/usd/zipFile.h>
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/usd/sdf/zipFile.h>
 #include <pxr/base/tf/debug.h>
 #include <pxr/usd/usdUtils/dependencies.h>
-
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-#include <Python.h>
-#endif // PXR_PYTHON_SUPPORT_ENABLED
+#include "pxr/usdValidation/usdValidation/context.h"
+#include "pxr/usdValidation/usdValidation/registry.h"
+#include "pxr/usdValidation/usdValidation/validatorTokens.h"
+#include "pxr/usdValidation/usdUtilsValidators/validatorTokens.h"
 
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -64,22 +47,14 @@ void Configure(CLI::App *app, Args &args) {
     app->add_flag("-r,--recurse", args.recurse,
                   "If specified, files in sub-directories are recursively added to the package");
     app->add_option("-a,--asset", args.asset,
-                    "Resolvable asset path pointing to the root layer" \
-                  "of the asset to be isolated and copied into the package.");
+                    "Resolvable asset path pointing to the root layer"
+                    "of the asset to be isolated and copied into the package.");
     app->add_option("--arkitAsset", args.arkitAsset,
                     "Similar to the --asset option, the --arkitAsset "\
-                  "option packages all of the dependencies of the named scene file.\n"\
-                  "Assets targeted at the initial usdz " \
-                  "implementation in ARKit operate under greater " \
-                  "constraints than usdz files for more general 'in " \
-                  "house' uses, and this option attempts to ensure that " \
-                  "these constraints are honored; this may involve more " \
-                  "transformations to the data, which may cause loss of " \
-                  "features such as VariantSets."
+                    "option packages all of the dependencies of the named scene file.\n"\
+                    "This mode flattens composition arcs, consolidates resources and may transform data to adhere to RealityKit requirements."
     );
-
     app->add_flag("-c,--checkCompliance", args.checkCompliance,
-                  "(Currently does nothing)"
                   "Perform compliance checking of the input files."
                   "If the input asset or \"root\" layer fails any of the compliance checks,"
                   "the package is not created and the program fails."
@@ -104,77 +79,75 @@ void Configure(CLI::App *app, Args &args) {
                   " output to stdout");
 }
 
-/// CheckCompliance has to use the Python checker functions currently.
-/// So we call out to Python if USD has been built with Python, otherwise we print an error and fail
-/// Return true if successful or false if not
+static
+void
+_PrintMessage(std::ostream &output, const std::string &msg,
+              char const *color = "") {
+    // use ArchFileIsaTTY to check if the output stream is a terminal
+    // and if so, color the message. color for cout and cerr.
+    if ((color && color[0] != '\0') &&
+        ((&output == &std::cout && ArchFileIsaTTY(fileno(stdout))) ||
+         (&output == &std::cerr && ArchFileIsaTTY(fileno(stderr))))) {
+        output << color << msg << "\033[0m\n";
+    } else {
+        output << msg << '\n';
+    }
+};
+// Ported over from _ReportValidationErrors in usdchecker.cpp
 bool CheckCompliance(const std::string &rootLayer, bool arkit = false) {
-#ifdef PXR_PYTHON_SUPPORT_ENABLED
-    auto cmd = TfStringPrintf(
-            "import sys\n"
-            "from pxr import Ar, Sdf, Tf, Usd, UsdUtils\n"
-            "def _Err(msg):\n"
-            "    sys.stderr.write(msg + '\\n')\n"
-            "\n\n"
-            "def _CheckUsdzCompliance():\n"
-            "    checker = UsdUtils.ComplianceChecker(arkit=%d, skipARKitRootLayerCheck=True)\n"
-            "    checker.CheckCompliance('%s')\n"
-            "    errors = checker.GetErrors()\n"
-            "    failedChecks = checker.GetFailedChecks()\n"
-            "    warnings = checker.GetWarnings()\n"
-            "    for msg in errors + failedChecks:\n"
-            "        _Err(msg)\n"
-            "    if len(warnings) > 0:\n"
-            "        _Err(\"*********************************************\\n\"\n"
-            "             \"Possible correctness problems to investigate:\\n\"\n"
-            "             \"*********************************************\\n\")\n"
-            "        for msg in warnings:\n"
-            "            _Err(msg)\n"
-            "    return len(errors) == 0 and len(failedChecks) == 0\n", arkit, rootLayer.c_str());
+    const char *_ErrorColor = "\033[91m";
+    const char *_WarningColor = "\033[93m";
+    const char *_InfoColor = "\033[94m";
+    const char *_SuccessColor = "\033[92m";
 
-    // Using regular Py_Initialize because TfPyInitialize was causing random segfaults
-    Py_Initialize();
-    PyObject * pymodule = PyImport_AddModule("__main__");
-    if (!pymodule) {
-        TF_CODING_ERROR("Failed to initialize __main__ module");
-        return false;
+    UsdValidationRegistry &validationReg = UsdValidationRegistry::GetInstance();
+    UsdValidationValidatorMetadataVector metadata = validationReg.GetAllValidatorMetadata();
+    UsdValidationContext ctx(metadata);
+
+    auto layer = SdfLayer::FindOrOpen(rootLayer);
+    UsdValidationErrorVector errors = ctx.Validate(layer);
+    if (!errors.size()) {
+        return true;
     }
-    auto localDict = PyDict_Copy(PyModule_GetDict(pymodule));
-    if (!localDict) {
-        TF_CODING_ERROR("Failed to initialize __main__ module dictionary");
-        return false;
+
+    std::ofstream output;
+
+    bool reportFailure = false;
+    bool reportWarning = false;
+
+    for (const UsdValidationError &error: errors) {
+        switch (error.GetType()) {
+            case UsdValidationErrorType::Error:
+                reportFailure = true;
+                _PrintMessage(output, error.GetErrorAsString(), _ErrorColor);
+                break;
+            case UsdValidationErrorType::Warn:
+                reportWarning = true;
+                _PrintMessage(output, error.GetErrorAsString(), _WarningColor);
+                break;
+            case UsdValidationErrorType::Info:
+            case UsdValidationErrorType::None:
+                _PrintMessage(output, error.GetErrorAsString(), _InfoColor);
+                break;
+            default:
+                std::cerr << "Error: Unknown error type." << '\n';
+                break;
+        }
     }
-    PyObject * code = Py_CompileString(cmd.c_str(), "__main__", Py_file_input);
-    if (!code) {
-        TF_CODING_ERROR("Failed to compile checker Python code");
-        return false;
-    }
-    auto evaluated = PyEval_EvalCode(code, localDict, localDict);
-    if (!evaluated) {
-        TF_CODING_ERROR("Failed to evaluate checker Python code");
-        return false;
-    }
-    auto func = PyDict_GetItemString(localDict, "_CheckUsdzCompliance");
-    if (!func) {
-        TF_CODING_ERROR("Failed to find _CheckUsdzCompliance function.");
+
+    if (reportFailure) {
+        _PrintMessage(output, "Failed!", _ErrorColor);
         return false;
     }
 
-    PyObject * args = PyTuple_New(0);
-    auto called = PyObject_Call(func, args, NULL);
-    if (!called) {
-        TF_CODING_ERROR("Failed to run checker python code.");
-        return false;
+    if (reportWarning) {
+        _PrintMessage(output, "Success with warnings...", _WarningColor);
+    } else {
+        _PrintMessage(output, "Success!", _SuccessColor);
     }
-    bool value = PyObject_IsTrue(called);
-    Py_Finalize();
-    if (!value) {
-        std::cerr << "Failed USD Checker." << std::endl;
-    }
-    return value;
-#else
-    std::cerr << "Compliance checking requires a build with Python." << std::endl;
+
+
     return false;
-#endif // PXR_PYTHON_SUPPORT_ENABLED
 }
 
 bool CreateUsdzPackage(const std::string &usdzFile, const std::vector<std::string> &filesToAdd, bool recurse,
@@ -212,7 +185,7 @@ bool CreateUsdzPackage(const std::string &usdzFile, const std::vector<std::strin
         }
     }
 
-    auto writer = UsdZipFileWriter::CreateNew(usdzFile);
+    auto writer = SdfZipFileWriter::CreateNew(usdzFile);
     for (auto &f: fileList) {
         if (writer.AddFile(f).empty()) {
             std::cerr << "Failed to add file " << f << " to package. Discarding package" << std::endl;
@@ -224,7 +197,7 @@ bool CreateUsdzPackage(const std::string &usdzFile, const std::vector<std::strin
     return true;
 }
 
-void ListContents(const std::string &path, UsdZipFile &zipfile) {
+void ListContents(const std::string &path, SdfZipFile &zipfile) {
     std::ostream *out = &std::cout;
     bool closeAfterUse = false;
     if (path != "-") {
@@ -241,7 +214,6 @@ void ListContents(const std::string &path, UsdZipFile &zipfile) {
         static_cast<std::ofstream *>(out)->close();
         delete out;
     }
-
 }
 
 std::string padded(const size_t data, const size_t padding, const char spacer = ' ') {
@@ -252,7 +224,7 @@ std::string padded(const size_t data, const size_t padding, const char spacer = 
     return str;
 }
 
-void DumpContents(const std::string &path, UsdZipFile &zipfile) {
+void DumpContents(const std::string &path, SdfZipFile &zipfile) {
     std::ostream *out = &std::cout;
     bool closeAfterUse = false;
     if (path != "-") {
@@ -268,10 +240,9 @@ void DumpContents(const std::string &path, UsdZipFile &zipfile) {
         // Copying the logic from Python, instead of trying to be fast
         auto info = zipfile.Find(fn).GetFileInfo();
         *out << padded(info.dataOffset, 10) << "\t"
-             << padded(info.size, 10) << "\t"
-             << padded(info.uncompressedSize, 10) << "\t"
-             << fn << std::endl;
-
+                << padded(info.size, 10) << "\t"
+                << padded(info.uncompressedSize, 10) << "\t"
+                << fn << std::endl;
     }
 
     *out << "----------\n" << std::to_string(filenames.size()) << " files total" << std::endl;
@@ -282,6 +253,42 @@ void DumpContents(const std::string &path, UsdZipFile &zipfile) {
     }
 }
 
+
+/// Deal with symlinks in case AssetResolver doesn't know how to anchor it properly given the current context.
+std::string ResolveAllInputs(Args &args) {
+    std::string error;
+    if (args.inputFiles.size() > 0) {
+        std::vector<std::string> inputFiles;
+        inputFiles.reserve(args.inputFiles.size());
+        std::string path;
+        for (size_t i = 0; i < args.inputFiles.size(); ++i) {
+            path = args.inputFiles[i];
+            if (TfIsLink(path)) {
+                path = TfRealPath(args.inputFiles[i], false, &error);
+                if (!error.empty()) {
+                    return error;
+                }
+            }
+            inputFiles.emplace_back(path);
+        }
+
+        args.inputFiles = inputFiles;
+    }
+
+    if (!args.asset.empty() && TfIsLink(args.asset)) {
+        args.asset = TfRealPath(args.asset, false, &error);
+        if (!error.empty()) {
+            return error;
+        }
+    }
+
+    if (!args.arkitAsset.empty() && TfIsLink(args.arkitAsset)) {
+        args.arkitAsset = TfRealPath(args.arkitAsset, false, &error);
+    }
+
+    return error;
+}
+
 int USDZip(Args &args) {
     if (!args.asset.empty() && !args.arkitAsset.empty()) {
         std::cerr << "Specify either --asset or --arkitAsset, not both." << std::endl;
@@ -290,7 +297,13 @@ int USDZip(Args &args) {
 
     if (args.inputFiles.size() > 0 && (!args.asset.empty() || !args.arkitAsset.empty())) {
         std::cerr << "Specify either inputFiles or an asset (via --asset or "
-                  << "--arKitAsset, not both" << std::endl;
+                << "--arKitAsset, not both" << std::endl;
+        return 1;
+    }
+
+    auto resolveError = ResolveAllInputs(args);
+    if (!resolveError.empty()) {
+        std::cerr << "Failed to find real paths for input files: " << resolveError << std::endl;
         return 1;
     }
 
@@ -315,7 +328,6 @@ int USDZip(Args &args) {
             std::cerr << "No usdz file specified." << std::endl;
             return 1;
         }
-
     }
 
     // Check if we're in package creation mode and verbose mode is enabled
@@ -328,7 +340,7 @@ int USDZip(Args &args) {
         if (args.verbose) {
             if (TfPathExists(usdzFile)) {
                 std::cout << "File at path " << usdzFile << " already exists. "
-                          << "Overwriting file." << std::endl;
+                        << "Overwriting file." << std::endl;
             }
 
             if (args.inputFiles.size() > 0) {
@@ -350,8 +362,8 @@ int USDZip(Args &args) {
     } else {
         if (args.checkCompliance) {
             std::cerr << "--checkCompliance should only be specified when "
-                      << "creating a usdz package. Please use 'usdchecker' to check "
-                      << "compliance of an existing .usdz file." << std::endl;
+                    << "creating a usdz package. Please use 'usdchecker' to check "
+                    << "compliance of an existing .usdz file." << std::endl;
             return 1;
         }
     }
@@ -392,12 +404,12 @@ int USDZip(Args &args) {
 
     if (!listTarget.empty() || !dumpTarget.empty()) {
         if (TfPathExists(usdzFile)) {
-            auto zipfile = UsdZipFile::Open(usdzFile);
+            auto zipfile = SdfZipFile::Open(usdzFile);
             if (zipfile) {
                 if (!dumpTarget.empty()) {
                     if (dumpTarget == usdzFile) {
                         std::cerr << "The file into which the contents will be dumped "
-                                  << usdzFile << " must be different from the file itself." << std::endl;
+                                << usdzFile << " must be different from the file itself." << std::endl;
                         return 1;
                     }
                     DumpContents(dumpTarget, zipfile);
@@ -405,7 +417,7 @@ int USDZip(Args &args) {
                 if (!listTarget.empty()) {
                     if (listTarget == usdzFile) {
                         std::cerr << "The file into which the contents will be listed "
-                                  << usdzFile << " must be different from the file itself." << std::endl;
+                                << usdzFile << " must be different from the file itself." << std::endl;
                         return 1;
                     }
                     ListContents(listTarget, zipfile);
@@ -429,6 +441,5 @@ int main(int argc, char const *argv[]) {
     Args args;
     Configure(&app, args);
     CLI11_PARSE(app, argc, argv);
-
     return USDZip(args);
 }


### PR DESCRIPTION
This PR depends on https://github.com/PixarAnimationStudios/USD/pull/2090 , and follows up by converting usdzip to C++.
The files that are changed from that PR are:

* `pxr/usd/bin/usdzip/CMakeLists.txt`
* `pxr/usd/bin/usdzip/usdzip.cpp`

additionally a new `GetFileSize` function was added to the `pxr/usd/bin/common.h/cpp` files.

Some notes:

* Compliance Checking results in an error being surfaced to the user since those have yet to be ported to C++. I was torn on whether to leave the argument in place or not, but either way an error seems best for now.
* `testUsdZipInputFiles2` fails because the order of the files listed from the UDSZ are in a different order. I'm not sure what to do here. I'm not sure what causes the files to be listed in a different order, but I don't see anything obvious. I'm getting the filelist in the same order as the `UsdZipFile` provides it, but it looks like `UsdZipFile` gives it to me in a different order? specifically `src/sub/c.png` and `src/sub/d.txt` are returned in flipped positions.


- [X] I have verified that all unit tests pass with the proposed changes **with one minor exception**
- [X] I have submitted a signed Contributor License Agreement
