### PR TITLE
Remove use of Boost program options

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -43,7 +43,7 @@ find_package(Boost REQUIRED)
 
 # Boost provided cmake files (introduced in boost version 1.70) result in 
 # inconsistent build failures on different platforms, when trying to find boost 
-# component dependencies like python, program options, etc. Refer some related 
+# component dependencies like python, etc. Refer some related
 # discussions:
 # https://github.com/boostorg/python/issues/262#issuecomment-483069294
 # https://github.com/boostorg/boost_install/issues/12#issuecomment-508683006
@@ -140,14 +140,6 @@ else()
     endif()
 endif()
 
-# --USD tools
-if(PXR_BUILD_USD_TOOLS OR PXR_BUILD_TESTS)
-    find_package(Boost
-    COMPONENTS
-        program_options
-    REQUIRED
-    )
-endif()
 
 # --TBB
 find_package(TBB REQUIRED COMPONENTS tbb)


### PR DESCRIPTION
### Description of Change(s)

Small PR to remove the lookup for Boost::Program_Options as a required library component.

Depends on the following PRs:

https://github.com/PixarAnimationStudios/USD/pull/2113
https://github.com/PixarAnimationStudios/USD/pull/2111
https://github.com/PixarAnimationStudios/USD/pull/2110
https://github.com/PixarAnimationStudios/USD/pull/2109

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
