### PR TITLE
Test fixes for float precision issues (ie, on Linux aarch64)

### DIFF
--- a/extras/usd/examples/usdDancingCubesExample/CMakeLists.txt
+++ b/extras/usd/examples/usdDancingCubesExample/CMakeLists.txt
@@ -34,14 +34,15 @@ pxr_install_test_dir(
 )
 
 # XXX:
-# Baselines for this test were generated on a build on Linux
+# Baselines for this test were generated on a build on Linux x86_64
 # using GCC. The results may differ on other platforms and compilers
 # due to floating point precision issues. So, we only perform the
 # comparison on matching platforms. Ideally, we'd have a diff tool
 # with numerical tolerances that would allow using the same baseline
 # on all platforms.
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Linux" AND
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+    "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
     pxr_register_test(testUsdDancingCubesExample
         PYTHON
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdDancingCubesExample"

--- a/pxr/base/gf/testenv/testGfMatrix.py
+++ b/pxr/base/gf/testenv/testGfMatrix.py
@@ -760,12 +760,14 @@ class TestGfMatrix(unittest.TestCase):
                     Gf.Matrix4f]
         for Matrix in Matrices:
             # Test GetDeterminant and GetInverse on Matrix4
+
+            epsilon = 1e-10 if Matrix.__name__.endswith("d") else 1e-5
             def AssertDeterminant(m, det):
                 # Unfortunately, we don't have an override of Gf.IsClose
                 # for Gf.Matrix4*
                 for row1, row2 in zip(m * m.GetInverse(), Matrix()):
-                    self.assertTrue(Gf.IsClose(row1, row2, 1e-6))
-                self.assertTrue(Gf.IsClose(m.GetDeterminant(), det, 1e-6))
+                    self.assertTrue(Gf.IsClose(row1, row2, epsilon))
+                self.assertTrue(Gf.IsClose(m.GetDeterminant(), det, epsilon))
 
             m1   = Matrix(0.0, 1.0, 0.0, 0.0,
                             1.0, 0.0, 0.0, 0.0,

--- a/pxr/base/gf/testenv/testGfRotation.py
+++ b/pxr/base/gf/testenv/testGfRotation.py
@@ -113,6 +113,13 @@ class TestGfRotation(unittest.TestCase):
         self.assertTrue(len(str(r)))
 
     def test_Operators(self):
+
+        def AssertRotationIsClose(rot1, rot2, epsilon=1e-15):
+            axis1 = rot1.GetAxis()
+            axis2 = rot2.GetAxis()
+            self.assertTrue(Gf.IsClose(axis1, axis2, epsilon))
+            self.assertAlmostEqual(rot1.GetAngle(), rot2.GetAngle())
+
         r1 = Gf.Rotation(Gf.Vec3d(1,1,1), 30)
         r2 = Gf.Rotation(Gf.Vec3d(1,1,1), 30)
         r3 = Gf.Rotation(Gf.Vec3d(1,0,0), 60)
@@ -165,7 +172,7 @@ class TestGfRotation(unittest.TestCase):
 
         # check for associativity
         r6 = Gf.Rotation(Gf.Vec3d(0,0,1), 45)
-        self.assertEqual((r1*r2)*r6, r1*(r2*r6))
+        AssertRotationIsClose((r1*r2)*r6, r1*(r2*r6))
 
         # Test that setting via a quaternion gives a valid repr.
         m = Gf.Matrix4d().SetRotate(Gf.Rotation(Gf.Vec3d(1,1,1), 30))


### PR DESCRIPTION
### Description of Change(s)

A collection of float precision tolerance fixes, to resolve test failures on Linux aarch64 platforms (tested on an Arm Neoverse N1).

- [gf] testGfMatrix: increase tolerance for float AssertDeterminant test
- [gf] testGfRotation: add a small tolerance for associativity test
- [examples] testUsdDancingCubeExample - only do diff if on x86_64 (not aarch64)

For more aarch64 related fixes, also see:
- https://github.com/PixarAnimationStudios/USD/pull/2131
- https://github.com/PixarAnimationStudios/USD/pull/2132
- https://github.com/PixarAnimationStudios/USD/pull/2154

### Fixes Issue(s)
- testGfMatrix failure on Linux aarch64
- testGfRotation failure on Linux aarch64
- testUsdDancingCubesExample failure on Linux aarch64

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
