### PR TITLE
Allow external configuration of TBB Build Type

### DIFF
--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -108,16 +108,17 @@ if(NOT TBB_FOUND)
   
   if(NOT DEFINED TBB_USE_DEBUG_BUILD)
     if(CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug|RelWithDebInfo|RELWITHDEBINFO|relwithdebinfo)")
-      set(TBB_BUILD_TYPE DEBUG)
+      set(_TBB_BUILD_TYPE DEBUG)
     else()
-      set(TBB_BUILD_TYPE RELEASE)
+      set(_TBB_BUILD_TYPE RELEASE)
     endif()
   elseif(TBB_USE_DEBUG_BUILD)
-    set(TBB_BUILD_TYPE DEBUG)
+    set(_TBB_BUILD_TYPE DEBUG)
   else()
-    set(TBB_BUILD_TYPE RELEASE)
+    set(_TBB_BUILD_TYPE RELEASE)
   endif()
-  
+
+  set(TBB_BUILD_TYPE ${_TBB_BUILD_TYPE} CACHE STRING "Set TBB to specific build type (RELEASE or DEBUG)")
   ##################################
   # Set the TBB search directories
   ##################################


### PR DESCRIPTION
### Description of Change(s)

This PR allows external configuration of which TBB build type to look for.
This helps in setups like ours where we only distribute the Release TBB build in our Rez environment, so USD builds fail unless we override this variable. Typically we've just force set it internally, but this change allows it to be configured as a parameter to CMake.

The default is the same as it is today,  but it allows configurations like ours to work around it without needing to also distribute the debug TBB builds within Rez. I know it's logical for most people to build Debug USD against Debug USD, but in a lot of cases, I find people aren't interacting with TBB symbols.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
