### PR TITLE
APPLE: Rename MemoryBarrier func to InsertMemoryBarrier to avoid Windows issue

### DIFF
--- a/pxr/imaging/hdSt/indirectDrawBatch.cpp
+++ b/pxr/imaging/hdSt/indirectDrawBatch.cpp
@@ -1423,7 +1423,7 @@ HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
 
         // Make sure the reset-pass memory writes
         // are visible to the culling shader pass.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
 
         // Perform Culling Pass
         cullParamsInstanced.resetPass = 0;
@@ -1439,7 +1439,7 @@ HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
 
         // Make sure culling memory writes are
         // visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
     } else {
         // set cull parameters
         Uniforms cullParams;
@@ -1455,7 +1455,7 @@ HdSt_IndirectDrawBatch::_ExecuteFrustumCull(
         cullGfxCmds->Draw(_dispatchBufferCullInput->GetCount(), 0, 1, 0);
 
         // Make sure culling memory writes are visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
     }
 
     cullGfxCmds->PopDebugGroup();

--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -1690,7 +1690,7 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
 
         // Make sure the reset-pass memory writes
         // are visible to the culling shader pass.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
 
         // Perform Culling Pass
         cullParamsInstanced.resetPass = 0;
@@ -1706,7 +1706,7 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
 
         // Make sure culling memory writes are
         // visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
     } else {
         // set cull parameters
         Uniforms cullParams;
@@ -1722,7 +1722,7 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
         cullGfxCmds->Draw(_dispatchBufferCullInput->GetCount(), 0, 1, 0);
 
         // Make sure culling memory writes are visible to execute draw.
-        cullGfxCmds->MemoryBarrier(HgiMemoryBarrierAll);
+        cullGfxCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
     }
 
     cullGfxCmds->PopDebugGroup();

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -945,7 +945,7 @@ HdStResourceRegistry::_Commit()
 
         // Make sure the writes are visible to computations that follow
         if (_blitCmds) {
-            _blitCmds->MemoryBarrier(HgiMemoryBarrierAll);
+            _blitCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
         }
         SubmitBlitWork();
     }
@@ -972,11 +972,11 @@ HdStResourceRegistry::_Commit()
             // We must ensure that shader writes are visible to computations
             // in the next queue by setting a memory barrier.
             if (_blitCmds) {
-                _blitCmds->MemoryBarrier(HgiMemoryBarrierAll);
+                _blitCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
                 SubmitBlitWork();
             }
             if (_computeCmds) {
-                _computeCmds->MemoryBarrier(HgiMemoryBarrierAll);
+                _computeCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
                 SubmitComputeWork();
             }
         }

--- a/pxr/imaging/hgi/blitCmds.h
+++ b/pxr/imaging/hgi/blitCmds.h
@@ -109,7 +109,7 @@ public:
     /// Inserts a barrier so that data written to memory by commands before
     /// the barrier is available to commands after the barrier.
     HGI_API
-    virtual void MemoryBarrier(HgiMemoryBarrier barrier) = 0;
+    virtual void InsertMemoryBarrier(HgiMemoryBarrier barrier) = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgi/computeCmds.h
+++ b/pxr/imaging/hgi/computeCmds.h
@@ -92,7 +92,7 @@ public:
     /// Inserts a barrier so that data written to memory by commands before
     /// the barrier is available to commands after the barrier.
     HGI_API
-    virtual void MemoryBarrier(HgiMemoryBarrier barrier) = 0;
+    virtual void InsertMemoryBarrier(HgiMemoryBarrier barrier) = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -201,7 +201,7 @@ public:
     /// Inserts a barrier so that data written to memory by commands before
     /// the barrier is available to commands after the barrier.
     HGI_API
-    virtual void MemoryBarrier(HgiMemoryBarrier barrier) = 0;
+    virtual void InsertMemoryBarrier(HgiMemoryBarrier barrier) = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgiGL/blitCmds.cpp
+++ b/pxr/imaging/hgiGL/blitCmds.cpp
@@ -119,9 +119,9 @@ HgiGLBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
 }
 
 void
-HgiGLBlitCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiGLBlitCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
-    _ops.push_back( HgiGLOps::MemoryBarrier(barrier) );
+    _ops.push_back( HgiGLOps::InsertMemoryBarrier(barrier) );
 }
 
 bool

--- a/pxr/imaging/hgiGL/blitCmds.h
+++ b/pxr/imaging/hgiGL/blitCmds.h
@@ -76,7 +76,7 @@ public:
     void FillBuffer(HgiBufferHandle const& buffer, uint8_t value) override;
 
     HGIGL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
 protected:
     friend class HgiGL;

--- a/pxr/imaging/hgiGL/computeCmds.cpp
+++ b/pxr/imaging/hgiGL/computeCmds.cpp
@@ -135,9 +135,9 @@ HgiGLComputeCmds::PopDebugGroup()
 }
 
 void
-HgiGLComputeCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiGLComputeCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
-    _ops.push_back( HgiGLOps::MemoryBarrier(barrier) );
+    _ops.push_back( HgiGLOps::InsertMemoryBarrier(barrier) );
 }
 
 bool

--- a/pxr/imaging/hgiGL/computeCmds.h
+++ b/pxr/imaging/hgiGL/computeCmds.h
@@ -66,7 +66,7 @@ public:
     void Dispatch(int dimX, int dimY) override;
 
     HGIGL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
 protected:
     friend class HgiGL;

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -232,9 +232,9 @@ HgiGLGraphicsCmds::PopDebugGroup()
 }
 
 void
-HgiGLGraphicsCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiGLGraphicsCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
-    _ops.push_back( HgiGLOps::MemoryBarrier(barrier) );
+    _ops.push_back( HgiGLOps::InsertMemoryBarrier(barrier) );
 }
 
 bool

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -118,7 +118,7 @@ public:
         uint32_t patchBaseVertexByteOffset) override;
 
     HGIGL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
 protected:
     friend class HgiGL;

--- a/pxr/imaging/hgiGL/ops.cpp
+++ b/pxr/imaging/hgiGL/ops.cpp
@@ -945,7 +945,7 @@ HgiGLOps::ResolveFramebuffer(
 }
 
 HgiGLOpsFn
-HgiGLOps::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiGLOps::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     return [barrier] {
         if (TF_VERIFY(barrier == HgiMemoryBarrierAll)) {

--- a/pxr/imaging/hgiGL/ops.h
+++ b/pxr/imaging/hgiGL/ops.h
@@ -190,7 +190,7 @@ public:
     static HgiGLOpsFn GenerateMipMaps(HgiTextureHandle const& texture);
 
     HGIGL_API
-    static HgiGLOpsFn MemoryBarrier(HgiMemoryBarrier barrier);
+    static HgiGLOpsFn InsertMemoryBarrier(HgiMemoryBarrier barrier);
 
 };
 

--- a/pxr/imaging/hgiMetal/blitCmds.h
+++ b/pxr/imaging/hgiMetal/blitCmds.h
@@ -77,7 +77,7 @@ public:
     void FillBuffer(HgiBufferHandle const& buffer, uint8_t value) override;
 
     HGIMETAL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
 protected:
     friend class HgiMetal;

--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -455,7 +455,7 @@ HgiMetalBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
 }
 
 void
-HgiMetalBlitCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiMetalBlitCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     TF_VERIFY(barrier==HgiMemoryBarrierAll, "Unknown barrier");
     // Do nothing. All blit encoder work will be visible to next encoder.

--- a/pxr/imaging/hgiMetal/computeCmds.h
+++ b/pxr/imaging/hgiMetal/computeCmds.h
@@ -69,7 +69,7 @@ public:
     void PopDebugGroup() override;
 
     HGIMETAL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
     HGIMETAL_API
     id<MTLComputeCommandEncoder> GetEncoder();

--- a/pxr/imaging/hgiMetal/computeCmds.mm
+++ b/pxr/imaging/hgiMetal/computeCmds.mm
@@ -163,7 +163,7 @@ HgiMetalComputeCmds::PopDebugGroup()
 }
 
 void
-HgiMetalComputeCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiMetalComputeCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     if (TF_VERIFY(barrier == HgiMemoryBarrierAll)) {
         _CreateEncoder();

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -113,7 +113,7 @@ public:
     void PopDebugGroup() override;
 
     HGIMETAL_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
     
     HGIMETAL_API
     void EnableParallelEncoder(bool enable);

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -812,7 +812,7 @@ HgiMetalGraphicsCmds::PopDebugGroup()
 }
 
 void
-HgiMetalGraphicsCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiMetalGraphicsCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     TF_VERIFY(barrier==HgiMemoryBarrierAll, "Unknown barrier");
     

--- a/pxr/imaging/hgiVulkan/blitCmds.cpp
+++ b/pxr/imaging/hgiVulkan/blitCmds.cpp
@@ -497,10 +497,10 @@ HgiVulkanBlitCmds::FillBuffer(HgiBufferHandle const& buffer, uint8_t value)
 }
 
 void
-HgiVulkanBlitCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiVulkanBlitCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     _CreateCommandBuffer();
-    _commandBuffer->MemoryBarrier(barrier);
+    _commandBuffer->InsertMemoryBarrier(barrier);
 }
 
 HgiVulkanCommandBuffer*

--- a/pxr/imaging/hgiVulkan/blitCmds.h
+++ b/pxr/imaging/hgiVulkan/blitCmds.h
@@ -78,7 +78,7 @@ public:
     void FillBuffer(HgiBufferHandle const& buffer, uint8_t value) override;
 
     HGIVULKAN_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
         
     /// Returns the command buffer used inside this cmds.
     HGIVULKAN_API

--- a/pxr/imaging/hgiVulkan/commandBuffer.cpp
+++ b/pxr/imaging/hgiVulkan/commandBuffer.cpp
@@ -238,7 +238,7 @@ HgiVulkanCommandBuffer::GetDevice() const
 }
 
 void
-HgiVulkanCommandBuffer::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiVulkanCommandBuffer::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     if (!_vkCommandBuffer) {
         return;

--- a/pxr/imaging/hgiVulkan/commandBuffer.h
+++ b/pxr/imaging/hgiVulkan/commandBuffer.h
@@ -101,7 +101,7 @@ public:
     /// Inserts a barrier so that data written to memory by commands before
     /// the barrier is available to commands after the barrier.
     HGIVULKAN_API
-    void MemoryBarrier(HgiMemoryBarrier barrier);
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier);
 
     /// Returns the id that uniquely identifies this command buffer amongst
     /// all in-flight command buffers.

--- a/pxr/imaging/hgiVulkan/computeCmds.cpp
+++ b/pxr/imaging/hgiVulkan/computeCmds.cpp
@@ -210,10 +210,10 @@ HgiVulkanComputeCmds::_BindResources()
 }
 
 void
-HgiVulkanComputeCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiVulkanComputeCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     _CreateCommandBuffer();
-    _commandBuffer->MemoryBarrier(barrier);
+    _commandBuffer->InsertMemoryBarrier(barrier);
 }
 
 void

--- a/pxr/imaging/hgiVulkan/computeCmds.h
+++ b/pxr/imaging/hgiVulkan/computeCmds.h
@@ -69,7 +69,7 @@ public:
     void Dispatch(int dimX, int dimY) override;
 
     HGIVULKAN_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
 protected:
     friend class HgiVulkan;

--- a/pxr/imaging/hgiVulkan/graphicsCmds.cpp
+++ b/pxr/imaging/hgiVulkan/graphicsCmds.cpp
@@ -338,10 +338,10 @@ HgiVulkanGraphicsCmds::DrawIndexedIndirect(
 }
 
 void
-HgiVulkanGraphicsCmds::MemoryBarrier(HgiMemoryBarrier barrier)
+HgiVulkanGraphicsCmds::InsertMemoryBarrier(HgiMemoryBarrier barrier)
 {
     _CreateCommandBuffer();
-    _commandBuffer->MemoryBarrier(barrier);
+    _commandBuffer->InsertMemoryBarrier(barrier);
 }
 
 HgiVulkanCommandBuffer*

--- a/pxr/imaging/hgiVulkan/graphicsCmds.h
+++ b/pxr/imaging/hgiVulkan/graphicsCmds.h
@@ -117,7 +117,7 @@ public:
         uint32_t patchBaseVertexByteOffset) override;
 
     HGIVULKAN_API
-    void MemoryBarrier(HgiMemoryBarrier barrier) override;
+    void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
     /// Returns the command buffer used inside this cmds.
     HGIVULKAN_API


### PR DESCRIPTION
### Description of Change(s)

In `Windows.h` there is the statement: `#define MemoryBarrier __faststorefence`. Depending on whether this header is included and in which order it is, this results in the `MemoryBarrier` symbol on `HgiGraphicsCmds` `HgiComputeCmds` and `HgiBlitCmds` being renamed as `__faststorefence`

We had to work around this in the GPU frustum culling PR, https://github.com/PixarAnimationStudios/USD/pull/2053, by using an `#undef`, but this is fragile since re-ordering the includes could cause a regression.

Perhaps a more effective solution is to rename the function?  In this case to `InsertMemoryBarrier`.

### Fixes Issue(s)
- Potential build issues on Windows platforms.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
