### PR TITLE
APPLE: Fix for dome light not changing

### DIFF
--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -1777,10 +1777,10 @@ HdxTaskController::_SetBuiltInLightingState(
             _delegate.SetParameter(
                 _lightIds[i], HdTokens->transform, lights[i].GetTransform());
 
-            if (light.IsDomeLight()) {
+            if (lights[i].IsDomeLight()) {
                 _delegate.SetParameter(
                     _lightIds[i], HdLightTokens->textureFile,
-                    _GetDomeLightTexture(light));
+                    _GetDomeLightTexture(lights[i]));
             }
             GetRenderIndex()->GetChangeTracker().MarkSprimDirty(
                 _lightIds[i], HdLight::DirtyParams | HdLight::DirtyTransform);


### PR DESCRIPTION
### Description of Change(s)

If the dome light texture was changed then the lighting system wouldn't pick it up until another file was selected.

### Fixes Issue(s)
- Dome light not changing.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
