### PR TITLE
Draft: Spec and Grammar for USDA 

### DIFF
--- a/docs/_ext/usda.peg
+++ b/docs/_ext/usda.peg
@@ -1,0 +1,84 @@
+# Top Level Parsing Element
+layer = format
+        whitespace
+        (whitespace_newline metadata_block?)?
+        (whitespace_newline prim_spec*)?
+        whitespace
+
+
+# Base Components
+space = ~"([ \s])"
+any_space = (space/"\t")
+newline = "\n"/"\r\n"/"\r"/ "\u2028"/"\u2029"
+whitespace = (any_space/newline/comment)*
+whitespace_newline = whitespace # Indicates requiring a newline
+comment_start = "#"
+comment = comment_start ~"[^\n]*"
+boolean = "true"/"false"
+digits = ~"\d+"
+integer = "-"? digits
+exponent = "e" digits
+float = (integer ("." digits exponent?)?)/("." (digits exponent?)?)
+numerical = float
+identifier = ascii_identifier/unicode_identifier
+unicode_identifier = ~"^(?:((?!\d)\w+(?:\.(?!\d)\w+)*)\.)?((?!\d)\w+)"
+ascii_identifier = ~"[a-zA-Z_]+[a-zA-Z_0-9]*"
+string = string_double_quotes/string_single_quotes/string_triple_quotes
+string_double_quotes = ~"\".*\""
+string_single_quotes = ~"'.*'"
+string_triple_quotes = ~"\"\"\".*\"\"\""
+
+tuple = "(" any_space* (value any_space* "," any_space*)* value any_space*")"
+assignment = any_space* "=" any_space*
+value = (boolean/numerical/string/tuple/array/reference/dictionary/timesamples)
+array = "[" (whitespace (value any_space* "," whitespace*)* value (whitespace* ",")?)? whitespace*  "]"
+list_modifier = "prepend"/"add"/"append"/"delete"
+dictionary = "{" whitespace property* whitespace "}"
+timesamples = "{" (whitespace (sample any_space* "," whitespace*)* sample)? whitespace*"}"
+sample = numerical any_space* ":" any_space* value
+
+
+# Header Components
+format = comment_start filetype space version
+version = digits "." digits
+filetype = "usda"/"sdf"
+
+# Reference Components
+reference = (external_reference stage_reference)/external_reference/stage_reference
+stage_reference = "<" stage_path ">"
+stage_path = (identifier/~"[/\.:]")*
+external_reference = "@" external_path "@"
+external_path = ~"[^@]*"
+
+# Metadata Components
+metadata_block = metadata_start whitespace_newline*  metadata*  whitespace_newline* metadata_end
+metadata_start = "("
+metadata_end = ")"
+metadata = (list_modifier any_space)? identifier assignment value whitespace_newline+
+
+# Prim Spec Components
+prim_spec = specifier space (prim_type space)? prim_name (whitespace metadata_block)? whitespace
+            prim_block whitespace_newline
+specifier = "def"/"over"/"class"
+prim_type = identifier
+prim_name = "\"" identifier "\""
+prim_block = "{" whitespace (prim_spec/property/variant_set)* whitespace "}"
+
+# Property Components
+property = (property_specifiers any_space)* property_type any_space property_name
+            ("." property_field)?
+            (assignment value)?
+            (any_space* metadata_block)?
+            whitespace_newline*
+property_type = identifier is_array?
+property_name = namespace identifier
+property_field = identifier
+property_specifiers = "uniform"/"custom"/list_modifier
+namespace = (identifier ":")*
+is_array = "[]"
+
+# Variant Components
+variant_set = "variantSet" any_space* variant_set_name assignment "{" whitespace_newline variant* whitespace_newline "}"
+variant_set_name = "\"" identifier "\""
+variant = variant_name any_space prim_block
+variant_name = "\"" identifier "\""

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -8,4 +8,4 @@ Specifications
 
    spec_usdpreviewsurface
    spec_usdz
-
+   spec_usda

--- a/docs/spec_usda.rst
+++ b/docs/spec_usda.rst
@@ -1,0 +1,276 @@
+==============================
+USDA File Format Specification
+==============================
+
+.. include:: rolesAndUtils.rst
+.. include:: <isonum.txt>
+
+Copyright |copy| 2022, Pixar Animation Studios,  *version 0.1.0*
+
+.. contents:: :local:
+
+Introduction
+=============
+
+The **USDA** file format is a textual representation of a USD scene.
+
+The file format is a UTF-8 encoded format today, though historically (as the name suggests), it was an ASCII format and
+retains some ASCII specific limitations. Please refer to the **Notes** section for documentation on limits.
+
+.. warning::
+    This is a Work in Progress documentation of the USDA format. It is not guaranteed to
+    be an exact description of the format right now. Contributions to improve accuracy are welcome.
+
+    If areas are unspecified, or if a discrepancy occurs, the implementation in the official USD library
+    should always take precedence as being the canonical implementation of the format.
+
+    It is **NOT** yet recommended to make your own implementation based on this document
+    , and we encourage developers to use the official implementation.
+
+    This document does not describe the composition elements of USD. Implementing this document
+    will only allow for reading a single USD layer.
+
+Grammar
+=======
+
+USD uses `Yacc <https://www.cs.utexas.edu/users/novak/yaccpaper.htm>`_ and `Bison <https://www.gnu.org/software/bison/>`_
+to read USD files.
+
+However for the purposes of this specification, we describe the grammar in a
+`Parsing Expression Grammar (PEG) <https://en.wikipedia.org/wiki/Parsing_expression_grammar>`_.
+
+Since it is not the same parser used by USD, there may be slight differences that will be documented in the
+**Notes** section.
+
+
+The grammar is included here in its entirety. Please make sure to read the explanations below for further clarifications
+on elements.
+
+.. literalinclude:: _ext/usda.peg
+   :language: peg
+
+
+Layer
+-----
+
+Header
+^^^^^^
+
+Each USDA layer starts with a header of `#usda 1.0` to specify the file type and version.
+Most files are going to be `usda` but this repo also contains a few with `sdf` as the filetype.
+
+This must be the opening characters of the file.
+
+Contents
+^^^^^^^^
+
+Layers have an optional top level metadata block to specify layer metadata, and can have multiple top level prim specs
+at this level.
+
+A layer is allowed to be empty as long as it contains the header.
+
+Base Components
+---------------
+
+Spaces
+^^^^^^
+
+USD allows for multiple spaces between components and can be represented as either a single space or a tab.
+
+WhiteSpace and Newlines
+^^^^^^^^^^^^^^^^^^^^^^^
+
+In the PEG grammar, there are two types of whitespace definitions.
+
+**whitespace_newline** is meant to represent that there is a hard expectation of a newline.
+
+Newlines are required between metadata items, prim specs and properties since USD has no semicolon style line ending.
+
+
+Identifier
+^^^^^^^^^^
+
+USDA uses ASCII identifiers. These conform to the valid identifier specification for C and Python.
+
+ASCII identifiers may only contain letters, numbers and underscores. They cannot start with a number.
+
+A Work in Progress unicode identifier specification is also provided, awaiting Unicode identifier support in USD.
+These must conform to the `unicode identifier standard <https://unicode.org/reports/tr31/>`_.
+
+
+Values
+^^^^^^
+
+Valid value types for metadata and properties are:
+
+* Strings
+* Numbers
+* Booleans
+* References
+* Dictionaries
+* TimeSamples
+* Tuples
+* Arrays
+
+
+Strings
+^^^^^^^
+
+Strings may be single quoted, double quoted or triple quoted.
+
+Numbers
+^^^^^^^
+
+Numerical values are represented as floats in this grammar.
+
+They may start with an optional negative sign. They cannot start with a positive sign.
+
+Both the left and right hand side of the decimal point are optional as long as at least one is specified.
+You may also specify an exponent.
+
+Booleans
+^^^^^^^^
+
+Booleans are represented as `true` and `false`
+
+References
+^^^^^^^^^^
+
+References are stored as two optional components, though at least one must be provided.
+
+First is the external reference path, which is a path that will be resolved by the AssetResolver. This is stored between
+two **@** symbols.
+
+Second is the stage path specifier, that is enclosed in **<>** to represent the path to reference.
+
+Dictionaries
+^^^^^^^^^^^^
+
+Dictionaries are stored as properties within curly braces.
+
+TimeSamples
+^^^^^^^^^^^
+
+TimeSamples store animation data for a property.
+
+They are stored as comma separated key value pairs in the form **time: value**, where the value is any other value type.
+
+
+Tuples
+^^^^^^
+Tuples are fixed size elements to represent a group of values that must be read together, such as a double3 or position value.
+
+Array
+^^^^^
+
+Arrays are meant for variable length values and can contain any other value type within them.
+
+Arrays can have several operations done to them, specified by keywords on the metadata or property that holds this array.
+Those operations are:
+
+* prepend
+* append
+* add
+* delete
+
+Properties
+----------
+
+Properties are children of prim specs that store the following information:
+
+**Specifier Type[] Namespace:Name = Value**
+
+Property definitions require the type and name be provided, while the other elements are optional.
+
+The specifier lets you know if the property is custom and/or uniform.
+
+The type can be singular or specify **[]** if it's an array of that type.
+
+Namespaces are colon separated identifiers for this property.
+
+Metadata
+--------
+
+Metadata are elements stored on the layer, prim specs or properties within **( )**
+
+Unlike properties they do not store type information, but are otherwise similar in definition.
+
+Prim Specs
+----------
+
+Prim Specs allow for defining a Prim.
+
+Prims are defined as
+
+**Specifier Type "Name" Metadata PrimBlock**
+
+Specifiers can be:
+* def
+* over
+* class
+
+The type is optional and is the schema type that this prim conforms to.
+
+The name is a valid USD identifier.
+
+Metadata is optional, and the prim block holds any of the following:
+
+* Properties
+* Other Prim Specs
+* Variant Sets
+
+Variant Sets
+------------
+
+Variant Sets are defined with the **variantSet** keyword
+
+**variantSet "Name" { ... }**
+
+The Name has to be a valid identifier.
+
+The curly braces contain the variants of this variant set
+
+Variants
+^^^^^^^^
+
+Variants are defined as
+
+**"Name" PrimBlock**
+
+Where name can be any valid identifier, and the prim block is the same as the prim block definition for the Prim Spec
+
+
+Notes
+============
+
+As with many text formats, there are specific issues one must be aware of when parsing or generating the file.
+While some of these may be resolved in future versions of the format, they're mentioned here for interoperability with
+older versions of USD.
+
+PEG Notes
+---------
+
+The specific PEG variant used here is compatible with the `Parsimonious <https://github.com/erikrose/parsimonious>`_
+Python library, but should be adaptable to PEG libraries in other languages with minor modifications.
+
+This version of the PEG grammar was picked because it was very close to the original PEG grammar specification.
+
+Each parser library might have specific limitations or strengths, and outputs should be tested against the canonical
+USD library to verify compatibility.
+
+
+Type Validation
+---------------
+
+The PEG grammar doesn't attempt to try and validate values against the type expected by metadata or properties.
+This is left to the runtime to verify that the types are valid, and within range.
+
+
+
+Block Opens and Close
+---------------------
+
+The opening and closing of each block for Metadata, PrimSpecs or other containers should not share the same line as
+the opening or close of another block.
+
+For example you should not close two prim specs on the same line and `}}` will be seen as invalid.


### PR DESCRIPTION
### Description of Change(s)

This is a draft PR to create a specification for the USDA file format.
It includes a PEG grammar for USDA, and explanations of various elements.
The PEG grammar is fairly vanilla and geared towards the parsimonious Python library.

@meshula had asked for railroad diagrams, however I wanted to handle that as a V2 of this. It should be straightforward to setup later, but I didn't want to make this larger than it had to be

I also stubbed in a `unicode_identifier` based on a C# identifier regex. It is definitely not correct, and I'd appreciate if I could get some advice/help from  @erslavin on that front to line up with his PR: https://github.com/PixarAnimationStudios/USD/pull/2120

A preview is included here:
[USDA File Format Specification — Universal Scene Description 23.02 documentation.pdf](https://github.com/PixarAnimationStudios/USD/files/10180841/USDA.File.Format.Specification.Universal.Scene.Description.23.02.documentation.pdf)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
