### PR TITLE
Fix windows debug build assertion in std::stl

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -1089,7 +1089,7 @@ UsdImagingDelegate::ApplyPendingUpdates()
 
         // Pre-cache dependencies in parallel
         WorkDispatcher updatePathsCacheDispatcher;
-        for (auto pathIt: usdPathsToUpdate) {
+        for (const auto& pathIt: usdPathsToUpdate) {
             const auto& usdPath = pathIt.first;
             auto pair = _flattenedDependenciesCacheMap.insert(std::make_pair(usdPath, SdfPathVector()));
             if (!pair.second) {


### PR DESCRIPTION
On a windows debug build we were faced with few crashes due to asserts in std::stl. The crash is tripped inside pxr/usdImaging/usdImaging/delegate.cpp#L1100 .  In there, the alg. is multithreaded with a final wait for completion in line 1105.  This problem appears to be related to threading. In each thread, one is passing usdPath by reference which is not thread safe.
This change makes it thread safe by passing a const reference.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
