### PR TITLE
[usdShade] GetPrimvarNamesMetadataString - only append non-empty string

### DIFF
--- a/pxr/usd/usdShade/shaderDefUtils.cpp
+++ b/pxr/usd/usdShade/shaderDefUtils.cpp
@@ -436,7 +436,15 @@ UsdShadeShaderDefUtils::GetPrimvarNamesMetadataString(
     // If there's an existing value in the definition, we must append to it.
     std::vector<std::string> primvarNames; 
     if (metadata.count(SdrNodeMetadata->Primvars)) {
-        primvarNames.push_back(metadata.at(SdrNodeMetadata->Primvars));
+        auto& existingValue = metadata.at(SdrNodeMetadata->Primvars);
+        // Only append if it's non-empty - calling code may do, ie,
+        //    metadata["primvars"] = this_function()
+        // ...and on some compilers / architectures, that will result in a
+        // default empty string being inserted into metadata BEFORE this
+        // function is called
+        if (!existingValue.empty()) {
+            primvarNames.push_back(existingValue);
+        }
     }
 
     for (auto &shdInput : shaderDef.GetInputs(/* onlyAuthored */ false)) {


### PR DESCRIPTION
### Description of Change(s)

on some compilers / architectures, if you do:

    metadata["primvars] = GetPrimvarNamesMetadataString(...)

...this results in a default / empty string being inserted into metadata["primvars"] BEFORE GetPrimvarNamesMetadataString is called. Therefore, we only insert existing non-empty strings into the list that GetPrimvarNamesMetadataString builds. (And it's a good check in general anyway.)

For more aarch64 related fixes, also see:
- https://github.com/PixarAnimationStudios/USD/pull/2115
- https://github.com/PixarAnimationStudios/USD/pull/2132
- https://github.com/PixarAnimationStudios/USD/pull/2154

### Fixes Issue(s)
- failure of testUsdShadeShaderDef  on linux aarch64 using gcc 7.5.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
