### PR TITLE
[gf] testGfCamera: add a small tolerance (ie, for aarch64)

### DIFF
--- a/pxr/base/gf/testenv/testGfCamera.py
+++ b/pxr/base/gf/testenv/testGfCamera.py
@@ -28,14 +28,36 @@ from pxr import Gf
 import math
 import unittest
 
+if 'unittest.util' in __import__('sys').modules:
+    # Show full diff in self.assertEqual.
+    __import__('sys').modules['unittest.util']._MAX_LENGTH = 999999999
+
 class TestGfCamera(unittest.TestCase):
+    maxDiff = None
 
     def AssertListGfClose(self, l1, l2, delta = 1e-6):
         for v1, v2 in zip(l1, l2):
             self.assertTrue(Gf.IsClose(v1, v2, delta))
 
-    def AssertEqualCams(self, cam1, cam2):
-        # Check fields
+    def AssertCamsClose(self, cam1, cam2, delta = 1e-6):
+        self.AssertListGfClose(cam1.transform, cam2.transform, delta=delta)
+        self.assertEqual(cam1.projection, cam2.projection)
+        self.assertAlmostEqual(cam1.horizontalAperture, cam2.horizontalAperture, delta=delta)
+        self.assertAlmostEqual(cam1.verticalAperture, cam2.verticalAperture, delta=delta)
+        self.assertAlmostEqual(cam1.horizontalApertureOffset, cam2.horizontalApertureOffset, delta=delta)
+        self.assertAlmostEqual(cam1.verticalApertureOffset, cam2.verticalApertureOffset, delta=delta)
+        self.assertAlmostEqual(cam1.focalLength, cam2.focalLength, delta=delta)
+        self.assertAlmostEqual(cam1.clippingRange, cam2.clippingRange, delta=delta)
+        self.assertAlmostEqual(cam1.clippingPlanes, cam2.clippingPlanes, delta=delta)
+        self.assertAlmostEqual(cam1.fStop, cam2.fStop, delta=delta)
+        self.assertAlmostEqual(cam1.focusDistance, cam2.focusDistance, delta=delta)
+
+        # Check computation of frustum
+        self.AssertListGfClose(cam1.frustum.ComputeCorners(),
+                               cam2.frustum.ComputeCorners(),
+                               delta=delta)
+
+    def AssertCamsEqual(self, cam1, cam2):
         self.assertEqual(cam1.transform, cam2.transform)
         self.assertEqual(cam1.projection, cam2.projection)
         self.assertEqual(cam1.horizontalAperture, cam2.horizontalAperture)
@@ -58,7 +80,7 @@ class TestGfCamera(unittest.TestCase):
 
     def AssertCamSelfEvaluating(self, cam):
 
-        self.AssertEqualCams(cam, eval(repr(cam)))
+        self.AssertCamsEqual(cam, eval(repr(cam)))
 
 
     def test_CameraEqualOperator(self):
@@ -369,7 +391,7 @@ class TestGfCamera(unittest.TestCase):
             verticalAperture = 20.0,
             focalLength = 26.684656143188477)
 
-        self.AssertEqualCams(cam, otherCam)
+        self.AssertCamsClose(cam, otherCam)
 
         self.assertEqual(cam.projection, Gf.Camera.Perspective)
             


### PR DESCRIPTION
### Description of Change(s)

allows test to pass on linux aarch64 architecture

For more aarch64 related fixes, also see:
- https://github.com/PixarAnimationStudios/USD/pull/2115
- https://github.com/PixarAnimationStudios/USD/pull/2131
- https://github.com/PixarAnimationStudios/USD/pull/2154

### Fixes Issue(s)
- test failure in testGfCamera on linux aarch64

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
