### PR TITLE
[UsdUtils] Add UDIM support for dependencies/usdz and switch material…

### DIFF
--- a/pxr/usd/usdUtils/CMakeLists.txt
+++ b/pxr/usd/usdUtils/CMakeLists.txt
@@ -82,6 +82,7 @@ pxr_test_scripts(
     testenv/testUsdUtilsStitch.py
     testenv/testUsdUtilsStitchClips.py
     testenv/testUsdUtilsTimeCodeRange.py
+    testenv/testUsdUtilsUdims.py
     testenv/testUsdUtilsUpdateSchemaWithSdrNode.py
     testenv/testUsdUtilsVarSelsSessionLayer.py
 )
@@ -189,6 +190,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdUtilsStitchClips.testenv
     DEST testUsdUtilsStitchClips
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdUtilsUdims
+    DEST testUsdUtilsUdims
 )
 
 pxr_install_test_dir(
@@ -472,6 +478,12 @@ pxr_register_test(testUsdUtilsStitch
 pxr_register_test(testUsdUtilsStitchClips
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchClips"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdUtilsUdims
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsUdims"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdUtils/dependencies.h
+++ b/pxr/usd/usdUtils/dependencies.h
@@ -179,6 +179,32 @@ void UsdUtilsModifyAssetPaths(
         const SdfLayerHandle& layer,
         const UsdUtilsModifyAssetPathFn& modifyFn);
 
+/// Checks if \p identifier contains a UDIM token. Currently only "<UDIM>" is
+/// supported, but other patterns such as "_MAPID_" may be supported in the future.
+USDUTILS_API
+bool
+UsdUtilsIsUdimIdentifier(const std::string &identifier);
+
+/// Retrieves all UDIM tiles matching \p udimPath. The path is first anchored with
+/// the passed \p layer if needed, then the function attempts to resolve all possible
+/// UDIM numbers in the path, returning all successfully resolved paths.
+USDUTILS_API
+std::vector<std::string>
+UsdUtilsGetUdimFiles(
+    const std::string &udimPath,
+    const SdfLayerHandle& layer);
+
+/// Resolves a \p udimPath containing a UDIM token. The path is first
+/// anchored with the passed \p layer if needed, then the function attempts to
+/// resolve any possible UDIM tiles. If any exist, the resolved path is returned
+/// with "<UDIM>" subsituted back in. If no resolves succeed or \p udimPath does
+/// not contain a UDIM token, an empty string is returned.
+USDUTILS_API
+std::string 
+UsdUtilsResolveUdimPath(
+    const std::string &udimPath,
+    const SdfLayerHandle& layer);
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // PXR_USD_USD_UTILS_DEPENDENCIES_H

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
@@ -99,5 +99,32 @@ class TestUsdUtilsDependencies(unittest.TestCase):
         stage.Save()
         UsdUtils.ComputeAllDependencies(stage.GetRootLayer().identifier)
 
+    def test_ComputeAllDependenciesUdims(self):
+        """Test for catching UDIMs with UsdUtils.ComputeAllDependencies.
+        Not included in the main test to keep it cleaner."""
+
+        rootLayer = "computeAllDependenciesUdims/layer.usda"
+        layers, assets, unresolved = \
+            UsdUtils.ComputeAllDependencies(rootLayer)
+
+        self.assertEqual(
+            set(layers), 
+            set([Sdf.Layer.Find(rootLayer)]))
+
+        self.assertEqual(
+            set([os.path.normcase(f) for f in assets]),
+            set([os.path.normcase(
+                    os.path.abspath("computeAllDependenciesUdims/" + f))
+                    for f in ["image_a.1001.exr", 
+                            "image_b.1002.exr", 
+                            "image_c.1003.exr"]]))
+
+        self.assertEqual(
+            set([os.path.normcase(f) for f in unresolved]),
+            set([os.path.normcase(
+                    os.path.abspath("computeAllDependenciesUdims/" + f))
+                    for f in ["image_d.<UDIM>.exr",
+                            "image_e.<UDIM>.exr"]]))
+
 if __name__=="__main__":
     unittest.main()

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_a.1001.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_a.1001.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_b.1002.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_b.1002.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_c.1003.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/image_c.1003.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/layer.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesUdims/layer.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+
+def "foo"
+{
+    asset udim_attr = @./image_a.<UDIM>.exr@
+    asset[] udim_list = [
+        @./image_b.<UDIM>.exr@,
+        @./image_c.<UDIM>.exr@,
+        @./image_d.<UDIM>.exr@,
+    ]
+    asset udim_missing = @./image_e.<UDIM>.exr@
+}

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims.py
@@ -1,0 +1,83 @@
+#!/pxrpythonsubst
+#
+# Copyright 2022 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+
+from pxr import UsdUtils, Sdf
+import os
+import unittest
+
+class TestUsdUtilUdims(unittest.TestCase):
+    def test_IsUdimIdentifier(self):
+        """Basic test for UsdUtils.IsUdimIdentifier"""
+        def _test(layer, propPath, value):
+            attr = layer.GetPropertyAtPath(propPath)
+            self.assertEqual(
+                UsdUtils.IsUdimIdentifier(attr.default.path),
+                value,
+            )
+
+        layer = Sdf.Layer.FindOrOpen("./layer.usda")
+        _test(layer, "/foo.udim_style_a", True)
+        _test(layer, "/foo.udim_style_b", True)
+        _test(layer, "/foo.udim_missing", True)
+        _test(layer, "/foo.not_udim", False)
+
+    def test_GetUdimFiles(self):
+        """Basic test for UsdUtils.GetUdimFiles"""
+        def _test(layer, propPath, value):
+            attr = layer.GetPropertyAtPath(propPath)
+            paths = UsdUtils.GetUdimFiles(attr.default.path, layer)
+            self.assertEqual(
+                set(os.path.normcase(f) for f in paths),
+                set(os.path.normcase(os.path.abspath(f)) for f in value),
+            )
+
+        layer = Sdf.Layer.FindOrOpen("./layer.usda")
+        _test(
+            layer, "/foo.udim_style_a", 
+            ["style_a.1001.exr", "style_a.1011.exr"],
+        )
+        _test(
+            layer, "/foo.udim_style_b", 
+            ["style_b_1002.exr", "style_b_1021.exr"],
+        )
+        _test(layer, "/foo.udim_missing", [])
+        _test(layer, "/foo.not_udim", [])
+
+    def test_ResolveUdimPath(self):
+        """Basic test for UsdUtils.ResolveUdimPath"""
+        def _test(layer, propPath, value):
+            attr = layer.GetPropertyAtPath(propPath)
+            self.assertEqual(
+                os.path.normcase(UsdUtils.ResolveUdimPath(attr.default.path, layer)),
+                os.path.normcase(os.path.abspath(value)) if value != "" else value,
+            )
+
+        layer = Sdf.Layer.FindOrOpen("./layer.usda")
+        _test(layer, "/foo.udim_style_a", "style_a.<UDIM>.exr")
+        _test(layer, "/foo.udim_style_b", "style_b_<UDIM>.exr")
+        _test(layer, "/foo.udim_missing", "")
+        _test(layer, "/foo.not_udim", "")
+
+if __name__=="__main__":
+    unittest.main()

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/layer.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/layer.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+
+def "foo"
+{
+    asset udim_style_a = @./style_a.<UDIM>.exr@
+    asset udim_style_b = @./style_b_<UDIM>.exr@
+    asset not_udim = @./style_a.1001.exr@
+    asset udim_missing = @./missing.<UDIM>.exr@
+}

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1001.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1001.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1011.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1011.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1101.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_a.1101.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1002.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1002.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1021.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1021.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1201.exr
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsUdims/style_b_1201.exr
@@ -1,0 +1,1 @@
+Not a real exr file

--- a/pxr/usd/usdUtils/wrapDependencies.cpp
+++ b/pxr/usd/usdUtils/wrapDependencies.cpp
@@ -101,4 +101,15 @@ void wrapDependencies()
     bp::def("ModifyAssetPaths", &UsdUtilsModifyAssetPaths,
         (bp::arg("layer"), bp::arg("modifyFn")));
 
+    bp::def("IsUdimIdentifier", UsdUtilsIsUdimIdentifier,
+            (bp::arg("identifier")));
+
+    bp::def("GetUdimFiles", UsdUtilsGetUdimFiles,
+            (bp::arg("udimPath"),
+             bp::arg("layer")));
+
+    bp::def("ResolveUdimPath", UsdUtilsResolveUdimPath,
+            (bp::arg("udimPath"),
+             bp::arg("layer")));
+
 }

--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -20,6 +20,7 @@ pxr_library(usdImaging
         usdLux
         usdRender
         usdShade
+        usdUtils
         usdVol
         ar
         ${TBB_tbb_LIBRARY}

--- a/pxr/usdImaging/usdImaging/materialParamUtils.cpp
+++ b/pxr/usdImaging/usdImaging/materialParamUtils.cpp
@@ -36,13 +36,9 @@
 #include "pxr/usd/usdShade/nodeDefAPI.h"
 #include "pxr/usd/usdLux/lightAPI.h"
 #include "pxr/usd/usdLux/lightFilter.h"
+#include "pxr/usd/usdUtils/dependencies.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
-
-static const char UDIM_PATTERN[] = "<UDIM>";
-static const int UDIM_START_TILE = 1001;
-static const int UDIM_END_TILE = 1100;
-static const std::string::size_type UDIM_TILE_NUMBER_LENGTH = 4;
 
 // We need to find the first layer that changes the value
 // of the parameter so that we anchor relative paths to that.
@@ -95,60 +91,6 @@ _ResolveAssetSymlinks(const SdfAssetPath& assetPath)
     }
 }
 
-// Given the prefix (e.g., /someDir/myImage.) and suffix (e.g., .exr),
-// add integer between them and try to resolve. Iterate until
-// resolution succeeded.
-static
-std::string
-_ResolvedPathForFirstTile(
-    const std::pair<std::string, std::string> &splitPath,
-    SdfLayerHandle const &layer)
-{
-    TRACE_FUNCTION();
-
-    ArResolver& resolver = ArGetResolver();
-    
-    for (int i = UDIM_START_TILE; i < UDIM_END_TILE; i++) {
-        // Fill in integer
-        std::string path =
-            splitPath.first + std::to_string(i) + splitPath.second;
-        if (layer) {
-            // Deal with layer-relative paths.
-            path = SdfComputeAssetPathRelativeToLayer(layer, path);
-        }
-        // Resolve. Unlike the non-UDIM case, we do not resolve symlinks
-        // here to handle the case where the symlinks follow the UDIM
-        // naming pattern but the files that are linked do not. We'll
-        // let whoever consumes the pattern determine if they want to
-        // resolve symlinks themselves.
-        path = resolver.Resolve(path);
-        if (!path.empty())
-            return path;
-    }
-    return std::string();
-}
-
-// Split a udim file path such as /someDir/myFile.<UDIM>.exr into a
-// prefix (/someDir/myFile.) and suffix (.exr).
-//
-// We might support other patterns such as /someDir/myFile._MAPID_.exr
-// in the future.
-static
-std::pair<std::string, std::string>
-_SplitUdimPattern(const std::string &path)
-{
-    static const std::vector<std::string> patterns = { UDIM_PATTERN };
-
-    for (const std::string &pattern : patterns) {
-        const std::string::size_type pos = path.find(pattern);
-        if (pos != std::string::npos) {
-            return { path.substr(0, pos), path.substr(pos + pattern.size()) };
-        }
-    }
-
-    return { std::string(), std::string() };
-}
-
 // If given assetPath contains UDIM pattern, resolve the UDIM pattern.
 // Otherwise, leave assetPath untouched.
 static
@@ -160,60 +102,19 @@ _ResolveAssetAttribute(
 {
     TRACE_FUNCTION();
 
-    // See whether the asset path contains UDIM pattern.
-    const std::pair<std::string, std::string>
-        splitPath = _SplitUdimPattern(assetPath.GetAssetPath());
-
-    if (splitPath.first.empty() && splitPath.second.empty()) {
-        // Not a UDIM, resolve symlinks and exit.
+    // Not a UDIM, resolve symlinks and exit.
+    if (!UsdUtilsIsUdimIdentifier(assetPath.GetAssetPath())) {
         return _ResolveAssetSymlinks(assetPath);
     }
 
-    // Find first tile.
-    std::string firstTilePackage;
-    std::string firstTilePath =
-        _ResolvedPathForFirstTile(splitPath, _FindLayerHandle(attr, time));
-
-    if (firstTilePath.empty()) {
+    std::string resolvedPath = 
+        UsdUtilsResolveUdimPath(
+            assetPath.GetAssetPath(), _FindLayerHandle(attr, time));
+    // If the path doesn't resolve, return the input path
+    if (resolvedPath.empty()) {
         return assetPath;
     }
-
-    // If the resolved path of the first tile is located in a packaged asset,
-    // like /foo/bar/baz.usdz[myImage.0001.exr], we need to separate the
-    // paths to restore the "<UDIM>" prefix to the image filename in the
-    // code below, then join the path back togther before we return.
-    if (ArIsPackageRelativePath(firstTilePath)) {
-        std::tie(firstTilePackage, firstTilePath) =
-            ArSplitPackageRelativePathInner(firstTilePath);
-    }
-
-    // Construct the file path /filePath/myImage.<UDIM>.exr by using
-    // the first part from the first resolved tile, "<UDIM>" and the
-    // suffix.
-
-    const std::string &suffix = splitPath.second;
-
-    // Sanity check that the part after <UDIM> did not change.
-    if (!TfStringEndsWith(firstTilePath, suffix)) {
-        TF_WARN(
-            "Resolution of first udim tile gave ambigious result. "
-            "First tile for '%s' is '%s'.",
-            assetPath.GetAssetPath().c_str(), firstTilePath.c_str());
-        return assetPath;
-    }
-
-    // Length of the part /filePath/myImage.<UDIM>.exr.
-    const std::string::size_type prefixLength =
-        firstTilePath.size() - suffix.size() - UDIM_TILE_NUMBER_LENGTH;
-
-    firstTilePath = 
-        firstTilePath.substr(0, prefixLength) + UDIM_PATTERN + suffix;
-
-    return SdfAssetPath( 
-        assetPath.GetAssetPath(),
-        firstTilePackage.empty() ? 
-            firstTilePath : 
-            ArJoinPackageRelativePath(firstTilePackage, firstTilePath));
+    return SdfAssetPath(assetPath.GetAssetPath(), resolvedPath);
 }
 
 // Get the value from the usd attribute at given time. If it is an


### PR DESCRIPTION
…ParamUtils to use shared functions

This PR is a continuation of the work from #1477, which is closed since the related accounts are no longer accessible. I tried to vet these changes as much as possible, but I wouldn't be surprised if there are some uses of UDIMs that I missed, so definitely let me know of any uncommon cases to include tests for.

### Description of Change(s)

- Added three UDIM utility functions to UsdUtils: `UsdUtilsIsUdimIdentifier`, `UsdUtilsGetUdimFiles`, and `UsdUtilsResolveUdimPath`. These are also Python-wrapped.
- Switched UsdImaging's materialParamUtils to use these functions (the previous UDIM utilities were moved and are used by the functions).
- Changed _AssetLocalizer to use these functions and include UDIM files with dependency computation and USDZ creation.
- Added a test module for these UDIM functions and an additional dependency computation test. I didn't add a new USDZ test since the dependency test should account for the changes.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
