### PR TITLE
[tf] fix docstring of TfGetPathName and TfGetBaseName

### DIFF
--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -327,7 +327,9 @@ std::string TfStringGetSuffix(const std::string& name, char delimiter = '.');
 TF_API
 std::string TfStringGetBeforeSuffix(const std::string& name, char delimiter = '.');
 
-/// Returns the base name of a file (final component of the path).
+/// Returns the base name of a file (final component of the path, after
+/// stripping all trailing slashes - forward only on Linux / MacOS, forward and
+/// and backward on Windows).
 TF_API
 std::string TfGetBaseName(const std::string& fileName);
 
@@ -336,8 +338,12 @@ std::string TfGetBaseName(const std::string& fileName);
 /// The returned string ends in a '/' (or possibly a '\' on Windows), unless
 /// none was found in \c fileName, in which case the empty string is returned.
 /// In particular, \c TfGetPathName(s)+TfGetBaseName(s) == \c s for any string
-/// \c s (as long as \c s doesn't end with multiple adjacent slashes, which is
-/// illegal).
+/// \c s which doesn't end with a trailing slash.  If \c s does end with a
+/// trailing slash (forward only on Linux / MacOS, foward and backward on
+/// Windows), then \c TfGetPathName(s) == \c s, but \c TfGetBaseName(s) will
+/// only be \c "" if and only if \c s is an empty string or consists of nothing
+/// but slashes.
+
 TF_API
 std::string TfGetPathName(const std::string& fileName);
 


### PR DESCRIPTION
### Description of Change(s)

The docstring for TfGetPathName stated that:

    TfGetPathName(s)+TfGetBaseName(s) == s

"as long as \c s doesn't end with multiple adjacent slashes".  This is incorrect - the equation holds only if s doesn't end with ANY trailing slashes, as TfGetBaseName first strips all trailing slashes.  Fixed it to have the correct condition.

Also added further clarification to the docstring of TfGetBaseName to note it's strailing-slash stripping behavior.

### Fixes Issue(s)
- Incorrect docstring for TfGetPathName

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
