### PR TITLE
APPLE: Support for other AOVs in usdrecord

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -153,6 +153,10 @@ def main():
             'Width of the output image. The height will be computed from this '
             'value and the camera\'s aspect ratio (default=%(default)s)'))
 
+    parser.add_argument('--outputAOV', '-a', action='store', type=str,
+        default='color', choices=['color', 'depth', 'primId'],
+        help=('Select an AOV for rendering (default=%(default)s)'))
+
     args = parser.parse_args()
 
     UsdAppUtils.framesArgs.ValidateCmdlineArgs(parser, args,
@@ -204,8 +208,9 @@ def main():
     for timeCode in args.frames:
         _Msg('Recording time code: %s' % timeCode)
         outputImagePath = args.outputImagePath.format(frame=timeCode.GetValue())
+        outputAOV = args.outputAOV
         try:
-            frameRecorder.Record(usdStage, usdCamera, timeCode, outputImagePath)
+            frameRecorder.Record(usdStage, usdCamera, timeCode, outputImagePath, outputAOV)
         except Tf.ErrorException as e:
 
             _Err("Recording aborted due to the following failure at time code "

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -280,7 +280,8 @@ UsdAppUtilsFrameRecorder::Record(
         const UsdStagePtr& stage,
         const UsdGeomCamera& usdCamera,
         const UsdTimeCode timeCode,
-        const std::string& outputImagePath)
+        const std::string& outputImagePath, 
+        const std::string& outputAOV)
 {
     if (!stage) {
         TF_CODING_ERROR("Invalid stage");
@@ -319,7 +320,13 @@ UsdAppUtilsFrameRecorder::Record(
     const GfFrustum frustum = gfCamera.GetFrustum();
     const GfVec3d cameraPos = frustum.GetPosition();
 
-    _imagingEngine.SetRendererAov(HdAovTokens->color);
+    TfToken aov = TfToken::Find(outputAOV);
+    if (aov == TfToken()) {
+      TF_WARN("Missing AOV. Defaulting to 'color' AOV.");
+      _imagingEngine.SetRendererAov(HdAovTokens->color);  // Defaults to 'color' AOV.
+    } else {
+      _imagingEngine.SetRendererAov(aov);
+    }
 
     _imagingEngine.SetCameraState(
         frustum.ComputeViewMatrix(),

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -137,7 +137,8 @@ public:
             const UsdStagePtr& stage,
             const UsdGeomCamera& usdCamera,
             const UsdTimeCode timeCode,
-            const std::string& outputImagePath);
+            const std::string& outputImagePath, 
+            const std::string& outputAOV);
 
 private:
     UsdImagingGLEngine _imagingEngine;

--- a/pxr/usdImaging/usdAppUtils/testenv/testUsdAppUtilsFrameRecorder.py
+++ b/pxr/usdImaging/usdAppUtils/testenv/testUsdAppUtilsFrameRecorder.py
@@ -99,9 +99,10 @@ class TestUsdAppUtilsFrameRecorder(unittest.TestCase):
         Tests recording a single frame.
         """
         outputImagePath = os.path.abspath('AnimCube.png')
+        outputAOV = 'color'
         self.assertTrue(
             self._frameRecorder.Record(self._stage, self._usdCamera,
-                Usd.TimeCode.EarliestTime(), outputImagePath))
+                Usd.TimeCode.EarliestTime(), outputImagePath, outputAOV))
 
     def testRecordMultipleFrames(self):
         """
@@ -110,12 +111,13 @@ class TestUsdAppUtilsFrameRecorder(unittest.TestCase):
         outputImagePath = os.path.abspath('AnimCube.#.png')
         outputImagePath = UsdAppUtils.framesArgs.ConvertFramePlaceholderToFloatSpec(
             outputImagePath)
+        outputAOV = 'color'
 
         frameSpecIter = UsdAppUtils.framesArgs.FrameSpecIterator('1,5,10')
         for timeCode in frameSpecIter:
             self.assertTrue(
                 self._frameRecorder.Record(self._stage, self._usdCamera,
-                    timeCode, outputImagePath.format(frame=timeCode.GetValue())))
+                    timeCode, outputImagePath.format(frame=timeCode.GetValue()), outputAOV))
 
 
 if __name__ == "__main__":

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -56,6 +56,7 @@ wrapFrameRecorder()
             (arg("stage"),
              arg("usdCamera"),
              arg("timeCode"),
-             arg("outputImagePath")))
+             arg("outputImagePath"),
+             arg("outputAOV")))
     ;
 }


### PR DESCRIPTION
### Description of Change(s)

Allow usdrecord to output the contents of other AOVs.  This is specified by setting the `outputAOV` argument on running it to `color` `depth` etc.

Thanks to the other engineers at Apple for the help with this.

### Fixes Issue(s)
- Export images from other AOVs in Storm.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
