### PR TITLE
APPLE: Fix for build issues with boost 1.78

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -736,23 +736,19 @@ def InstallBoost_Helper(context, force, buildArgs):
         bootstrapCmd = '{bootstrap} --prefix="{instDir}"'.format(
             bootstrap=bootstrap, instDir=context.instDir)
 
-        macOSArchitecture = ""
         macOSArch = ""
 
         if MacOS():
             if apple_utils.GetTargetArch(context) == \
                         apple_utils.TARGET_X86:
-                macOSArchitecture = "architecture=x86"
                 macOSArch = "-arch {0}".format(apple_utils.TARGET_X86)
             elif apple_utils.GetTargetArch(context) == \
                         apple_utils.GetTargetArmArch():
-                macOSArchitecture = "architecture=arm"
                 macOSArch = "-arch {0}".format(
                         apple_utils.GetTargetArmArch())
             elif context.targetUniversal:
                 (primaryArch, secondaryArch) = \
                         apple_utils.GetTargetArchPair(context)
-                macOSArchitecture = "architecture=combined"
                 macOSArch="-arch {0} -arch {1}".format(
                         primaryArch, secondaryArch)
 
@@ -761,6 +757,10 @@ def InstallBoost_Helper(context, force, buildArgs):
                                 " cflags=\"{0}\" " \
                                 " linkflags=\"{0}\"".format(macOSArch)
             bootstrapCmd += " --with-toolset=clang"
+
+            # If Python2 is also installed in the system then it is sometimes
+            # found first, so we force the bootstrap to Python3
+            bootstrapCmd += " --with-python-version=3"
 
         Run(bootstrapCmd)
 
@@ -864,10 +864,6 @@ def InstallBoost_Helper(context, force, buildArgs):
             # Must specify toolset=clang to ensure install_name for boost
             # libraries includes @rpath
             b2_settings.append("toolset=clang")
-
-            # Specify target for macOS cross-compilation.
-            if macOSArchitecture:
-                b2_settings.append(macOSArchitecture)
 
             if macOSArch:
                 b2_settings.append("cxxflags=\"{0}\"".format(macOSArch))


### PR DESCRIPTION
### Description of Change(s)

Recreating https://github.com/PixarAnimationStudios/USD/pull/2144

With the latest dev push, boost has been updated to 1.78.

With this version b2 no longer requires the` architecture=combined` option for universal builds and throws an error if it is defined.

### Fixes Issue(s)
- Boost build failure with universal binaries

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
