### PR TITLE
[usd] zipFile: add missing #include <mutex>

### DIFF
--- a/pxr/usd/usd/zipFile.cpp
+++ b/pxr/usd/usd/zipFile.cpp
@@ -37,6 +37,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <mutex>
 #include <shared_mutex>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
### Description of Change(s)

This only seems to become an issue on certain compiler / operating systems, but on Ubuntu 22.04.1 LTS with gcc 11.3.0, you get:

```
/Projects/Dev/USD/USD/pxr/usd/usd/zipFile.cpp: In member function ‘pxrInternal_v0_23__pxrReserved__::UsdZipFile::Iterator pxrInternal_v0_23__pxrReserved__::UsdZipFile::_Impl::CachedBegin()’:
/Projects/Dev/USD/USD/pxr/usd/usd/zipFile.cpp:507:14: error: ‘unique_lock’ is not a member of ‘std’
  507 |         std::unique_lock<std::shared_timed_mutex> l(_rwMutex);
      |              ^~~~~~~~~~~
/Projects/Dev/USD/USD/pxr/usd/usd/zipFile.cpp:43:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
   42 | #include <unordered_map>
  +++ |+#include <mutex>
   43 |
```

Adding the `#include <mutex>` as suggested fixes the issue.

### Fixes Issue(s)
- Error compiling on Ubuntu 22.04 w/ gcc-11.3.0

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
