### PR TITLE
[usdSkel] testUsdSkelBakeSkinning - only do usda diff on x86_64 arch

### DIFF
--- a/pxr/usd/usdSkel/CMakeLists.txt
+++ b/pxr/usd/usdSkel/CMakeLists.txt
@@ -142,12 +142,25 @@ pxr_register_test(testUsdSkelAnimQuery
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdSkelBakeSkinning
-    PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBakeSkinning"
-    EXPECTED_RETURN_CODE 0
-    DIFF_COMPARE blendshapes.baked.usda blendshapesWithNormals.baked.usda lbs.baked.usda lbs.bakedInterval.usda
-)
+# Baselines for this test were generated on an x86_64 chip. The results may
+# differ on other architectures due to floating point precision issues. So, we
+# only perform the comparison on matching architectures. Ideally, we'd have a
+# diff tool with numerical tolerances that would allow using the same baseline
+# on all architectures.
+if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    pxr_register_test(testUsdSkelBakeSkinning
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBakeSkinning"
+        EXPECTED_RETURN_CODE 0
+        DIFF_COMPARE blendshapes.baked.usda blendshapesWithNormals.baked.usda lbs.baked.usda lbs.bakedInterval.usda
+    )
+else ()
+    pxr_register_test(testUsdSkelBakeSkinning
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelBakeSkinning"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdSkelBindingAPI
     PYTHON


### PR DESCRIPTION
### Description of Change(s)

...as floating point precision issues may result in differences on other architectures.

(ie, the test would fail on linux aarch64 hardware)

This change follows the pattern from testUsdDancingCubesExample:

https://github.com/PixarAnimationStudios/USD/blob/4ee62b99c91afbea38f2afd855fbd21cb23d6e64/extras/usd/examples/usdDancingCubesExample/CMakeLists.txt#L37

For more aarch64 related fixes, also see:
- https://github.com/PixarAnimationStudios/USD/pull/2115
- https://github.com/PixarAnimationStudios/USD/pull/2131
- https://github.com/PixarAnimationStudios/USD/pull/2132

### Fixes Issue(s)
- Failure of testUsdSkelBakeSkinning on aarch64 hardware

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
