### PR TITLE
Fix #2149. 

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -2626,7 +2626,7 @@ UsdImagingInstanceAdapter::GetScenePrimPaths(
 
             // set bits for all requested indices to true
             for (size_t i = 0; i < instanceIndices.size(); i++) {
-                requestedIndicesMap[instanceIndices[i]] = i;
+                requestedIndicesMap[instanceIndices[i] - minIdx] = i;
             }
 
             result.resize(instanceIndices.size());


### PR DESCRIPTION
### Description of Change(s)
When building the requestedIndicesMap in GetScenePrimPaths in one case the shift by minIndex was missing resulting in a out of bounds access.

### Fixes Issue(s)
#2149, crash under certain conditions when calling GetScenePrimPath/GetScenePrimPath(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
