### PR TITLE
Use explicit integer division as argument to truncate in testUsdBugs

### DIFF
--- a/pxr/usd/usd/testenv/testUsdBugs.py
+++ b/pxr/usd/usd/testenv/testUsdBugs.py
@@ -430,7 +430,7 @@ class TestUsdBugs(unittest.TestCase):
             # Now truncate layer to corrupt it.
             fobj = open(f.name, "r+")
             size = os.path.getsize(f.name)
-            fobj.truncate(size / 2)
+            fobj.truncate(size // 2)
             fobj.close()
             # Attempting to open the file should raise an exception.
             with self.assertRaises(Tf.ErrorException):


### PR DESCRIPTION
### Description of Change(s)

Explicit integer division avoids passing a float to truncate.

### Fixes Issue(s)
#2170

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
