### PR TITLE
Replace boost hash usage with TfHash in pxr/base/tf

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -35,8 +35,8 @@
 #include "pxr/base/arch/errno.h"
 
 #include <boost/assign.hpp>
-#include <boost/functional/hash.hpp>
 #include <boost/noncopyable.hpp>
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashset.h"
 
 #include <set>
@@ -492,13 +492,10 @@ struct Tf_FileId {
 };
 
 static size_t hash_value(const Tf_FileId& fileId) {
-    size_t seed = 0;
-    boost::hash_combine(seed, fileId.dev);
-    boost::hash_combine(seed, fileId.ino);
-    return seed;
+    return TfHash::Combine(fileId.dev, fileId.ino);
 }
 
-typedef TfHashSet<Tf_FileId, boost::hash<Tf_FileId> > Tf_FileIdSet;
+typedef TfHashSet<Tf_FileId, TfHash> Tf_FileIdSet;
 
 static bool
 Tf_WalkDirsRec(

--- a/pxr/base/tf/hash.h
+++ b/pxr/base/tf/hash.h
@@ -33,6 +33,9 @@
 
 #include <cstring>
 #include <string>
+#include <map>
+#include <set>
+#include <typeindex>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -92,6 +95,35 @@ inline void
 TfHashAppend(HashState &h, std::vector<T> const &vec)
 {
     h.AppendContiguous(vec.data(), vec.size());
+}
+
+// Support std::set.
+// NOTE: Supporting std::unordered_set is complicated because the traversal
+// order is not guaranteed
+template <class HashState, class T, class Compare>
+inline void
+TfHashAppend(HashState& h, std::set<T, Compare> const &elements)
+{
+    h.AppendRange(std::begin(elements), std::end(elements));
+}
+
+// Support std::map.
+// NOTE: Supporting std::unordered_map is complicated because the traversal
+// order is not guaranteed
+template <class HashState, class Key, class Value, class Compare>
+inline void
+TfHashAppend(HashState& h, std::map<Key, Value, Compare> const &elements)
+{
+    h.AppendRange(std::begin(elements), std::end(elements));
+}
+
+// Support std::type_index.  When TfHash support for std::hash is enabled,
+// this explicit specialization will no longer be necessary.
+template <class HashState>
+inline void
+TfHashAppend(HashState& h, std::type_index const &type_index)
+{
+    return h.Append(type_index.hash_code());
 }
 
 // Support for hashing std::string.

--- a/pxr/base/tf/refPtr.h
+++ b/pxr/base/tf/refPtr.h
@@ -427,6 +427,7 @@
 #include "pxr/pxr.h"
 
 #include "pxr/base/tf/diagnosticLite.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/nullPtr.h"
 #include "pxr/base/tf/refBase.h"
 #include "pxr/base/tf/safeTypeCompare.h"
@@ -435,7 +436,6 @@
 
 #include "pxr/base/arch/hints.h"
 
-#include <boost/functional/hash_fwd.hpp>
 
 #include <typeinfo>
 #include <type_traits>
@@ -1329,11 +1329,7 @@ template <class T>
 inline size_t
 hash_value(const TfRefPtr<T>& ptr)
 {
-    // Make the boost::hash type depend on T so that we don't have to always
-    // include boost/functional/hash.hpp in this header for the definition of
-    // boost::hash.
-    auto refBase = ptr._refBase;
-    return boost::hash<decltype(refBase)>()(refBase);
+    return TfHash()(ptr);
 }
 
 template <class HashState, class T>

--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -294,6 +294,12 @@ Test_TfHash()
     std::vector<int> vint = {1, 2, 3, 4, 5};
     printf("hash(vector<int>): %zu\n", h(vint));
 
+    std::set<int> sint = {1, 2, 3, 4, 5};
+    printf("hash(set<int>): %zu\n", h(sint));
+
+    std::map<int, uint32_t> mint = {{-1, 1}, {2, 3}, {-4, 5}};
+    printf("hash(map<int, uint32_t>): %zu\n", h(mint));
+
     std::pair<int, float> intfloat = {1, 2.34};
     printf("hash(pair<int, float>): %zu\n", h(intfloat));
 
@@ -305,6 +311,9 @@ Test_TfHash()
 
     printf("combine hash of the 3: %zu\n",
            TfHash::Combine(vint, intfloat, vp));
+
+    // Validate support for std::type_index
+    printf("hash(type_index): %zu\n", h(std::type_index(typeid(int))));
 
     TfHasher tfh;
     //BoostHasher bh;

--- a/pxr/base/tf/testenv/refPtr.cpp
+++ b/pxr/base/tf/testenv/refPtr.cpp
@@ -163,11 +163,23 @@ static void TestNullptrComparisons()
     TF_AXIOM(NULL == p);
 }
 
+static void TestHash(){
+    TF_AXIOM(TfHash()(NodeRefPtr()) == TfHash()(NodeRefPtr(nullptr)));
+
+    {
+        NodeRefPtr p = Node::New();
+        TF_AXIOM(TfHash()(p) == TfHash()(p));
+        TF_AXIOM(TfHash()(p) == TfHash()(NodeRefPtr(p)));
+        TF_AXIOM(TfHash()(p) == TfHash()(p.operator->()));
+    }
+}
+
 static bool
 Test_TfRefPtr()
 {
     TestConversions();
     TestNullptrComparisons();
+    TestHash();
     
     NodeRefPtr chain1 = MakeChain(10);
     NodeRefPtr chain2 = MakeChain(5);

--- a/pxr/base/tf/testenv/weakPtr.cpp
+++ b/pxr/base/tf/testenv/weakPtr.cpp
@@ -124,6 +124,19 @@ static void _TestComparisons()
     TF_AXIOM( !(NULL == x) );
 }
 
+static void _TestHash()
+{
+    TF_AXIOM(TfHash()(MonkeyInterfaceWeakPtr()) ==
+             TfHash()(MonkeyInterfaceWeakPtr(nullptr)));
+    {
+        Human h;
+        MonkeyInterfaceWeakPtr p(&h);
+        TF_AXIOM(TfHash()(p) == TfHash()(p));
+        TF_AXIOM(TfHash()(p) == TfHash()(MonkeyInterfaceWeakPtr(p)));
+    }
+}
+
+
 static bool
 Test_TfWeakPtr()
 {
@@ -173,6 +186,7 @@ Test_TfWeakPtr()
     delete human;
     TF_AXIOM(!hPtr);
     _TestComparisons();
+    _TestHash();
 
     return true;
 }

--- a/pxr/base/tf/weakPtrFacade.h
+++ b/pxr/base/tf/weakPtrFacade.h
@@ -27,12 +27,12 @@
 #include "pxr/pxr.h"
 
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/refPtr.h"
 #include "pxr/base/tf/weakBase.h"
 
 #include "pxr/base/arch/demangle.h"
 
-#include <boost/functional/hash_fwd.hpp>
 #include <boost/mpl/or.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/is_same.hpp>
@@ -431,11 +431,7 @@ template <template <class> class X, class T>
 inline size_t
 hash_value(TfWeakPtrFacade<X, T> const &ptr)
 {
-    // Make the boost::hash type depend on T so that we don't have to always
-    // include boost/functional/hash.hpp in this header for the definition of
-    // boost::hash.
-    auto uniqueId = ptr.GetUniqueIdentifier();
-    return boost::hash<decltype(uniqueId)>()(uniqueId);
+    return TfHash()(ptr);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

To remove the dependency of `pxr/base/tf` on boost's hashing functions
* `fileUtils` replaces `boost::hash_combine` with `TfHash::Combine`
* `TfRefPtr` and `TfWeakPtrFacade` now implement `hash_value` in terms of the existing `TfHashAppend`
* Hash test coverages is added to `TfRefPtr` and `TfWeakPtr` tests
* Until support for `std::hash` is enabled, an overload for `std::type_index` to `TfHashAppend` is now provided
* Support is added for `std::set` and `std::map` to `TfHash`.  This will facilitate changes changes in other downstream libraries.

### Fixes Issue(s)
-#2172 (first of several forthcoming PRs)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
