### PR TITLE
Replace boost hash usage with TfHash in pxr/base/vt

### DIFF
--- a/pxr/base/vt/dictionary.h
+++ b/pxr/base/vt/dictionary.h
@@ -34,7 +34,6 @@
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 
 #include <initializer_list>
@@ -273,7 +272,7 @@ public:
         if (dict.empty())
             return 0;
         // Otherwise hash the map.
-        return boost::hash_value(*dict._dictMap);
+        return TfHash()(*dict._dictMap);
     }
 
     /// Inserts a range into the \p VtDictionary. 

--- a/pxr/base/vt/hash.cpp
+++ b/pxr/base/vt/hash.cpp
@@ -37,8 +37,8 @@ void
 _IssueUnimplementedHashError(std::type_info const &t)
 {
     TF_CODING_ERROR("Invoked VtHashValue on an object of type <%s>, which "
-                    "is not hashable by boost::hash<>() or TfHash().  Consider "
-                    "providing an overload of hash_value().",
+                    "is not hashable by TfHash().  Consider "
+                    "providing an overload of hash_value() or TfHashAppend().",
                     ArchGetDemangled(t).c_str());
 }
 

--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -1549,6 +1549,9 @@ static void
 testValueHash()
 {
     static_assert(VtIsHashable<int>(), "");
+    static_assert(VtIsHashable<double>(), "");
+    static_assert(VtIsHashable<GfVec3f>(), "");
+    static_assert(VtIsHashable<std::string>(), "");
     static_assert(!VtIsHashable<_Unhashable>(), "");
 
     VtValue vHashable{1};
@@ -1572,6 +1575,14 @@ testValueHash()
         TF_AXIOM(!m.IsClean());
         m.Clear();
     }
+}
+
+static void
+testArrayHash()
+{
+    VtArray<int> array = {1, 2, 3, 4, 5, 10, 100};
+    TF_AXIOM(TfHash()(array) == TfHash()(array));
+    TF_AXIOM(TfHash()(array) == TfHash()(VtArray<int>(array)));
 }
 
 template <class T>
@@ -1849,6 +1860,7 @@ int main(int argc, char *argv[])
 
     testValue();
     testValueHash();
+    testArrayHash();
     testTypedVtValueProxy();
     testErasedVtValueProxy();
     testCombinedVtValueProxies();

--- a/pxr/base/vt/value.cpp
+++ b/pxr/base/vt/value.cpp
@@ -309,20 +309,10 @@ class Vt_CastRegistry {
     using _ConversionSourceToTarget =
         std::pair<std::type_index, std::type_index>;
 
-    struct _ConversionSourceToTargetHash
-    {
-        std::size_t operator()(_ConversionSourceToTarget p) const
-        {
-            std::size_t h = p.first.hash_code();
-            boost::hash_combine(h, p.second.hash_code());
-            return h;
-        }
-    };
-
     using _Conversions = tbb::concurrent_unordered_map<
         _ConversionSourceToTarget,
         VtValue (*)(VtValue const &),
-        _ConversionSourceToTargetHash>;
+        TfHash>;
 
     _Conversions _conversions;
     


### PR DESCRIPTION
### Description of Change(s)
Requires #2173, #2304, #2298

To remove the dependency of pxr/base/vt on boost's hashing functions
* `VtDictionary` defers its hashing to `TfHash`'s default `std::map` hashing
* `VtArray` implements a `TfHashAppend` overload to take advantage of the hashability of its contiguous elements.  `hash_value` has been modified to use this via `TfHash`.
* Remove explicit `hash_value` support in `hash.h` as `TfHash` will fallback to `hash_value` if no explicit `TfHashAppend` is defined.  This may change the order of which hash implementation is chosen (now preferring `TfHashAppend` to `hash_value`) but the implementations should not vary for most types.
* `testVtCpp` now provides test coverage for `VtArray` hashing
* Since `TfHash` supports hashing via `std::type_index` and `std::pair`, an explicit implementation hashing the type index pair is no longer necessary

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
