### PR TITLE
Export the Sync function in HdTask to allow for custom render task creation and use.

### DIFF
--- a/pxr/imaging/hdx/task.h
+++ b/pxr/imaging/hdx/task.h
@@ -66,6 +66,7 @@ public:
     /// classes can't override it and instead override _Sync.
     /// This 'non-virtual interface'-like pattern allows us to ensure we always
     /// initialized Hgi during the Sync task so derived classes don't have to.
+    HDX_API 
     void Sync(
         HdSceneDelegate* delegate,
         HdTaskContext* ctx,


### PR DESCRIPTION
We would like to create new HdTasks outside of the hdx project which is not possible unless the HdTask::Sync function is exported.

Exporting this function allows for the creation and use of custom render tasks.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X] I have submitted a signed Contributor License Agreement
