### PR TITLE
Fix the install syntax for testArchStackTrace.pdb to use TARGET_PDB_FILE 

### DIFF
--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -171,7 +171,7 @@ if (PXR_BUILD_TESTS AND WIN32)
     # place that .pdbs will be searched for, other than the baked-in absolute
     # path in the windows binary
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/testArchStackTrace.pdb
+        FILES $<TARGET_PDB_FILE:testArchStackTrace>
         DESTINATION tests/ctest/testArchStackTrace
         CONFIGURATIONS Debug RelWithDebInfo
     )


### PR DESCRIPTION
Fix the install syntax for testArchStackTrace.pdb to use the TARGET_PDB_FILE directive which is the preferred way to install pdb files.
We have problems building and running unit tests locally without this fix.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
