### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/sdf (except SdfPath)

### DIFF
--- a/pxr/usd/sdf/assetPath.h
+++ b/pxr/usd/sdf/assetPath.h
@@ -28,8 +28,8 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
+#include "pxr/base/tf/hash.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/operators.hpp>
 #include <iosfwd>
 #include <string>
@@ -86,10 +86,7 @@ public:
 
     /// Hash function
     size_t GetHash() const {
-        size_t hash = 0;
-        boost::hash_combine(hash, _assetPath);
-        boost::hash_combine(hash, _resolvedPath);
-        return hash;
+        return TfHash::Combine(_assetPath, _resolvedPath);
     }
 
     /// \class Hash

--- a/pxr/usd/sdf/layerOffset.cpp
+++ b/pxr/usd/sdf/layerOffset.cpp
@@ -29,9 +29,8 @@
 #include "pxr/usd/sdf/timeCode.h"
 #include "pxr/base/gf/math.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/type.h"
-
-#include <boost/functional/hash/hash.hpp>
 
 #include <climits>
 #include <limits>
@@ -138,10 +137,10 @@ SdfLayerOffset::operator<(const SdfLayerOffset &rhs) const
 size_t
 SdfLayerOffset::GetHash() const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, _offset);
-    boost::hash_combine(hash, _scale);
-    return hash;
+    return TfHash::Combine(
+        _offset,
+        _scale
+    );
 }
 
 std::ostream & operator<<( std::ostream &out,

--- a/pxr/usd/sdf/listOp.h
+++ b/pxr/usd/sdf/listOp.h
@@ -27,8 +27,8 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/tf/hash.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/optional/optional_fwd.hpp>
 
 #include <functional>
@@ -238,15 +238,15 @@ public:
     void ComposeOperations(const SdfListOp<T>& stronger, SdfListOpType op);
 
     friend inline size_t hash_value(const SdfListOp &op) {
-        size_t h = 0;
-        boost::hash_combine(h, op._isExplicit);
-        boost::hash_combine(h, op._explicitItems);
-        boost::hash_combine(h, op._addedItems);
-        boost::hash_combine(h, op._prependedItems);
-        boost::hash_combine(h, op._appendedItems);
-        boost::hash_combine(h, op._deletedItems);
-        boost::hash_combine(h, op._orderedItems);
-        return h;
+        return TfHash::Combine(
+            op._isExplicit,
+            op._explicitItems,
+            op._addedItems,
+            op._prependedItems,
+            op._appendedItems,
+            op._deletedItems,
+            op._orderedItems
+        );
     }
 
     bool operator==(const SdfListOp<T> &rhs) const {

--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -37,7 +37,6 @@
 
 #include "pxr/base/trace/trace.h"
 
-#include <boost/functional/hash.hpp>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/spin_mutex.h>
 

--- a/pxr/usd/sdf/payload.h
+++ b/pxr/usd/sdf/payload.h
@@ -31,8 +31,8 @@
 #include "pxr/usd/sdf/assetPath.h"
 #include "pxr/usd/sdf/layerOffset.h"
 #include "pxr/usd/sdf/path.h"
+#include "pxr/base/tf/hash.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/operators.hpp>
 
 #include <iosfwd>
@@ -113,11 +113,11 @@ public:
 
 private:
     friend inline size_t hash_value(const SdfPayload &p) {
-        size_t h = 0;
-        boost::hash_combine(h, p._assetPath);
-        boost::hash_combine(h, p._primPath);
-        boost::hash_combine(h, p._layerOffset);
-        return h;
+        return TfHash::Combine(
+            p._assetPath,
+            p._primPath,
+            p._layerOffset
+        );
     }
 
     // The asset path to the external layer.

--- a/pxr/usd/sdf/pyListOp.h
+++ b/pxr/usd/sdf/pyListOp.h
@@ -27,6 +27,7 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/listOp.h"
 #include "pxr/base/arch/demangle.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/stringUtils.h"
 #include <boost/python.hpp>
@@ -67,6 +68,10 @@ private:
         }
     }
 
+    static size_t _Hash(const T &self){
+        return TfHash()(self);
+    }
+
     static void _Wrap(const std::string& name)
     {
         using namespace boost::python;
@@ -75,6 +80,7 @@ private:
 
         class_<T>(name.c_str())
             .def("__str__", &This::_GetStr)
+            .def("__hash__", &This::_Hash)
 
             .def("Create", &T::Create,
                  (arg("prependedItems") = ItemVector(),

--- a/pxr/usd/sdf/reference.h
+++ b/pxr/usd/sdf/reference.h
@@ -31,6 +31,7 @@
 #include "pxr/usd/sdf/assetPath.h"
 #include "pxr/usd/sdf/layerOffset.h"
 #include "pxr/usd/sdf/path.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
@@ -163,12 +164,12 @@ public:
     SDF_API bool IsInternal() const;
 
     friend inline size_t hash_value(const SdfReference &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._assetPath);
-        boost::hash_combine(h, r._primPath);
-        boost::hash_combine(h, r._layerOffset);
-        boost::hash_combine(h, r._customData);
-        return h;
+        return TfHash::Combine(
+            r._assetPath,
+            r._primPath,
+            r._layerOffset,
+            r._customData
+        );
     }
 
     /// Returns whether this reference equals \a rhs.

--- a/pxr/usd/sdf/testenv/testSdfListOp.py
+++ b/pxr/usd/sdf/testenv/testSdfListOp.py
@@ -237,5 +237,21 @@ class TestSdfListOp(unittest.TestCase):
             self.assertTrue(listOp.HasItem(v))
         self.assertFalse(listOp.HasItem(4))
 
+    def test_Hash(self):
+        listOp = Sdf.IntListOp.Create(appendedItems = [1, 2, 3],
+                                      prependedItems = [0, 8, 9],
+                                      deletedItems = [-1, -2])
+        self.assertEqual(hash(listOp), hash(listOp))
+        self.assertEqual(
+            hash(listOp),
+            hash(
+                Sdf.IntListOp.Create(
+                    appendedItems=listOp.appendedItems,
+                    prependedItems=listOp.prependedItems,
+                    deletedItems=listOp.deletedItems
+                )
+            )
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/testenv/testSdfPayload.py
+++ b/pxr/usd/sdf/testenv/testSdfPayload.py
@@ -83,7 +83,22 @@ class TestSdfPayload(unittest.TestCase):
         with self.assertRaises(Tf.ErrorException):
             p = Sdf.AssetPath('\x01\x02\x03')
             p = Sdf.AssetPath('foobar', '\x01\x02\x03')
-            
+
+    def test_Hash(self):
+        self.assertEqual(
+            hash(Sdf.Payload()),
+            hash(Sdf.Payload("", Sdf.Path(), Sdf.LayerOffset()))
+        )
+        payload = Sdf.Payload(
+            "/path/to/asset",
+            Sdf.Path("/path/to/prim"),
+            Sdf.LayerOffset(offset = 10.0, scale = 1.5)
+        )
+        self.assertEqual(
+            hash(payload),
+            hash(Sdf.Payload(payload))
+        )
+
 
 
 if __name__ == "__main__":

--- a/pxr/usd/sdf/testenv/testSdfReference.py
+++ b/pxr/usd/sdf/testenv/testSdfReference.py
@@ -110,5 +110,15 @@ class TestSdfReferences(unittest.TestCase):
             p = Sdf.AssetPath('\x01\x02\x03')
             p = Sdf.AssetPath('foobar', '\x01\x02\x03')
 
+    def test_Hash(self):
+        reference = Sdf.Reference(
+            "//path/to/asset",
+            "/path/to/prim",
+            layerOffset=Sdf.LayerOffset(1.5, 2.8),
+            customData={"key" : "value"}
+        )
+        self.assertEqual(hash(reference), hash(reference))
+        self.assertEqual(hash(reference), hash(Sdf.Reference(reference)))
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/testenv/testSdfTypes.py
+++ b/pxr/usd/sdf/testenv/testSdfTypes.py
@@ -377,6 +377,9 @@ class TestSdfTypes(unittest.TestCase):
         _TestValueTypeName("/OldAttrTest.a25", Sdf.ValueTypeNames.Matrix3d)
         _TestValueTypeName("/OldAttrTest.a26", Sdf.ValueTypeNames.Matrix4d)
         _TestValueTypeName("/OldAttrTest.a27", Sdf.ValueTypeNames.Frame4d)
+
+    def test_Hash(self):
+        self.assertEqual(hash(Sdf.ValueTypeNames.Point3d), hash(Sdf.ValueTypeNames.Point3d))
    
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/valueTypeName.cpp
+++ b/pxr/usd/sdf/valueTypeName.cpp
@@ -26,7 +26,6 @@
 #include "pxr/usd/sdf/valueTypeName.h"
 #include "pxr/usd/sdf/valueTypePrivate.h"
 
-#include <boost/functional/hash.hpp>
 #include <ostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -176,10 +175,10 @@ size_t
 SdfValueTypeName::GetHash() const
 {
     // See comment in operator==.
-    size_t hash = 0;
-    boost::hash_combine(hash, TfHash()(_impl->type->type));
-    boost::hash_combine(hash, _impl->type->role.Hash());
-    return hash;
+    return TfHash::Combine(
+        _impl->type->type,
+        _impl->type->role.Hash()
+    );
 }
 
 bool

--- a/pxr/usd/sdf/valueTypeRegistry.cpp
+++ b/pxr/usd/sdf/valueTypeRegistry.cpp
@@ -28,9 +28,9 @@
 #include "pxr/usd/sdf/valueTypePrivate.h"
 #include "pxr/usd/sdf/types.h" // For SdfDimensionlessUnitDefault
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/type.h"
-#include <boost/functional/hash.hpp>
 
 #include <tbb/spin_rw_mutex.h>
 
@@ -183,17 +183,7 @@ private:
     // can be the core type for multiple roles but all types that have
     // the same TfType and role are aliases of each other.
     typedef std::pair<TfType, TfToken> CoreTypeKey;
-    struct CoreTypeKeyHash {
-        size_t operator()(const CoreTypeKey& x) const
-        {
-            size_t hash = 0;
-            boost::hash_combine(hash, TfHash()(x.first));
-            boost::hash_combine(hash, x.second.Hash());
-            return hash;
-        }
-    };
-
-    typedef TfHashMap<CoreTypeKey, CoreType, CoreTypeKeyHash> CoreTypeMap;
+    typedef TfHashMap<CoreTypeKey, CoreType, TfHash> CoreTypeMap;
     typedef TfHashMap<TfToken, Sdf_ValueTypeImpl, TfHash> TypeMap;
     typedef TfHashMap<TfToken, CoreType, TfHash> TemporaryCoreTypeMap;
     typedef TfHashMap<TfToken, Sdf_ValueTypeImpl, TfHash> TemporaryNameMap;

--- a/pxr/usd/sdf/wrapAssetPath.cpp
+++ b/pxr/usd/sdf/wrapAssetPath.cpp
@@ -74,10 +74,7 @@ static bool _Nonzero(SdfAssetPath const &self)
 
 static size_t _Hash(SdfAssetPath const &self)
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, self.GetAssetPath());
-    boost::hash_combine(hash, self.GetResolvedPath());
-    return hash;
+    return self.GetHash();
 }
 
 static std::string

--- a/pxr/usd/sdf/wrapPayload.cpp
+++ b/pxr/usd/sdf/wrapPayload.cpp
@@ -69,6 +69,11 @@ _Repr(const SdfPayload &self)
     return TF_PY_REPR_PREFIX + "Payload(" + args + ")";
 }
 
+static size_t __hash__(const SdfPayload &self)
+{
+    return TfHash()(self);
+}
+
 } // anonymous namespace 
 
 void wrapPayload()
@@ -107,6 +112,7 @@ void wrapPayload()
         .def(self >= self)
 
         .def("__repr__", _Repr)
+        .def("__hash__", __hash__)
 
         ;
 

--- a/pxr/usd/sdf/wrapReference.cpp
+++ b/pxr/usd/sdf/wrapReference.cpp
@@ -73,6 +73,11 @@ _Repr(const SdfReference &self)
     return TF_PY_REPR_PREFIX + "Reference(" + args + ")";
 }
 
+static size_t __hash__(const SdfReference &self)
+{
+    return TfHash()(self);
+}
+
 } // anonymous namespace 
 
 void wrapReference()
@@ -128,7 +133,7 @@ void wrapReference()
         .def(self >= self)
 
         .def("__repr__", _Repr)
-
+        .def("__hash__", __hash__)
         ;
 
 }


### PR DESCRIPTION
### Description of Change(s)
Requires #2173
To remove the dependency of pxr/usd/sdf on boost's hashing functions
* Python bindings for `__hash__` added to `SdfAssetPath`, `SdfPayload`, `SdfListOp`, and `SdfReference`.
* Test coverage for hashing added for `SdfListOp`, `SdfReference`, `SdfPayload`, and `SdfValueTypeName`
* `boost::hash_combine` usage replaced with `TfHash::Combine`
* `SdfPath` will be put into its own PR so it's easier to back out this fundamental and commonly hashed type without affecting the rest of `sdf`

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
