### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/sdf/path.cpp

### DIFF
--- a/pxr/usd/sdf/path.cpp
+++ b/pxr/usd/sdf/path.cpp
@@ -767,7 +767,7 @@ struct _PerThreadPrimPathCache
         size_t h = childName.Hash();
         uint32_t parentAsInt;
         memcpy(&parentAsInt, &parent, sizeof(uint32_t));
-        boost::hash_combine(h, parentAsInt >> 8);
+        h = TfHash::Combine(h, parentAsInt >> 8);
         unsigned index = (h & (Size-1));
 
         for (unsigned probe = 0; probe != Probes; ++probe) {


### PR DESCRIPTION
### Description of Change(s)
To remove the dependency of pxr/usd/sdf/path.cpp on boost's hashing functions
* Replaces `boost::hash_combine` with `TfHash::Combine`

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
