### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/ndr

### DIFF
--- a/pxr/usd/ndr/registry.cpp
+++ b/pxr/usd/ndr/registry.cpp
@@ -23,6 +23,7 @@
 //
 
 #include "pxr/pxr.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/type.h"
@@ -40,8 +41,6 @@
 
 #include "pxr/base/plug/registry.h"
 #include "pxr/base/tf/envSetting.h"
-
-#include <boost/functional/hash.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -165,11 +164,9 @@ _GetIdentifierForAsset(const SdfAssetPath &asset,
                        const TfToken &subIdentifier,
                        const TfToken &sourceType)
 {
-    size_t h = 0;
-    boost::hash_combine(h, asset);
-    for (const auto &i : metadata) { 
-        boost::hash_combine(h, i.first.GetString());
-        boost::hash_combine(h, i.second);
+    size_t h = TfHash()(asset);
+    for (const auto &i : metadata) {
+        h = TfHash::Combine(h, i.first.GetString(), i.second);
     }
 
     return NdrIdentifier(TfStringPrintf(
@@ -183,11 +180,9 @@ static NdrIdentifier
 _GetIdentifierForSourceCode(const std::string &sourceCode, 
                             const NdrTokenMap &metadata) 
 {
-    size_t h = 0;
-    boost::hash_combine(h, sourceCode);
-    for (const auto &i : metadata) { 
-        boost::hash_combine(h, i.first.GetString());
-        boost::hash_combine(h, i.second);
+    size_t h = TfHash()(sourceCode);
+    for (const auto &i : metadata) {
+        h = TfHash::Combine(h, i.first.GetString(), i.second);
     }
     return NdrIdentifier(std::to_string(h));
 }


### PR DESCRIPTION
### Description of Change(s)
To remove the dependency of pxr/usd/ndr on boost's hashing functions
* `boost::hash_combine` usage replaced with `TfHash::Combine`

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
