### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/ar

### DIFF
--- a/pxr/usd/ar/defaultResolverContext.cpp
+++ b/pxr/usd/ar/defaultResolverContext.cpp
@@ -30,8 +30,6 @@
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/stringUtils.h"
 
-#include <boost/functional/hash.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 ArDefaultResolverContext::ArDefaultResolverContext(
@@ -91,11 +89,7 @@ ArDefaultResolverContext::GetAsString() const
 size_t 
 hash_value(const ArDefaultResolverContext& context)
 {
-    size_t hash = 0;
-    for (const std::string& p : context.GetSearchPath()) {
-        boost::hash_combine(hash, TfHash()(p));
-    }
-    return hash;
+    return TfHash()(context.GetSearchPath());
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/ar/testenv/testArDefaultResolver.py
+++ b/pxr/usd/ar/testenv/testArDefaultResolver.py
@@ -320,6 +320,18 @@ class TestArDefaultResolver(unittest.TestCase):
 
         self.assertNotEqual(emptyContext, context)
 
+    def test_ResolverContextHash(self):
+        self.assertEqual(
+            hash(Ar.DefaultResolverContext()),
+            hash(Ar.DefaultResolverContext())
+        )
+
+        paths = ["/path1", "/path2", "/path3", "/path4"]
+        self.assertEqual(
+            hash(Ar.DefaultResolverContext(paths)),
+            hash(Ar.DefaultResolverContext(paths))
+        )
+
     def test_ResolveForNewAsset(self):
         resolver  = Ar.GetResolver()
 


### PR DESCRIPTION
### Description of Change(s)
To remove the dependency of pxr/usd/ar on boost's hashing functions
* Test coverage of `__hash__` has been added for `ArDefaultResolverContext`
* Replaces usage of `boost::hash_combine` with `TfHash`'s default hashing of vectors and strings

### Fixes Issue(s)
-https://github.com/PixarAnimationStudios/USD/issues/2172 (more PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
