### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/pcp

### DIFF
--- a/pxr/usd/pcp/instanceKey.cpp
+++ b/pxr/usd/pcp/instanceKey.cpp
@@ -82,13 +82,7 @@ PcpInstanceKey::PcpInstanceKey(const PcpPrimIndex& primIndex)
         }
     }
     _variantSelection.assign(variantSelection.begin(), variantSelection.end());
-    
-    for (const auto& arc : _arcs) {
-        boost::hash_combine(_hash, arc.GetHash());
-    }
-    for (const auto& vsel : _variantSelection) {
-        boost::hash_combine(_hash, vsel);
-    }
+    _hash = TfHash::Combine(_hash, _arcs, _variantSelection);
 }
 
 bool 

--- a/pxr/usd/pcp/instanceKey.h
+++ b/pxr/usd/pcp/instanceKey.h
@@ -32,8 +32,7 @@
 #include "pxr/usd/pcp/types.h"
 
 #include "pxr/usd/sdf/layerOffset.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <string>
 #include <utility>
@@ -67,6 +66,12 @@ public:
     PCP_API
     bool operator!=(const PcpInstanceKey& rhs) const;
 
+    /// Appends hash value for this instance key.
+    template <typename HashState>
+    friend void TfHashAppend(HashState& h, const PcpInstanceKey& key)
+    {
+        h.Append(key._hash);
+    }
     /// Returns hash value for this instance key.
     friend size_t hash_value(const PcpInstanceKey& key) 
     {
@@ -108,12 +113,11 @@ private:
                 _timeOffset == rhs._timeOffset;
         }
 
-        size_t GetHash() const
-        {
-            size_t hash = _arcType;
-            boost::hash_combine(hash, _sourceSite);
-            boost::hash_combine(hash, _timeOffset.GetHash());
-            return hash;
+        template <typename HashState>
+        friend void TfHashAppend(HashState &h, const _Arc& arc) {
+            h.Append(arc._arcType);
+            h.Append(arc._sourceSite);
+            h.Append(arc._timeOffset);
         }
 
         PcpArcType _arcType;

--- a/pxr/usd/pcp/layerStackIdentifier.cpp
+++ b/pxr/usd/pcp/layerStackIdentifier.cpp
@@ -29,7 +29,6 @@
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/stringUtils.h"
 
-#include <boost/functional/hash.hpp>
 #include <ostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -95,11 +94,7 @@ PcpLayerStackIdentifier::operator<(const This &rhs) const
 size_t
 PcpLayerStackIdentifier::_ComputeHash() const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, TfHash()(rootLayer));
-    boost::hash_combine(hash, TfHash()(sessionLayer));
-    boost::hash_combine(hash, pathResolverContext);
-    return hash;
+    return TfHash::Combine(rootLayer, sessionLayer, pathResolverContext);
 }
 
 PcpLayerStackIdentifierStr::PcpLayerStackIdentifierStr(
@@ -156,11 +151,7 @@ PcpLayerStackIdentifierStr::operator<(const This &rhs) const
 size_t
 PcpLayerStackIdentifierStr::_ComputeHash() const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, TfHash()(rootLayerId));
-    boost::hash_combine(hash, TfHash()(sessionLayerId));
-    boost::hash_combine(hash, pathResolverContext);
-    return hash;
+    return TfHash::Combine(rootLayerId, sessionLayerId, pathResolverContext);
 }
 
 enum Pcp_IdentifierFormat {

--- a/pxr/usd/pcp/layerStackIdentifier.h
+++ b/pxr/usd/pcp/layerStackIdentifier.h
@@ -176,19 +176,32 @@ private:
     size_t _hash;
 };
 
+template <typename HashState>
+inline void
+TfHashAppend(HashState& h, const PcpLayerStackIdentifier& x)
+{
+    h.Append(x.GetHash());
+}
+
+template <typename HashState>
+inline void
+TfHashAppend(HashState& h, const PcpLayerStackIdentifierStr& x)
+{
+    h.Append(x.GetHash());
+}
 
 inline
 size_t
 hash_value(const PcpLayerStackIdentifier& x)
 {
-    return x.GetHash();
+    return TfHash{}(x);
 }
 
 inline
 size_t
 hash_value(const PcpLayerStackIdentifierStr& x)
 {
-    return x.GetHash();
+    return TfHash{}(x);
 }
 
 PCP_API

--- a/pxr/usd/pcp/mapExpression.cpp
+++ b/pxr/usd/pcp/mapExpression.cpp
@@ -362,11 +362,12 @@ PcpMapExpression::_Node::SetValueForVariable(Value && value)
 inline size_t
 PcpMapExpression::_Node::Key::GetHash() const
 {
-    size_t hash = op;
-    boost::hash_combine(hash, boost::get_pointer(arg1));
-    boost::hash_combine(hash, boost::get_pointer(arg2));
-    boost::hash_combine(hash, valueForConstant);
-    return hash;
+    return TfHash::Combine(
+        op,
+        boost::get_pointer(arg1),
+        boost::get_pointer(arg2),
+        valueForConstant
+    );
 }
 
 bool

--- a/pxr/usd/pcp/mapFunction.cpp
+++ b/pxr/usd/pcp/mapFunction.cpp
@@ -27,12 +27,11 @@
 #include "pxr/base/trace/trace.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/enum.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/mallocTag.h"
 #include "pxr/base/tf/staticData.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/ostreamMethods.h"
-
-#include <boost/functional/hash.hpp>
 
 #include <limits>
 
@@ -535,14 +534,7 @@ PcpMapFunction::GetString() const
 size_t
 PcpMapFunction::Hash() const
 {
-    size_t hash = _data.hasRootIdentity;
-    boost::hash_combine(hash, _data.numPairs);
-    for (PathPair const &p: _data) {
-        boost::hash_combine(hash, p.first.GetHash());
-        boost::hash_combine(hash, p.second.GetHash());
-    }
-    boost::hash_combine(hash, _offset.GetHash());
-    return hash;
+    return TfHash{}(*this);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/pcp/mapFunction.h
+++ b/pxr/usd/pcp/mapFunction.h
@@ -290,6 +290,13 @@ private:
             return !(*this == other);
         }
 
+        template <class HashState>
+        friend void TfHashAppend(HashState &h, _Data const &data){
+            h.Append(data.hasRootIdentity);
+            h.Append(data.numPairs);
+            h.AppendRange(std::begin(data), std::end(data));
+        }
+
         union {
             PathPair localPairs[_MaxLocalPairs > 0 ? _MaxLocalPairs : 1];
             std::shared_ptr<PathPair> remotePairs;
@@ -299,6 +306,14 @@ private:
         bool hasRootIdentity = false;
     };
 
+    // Specialize TfHashAppend for PcpMapFunction.
+    template <typename HashState>
+    friend inline
+    void TfHashAppend(HashState& h, const PcpMapFunction& x){
+        h.Append(x._data);
+        h.Append(x._offset);
+    }
+
     _Data _data;
     SdfLayerOffset _offset;
 };
@@ -307,7 +322,7 @@ private:
 inline
 size_t hash_value(const PcpMapFunction& x)
 {
-    return x.Hash();
+    return TfHash{}(x);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/pcp/node.h
+++ b/pxr/usd/pcp/node.h
@@ -311,11 +311,17 @@ private: // Data
 };
 
 /// Typedefs and support functions
+template <typename HashState>
+inline
+void
+TfHashAppend(HashState& h, const PcpNodeRef& x){
+    h.Append((size_t)(x.GetUniqueIdentifier()));
+}
 inline
 size_t
 hash_value(const PcpNodeRef& x)
 {
-    return (size_t)x.GetUniqueIdentifier();
+    return TfHash{}(x);
 }
 
 typedef TfHashSet<PcpNodeRef, PcpNodeRef::Hash> PcpNodeRefHashSet;

--- a/pxr/usd/pcp/site.cpp
+++ b/pxr/usd/pcp/site.cpp
@@ -25,6 +25,7 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/pcp/site.h"
 #include "pxr/usd/pcp/layerStack.h"
+#include "pxr/base/tf/hash.h"
 
 #include <ostream>
 
@@ -87,10 +88,10 @@ PcpSite::operator<(const PcpSite &rhs) const
 size_t
 PcpSite::Hash::operator()(const PcpSite &site) const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, site.layerStackIdentifier);
-    boost::hash_combine(hash, site.path);
-    return hash;
+    return TfHash::Combine(
+        site.layerStackIdentifier,
+        site.path
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -153,10 +154,10 @@ PcpSiteStr::operator<(const PcpSiteStr &rhs) const
 size_t
 PcpSiteStr::Hash::operator()(const PcpSiteStr &site) const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, site.layerStackIdentifierStr);
-    boost::hash_combine(hash, site.path);
-    return hash;
+    return TfHash::Combine(
+        site.layerStackIdentifierStr,
+        site.path
+    );
 }
 
 
@@ -192,10 +193,10 @@ PcpLayerStackSite::operator<(const PcpLayerStackSite &rhs) const
 size_t
 PcpLayerStackSite::Hash::operator()(const PcpLayerStackSite &site) const
 {
-    size_t hash = 0;
-    boost::hash_combine(hash, site.layerStack);
-    boost::hash_combine(hash, site.path);
-    return hash;
+    return TfHash::Combine(
+        site.layerStack,
+        site.path
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/pxr/usd/pcp/testenv/testPcpInstanceKey.py
+++ b/pxr/usd/pcp/testenv/testPcpInstanceKey.py
@@ -76,6 +76,14 @@ class TestPcpInstanceKey(unittest.TestCase):
         notAnInstanceKey = self._GetInstanceKey(cache, '/NotAnInstance')
         self.assertEqual(notAnInstanceKey, Pcp.InstanceKey())
 
+    def test_Hashing(self):
+        cache = self._LoadPcpCache("basic.sdf")
+
+        self.assertEqual(
+            hash(self._GetInstanceKey(cache, "/Set_1")),
+            hash(self._GetInstanceKey(cache, "/Set_1"))
+        )
+
     def test_Variants(self):
         """Test instance key functionality on asset
         structure involving references and variants."""

--- a/pxr/usd/pcp/testenv/testPcpMapExpression.cpp
+++ b/pxr/usd/pcp/testenv/testPcpMapExpression.cpp
@@ -36,9 +36,21 @@ _GetArcFunction(const std::string & source, const std::string & target)
     return PcpMapFunction::Create(pathMap, SdfLayerOffset());
 }
 
+void TestMapFunctionHash(){
+    TF_AXIOM(TfHash()(PcpMapFunction()) == TfHash()(PcpMapFunction()));
+
+    const auto pair_1 = std::make_pair(SdfPath("/path/source"), SdfPath("/path/target"));
+    const auto pair_2 = std::make_pair(SdfPath("/path/source2"), SdfPath("/path/target2"));
+    TF_AXIOM(TfHash()(PcpMapFunction::Create({pair_1, pair_2}, SdfLayerOffset())) ==
+             TfHash()(PcpMapFunction::Create({pair_1, pair_2}, SdfLayerOffset())));
+    TF_AXIOM(TfHash()(PcpMapFunction::Create({pair_1, pair_2}, SdfLayerOffset(1.0, 2.0))) ==
+             TfHash()(PcpMapFunction::Create({pair_1, pair_2}, SdfLayerOffset(1.0, 2.0))));
+}
+
 int 
 main(int argc, char** argv)
 {
+    TestMapFunctionHash();
     // Here we focus on testing the core PcpMapExpression API;
     // We don't bother testing convenience API that passes
     // queries onto the MapFunction value.

--- a/pxr/usd/pcp/wrapInstanceKey.cpp
+++ b/pxr/usd/pcp/wrapInstanceKey.cpp
@@ -38,7 +38,7 @@ namespace {
 static size_t
 __hash__(const PcpInstanceKey& key)
 {
-    return hash_value(key);
+    return TfHash{}(key);
 }
 
 } // anonymous namespace 
@@ -53,6 +53,6 @@ wrapInstanceKey()
         .def(self != self)
 
         .def("__str__", &PcpInstanceKey::GetString)
-        .def("__hash_", __hash__)
+        .def("__hash__", __hash__)
         ;
 }


### PR DESCRIPTION
### Description of Change(s)
Requires #2173
To remove the dependency of pxr/usd/pcp on boost's hashing functions
* `PcpInstanceKey` now relies on `TfHash`'s hashing of containers instead of its own iteration.  To support this, the method `_Arc::GetHash` has been replaced with a `TfHashAppend` overload
* `PcpLayerStackIdentifier{,Str}`, `PcpMapExpression`, `PcpSite{,Str}`  use `TfHash::Combine` instead of `boost::hash_combine`
* Hashing test coverage has been added for `PcpInstanceKey` and `PcpMapFunction`
* `PcpMapFunction`'s hashing has been split off into an overload of `TfHashAppend` for its `_Data` which is `TfHash::Combine`d with the hash of its `_offset` field

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement