### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/usd

### DIFF
--- a/pxr/usd/usd/clipCache.cpp
+++ b/pxr/usd/usd/clipCache.cpp
@@ -38,6 +38,7 @@
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/trace/trace.h"
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/mallocTag.h"
 #include "pxr/base/tf/ostreamMethods.h"
 
@@ -84,13 +85,12 @@ public:
         {
             inline size_t operator()(const ManifestKey& key) const
             {
-                size_t hash = key.primPath.GetHash();
-                boost::hash_combine(hash, TfHash()(key.clipSetName));
-                boost::hash_combine(hash, key.clipPrimPath.GetHash());
-                for (const auto& p : key.clipAssetPaths) {
-                    boost::hash_combine(hash, p.GetHash());
-                }
-                return hash;
+                return TfHash::Combine(
+                    key.primPath,
+                    key.clipSetName,
+                    key.clipPrimPath,
+                    key.clipAssetPaths
+                );
             }
         };
     };

--- a/pxr/usd/usd/clipSetDefinition.h
+++ b/pxr/usd/usd/clipSetDefinition.h
@@ -31,6 +31,7 @@
 #include "pxr/base/vt/array.h"
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/tf/declarePtrs.h"
+#include "pxr/base/tf/hash.h"
 
 #include <boost/optional.hpp>
 
@@ -76,38 +77,37 @@ public:
 
     size_t GetHash() const
     {
-        size_t hash = indexOfLayerWhereAssetPathsFound;
-        boost::hash_combine(hash, sourceLayerStack);
-        boost::hash_combine(hash, sourcePrimPath);
+        size_t hash = TfHash::Combine(
+            indexOfLayerWhereAssetPathsFound,
+            sourceLayerStack,
+            sourcePrimPath
+        );
 
         if (clipAssetPaths) {
-            for (const auto& assetPath : *clipAssetPaths) {
-                boost::hash_combine(hash, assetPath.GetHash());
-            }
+            hash = TfHash::Combine(hash, *clipAssetPaths);
         }
         if (clipManifestAssetPath) {
-            boost::hash_combine(hash, clipManifestAssetPath->GetHash());
+            hash = TfHash::Combine(hash, *clipManifestAssetPath);
         }
         if (clipPrimPath) {
-            boost::hash_combine(hash, *clipPrimPath);
+            hash = TfHash::Combine(hash, *clipPrimPath);
         }               
         if (clipActive) {
-            for (const auto& active : *clipActive) {
-                boost::hash_combine(hash, active[0]);
-                boost::hash_combine(hash, active[1]);
-            }
+            hash = TfHash::Combine(hash, *clipActive);
         }
         if (clipTimes) {
-            for (const auto& time : *clipTimes) {
-                boost::hash_combine(hash, time[0]);
-                boost::hash_combine(hash, time[1]);
-            }
+            hash = TfHash::Combine(hash, *clipTimes);
         }
         if (interpolateMissingClipValues) {
-            boost::hash_combine(hash, *interpolateMissingClipValues);
+            hash = TfHash::Combine(hash, *interpolateMissingClipValues);
         }
-
         return hash;
+    }
+
+    template <typename HashState>
+    friend void TfHashAppend(HashState& h,
+                             const Usd_ClipSetDefinition& definition) {
+        h.Append(definition.GetHash());
     }
 
     boost::optional<VtArray<SdfAssetPath> > clipAssetPaths;

--- a/pxr/usd/usd/collectionAPI.cpp
+++ b/pxr/usd/usd/collectionAPI.cpp
@@ -339,8 +339,6 @@ PXR_NAMESPACE_CLOSE_SCOPE
 
 #include "pxr/usd/usd/primRange.h"
 
-#include <boost/functional/hash.hpp>
-
 #include <set>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/usd/usd/collectionMembershipQuery.cpp
+++ b/pxr/usd/usd/collectionMembershipQuery.cpp
@@ -360,14 +360,10 @@ UsdCollectionMembershipQuery::Hash::operator()(
     std::vector<_Entry> entries(q._pathExpansionRuleMap.begin(),
                                 q._pathExpansionRuleMap.end());
     std::sort(entries.begin(), entries.end());
-    size_t h = 0;
-    for (_Entry const& entry: entries) {
-        boost::hash_combine(h, entry.first);
-        boost::hash_combine(h, entry.second);
-    }
+
     // Don't hash _hasExcludes because it is derived from
     // the contents of _pathExpansionRuleMap.
-    return h;
+    return TfHash()(entries);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usd/instanceCache.h
+++ b/pxr/usd/usd/instanceCache.h
@@ -261,7 +261,7 @@ private:
     // Mapping from instance key <-> prototype prim path.
     // This stores the path of the prototype prim that should be used
     // for all instanceable prim indexes with the given instance key.
-    typedef TfHashMap<Usd_InstanceKey, SdfPath, boost::hash<Usd_InstanceKey> >
+    typedef TfHashMap<Usd_InstanceKey, SdfPath, TfHash>
         _InstanceKeyToPrototypeMap;
     typedef TfHashMap<SdfPath, Usd_InstanceKey, SdfPath::Hash>
         _PrototypeToInstanceKeyMap;
@@ -288,7 +288,7 @@ private:
     // These maps contain lists of pending changes and are the only containers 
     // that should be modified during registration and unregistration.
     typedef TfHashMap<
-        Usd_InstanceKey, _PrimIndexPaths, boost::hash<Usd_InstanceKey> > 
+        Usd_InstanceKey, _PrimIndexPaths, TfHash>
         _InstanceKeyToPrimIndexesMap;
     _InstanceKeyToPrimIndexesMap _pendingAddedPrimIndexes;
     _InstanceKeyToPrimIndexesMap _pendingRemovedPrimIndexes;

--- a/pxr/usd/usd/instanceKey.cpp
+++ b/pxr/usd/usd/instanceKey.cpp
@@ -25,8 +25,7 @@
 #include "pxr/usd/usd/instanceKey.h"
 #include "pxr/usd/usd/resolver.h"
 #include "pxr/usd/pcp/primIndex.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iostream>
 
@@ -140,13 +139,12 @@ Usd_InstanceKey::operator==(const Usd_InstanceKey& rhs) const
 size_t
 Usd_InstanceKey::_ComputeHash() const
 {
-    size_t hash = hash_value(_pcpInstanceKey);
-    for (const Usd_ClipSetDefinition& clipDefs: _clipDefs) {
-        boost::hash_combine(hash, clipDefs.GetHash());
-    }
-    boost::hash_combine(hash, _mask);
-    boost::hash_combine(hash, _loadRules);
-    return hash;
+    return TfHash::Combine(
+        _pcpInstanceKey,
+        _clipDefs,
+        _mask,
+        _loadRules
+    );
 }
 
 std::ostream &

--- a/pxr/usd/usd/object.cpp
+++ b/pxr/usd/usd/object.cpp
@@ -412,11 +412,13 @@ size_t
 hash_value(const UsdObject &obj)
 {
     size_t seed = 510-922-3000;
-    boost::hash_combine(seed, long(obj._type));
-    boost::hash_combine(seed, obj._prim);
-    boost::hash_combine(seed, obj._proxyPrimPath);
-    boost::hash_combine(seed, obj._propName.Hash());
-    return seed;
+    return TfHash::Combine(
+        seed,
+        long(obj._type),
+        obj._prim,
+        obj._proxyPrimPath,
+        obj._propName.Hash()
+    );
 }
 
 std::string

--- a/pxr/usd/usd/prim.cpp
+++ b/pxr/usd/usd/prim.cpp
@@ -54,8 +54,7 @@
 
 #include "pxr/base/tf/ostreamMethods.h"
 #include "pxr/base/tf/pxrTslRobinMap/robin_set.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>
@@ -1670,7 +1669,7 @@ private:
     WorkSingularTask _consumerTask;
     Predicate const &_predicate;
     tbb::concurrent_queue<SdfPath> _workQueue;
-    tbb::concurrent_unordered_set<UsdPrim, boost::hash<UsdPrim> > _seenPrims;
+    tbb::concurrent_unordered_set<UsdPrim, TfHash> _seenPrims;
     SdfPathVector _result;
     bool _recurse;
 };

--- a/pxr/usd/usd/primDataHandle.h
+++ b/pxr/usd/usd/primDataHandle.h
@@ -26,7 +26,8 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/api.h"
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
+
 #include <boost/intrusive_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -126,7 +127,7 @@ private:
 
     // Provide hash_value.
     friend size_t hash_value(const Usd_PrimDataHandle &h) {
-        return boost::hash_value(h._p.get());
+        return TfHash()(h._p.get());
     }
 
     friend element_type *get_pointer(const Usd_PrimDataHandle &h) {

--- a/pxr/usd/usd/primFlags.h
+++ b/pxr/usd/usd/primFlags.h
@@ -76,8 +76,7 @@
 #include "pxr/usd/usd/api.h"
 #include "pxr/base/arch/hints.h"
 #include "pxr/base/tf/bitUtils.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <bitset>
 
@@ -275,10 +274,9 @@ private:
 
     // hash overload.
     friend size_t hash_value(const Usd_PrimFlagsPredicate &p) {
-        size_t hash = p._mask.to_ulong();
-        boost::hash_combine(hash, p._values.to_ulong());
-        boost::hash_combine(hash, p._negate);
-        return hash;
+        return TfHash::Combine(
+            p._mask.to_ulong(), p._values.to_ulong(), p._negate
+        );
     }
 
     // Whether or not to negate the predicate's result.

--- a/pxr/usd/usd/shared.h
+++ b/pxr/usd/usd/shared.h
@@ -26,8 +26,8 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/api.h"
+#include "pxr/base/tf/hash.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <atomic>
 
@@ -105,8 +105,7 @@ struct Usd_Shared
 
     // hash_value.
     friend inline size_t hash_value(Usd_Shared const &sh) {
-        using boost::hash_value;
-        return hash_value(sh._held->data);
+        return TfHash()(sh._held->data);
     }
 private:
     boost::intrusive_ptr<Usd_Counted<T>> _held;

--- a/pxr/usd/usd/stageCache.cpp
+++ b/pxr/usd/usd/stageCache.cpp
@@ -25,12 +25,12 @@
 #include "pxr/usd/usd/stageCache.h"
 
 #include "pxr/usd/sdf/layer.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/usd/usd/debugCodes.h"
 #include "pxr/usd/usd/stage.h"
 
 #include "pxr/usd/ar/resolverContext.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>

--- a/pxr/usd/usd/stageLoadRules.cpp
+++ b/pxr/usd/usd/stageLoadRules.cpp
@@ -24,11 +24,10 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/stageLoadRules.h"
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/ostreamMethods.h"
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/stl.h"
-
-#include <boost/functional/hash.hpp>
 
 #include <algorithm>
 
@@ -341,8 +340,7 @@ operator<<(std::ostream &os, UsdStageLoadRules const &rules)
 size_t
 hash_value(UsdStageLoadRules const &rules)
 {
-    boost::hash<std::vector<std::pair<SdfPath, UsdStageLoadRules::Rule> > > h;
-    return h(rules._rules);
+    return TfHash()(rules._rules);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usd/stagePopulationMask.cpp
+++ b/pxr/usd/usd/stagePopulationMask.cpp
@@ -24,9 +24,8 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/stagePopulationMask.h"
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/ostreamMethods.h"
-
-#include <boost/functional/hash.hpp>
 
 #include <algorithm>
 
@@ -272,8 +271,7 @@ operator<<(std::ostream &os, UsdStagePopulationMask const &mask)
 size_t
 hash_value(UsdStagePopulationMask const &mask)
 {
-    boost::hash<std::vector<SdfPath> > h;
-    return h(mask._paths);
+    return TfHash()(mask._paths);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usd/testenv/testUsdCollectionAPI.py
+++ b/pxr/usd/usd/testenv/testUsdCollectionAPI.py
@@ -662,6 +662,15 @@ class TestUsdCollectionAPI(unittest.TestCase):
         self.assertEqual(
             Usd.ComputeIncludedPathsFromCollection(query, stage), [])
 
+    def test_HashMembershipQuery(self):
+        self.assertEqual(
+            hash(Usd.UsdCollectionMembershipQuery()),
+            hash(Usd.UsdCollectionMembershipQuery())
+        )
+        self.assertEqual(
+            hash(Usd.CollectionAPI.Get(testPrim, 'allGeom').ComputeMembershipQuery()),
+            hash(Usd.CollectionAPI.Get(testPrim, 'allGeom').ComputeMembershipQuery())
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/usd/testenv/testUsdStageLoadUnload.py
+++ b/pxr/usd/usd/testenv/testUsdStageLoadUnload.py
@@ -426,7 +426,13 @@ class TestUsdLoadUnload(unittest.TestCase):
              '/other/child/none/child/all/two/prim'])
 
         self.assertEqual(testStage.GetLoadRules(), r)
-        
+
+    def test_HashLoadRules(self):
+        self.assertEqual(Usd.StageLoadRules(), Usd.StageLoadRules())
+        self.assertEqual(Usd.StageLoadRules.LoadAll(),
+                         Usd.StageLoadRules.LoadAll())
+        self.assertEqual(Usd.StageLoadRules.LoadNone(),
+                         Usd.StageLoadRules.LoadNone())
 
     def test_LoadAndUnload(self):
         """Test Stage::LoadUnload thoroughly, as all other requests funnel into it.

--- a/pxr/usd/usd/timeCode.h
+++ b/pxr/usd/usd/timeCode.h
@@ -29,8 +29,7 @@
 #include "pxr/usd/sdf/timeCode.h"
 #include "pxr/base/arch/hints.h"
 #include "pxr/base/tf/staticTokens.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <limits>
 #include <iosfwd>
@@ -195,7 +194,7 @@ public:
 
     /// Hash function.
     friend size_t hash_value(const UsdTimeCode &time) {
-        return boost::hash_value(time._value);
+        return TfHash()(time._value);
     }
 
 private:

--- a/pxr/usd/usd/wrapPrimFlags.cpp
+++ b/pxr/usd/usd/wrapPrimFlags.cpp
@@ -22,6 +22,7 @@
 // language governing permissions and limitations under the Apache License.
 //
 #include "pxr/pxr.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/primFlags.h"
 
@@ -30,7 +31,6 @@
 #include <boost/python/implicit.hpp>
 #include <boost/python/operators.hpp>
 #include <boost/python/scope.hpp>
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -80,13 +80,11 @@ namespace {
 
 // Hash implementations.
 size_t __hash__Term(const Usd_Term &t) {
-    size_t h = static_cast<size_t>(t.flag);
-    boost::hash_combine(h, t.negated);
-    return h;
+    return TfHash::Combine(t.flag, t.negated);
 }
 
 size_t __hash__Predicate(const Usd_PrimFlagsPredicate &p) {
-    return hash_value(p);
+    return TfHash{}(p);
 }
 
 // Call implementations.


### PR DESCRIPTION
### Description of Change(s)
Requires #2173
To remove the dependency of pxr/usd/usd on boost's hashing functions
* `boost::hash_combine` is replaced with `TfHash::Combine`, delegating hashing of containers instead of iterating
* `boost::hash` is replaced with `TfHash`
* Hashing test coverage has been extended to cover `UsdStageLoadRules`, `UsdObject` derived classes, and `UsdCollectionMembershipQuery`.

### Fixes Issue(s)
-#2172 (additional PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
