### PR TITLE
APPLE: Multithreaded rendering for usdRecord

### DIFF
--- a/docs/toolset.rst
+++ b/docs/toolset.rst
@@ -293,6 +293,7 @@ by Hydra and are equivalent to those displayed in the viewer in `usdview`_ .
                     [--colorCorrectionMode {disabled,sRGB,openColorIO}]
                     [--renderer {GL,Embree,Prman}]
                     [--imageWidth IMAGEWIDTH]
+                    [--multithreaded | --mt]
                     usdFilePath outputImagePath
    
    Generates images from a USD file
@@ -344,6 +345,13 @@ by Hydra and are equivalent to those displayed in the viewer in `usdview`_ .
                            Width of the output image. The height will be computed
                            from this value and the camera's aspect ratio
                            (default=960)
+     --multithreaded, -mt
+                           The time taken to export a large number of frames from
+                           an animated stage can be improved by enabling multithreaded
+                           renderering with this option.  This creates a single instance
+                           of the Storm engine, saving the setup time for each frame.
+                           The frames are then written to storage in parallel.
+                           (default=disabled)
 
 **Further Notes on Command Line Options**
 

--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -153,6 +153,10 @@ def main():
             'Width of the output image. The height will be computed from this '
             'value and the camera\'s aspect ratio (default=%(default)s)'))
 
+    parser.add_argument('--multithreaded', '-mt', action='store_true', 
+                        help=('Enable for multi-threaded rendering of a sequence of frames.'
+                              'Defaults to a single thread.'))
+
     args = parser.parse_args()
 
     UsdAppUtils.framesArgs.ValidateCmdlineArgs(parser, args,
@@ -200,17 +204,24 @@ def main():
 
     _Msg('Camera: %s' % usdCamera.GetPath().pathString)
     _Msg('Renderer plugin: %s' % frameRecorder.GetCurrentRendererId())
+    _Msg('Multithreaded: %s' % args.multithreaded)
 
-    for timeCode in args.frames:
-        _Msg('Recording time code: %s' % timeCode)
-        outputImagePath = args.outputImagePath.format(frame=timeCode.GetValue())
+    timeCode = [x for x in args.frames]
+    outputImagePath = [args.outputImagePath.format(frame=x.GetValue()) for x in timeCode]
+
+    if args.multithreaded:
         try:
             frameRecorder.Record(usdStage, usdCamera, timeCode, outputImagePath)
         except Tf.ErrorException as e:
-
-            _Err("Recording aborted due to the following failure at time code "
-                 "{0}: {1}".format(timeCode, str(e)))
-            break
+            _Err("Recording aborted. Exception: {0}".format(str(e)))
+    else:
+        for eachTimeCode, eachOutputImagePath in zip(timeCode, outputImagePath):
+            try:
+                frameRecorder.Record(usdStage, usdCamera, [eachTimeCode], [eachOutputImagePath])
+            except Tf.ErrorException as e:
+                _Err("Recording aborted due to the following failure at time code "
+                                "{0}: {1}".format(eachTimeCode, str(e)))
+                break
 
     # Release our reference to the frame recorder so it can be deleted before
     # the Qt stuff.

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -136,8 +136,8 @@ public:
     bool Record(
             const UsdStagePtr& stage,
             const UsdGeomCamera& usdCamera,
-            const UsdTimeCode timeCode,
-            const std::string& outputImagePath);
+            const std::vector<UsdTimeCode>& timeCode,
+            const std::vector<std::string>& outputImagePath);
 
 private:
     UsdImagingGLEngine _imagingEngine;

--- a/pxr/usdImaging/usdAppUtils/testenv/testUsdAppUtilsFrameRecorder.py
+++ b/pxr/usdImaging/usdAppUtils/testenv/testUsdAppUtilsFrameRecorder.py
@@ -101,11 +101,11 @@ class TestUsdAppUtilsFrameRecorder(unittest.TestCase):
         outputImagePath = os.path.abspath('AnimCube.png')
         self.assertTrue(
             self._frameRecorder.Record(self._stage, self._usdCamera,
-                Usd.TimeCode.EarliestTime(), outputImagePath))
+                [Usd.TimeCode.EarliestTime()], [outputImagePath]))
 
     def testRecordMultipleFrames(self):
         """
-        Tests recording multiple frames.
+        Tests recording multiple frames, using a single thread.
         """
         outputImagePath = os.path.abspath('AnimCube.#.png')
         outputImagePath = UsdAppUtils.framesArgs.ConvertFramePlaceholderToFloatSpec(
@@ -115,7 +115,25 @@ class TestUsdAppUtilsFrameRecorder(unittest.TestCase):
         for timeCode in frameSpecIter:
             self.assertTrue(
                 self._frameRecorder.Record(self._stage, self._usdCamera,
-                    timeCode, outputImagePath.format(frame=timeCode.GetValue())))
+                    [timeCode], [outputImagePath.format(frame=timeCode.GetValue())], outputAOV))
+
+    def testRecordMultipleFramesMultithreaded(self):
+        """
+        Tests recording multiple frames, multi-threaded.
+        """
+        outputImagePath = os.path.abspath('AnimCube.#.png')
+        outputImagePath = UsdAppUtils.framesArgs.ConvertFramePlaceholderToFloatSpec(
+                outputImagePath)
+
+        frameSpecIter = UsdAppUtils.framesArgs.FrameSpecIterator('1,5,10')
+        timeCodes = [x for x in frameSpecIter]
+        outputImagePaths = [
+            outputImagePath.format(frame=t.GetValue()) for t in timeCodes
+        ]
+
+        self.assertTrue(
+            self._frameRecorder.Record(self._stage, self._usdCamera, timeCodes,
+                                       outputImagePaths))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of Change(s)

Optimise the exporting of large number of frames in usdrecord by setting up the renderer once, rendering all frames with the same context and multi-thread the output.  This can be enabled by setting the `--multithreaded` option in `usdrecord`

On the Dory sample scene, this improves the export time from:

```
python3 build_usd/bin/usdrecord  --frames 136:770   45.39s user 6.08s system 130% cpu 39.329 total
```

To:

```
python3 build_usd/bin/usdrecord  --frames 136:770 --multithreaded   49.49s user 5.70s system 459% cpu 12.008 total
```

So from almost 40 seconds down to 12.

This PR builds on the work in PR: https://github.com/PixarAnimationStudios/USD/pull/2145

Thanks to the wider team at Apple for this.

### Fixes Issue(s)
- Time taken to export large number of frames in usdRecord.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
