### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/usdGeom

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -39,6 +39,7 @@
 
 #include "pxr/base/work/withScopedParallelism.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyLock.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/token.h"
@@ -1519,14 +1520,6 @@ UsdGeomBBoxCache::_PrimContext::ToString() const {
                               prim.GetPath().GetText());
     }
 }
-
-size_t hash_value(const UsdGeomBBoxCache::_PrimContext &key)
-{
-    size_t hash = hash_value(key.prim);
-    boost::hash_combine(hash, key.instanceInheritablePurpose.Hash());
-    return hash;
-}
-
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/usd/usdGeom/bboxCache.h
+++ b/pxr/usd/usdGeom/bboxCache.h
@@ -30,6 +30,7 @@
 #include "pxr/usd/usdGeom/pointInstancer.h"
 #include "pxr/usd/usd/attributeQuery.h"
 #include "pxr/base/gf/bbox3d.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/work/dispatcher.h"
 
@@ -541,10 +542,18 @@ private:
     // Helper to determine if we should use extents hints for \p prim.
     inline bool _UseExtentsHintForPrim(UsdPrim const &prim) const;
 
-    // Need hash_value for boost to key cache entries by prim context.
-    friend size_t hash_value(const _PrimContext &key);
+    // Specialize TfHashAppend for TfHash
+    template <typename HashState>
+    friend void TfHashAppend(HashState& h, const _PrimContext &key)
+    {
+        h.Append(key.prim);
+        h.Append(key.instanceInheritablePurpose);
+    }
 
-    typedef boost::hash<_PrimContext> _PrimContextHash;
+    // Need hash_value for boost to key cache entries by prim context.
+    friend size_t hash_value(const _PrimContext &key) { return TfHash{}(key); }
+
+    typedef TfHash _PrimContextHash;
     typedef TfHashMap<_PrimContext, _Entry, _PrimContextHash> _PrimBBoxHashMap;
 
     // Finds the cache entry for the prim context if it exists.

--- a/pxr/usd/usdGeom/primvar.h
+++ b/pxr/usd/usdGeom/primvar.h
@@ -694,10 +694,15 @@ public:
         return lhs.GetAttr().GetPath() < rhs.GetAttr().GetPath();
     }
 
+    // Specialize TfHashAppend for TfHash
+    template <typename HashState>
+    friend void TfHashAppend(HashState& h, const UsdGeomPrimvar& obj) {
+        h.Append(obj.GetAttr());
+    }
+
     // hash_value overload for std/boost hash.
-    USDGEOM_API
     friend size_t hash_value(const UsdGeomPrimvar &obj) {
-        return hash_value(obj.GetAttr());
+        return TfHash{}(obj);
     }
 
 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
@@ -692,5 +692,17 @@ class TestUsdGeomPrimvarsAPI(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             u1.GetElementSize()
 
+    def test_Hash(self):
+        """Validate different primvar objects referring to the same underlying
+        property hash to the same value."""
+        stage = Usd.Stage.CreateInMemory()
+        mesh = UsdGeom.Mesh.Define(stage, '/mesh')
+        meshPrimvarsAPI = UsdGeom.PrimvarsAPI(mesh)
+        primvar = meshPrimvarsAPI.CreatePrimvar("pv", Sdf.ValueTypeNames.Int)
+        self.assertTrue(primvar)
+        self.assertIsNot(primvar, meshPrimvarsAPI.GetPrimvar("pv"))
+        self.assertEqual(primvar, meshPrimvarsAPI.GetPrimvar("pv"))
+        self.assertEqual(hash(primvar), hash(meshPrimvarsAPI.GetPrimvar("pv")))
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/usdGeom/wrapPrimvar.cpp
+++ b/pxr/usd/usdGeom/wrapPrimvar.cpp
@@ -100,7 +100,7 @@ _GetTimeSamplesInInterval(const UsdGeomPrimvar &self,
     return result;
 }
 
-static size_t __hash__(const UsdGeomPrimvar &self) { return hash_value(self); }
+static size_t __hash__(const UsdGeomPrimvar &self) { return TfHash{}(self); }
 
 // We override __getattribute__ for UsdGeomPrimvar to check object validity
 // and raise an exception instead of crashing from Python.

--- a/pxr/usd/usdGeom/xformCache.h
+++ b/pxr/usd/usdGeom/xformCache.h
@@ -32,10 +32,9 @@
 #include "pxr/usd/usdGeom/xformable.h"
 
 #include "pxr/base/gf/matrix4d.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/token.h"
-
-#include <boost/functional/hash.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -170,7 +169,7 @@ private:
     // Helper function to get or create a new entry for a prim in the ctm cache.
     _Entry * _GetCacheEntryForPrim(const UsdPrim &prim);
 
-    typedef TfHashMap<UsdPrim, _Entry, boost::hash<UsdPrim> > _PrimHashMap;
+    typedef TfHashMap<UsdPrim, _Entry, TfHash> _PrimHashMap;
     _PrimHashMap _ctmCache;
     
     // The time at which this stack is querying and caching attribute values.


### PR DESCRIPTION
### Description of Change(s)
Requires: #2173
To remove the dependency of pxr/usd/usdGeom on boost's hashing functions
- Replaces usage of `boost::hash_combine` and `boost::hash` with `TfHash`
- Add `TfHashAppend` overloads and update `hash_value` to use this via `TfHash`
- Add unit tests for hashing of `UsdGeom.Primvar`

### Fixes Issue(s)
-#2172 (more PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
