### PR TITLE
Replace boost hash usage with TfHash in pxr/usd/usdSkel

### DIFF
--- a/pxr/usd/usdSkel/skeletonQuery.cpp
+++ b/pxr/usd/usdSkel/skeletonQuery.cpp
@@ -63,9 +63,8 @@ UsdSkelSkeletonQuery::HasRestPose() const
 size_t
 hash_value(const UsdSkelSkeletonQuery& query)
 {
-    size_t hash = hash_value(query._definition);
-    boost::hash_combine(hash, query._animQuery);
-    return hash;
+    return TfHash::Combine(query._definition,
+                           query._animQuery);
 }
 
 

--- a/pxr/usd/usdSkel/testenv/testUsdSkelSkeletonQuery.py
+++ b/pxr/usd/usdSkel/testenv/testUsdSkelSkeletonQuery.py
@@ -112,6 +112,9 @@ class TestUsdSkelSkeletonQuery(unittest.TestCase):
         query = skelCache.GetSkelQuery(skel)
         self.assertTrue(query)
 
+        self.assertEqual(hash(query), hash(query))
+        self.assertEqual(hash(query), hash(skelCache.GetSkelQuery(skel)))
+
         # Validate joint rest xform computations.
 
         xforms = query.ComputeJointLocalTransforms(0, atRest=True)

--- a/pxr/usd/usdSkel/wrapSkeletonQuery.cpp
+++ b/pxr/usd/usdSkel/wrapSkeletonQuery.cpp
@@ -104,6 +104,10 @@ _ComputeJointRestRelativeTransforms(UsdSkelSkeletonQuery& self,
     return xforms;
 }
 
+static size_t __hash__(const UsdSkelSkeletonQuery &self)
+{
+    return TfHash{}(self);
+}
 
 } // namespace
 
@@ -119,6 +123,7 @@ void wrapUsdSkelSkeletonQuery()
         .def(self != self)
         
         .def("__str__", &This::GetDescription)
+        .def("__hash__" , __hash__)
 
         .def("GetPrim", &This::GetPrim,
              return_value_policy<return_by_value>())


### PR DESCRIPTION
### Description of Change(s)
Requires: #2173
To remove the dependency of pxr/usd/usdSkel on boost's hashing functions
- Add python bindings for `__hash__` to `UsdSkelSkeletonQuery`
- Add `__hash__` test coverage for `UsdSkelSkeletonQuery`
- Replaces usage of `boost::hash_combine` with `TfHash::Combine`

### Fixes Issue(s)
-#2172 (more PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
