### PR TITLE
[build_usd] win: only add -A if generator supports it (ie, not ninja)

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -387,7 +387,8 @@ def RunCMake(context, force, extraArgs = None):
     if generator is not None:
         generator = '-G "{gen}"'.format(gen=generator)
 
-    if IsVisualStudio2019OrGreater():
+    # Note - don't want to add -A (architecture flag) if generator is, ie, Ninja
+    if IsVisualStudio2019OrGreater() and "Visual Studio" in generator:
         generator = generator + " -A x64"
 
     toolset = context.cmakeToolset


### PR DESCRIPTION
### Description of Change(s)

build_usd.py would error on VS2019+ systems when building with `--generator Ninja`.  Fixes by only adding the `-A` flag to cmake if the generator supports it (ie, `Visual Studio *` generators do, `Ninja` doesn't.)

### Fixes Issue(s)
- error when building on windows + VS2019+ with Ninja generator

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
