### PR TITLE
[cmake] fix vs2019 debug builds with tests

### DIFF
--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -158,7 +158,7 @@ pxr_build_test(testArchVsnprintf
         testenv/testVsnprintf.cpp
 )
 
-# On windows, in debug mode, we need to copy testArchStaceTrace.pdb into the
+# On windows, in debug mode, we need to copy testArchStackTrace.pdb into the
 # testing folder, so the test can find it (and print out the right stack),
 # even if the build or test folder has been moved (ie, when the baked-in path in
 # executable, where it also looks for the pdb, doesn't work)
@@ -171,7 +171,7 @@ if (PXR_BUILD_TESTS AND WIN32)
     # place that .pdbs will be searched for, other than the baked-in absolute
     # path in the windows binary
     install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/testArchStackTrace.pdb
+        FILES $<TARGET_PDB_FILE:testArchStackTrace>
         DESTINATION tests/ctest/testArchStackTrace
         CONFIGURATIONS Debug RelWithDebInfo
     )


### PR DESCRIPTION
### Description of Change(s)

Was trying to install a pdb file from the wrong location (no Debug subdir); fix by using a cmake generator expression to ensure we always have the correct file location

### Fixes Issue(s)
- failure during cmake install on windows VS2019 debug builds with tests

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
