### PR TITLE
[work] add missing include <algorithm> for std::max

### DIFF
--- a/pxr/base/work/testenv/testWorkThreadLimits.cpp
+++ b/pxr/base/work/testenv/testWorkThreadLimits.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/staticData.h"
 
+#include <algorithm>
 #include <functional>
 
 #include <cstdlib>


### PR DESCRIPTION
### Description of Change(s)

was getting errors when building without python on windows VS2022 - I think python and the older boost version were both bringing in the <algorithm> header; without either, it errored.

### Fixes Issue(s)
- error with no-python VS2022 build - max not a member of std, due to missing <algorithm> header

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
