### PR TITLE
Allow first Embree frame to be interrupted

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -313,7 +313,7 @@ HdEmbreeRenderer::Clear()
             continue;
         }
 
-        HdEmbreeRenderBuffer *rb = 
+        HdEmbreeRenderBuffer *rb =
             static_cast<HdEmbreeRenderBuffer*>(_aovBindings[i].renderBuffer);
 
         rb->Map();
@@ -413,7 +413,7 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
         if (!_IsContained(_dataWindow, _width, _height)) {
             TF_CODING_ERROR(
                 "dataWindow is larger than render buffer");
-        
+
         }
     }
 
@@ -444,9 +444,12 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
 
         // Render by scheduling square tiles of the sample buffer in a parallel
         // for loop.
+        // Always pass the renderThread to _RenderTiles to allow the first frame
+        // to be interrupted.
         WorkParallelForN(numTilesX*numTilesY,
             std::bind(&HdEmbreeRenderer::_RenderTiles, this,
-                (i == 0) ? nullptr : renderThread,
+                // (i == 0) ? nullptr : renderThread,
+                renderThread,
                 std::placeholders::_1, std::placeholders::_2));
 
         // After the first pass, mark the single-sampled attachments as
@@ -529,7 +532,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 
         // Compute the pixel location of tile boundaries.
         const unsigned int tileY = tile / numTilesX;
-        const unsigned int tileX = tile - tileY * numTilesX; 
+        const unsigned int tileX = tile - tileY * numTilesX;
         // (Above is equivalent to: tileX = tile % numTilesX)
         const unsigned int x0 = tileX * tileSize + minX;
         const unsigned int y0 = tileY * tileSize + minY;
@@ -589,7 +592,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 
 /// Fill in an RTCRay structure from the given parameters.
 static void
-_PopulateRay(RTCRay *ray, GfVec3f const& origin, 
+_PopulateRay(RTCRay *ray, GfVec3f const& origin,
              GfVec3f const& dir, float nearest)
 {
     ray->org_x = origin[0];

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -313,7 +313,7 @@ HdEmbreeRenderer::Clear()
             continue;
         }
 
-        HdEmbreeRenderBuffer *rb =
+        HdEmbreeRenderBuffer *rb = 
             static_cast<HdEmbreeRenderBuffer*>(_aovBindings[i].renderBuffer);
 
         rb->Map();
@@ -413,7 +413,7 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
         if (!_IsContained(_dataWindow, _width, _height)) {
             TF_CODING_ERROR(
                 "dataWindow is larger than render buffer");
-
+        
         }
     }
 
@@ -532,7 +532,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 
         // Compute the pixel location of tile boundaries.
         const unsigned int tileY = tile / numTilesX;
-        const unsigned int tileX = tile - tileY * numTilesX;
+        const unsigned int tileX = tile - tileY * numTilesX; 
         // (Above is equivalent to: tileX = tile % numTilesX)
         const unsigned int x0 = tileX * tileSize + minX;
         const unsigned int y0 = tileY * tileSize + minY;
@@ -592,7 +592,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 
 /// Fill in an RTCRay structure from the given parameters.
 static void
-_PopulateRay(RTCRay *ray, GfVec3f const& origin,
+_PopulateRay(RTCRay *ray, GfVec3f const& origin, 
              GfVec3f const& dir, float nearest)
 {
     ray->org_x = origin[0];


### PR DESCRIPTION
### Description of Change(s)
Always pass HdRenderThread to HdEmbreeRenderer::_RenderTiles to allow the first frame to be interrupted.
### Fixes Issue(s)
- For some reason, inside the HdEmbreeRenderer::Render() method, the renderThread pointer is only passed to the _RenderTiles method after the first pass of rendering samples. This makes it impossible for the first frame to be interrupted/stopped using the renderThread->IsStopRequested() check inside _RenderTiles. For larger scenes or with debug builds, the time to wait for the first pass can be significant.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
