### PR TITLE
MAYA-127137: fix crash due to incompatible dictionary iterator

### DIFF
--- a/pxr/usdImaging/usdImaging/adapterRegistry.cpp
+++ b/pxr/usdImaging/usdImaging/adapterRegistry.cpp
@@ -335,7 +335,7 @@ UsdImagingAdapterRegistry::_ConstructAdapter(
     // Lookup the plug-in type name based on the prim type.
     _TypeMap::const_iterator typeIt = tm.find(adapterKey);
 
-    if (typeIt == _typeMap.end()) {
+    if (typeIt == tm.end()) {
         // Unknown prim type.
         TF_DEBUG(USDIMAGING_PLUGINS).Msg("[PluginLoad] Unknown prim "
                 "type '%s'\n",


### PR DESCRIPTION
Summary:
The type map passed as a parameter, and the one cached as a variable are different resulting in a crash.

From the following callstack
```
>	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingAdapterRegistry::_ConstructAdapter<pxrInternal_v0_22__pxrReserved__::UsdImagingAPISchemaAdapter,pxrInternal_v0_22__pxrReserved__::UsdImagingAPISchemaAdapterFactoryBase>(const pxrInternal_v0_22__pxrReserved__::TfToken & adapterKey, const std::unordered_map<pxrInternal_v0_22__pxrReserved__::TfToken,pxrInternal_v0_22__pxrReserved__::TfType,pxrInternal_v0_22__pxrReserved__::TfToken::HashFunctor,std::equal_to<pxrInternal_v0_22__pxrReserved__::TfToken>,std::allocator<std::pair<pxrInternal_v0_22__pxrReserved__::TfToken const ,pxrInternal_v0_22__pxrReserved__::TfType>>> & tm) Line 330	C++
 	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingAdapterRegistry::ConstructAPISchemaAdapter(const pxrInternal_v0_22__pxrReserved__::TfToken & adapterKey) Line 397	C++
 	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingStageSceneIndex::_APIAdapterLookup(const pxrInternal_v0_22__pxrReserved__::TfToken & adapterKey) Line 374	C++
 	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingStageSceneIndex::_AdapterSetLookup(pxrInternal_v0_22__pxrReserved__::UsdPrim prim) Line 337	C++
 	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingStageSceneIndex::_Populate(pxrInternal_v0_22__pxrReserved__::UsdPrim subtreeRoot) Line 548	C++
 	usd_usdImaging.dll!pxrInternal_v0_22__pxrReserved__::UsdImagingStageSceneIndex::Populate() Line 525	C++

```

Changes:
Ensure that the one end() iterator is retrieved from the type map passed as a parameter.

