### PR TITLE
Add /lib to the PATH variable for running examples

### DIFF
--- a/docs/tut_usd_tutorials.rst
+++ b/docs/tut_usd_tutorials.rst
@@ -29,7 +29,7 @@ tutorials assume the interpreter is named "python".
 |                     |search path |                                        |
 +---------------------+------------+----------------------------------------+
 |:envvar:`PATH`       |Program     |:filename:`USD_INSTALL_ROOT/bin`        |
-|                     |search path |                                        |
+|                     |search path |:filename:`USD_INSTALL_ROOT/lib`        |
 +---------------------+------------+----------------------------------------+
 
 For more information see `Advanced Build Configuration


### PR DESCRIPTION
At least on Windows it is required

### Description of Change(s)

In the tutorial's Environment Setup section, which is where a lot of newcomers pass by, one is advised to add to the `PATH` variable the binary directory `USD_INSTALL_ROOT/bin`, but `USD_INSTALL_ROOT/lib` is actually required (at least on Windows), without what the following issue is encountered:

```
C:\Users\emichel\SourceCode>usdview USD/extras/usd/tutorials/convertingLayerFormats/Sphere.usda
Traceback (most recent call last):
  File "C:\Users\emichel\SourceCode\USD_install\bin\usdview", line 28, in <module>
    import pxr.Usdviewq as Usdviewq
  File "C:\Users\emichel\SourceCode\USD_install\lib\python\pxr\Usdviewq\__init__.py", line 27, in <module>
    from pxr import Tf
  File "C:\Users\emichel\SourceCode\USD_install\lib\python\pxr\Tf\__init__.py", line 163, in <module>
    PreparePythonModule()
  File "C:\Users\emichel\SourceCode\USD_install\lib\python\pxr\Tf\__init__.py", line 88, in PreparePythonModule
    module = importlib.import_module(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python311\Lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ImportError: DLL load failed while importing _tf: The specified module could not be found.
```

- [X] I have submitted a signed Contributor License Agreement
