### PR TITLE
Account for MaterialX namespaces when adding MaterialX nodes to a node graph.

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -208,8 +208,16 @@ _AddMaterialXNode(
         TF_WARN("NodeDef not found for Node '%s'", hdNodeType.GetText());
         return mx::NodePtr();
     }
+	
+	// account for namespace.
+	auto nodeCategoryName = [&]() ->std::string 
+	{
+		TfToken tok(mxNodeDef->getNamespace() + ":" + mxNodeDef->getNodeString());
+		return tok.GetString();
+	};
+
     const SdfPath hdNodePath(hdNodeName.GetString());
-    const std::string &mxNodeCategory = mxNodeDef->getNodeString();
+    const std::string mxNodeCategory = mxNodeDef->hasNamespace() ? nodeCategoryName() : mxNodeDef->getNodeString();
     const std::string &mxNodeType = mxNodeDef->getType();
     const std::string &mxNodeName = hdNodePath.GetName();
 


### PR DESCRIPTION
Include the MaterialX namespace when adding MaterialX nodes to a node graph.  Namespace support was added last year, but somehow this piece was omitted from the namespace updates but is required when using MaterialX libraries that include namespaces.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
