### PR TITLE
Replace `boost::reverse_iterator` with `std::reverse_iterator` for proxy-less iterators

### DIFF
--- a/pxr/base/vt/array.h
+++ b/pxr/base/vt/array.h
@@ -40,12 +40,12 @@
 
 #include <boost/functional/hash.hpp>
 #include <boost/iterator_adaptors.hpp>
-#include <boost/iterator/reverse_iterator.hpp>
 
 #include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <new>
@@ -243,9 +243,9 @@ class VtArray : public Vt_ArrayBase {
     using const_iterator = ElementType const *;
     
     /// Reverse iterator type.
-    typedef boost::reverse_iterator<iterator> reverse_iterator;
+    typedef std::reverse_iterator<iterator> reverse_iterator;
     /// Reverse const iterator type.
-    typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
     /// Reference type.
     typedef ElementType &reference;

--- a/pxr/usd/pcp/iterator.h
+++ b/pxr/usd/pcp/iterator.h
@@ -36,6 +36,7 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
+#include <iterator>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -240,12 +241,12 @@ private:
 /// weak-to-strong order.
 ///
 class PcpPropertyReverseIterator
-    : public boost::reverse_iterator<PcpPropertyIterator>
+    : public std::reverse_iterator<PcpPropertyIterator>
 {
 public:
     PcpPropertyReverseIterator() { }
     explicit PcpPropertyReverseIterator(const PcpPropertyIterator& iter)
-        : boost::reverse_iterator<PcpPropertyIterator>(iter) { }
+        : std::reverse_iterator<PcpPropertyIterator>(iter) { }
         
     PcpNodeRef GetNode() const
     {


### PR DESCRIPTION
### Description of Change(s)
`std::reverse_iterator` can be used whenever the underlying iterator's `operator*` returns true references (and not proxy temporary values).

The C++ specification states that until C++20, `std::addressof(operator*())` should be used as `std::reverse_iterator`'s implementation of `operator->`. This does not work when the result of `operator*` is a temporary.

For the remaining cases, explicit reverse iterator implementations will be required compilers consistently support the C++20 specification (which is compatible with proxy reference types). This is addressed by #2333.

### Fixes Issue(s)
- #2202

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
