### PR TITLE
Add [[maybe_unused]] attribute to `TfPyObjWrapperStub._stub` 

### DIFF
--- a/cmake/defaults/gccdefaults.cmake
+++ b/cmake/defaults/gccdefaults.cmake
@@ -40,4 +40,8 @@ endif()
 # See https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=maybe%20uninitialized&list_id=394666
 _disable_warning("maybe-uninitialized")
 
+# MSVC and Clang support a super-set of GCC attributes.
+# Unfortunately, GCC warns when it doesn't use said attributes
+_disable_warning("ignored-attributes)
+
 set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")

--- a/pxr/base/tf/pyObjWrapper.h
+++ b/pxr/base/tf/pyObjWrapper.h
@@ -60,7 +60,7 @@ public:
 private:
     ARCH_PRAGMA_PUSH
     ARCH_PRAGMA_UNUSED_PRIVATE_FIELD
-    std::aligned_storage<Size, Align>::type _stub;
+    [[maybe_unused]] std::aligned_storage<Size, Align>::type _stub;
     ARCH_PRAGMA_POP
 };
 


### PR DESCRIPTION
I'm trying to reduce a bunch of the warnings that take up the build logs (I build often...so any reduction really helps). TfPyObjWrapper is one of the heavy offenders in the logs, but `_stub` is necessary per https://github.com/PixarAnimationStudios/USD/issues/1716 , so this just says that `_stub` can be unused.

**NOTE:** This does require C++17, I'm just putting it up now so that it's logged for whenever that happens.

I also think this is something that should be applied to `_schemaTokens` in the API schemas too, as those are the other major offenders. But I can hit that up in a different PR if this one doesn't raise any concerns.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
