### PR TITLE
Replace boost::noncopyable with explicit deletion of copy constructor and assignment operator in pxr/base/tf

### DIFF
--- a/pxr/base/tf/atomicOfstreamWrapper.h
+++ b/pxr/base/tf/atomicOfstreamWrapper.h
@@ -30,8 +30,6 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/api.h"
 
-#include <boost/noncopyable.hpp>
-
 #include <fstream>
 #include <string>
 
@@ -76,8 +74,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// // called, and the temporary file is removed.
 /// \endcode
 ///
-class TfAtomicOfstreamWrapper : boost::noncopyable
+class TfAtomicOfstreamWrapper
 {
+    TfAtomicOfstreamWrapper(const TfAtomicOfstreamWrapper&) = delete;
+    TfAtomicOfstreamWrapper& operator=(
+        const TfAtomicOfstreamWrapper&) = delete;
 public:
     /// Constructor.
     TF_API explicit TfAtomicOfstreamWrapper(const std::string& filePath);

--- a/pxr/base/tf/enum.cpp
+++ b/pxr/base/tf/enum.cpp
@@ -37,7 +37,6 @@
 
 #include "pxr/base/arch/demangle.h"
 
-#include <boost/noncopyable.hpp>
 #include "pxr/base/tf/hashmap.h"
 
 #include <tbb/spin_mutex.h>
@@ -62,7 +61,9 @@ typedef TfHashMap<string, TfEnum, TfHash> _NameToEnumTableType;
 typedef TfHashMap<string, vector<string>, TfHash> _TypeNameToNameVectorTableType;
 typedef TfHashMap<string, const type_info *, TfHash> _TypeNameToTypeTableType;
 
-class Tf_EnumRegistry : boost::noncopyable {
+class Tf_EnumRegistry {
+    Tf_EnumRegistry(const Tf_EnumRegistry&) = delete;
+    Tf_EnumRegistry& operator=(Tf_EnumRegistry&) = delete;
 private:
     static Tf_EnumRegistry& _GetInstance() {
         return TfSingleton<Tf_EnumRegistry>::GetInstance();

--- a/pxr/base/tf/errorMark.h
+++ b/pxr/base/tf/errorMark.h
@@ -31,8 +31,6 @@
 #include "pxr/base/tf/errorTransport.h"
 #include "pxr/base/tf/api.h"
 
-#include <boost/noncopyable.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class TfErrorMark
@@ -63,8 +61,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///      }
 /// \endcode
 ///
-class TfErrorMark : boost::noncopyable
+class TfErrorMark
 {
+    TfErrorMark(const TfErrorMark&) = delete;
+    TfErrorMark& operator=(const TfErrorMark&) = delete;
   public:
 
     typedef TfDiagnosticMgr::ErrorIterator Iterator;

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -35,7 +35,6 @@
 #include "pxr/base/arch/errno.h"
 
 #include <boost/assign.hpp>
-#include <boost/noncopyable.hpp>
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashset.h"
 

--- a/pxr/base/tf/noticeRegistry.h
+++ b/pxr/base/tf/noticeRegistry.h
@@ -36,8 +36,6 @@
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/type.h"
 
-#include <boost/noncopyable.hpp>
-
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_mutex.h>
 #include <atomic>
@@ -68,7 +66,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// registry, since multiple active traversals (either by different threads,
 /// or because of reentrancy) should be rare.
 ///
-class Tf_NoticeRegistry : boost::noncopyable {
+class Tf_NoticeRegistry {
+    Tf_NoticeRegistry(const Tf_NoticeRegistry&) = delete;
+    Tf_NoticeRegistry& operator=(const Tf_NoticeRegistry&) = delete;
 public:
     TF_API
     void _BeginDelivery(const TfNotice &notice,

--- a/pxr/base/tf/refPtrTracker.h
+++ b/pxr/base/tf/refPtrTracker.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/tf/weakBase.h"
 #include "pxr/base/tf/singleton.h"
-#include <boost/noncopyable.hpp>
 #include <iosfwd>
 #include <mutex>
 #include <vector>
@@ -94,7 +93,9 @@ template <class T> class TfRefPtr;
 /// \c TfRefPtrTracker::WatchNone() when tracking \c B if you're not
 /// interested in instances of \c B.
 ///
-class TfRefPtrTracker : public TfWeakBase, boost::noncopyable {
+class TfRefPtrTracker : public TfWeakBase {
+    TfRefPtrTracker(const TfRefPtrTracker&) = delete;
+    TfRefPtrTracker& operator=(const TfRefPtrTracker&) = delete;
 public:
     enum TraceType { Add, Assign };
 

--- a/pxr/base/tf/singleton.h
+++ b/pxr/base/tf/singleton.h
@@ -57,9 +57,10 @@
 /// \code
 ///     // file: registry.h
 ///     #include "pxr/base/tf/singleton.h"
-///     #include <boost/noncopyable.hpp>
 ///
-///     class Registry : boost::noncopyable {
+///     class Registry {
+///         Registry(const Registry&) = delete;
+///         Registry& operator=(const Registry&) = delete;
 ///     public:
 ///         static Registry& GetInstance() {
 ///              return TfSingleton<Registry>::GetInstance();
@@ -92,9 +93,10 @@
 /// \endcode
 ///
 /// The constructor and destructor are declared private, and the singleton
-/// object will typically derive off of \c boost::noncopyable to prevent
-/// copying. Note that singleton objects quite commonly also make use of \c
-/// TfRegistryManager to acquire the data they need throughout a program.
+/// object will typically delete its copy constructor and assignment operator
+/// to prevent copying. Note that singleton objects quite commonly also make
+/// use of \c TfRegistryManager to acquire the data they need throughout a
+/// program.
 ///
 /// The friend class \c TfSingleton<Registry> is the only class allowed to
 /// create an instance of a Registry.  The helper function \c

--- a/pxr/base/tf/testenv/weakPtr.cpp
+++ b/pxr/base/tf/testenv/weakPtr.cpp
@@ -28,8 +28,6 @@
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/weakPtr.h"
 
-#include <boost/noncopyable.hpp>
-
 #include <chrono>
 #include <condition_variable>
 #include <cstdio>
@@ -202,7 +200,10 @@ Test_TfWeakPtr()
 TF_DECLARE_WEAK_AND_REF_PTRS(ProtectedBase);
 
 // Singleton registry of instances.
-class ProtectedBase_Registry : public boost::noncopyable {
+class ProtectedBase_Registry {
+    ProtectedBase_Registry() = default;
+    ProtectedBase_Registry(const ProtectedBase_Registry&) = delete;
+    ProtectedBase_Registry& operator=(const ProtectedBase_Registry&) = delete;
 public:
     static ProtectedBase_Registry &GetInstance() {
         return TfSingleton<ProtectedBase_Registry>::GetInstance();
@@ -222,7 +223,9 @@ private:
 std::mutex ProtectedBase_Registry::_mutex;
 
 // Simple semaphore.
-class Semaphore : boost::noncopyable {
+class Semaphore {
+    Semaphore(const Semaphore&) = delete;
+    Semaphore& operator=(const Semaphore&) = delete;
 public:
     Semaphore() : _count(0) { }
 

--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -51,7 +51,6 @@
 #include "pxr/base/tf/pyUtils.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
@@ -89,8 +88,10 @@ TfType::PyPolymorphicBase::~PyPolymorphicBase()
 // Stored data for a TfType.
 // A unique instance of _TypeInfo is allocated for every type declared.
 //
-struct TfType::_TypeInfo : boost::noncopyable
-{
+struct TfType::_TypeInfo {
+    _TypeInfo(const _TypeInfo&) = delete;
+    _TypeInfo& operator=(const _TypeInfo&) = delete;
+
     typedef TfHashMap<string, TfType::_TypeInfo*, TfHash> NameToTypeMap;
     typedef TfHashMap<
         TfType::_TypeInfo*, vector<string>, TfHash> TypeToNamesMap;
@@ -218,8 +219,10 @@ struct Tf_PyHandleLess
 
 // Registry for _TypeInfos.
 //
-class Tf_TypeRegistry : boost::noncopyable
+class Tf_TypeRegistry
 {
+    Tf_TypeRegistry(const Tf_TypeRegistry&) = delete;
+    Tf_TypeRegistry& operator=(const Tf_TypeRegistry&) = delete;
 public:
     static Tf_TypeRegistry& GetInstance() {
         return TfSingleton<Tf_TypeRegistry>::GetInstance();

--- a/pxr/base/tf/typeInfoMap.h
+++ b/pxr/base/tf/typeInfoMap.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/iterator.h"
 
-#include <boost/noncopyable.hpp>
 #include "pxr/base/tf/hashmap.h"
 
 #include <typeinfo>
@@ -60,7 +59,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// given entry.
 ///
 template <class VALUE>
-class TfTypeInfoMap : public boost::noncopyable {
+class TfTypeInfoMap {
+    TfTypeInfoMap(const TfTypeInfoMap&) = delete;
+    TfTypeInfoMap& operator=(const TfTypeInfoMap&) = delete;
 public:
 
     // Default constructor passes 0 to TfHashMap constructors to keep size


### PR DESCRIPTION
### Description of Change(s)
- `TfAtomicOfstreamWrapper`, `Tf_EnumRegistry`, `TfErrorMark`, `Tf_NoticeRegistry`, `TfTypeInfoMap`, `Tf_TypeRegistry`, `TfType::_TypeInfo`, and `TfRefPtrTracker` have been updated to use explicit deletion of the copy constructor and assignment operator
- A spurious include of `boost/noncopyable.hpp` in `pxr/base/tf/fileUtils.cpp` has been removed
- The documentation for `TfSingleton` has removed references to `boost::noncopyable`
- The `TfWeakPtr` test case has been updated to avoid using `boost::noncopyable`

### Fixes Issue(s)
- #2203 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
