### PR TITLE
Replace boost::noncopyable with explicit deletion of copy constructor and assignment operator in pxr/usd/sdf and pxr/usd/pcp

### DIFF
--- a/pxr/usd/pcp/mapExpression.h
+++ b/pxr/usd/pcp/mapExpression.h
@@ -198,7 +198,9 @@ private: // data
         _OpAddRootIdentity
     };
 
-    class _Node : public boost::noncopyable {
+    class _Node {
+        _Node(const _Node&) = delete;
+        _Node& operator=(const _Node&) = delete;
     public:
         // The Key holds all the state needed to uniquely identify
         // this (sub-)expression.

--- a/pxr/usd/sdf/changeManager.h
+++ b/pxr/usd/sdf/changeManager.h
@@ -32,7 +32,6 @@
 #include "pxr/usd/sdf/spec.h"
 #include "pxr/base/tf/singleton.h"
 
-#include <boost/noncopyable.hpp>
 #include <tbb/enumerable_thread_specific.h>
 #include <string>
 #include <vector>
@@ -54,7 +53,9 @@ class SdfSpec;
 ///
 /// For now this class uses TfNotices to represent invalidations.
 ///
-class Sdf_ChangeManager : boost::noncopyable {
+class Sdf_ChangeManager {
+    Sdf_ChangeManager(const Sdf_ChangeManager&) = delete;
+    Sdf_ChangeManager& operator=(const Sdf_ChangeManager&) = delete;
 public:
     SDF_API
     static Sdf_ChangeManager& Get() {

--- a/pxr/usd/sdf/fileFormatRegistry.h
+++ b/pxr/usd/sdf/fileFormatRegistry.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/type.h"
 #include "pxr/base/tf/weakBase.h"
-#include <boost/noncopyable.hpp>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -50,8 +49,10 @@ TF_DECLARE_WEAK_PTRS(PlugPlugin);
 /// providing methods for finding registered formats either by format
 /// identifier or file extension.
 ///
-class Sdf_FileFormatRegistry : boost::noncopyable
+class Sdf_FileFormatRegistry
 {
+    Sdf_FileFormatRegistry(const Sdf_FileFormatRegistry&) = delete;
+    Sdf_FileFormatRegistry& operator=(const Sdf_FileFormatRegistry&) = delete;
 public:
     /// Constructor.
     Sdf_FileFormatRegistry();

--- a/pxr/usd/sdf/identity.h
+++ b/pxr/usd/sdf/identity.h
@@ -94,7 +94,9 @@ inline void intrusive_ptr_release(PXR_NS::Sdf_Identity* p) {
     }
 }
 
-class Sdf_IdentityRegistry : public boost::noncopyable {
+class Sdf_IdentityRegistry {
+    Sdf_IdentityRegistry(const Sdf_IdentityRegistry&) = delete;
+    Sdf_IdentityRegistry& operator=(const Sdf_IdentityRegistry&) = delete;
 public:
     Sdf_IdentityRegistry(const SdfLayerHandle &layer);
     ~Sdf_IdentityRegistry();

--- a/pxr/usd/sdf/layerRegistry.h
+++ b/pxr/usd/sdf/layerRegistry.h
@@ -33,7 +33,6 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/identity.hpp>
-#include <boost/noncopyable.hpp>
 
 #include <string>
 #include <iosfwd>
@@ -49,8 +48,10 @@ SDF_DECLARE_HANDLES(SdfLayer);
 /// is inserted into the layer registry. This allows SdfLayer::Find/FindOrOpen
 /// to locate loaded layers.
 ///
-class Sdf_LayerRegistry : boost::noncopyable
+class Sdf_LayerRegistry
 {
+    Sdf_LayerRegistry(const Sdf_LayerRegistry&) = delete;
+    Sdf_LayerRegistry& operator=(const Sdf_LayerRegistry&) = delete;
 public:
     /// Constructor.
     Sdf_LayerRegistry();

--- a/pxr/usd/sdf/layerTree.h
+++ b/pxr/usd/sdf/layerTree.h
@@ -31,7 +31,6 @@
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/usd/sdf/layerOffset.h"
 
-#include <boost/noncopyable.hpp>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -55,7 +54,9 @@ SDF_DECLARE_HANDLES(SdfLayer);
 /// We use TfRefPtr<SdfLayerTree> as handles to LayerTrees, as a simple way
 /// to pass them around as immutable trees without worrying about lifetime.
 ///
-class SdfLayerTree : public TfRefBase, public TfWeakBase, boost::noncopyable {
+class SdfLayerTree : public TfRefBase, public TfWeakBase {
+    SdfLayerTree(const SdfLayerTree&) = delete;
+    SdfLayerTree& operator=(const SdfLayerTree&) = delete;
 public:
     /// Create a new layer tree node.
     SDF_API

--- a/pxr/usd/sdf/listEditor.h
+++ b/pxr/usd/sdf/listEditor.h
@@ -33,7 +33,6 @@
 #include "pxr/usd/sdf/schema.h"
 #include "pxr/usd/sdf/spec.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 
 #include <functional>
@@ -50,8 +49,9 @@ SDF_DECLARE_HANDLES(SdfSpec);
 ///
 template <class TypePolicy>
 class Sdf_ListEditor
-    : public boost::noncopyable 
 {
+    Sdf_ListEditor(const Sdf_ListEditor&) = delete;
+    Sdf_ListEditor& operator=(const Sdf_ListEditor&) = delete;
 private:
     typedef Sdf_ListEditor<TypePolicy> This;
 

--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/stringUtils.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/ptr_container/ptr_map.hpp>
 #include <boost/ptr_container/ptr_set.hpp>
 #include <boost/variant.hpp>
@@ -53,7 +52,9 @@ TF_REGISTRY_FUNCTION(TfEnum)
 // This class is used to track edits to a namespace without modifying the
 // namespace.  Using it we can see what would've been changed and how.
 //
-class SdfNamespaceEdit_Namespace : boost::noncopyable {
+class SdfNamespaceEdit_Namespace {
+    SdfNamespaceEdit_Namespace(const SdfNamespaceEdit_Namespace&) = delete;
+    SdfNamespaceEdit_Namespace& operator=(const SdfNamespaceEdit_Namespace&) = delete;
 public:
     SdfNamespaceEdit_Namespace(bool fixBackpointers) :
         _fixBackpointers(fixBackpointers) { }
@@ -103,7 +104,9 @@ private:
     // namespace edits.  Simulating edits in an SdfPathTable would mean lots
     // of edits, while for this object it means moving pointers around
     // and/or changing a key.
-    class _Node : boost::noncopyable {
+    class _Node {
+        _Node(const _Node&) = delete;
+        _Node& operator=(const _Node&) = delete;
         typedef boost::ptr_set<_Node> _Children;
     public:
         // Create the root node.

--- a/pxr/usd/sdf/pathNode.h
+++ b/pxr/usd/sdf/pathNode.h
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #include <tbb/atomic.h>

--- a/pxr/usd/sdf/pathTable.h
+++ b/pxr/usd/sdf/pathTable.h
@@ -31,7 +31,6 @@
 #include "pxr/base/tf/functionRef.h"
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/noncopyable.hpp>
 
 #include <algorithm>
 #include <utility>
@@ -96,7 +95,9 @@ private:
     // pointer (\a next) to the next item in the hash bucket's linked list, and
     // two pointers (\a firstChild and \a nextSibling) that describe the tree
     // structure.
-    struct _Entry : boost::noncopyable {
+    struct _Entry {
+        _Entry(const _Entry&) = delete;
+        _Entry& operator=(const _Entry&) = delete;
         _Entry(value_type const &value, _Entry *n)
             : value(value)
             , next(n)

--- a/pxr/usd/sdf/schema.h
+++ b/pxr/usd/sdf/schema.h
@@ -59,8 +59,9 @@ TF_DECLARE_WEAK_PTRS(PlugPlugin);
 /// Generic class that provides information about scene description fields
 /// but doesn't actually provide any fields.
 ///
-class SdfSchemaBase : public TfWeakBase, public boost::noncopyable {
-
+class SdfSchemaBase : public TfWeakBase {
+    SdfSchemaBase(const SdfSchemaBase&) = delete;
+    SdfSchemaBase& operator=(const SdfSchemaBase&) = delete;
 protected:
     class _SpecDefiner;
 

--- a/pxr/usd/sdf/textFileFormat.tab.cpp
+++ b/pxr/usd/sdf/textFileFormat.tab.cpp
@@ -131,7 +131,6 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
@@ -6402,8 +6401,10 @@ static void _ReportParseError(Sdf_TextParserContext *context,
 // blocks of 8KB, which leads to O(n^2) behavior when trying to match strings
 // that are over this size. Giving flex a pre-filled buffer avoids this
 // behavior.
-struct Sdf_MemoryFlexBuffer : public boost::noncopyable
+struct Sdf_MemoryFlexBuffer
 {
+    Sdf_MemoryFlexBuffer(const Sdf_MemoryFlexBuffer&) = delete;
+    Sdf_MemoryFlexBuffer& operator=(const Sdf_MemoryFlexBuffer&) = delete;
 public:
     Sdf_MemoryFlexBuffer(const std::shared_ptr<ArAsset>& asset,
                          const std::string& name, yyscan_t scanner);

--- a/pxr/usd/sdf/textFileFormat.yy
+++ b/pxr/usd/sdf/textFileFormat.yy
@@ -53,7 +53,6 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
@@ -3179,8 +3178,10 @@ static void _ReportParseError(Sdf_TextParserContext *context,
 // blocks of 8KB, which leads to O(n^2) behavior when trying to match strings
 // that are over this size. Giving flex a pre-filled buffer avoids this
 // behavior.
-struct Sdf_MemoryFlexBuffer : public boost::noncopyable
+struct Sdf_MemoryFlexBuffer
 {
+    Sdf_MemoryFlexBuffer(const Sdf_MemoryFlexBuffer&) = delete;
+    Sdf_MemoryFlexBuffer& operator=(const Sdf_MemoryFlexBuffer&) = delete;
 public:
     Sdf_MemoryFlexBuffer(const std::shared_ptr<ArAsset>& asset,
                          const std::string& name, yyscan_t scanner);

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -66,7 +66,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/noncopyable.hpp>
 #include <boost/preprocessor/list/for_each.hpp>
 #include <boost/preprocessor/list/size.hpp>
 #include <boost/preprocessor/punctuation/comma.hpp>
@@ -521,7 +520,9 @@ private:
 /// Writes the string representation of \c SdfUnregisteredValue to \a out.
 SDF_API std::ostream &operator << (std::ostream &out, const SdfUnregisteredValue &value);
 
-class Sdf_ValueTypeNamesType : boost::noncopyable {
+class Sdf_ValueTypeNamesType {
+    Sdf_ValueTypeNamesType(const Sdf_ValueTypeNamesType&) = delete;
+    Sdf_ValueTypeNamesType& operator=(const Sdf_ValueTypeNamesType&) = delete;
 public:
     SdfValueTypeName Bool;
     SdfValueTypeName UChar, Int, UInt, Int64, UInt64;

--- a/pxr/usd/sdf/valueTypeRegistry.cpp
+++ b/pxr/usd/sdf/valueTypeRegistry.cpp
@@ -88,7 +88,9 @@ namespace {
 // Registry -- The implementation of the value type name registry.
 //
 
-class Registry : boost::noncopyable {
+class Registry {
+    Registry(const Registry&) = delete;
+    Registry& operator=(const Registry&) = delete;
 public:
     typedef Sdf_ValueTypePrivate::CoreType CoreType;
 

--- a/pxr/usd/sdf/valueTypeRegistry.h
+++ b/pxr/usd/sdf/valueTypeRegistry.h
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/array.h"
 #include "pxr/base/vt/value.h"
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <vector>
 
@@ -42,7 +41,9 @@ class TfType;
 ///
 /// A registry of value type names used by a schema.
 ///
-class Sdf_ValueTypeRegistry : boost::noncopyable {
+class Sdf_ValueTypeRegistry {
+    Sdf_ValueTypeRegistry(const Sdf_ValueTypeRegistry&) = delete;
+    Sdf_ValueTypeRegistry& operator=(const Sdf_ValueTypeRegistry&) = delete;
 public:
     Sdf_ValueTypeRegistry();
     ~Sdf_ValueTypeRegistry();


### PR DESCRIPTION
### Description of Change(s)
- `PcpMapExpression::_Node`, `Sdf_ChangeManager`, `Sdf_FileFormatRegistry`, `Sdf_IdentityRegistry`, `Sdf_LayerRegistry`, `SdfLayerTree`, `Sdf_ListEditor`, `SdfNamespaceEdit_Namespace`, `SdfPath::_Entry`, `SdfValueTypeRegistry`, `Sdf_MemoryFlexBuffer`, `SdfSchemaBase`  have been updated to use explicit deletion of the copy constructor and assignment operator.  `pxr/usd/pcp/mapExpression.h` was getting its include of `boost::noncopyable` indirectly from `pxr/usd/sdf` which is why its included in this change.
- A spurious include of `boost/noncopyable.hpp` in `pxr/usd/sdf/pathNode.h` has been removed

### Fixes Issue(s)
- #2203

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
