### PR TITLE
Replace boost::noncopyable with explicit deletion of copy constructor and assignment operator in pxr/usd/kind

### DIFF
--- a/pxr/usd/kind/registry.h
+++ b/pxr/usd/kind/registry.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/noncopyable.hpp>
 #include <unordered_map>
 #include <vector>
 
@@ -68,8 +67,10 @@ TF_DECLARE_PUBLIC_TOKENS(KindTokens, KIND_API, KIND_TOKENS);
 /// To make this robust, KindRegistry exposes no means to mutate the registry.
 /// All extensions must be accomplished via plugInfo.json files, which are
 /// consumed once during the registry initialization (See \ref kind_extensions )
-class KindRegistry : public TfWeakBase, boost::noncopyable
+class KindRegistry : public TfWeakBase
 {
+    KindRegistry(const KindRegistry&) = delete;
+    KindRegistry& operator=(const KindRegistry&) = delete;
 public:
     /// Return the single \c KindRegistry instance.
     KIND_API static KindRegistry& GetInstance();


### PR DESCRIPTION
### Description of Change(s)
- `KindRegistry` has been updated to use explicit deletion of the copy constructor and assignment operator
### Fixes Issue(s)
- #2203

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
