### PR TITLE
Replace boost::noncopyable with explicit deletion of copy constructor and assignment operator in pxr/usd/usd

### DIFF
--- a/pxr/usd/usd/schemaRegistry.h
+++ b/pxr/usd/usd/schemaRegistry.h
@@ -66,7 +66,9 @@ using UsdSchemaVersion = unsigned int;
 /// classes, to enumerate all properties for a given schema class, and finally 
 /// to provide fallback values for unauthored built-in properties.
 ///
-class UsdSchemaRegistry : public TfWeakBase, boost::noncopyable {
+class UsdSchemaRegistry : public TfWeakBase {
+    UsdSchemaRegistry(const UsdSchemaRegistry&) = delete;
+    UsdSchemaRegistry& operator=(const UsdSchemaRegistry&) = delete;
 public:
     using TokenToTokenVectorMap = 
         std::unordered_map<TfToken, TfTokenVector, TfHash>;


### PR DESCRIPTION
### Description of Change(s)
- `UsdSchemaRegistry` has been updated to use explicit deletion of the copy constructor and assignment operator

### Fixes Issue(s)
- #2203

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
