### PR TITLE
Replace boost traits and mpl with STL traits in pxr/base/vt

### DIFF
--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -1854,6 +1854,16 @@ testKnownValueTypeIndex()
     TF_AXIOM(!VtIsKnownValueType<TypeNotKnownToVt>());
 }
 
+static void testVtCheapToCopy() {
+    static_assert(VtValueTypeHasCheapCopy<float>::value, "");
+    static_assert(VtValueTypeHasCheapCopy<int>::value, "");
+    static_assert(VtValueTypeHasCheapCopy<GfVec3d>::value, "");
+    static_assert(VtValueTypeHasCheapCopy<TfToken>::value, "");
+    static_assert(!VtValueTypeHasCheapCopy<std::string>::value, "");
+    static_assert(!VtValueTypeHasCheapCopy<VtArray<float>>::value, "");
+    static_assert(!VtValueTypeHasCheapCopy<VtArray<TfToken>>::value, "");
+}
+
 int main(int argc, char *argv[])
 {
     testArray();
@@ -1874,6 +1884,7 @@ int main(int argc, char *argv[])
 
     testVisitValue();
     testKnownValueTypeIndex();
+    testVtCheapToCopy();
 
     printf("Test SUCCEEDED\n");
 

--- a/pxr/base/vt/traits.h
+++ b/pxr/base/vt/traits.h
@@ -30,8 +30,6 @@
 #include "pxr/base/vt/api.h"
 #include "pxr/base/tf/preprocessorUtils.h"
 
-#include <boost/type_traits/has_trivial_assign.hpp>
-
 #include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -46,8 +44,10 @@ struct VtIsArray : public std::false_type {};
 // space but do not have a trivial assignment are not cheap to copy.  E.g. std::
 // containers.  Clients can specialize this template for their own types that
 // aren't trivially assignable but are cheap to copy to enable local storage.
+// In C++17, std::is_trivially_copy_assignable<T> could be used in place of
+// std::is_trivially_assignable
 template <class T>
-struct VtValueTypeHasCheapCopy : boost::has_trivial_assign<T> {};
+struct VtValueTypeHasCheapCopy : std::is_trivially_assignable<T&, const T&> {};
 
 #define VT_TYPE_IS_CHEAP_TO_COPY(T)                                            \
     template <> struct VtValueTypeHasCheapCopy<TF_PP_EAT_PARENS(T)>            \

--- a/pxr/base/vt/value.h
+++ b/pxr/base/vt/value.h
@@ -49,10 +49,6 @@
 #include "pxr/base/vt/types.h"
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/type_traits/has_trivial_assign.hpp>
-#include <boost/type_traits/has_trivial_constructor.hpp>
-#include <boost/type_traits/has_trivial_copy.hpp>
-#include <boost/type_traits/has_trivial_destructor.hpp>
 
 #include <iosfwd>
 #include <typeinfo>
@@ -201,12 +197,14 @@ class VtValue
     typedef std::aligned_storage<
         /* size */_MaxLocalSize, /* alignment */_MaxLocalSize>::type _Storage;
 
+    // In C++17, std::is_trivially_copy_assignable<T> could be used in place of
+    // std::is_trivially_assignable
     template <class T>
     using _IsTriviallyCopyable = std::integral_constant<bool,
-        boost::has_trivial_constructor<T>::value &&
-        boost::has_trivial_copy<T>::value &&
-        boost::has_trivial_assign<T>::value &&
-        boost::has_trivial_destructor<T>::value>;
+        std::is_trivially_default_constructible<T>::value &&
+        std::is_trivially_copyable<T>::value &&
+        std::is_trivially_assignable<T&, const T&>::value &&
+        std::is_trivially_destructible<T>::value>;
 
     // Metafunction that returns true if T should be stored locally, false if it
     // should be stored remotely.


### PR DESCRIPTION
### Description of Change(s)
Depends on #2214
- `std::is_trivially_default_constructible`, `std::is_trivially_copyable`, `std::is_trivially_assignable`, and `std::is_trivially_destructible` are used to replace `boost::has_trivial_constructor`, `boost::has_trivial_copy`, `boost::has_trivial_assign`, and `boost::has_trivial_destructor`
- Test coverage has been added for `VtValueTypeHasCheapCopy` to guard against regressions

### Fixes Issue(s)
- #2211

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
