### PR TITLE
Replace boost traits and mpl with STL traits in pxr/base/tf

### DIFF
--- a/pxr/base/tf/errorMark.cpp
+++ b/pxr/base/tf/errorMark.cpp
@@ -30,8 +30,6 @@
 #include "pxr/base/tf/iterator.h"
 #include "pxr/base/arch/stackTrace.h"
 
-#include <boost/utility.hpp>
-
 #include <tbb/spin_mutex.h>
 
 #include <sstream>

--- a/pxr/base/tf/pyIdentity.h
+++ b/pxr/base/tf/pyIdentity.h
@@ -40,8 +40,6 @@
 #include <boost/python/class.hpp>
 #include <boost/python/handle.hpp>
 #include <boost/python/object.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility.hpp>
 
 #include "pxr/base/tf/hashmap.h"
 
@@ -135,9 +133,9 @@ struct Tf_PyOwnershipHelper {
 
 template <typename Ptr>
 struct Tf_PyOwnershipHelper<Ptr,
-    typename boost::enable_if<
-        boost::mpl::and_<boost::is_same<TfRefPtr<typename Ptr::DataType>, Ptr>,
-            boost::is_base_of<TfRefBase, typename Ptr::DataType> > >::type>
+    std::enable_if_t<
+        std::is_same<TfRefPtr<typename Ptr::DataType>, Ptr>::value &&
+        std::is_base_of<TfRefBase, typename Ptr::DataType>::value>>
 {
     struct _RefPtrHolder {
         static boost::python::object
@@ -229,13 +227,13 @@ struct Tf_PyIsRefPtr<TfRefPtr<T> > {
 
 
 template <class Ptr>
-typename boost::enable_if<Tf_PyIsRefPtr<Ptr> >::type
+std::enable_if_t<Tf_PyIsRefPtr<Ptr>::value>
 Tf_PySetPythonIdentity(Ptr const &, PyObject *)
 {
 }
 
 template <class Ptr>
-typename boost::disable_if<Tf_PyIsRefPtr<Ptr> >::type
+std::enable_if_t<!Tf_PyIsRefPtr<Ptr>::value>
 Tf_PySetPythonIdentity(Ptr const &ptr, PyObject *obj)
 {
     if (ptr.GetUniqueIdentifier()) {

--- a/pxr/base/tf/pyNoticeWrapper.h
+++ b/pxr/base/tf/pyNoticeWrapper.h
@@ -33,9 +33,6 @@
 #include "pxr/base/tf/pyObjectFinder.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/or.hpp>
 #include <boost/python/bases.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/extract.hpp>
@@ -114,9 +111,9 @@ public:
 
     // If Notice is really TfNotice, then this is the root of the hierarchy and
     // bases is empty, otherwise bases contains the base class.
-    typedef typename boost::mpl::if_<
-        boost::is_same<NoticeType, TfNotice>
-        , boost::python::bases<>, boost::python::bases<BaseType> >::type Bases;
+    using Bases = std::conditional_t<std::is_same<NoticeType, TfNotice>::value,
+                                     boost::python::bases<>,
+                                     boost::python::bases<BaseType>>;
 
     typedef boost::python::class_<NoticeType, This, Bases> ClassType;
 

--- a/pxr/base/tf/pyPolymorphic.h
+++ b/pxr/base/tf/pyPolymorphic.h
@@ -39,7 +39,6 @@
 
 #include <boost/python/object/class_detail.hpp>
 #include <boost/python/wrapper.hpp>
-#include <boost/type_traits.hpp>
 #include <boost/python/has_back_reference.hpp>
 
 #include <functional>

--- a/pxr/base/tf/pyResultConversions.h
+++ b/pxr/base/tf/pyResultConversions.h
@@ -32,9 +32,6 @@
 #include <boost/python/list.hpp>
 #include <boost/python/dict.hpp>
 
-#include <boost/type_traits/add_reference.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-
 #include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -138,7 +135,7 @@ struct TfPyPairToTuple {
 
 template <typename T>
 struct Tf_PySequenceToListConverter {
-    typedef typename boost::remove_reference<T>::type SeqType;
+    typedef std::remove_reference_t<T> SeqType;
     bool convertible() const {
         return true;
     }
@@ -152,7 +149,7 @@ struct Tf_PySequenceToListConverter {
 
 template <typename T>
 struct Tf_PySequenceToSetConverter {
-    typedef typename std::remove_reference<T>::type SeqType;
+    typedef std::remove_reference_t<T> SeqType;
     bool convertible() const {
         return true;
     }
@@ -166,7 +163,7 @@ struct Tf_PySequenceToSetConverter {
 
 template <typename T>
 struct Tf_PyMapToDictionaryConverter {
-    typedef typename boost::remove_reference<T>::type SeqType;
+    typedef std::remove_reference_t<T> SeqType;
     // TODO: convertible() should be made more robust by checking that the
     // value_type of the container is pair<const key_type, data_type> 
     bool convertible() const {
@@ -182,7 +179,7 @@ struct Tf_PyMapToDictionaryConverter {
 
 template <typename T>
 struct Tf_PySequenceToTupleConverter {
-    typedef typename boost::remove_reference<T>::type SeqType;
+    typedef std::remove_reference_t<T> SeqType;
     bool convertible() const {
         return true;
     }

--- a/pxr/base/tf/pySingleton.h
+++ b/pxr/base/tf/pySingleton.h
@@ -33,8 +33,6 @@
 #include "pxr/base/tf/singleton.h"
 #include "pxr/base/tf/weakPtr.h"
 
-#include <boost/mpl/vector/vector10.hpp>
-
 #include <boost/python/class.hpp>
 #include <boost/python/default_call_policies.hpp>
 #include <boost/python/def_visitor.hpp>

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -34,9 +34,6 @@
 #include "pxr/base/arch/math.h"
 #include "pxr/base/arch/vsnprintf.h"
 
-#include <boost/type_traits/is_signed.hpp>
-#include <boost/utility/enable_if.hpp>
-
 #include <algorithm>
 #include <climits>
 #include <cstdarg>
@@ -45,6 +42,7 @@
 #include <string>
 #include <utility>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 #include <memory>
 
@@ -125,7 +123,7 @@ TfStringToDouble(const string& s)
 // return that minimum representable value and set *outOfRange to true (if
 // outOfRange is not NULL).
 template <class Int>
-static typename boost::enable_if<boost::is_signed<Int>, Int>::type
+static std::enable_if_t<std::is_signed<Int>::value, Int>
 _StringToNegative(const char *p, bool *outOfRange)
 {
     const Int M = std::numeric_limits<Int>::min();

--- a/pxr/base/tf/weakPtrFacade.h
+++ b/pxr/base/tf/weakPtrFacade.h
@@ -33,10 +33,7 @@
 
 #include "pxr/base/arch/demangle.h"
 
-#include <boost/mpl/or.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -377,9 +374,9 @@ inline TfRefPtr<T>::TfRefPtr(const TfWeakPtrFacade<X, U>& p,
 //
 template <template <class> class Ptr, class T>
 struct TfTypeFunctions<Ptr<T>,
-                       typename boost::enable_if<
-                           boost::is_base_of<TfWeakPtrFacadeBase, Ptr<T> >
-                           >::type>
+                       std::enable_if_t<
+                           std::is_base_of<TfWeakPtrFacadeBase, Ptr<T>>::value
+                       >>
 {
     static T* GetRawPtr(const Ptr<T>& t) {
         return get_pointer(t);
@@ -399,9 +396,9 @@ struct TfTypeFunctions<Ptr<T>,
 
 template <template <class> class Ptr, class T>
 struct TfTypeFunctions<Ptr<const T>,
-                       typename boost::enable_if<
-                           boost::is_base_of<TfWeakPtrFacadeBase, Ptr<const T> >
-                           >::type>
+                       std::enable_if_t<
+                           std::is_base_of<TfWeakPtrFacadeBase, Ptr<const T>>::value
+                       >>
 {
     static const T* GetRawPtr(const Ptr<const T>& t) {
         return get_pointer(t);


### PR DESCRIPTION
### Description of Change(s)
- Remove spurious `boost/utility` include from `errorMark.cc`
- Removes spurious reference to `boost/mpl/vector/vector10.hpp` in `pySingleton.h`
- Replaces `boost::mpl::if_` with `std::conditional_t`
- Replaces `boost::is_same` with `std::is_same`
- Replaces `boost::remove_reference` with `std::remove_reference_t`
- Replaces `boost::enable_if` with `std::enable_if_t`
- Replaces `boost::disable_if` with `std::enable_if_t` and the negation of the condition
- Replaces `boost::is_base_of` with `std::is_base_of`

### Fixes Issue(s)
- #2211

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
