### PR TITLE
Replace boost traits and mpl with STL traits in pxr/usd/sdf, pxr/usd/pcp, and pxr/usd/usd

### DIFF
--- a/pxr/usd/pcp/iterator.h
+++ b/pxr/usd/pcp/iterator.h
@@ -304,10 +304,10 @@ public:
     };                                                                  \
                                                                         \
     template <>                                                         \
-    struct Tf_ShouldIterateOverCopy<Range> : boost::true_type {};       \
+    struct Tf_ShouldIterateOverCopy<Range> : std::true_type {};         \
                                                                         \
     template <>                                                         \
-    struct Tf_ShouldIterateOverCopy<const Range> : boost::true_type {}
+    struct Tf_ShouldIterateOverCopy<const Range> : std::true_type {}
 
 PCP_DEFINE_RANGE(PcpNodeRange, PcpNodeIterator, PcpNodeReverseIterator);
 PCP_DEFINE_RANGE(PcpPrimRange, PcpPrimIterator, PcpPrimReverseIterator);

--- a/pxr/usd/pcp/node.h
+++ b/pxr/usd/pcp/node.h
@@ -447,7 +447,7 @@ struct Tf_IteratorInterface<PcpNodeRef::child_const_range, true> {
 
 template <>
 struct Tf_ShouldIterateOverCopy<PcpNodeRef::child_const_range> :
-    boost::true_type {};
+    std::true_type {};
 
 /// Support for range-based for loops for PcpNodeRef children ranges.
 inline

--- a/pxr/usd/pcp/node_Iterator.h
+++ b/pxr/usd/pcp/node_Iterator.h
@@ -176,7 +176,7 @@ struct Tf_IteratorInterface<PcpNodeRef_PrivateChildrenConstRange, true> {
 };
 template <>
 struct Tf_ShouldIterateOverCopy<PcpNodeRef_PrivateChildrenConstRange> :
-    boost::true_type {};
+    std::true_type {};
 
 // Wrap a node for use by TF_FOR_ALL().
 inline

--- a/pxr/usd/sdf/accessorHelpers.h
+++ b/pxr/usd/sdf/accessorHelpers.h
@@ -31,6 +31,8 @@
 #include "pxr/usd/sdf/spec.h"
 #include "pxr/usd/sdf/types.h"
 
+#include <type_traits>
+
 // This file defines macros intended to reduce the amount of boilerplate code
 // associated with adding new metadata to SdfSpec subclasses.  There's still a
 // lot of files to touch, but these at least reduce the copy/paste/edit load.
@@ -203,7 +205,7 @@ SDF_DEFINE_DICTIONARY_SET(setName_, key_)
 // spec. These templates capture those differences.
 
 template <class T,
-          bool IsForSpec = boost::is_base_of<SdfSpec, T>::value>
+          bool IsForSpec = std::is_base_of<SdfSpec, T>::value>
 struct Sdf_AccessorHelpers;
 
 template <class T>

--- a/pxr/usd/sdf/childrenProxy.h
+++ b/pxr/usd/sdf/childrenProxy.h
@@ -463,7 +463,7 @@ private:
 
 // Allow TfIteration over children proxies.
 template <typename _View>
-struct Tf_ShouldIterateOverCopy<SdfChildrenProxy<_View> > : boost::true_type
+struct Tf_ShouldIterateOverCopy<SdfChildrenProxy<_View> > : std::true_type
 {
 };
 

--- a/pxr/usd/sdf/childrenView.h
+++ b/pxr/usd/sdf/childrenView.h
@@ -514,7 +514,7 @@ struct SdfAdaptedChildrenViewCreator
 
 // Allow TfIteration over children views.
 template <typename C, typename P, typename A>
-struct Tf_ShouldIterateOverCopy<SdfChildrenView<C, P, A> > : boost::true_type
+struct Tf_ShouldIterateOverCopy<SdfChildrenView<C, P, A> > : std::true_type
 {
 };
 template <typename C, typename P, typename A>

--- a/pxr/usd/sdf/listProxy.h
+++ b/pxr/usd/sdf/listProxy.h
@@ -39,11 +39,9 @@
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/operators.hpp>
 #include <boost/optional.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/remove_cv.hpp>
-#include <boost/type_traits/remove_reference.hpp>
 
 #include <memory>
+#include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -126,11 +124,11 @@ private:
     class _Iterator :
         public boost::iterator_facade<
             _Iterator<Owner, GetItem>,
-            typename boost::remove_cv<
-                typename boost::remove_reference<
+            std::remove_cv_t<
+                std::remove_reference_t<
                     typename GetItem::result_type
-                >::type
-            >::type,
+                >
+            >,
             std::random_access_iterator_tag,
             typename GetItem::result_type> {
     public:
@@ -138,11 +136,11 @@ private:
         typedef
             boost::iterator_facade<
                 _Iterator<Owner, GetItem>,
-                typename boost::remove_cv<
-                    typename boost::remove_reference<
+                std::remove_cv_t<
+                    std::remove_reference_t<
                         typename GetItem::result_type
-                    >::type
-                >::type,
+                    >
+                >,
                 std::random_access_iterator_tag,
                 typename GetItem::result_type> Parent;
         typedef typename Parent::reference reference;
@@ -627,7 +625,7 @@ private:
 
 // Allow TfIteration over list proxies.
 template <typename T>
-struct Tf_ShouldIterateOverCopy<SdfListProxy<T> > : boost::true_type
+struct Tf_ShouldIterateOverCopy<SdfListProxy<T> > : std::true_type
 {
 };
 

--- a/pxr/usd/sdf/spec.h
+++ b/pxr/usd/sdf/spec.h
@@ -37,9 +37,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/type.h"
 
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
-
 #include <iosfwd>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -319,10 +319,13 @@ namespace Usd_CrateFile {
 
 // XXX: These checks ensure VtValue can hold ValueRep in the lightest
 // possible way -- WBN not to rely on internal knowledge of that.
-static_assert(boost::has_trivial_constructor<ValueRep>::value, "");
-static_assert(boost::has_trivial_copy<ValueRep>::value, "");
-static_assert(boost::has_trivial_assign<ValueRep>::value, "");
-static_assert(boost::has_trivial_destructor<ValueRep>::value, "");
+static_assert(std::is_trivially_constructible<ValueRep>::value, "");
+static_assert(std::is_trivially_copyable<ValueRep>::value, "");
+// In C++17, std::is_trivially_copy_assignable<T> could be used in place of
+// std::is_trivially_assignable
+static_assert(std::is_trivially_assignable<ValueRep&, const ValueRep&>::value,
+              "");
+static_assert(std::is_trivially_destructible<ValueRep>::value, "");
 
 using namespace Usd_CrateValueInliners;
 

--- a/pxr/usd/usd/prim.h
+++ b/pxr/usd/usd/prim.h
@@ -2362,10 +2362,10 @@ typedef boost::iterator_range<UsdPrimSiblingIterator> UsdPrimSiblingRange;
 // Inform TfIterator it should feel free to make copies of the range type.
 template <>
 struct Tf_ShouldIterateOverCopy<
-    UsdPrimSiblingRange> : boost::true_type {};
+    UsdPrimSiblingRange> : std::true_type {};
 template <>
 struct Tf_ShouldIterateOverCopy<
-    const UsdPrimSiblingRange> : boost::true_type {};
+    const UsdPrimSiblingRange> : std::true_type {};
 
 #endif // doxygen
 
@@ -2560,10 +2560,10 @@ typedef boost::iterator_range<UsdPrimSubtreeIterator> UsdPrimSubtreeRange;
 // Inform TfIterator it should feel free to make copies of the range type.
 template <>
 struct Tf_ShouldIterateOverCopy<
-    UsdPrimSubtreeRange> : boost::true_type {};
+    UsdPrimSubtreeRange> : std::true_type {};
 template <>
 struct Tf_ShouldIterateOverCopy<
-    const UsdPrimSubtreeRange> : boost::true_type {};
+    const UsdPrimSubtreeRange> : std::true_type {};
 
 #endif // doxygen
 

--- a/pxr/usd/usd/primData.h
+++ b/pxr/usd/usd/primData.h
@@ -387,10 +387,10 @@ typedef boost::iterator_range<
 // Inform TfIterator it should feel free to make copies of the range type.
 template <>
 struct Tf_ShouldIterateOverCopy<
-    Usd_PrimDataSiblingRange> : boost::true_type {};
+    Usd_PrimDataSiblingRange> : std::true_type {};
 template <>
 struct Tf_ShouldIterateOverCopy<
-    const Usd_PrimDataSiblingRange> : boost::true_type {};
+    const Usd_PrimDataSiblingRange> : std::true_type {};
 
 Usd_PrimDataSiblingIterator
 Usd_PrimData::_ChildrenBegin() const
@@ -448,10 +448,10 @@ typedef boost::iterator_range<
 // Inform TfIterator it should feel free to make copies of the range type.
 template <>
 struct Tf_ShouldIterateOverCopy<
-    Usd_PrimDataSubtreeRange> : boost::true_type {};
+    Usd_PrimDataSubtreeRange> : std::true_type {};
 template <>
 struct Tf_ShouldIterateOverCopy<
-    const Usd_PrimDataSubtreeRange> : boost::true_type {};
+    const Usd_PrimDataSubtreeRange> : std::true_type {};
 
 Usd_PrimDataSubtreeIterator
 Usd_PrimData::_SubtreeBegin() const


### PR DESCRIPTION
### Description of Change(s)
- Replaces `boost::remove_cv` and `boost::remove_reference` with `std::remove_cv_t` and `std::remove_reference_t`
- Replaces `boost::true_type` with `std::true_type`
- Replaces `boost::is_base_of` with `std::is_base_of`
- Replaces `boost::has_trivial_constructor`, `boost::has_trivial_copy`, `boost::has_trivial_assign`, and `has::trivial_destructor` with `std::is_trivially_constructible`, `std::is_trivially_copyable`, `std::is_trivially_assignable`, and `std::is_trivially_desctructible`.

### Fixes Issue(s)
- #2211

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
