### PR TITLE
Add missing #include for GCC13

### DIFF
--- a/pxr/base/arch/virtualMemory.cpp
+++ b/pxr/base/arch/virtualMemory.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/systemInfo.h"
 
+#include <cstdint>
 #if defined(ARCH_OS_WINDOWS)
 #include <Windows.h>
 #include <Memoryapi.h>


### PR DESCRIPTION
### Description of Change(s)

Adds `#include <cstdint>` for `uint64_t` and friends.

See “Header Dependency Changes” in https://www.gnu.org/software/gcc/gcc-13/porting_to.html.

### Fixes Issue(s)

(Fixes build of USD 22.05b in Fedora Linux Rawhide.)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
