### PR TITLE
[build] Fix toolchain detection when using Microsoft Build Tools

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -127,11 +127,11 @@ def GetVisualStudioCompilerAndVersion():
 
     msvcCompiler = which('cl')
     if msvcCompiler:
-        # VisualStudioVersion environment variable should be set by the
+        # VCToolsVersion environment variable should be set by the
         # Visual Studio Command Prompt.
         match = re.search(
             r"(\d+)\.(\d+)",
-            os.environ.get("VisualStudioVersion", ""))
+            os.environ.get("VCToolsVersion", ""))
         if match:
             return (msvcCompiler, tuple(int(v) for v in match.groups()))
     return None
@@ -146,16 +146,17 @@ def IsVisualStudioVersionOrGreater(desiredVersion):
         return version >= desiredVersion
     return False
 
+# Helpers to determine the version of "Visual Studio" (also support the Build Tools) based
+# on the version of the MSVC compiler.
+# See MSVC++ versions table on https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
 def IsVisualStudio2022OrGreater():
-    VISUAL_STUDIO_2022_VERSION = (17, 0)
+    VISUAL_STUDIO_2022_VERSION = (14, 30)
     return IsVisualStudioVersionOrGreater(VISUAL_STUDIO_2022_VERSION)
-
 def IsVisualStudio2019OrGreater():
-    VISUAL_STUDIO_2019_VERSION = (16, 0)
+    VISUAL_STUDIO_2019_VERSION = (14, 20)
     return IsVisualStudioVersionOrGreater(VISUAL_STUDIO_2019_VERSION)
-
 def IsVisualStudio2017OrGreater():
-    VISUAL_STUDIO_2017_VERSION = (15, 0)
+    VISUAL_STUDIO_2017_VERSION = (14, 1)
     return IsVisualStudioVersionOrGreater(VISUAL_STUDIO_2017_VERSION)
 
 def GetPythonInfo(context):
@@ -387,7 +388,7 @@ def RunCMake(context, force, extraArgs = None):
     if generator is not None:
         generator = '-G "{gen}"'.format(gen=generator)
 
-    if IsVisualStudio2019OrGreater():
+    if "Visual Studio" in generator and IsVisualStudio2019OrGreater():
         generator = generator + " -A x64"
 
     toolset = context.cmakeToolset


### PR DESCRIPTION
### Description of Change(s)

The environment variable used by `build_usd.py` to detect the version of the MSVC compiler is in fact an environment variable storing the version of Visual Studio, which is the IDE and has a different versioning than the compiler. And when using Microsoft Build Tools, only the compiler and SDKs are installed, and that environment variable doesn't even exist.

This commit just uses the actual environment variable storing the MSVC compiler version (it's setup by both Visual Studio and the Build Tools) and fixes the `IsVisualStudio20XXOrGreater` helper functions to check against the compiler versions (see https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B the table `MSVC++ versions`)

**Edit**: It also skips adding the `-A x64` platform option to the CMake command if the generator used isn't a Visual Studio Variant, because only those support that option (it gives an error when using Ninja for instance)

### Fixes Issue(s)

- Fixes build using Microsoft Build Tools instead of Visual Studio.

- [ ] I have verified that all unit tests pass with the proposed changes (not applicable, build issue only)
- [x] I have submitted a signed Contributor License Agreement
