### PR TITLE
Replace `boost::scoped_ptr` with `std::unique_ptr` in `testVtCpp`

### DIFF
--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -71,13 +71,12 @@
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/fileSystem.h"
 
-#include <boost/scoped_ptr.hpp>
-
 #include <cstdio>
 #include <cmath>
 #include <iterator>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <new>
 #include <string>
 #include <type_traits>
@@ -873,7 +872,7 @@ testDictionaryIterators()
         VtDictionary::iterator i = a.find(key2.first);
 
         {
-            boost::scoped_ptr<VtDictionary> b(new VtDictionary(a));
+            const auto b = std::make_unique<VtDictionary>(a);
             a.insert(std::make_pair(key3.first, key3.second));
         }
 
@@ -905,7 +904,7 @@ testDictionaryIterators()
         VtDictionary::const_iterator i = a.find(key2.first);
         VtDictionary::const_iterator j = expected.find(key2.first);
         {
-            boost::scoped_ptr<VtDictionary> b(new VtDictionary(a));
+            const auto b = std::make_unique<VtDictionary>(a);
             VtDictionary::value_type v(key3.first, key3.second);
             a.insert(v);
             expected.insert(v);
@@ -923,7 +922,7 @@ testDictionaryIterators()
         VtDictionary a = {key1, key2};
         VtDictionary::const_iterator i = a.find(key1.first);
         {
-            boost::scoped_ptr<VtDictionary> b(new VtDictionary(a));
+            const auto b = std::make_unique<VtDictionary>(a);
             a[key1.first] = VtValue(12);
         }
 


### PR DESCRIPTION
### Description of Change(s)
- Replaces usage of `boost::scoped_ptr` with a `const` `std::unique_ptr` to prevent moving and copying
- `std::unique_ptr` is constructed with `std::make_unique` instead of `new` per https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-make_unique

### Fixes Issue(s)
- #2222

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
