### PR TITLE
Replace `boost::unordered_map` with `std::unordered_map` in `pxr/usd/pcp/layerStackRegistry.cpp`

### DIFF
--- a/pxr/usd/pcp/layerStackRegistry.cpp
+++ b/pxr/usd/pcp/layerStackRegistry.cpp
@@ -35,9 +35,8 @@
 
 #include <tbb/queuing_rw_mutex.h>
 
-#include <boost/unordered_map.hpp>
-
 #include <algorithm>
+#include <unordered_map>
 #include <utility>
 
 using std::pair;
@@ -55,16 +54,16 @@ public:
 
     typedef SdfLayerHandleVector Layers;
     typedef PcpLayerStackPtrVector LayerStacks;
-    typedef boost::unordered_map<PcpLayerStackIdentifier, PcpLayerStackPtr>
-        IdentifierToLayerStack;
-    typedef boost::unordered_map<SdfLayerHandle, LayerStacks>
+    typedef std::unordered_map<PcpLayerStackIdentifier, PcpLayerStackPtr,
+                               TfHash> IdentifierToLayerStack;
+    typedef std::unordered_map<SdfLayerHandle, LayerStacks, TfHash>
         LayerToLayerStacks;
-    typedef boost::unordered_map<PcpLayerStackPtr, Layers>
+    typedef std::unordered_map<PcpLayerStackPtr, Layers, TfHash>
         LayerStackToLayers;
 
-    typedef boost::unordered_map<std::string, LayerStacks>
+    typedef std::unordered_map<std::string, LayerStacks, TfHash>
         MutedLayerIdentifierToLayerStacks;
-    typedef boost::unordered_map<PcpLayerStackPtr, std::set<std::string> >
+    typedef std::unordered_map<PcpLayerStackPtr, std::set<std::string>, TfHash>
         LayerStackToMutedLayerIdentifiers;
 
     IdentifierToLayerStack identifierToLayerStack;


### PR DESCRIPTION
### Description of Change(s)
- Replaces all usage of `boost::unordered_map` with `std::unordered_map` and `TfHash`

### Fixes Issue(s)
- #2226 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
