### PR TITLE
Replace `boost::iterator_adaptor` with explicitly specified iterator definition for `UsdPrimRange`

### DIFF
--- a/pxr/usd/usd/primRange.cpp
+++ b/pxr/usd/usd/primRange.cpp
@@ -52,7 +52,7 @@ UsdPrimRange::Stage(const UsdStagePtr &stage,
 void
 UsdPrimRange::iterator::PruneChildren()
 {
-    if (base() == _range->_end) {
+    if (_underlyingIterator == _range->_end) {
         TF_CODING_ERROR("Iterator past-the-end");
         return;
     }
@@ -68,33 +68,35 @@ UsdPrimRange::iterator::PruneChildren()
 void
 UsdPrimRange::iterator::increment()
 {
-    base_type &base = base_reference();
-    base_type end = _range->_end;
+    _UnderlyingIterator end = _range->_end;
     if (ARCH_UNLIKELY(_isPost)) {
         _isPost = false;
-        if (Usd_MoveToNextSiblingOrParent(
-                base, _proxyPrimPath, end, _range->_predicate)) {
+        if (Usd_MoveToNextSiblingOrParent(_underlyingIterator, _proxyPrimPath,
+                                          end, _range->_predicate)) {
             if (_depth) {
                 --_depth;
                 _isPost = true;
             } else {
-                base = end;
+                _underlyingIterator = end;
                 _proxyPrimPath = SdfPath();
             }
         }
     } else if (!_pruneChildrenFlag &&
-               Usd_MoveToChild(base, _proxyPrimPath, end, _range->_predicate)) {
+               Usd_MoveToChild(_underlyingIterator, _proxyPrimPath, end,
+                               _range->_predicate)) {
         ++_depth;
     } else {
         if (_range->_postOrder) {
             _isPost = true;
         } else {
-            while (Usd_MoveToNextSiblingOrParent(
-                       base, _proxyPrimPath, end, _range->_predicate)) {
+            while (Usd_MoveToNextSiblingOrParent(_underlyingIterator,
+                                                 _proxyPrimPath,
+                                                 end,
+                                                 _range->_predicate)) {
                 if (_depth) {
                     --_depth;
                 } else {
-                    base = end;
+                    _underlyingIterator = end;
                     _proxyPrimPath = SdfPath();
                     break;
                 }


### PR DESCRIPTION
### Description of Change(s)

- Introduces an `_UnderlyingIterator` type alias for `Usd_PrimDataConstPtr` in `UsdPrimRange::iterator`
- Introduces a `_PtrProxy` private class to be used as the `pointer` type for `UsdPrimRange::iterator`.  This special proxy is required because `UsdPrimRange::reference` is not a true reference type and it's not safe to take the address of a temporary.
- Explicitly implement the increment, dereference, and arrow operators for `UsdPrimRange::iterator`

### Fixes Issue(s)
- #2228 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
