### PR TITLE
Replace `boost::iterator_adaptor` with explicitly specified iterator definition for `Usd_PrimData{Sibling,Subtree}Iterator`

### DIFF
--- a/pxr/usd/usd/primData.h
+++ b/pxr/usd/usd/primData.h
@@ -41,7 +41,6 @@
 #include "pxr/usd/sdf/path.h"
 
 #include <boost/range/iterator_range.hpp>
-#include <boost/iterator/iterator_adaptor.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #include <atomic>
@@ -353,31 +352,62 @@ private:
 };
 
 // Sibling iterator class.
-class Usd_PrimDataSiblingIterator : public boost::iterator_adaptor<
-    Usd_PrimDataSiblingIterator,                  // crtp.
-    Usd_PrimData *,                               // base iterator.
-    Usd_PrimData *,                               // value.
-    boost::forward_traversal_tag,                 // traversal.
-    Usd_PrimData *                                // reference.
-    >
-{
+class Usd_PrimDataSiblingIterator {
+    using _UnderylingIterator = Usd_PrimData*;
+    class _PtrProxy {
+    public:
+        Usd_PrimData** operator->() { return &_primData; }
+    private:
+        friend class Usd_PrimDataSiblingIterator;
+        explicit _PtrProxy(Usd_PrimData* primData) : _primData(primData) {}
+        Usd_PrimData* _primData = nullptr;
+    };
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Usd_PrimData*;
+    using reference = Usd_PrimData*;
+    using pointer = _PtrProxy;
+    using difference_type = std::ptrdiff_t;
+
     // Default ctor.
-    Usd_PrimDataSiblingIterator() {}
+    Usd_PrimDataSiblingIterator() = default;
+
+    reference operator*() const { return _underlyingIterator; }
+    pointer operator->() const { return pointer(_underlyingIterator); }
+
+    // pre-increment
+    Usd_PrimDataSiblingIterator& operator++() {
+        increment();
+        return *this;
+    }
+
+    // post-increment
+    Usd_PrimDataSiblingIterator operator++(int) {
+        Usd_PrimDataSiblingIterator result = *this;
+        increment();
+        return result;
+    }
+
+    bool operator==(const Usd_PrimDataSiblingIterator& other) const {
+        return _underlyingIterator == other._underlyingIterator;
+    }
+
+    bool operator!=(const Usd_PrimDataSiblingIterator& other) const {
+        return _underlyingIterator != other._underlyingIterator;
+    }
 
 private:
     friend class Usd_PrimData;
 
     // Constructor used by Prim.
-    Usd_PrimDataSiblingIterator(const base_type &i)
-        : iterator_adaptor_(i) {}
+    Usd_PrimDataSiblingIterator(const _UnderylingIterator &i)
+        : _underlyingIterator(i) {}
 
-    // Core primitives implementation.
-    friend class boost::iterator_core_access;
-    reference dereference() const { return base(); }
     void increment() {
-        base_reference() = base_reference()->GetNextSibling();
+        _underlyingIterator = _underlyingIterator->GetNextSibling();
     }
+
+    _UnderylingIterator _underlyingIterator = nullptr;
 };
 
 // Sibling range.
@@ -412,33 +442,65 @@ Usd_PrimData::_GetChildrenRange() const
 
 
 // Tree iterator class.
-class Usd_PrimDataSubtreeIterator : public boost::iterator_adaptor<
-    Usd_PrimDataSubtreeIterator,                  // crtp.
-    Usd_PrimData *,                               // base iterator.
-    Usd_PrimData *,                               // value.
-    boost::forward_traversal_tag,                 // traversal.
-    Usd_PrimData *                                // reference.
-    >
-{
+class Usd_PrimDataSubtreeIterator {
+    using _UnderlyingIterator = Usd_PrimData*;
+    class _PtrProxy {
+    public:
+        Usd_PrimData** operator->() { return &_primData; }
+    private:
+        friend class Usd_PrimDataSubtreeIterator;
+        explicit _PtrProxy(Usd_PrimData* primData) : _primData(primData) {}
+        Usd_PrimData* _primData = nullptr;
+    };
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Usd_PrimData*;
+    using reference = Usd_PrimData*;
+    using pointer = _PtrProxy;
+    using difference_type = std::ptrdiff_t;
+
     // Default ctor.
-    Usd_PrimDataSubtreeIterator() {}
+    Usd_PrimDataSubtreeIterator() = default;
+
+    reference operator*() const { return _underlyingIterator; }
+    pointer operator->() const { return pointer(_underlyingIterator); }
+
+    // pre-increment
+    Usd_PrimDataSubtreeIterator& operator++() {
+        increment();
+        return *this;
+    }
+
+    // post-increment
+    Usd_PrimDataSubtreeIterator operator++(int) {
+        Usd_PrimDataSubtreeIterator result = *this;
+        increment();
+        return result;
+    }
+
+    bool operator==(const Usd_PrimDataSubtreeIterator& other) const {
+        return _underlyingIterator == other._underlyingIterator;
+    }
+
+    bool operator!=(const Usd_PrimDataSubtreeIterator& other) const {
+        return _underlyingIterator != other._underlyingIterator;
+    }
 
 private:
     friend class Usd_PrimData;
     friend class UsdPrimSubtreeIterator;
 
     // Constructor used by Prim.
-    Usd_PrimDataSubtreeIterator(const base_type &i)
-        : iterator_adaptor_(i) {}
+    Usd_PrimDataSubtreeIterator(const _UnderlyingIterator &i)
+        : _underlyingIterator(i) {}
 
-    // Core primitives implementation.
-    friend class boost::iterator_core_access;
-    reference dereference() const { return base(); }
     void increment() {
-        base_type &b = base_reference();
-        b = b->GetFirstChild() ? b->GetFirstChild() : b->GetNextPrim();
+        _underlyingIterator = _underlyingIterator->GetFirstChild() ?
+            _underlyingIterator->GetFirstChild() :
+            _underlyingIterator->GetNextPrim();
     }
+
+    _UnderlyingIterator _underlyingIterator = nullptr;
 };
 
 // Tree range.

--- a/pxr/usd/usd/primData.h
+++ b/pxr/usd/usd/primData.h
@@ -354,26 +354,17 @@ private:
 // Sibling iterator class.
 class Usd_PrimDataSiblingIterator {
     using _UnderylingIterator = Usd_PrimData*;
-    class _PtrProxy {
-    public:
-        Usd_PrimData** operator->() { return &_primData; }
-    private:
-        friend class Usd_PrimDataSiblingIterator;
-        explicit _PtrProxy(Usd_PrimData* primData) : _primData(primData) {}
-        Usd_PrimData* _primData = nullptr;
-    };
 public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = Usd_PrimData*;
     using reference = Usd_PrimData*;
-    using pointer = _PtrProxy;
+    using pointer = void;
     using difference_type = std::ptrdiff_t;
 
     // Default ctor.
     Usd_PrimDataSiblingIterator() = default;
 
     reference operator*() const { return _underlyingIterator; }
-    pointer operator->() const { return pointer(_underlyingIterator); }
 
     // pre-increment
     Usd_PrimDataSiblingIterator& operator++() {
@@ -444,26 +435,17 @@ Usd_PrimData::_GetChildrenRange() const
 // Tree iterator class.
 class Usd_PrimDataSubtreeIterator {
     using _UnderlyingIterator = Usd_PrimData*;
-    class _PtrProxy {
-    public:
-        Usd_PrimData** operator->() { return &_primData; }
-    private:
-        friend class Usd_PrimDataSubtreeIterator;
-        explicit _PtrProxy(Usd_PrimData* primData) : _primData(primData) {}
-        Usd_PrimData* _primData = nullptr;
-    };
 public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = Usd_PrimData*;
     using reference = Usd_PrimData*;
-    using pointer = _PtrProxy;
+    using pointer = void;
     using difference_type = std::ptrdiff_t;
 
     // Default ctor.
     Usd_PrimDataSubtreeIterator() = default;
 
     reference operator*() const { return _underlyingIterator; }
-    pointer operator->() const { return pointer(_underlyingIterator); }
 
     // pre-increment
     Usd_PrimDataSubtreeIterator& operator++() {


### PR DESCRIPTION
### Description of Change(s)
- Introduces an `_UnderlyingIterator` type alias for `Usd_PrimData*` in `Usd_PrimDataSiblingIterator` and  `Usd_PrimDataSubtreeIterator`
- Elides implementing `operator->` for these internal types as it is currently not used. As the `reference` type is not a true reference, a spurious proxy class would be required to properly support `pointer` semantics.
- Explicitly implements the increment, dereference, equality and arrow operators for `Usd_PrimDataSiblingIterator` and `Usd_PrimDataSubtreeIterator`

### Fixes Issue(s)
- #2228 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
