### PR TITLE
Replace `boost::equality_comparable` with explicit implementation of `operator!=` in `pxr/usd/sdf`

### DIFF
--- a/pxr/usd/sdf/allowed.h
+++ b/pxr/usd/sdf/allowed.h
@@ -32,7 +32,6 @@
 
 #include <string>
 #include <utility>
-#include <boost/operators.hpp>
 #include <boost/optional.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -44,7 +43,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// A \c SdfAllowed either evaluates to \c true in a boolean context
 /// or evaluates to \c false and has a string annotation.
 ///
-class SdfAllowed : private boost::equality_comparable<SdfAllowed> {
+class SdfAllowed {
 private:
     typedef boost::optional<std::string> _State;
 
@@ -111,6 +110,11 @@ public:
     bool operator==(const SdfAllowed& other) const
     {
         return _state == other._state;
+    }
+
+    bool operator!=(const SdfAllowed& other) const
+    {
+        return !(*this == other);
     }
 
 private:

--- a/pxr/usd/sdf/childrenProxy.h
+++ b/pxr/usd/sdf/childrenProxy.h
@@ -35,7 +35,6 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
-#include <boost/operators.hpp>
 #include <iterator>
 #include <map>
 #include <utility>
@@ -43,7 +42,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 template <class _View>
-class SdfChildrenProxy : boost::equality_comparable<SdfChildrenProxy<_View> > {
+class SdfChildrenProxy {
 public:
     typedef _View View;
     typedef typename View::Adapter Adapter;
@@ -351,6 +350,11 @@ public:
     bool operator==(const This& other) const
     {
         return _view == other._view;
+    }
+
+    bool operator!=(const This& other) const
+    {
+        return !(*this == other);
     }
 
     /// Explicit bool conversion operator. The proxy object converts to 

--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -665,6 +665,12 @@ SdfNamespaceEdit::operator==(const SdfNamespaceEdit& rhs) const
            index       == rhs.index;
 }
 
+bool
+SdfNamespaceEdit::operator!=(const SdfNamespaceEdit& rhs) const
+{
+    return !(*this == rhs);
+}
+
 std::ostream&
 operator<<(std::ostream& s, const SdfNamespaceEdit& x)
 {
@@ -713,6 +719,12 @@ SdfNamespaceEditDetail::operator==(const SdfNamespaceEditDetail& rhs) const
     return result == rhs.result  && 
            edit   == rhs.edit    &&
            reason == rhs.reason;
+}
+
+bool
+SdfNamespaceEditDetail::operator!=(const SdfNamespaceEditDetail& other) const
+{
+    return !(*this == other);
 }
 
 std::ostream&

--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -722,9 +722,9 @@ SdfNamespaceEditDetail::operator==(const SdfNamespaceEditDetail& rhs) const
 }
 
 bool
-SdfNamespaceEditDetail::operator!=(const SdfNamespaceEditDetail& other) const
+SdfNamespaceEditDetail::operator!=(const SdfNamespaceEditDetail& rhs) const
 {
-    return !(*this == other);
+    return !(*this == rhs);
 }
 
 std::ostream&

--- a/pxr/usd/sdf/namespaceEdit.h
+++ b/pxr/usd/sdf/namespaceEdit.h
@@ -30,8 +30,6 @@
 #include "pxr/usd/sdf/api.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/operators.hpp>
-
 #include <functional>
 #include <iosfwd>
 #include <string>
@@ -44,8 +42,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// A single namespace edit.  It supports renaming, reparenting, reparenting
 /// with a rename, reordering, and removal.
 ///
-struct SdfNamespaceEdit :
-    boost::equality_comparable<SdfNamespaceEdit> {
+struct SdfNamespaceEdit {
 public:
     typedef SdfNamespaceEdit This;
     typedef SdfPath Path;
@@ -114,6 +111,7 @@ public:
     }
 
     SDF_API bool operator==(const This& rhs) const;
+    SDF_API bool operator!=(const This& rhs) const;
 
 public:
     Path currentPath;   ///< Path of the object when this edit starts.
@@ -131,8 +129,7 @@ SDF_API std::ostream& operator<<(std::ostream&, const SdfNamespaceEditVector&);
 ///
 /// Detailed information about a namespace edit.
 ///
-struct SdfNamespaceEditDetail :
-    boost::equality_comparable<SdfNamespaceEditDetail> {
+struct SdfNamespaceEditDetail {
 public:
     /// Validity of an edit.
     enum Result {
@@ -146,6 +143,7 @@ public:
                            const std::string& reason);
 
     SDF_API bool operator==(const SdfNamespaceEditDetail& rhs) const;
+    SDF_API bool operator!=(const SdfNamespaceEditDetail& other) const;
 
 public:
     Result result;          ///< Validity.

--- a/pxr/usd/sdf/namespaceEdit.h
+++ b/pxr/usd/sdf/namespaceEdit.h
@@ -143,7 +143,7 @@ public:
                            const std::string& reason);
 
     SDF_API bool operator==(const SdfNamespaceEditDetail& rhs) const;
-    SDF_API bool operator!=(const SdfNamespaceEditDetail& other) const;
+    SDF_API bool operator!=(const SdfNamespaceEditDetail& rhs) const;
 
 public:
     Result result;          ///< Validity.

--- a/pxr/usd/sdf/testenv/testSdfBatchNamespaceEdit.py
+++ b/pxr/usd/sdf/testenv/testSdfBatchNamespaceEdit.py
@@ -31,6 +31,47 @@ verbose = False
 #verbose = True
 
 class TestSdfBatchNamespaceEdit(unittest.TestCase):
+    def test_EqualityOperators(self):
+        self.assertTrue(Sdf.NamespaceEdit('/A', '/B') == Sdf.NamespaceEdit('/A', '/B'))
+        self.assertFalse(Sdf.NamespaceEdit('/A', '/B') != Sdf.NamespaceEdit('/A', '/B'))
+        self.assertFalse(Sdf.NamespaceEdit('/B', '/A') == Sdf.NamespaceEdit('/A', '/B'))
+        self.assertTrue(Sdf.NamespaceEdit('/B', '/A') != Sdf.NamespaceEdit('/A', '/B'))
+
+        # Validate the equality operators by varying a single field from a prototype edit
+        # at a time
+        prototype = Sdf.NamespaceEditDetail(
+            Sdf.NamespaceEditDetail.Okay,
+            Sdf.NamespaceEdit('/A', '/B'),
+            "reason"
+        )
+        self.assertTrue(prototype == prototype)
+        self.assertFalse(prototype != prototype)
+        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
+            Sdf.NamespaceEditDetail.Unbatched,
+            prototype.edit,
+            prototype.reason))
+        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
+            Sdf.NamespaceEditDetail.Unbatched,
+            prototype.edit,
+            prototype.reason))
+        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
+            prototype.result,
+            Sdf.NamespaceEdit('/C', '/D'),
+            prototype.reason))
+        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
+            prototype.result,
+            Sdf.NamespaceEdit('/C', '/D'),
+            prototype.reason))
+        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
+            prototype.result,
+            prototype.edit,
+            "a different reason"))
+        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
+            prototype.result,
+            prototype.edit,
+            "a different reason"))
+
+
     def test_Basic(self):
         print('Test constructors')
 

--- a/pxr/usd/sdf/testenv/testSdfBatchNamespaceEdit.py
+++ b/pxr/usd/sdf/testenv/testSdfBatchNamespaceEdit.py
@@ -32,10 +32,8 @@ verbose = False
 
 class TestSdfBatchNamespaceEdit(unittest.TestCase):
     def test_EqualityOperators(self):
-        self.assertTrue(Sdf.NamespaceEdit('/A', '/B') == Sdf.NamespaceEdit('/A', '/B'))
-        self.assertFalse(Sdf.NamespaceEdit('/A', '/B') != Sdf.NamespaceEdit('/A', '/B'))
-        self.assertFalse(Sdf.NamespaceEdit('/B', '/A') == Sdf.NamespaceEdit('/A', '/B'))
-        self.assertTrue(Sdf.NamespaceEdit('/B', '/A') != Sdf.NamespaceEdit('/A', '/B'))
+        self.assertEqual(Sdf.NamespaceEdit('/A', '/B'), Sdf.NamespaceEdit('/A', '/B'))
+        self.assertNotEqual(Sdf.NamespaceEdit('/B', '/A'), Sdf.NamespaceEdit('/A', '/B'))
 
         # Validate the equality operators by varying a single field from a prototype edit
         # at a time
@@ -44,29 +42,19 @@ class TestSdfBatchNamespaceEdit(unittest.TestCase):
             Sdf.NamespaceEdit('/A', '/B'),
             "reason"
         )
-        self.assertTrue(prototype == prototype)
-        self.assertFalse(prototype != prototype)
-        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
+        self.assertEqual(prototype, Sdf.NamespaceEditDetail(
+            prototype.result,
+            prototype.edit,
+            prototype.reason))
+        self.assertNotEqual(prototype, Sdf.NamespaceEditDetail(
             Sdf.NamespaceEditDetail.Unbatched,
             prototype.edit,
             prototype.reason))
-        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
-            Sdf.NamespaceEditDetail.Unbatched,
-            prototype.edit,
-            prototype.reason))
-        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
+        self.assertNotEqual(prototype, Sdf.NamespaceEditDetail(
             prototype.result,
             Sdf.NamespaceEdit('/C', '/D'),
             prototype.reason))
-        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
-            prototype.result,
-            Sdf.NamespaceEdit('/C', '/D'),
-            prototype.reason))
-        self.assertTrue(prototype != Sdf.NamespaceEditDetail(
-            prototype.result,
-            prototype.edit,
-            "a different reason"))
-        self.assertFalse(prototype == Sdf.NamespaceEditDetail(
+        self.assertNotEqual(prototype, Sdf.NamespaceEditDetail(
             prototype.result,
             prototype.edit,
             "a different reason"))

--- a/pxr/usd/sdf/testenv/testSdfTypes.py
+++ b/pxr/usd/sdf/testenv/testSdfTypes.py
@@ -382,14 +382,10 @@ class TestSdfTypes(unittest.TestCase):
         self.assertEqual(hash(Sdf.ValueTypeNames.Point3d), hash(Sdf.ValueTypeNames.Point3d))
 
     def test_UnregisteredValueEquality(self):
-        self.assertTrue(Sdf.UnregisteredValue(str(5)) ==
-                        Sdf.UnregisteredValue(str(5)))
-        self.assertFalse(Sdf.UnregisteredValue(str(5)) !=
+        self.assertEqual(Sdf.UnregisteredValue(str(5)),
                          Sdf.UnregisteredValue(str(5)))
-        self.assertTrue(Sdf.UnregisteredValue(str(5)) !=
-                        Sdf.UnregisteredValue(str(6)))
-        self.assertFalse(Sdf.UnregisteredValue(str(5)) ==
-                         Sdf.UnregisteredValue(str(6)))
+        self.assertNotEqual(Sdf.UnregisteredValue(str(5)),
+                            Sdf.UnregisteredValue(str(6)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/testenv/testSdfTypes.py
+++ b/pxr/usd/sdf/testenv/testSdfTypes.py
@@ -380,6 +380,16 @@ class TestSdfTypes(unittest.TestCase):
 
     def test_Hash(self):
         self.assertEqual(hash(Sdf.ValueTypeNames.Point3d), hash(Sdf.ValueTypeNames.Point3d))
-   
+
+    def test_UnregisteredValueEquality(self):
+        self.assertTrue(Sdf.UnregisteredValue(str(5)) ==
+                        Sdf.UnregisteredValue(str(5)))
+        self.assertFalse(Sdf.UnregisteredValue(str(5)) !=
+                         Sdf.UnregisteredValue(str(5)))
+        self.assertTrue(Sdf.UnregisteredValue(str(5)) !=
+                        Sdf.UnregisteredValue(str(6)))
+        self.assertFalse(Sdf.UnregisteredValue(str(5)) ==
+                         Sdf.UnregisteredValue(str(6)))
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -756,6 +756,11 @@ bool SdfUnregisteredValue::operator==(const SdfUnregisteredValue &other) const
     return _value == other._value;
 }
 
+bool SdfUnregisteredValue::operator!=(const SdfUnregisteredValue &other) const
+{
+    return !(*this == other);
+}
+
 std::ostream &operator << (std::ostream &out, const SdfUnregisteredValue &value)
 {
     return out << value.GetValue();

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -484,8 +484,7 @@ std::ostream &VtStreamOut(const SdfVariantSelectionMap &, std::ostream &);
 /// well as limited inspection and editing capabilities (e.g., moving
 /// this data to a different spec or field) even when the data type
 /// of the value isn't known.
-class SdfUnregisteredValue : 
-    public boost::equality_comparable<SdfUnregisteredValue>
+class SdfUnregisteredValue
 {
 public:
     /// Wraps an empty VtValue
@@ -512,6 +511,9 @@ public:
 
     /// Returns true if the wrapped VtValues are equal
     SDF_API bool operator==(const SdfUnregisteredValue &other) const;
+
+    /// Returns true if the wrapped VtValues are not equal
+    SDF_API bool operator!=(const SdfUnregisteredValue &other) const;
 
 private:
     VtValue _value;


### PR DESCRIPTION
### Description of Change(s)
- Adds explicit implementation of `operator!=` to `SdfAllowed`, `SdfChildrenProxy`, `SdfNamespaceEdit`, `SdfNamespaceEditDetail`, and `SdfUnregisteredValue`
- Equality operator test coverage has been extended to `Sdf.NamespaceEdit`, `Sdf.NamespaceEditDetail`, and `Sdf.UnregisteredValue`.

### Fixes Issue(s)
- #2236 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
