### PR TITLE
Add support for long Windows paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .p4*
 .DS_Store
 .AppleDouble
-
+.idea

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -24,6 +24,7 @@
 #include <filesystem>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include <fcntl.h>
 #include <sys/types.h>
@@ -49,10 +50,17 @@ using std::set;
 
 #if defined (ARCH_OS_WINDOWS)
 namespace {
+
+const std::string LONG_PATH_PREFIX = "\\\\?\\";
+const std::wstring LONG_PATH_PREFIX_W = L"\\\\?\\";
+const std::string UNC_LONG_PATH_PREFIX = LONG_PATH_PREFIX + "UNC\\";
+const std::wstring UNC_LONG_PATH_PREFIX_W = LONG_PATH_PREFIX_W + L"UNC\\";
+
 static inline HANDLE _FileToWinHANDLE(FILE *file)
 {
     return reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(file)));
 }
+
 }
 #endif // ARCH_OS_WINDOWS
 
@@ -95,9 +103,11 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
         return nullptr;
     }
 
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+
     // Call CreateFileW.
     HANDLE hfile = CreateFileW(
-        ArchWindowsUtf8ToUtf16(fileName).c_str(),
+        apiPath.c_str(),
         desiredAccess,
         shareMode,
         /* securityAttributes=*/nullptr,
@@ -133,10 +143,20 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
 #endif
 }
 
+int ArchUnlinkFile(const char* path) {
+#if defined(ARCH_OS_WINDOWS)
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    return _wunlink(apiPath.c_str());
+#else
+    return unlink(path);
+#endif
+}
+
 #if defined(ARCH_OS_WINDOWS)
 int ArchRmDir(const char* path)
 {
-    return RemoveDirectoryW(ArchWindowsUtf8ToUtf16(path).c_str()) ? 0 : -1;
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    return RemoveDirectoryW(apiPath.c_str()) ? 0 : -1;
 }
 #endif
 
@@ -166,7 +186,8 @@ ArchGetModificationTime(const char* pathname, double* time)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    if (_wstat64(ArchWindowsUtf8ToUtf16(pathname).c_str(), &st) == 0)
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    if (_wstat64(apiPath.c_str(), &st) == 0)
 #else
     if (stat(pathname, &st) == 0)
 #endif
@@ -389,12 +410,20 @@ ArchAbsPath(const string& path)
     }
 
 #if defined(ARCH_OS_WINDOWS)
-    // @TODO support 32,767 long paths on windows by prepending "\\?\" to the
     // path
-    wchar_t buffer[ARCH_PATH_MAX];
-    if (GetFullPathNameW(ArchWindowsUtf8ToUtf16(path).c_str(),
-                         ARCH_PATH_MAX, buffer, nullptr)) {
-        return ArchWindowsUtf16ToUtf8(buffer);
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    std::vector<wchar_t> buffer(ARCH_PATH_MAX, 0);
+    auto requiredBufferSize = GetFullPathNameW(apiPath.c_str(), buffer.size(), buffer.data(), nullptr);
+    if (requiredBufferSize > buffer.size()) {
+        buffer.resize(requiredBufferSize, 0);
+        requiredBufferSize = GetFullPathNameW(apiPath.c_str(), buffer.size(), buffer.data(), nullptr);
+    }
+    if (requiredBufferSize > 0) {
+        std::string result = ArchWindowsUtf16ToUtf8(buffer.data());
+        if (result.find(LONG_PATH_PREFIX) == 0)
+            return result.substr(LONG_PATH_PREFIX.size());
+        else
+            return result; // implicit conversion through std::wstring
     }
     else {
         return path;
@@ -419,7 +448,8 @@ ArchGetStatMode(const char *pathname, int *mode)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    if (__stat64(pathname, &st) == 0) {
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    if (_wstat64(apiPath.c_str(), &st) == 0) {
 #else
     if (stat(pathname, &st) == 0) {
 #endif
@@ -497,10 +527,11 @@ ArchGetFileLength(const char* fileName)
 #elif defined (ARCH_OS_WINDOWS)
     // Open a handle with 0 as the desired access and full sharing.
     // This opens the file even if exclusively locked.
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
     HANDLE handle =
-        CreateFileW(ArchWindowsUtf8ToUtf16(fileName).c_str(), 0,
+        CreateFileW(apiPath.c_str(), 0,
                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                   nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+                    nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (handle) {
         const auto result = _GetFileLength(handle);
         CloseHandle(handle);
@@ -638,21 +669,27 @@ MakeUnique(
 
 #endif
 
+namespace {
+
+constexpr const char* TMPDIR_FMT = "%s" ARCH_PATH_SEP "%s.XXXXXX";
+
+} // namespace
+
 int
 ArchMakeTmpFile(const std::string& tmpdir,
                 const std::string& prefix, std::string* pathname)
 {
     // Format the template.
-    std::string sTemplate =
-        ArchStringPrintf("%s/%s.XXXXXX", tmpdir.c_str(), prefix.c_str());
+    std::string sTemplate = ArchStringPrintf(TMPDIR_FMT, tmpdir.c_str(), prefix.c_str());
 
 #if defined(ARCH_OS_WINDOWS)
     int fd = -1;
     auto cTemplate =
         MakeUnique(sTemplate, [&fd](const char* name){
-                    _wsopen_s(&fd, ArchWindowsUtf8ToUtf16(name).c_str(),
-                              _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
-                              _SH_DENYNO, _S_IREAD | _S_IWRITE);
+            const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            _wsopen_s(&fd, apiPath.c_str(),
+          _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
+          _SH_DENYNO, _S_IREAD | _S_IWRITE);
             return fd != -1;
         });
 #else
@@ -688,13 +725,13 @@ ArchMakeTmpSubdir(const std::string& tmpdir,
 
     // Format the template.
     std::string sTemplate =
-        ArchStringPrintf("%s/%s.XXXXXX", tmpdir.c_str(), prefix.c_str());
+        ArchStringPrintf(TMPDIR_FMT, tmpdir.c_str(), prefix.c_str());
 
 #if defined(ARCH_OS_WINDOWS)
     retstr =
         MakeUnique(sTemplate, [](const char* name){
-            return CreateDirectoryW(
-                ArchWindowsUtf8ToUtf16(name).c_str(), NULL) != FALSE;
+            const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            return (CreateDirectoryW(apiPath.c_str(), NULL) != 0);
         });
 #else
     // Copy template to a writable buffer.
@@ -722,11 +759,15 @@ void
 Arch_InitTmpDir()
 {
 #if defined(ARCH_OS_WINDOWS)
-    wchar_t tmpPath[MAX_PATH];
+    std::vector<wchar_t> tmpPath(ARCH_PATH_MAX, 0);
 
     // On Windows, let GetTempPath use the standard env vars, not our own.
-    int sizeOfPath = GetTempPathW(MAX_PATH - 1, tmpPath);
-    if (sizeOfPath > MAX_PATH || sizeOfPath == 0) {
+    int sizeOfPath = GetTempPathW(tmpPath.size() - 1, tmpPath.data());
+    if (sizeOfPath > tmpPath.size()) {
+        tmpPath.resize(sizeOfPath, 0);
+        sizeOfPath = GetTempPathW(tmpPath.size() - 1, tmpPath.data());
+    }
+    if (sizeOfPath > tmpPath.size() || sizeOfPath == 0) {
         ARCH_ERROR("Call to GetTempPath failed.");
         _TmpDir = ".";
         return;
@@ -734,7 +775,7 @@ Arch_InitTmpDir()
 
     // Strip the trailing slash
     tmpPath[sizeOfPath-1] = 0;
-    _TmpDir = _strdup(ArchWindowsUtf16ToUtf8(tmpPath).c_str());
+    _TmpDir = _strdup(ArchWindowsUtf16ToUtf8(tmpPath.data()).c_str());
 #else
     const std::string tmpdir = ArchGetEnv("TMPDIR");
     if (!tmpdir.empty()) {
@@ -1097,9 +1138,9 @@ static int Arch_FileAccessError()
 int ArchFileAccess(const char* path, int mode)
 {
     // Simple existence check is handled specially.
-    std::wstring wpath{ ArchWindowsUtf8ToUtf16(path) };
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     if (mode == F_OK) {
-        return (GetFileAttributesW(wpath.c_str()) != INVALID_FILE_ATTRIBUTES)
+        return (GetFileAttributesW(apiPath.c_str()) != INVALID_FILE_ATTRIBUTES)
                 ? 0 : Arch_FileAccessError();
     }
 
@@ -1109,7 +1150,7 @@ int ArchFileAccess(const char* path, int mode)
 
     // Get the SECURITY_DESCRIPTOR size.
     DWORD length = 0;
-    if (!GetFileSecurityW(wpath.c_str(), securityInfo, NULL, 0, &length)) {
+    if (!GetFileSecurityW(apiPath.c_str(), securityInfo, NULL, 0, &length)) {
         if (GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
             return Arch_FileAccessError();
         }
@@ -1119,7 +1160,7 @@ int ArchFileAccess(const char* path, int mode)
     std::unique_ptr<unsigned char[]> buffer(new unsigned char[length]);
     PSECURITY_DESCRIPTOR security = (PSECURITY_DESCRIPTOR)buffer.get();
     if (!GetFileSecurityW(
-            wpath.c_str(), securityInfo, security, length, &length)) {
+            apiPath.c_str(), securityInfo, security, length, &length)) {
         return Arch_FileAccessError();
     }
 
@@ -1211,9 +1252,10 @@ typedef struct _REPARSE_DATA_BUFFER {
 
 std::string ArchReadLink(const char* path)
 {
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     HANDLE handle = ::CreateFileW(
-        ArchWindowsUtf8ToUtf16(path).c_str(), GENERIC_READ, FILE_SHARE_READ,
-        NULL, OPEN_EXISTING,
+            apiPath.c_str(), GENERIC_READ, FILE_SHARE_READ,
+            NULL, OPEN_EXISTING,
         FILE_FLAG_OPEN_REPARSE_POINT |
         FILE_FLAG_BACKUP_SEMANTICS, NULL);
 
@@ -1376,5 +1418,36 @@ void ArchFileAdvise(
     }
 #endif
 }
+
+#if defined(ARCH_OS_WINDOWS)
+
+ARCH_API
+std::wstring ArchHandleLongWindowsPaths(const std::wstring& path)
+{
+    // Subtracting 12 (8.3) so this function also works for CreateDirectoryW:
+    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
+    // ARCH_PATH_MAX counts the null terminator as well
+    if (path.size() >= ARCH_PATH_MAX - 12 - 1) {
+        std::wstring longPath = path;
+
+        // the \\?\ prefix requires strict backslash separators:
+        // see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+        std::replace(std::begin(longPath), std::end(longPath), L'/', L'\\');
+
+        // prevent duplicate prefixing
+        if (longPath.find(LONG_PATH_PREFIX_W) != 0) {
+            // if it still starts with two backslashes, it is a network path
+            if (longPath[0] == L'\\' && longPath[1] == L'\\') {
+                return UNC_LONG_PATH_PREFIX_W + longPath.substr(2);
+            } else {
+                return LONG_PATH_PREFIX_W + longPath;
+            }
+        }
+    }
+
+    return path;
+}
+
+#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -92,6 +92,14 @@ std::wstring _ArchHandleLongWindowsPaths(const std::wstring& path)
     return path;
 }
 
+/// convenience wrapper for the above
+/// Expects a non-null UTF-8 string pointer.
+std::wstring _ArchHandleLongWindowsPaths(const char* path) {
+    if (path == nullptr)
+        return {};
+    return _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+}
+
 }
 #endif // ARCH_OS_WINDOWS
 
@@ -134,7 +142,7 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
         return nullptr;
     }
 
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(fileName);
 
     // Call CreateFileW.
     HANDLE hfile = CreateFileW(
@@ -176,7 +184,7 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
 
 bool ArchTouchFile(const std::string& fileName, bool create) {
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(fileName.c_str());
 #endif
 
     if (create) {
@@ -220,7 +228,7 @@ bool ArchTouchFile(const std::string& fileName, bool create) {
 
 int ArchUnlinkFile(const char* path) {
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(path);
     return _wunlink(apiPath.c_str());
 #else
     return unlink(path);
@@ -230,7 +238,7 @@ int ArchUnlinkFile(const char* path) {
 #if defined(ARCH_OS_WINDOWS)
 int ArchRmDir(const char* path)
 {
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(path);
     return RemoveDirectoryW(apiPath.c_str()) ? 0 : -1;
 }
 #endif
@@ -261,7 +269,7 @@ ArchGetModificationTime(const char* pathname, double* time)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(pathname);
     if (_wstat64(apiPath.c_str(), &st) == 0)
 #else
     if (stat(pathname, &st) == 0)
@@ -486,7 +494,7 @@ ArchAbsPath(const string& path)
 
 #if defined(ARCH_OS_WINDOWS)
     // path
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(path.c_str());
     std::vector<wchar_t> buffer(ARCH_PATH_MAX, 0);
     auto requiredBufferSize = GetFullPathNameW(apiPath.c_str(), buffer.size(), buffer.data(), nullptr);
     if (requiredBufferSize > buffer.size()) {
@@ -523,7 +531,7 @@ ArchGetStatMode(const char *pathname, int *mode)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(pathname);
     if (_wstat64(apiPath.c_str(), &st) == 0) {
 #else
     if (stat(pathname, &st) == 0) {
@@ -602,7 +610,7 @@ ArchGetFileLength(const char* fileName)
 #elif defined (ARCH_OS_WINDOWS)
     // Open a handle with 0 as the desired access and full sharing.
     // This opens the file even if exclusively locked.
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(fileName);
     HANDLE handle =
         CreateFileW(apiPath.c_str(), 0,
                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -761,7 +769,7 @@ ArchMakeTmpFile(const std::string& tmpdir,
     int fd = -1;
     auto cTemplate =
         MakeUnique(sTemplate, [&fd](const char* name){
-            const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            const std::wstring apiPath = _ArchHandleLongWindowsPaths(name);
             _wsopen_s(&fd, apiPath.c_str(),
           _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
           _SH_DENYNO, _S_IREAD | _S_IWRITE);
@@ -805,7 +813,7 @@ ArchMakeTmpSubdir(const std::string& tmpdir,
 #if defined(ARCH_OS_WINDOWS)
     retstr =
         MakeUnique(sTemplate, [](const char* name){
-            const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            const std::wstring apiPath = _ArchHandleLongWindowsPaths(name);
             return (CreateDirectoryW(apiPath.c_str(), NULL) != 0);
         });
 #else
@@ -1213,7 +1221,7 @@ static int Arch_FileAccessError()
 int ArchFileAccess(const char* path, int mode)
 {
     // Simple existence check is handled specially.
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(path);
     if (mode == F_OK) {
         return (GetFileAttributesW(apiPath.c_str()) != INVALID_FILE_ATTRIBUTES)
                 ? 0 : Arch_FileAccessError();
@@ -1327,7 +1335,7 @@ typedef struct _REPARSE_DATA_BUFFER {
 
 std::string ArchReadLink(const char* path)
 {
-    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(path);
     HANDLE handle = ::CreateFileW(
             apiPath.c_str(), GENERIC_READ, FILE_SHARE_READ,
             NULL, OPEN_EXISTING,

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -49,14 +49,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 using std::pair;
 using std::string;
+using std::basic_string;
 using std::set;
 
 namespace { // Helpers for ArchNormPath.
 
 enum TokenType { Dot, DotDot, Elem };
 
-typedef pair<string::const_iterator, string::const_iterator> Token;
-typedef pair<string::reverse_iterator, string::reverse_iterator> RToken;
+template<typename C>
+using Token = pair<typename basic_string<C>::const_iterator, typename basic_string<C>::const_iterator>;
+template<typename C>
+using RToken = pair<typename basic_string<C>::reverse_iterator, typename basic_string<C>::reverse_iterator>;
 
 template <class Iter>
 inline pair<Iter, Iter>
@@ -81,8 +84,9 @@ _GetTokenType(pair<Iter, Iter> t) {
     return Elem;
 }
 
-string
-_NormPath(string const &inPath)
+template<typename C>
+basic_string<C>
+_NormPath(basic_string<C> const &inPath)
 {
     // We take one pass through the string, transforming it into a normalized
     // path in-place.  This works since the normalized path never grows, except
@@ -128,10 +132,10 @@ _NormPath(string const &inPath)
     // and deep copy so we want to avoid that in the common case where the input
     // path is already normalized.
 
-    string path(inPath);
+    basic_string<C> path(inPath);
 
     // Find the first path token.
-    Token t = _NextToken(inPath.begin(), inPath.end());
+    Token<C> t = _NextToken(inPath.begin(), inPath.end());
 
     // Allow zero, one, or two leading slashes, per POSIX.  Three or more get
     // collapsed to one.
@@ -168,12 +172,12 @@ _NormPath(string const &inPath)
         case DotDot: {
             // Here we are very likely to be modifying the string, so we use
             // non-const iterators and mutate.
-            string::reverse_iterator
+            typename basic_string<C>::reverse_iterator
                 rstart(path.begin() + firstWriteIdx),
                 rwrite(path.begin() + writeIdx);
             // Find the last token of the output by finding the next token in
             // reverse.
-            RToken backToken = _NextToken(rwrite, rstart);
+            RToken<C> backToken = _NextToken(rwrite, rstart);
             // If there are no more Elems to consume with DotDots and this is a
             // relative path, or this token is already a DotDot, then copy it to
             // the output.
@@ -205,7 +209,7 @@ _NormPath(string const &inPath)
 
     // If the resulting path is empty, return "."
     if (path.empty())
-        path.assign(".");
+        path.assign(1, '.');
 
     return path;
 }

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -236,7 +236,8 @@ std::wstring _ArchHandleLongWindowsPaths(const std::wstring& path)
     // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
     // ARCH_PATH_MAX counts the null terminator as well
     if (path.size() >= ARCH_PATH_MAX - 12 - 1) {
-        std::wstring longPath = path;
+        // the \\?\ prefix requires removal of any dotdot and dot, need to normalize
+        std::wstring longPath = _NormPath(path);
 
         // the \\?\ prefix requires strict backslash separators:
         // see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -51,6 +51,166 @@ using std::pair;
 using std::string;
 using std::set;
 
+namespace { // Helpers for ArchNormPath.
+
+enum TokenType { Dot, DotDot, Elem };
+
+typedef pair<string::const_iterator, string::const_iterator> Token;
+typedef pair<string::reverse_iterator, string::reverse_iterator> RToken;
+
+template <class Iter>
+inline pair<Iter, Iter>
+_NextToken(Iter i, Iter end)
+{
+    pair<Iter, Iter> t;
+    for (t.first = i;
+         t.first != end && *t.first == '/'; ++t.first) {}
+    for (t.second = t.first;
+         t.second != end && *t.second != '/'; ++t.second) {}
+    return t;
+}
+
+template <class Iter>
+inline TokenType
+_GetTokenType(pair<Iter, Iter> t) {
+    size_t len = distance(t.first, t.second);
+    if (len == 1 && t.first[0] == '.')
+        return Dot;
+    if (len == 2 && t.first[0] == '.' && t.first[1] == '.')
+        return DotDot;
+    return Elem;
+}
+
+string
+_NormPath(string const &inPath)
+{
+    // We take one pass through the string, transforming it into a normalized
+    // path in-place.  This works since the normalized path never grows, except
+    // in the trivial case of '' -> '.'.  In all other cases, every
+    // transformation we make either shrinks the string or maintains its size.
+    //
+    // We track a current 'write' iterator, indicating the end of the normalized
+    // path we've built so far and a current token 't', the next slash-delimited
+    // path element we will process.  For example, let's walk through the steps
+    // we take to normalize the input '/foo/../bar' to produce '/bar'.  To
+    // start, the state looks like the following, with the write iterator past
+    // any leading slashes, and 't' at the first path token.
+    //
+    // /foo/../bar
+    //  w            <------ 'write' iterator
+    //  [  ]         <------ next token 't'
+    //
+    // We look at the token 't' to determine its type: one of DotDot, Dot, or
+    // Elem.  In this case, it's a regular path Elem 'foo' so we simply copy it
+    // to the 'write' iterator and advance 't' to the next token.  Then the
+    // state looks like:
+    //
+    // /foo/../bar
+    //      w
+    //      [ ]
+    //
+    // Now 't' is a DotDot token '..', so we remove the last path element in the
+    // normalized result by scanning backwards from 'w' resetting 'w' to that
+    // location to effectively remove the element, then advance 't' to the next
+    // token.  Now the state looks like:
+    //
+    // /foo/../bar
+    //  w      [  ]
+    //
+    // The final token is the regular path Elem 'bar' so we copy it and trim the
+    // string to produce the final result '/bar'.
+    //
+
+    // This code is fairly optimized for libstdc++'s copy-on-write string.  It
+    // takes a copy of 'inPath' to start (refcount bump) but it avoids doing any
+    // mutating operation on 'path' until it actually has to.  Doing a mutating
+    // operation (even grabbing a non-const iterator) will pay for the malloc
+    // and deep copy so we want to avoid that in the common case where the input
+    // path is already normalized.
+
+    string path(inPath);
+
+    // Find the first path token.
+    Token t = _NextToken(inPath.begin(), inPath.end());
+
+    // Allow zero, one, or two leading slashes, per POSIX.  Three or more get
+    // collapsed to one.
+    const size_t numLeadingSlashes = distance(inPath.begin(), t.first);
+    size_t writeIdx = numLeadingSlashes >= 3 ? 1 : numLeadingSlashes;
+
+    // Save a reverse iterator at where we start the output, we'll use this when
+    // scanning backward to handle DotDot tokens.
+    size_t firstWriteIdx = writeIdx;
+
+    // Now walk through the string, copying tokens, looking for slashes and dots
+    // to handle.
+    for (; t.first != inPath.end(); t = _NextToken(t.second, inPath.end())) {
+        switch (_GetTokenType(t)) {
+        case Elem:
+            // Copy the elem.  We avoid mutating 'path' if we've made no changes
+            // to the output yet, which is true if the write head is in the same
+            // place in the output as it is in the input.
+            if (inPath.begin() + writeIdx == t.first) {
+                writeIdx += distance(t.first, t.second);
+                t.first = t.second;
+                if (writeIdx != path.size())
+                    ++writeIdx;
+            } else {
+                while (t.first != t.second)
+                    path[writeIdx++] = *t.first++;
+                if (writeIdx != path.size())
+                    path[writeIdx++] = '/';
+            }
+            break;
+        case Dot:
+            // Do nothing, Dots are simply ignored.
+            break;
+        case DotDot: {
+            // Here we are very likely to be modifying the string, so we use
+            // non-const iterators and mutate.
+            string::reverse_iterator
+                rstart(path.begin() + firstWriteIdx),
+                rwrite(path.begin() + writeIdx);
+            // Find the last token of the output by finding the next token in
+            // reverse.
+            RToken backToken = _NextToken(rwrite, rstart);
+            // If there are no more Elems to consume with DotDots and this is a
+            // relative path, or this token is already a DotDot, then copy it to
+            // the output.
+            if ((rstart == path.rend() && backToken.first == rstart) ||
+                _GetTokenType(backToken) == DotDot) {
+                path[writeIdx++] = '.';
+                path[writeIdx++] = '.';
+                if (writeIdx != path.size())
+                    path[writeIdx++] = '/';
+            } else if (backToken.first != rstart) {
+                // Otherwise, consume the last elem by moving writeIdx back to
+                // before the elem.
+                writeIdx = distance(path.begin(), backToken.second.base());
+            }
+        }
+            break;
+        };
+    }
+
+    // Remove a trailing slash if we wrote one.  We're careful to use const
+    // iterators here to avoid incurring a string copy if it's not necessary (in
+    // the case of libstdc++'s copy-on-write basic_string)
+    if (writeIdx > firstWriteIdx && path.cbegin()[writeIdx-1] == '/')
+        --writeIdx;
+
+    // Trim the string to length if necessary.
+    if (writeIdx != path.size())
+        path.erase(writeIdx);
+
+    // If the resulting path is empty, return "."
+    if (path.empty())
+        path.assign(".");
+
+    return path;
+}
+} // anon
+
 #if defined (ARCH_OS_WINDOWS)
 namespace {
 
@@ -295,166 +455,6 @@ ArchGetModificationTime(const ArchStatType& st)
 #error Unknown system architecture
 #endif
 }
-
-namespace { // Helpers for ArchNormPath.
-
-enum TokenType { Dot, DotDot, Elem };
-
-typedef pair<string::const_iterator, string::const_iterator> Token;
-typedef pair<string::reverse_iterator, string::reverse_iterator> RToken;
-
-template <class Iter>
-inline pair<Iter, Iter>
-_NextToken(Iter i, Iter end)
-{
-    pair<Iter, Iter> t;
-    for (t.first = i;
-         t.first != end && *t.first == '/'; ++t.first) {}
-    for (t.second = t.first;
-         t.second != end && *t.second != '/'; ++t.second) {}
-    return t;
-}
-
-template <class Iter>
-inline TokenType
-_GetTokenType(pair<Iter, Iter> t) {
-    size_t len = distance(t.first, t.second);
-    if (len == 1 && t.first[0] == '.')
-        return Dot;
-    if (len == 2 && t.first[0] == '.' && t.first[1] == '.')
-        return DotDot;
-    return Elem;
-}
-
-string
-_NormPath(string const &inPath)
-{
-    // We take one pass through the string, transforming it into a normalized
-    // path in-place.  This works since the normalized path never grows, except
-    // in the trivial case of '' -> '.'.  In all other cases, every
-    // transformation we make either shrinks the string or maintains its size.
-    //
-    // We track a current 'write' iterator, indicating the end of the normalized
-    // path we've built so far and a current token 't', the next slash-delimited
-    // path element we will process.  For example, let's walk through the steps
-    // we take to normalize the input '/foo/../bar' to produce '/bar'.  To
-    // start, the state looks like the following, with the write iterator past
-    // any leading slashes, and 't' at the first path token.
-    //
-    // /foo/../bar
-    //  w            <------ 'write' iterator
-    //  [  ]         <------ next token 't'
-    //
-    // We look at the token 't' to determine its type: one of DotDot, Dot, or
-    // Elem.  In this case, it's a regular path Elem 'foo' so we simply copy it
-    // to the 'write' iterator and advance 't' to the next token.  Then the
-    // state looks like:
-    //
-    // /foo/../bar
-    //      w
-    //      [ ]
-    //
-    // Now 't' is a DotDot token '..', so we remove the last path element in the
-    // normalized result by scanning backwards from 'w' resetting 'w' to that
-    // location to effectively remove the element, then advance 't' to the next
-    // token.  Now the state looks like:
-    //
-    // /foo/../bar
-    //  w      [  ]
-    // 
-    // The final token is the regular path Elem 'bar' so we copy it and trim the
-    // string to produce the final result '/bar'.
-    //
-
-    // This code is fairly optimized for libstdc++'s copy-on-write string.  It
-    // takes a copy of 'inPath' to start (refcount bump) but it avoids doing any
-    // mutating operation on 'path' until it actually has to.  Doing a mutating
-    // operation (even grabbing a non-const iterator) will pay for the malloc
-    // and deep copy so we want to avoid that in the common case where the input
-    // path is already normalized.
-
-    string path(inPath);
-
-    // Find the first path token.
-    Token t = _NextToken(inPath.begin(), inPath.end());
-
-    // Allow zero, one, or two leading slashes, per POSIX.  Three or more get
-    // collapsed to one.
-    const size_t numLeadingSlashes = distance(inPath.begin(), t.first);
-    size_t writeIdx = numLeadingSlashes >= 3 ? 1 : numLeadingSlashes;
-
-    // Save a reverse iterator at where we start the output, we'll use this when
-    // scanning backward to handle DotDot tokens.
-    size_t firstWriteIdx = writeIdx;
-    
-    // Now walk through the string, copying tokens, looking for slashes and dots
-    // to handle.
-    for (; t.first != inPath.end(); t = _NextToken(t.second, inPath.end())) {
-        switch (_GetTokenType(t)) {
-        case Elem:
-            // Copy the elem.  We avoid mutating 'path' if we've made no changes
-            // to the output yet, which is true if the write head is in the same
-            // place in the output as it is in the input.
-            if (inPath.begin() + writeIdx == t.first) {
-                writeIdx += distance(t.first, t.second);
-                t.first = t.second;
-                if (writeIdx != path.size())
-                    ++writeIdx;
-            } else {
-                while (t.first != t.second)
-                    path[writeIdx++] = *t.first++;
-                if (writeIdx != path.size())
-                    path[writeIdx++] = '/';
-            }
-            break;
-        case Dot:
-            // Do nothing, Dots are simply ignored.
-            break;
-        case DotDot: {
-            // Here we are very likely to be modifying the string, so we use
-            // non-const iterators and mutate.
-            string::reverse_iterator
-                rstart(path.begin() + firstWriteIdx),
-                rwrite(path.begin() + writeIdx);
-            // Find the last token of the output by finding the next token in
-            // reverse.
-            RToken backToken = _NextToken(rwrite, rstart);
-            // If there are no more Elems to consume with DotDots and this is a
-            // relative path, or this token is already a DotDot, then copy it to
-            // the output.
-            if ((rstart == path.rend() && backToken.first == rstart) ||
-                _GetTokenType(backToken) == DotDot) {
-                path[writeIdx++] = '.';
-                path[writeIdx++] = '.';
-                if (writeIdx != path.size())
-                    path[writeIdx++] = '/';
-            } else if (backToken.first != rstart) {
-                // Otherwise, consume the last elem by moving writeIdx back to
-                // before the elem.
-                writeIdx = distance(path.begin(), backToken.second.base());
-            }
-        }
-            break;
-        };
-    }
-    
-    // Remove a trailing slash if we wrote one.  We're careful to use const
-    // iterators here to avoid incurring a string copy if it's not necessary (in
-    // the case of libstdc++'s copy-on-write basic_string)
-    if (writeIdx > firstWriteIdx && path.cbegin()[writeIdx-1] == '/')
-        --writeIdx;
-
-    // Trim the string to length if necessary.
-    if (writeIdx != path.size())
-        path.erase(writeIdx);
-    
-    // If the resulting path is empty, return "."
-    if (path.empty())
-        path.assign(".");
-    
-    return path;
-}
-} // anon
 
 #if defined(ARCH_OS_WINDOWS)
 string

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -64,6 +64,34 @@ static inline HANDLE _FileToWinHANDLE(FILE *file)
     return reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(file)));
 }
 
+/// Expects an UTF-16 path and prepends the Windows long path prefix if necessary.
+/// see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+std::wstring _ArchHandleLongWindowsPaths(const std::wstring& path)
+{
+    // Subtracting 12 (8.3) so this function also works for CreateDirectoryW:
+    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
+    // ARCH_PATH_MAX counts the null terminator as well
+    if (path.size() >= ARCH_PATH_MAX - 12 - 1) {
+        std::wstring longPath = path;
+
+        // the \\?\ prefix requires strict backslash separators:
+        // see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+        std::replace(std::begin(longPath), std::end(longPath), L'/', L'\\');
+
+        // prevent duplicate prefixing
+        if (longPath.find(LONG_PATH_PREFIX_W) != 0) {
+            // if it still starts with two backslashes, it is a network path
+            if (longPath[0] == L'\\' && longPath[1] == L'\\') {
+                return UNC_LONG_PATH_PREFIX_W + longPath.substr(2);
+            } else {
+                return LONG_PATH_PREFIX_W + longPath;
+            }
+        }
+    }
+
+    return path;
+}
+
 }
 #endif // ARCH_OS_WINDOWS
 
@@ -106,7 +134,7 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
         return nullptr;
     }
 
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
 
     // Call CreateFileW.
     HANDLE hfile = CreateFileW(
@@ -148,7 +176,7 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
 
 bool ArchTouchFile(const std::string& fileName, bool create) {
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
 #endif
 
     if (create) {
@@ -192,7 +220,7 @@ bool ArchTouchFile(const std::string& fileName, bool create) {
 
 int ArchUnlinkFile(const char* path) {
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     return _wunlink(apiPath.c_str());
 #else
     return unlink(path);
@@ -202,7 +230,7 @@ int ArchUnlinkFile(const char* path) {
 #if defined(ARCH_OS_WINDOWS)
 int ArchRmDir(const char* path)
 {
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     return RemoveDirectoryW(apiPath.c_str()) ? 0 : -1;
 }
 #endif
@@ -233,7 +261,7 @@ ArchGetModificationTime(const char* pathname, double* time)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
     if (_wstat64(apiPath.c_str(), &st) == 0)
 #else
     if (stat(pathname, &st) == 0)
@@ -458,7 +486,7 @@ ArchAbsPath(const string& path)
 
 #if defined(ARCH_OS_WINDOWS)
     // path
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     std::vector<wchar_t> buffer(ARCH_PATH_MAX, 0);
     auto requiredBufferSize = GetFullPathNameW(apiPath.c_str(), buffer.size(), buffer.data(), nullptr);
     if (requiredBufferSize > buffer.size()) {
@@ -495,7 +523,7 @@ ArchGetStatMode(const char *pathname, int *mode)
 {
     ArchStatType st;
 #if defined(ARCH_OS_WINDOWS)
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(pathname));
     if (_wstat64(apiPath.c_str(), &st) == 0) {
 #else
     if (stat(pathname, &st) == 0) {
@@ -574,7 +602,7 @@ ArchGetFileLength(const char* fileName)
 #elif defined (ARCH_OS_WINDOWS)
     // Open a handle with 0 as the desired access and full sharing.
     // This opens the file even if exclusively locked.
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
     HANDLE handle =
         CreateFileW(apiPath.c_str(), 0,
                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
@@ -733,7 +761,7 @@ ArchMakeTmpFile(const std::string& tmpdir,
     int fd = -1;
     auto cTemplate =
         MakeUnique(sTemplate, [&fd](const char* name){
-            const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
             _wsopen_s(&fd, apiPath.c_str(),
           _O_CREAT | _O_EXCL | _O_RDWR | _O_BINARY,
           _SH_DENYNO, _S_IREAD | _S_IWRITE);
@@ -777,7 +805,7 @@ ArchMakeTmpSubdir(const std::string& tmpdir,
 #if defined(ARCH_OS_WINDOWS)
     retstr =
         MakeUnique(sTemplate, [](const char* name){
-            const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
+            const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(name));
             return (CreateDirectoryW(apiPath.c_str(), NULL) != 0);
         });
 #else
@@ -1185,7 +1213,7 @@ static int Arch_FileAccessError()
 int ArchFileAccess(const char* path, int mode)
 {
     // Simple existence check is handled specially.
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     if (mode == F_OK) {
         return (GetFileAttributesW(apiPath.c_str()) != INVALID_FILE_ATTRIBUTES)
                 ? 0 : Arch_FileAccessError();
@@ -1299,7 +1327,7 @@ typedef struct _REPARSE_DATA_BUFFER {
 
 std::string ArchReadLink(const char* path)
 {
-    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
+    const std::wstring apiPath = _ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(path));
     HANDLE handle = ::CreateFileW(
             apiPath.c_str(), GENERIC_READ, FILE_SHARE_READ,
             NULL, OPEN_EXISTING,
@@ -1465,36 +1493,5 @@ void ArchFileAdvise(
     }
 #endif
 }
-
-#if defined(ARCH_OS_WINDOWS)
-
-ARCH_API
-std::wstring ArchHandleLongWindowsPaths(const std::wstring& path)
-{
-    // Subtracting 12 (8.3) so this function also works for CreateDirectoryW:
-    // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectoryw
-    // ARCH_PATH_MAX counts the null terminator as well
-    if (path.size() >= ARCH_PATH_MAX - 12 - 1) {
-        std::wstring longPath = path;
-
-        // the \\?\ prefix requires strict backslash separators:
-        // see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-        std::replace(std::begin(longPath), std::end(longPath), L'/', L'\\');
-
-        // prevent duplicate prefixing
-        if (longPath.find(LONG_PATH_PREFIX_W) != 0) {
-            // if it still starts with two backslashes, it is a network path
-            if (longPath[0] == L'\\' && longPath[1] == L'\\') {
-                return UNC_LONG_PATH_PREFIX_W + longPath.substr(2);
-            } else {
-                return LONG_PATH_PREFIX_W + longPath;
-            }
-        }
-    }
-
-    return path;
-}
-
-#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -33,13 +33,16 @@
 #include <functional>
 #include <io.h>
 #include <process.h>
+#include <sys/utime.h>
 #include <Windows.h>
 #include <WinIoCtl.h>
 #else
 #include <alloca.h>
 #include <sys/mman.h>
 #include <sys/file.h>
+#include <sys/time.h>
 #include <unistd.h>
+#include <utime.h>
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -141,6 +144,50 @@ FILE* ArchOpenFile(char const* fileName, char const* mode)
 #else
     return fopen(fileName, mode);
 #endif
+}
+
+bool ArchTouchFile(const std::string& fileName, bool create) {
+#if defined(ARCH_OS_WINDOWS)
+    const std::wstring apiPath = ArchHandleLongWindowsPaths(ArchWindowsUtf8ToUtf16(fileName));
+#endif
+
+    if (create) {
+#if !defined(ARCH_OS_WINDOWS)
+        // Attempt to create the file so it is readable and writable by user,
+        // group and other.
+        int fd = open(fileName.c_str(),
+            O_WRONLY | O_CREAT | O_NONBLOCK | O_NOCTTY,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+        if (fd == -1)
+            return false;
+        close(fd);
+#else
+        HANDLE fileHandle =
+                ::CreateFileW(apiPath.c_str(),
+                              GENERIC_WRITE,          // open for write
+                              0,                      // not for sharing
+                              NULL,                   // default security
+                              OPEN_ALWAYS,            // opens existing
+                              FILE_ATTRIBUTE_NORMAL,  //normal file
+                              NULL);                  // no template
+
+        if (fileHandle == INVALID_HANDLE_VALUE) {
+            return false;
+        }
+
+        // Close the file
+        ::CloseHandle(fileHandle);
+#endif
+    }
+
+    // Passing NULL to the 'times' argument sets both the atime and mtime to
+    // the current time, with millisecond precision.
+#if defined(ARCH_OS_WINDOWS)
+    return _wutime(apiPath.c_str(), /* times */ NULL) == 0;
+#else
+    return utimes(fileName.c_str(), /* times */ NULL) == 0;
+#endif
+
 }
 
 int ArchUnlinkFile(const char* path) {

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -450,11 +450,6 @@ inline std::wstring ArchWindowsUtf8ToUtf16(const std::string &str)
     return wstr;
 }
 
-/// Expects an UTF-16 path and prepends the Windows long path prefix if necessary.
-/// see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
-ARCH_API
-std::wstring ArchHandleLongWindowsPaths(const std::wstring& path);
-
 #endif
 
 ///@}

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -128,11 +128,10 @@ ArchOpenFile(char const* fileName, char const* mode);
 #   define ArchCloseFile(fd)            close(fd)
 #endif
 
-#if defined(ARCH_OS_WINDOWS)
-#   define ArchUnlinkFile(path)         _unlink(path)
-#else
-#   define ArchUnlinkFile(path)         unlink(path)
-#endif
+/// Deletes a file.
+///
+/// Returns 0 on success, or -1 otherwise.
+ARCH_API int ArchUnlinkFile(const char* path);
 
 #if defined(ARCH_OS_WINDOWS)
     ARCH_API int ArchFileAccess(const char* path, int mode);
@@ -158,6 +157,9 @@ ArchOpenFile(char const* fileName, char const* mode);
 #   define ArchFileIsaTTY(stream)       isatty(stream)
 #endif
 
+/// Delete an empty directory
+///
+/// Returns 0 on success, or -1 otherwise.
 #if defined(ARCH_OS_WINDOWS)
     ARCH_API int ArchRmDir(const char* path);
 #else
@@ -274,10 +276,10 @@ ARCH_API
 int ArchMakeTmpFile(const std::string& tmpdir,
                     const std::string& prefix, std::string* pathname = 0);
 
-/// Create a temporary sub-direcrory, in a given temporary directory.
+/// Create a temporary sub-directory, in a given temporary directory.
 ///
 /// The result returned has the form TMPDIR/prefix.XXXXXX/ where TMPDIR is the
-/// given temporary directory and XXXXXX is a unique suffix.  Returns the the
+/// given temporary directory and XXXXXX is a unique suffix.  Returns the
 /// full path to the subdir in pathname.  Returns empty string on failure and
 /// errno is set.
 ///
@@ -442,6 +444,11 @@ inline std::wstring ArchWindowsUtf8ToUtf16(const std::string &str)
     }
     return wstr;
 }
+
+/// Expects an UTF-16 path and prepends the Windows long path prefix if necessary.
+/// see https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+ARCH_API
+std::wstring ArchHandleLongWindowsPaths(const std::wstring& path);
 
 #endif
 

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -128,6 +128,11 @@ ArchOpenFile(char const* fileName, char const* mode);
 #   define ArchCloseFile(fd)            close(fd)
 #endif
 
+/// Touch a file.
+///
+/// Returns true upon success, false otherwise.
+ARCH_API bool ArchTouchFile(const std::string& fileName, bool create);
+
 /// Deletes a file.
 ///
 /// Returns 0 on success, or -1 otherwise.

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -97,14 +97,31 @@ std::string _CreateLongWindowsPath(bool dir, bool dotted) {
     return p;
 }
 
+// slightly awkward way of creating and deleting a long path without
+// having to introduce recursive deletion etc.
 std::string _CreatePhysicalLongPathDirectory() {
+    static const std::string tmpDirPart0("UsdArchTestLongPaths");
+    static const std::string tmpDirPart1(150, 'a');
+    static const std::string tmpDirPart2(150, 'b');
     std::string tmpDir(ArchGetTmpDir());
-    std::string prefix(150, 'a');
-    tmpDir = ArchMakeTmpSubdir(tmpDir, prefix);
-    prefix.assign(150, 'b');
-    tmpDir = ArchMakeTmpSubdir(tmpDir, prefix);
+    tmpDir = ArchMakeTmpSubdir(tmpDir, tmpDirPart0);
+    tmpDir = ArchMakeTmpSubdir(tmpDir, tmpDirPart1);
+    tmpDir = ArchMakeTmpSubdir(tmpDir, tmpDirPart2);
     ARCH_AXIOM(tmpDir.size() > ARCH_PATH_MAX);
     return tmpDir;
+}
+
+// implying structure from above
+void _RemoveLongPathDirectory(const std::string& longTmpDir) {
+    ARCH_AXIOM(ArchRmDir(longTmpDir.c_str()) == 0);
+
+    std::string::size_type lastSep = longTmpDir.find_last_of('\\');
+    ARCH_AXIOM(lastSep != std::string::npos);
+    ARCH_AXIOM(ArchRmDir(longTmpDir.substr(0, lastSep).c_str()) == 0);
+
+    lastSep = longTmpDir.find_last_of('\\', lastSep-1);
+    ARCH_AXIOM(lastSep != std::string::npos);
+    ARCH_AXIOM(ArchRmDir(longTmpDir.substr(0, lastSep).c_str()) == 0);
 }
 
 } // namespace
@@ -136,17 +153,33 @@ static bool TestLongPaths()
         FILE *file;
         ARCH_AXIOM((file = ArchOpenFile(longTmpFilePath.c_str(), "wb")) != NULL);
         std::fprintf(file, "%s", "hello");
-        fclose(file); // TODO: fd arg of ArchCloseFile is not symmetrical??
-        ARCH_AXIOM(ArchUnlinkFile(longTmpFilePath.c_str()) == 0);
-        ARCH_AXIOM(ArchRmDir(longTmpDir.c_str()) == 0);
-    }
+        fclose(file);
 
-    // ArchMakeTmpFile
-    // ArchFileAccess
-    // ArchReadLink
-    // ArchGetModificationTime
-    // ArchGetStatMode
-    // ArchGetFileLength
+        ARCH_AXIOM(ArchFileAccess(longTmpFilePath.c_str(), W_OK) == 0);
+        ARCH_AXIOM(ArchGetFileLength(longTmpFilePath.c_str()) == 5);
+
+        ARCH_AXIOM(ArchUnlinkFile(longTmpFilePath.c_str()) == 0);
+        _RemoveLongPathDirectory(longTmpDir);
+    }
+    {
+        std::string longTmpDir = _CreatePhysicalLongPathDirectory();
+        const std::string longTmpFilePath = longTmpDir + '\\' + "foo.bar";
+        ARCH_AXIOM(ArchTouchFile(longTmpFilePath, true));
+        ARCH_AXIOM(ArchUnlinkFile(longTmpFilePath.c_str()) == 0);
+        _RemoveLongPathDirectory(longTmpDir);
+    }
+    {
+        std::string longTmpDir = _CreatePhysicalLongPathDirectory();
+
+        std::string longTmpFilePath;
+        int tmpFileHandle = ArchMakeTmpFile(longTmpDir, "foo", &longTmpFilePath);
+        ARCH_AXIOM(tmpFileHandle != -1);
+        ArchCloseFile(tmpFileHandle);
+        ARCH_AXIOM(longTmpFilePath.size() == (longTmpDir.size() + 1 + 3 + 7));
+
+        ARCH_AXIOM(ArchUnlinkFile(longTmpFilePath.c_str()) == 0);
+        _RemoveLongPathDirectory(longTmpDir);
+    }
 
     return true;
 }

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -226,7 +226,7 @@ int main()
     mfm.get()[0] = 'T'; mfm.get()[2] = 's';
     ARCH_AXIOM(memcmp("Test", mfm.get(), strlen("Test")) == 0);
     mfm.reset();
-    ArchUnlinkFile(firstName.c_str());
+    ARCH_AXIOM(ArchUnlinkFile(firstName.c_str()) == 0);
 
     // Test ArchPWrite and ArchPRead.
     int64_t len = strlen(testContent);
@@ -242,6 +242,8 @@ int main()
     ARCH_AXIOM(ArchPRead(firstFile, buf2.get(), strlen("written in a"),
                      9/*index of 'written in a'*/) == strlen("written in a"));
     ARCH_AXIOM(memcmp("written in a", buf2.get(), strlen("written in a")) == 0);
+    fclose(firstFile);
+    ARCH_AXIOM(ArchUnlinkFile(firstName.c_str()) == 0);
 
     // create and remove a tmp subdir
     std::string retpath;

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <iostream>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -64,6 +65,7 @@ _AbsPathFilter(const std::string& path)
     return path;
 #endif
 }
+
 }
 
 static bool
@@ -74,8 +76,82 @@ TestArchAbsPath()
     ARCH_AXIOM(_AbsPathFilter(ArchAbsPath("/foo/bar")) == "/foo/bar");
     ARCH_AXIOM(_AbsPathFilter(ArchAbsPath("/foo/bar/../baz")) == "/foo/baz");
 
+    ARCH_AXIOM(_AbsPathFilter(ArchAbsPath("/foo/bar/../baz")) == "/foo/baz");
+
     return true;
 }
+
+#ifdef ARCH_OS_WINDOWS
+
+namespace {
+
+std::string _CreateLongWindowsPath(bool dir, bool dotted) {
+    std::string p = ArchGetTmpDir();
+    for (size_t i = 0; i < 15; ++i)
+        p += "\\abcdefghijklmnopqrs";
+    if (dotted)
+        p += "\\.\\..\\abcdefghijklmnopqrs";
+    if (!dir)
+        p += "\\foo.bar";
+    ARCH_AXIOM(p.size() > ARCH_PATH_MAX);
+    return p;
+}
+
+std::string _CreatePhysicalLongPathDirectory() {
+    std::string tmpDir(ArchGetTmpDir());
+    std::string prefix(150, 'a');
+    tmpDir = ArchMakeTmpSubdir(tmpDir, prefix);
+    prefix.assign(150, 'b');
+    tmpDir = ArchMakeTmpSubdir(tmpDir, prefix);
+    ARCH_AXIOM(tmpDir.size() > ARCH_PATH_MAX);
+    return tmpDir;
+}
+
+} // namespace
+
+static bool TestLongPaths()
+{
+    const std::string longFilePathDotted = _CreateLongWindowsPath(false, true);
+    const std::string longFilePath = _CreateLongWindowsPath(false, false);
+    const std::string longFilePathForwardSlash = [&longFilePath]() {
+        std::string t = longFilePath;
+        std::replace(t.begin(), t.end(), '\\', '/');
+        return t;
+    }();
+
+    {
+        const std::string actual = ArchNormPath(longFilePathDotted, false);
+        const std::string expected = longFilePathForwardSlash;
+        ARCH_AXIOM(actual == expected);
+    }
+    {
+        const std::string actual = ArchAbsPath(longFilePathDotted);
+        const std::string expected = longFilePath;
+        ARCH_AXIOM(actual == expected);
+    }
+    {
+        std::string longTmpDir = _CreatePhysicalLongPathDirectory();
+        const std::string longTmpFilePath = longTmpDir + '\\' + "foo.bar";
+
+        FILE *file;
+        ARCH_AXIOM((file = ArchOpenFile(longTmpFilePath.c_str(), "wb")) != NULL);
+        std::fprintf(file, "%s", "hello");
+        fclose(file); // TODO: fd arg of ArchCloseFile is not symmetrical??
+        ARCH_AXIOM(ArchUnlinkFile(longTmpFilePath.c_str()) == 0);
+        ARCH_AXIOM(ArchRmDir(longTmpDir.c_str()) == 0);
+    }
+
+    // ArchMakeTmpFile
+    // ArchFileAccess
+    // ArchReadLink
+    // ArchGetModificationTime
+    // ArchGetStatMode
+    // ArchGetFileLength
+
+    return true;
+}
+
+#endif
 
 int main()
 {
@@ -143,6 +219,10 @@ int main()
     // Test other utilities
     TestArchNormPath();
     TestArchAbsPath();
+
+#ifdef ARCH_OS_WINDOWS
+    TestLongPaths();
+#endif
 
     return 0;
 }


### PR DESCRIPTION
### Description of Change(s)

Prefix all file system paths longer than 248 characters with "\\\\?\\" before passing into Win32 File I/O API functions.

### Fixes Issue(s)

Avoids errors when reading/writing USD files on long Windows paths.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement

### Notes
* ~~The CLA is pending on my side.~~
* This is my first stab at fixing this problem and also my first time contributing larger changes to USD.
* ~~This PR is not complete yet (Arch and Tf test coverage). I submit it early to get some basic feedback.~~
* ~~This PR contains temporary/helper commits not intended for merge.~~
