### PR TITLE
Make `TF_PP_EAT_PARENS` not dependent on boost

### DIFF
--- a/pxr/base/tf/preprocessorUtils.h
+++ b/pxr/base/tf/preprocessorUtils.h
@@ -33,6 +33,7 @@
 
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/pragmas.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/arithmetic/sub.hpp>
 #include <boost/preprocessor/cat.hpp>
@@ -141,7 +142,7 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
 // 0.  No other values of c are allowed.  We can't use BOOST_PP_IFF() because
 // it won't expand during stringizing under MSVC.
 #define _TF_PP_EAT_PARENS_IFF(c, t, f) \
-    BOOST_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
+    TF_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
 #define _TF_PP_EAT_PARENS_IFF_0(t, f) f
 #define _TF_PP_EAT_PARENS_IFF_1(t, f) t
 


### PR DESCRIPTION
### Description of Change(s)
- Replaces usage of `BOOST_PP_CAT` with `TF_PP_CAT` 

### Fixes Issue(s)
- #2240 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
