### PR TITLE
Fix a `TfRefPtr<TfRefBase>()` constructor issue that prevents compilation with C++20

### DIFF
--- a/pxr/base/tf/refPtr.h
+++ b/pxr/base/tf/refPtr.h
@@ -1252,14 +1252,14 @@ TfConst_cast(const TfRefPtr<const typename T::DataType>& ptr)
 template <>
 class TfRefPtr<TfRefBase> {
 private:
-    TfRefPtr<TfRefBase>() {
+    TfRefPtr() {
     }
 };
 
 template <>
 class TfRefPtr<const TfRefBase> {
 private:
-    TfRefPtr<const TfRefBase>() {
+    TfRefPtr() {
     }
 };
 


### PR DESCRIPTION
### Description of Change(s)

I don't totally understand this issue and more testing might be needed before merging this. But this fixes a compilation issue with C++20 (and C++23) that I've been having.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/2183

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
