### PR TITLE
Replace `BOOST_PP_CAT` with `TF_PP_CAT` in `pxr/usd/pcp/diagnostic.h`

### DIFF
--- a/pxr/usd/pcp/diagnostic.h
+++ b/pxr/usd/pcp/diagnostic.h
@@ -33,8 +33,7 @@
 #include "pxr/usd/pcp/errors.h"
 
 #include "pxr/base/arch/hints.h"
-
-#include <boost/preprocessor/cat.hpp>
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 
 #include <string>
 
@@ -90,7 +89,7 @@ Pcp_ToIndex(T const &obj) { return obj->GetOriginatingIndex(); }
 
 /// Opens a scope indicating a particular phase during prim indexing.
 #define PCP_INDEXING_PHASE(indexer, node, ...)                                 \
-    auto BOOST_PP_CAT(_pcpIndexingPhase, __LINE__) =                           \
+    auto TF_PP_CAT(_pcpIndexingPhase, __LINE__) =                              \
         ARCH_UNLIKELY(TfDebug::IsEnabled(PCP_PRIM_INDEX)) ?                    \
         Pcp_IndexingPhaseScope(Pcp_ToIndex(indexer),                           \
                                node, TfStringPrintf(__VA_ARGS__)) :            \


### PR DESCRIPTION
### Description of Change(s)
- Replaces `BOOST_PP_CAT` with `TF_PP_CAT` in `pxr/usd/pcp/diagnostic.h` to remove the dependency on `boost/preprocessor`

### Fixes Issue(s)
- #2247 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
