### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `TfEnum`

### DIFF
--- a/pxr/base/tf/enum.h
+++ b/pxr/base/tf/enum.h
@@ -36,7 +36,6 @@
 #include "pxr/base/tf/safeTypeCompare.h"
 #include "pxr/base/tf/api.h"
 
-#include <boost/operators.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 
 #include <iosfwd>
@@ -136,7 +135,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// // Returns 5, sets found to \c true
 /// \endcode
 ///
-class TfEnum : boost::totally_ordered<TfEnum>
+class TfEnum
 {
 public:
     /// Default constructor assigns integer value zero.
@@ -169,6 +168,12 @@ public:
             TfSafeTypeCompare(*t._typeInfo, *_typeInfo);
     }
 
+    /// Inequality operator
+    /// \sa TfEnum::operator==(const TfEnum&)
+    bool operator!=(const TfEnum& t) const {
+        return !(*this == t);
+    }
+
     /// Less than comparison. Enum values belonging to the same type are
     /// ordered according to their numeric value.  Enum values belonging to
     /// different types are ordered in a consistent but arbitrary way which
@@ -176,6 +181,24 @@ public:
     bool operator<(const TfEnum& t) const {
         return _typeInfo->before(*t._typeInfo) ||
             (!t._typeInfo->before(*_typeInfo) && _value < t._value);
+    }
+
+    /// Less than or equal operator
+    /// \sa TfEnum::operator<(const TfEnum&)
+    bool operator<=(const TfEnum& t) const {
+        return !(t < *this);
+    }
+
+    /// Greater than operator
+    /// \sa TfEnum::operator<(const TfEnum&)
+    bool operator>(const TfEnum& t) const {
+        return t < *this;
+    }
+
+    /// Greater than or equal operator
+    /// \sa TfEnum::operator<(const TfEnum&)
+    bool operator>=(const TfEnum& t) const {
+        return !(*this < t);
     }
 
     /// True if \c *this has been assigned with \c value.

--- a/pxr/base/tf/testenv/enum.cpp
+++ b/pxr/base/tf/testenv/enum.cpp
@@ -156,6 +156,16 @@ Test_TfEnum()
     TF_AXIOM(e.GetValueAsInt() == 3);
     TF_AXIOM(e.GetValue<Season>() == SUMMER);
 
+    // Test coverage for operators
+    TF_AXIOM(TfEnum(SUMMER) == TfEnum(SUMMER));
+    TF_AXIOM(TfEnum(SUMMER) <= TfEnum(SUMMER));
+    TF_AXIOM(TfEnum(SUMMER) >= TfEnum(SUMMER));
+    TF_AXIOM(TfEnum(SUMMER) != TfEnum(SPRING));
+    TF_AXIOM(TfEnum(SUMMER) > TfEnum(SPRING));
+    TF_AXIOM(TfEnum(SUMMER) >= TfEnum(SPRING));
+    TF_AXIOM(TfEnum(SPRING) <= TfEnum(SUMMER));
+    TF_AXIOM(TfEnum(SPRING) < TfEnum(SUMMER));
+
     return true;
 }
 


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator<=`, `operator>`, `operator>=`, and `operator!=` to `TfEnum`
- Update doxygen comments so `operator!=`'s references `operator==` and  `operator<=`, `operator>`, and `operator>=` reference `operator<`
- Add operator test coverage for `TfEnum` 

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
