### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `TfAnyWeakPtr`

### DIFF
--- a/pxr/base/tf/anyWeakPtr.h
+++ b/pxr/base/tf/anyWeakPtr.h
@@ -39,7 +39,6 @@
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
 #include "pxr/base/tf/pyObjWrapper.h"
-#include <boost/operators.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -51,7 +50,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Provides the ability to hold an arbitrary TfWeakPtr in a non-type-specific
 /// manner in order to observe whether it has expired or not
-class TfAnyWeakPtr : boost::totally_ordered<TfAnyWeakPtr>
+class TfAnyWeakPtr
 {
     struct _Data {
         void* space[4];
@@ -118,8 +117,28 @@ public:
     /// equality operator
     TF_API bool operator ==(const TfAnyWeakPtr &rhs) const;
 
+    /// inequality operator
+    bool operator !=(const TfAnyWeakPtr &rhs) const {
+        return !(*this == rhs);
+    }
+
     /// comparison operator
     TF_API bool operator <(const TfAnyWeakPtr &rhs) const;
+
+    /// less than or equal operator
+    bool operator <=(const TfAnyWeakPtr& rhs) const {
+        return !(rhs < *this);
+    }
+
+    /// greater than operator
+    bool operator >(const TfAnyWeakPtr& rhs) const {
+        return rhs < *this;
+    }
+
+    /// greater than or equal operator
+    bool operator >=(const TfAnyWeakPtr& rhs) const {
+        return !(*this < rhs);
+    }
 
     /// returns the type_info of the underlying WeakPtr
     TF_API const std::type_info & GetTypeInfo() const;


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator<=`, `operator>`, `operator>=`, and `operator!=` to `TfAnyWeakPtr`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
