### PR TITLE
APPLE: Use unique name for debug View.

### DIFF
--- a/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
+++ b/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
@@ -52,9 +52,9 @@ Garch_GetModifierKeys(NSUInteger flags)
     return keys;
 }
 
-@class  View;
+@class Garch_GLPlatformView;
 
-@interface View : NSOpenGLView <NSWindowDelegate>
+@interface Garch_GLPlatformView : NSOpenGLView <NSWindowDelegate>
 {
     GarchGLDebugWindow *_callback;
     NSOpenGLContext *_ctx;
@@ -62,7 +62,7 @@ Garch_GetModifierKeys(NSUInteger flags)
 
 @end
 
-@implementation View
+@implementation Garch_GLPlatformView
 
 -(id)initGL:(NSRect)frame callback:(GarchGLDebugWindow*)cb
 {
@@ -206,7 +206,8 @@ Garch_GLPlatformDebugWindow::Init(const char *title,
     NSRect frame = NSMakeRect(0, 0, width, height);
     NSRect viewBounds = NSMakeRect(0, 0, width, height);
 
-    View *view = [[View alloc] initGL:viewBounds callback:_callback];
+    Garch_GLPlatformView *view = 
+        [[Garch_GLPlatformView alloc] initGL:viewBounds callback:_callback];
 
     NSWindow *window = [[NSWindow alloc]
                         initWithContentRect:frame


### PR DESCRIPTION
### Description of Change(s)

Using `View` as a classname in the code can cause issues when integrating with other Cocoa applications.  To avoid this, rename it to `Garch_GLView`

### Fixes Issue(s)
- Potential name conflicts in Cocoa applications.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
