### PR TITLE
Replace usage of `boost::compressed_pair` with explicit empty base optimization

### DIFF
--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -161,6 +161,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \hideinitializer
 #   define ARCH_DESTRUCTOR(_name, _priority, ...)
 
+/// Macro to begin the definition of a class that is using private inheritance
+/// to take advantage of the empty base optimization. Some compilers require
+/// an explicit tag.
+///
+/// In C++20, usage of private inheritance may be able to be retired with the
+/// [[no_unique_address]] tag.
+#   define ARCH_EMPTY_BASES
+
 #elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
 
 #   define ARCH_PRINTF_FUNCTION(_fmt, _firstArg) \
@@ -171,6 +179,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 #   define ARCH_UNUSED_ARG   __attribute__ ((unused))
 #   define ARCH_UNUSED_FUNCTION __attribute__((unused))
 #   define ARCH_USED_FUNCTION __attribute__((used))
+#   define ARCH_EMPTY_BASES
 
 #elif defined(ARCH_COMPILER_MSVC)
 
@@ -180,6 +189,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 #   define ARCH_UNUSED_ARG
 #   define ARCH_UNUSED_FUNCTION
 #   define ARCH_USED_FUNCTION
+#   define ARCH_EMPTY_BASES __declspec(empty_bases)
 
 #else
 

--- a/pxr/base/tf/denseHashMap.h
+++ b/pxr/base/tf/denseHashMap.h
@@ -32,9 +32,7 @@
 #include <memory>
 #include <vector>
 
-#include <boost/compressed_pair.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/utility.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -56,7 +54,13 @@ template <
     class    EqualKey  = std::equal_to<Key>,
     unsigned Threshold = 128
 >
-class TfDenseHashMap
+
+class TfDenseHashMap :
+    // Since sizeof(EqualKey) == 0 and sizeof(HashFn) == 0 in many cases
+    // we use the empty base optimization to not pay a size penalty.
+    // In C++20, explore using [[no_unique_address]] as an alternative
+    // way to get this optimization.
+    private HashFn, private EqualKey
 {
 public:
 
@@ -219,11 +223,9 @@ public:
     ///
     explicit TfDenseHashMap(
         const HashFn   &hashFn   = HashFn(),
-        const EqualKey &equalKey = EqualKey())
-    {
-        _hash() = hashFn;
-        _equ()  = equalKey;
-    }
+        const EqualKey &equalKey = EqualKey()) :
+            HashFn(hashFn),
+            EqualKey(equalKey) {}
 
     /// Construct with range.
     ///
@@ -241,11 +243,10 @@ public:
     /// Copy Ctor.
     ///
     TfDenseHashMap(const TfDenseHashMap &rhs)
-    :   _vectorHashFnEqualFn(rhs._vectorHashFnEqualFn) {
-        if (rhs._h) {
-            _h.reset(new _HashMap(*rhs._h));
-        }
-    }
+    :   HashFn(rhs),
+        EqualKey(rhs),
+        _vector(rhs._vector),
+        _h(rhs._h ? std::make_unique<_HashMap>(*rhs._h) : nullptr) {}
 
     /// Move Ctor.
     ///
@@ -308,7 +309,9 @@ public:
     /// Swaps the contents of two maps.
     ///
     void swap(TfDenseHashMap &rhs) {
-        _vectorHashFnEqualFn.swap(rhs._vectorHashFnEqualFn);
+        std::swap(_hash(), rhs._hash());
+        std::swap(_equ(), rhs._equ());
+        _vector.swap(rhs._vector);
         _h.swap(rhs._h);
     }
 
@@ -543,32 +546,32 @@ private:
 
     // Helper to access the storage vector.
     _Vector &_vec() {
-        return _vectorHashFnEqualFn.first().first();
+        return _vector;
     }
 
     // Helper to access the hash functor.
     HashFn &_hash() {
-        return _vectorHashFnEqualFn.first().second();
+        return *this;
     }
 
     // Helper to access the equality functor.
     EqualKey &_equ() {
-        return _vectorHashFnEqualFn.second();
+        return *this;
     }
 
     // Helper to access the storage vector.
     const _Vector &_vec() const {
-        return _vectorHashFnEqualFn.first().first();
+        return _vector;
     }
 
     // Helper to access the hash functor.
     const HashFn &_hash() const {
-        return _vectorHashFnEqualFn.first().second();
+        return *this;
     }
 
     // Helper to access the equality functor.
     const EqualKey &_equ() const {
-        return _vectorHashFnEqualFn.second();
+        return *this;
     }
 
     // Helper to linear-search the vector for a key.
@@ -612,20 +615,11 @@ private:
         }
     }
 
-    // Vector holding all elements along with the EqualKey functor.  Since
-    // sizeof(EqualKey) == 0 in many cases we use a compressed_pair to not
-    // pay a size penalty.
-
-    typedef
-        boost::compressed_pair<
-            boost::compressed_pair<_Vector, HashFn>,
-            EqualKey>
-        _VectorHashFnEqualFn;
-
-    _VectorHashFnEqualFn _vectorHashFnEqualFn;
+    // Vector holding all elements
+    _Vector _vector;
 
     // Optional hash map that maps from keys to vector indices.
-    std::unique_ptr<_HashMap> _h;
+    std::unique_ptr<_HashMap> _h = nullptr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/denseHashMap.h
+++ b/pxr/base/tf/denseHashMap.h
@@ -310,8 +310,9 @@ public:
     /// Swaps the contents of two maps.
     ///
     void swap(TfDenseHashMap &rhs) {
-        std::swap(_hash(), rhs._hash());
-        std::swap(_equ(), rhs._equ());
+        using std::swap;
+        swap(_hash(), rhs._hash());
+        swap(_equ(), rhs._equ());
         _vector.swap(rhs._vector);
         _h.swap(rhs._h);
     }
@@ -620,7 +621,7 @@ private:
     _Vector _vector;
 
     // Optional hash map that maps from keys to vector indices.
-    std::unique_ptr<_HashMap> _h = nullptr;
+    std::unique_ptr<_HashMap> _h;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/denseHashMap.h
+++ b/pxr/base/tf/denseHashMap.h
@@ -27,6 +27,7 @@
 /// \file tf/denseHashMap.h
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/attributes.h"
 #include "pxr/base/tf/hashmap.h"
 
 #include <memory>
@@ -55,7 +56,7 @@ template <
     unsigned Threshold = 128
 >
 
-class TfDenseHashMap :
+class ARCH_EMPTY_BASES TfDenseHashMap :
     // Since sizeof(EqualKey) == 0 and sizeof(HashFn) == 0 in many cases
     // we use the empty base optimization to not pay a size penalty.
     // In C++20, explore using [[no_unique_address]] as an alternative

--- a/pxr/base/tf/denseHashSet.h
+++ b/pxr/base/tf/denseHashSet.h
@@ -32,9 +32,7 @@
 #include <memory>
 #include <vector>
 
-#include <boost/compressed_pair.hpp>
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/utility.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -55,7 +53,12 @@ template <
     class    EqualElement  = std::equal_to<Element>,
     unsigned Threshold = 128
 >
-class TfDenseHashSet
+class TfDenseHashSet :
+    // Since sizeof(EqualElement) == 0 and sizeof(HashFn) == 0 in many cases
+    // we use the empty base optimization to not pay a size penalty.
+    // In C++20, explore using [[no_unique_address]] as an alternative
+    // way to get this optimization.
+    private HashFn, private EqualElement
 {
 public:
 
@@ -92,20 +95,17 @@ public:
     ///
     explicit TfDenseHashSet(
         const HashFn       &hashFn       = HashFn(),
-        const EqualElement &equalElement = EqualElement())
-    {
-        _hash() = hashFn;
-        _equ()  = equalElement;
-    }
+        const EqualElement &equalElement = EqualElement()) :
+        HashFn(hashFn),
+        EqualElement(equalElement) {}
 
     /// Copy Ctor.
     ///
     TfDenseHashSet(const TfDenseHashSet &rhs)
-    :   _vectorHashFnEqualFn(rhs._vectorHashFnEqualFn) {
-        if (rhs._h) {
-            _h.reset(new _HashMap(*rhs._h));
-        }
-    }
+    :   HashFn(rhs),
+        EqualElement(rhs),
+        _vector(rhs._vector),
+        _h(rhs._h ? std::make_unique<_HashMap>(*rhs._h) : nullptr) {}
 
     /// Move Ctor.
     ///
@@ -178,7 +178,9 @@ public:
     /// Swaps the contents of two sets.
     ///
     void swap(TfDenseHashSet &rhs) {
-        _vectorHashFnEqualFn.swap(rhs._vectorHashFnEqualFn);
+        std::swap(_hash(), rhs._hash());
+        std::swap(_equ(), rhs._equ());
+        _vector.swap(rhs._vector);
         _h.swap(rhs._h);
     }
 
@@ -389,32 +391,32 @@ private:
 
     // Helper to access the storage vector.
     _Vector &_vec() {
-        return _vectorHashFnEqualFn.first().first();
+        return _vector;
     }
 
     // Helper to access the hash functor.
     HashFn &_hash() {
-        return _vectorHashFnEqualFn.first().second();
+        return *this;
     }
 
     // Helper to access the equality functor.
     EqualElement &_equ() {
-        return _vectorHashFnEqualFn.second();
+        return *this;
     }
 
     // Helper to access the storage vector.
     const _Vector &_vec() const {
-        return _vectorHashFnEqualFn.first().first();
+        return _vector;
     }
 
     // Helper to access the hash functor.
     const HashFn &_hash() const {
-        return _vectorHashFnEqualFn.first().second();
+        return *this;
     }
 
     // Helper to access the equality functor.
     const EqualElement &_equ() const {
-        return _vectorHashFnEqualFn.second();
+        return *this;
     }
 
     // Helper to create the acceleration table if size dictates.
@@ -434,20 +436,11 @@ private:
         }
     }
 
-    // Vector holding all elements along with the EqualElement functor.  Since
-    // sizeof(EqualElement) == 0 in many cases we use a compressed_pair to not
-    // pay a size penalty.
-
-    typedef
-        boost::compressed_pair<
-            boost::compressed_pair<_Vector, HashFn>,
-            EqualElement>
-        _VectorHashFnEqualFn;
-
-    _VectorHashFnEqualFn _vectorHashFnEqualFn;
+    // Vector holding all elements
+    _Vector _vector;
 
     // Optional hash map that maps from keys to vector indices.
-    std::unique_ptr<_HashMap> _h;
+    std::unique_ptr<_HashMap> _h = nullptr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/denseHashSet.h
+++ b/pxr/base/tf/denseHashSet.h
@@ -179,8 +179,9 @@ public:
     /// Swaps the contents of two sets.
     ///
     void swap(TfDenseHashSet &rhs) {
-        std::swap(_hash(), rhs._hash());
-        std::swap(_equ(), rhs._equ());
+        using std::swap;
+        swap(_hash(), rhs._hash());
+        swap(_equ(), rhs._equ());
         _vector.swap(rhs._vector);
         _h.swap(rhs._h);
     }
@@ -441,7 +442,7 @@ private:
     _Vector _vector;
 
     // Optional hash map that maps from keys to vector indices.
-    std::unique_ptr<_HashMap> _h = nullptr;
+    std::unique_ptr<_HashMap> _h;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/denseHashSet.h
+++ b/pxr/base/tf/denseHashSet.h
@@ -27,6 +27,7 @@
 /// \file tf/denseHashSet.h
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/attributes.h"
 #include "pxr/base/tf/hashmap.h"
 
 #include <memory>
@@ -53,7 +54,7 @@ template <
     class    EqualElement  = std::equal_to<Element>,
     unsigned Threshold = 128
 >
-class TfDenseHashSet :
+class ARCH_EMPTY_BASES TfDenseHashSet :
     // Since sizeof(EqualElement) == 0 and sizeof(HashFn) == 0 in many cases
     // we use the empty base optimization to not pay a size penalty.
     // In C++20, explore using [[no_unique_address]] as an alternative

--- a/pxr/base/tf/testenv/denseHashMap.cpp
+++ b/pxr/base/tf/testenv/denseHashMap.cpp
@@ -52,7 +52,7 @@ static void Run()
     _Map _map;
 
     // Make sure size expectations are ok.
-    // Due to boost::compressed_pair, because both HashFn and EqualKey are
+    // Due to empty base optimization, because both HashFn and EqualKey are
     // 0-size, should only hold a vector + pointer
     // (Note that on windows, debug mode will change sizeof vector)
     TF_AXIOM(sizeof(_Map) == sizeof(std::vector<_Map::value_type>)

--- a/pxr/usd/sdf/childrenView.h
+++ b/pxr/usd/sdf/childrenView.h
@@ -31,7 +31,6 @@
 #include "pxr/usd/sdf/children.h"
 #include "pxr/base/tf/iterator.h"
 
-#include <boost/compressed_pair.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>


### PR DESCRIPTION
### Description of Change(s)
- Update `TfDenseHash{Set,Map}` to explicitly use private inheritance to take advantage of the empty base optimization instead of indirectly through `boost::compressed_pair`
- Decouples initialization of vector storage, `HashFn`, and `Equality{Key,Element}` in constructors
- Updates constructors to use `std::make_unique` instead of `new` operator (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rr-make_unique)
- Decouples swapping of vector storage, `HashFn`, and `Equality{Key,Element}` in `swap` methods
- Remove references to `compressed_pair` in test for `TfDenseHashMap`
- Remove spurious include of `utility.hpp` in `pxr/base/tf/denseHash{Set,Map}.h`
- Remove spurious include of `boost/compressed_pair.hpp` in `pxr/usd/sdf/childrenView.h`

### Fixes Issue(s)
- #2257 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
