### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `PcpNodeRef`

### DIFF
--- a/pxr/usd/pcp/node.h
+++ b/pxr/usd/pcp/node.h
@@ -106,7 +106,7 @@ public:
     }
 
     /// Greater than operator
-    /// \sa PcpNodeRef::PcpNodeRef<(const PcpNodeRef&)
+    /// \sa PcpNodeRef::operator<(const PcpNodeRef&)
     bool operator>(const PcpNodeRef& rhs) const {
         return rhs < *this;
     }

--- a/pxr/usd/pcp/node.h
+++ b/pxr/usd/pcp/node.h
@@ -31,7 +31,6 @@
 #include "pxr/base/tf/iterator.h"
 #include "pxr/base/tf/hashset.h"
 
-#include <boost/operators.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 
@@ -64,8 +63,7 @@ TF_DECLARE_REF_PTRS(PcpPrimIndex_Graph);
 /// as well as any value-mapping needed, such as to rename opinions
 /// from a model to use in a particular instance.
 ///
-class PcpNodeRef : 
-    public boost::totally_ordered<PcpNodeRef>
+class PcpNodeRef
 {
 public:
     typedef PcpNodeRef_ChildrenIterator child_const_iterator;
@@ -89,11 +87,35 @@ public:
         return _nodeIdx == rhs._nodeIdx && _graph == rhs._graph;
     }
 
+    /// Inequality operator
+    /// \sa PcpNodeRef::operator==(const PcpNodeRef&)
+    inline bool operator!=(const PcpNodeRef& rhs) const {
+        return !(*this == rhs);
+    }
+
     /// Returns true if this node is 'less' than \p rhs. 
     /// The ordering of nodes is arbitrary and does not indicate the relative
     /// strength of the nodes.
     PCP_API
     bool operator<(const PcpNodeRef& rhs) const;
+
+    /// Less than or equal operator
+    /// \sa PcpNodeRef::operator<(const PcpNodeRef&)
+    bool operator<=(const PcpNodeRef& rhs) const {
+        return !(rhs < *this);
+    }
+
+    /// Greater than operator
+    /// \sa PcpNodeRef::PcpNodeRef<(const PcpNodeRef&)
+    bool operator>(const PcpNodeRef& rhs) const {
+        return rhs < *this;
+    }
+
+    /// Greater than or equal operator
+    /// \sa PcpNodeRef::operator<(const PcpNodeRef&)
+    bool operator>=(const PcpNodeRef& rhs) const {
+        return !(*this < rhs);
+    }
 
     /// Hash functor.
     struct Hash {


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator<=`, `operator>`, `operator>=`, and `operator!=` to `PcpNodeRef`
- Update doxygen comments so `operator!=` references `operator==` and `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
