### PR TITLE
APPLE: Prevent mipmapping of 1x1 textures.

### DIFF
--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -467,9 +467,9 @@ _HgiTextureCanBeFiltered(HgiTextureDesc descriptor)
     bool const is3DTex = (type == HgiTextureType3D);
     HgiFormat const format = descriptor.format;
     bool const dimensionsCompatible =
-        (is1DTex && dims[0] > 1) ||
-        (is2DTex && dims[0] > 1 && dims[1] > 1) ||
-        (is3DTex && dims[0] > 1 && dims[1] > 1 && dims[2] > 1);
+        (is1DTex && (dims[0] > 1)) ||
+        (is2DTex && (dims[0] > 1 || dims[1] > 1)) ||
+        (is3DTex && (dims[0] > 1 || dims[1] > 1 || dims[2] > 1));
 
     return dimensionsCompatible;
 }

--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -444,27 +444,43 @@ HgiMetalBlitCmds::FillBuffer(HgiBufferHandle const& buffer, uint8_t value)
 }
 
 static bool
-_HgiCanBeFiltered(HgiFormat format)
+_HgiTextureCanBeFiltered(HgiTextureDesc descriptor)
 {
-    HgiFormat const componentFormat = HgiGetComponentBaseFormat(format);
+    HgiFormat const componentFormat =
+        HgiGetComponentBaseFormat(descriptor.format);
 
-    switch(componentFormat) {
-    case HgiFormatInt16:
-    case HgiFormatUInt16:
-    case HgiFormatInt32:
+    if (componentFormat == HgiFormatInt16 ||
+        componentFormat == HgiFormatUInt16 ||
+        componentFormat == HgiFormatInt32) {
         return false;
-    default:
-        return true;
     }
+
+    HgiTextureType const type = descriptor.type;
+    static_assert(HgiTextureTypeCount == (HgiTextureType2DArray+1),
+                  "New texture type is added that is not supported "
+                  "by GenerateMipMaps. Update GenerateMipMaps accordingly.");
+    GfVec3i const dims = descriptor.dimensions;
+    bool const is1DTex = (type == HgiTextureType1D ||
+                          type == HgiTextureType1DArray);
+    bool const is2DTex = (type == HgiTextureType2D ||
+                          type == HgiTextureType2DArray);
+    bool const is3DTex = (type == HgiTextureType3D);
+    HgiFormat const format = descriptor.format;
+    bool const dimensionsCompatible =
+        (is1DTex && dims[0] > 1) ||
+        (is2DTex && dims[0] > 1 && dims[1] > 1) ||
+        (is3DTex && dims[0] > 1 && dims[1] > 1 && dims[2] > 1);
+
+    return dimensionsCompatible;
 }
 
 void
 HgiMetalBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
 {
     HgiMetalTexture* metalTex = static_cast<HgiMetalTexture*>(texture.Get());
+
     if (metalTex) {
-        HgiFormat const format = metalTex->GetDescriptor().format;
-        if (_HgiCanBeFiltered(format)) {
+        if (_HgiTextureCanBeFiltered(metalTex->GetDescriptor())) {
             _CreateEncoder();
             // Can fail if the texture format is not filterable.
             [_blitEncoder generateMipmapsForTexture:metalTex->GetTextureId()];


### PR DESCRIPTION
### Description of Change(s)

In Metal, if a texture has any dimension being a single texel big the mipmapping call `generateMipmapsForTexture` will fail and throw an exception.  So we add a check to the existing one in `HgiMetalBlitCmds::GenerateMipMaps()` which catches this.

Thanks to @morteeza for this.

### Fixes Issue(s)
- Exception when mipmapping textures with any dimension being 1.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
