### PR TITLE
usdviewq: minor fixes when selecting and traversing collections in the property view

### DIFF
--- a/pxr/usdImaging/usdviewq/attributeViewContextMenu.py
+++ b/pxr/usdImaging/usdviewq/attributeViewContextMenu.py
@@ -24,6 +24,7 @@
 
 from .qt import QtGui, QtWidgets, QtCore
 from pxr import Sdf
+from pxr import Usd
 from .usdviewContextMenuItem import UsdviewContextMenuItem
 from .common import (PropertyViewIndex, PropertyViewDataRoles,
                      PrimNotFoundException, PropertyNotFoundException)
@@ -68,6 +69,11 @@ def _selectPrimsAndProps(dataModel, paths):
         if not prim:
             raise PrimNotFoundException(primPath)
         prims.append(prim)
+
+        # No property will exist for a CollectionAPI path, so skip trying
+        # to get one and just use the prim on which the collection is authored.
+        if Usd.CollectionAPI.IsCollectionAPIPath(path):
+            continue
 
         if path.IsPropertyPath():
             prop = prim.GetProperty(path.name)

--- a/pxr/usdImaging/usdviewq/selectionDataModel.py
+++ b/pxr/usdImaging/usdviewq/selectionDataModel.py
@@ -460,6 +460,11 @@ class SelectionDataModel(QtCore.QObject):
 
     def _ensureValidTargetPath(self, target):
         """Validate a property target or connection."""
+        if not target:
+            # This could be the case for example with CollectionAPIs where a
+            # relationship targets a collection name that does not map to an
+            # actual property.
+            return Sdf.Path.emptyPath
 
         return Sdf.Path(str(target))
 


### PR DESCRIPTION
Hello! :)

### Description of Change(s)

This PR addresses two small issues when working with `UsdCollectionAPI`s in the property view of `usdview`.

Collections can end up targeting other collections in their relationships using paths that identify the collection by name but otherwise do not correspond to a prim or a property. There were a few places in usdview that were getting tripped up by this.

The issues can both be seen when `usdview` is opened using the existing `UsdCollectionAPI` test scene:

```
usdview pxr/usd/usd/testenv/testUsdCollectionAPI/Test.usda
```

- Select the `/CollectionTest/Geom` prim in the prim view
- Expand the `collection:allGeom:includes` relationship in the property view
- Select the second target in the relationship that targets the path `/CollectionTest/Geom/Shapes.collection:allShapes`

You should see a warning similar to this output in the terminal:

```
Warning: in SdfPath at line 151 of C:\USD_src\pxr\usd\sdf\path.cpp -- Ill-formed SdfPath <>: syntax error
```

- Right-click that same target to open the context menu and click the "Select Target Path" action

You should see a warning similar to this output in the terminal:

```
Traceback (most recent call last):
      File "C:\USD_inst\lib\python\pxr\Usdviewq\attributeViewContextMenu.py", line 207, in RunCommand
        _selectPrimsAndProps(self._dataModel, paths)
      File "C:\USD_inst\lib\python\pxr\Usdviewq\attributeViewContextMenu.py", line 81, in _selectPrimsAndProps
        raise PropertyNotFoundException(path)
    pxr.Usdviewq.common.PropertyNotFoundException: Property not found at path in stage: /CollectionTest/Geom/Shapes.collection:allShapes
```

And the selection will not change off of the `/CollectionTest/Geom` prim.

---

With the changes here, neither of these warnings should appear, and using the "Select Target Path" action on a UsdCollectionAPI path will cause that collection's prim to be selected.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
