### PR TITLE
[build] remove unused lipoCommands* variables from build_usd.py

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1000,22 +1000,19 @@ def InstallTBB_MacOS(context, force, buildArgs):
             x86Dir = os.path.dirname(x86Files[0])
             armDir = os.path.dirname(armFiles[0])
 
-            lipoCommandsRelease = apple_utils.CreateUniversalBinaries(
-                                        context, libNames, x86Dir, armDir)
+            apple_utils.CreateUniversalBinaries(context, libNames, x86Dir, armDir)
 
             x86Files = glob.glob(
                 os.getcwd() + "/build/*intel64*_debug/libtbb*.*")
             armFiles = glob.glob(
                 os.getcwd() + "/build/*{0}*_debug/libtbb*.*".format(
                         apple_utils.GetTargetArmArch()))
-            lipoCommandsDebug = None
             if x86Files and armFiles:
                 libNames = [os.path.basename(x) for x in x86Files]
                 x86Dir = os.path.dirname(x86Files[0])
                 armDir = os.path.dirname(armFiles[0])
 
-                lipoCommandsDebug = apple_utils.CreateUniversalBinaries(
-                                        context, libNames, x86Dir, armDir)
+                apple_utils.CreateUniversalBinaries(context, libNames, x86Dir, armDir)
         else:
             CopyFiles(context, "build/*_release/libtbb*.*", "lib")
             try:


### PR DESCRIPTION
### Description of Change(s)

Just removes some unused variables from build_usd.py - they were confusing for me when trying to read the code.

See usd-interest thread:
https://groups.google.com/g/usd-interest/c/WAsjLJfdq2I

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
