### PR TITLE
Replace `boost::iterator_adaptor` with explicitly specified iterator definition for `UsdNotice::ObjectsChanged::PathRange`

### DIFF
--- a/pxr/usd/usd/notice.cpp
+++ b/pxr/usd/usd/notice.cpp
@@ -68,7 +68,7 @@ TfTokenVector
 UsdNotice::ObjectsChanged::PathRange::const_iterator::GetChangedFields() const
 {
     TfTokenVector fields;
-    for (const SdfChangeList::Entry* entry : base()->second) {
+    for (const SdfChangeList::Entry* entry : _underlyingIterator->second) {
         fields.reserve(fields.size() + entry->infoChanged.size());
         std::transform(
             entry->infoChanged.begin(), entry->infoChanged.end(),
@@ -83,7 +83,7 @@ UsdNotice::ObjectsChanged::PathRange::const_iterator::GetChangedFields() const
 bool 
 UsdNotice::ObjectsChanged::PathRange::const_iterator::HasChangedFields() const
 {
-    for (const SdfChangeList::Entry* entry : base()->second) {
+    for (const SdfChangeList::Entry* entry : _underlyingIterator->second) {
         if (!entry->infoChanged.empty()) {
             return true;
         }

--- a/pxr/usd/usd/notice.h
+++ b/pxr/usd/usd/notice.h
@@ -149,15 +149,38 @@ public:
         {
         public:
             /// \class iterator
-            class iterator : public boost::iterator_adaptor<
-                iterator,                           // crtp base,
-                _PathsToChangesMap::const_iterator, // base iterator
-                const SdfPath&                      // value type
-            >
-            {
+            class iterator {
+                using _UnderlyingIterator = _PathsToChangesMap::const_iterator;
             public:
-                iterator() 
-                    : iterator_adaptor_(base_type()) {}
+                using iterator_category = std::forward_iterator_tag;
+                using value_type = const SdfPath&;
+                using reference = const SdfPath&;
+                using pointer = const SdfPath*;
+                using difference_type =
+                    typename _UnderlyingIterator::difference_type;
+
+                iterator() = default;
+                reference operator*() const { return dereference(); }
+                pointer operator->() const { return &(dereference()); }
+
+                iterator& operator++() {
+                    ++_underlyingIterator;
+                    return *this;
+                }
+
+                iterator operator++(int) {
+                    iterator result = *this;
+                    ++_underlyingIterator;
+                    return result;
+                }
+
+                bool operator==(const iterator& other) const{
+                    return _underlyingIterator == other._underlyingIterator;
+                }
+
+                bool operator!=(const iterator& other) const{
+                    return _underlyingIterator != other._underlyingIterator;
+                }
 
                 /// Return the set of changed fields in layers that affected 
                 /// the object at the path specified by this iterator.  See
@@ -171,15 +194,27 @@ public:
                 /// details.
                 USD_API bool HasChangedFields() const;
 
+                /// Returns the underlying iterator
+                _UnderlyingIterator GetBase() const {
+                    return _underlyingIterator;
+                }
+
+                /// \deprecated Use GetBase() instead.
+                _UnderlyingIterator base() const {
+                    return GetBase();
+                }
+
             private:
                 friend class PathRange;
-                friend class boost::iterator_core_access;
 
-                iterator(base_type baseIter) 
-                    : iterator_adaptor_(baseIter) {}
+                explicit iterator(_UnderlyingIterator baseIter)
+                    : _underlyingIterator(baseIter) {}
+
                 inline reference dereference() const { 
-                    return base()->first;
+                    return _underlyingIterator->first;
                 }
+
+                _UnderlyingIterator _underlyingIterator;
             };
 
             using const_iterator = iterator;

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -1194,7 +1194,7 @@ _HasConnectionChanged(const SdfPath &path, const PathRange &pathRange)
 {
     PathRange::const_iterator itr = pathRange.find(path);
     if (itr != pathRange.end()) {
-        for (const SdfChangeList::Entry *entry : itr.base()->second) {
+        for (const SdfChangeList::Entry *entry : itr.GetBase()->second) {
             if (entry->flags.didChangeAttributeConnection) {
                 return true;
             }


### PR DESCRIPTION
### Description of Change(s)
- Introduces an `_UnderlyingIterator` type alias for `_PathsToChangesMap::const_iterator` in `UsdNotice::ObjectsChanged::PathRange::iterator`
- Explicitly implement the equality, increment, dereference, and arrow operators for `UsdNotice::ObjectsChanged::PathRange::iterator`
- Add `GetBase` method to the iterator for direct query of the underlying iterator

### Fixes Issue(s)
- #2228 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
