### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `PcpLayerStackIdentifier`

### DIFF
--- a/pxr/usd/pcp/layerStackIdentifier.h
+++ b/pxr/usd/pcp/layerStackIdentifier.h
@@ -31,8 +31,6 @@
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/usd/ar/resolverContext.h"
 
-#include <boost/operators.hpp>
-
 #include <iosfwd>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -45,8 +43,7 @@ SDF_DECLARE_HANDLES(SdfLayer);
 ///
 /// Objects of this type are immutable.
 ///
-class PcpLayerStackIdentifier :
-    boost::totally_ordered<PcpLayerStackIdentifier> {
+class PcpLayerStackIdentifier {
 public:
     typedef PcpLayerStackIdentifier This;
 
@@ -74,8 +71,13 @@ public:
     // Comparison.
     PCP_API
     bool operator==(const This &rhs) const;
+    bool operator!=(const This &rhs) const { return !(rhs == *this); }
+
     PCP_API
     bool operator<(const This &rhs) const;
+    bool operator<=(const This& rhs) const { return !(rhs < *this); }
+    bool operator>(const This& rhs) const { return rhs < *this; }
+    bool operator>=(const This& rhs) const { return !(*this < rhs); }
 
     // Hashing.
     struct Hash {

--- a/pxr/usd/pcp/layerStackIdentifier.h
+++ b/pxr/usd/pcp/layerStackIdentifier.h
@@ -71,13 +71,25 @@ public:
     // Comparison.
     PCP_API
     bool operator==(const This &rhs) const;
-    bool operator!=(const This &rhs) const { return !(rhs == *this); }
+    bool operator!=(const This &rhs) const
+    {
+        return !(rhs == *this);
+    }
 
     PCP_API
     bool operator<(const This &rhs) const;
-    bool operator<=(const This& rhs) const { return !(rhs < *this); }
-    bool operator>(const This& rhs) const { return rhs < *this; }
-    bool operator>=(const This& rhs) const { return !(*this < rhs); }
+    bool operator<=(const This& rhs) const
+    {
+        return !(rhs < *this);
+    }
+    bool operator>(const This& rhs) const
+    {
+        return rhs < *this;
+    }
+    bool operator>=(const This& rhs) const
+    {
+        return !(*this < rhs);
+    }
 
     // Hashing.
     struct Hash {


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator<=`, `operator>`, `operator>=`, and `operator!=` to `PcpLayerStackIdentifier`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
