### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `UsdStageCache::Id`

### DIFF
--- a/pxr/usd/usd/stageCache.h
+++ b/pxr/usd/usd/stageCache.h
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/declarePtrs.h"
 
 #include <boost/lexical_cast.hpp>
-#include <boost/operators.hpp>
 
 #include <string>
 #include <memory>
@@ -97,7 +96,7 @@ public:
     /// It never makes sense to use an Id with a stage other than the one it was
     /// obtained from.
     ///
-    struct Id : private boost::totally_ordered<Id> {
+    struct Id {
         /// Default construct an invalid id.
         Id() : _value(-1) {}
 
@@ -130,9 +129,25 @@ public:
         friend bool operator==(const Id &lhs, const Id &rhs) {
             return lhs.ToLongInt() == rhs.ToLongInt();
         }
+        /// Inequality comparison.
+        friend bool operator!=(const Id &lhs, const Id &rhs) {
+            return !(lhs == rhs);
+        }
         /// Less-than comparison.
         friend bool operator<(const Id &lhs, const Id &rhs) {
             return lhs.ToLongInt() < rhs.ToLongInt();
+        }
+        /// Less-than or equal comparison.
+        friend bool operator<=(const Id &lhs, const Id &rhs) {
+            return !(rhs < lhs);
+        }
+        /// Greater-than comparison.
+        friend bool operator>(const Id &lhs, const Id &rhs) {
+            return rhs < lhs;
+        }
+        /// Greater-than or equal comparison.
+        friend bool operator>=(const Id &lhs, const Id &rhs) {
+            return !(lhs < rhs);
         }
         /// Hash.
         friend size_t hash_value(Id id) {


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator<=`, `operator>`, `operator>=`, and `operator!=` to `UsdStageCache::Id`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
