### PR TITLE
Replace usage of `boost::transform_iterator` in `pxr/usd/usd`

### DIFF
--- a/pxr/usd/usd/property.cpp
+++ b/pxr/usd/usd/property.cpp
@@ -27,8 +27,6 @@
 #include "pxr/usd/usd/stage.h"
 #include "pxr/usd/pcp/targetIndex.h"
 
-#include <boost/iterator/transform_iterator.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -185,17 +183,14 @@ using _PathMap = std::vector<std::pair<SdfPath, SdfPath>>;
 static SdfPath
 _MapPath(_PathMap const &map, SdfPath const &path)
 {
-    using boost::make_transform_iterator;
-
     if (map.empty()) {
         return path;
     }
 
     auto it = SdfPathFindLongestPrefix(
-        make_transform_iterator(map.begin(), TfGet<0>()),
-        make_transform_iterator(map.end(), TfGet<0>()), path);
-    if (it.base() != map.end()) {
-        return path.ReplacePrefix(it.base()->first, it.base()->second);
+        map.begin(), map.end(), path, TfGet<0>());
+    if (it != map.end()) {
+        return path.ReplacePrefix(it->first, it->second);
     }
     return path;
 }

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -96,7 +96,6 @@
 #include "pxr/base/work/withScopedParallelism.h"
 
 #include <boost/optional.hpp>
-#include <boost/iterator/transform_iterator.hpp>
 
 #include <tbb/spin_rw_mutex.h>
 #include <tbb/spin_mutex.h>
@@ -111,7 +110,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-using boost::make_transform_iterator;
 using std::pair;
 using std::make_pair;
 using std::map;
@@ -3818,9 +3816,9 @@ template <class ChangedPaths>
 static std::string
 _Stringify(const ChangedPaths& paths)
 {
-    return _Stringify(SdfPathVector(
-        make_transform_iterator(paths.begin(), TfGet<0>()),
-        make_transform_iterator(paths.end(), TfGet<0>())));
+    SdfPathVector temp(paths.size());
+    std::transform(paths.cbegin(), paths.cend(), temp.begin(), TfGet<0>());
+    return _Stringify(temp);
 }
 
 // Add paths in the given cache that depend on the given path in the given 
@@ -4540,8 +4538,7 @@ UsdStage::_RecomposePrims(T *pathsToRecompose)
     // around this.
     std::vector<Usd_PrimDataPtr> subtreesToRecompose;
     _ComputeSubtreesToRecompose(
-        make_transform_iterator(pathsToRecompose->begin(), TfGet<0>()),
-        make_transform_iterator(pathsToRecompose->end(), TfGet<0>()),
+        pathsToRecompose->begin(), pathsToRecompose->end(),
         &subtreesToRecompose);
 
     // Recompose subtrees.
@@ -4583,14 +4580,14 @@ UsdStage::_ComputeSubtreesToRecompose(
         subtreesToRecompose->size() + std::distance(i, end));
 
     while (i != end) {
-        TF_DEBUG(USD_CHANGES).Msg("Recomposing: %s\n", i->GetText());
+        TF_DEBUG(USD_CHANGES).Msg("Recomposing: %s\n", i->first.GetText());
         // TODO: refactor into shared method
         // We only care about recomposing prim-like things
         // so avoid recomposing anything else.
-        if (!i->IsAbsoluteRootOrPrimPath() ||
-            i->ContainsPrimVariantSelection()) {
+        if (!i->first.IsAbsoluteRootOrPrimPath() ||
+            i->first.ContainsPrimVariantSelection()) {
             TF_DEBUG(USD_CHANGES).Msg("Skipping non-prim: %s\n",
-                                      i->GetText());
+                                      i->first.GetText());
             ++i;
             continue;
         }
@@ -4598,16 +4595,16 @@ UsdStage::_ComputeSubtreesToRecompose(
         // Add prototypes to list of subtrees to recompose and instantiate any 
         // new prototype not present in the primMap from before
         PathToNodeMap::const_accessor acc;
-        if (_instanceCache->IsPrototypePath(*i)) {
+        if (_instanceCache->IsPrototypePath(i->first)) {
             Usd_PrimDataPtr prototypePrim;
-            if (_primMap.find(acc, *i)) {
+            if (_primMap.find(acc, i->first)) {
                 // should be a changed prototype if already in the primMap
                 prototypePrim = acc->second.get();
                 acc.release();
             } else {
                 // newPrototype should be absent from the primMap, instantiate
                 // these now to be added to subtreesToRecompose
-                prototypePrim = _InstantiatePrototypePrim(*i);
+                prototypePrim = _InstantiatePrototypePrim(i->first);
             }
             subtreesToRecompose->push_back(prototypePrim);
             ++i;
@@ -4616,7 +4613,7 @@ UsdStage::_ComputeSubtreesToRecompose(
 
         // Collect all non-prototype prims (including descendants of prototypes)
         // to be added to subtreesToRecompute
-        SdfPath const &parentPath = i->GetParentPath();
+        SdfPath const &parentPath = i->first.GetParentPath();
         if (_primMap.find(acc, parentPath)) {
 
             // Since our input range contains no descendant paths, siblings
@@ -4634,18 +4631,18 @@ UsdStage::_ComputeSubtreesToRecompose(
 
             // Recompose the subtree for each affected sibling.
             do {
-                if (_primMap.find(acc, *i)) {
+                if (_primMap.find(acc, i->first)) {
                     subtreesToRecompose->push_back(acc->second.get());
                     acc.release();
-                } else if (_instanceCache->IsPrototypePath(*i)) {
+                } else if (_instanceCache->IsPrototypePath(i->first)) {
                     // If this path is a prototype path and is not present in
                     // the primMap, then this must be a new prototype added
                     // during this processing, instantiate and add it.
-                    Usd_PrimDataPtr protoPrim = _InstantiatePrototypePrim(*i);
+                    Usd_PrimDataPtr protoPrim = _InstantiatePrototypePrim(i->first);
                     subtreesToRecompose->push_back(protoPrim);
                 }
                 ++i;
-            } while (i != end && i->GetParentPath() == parentPath);
+            } while (i != end && i->first.GetParentPath() == parentPath);
         } else if (parentPath.IsEmpty()) {
             // This is the pseudo root, so we need to blow and rebuild
             // everything.

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -1922,7 +1922,8 @@ private:
     // Helper for _Recompose to find the subtrees that need to be
     // fully recomposed and to recompose the name children of the
     // parents of these subtrees. Note that [start, finish) must be a
-    // sorted range of paths with no descendent paths.
+    // sorted range of map iterators whose keys are paths with no descendent
+    // paths. In C++20, consider using the ranges API to improve this.
     template <class Iter>
     void _ComputeSubtreesToRecompose(Iter start, Iter finish,
                                      std::vector<Usd_PrimDataPtr>* recompose);


### PR DESCRIPTION
### Description of Change(s)
- Use the function argument to `SdfPathFindLongestPrefix` to apply the transform instead of `boost::transform_iterator` in `UsdProperty`
- Use `std::transform` to apply the transformation to an explicitly named temporary in `_Stringify` in `pxr/usd/usd/stage.h`
- Change private helper `_ComputeSubtreesToRecompose` in `UsdStage` to accept map iterators and apply the transformation inside of the function instead of via `boost::transform_iterator`

### Fixes Issue(s)
- #2272 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
