### PR TITLE
CMake: append should be used for `CMAKE_MODULE_PATH`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     endif()
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
+list(APPEND CMAKE_MODULE_PATH
                       ${PROJECT_SOURCE_DIR}/cmake/defaults
                       ${PROJECT_SOURCE_DIR}/cmake/modules
                       ${PROJECT_SOURCE_DIR}/cmake/macros)


### PR DESCRIPTION
### Description of Change(s)
`CMAKE_MODULE_PATH` is a directory list and shall be appended via `list(APPEND`


### Note
No major change but ensures when `CMAKE_MODULE_PATH` has been defined with alternative defaults on the command-line or via use of `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`

- [ ] I have verified that all unit tests pass with the proposed changes
- [x ] I have submitted a signed Contributor License Agreement

PR Note:
- First commit to confirm CLA
- This change is small enough and deemed self-explanatory to not affect tests, I will however look into executing tests as a sanity check soon but do not see this PR being blocked on this?
