### PR TITLE
Fixes MTLX split string array parsing.

### DIFF
--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxParser.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxParser.py
@@ -72,7 +72,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(input.GetLabel(), "UI Vector")
         self.assertEqual(input.GetPage(), "UI Page")
         self.assertEqual(input.GetOptions(),
-            [("X", "1, 0, 0"), ("Y", "0, 1, 0"), ("Z", "0, 0, 1")])
+            [("X Label", "1, 0, 0"), ("Y Label", "0, 1, 0"), ("Z Label", "0, 0, 1")])
 
         node = Sdr.Registry().GetShaderNodeByIdentifier(
             'UsdMtlxTestNamespace:nd_float')

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxParser.testenv/test.mtlx
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxParser.testenv/test.mtlx
@@ -16,7 +16,7 @@
     <output name="out" type="string" />
   </nodedef>
   <nodedef name="nd_vector" node="UsdMtlxTestNode" doc="Vector help">
-    <input name="in" type="vector3" enum="X,Y,Z" enumvalues="1,0,0, 0,1,0, 0,0,1" doc="Property help" uiname="UI Vector" uifolder="UI Page" />
+    <input name="in" type="vector3" enum="X Label, Y Label, Z Label" enumvalues="1,0,0, 0,1,0, 0,0,1" doc="Property help" uiname="UI Vector" uifolder="UI Page" />
     <input name="note" type="string" value="" uniform="true" />
     <output name="out" type="vector3" />
   </nodedef>

--- a/pxr/usd/usdMtlx/utils.cpp
+++ b/pxr/usd/usdMtlx/utils.cpp
@@ -57,6 +57,8 @@ TF_DEFINE_PUBLIC_TOKENS(UsdMtlxTokens, USD_MTLX_TOKENS);
 
 namespace {
 
+const std::string _CommaSeparator = ",";
+
 using DocumentCache = std::map<std::string, mx::DocumentPtr>;
 
 static
@@ -586,7 +588,11 @@ UsdMtlxGetPackedUsdValues(const std::string& values, const std::string& type)
 std::vector<std::string>
 UsdMtlxSplitStringArray(const std::string& s)
 {
-    return mx::splitString(s, mx::ARRAY_VALID_SEPARATORS);
+    std::vector<std::string> strs = mx::splitString(s, _CommaSeparator);
+    for (size_t i=0; i<strs.size(); ++i) {
+        strs[i] = mx::trimSpaces(strs[i]);
+    }
+    return strs;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
Splits on only commas instead of commas and spaces. Also removes leading and trailing whitespace.

### Fixes Issue(s)
Fixes #2268

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
