### PR TITLE
Replace `boost::iterator_range` usage for ranges of `UsdPrim`s

### DIFF
--- a/pxr/usd/usd/primData.h
+++ b/pxr/usd/usd/primData.h
@@ -40,7 +40,6 @@
 
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/range/iterator_range.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #include <atomic>
@@ -305,19 +304,11 @@ private:
         _flags[Usd_PrimClipsFlag] = hasClips;
     }
 
-    typedef boost::iterator_range<
-        class Usd_PrimDataSiblingIterator> SiblingRange;
-
     inline class Usd_PrimDataSiblingIterator _ChildrenBegin() const;
     inline class Usd_PrimDataSiblingIterator _ChildrenEnd() const;
-    inline SiblingRange _GetChildrenRange() const;
-
-    typedef boost::iterator_range<
-        class Usd_PrimDataSubtreeIterator> SubtreeRange;
 
     inline class Usd_PrimDataSubtreeIterator _SubtreeBegin() const;
     inline class Usd_PrimDataSubtreeIterator _SubtreeEnd() const;
-    inline SubtreeRange _GetSubtreeRange() const;
 
     // Data members.
     UsdStage *_stage;
@@ -401,18 +392,6 @@ private:
     _UnderylingIterator _underlyingIterator = nullptr;
 };
 
-// Sibling range.
-typedef boost::iterator_range<
-    class Usd_PrimDataSiblingIterator> Usd_PrimDataSiblingRange;
-
-// Inform TfIterator it should feel free to make copies of the range type.
-template <>
-struct Tf_ShouldIterateOverCopy<
-    Usd_PrimDataSiblingRange> : std::true_type {};
-template <>
-struct Tf_ShouldIterateOverCopy<
-    const Usd_PrimDataSiblingRange> : std::true_type {};
-
 Usd_PrimDataSiblingIterator
 Usd_PrimData::_ChildrenBegin() const
 {
@@ -424,13 +403,6 @@ Usd_PrimData::_ChildrenEnd() const
 {
     return Usd_PrimDataSiblingIterator(0);
 }
-
-Usd_PrimData::SiblingRange
-Usd_PrimData::_GetChildrenRange() const
-{
-    return Usd_PrimData::SiblingRange(_ChildrenBegin(), _ChildrenEnd());
-}
-
 
 // Tree iterator class.
 class Usd_PrimDataSubtreeIterator {
@@ -485,18 +457,6 @@ private:
     _UnderlyingIterator _underlyingIterator = nullptr;
 };
 
-// Tree range.
-typedef boost::iterator_range<
-    class Usd_PrimDataSubtreeIterator> Usd_PrimDataSubtreeRange;
-
-// Inform TfIterator it should feel free to make copies of the range type.
-template <>
-struct Tf_ShouldIterateOverCopy<
-    Usd_PrimDataSubtreeRange> : std::true_type {};
-template <>
-struct Tf_ShouldIterateOverCopy<
-    const Usd_PrimDataSubtreeRange> : std::true_type {};
-
 Usd_PrimDataSubtreeIterator
 Usd_PrimData::_SubtreeBegin() const
 {
@@ -508,12 +468,6 @@ Usd_PrimDataSubtreeIterator
 Usd_PrimData::_SubtreeEnd() const
 {
     return Usd_PrimDataSubtreeIterator(GetNextPrim());
-}
-
-Usd_PrimData::SubtreeRange
-Usd_PrimData::_GetSubtreeRange() const
-{
-    return Usd_PrimData::SubtreeRange(_SubtreeBegin(), _SubtreeEnd());
 }
 
 // Helpers for instance proxies.

--- a/pxr/usd/usd/testenv/testUsdPrimGetDescendants.cpp
+++ b/pxr/usd/usd/testenv/testUsdPrimGetDescendants.cpp
@@ -34,6 +34,84 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 static void
+TestRangeEqualityOperators()
+{
+    const std::string layerFile = "test.usda";
+    UsdStageRefPtr stage = UsdStage::Open(layerFile, UsdStage::LoadNone);
+    TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants());
+    TF_AXIOM(!stage->GetPseudoRoot().GetAllDescendants().empty());
+
+    // Test UsdPrimSubtreeRange equality operator
+    TF_AXIOM(UsdPrimSubtreeRange() == UsdPrimSubtreeRange());
+    TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() ==
+             stage->GetPseudoRoot().GetAllDescendants());
+
+    // Test UsdPrimSubtreeRange templated equality operator
+    TF_AXIOM(UsdPrimSubtreeRange() == std::vector<UsdPrim>());
+    TF_AXIOM(std::vector<UsdPrim>() == UsdPrimSubtreeRange());
+    {
+        const auto allDescendants = stage->GetPseudoRoot().GetAllDescendants();
+        std::vector<UsdPrim> allPrims(
+            std::begin(allDescendants),
+            std::end(allDescendants)
+        );
+        TF_AXIOM(!allPrims.empty());
+        TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() == allPrims);
+        TF_AXIOM(allPrims == stage->GetPseudoRoot().GetAllDescendants());
+    }
+
+    // Test UsdPrimSubtreeRange inequality operator
+    TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() !=
+             stage->GetPseudoRoot().GetFilteredDescendants(UsdPrimIsModel));
+
+    // Test UsdPrimSubtreeRange templated inequality operator
+    TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() !=
+             std::vector<UsdPrim>());
+    TF_AXIOM(std::vector<UsdPrim>() !=
+             stage->GetPseudoRoot().GetAllDescendants());
+    {
+        const auto allDescendants = stage->GetPseudoRoot().GetAllDescendants();
+        std::vector<UsdPrim> allDescendantsPlusOne(
+            std::begin(allDescendants),
+            std::end(allDescendants)
+        );
+        allDescendantsPlusOne.push_back(UsdPrim());
+        TF_AXIOM(allDescendantsPlusOne.size() > 1);
+        TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() !=
+                 allDescendantsPlusOne);
+        TF_AXIOM(allDescendantsPlusOne !=
+                 stage->GetPseudoRoot().GetAllDescendants());
+    }
+    {
+        const auto allDescendants = stage->GetPseudoRoot().GetAllDescendants();
+        std::vector<UsdPrim> allDescendantsMinusOne(
+            std::begin(allDescendants),
+            std::end(allDescendants)
+        );
+        TF_AXIOM(!allDescendantsMinusOne.empty());
+        allDescendantsMinusOne.pop_back();
+        TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() !=
+                 allDescendantsMinusOne);
+        TF_AXIOM(allDescendantsMinusOne !=
+                 stage->GetPseudoRoot().GetAllDescendants());
+    }
+    {
+        const auto allDescendants = stage->GetPseudoRoot().GetAllDescendants();
+        std::vector<UsdPrim> allDescendantsBackReplaced(
+            std::begin(allDescendants),
+            std::end(allDescendants)
+        );
+        TF_AXIOM(!allDescendantsBackReplaced.empty());
+        TF_AXIOM(allDescendantsBackReplaced.back() != UsdPrim());
+        allDescendantsBackReplaced.back() = UsdPrim();
+        TF_AXIOM(stage->GetPseudoRoot().GetAllDescendants() !=
+                 allDescendantsBackReplaced);
+        TF_AXIOM(allDescendantsBackReplaced !=
+                 stage->GetPseudoRoot().GetAllDescendants());
+    }
+}
+
+static void
 TestGetDescendants()
 {
     std::string layerFile = "test.usda";
@@ -249,6 +327,7 @@ TestGetDescendantsAsInstanceProxies()
 int 
 main(int argc, char** argv)
 {
+    TestRangeEqualityOperators();
     TestGetDescendants();
     TestGetDescendantsAsInstanceProxies();
 


### PR DESCRIPTION
### Description of Change(s)
Depends on #2235
- Implement `UsdPrim{Sibling,Subtree}Range` using the existing doxygen stubs
- Relocate class declarations to after their corresponding iterator declarations
- Make templated constructor and operators explicit
- Add `cbegin` and `cend` methods
- Remove unused references to `boost::iterator_range` in `pxr/usd/usd/primData.h`
- Add test coverage for equality operators of `UsdPrimSubtreeRange` to `testUsdPrimGetDescendants`

### Fixes Issue(s)
- #2276 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
