### PR TITLE
Fix linking whole archives on Linux Clang

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -611,12 +611,12 @@ archive.  That's platform dependent and you'll want code something like
 this:
 
 ```cmake
-if(MSVC)
-    target_link_libraries(mylib -WHOLEARCHIVE:$<TARGET_FILE:usd_m> usd_m)
-elseif(CMAKE_COMPILER_IS_GNUCXX)
-    target_link_libraries(mylib -Wl,--whole-archive usd_m -Wl,--no-whole-archive)
-elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_link_libraries(mylib -Wl,-force_load usd_m)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(mylib -Wl,--whole-archive usd_m -Wl,--no-whole-archive)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    target_link_libraries(mylib -WHOLEARCHIVE:$<TARGET_FILE:usd_m> usd_m)
 endif()
 ```
 

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -848,7 +848,11 @@ function(_pxr_target_link_libraries NAME)
                 if(";${PXR_STATIC_LIBS};" MATCHES ";${lib};")
                     # The library is explicitly static.
                     list(APPEND final ${lib})
-                elseif(MSVC)
+                elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+                    list(APPEND final -Wl,-force_load ${lib})
+                elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+                    list(APPEND final -Wl,--whole-archive ${lib} -Wl,--no-whole-archive)
+                elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
                     # The syntax here is -WHOLEARCHIVE[:lib] but CMake will
                     # treat that as a link flag and not "see" the library.
                     # As a result it won't replace a target with the path
@@ -871,10 +875,6 @@ function(_pxr_target_link_libraries NAME)
                     #
                     list(APPEND final -WHOLEARCHIVE:$<TARGET_FILE:${lib}>)
                     list(APPEND final ${lib})
-                elseif(CMAKE_COMPILER_IS_GNUCXX)
-                    list(APPEND final -Wl,--whole-archive ${lib} -Wl,--no-whole-archive)
-                elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-                    list(APPEND final -Wl,-force_load ${lib})
                 else()
                     # Unknown platform.
                     list(APPEND final ${lib})

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1043,21 +1043,20 @@ function(pxr_toplevel_epilogue)
         # that we carefully avoid adding the usd_m target itself by using
         # TARGET_FILE.  Linking the usd_m target would link usd_m and
         # everything it links to.
-        
-        if(MSVC)
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             target_link_libraries(usd_ms
                 PRIVATE
-                    -WHOLEARCHIVE:$<BUILD_INTERFACE:$<TARGET_FILE:usd_m>>
+                    -Wl,-force_load $<BUILD_INTERFACE:$<TARGET_FILE:usd_m>>
             )
-        elseif(CMAKE_COMPILER_IS_GNUCXX)
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
             target_link_libraries(usd_ms
                 PRIVATE
                     -Wl,--whole-archive $<BUILD_INTERFACE:$<TARGET_FILE:usd_m>> -Wl,--no-whole-archive
             )
-        elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
             target_link_libraries(usd_ms
                 PRIVATE
-                    -Wl,-force_load $<BUILD_INTERFACE:$<TARGET_FILE:usd_m>>
+                    -WHOLEARCHIVE:$<BUILD_INTERFACE:$<TARGET_FILE:usd_m>>
             )
         endif()
 


### PR DESCRIPTION
### Description of Change(s)

Building static archives wasn't working with Clang on Linux because lld uses --whole-archive and not -force_load like AppleClang.

CMake 3.24 introduces a WHOLE_ARCHIVE feature to make loading whole static libraries easier, but the minimum CMake version for USD is 3.12 so I have copied from the example provided by CMake instead which fixes the issue:
https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_LINK_LIBRARY_USING_FEATURE.html#loading-a-whole-static-library

### Fixes Issue(s)
```
[ 28%] Linking CXX executable testArchError
ld.lld: error: unknown argument '-force_load'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
pxr/base/arch/CMakeFiles/testArchAttributes.dir/build.make:98: recipe for target 'pxr/base/arch/testArchAttributes' failed
make[2]: *** [pxr/base/arch/testArchAttributes] Error 1
CMakeFiles/Makefile2:2395: recipe for target 'pxr/base/arch/CMakeFiles/testArchAttributes.dir/all' failed
make[1]: *** [pxr/base/arch/CMakeFiles/testArchAttributes.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
ld.lld: error: unknown argument '-force_load'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
ld.lld: error: unknown argument '-force_load'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
pxr/base/arch/CMakeFiles/testArchDemangle.dir/build.make:98: recipe for target 'pxr/base/arch/testArchDemangle' failed
make[2]: *** [pxr/base/arch/testArchDemangle] Error 1
CMakeFiles/Makefile2:2421: recipe for target 'pxr/base/arch/CMakeFiles/testArchDemangle.dir/all' failed
make[1]: *** [pxr/base/arch/CMakeFiles/testArchDemangle.dir/all] Error 2
pxr/base/arch/CMakeFiles/testArchAbi.dir/build.make:98: recipe for target 'pxr/base/arch/testArchAbi' failed
make[2]: *** [pxr/base/arch/testArchAbi] Error 1
CMakeFiles/Makefile2:2369: recipe for target 'pxr/base/arch/CMakeFiles/testArchAbi.dir/all' failed
make[1]: *** [pxr/base/arch/CMakeFiles/testArchAbi.dir/all] Error 2
ld.lld: error: unknown argument '-force_load'
clang-9: error: linker command failed with exit code 1 (use -v to see invocation)
pxr/base/arch/CMakeFiles/testArchError.dir/build.make:114: recipe for target 'pxr/base/arch/testArchError' failed
make[2]: *** [pxr/base/arch/testArchError] Error 1
CMakeFiles/Makefile2:2447: recipe for target 'pxr/base/arch/CMakeFiles/testArchError.dir/all' failed
make[1]: *** [pxr/base/arch/CMakeFiles/testArchError.dir/all] Error 2
Makefile:145: recipe for target 'all' failed
make: *** [all] Error 2
```

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
