### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfListProxy`

### DIFF
--- a/pxr/usd/sdf/listProxy.h
+++ b/pxr/usd/sdf/listProxy.h
@@ -37,7 +37,6 @@
 #include "pxr/base/tf/iterator.h"
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
-#include <boost/operators.hpp>
 #include <boost/optional.hpp>
 #include <boost/type_traits/is_base_of.hpp>
 #include <boost/type_traits/remove_cv.hpp>
@@ -56,9 +55,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// insertion sequence). 
 ///
 template <class _TypePolicy>
-class SdfListProxy :
-    boost::totally_ordered<SdfListProxy<_TypePolicy>,
-                           std::vector<typename _TypePolicy::value_type> > {
+class SdfListProxy {
 public:
     typedef _TypePolicy TypePolicy;
     typedef SdfListProxy<TypePolicy> This;
@@ -67,7 +64,7 @@ public:
 
 private:
     // Proxies an item in a list editor list.
-    class _ItemProxy : boost::totally_ordered<_ItemProxy> {
+    class _ItemProxy {
     public:
         explicit _ItemProxy(This* owner, size_t index) :
             _owner(owner), _index(index)
@@ -89,12 +86,30 @@ private:
             return _owner->_Get(_index);
         }
 
+        // Operators rely on implicit conversion to value_type
+        // for comparing two _ItemProxy instances
         bool operator==(const value_type& x) const {
             return _owner->_Get(_index) == x;
         }
 
+        bool operator!=(const value_type& x) const {
+            return !(*this == x);
+        }
+
         bool operator<(const value_type& x) const {
             return _owner->_Get(_index) < x;
+        }
+
+        bool operator>(const value_type& x) const {
+            return x < value_type(*this);
+        }
+
+        bool operator>=(const value_type& x) const {
+            return !(*this < x);
+        }
+
+        bool operator<=(const value_type& x) const {
+            return !(x < value_type(*this));
         }
 
     private:
@@ -416,14 +431,59 @@ public:
         return value_vector_type(*this) == y;
     }
 
+    /// Equality comparision
+    friend bool operator==(const value_vector_type& x, const SdfListProxy& y) {
+        return y == x;
+    }
+
+    /// Inequality comparison.
+    bool operator!=(const value_vector_type& y) const {
+        return !(*this == y);
+    }
+
+    /// Inequality comparision
+    friend bool operator!=(const value_vector_type& x, const SdfListProxy& y) {
+        return y != x;
+    }
+
     /// Less-than comparison.
     bool operator<(const value_vector_type& y) const {
         return value_vector_type(*this) < y;
     }
 
+    /// Less-than comparison
+    friend bool operator<(const value_vector_type& x, const SdfListProxy& y) {
+        return x < value_vector_type(y);
+    }
+
     /// Greater-than comparison.
     bool operator>(const value_vector_type& y) const {
         return value_vector_type(*this) > y;
+    }
+
+    /// Greater-than comparison.
+    friend bool operator>(const value_vector_type& x, const SdfListProxy& y) {
+        return x > value_vector_type(y);
+    }
+
+    /// Less-than or equal to comparison.
+    bool operator<=(const value_vector_type& y) const {
+        return !(*this > y);
+    }
+
+    /// Less-than or equal to comparison.
+    friend bool operator<=(const value_vector_type& x, const SdfListProxy& y) {
+        return x <= value_vector_type(y);
+    }
+
+    /// Greater-than or equal to comparison.
+    bool operator>=(const value_vector_type& y) const {
+        return !(*this < y);
+    }
+
+    /// Greater-than or equal to comparison.
+    friend bool operator>=(const value_vector_type& x, const SdfListProxy& y) {
+        return x >= value_vector_type(y);
     }
 
     /// Explicit bool conversion operator. The list proxy object converts to 


### PR DESCRIPTION
### Description of Change(s)
- Explicitly implement `operator{!=,<=,>=,>}` for `SdfListProxy::_ItemProxy`, following the pattern of using `value_type` as the operand established by `operator==` and `operator<`.
- Explicitly implement `operator{!=,<=,>=,>}` for `SdfListProxy` when `value_vector_type` is the operand

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
