### PR TITLE
Preserve granularity of payload resync notices

### DIFF
--- a/pxr/usd/usd/testenv/testUsdStageLoadUnload.py
+++ b/pxr/usd/usd/testenv/testUsdStageLoadUnload.py
@@ -974,5 +974,39 @@ class TestUsdLoadUnload(unittest.TestCase):
             if not (platform.system() == 'Windows' and fmt == 'usdc'):
                 _TestLayerReload(fmt)
 
+    def test_LoadResyncNotice(self):
+        for fmt in allFormats:
+            p = PayloadedScene(fmt)
+            sad = p.stage.GetPrimAtPath('/Sad')
+            with _AssertObjectsChanged(p.stage, {sad.GetPath()}):
+                sad.Load()
+            foobaz = p.stage.GetPrimAtPath('/Foo/Baz')
+            with _AssertObjectsChanged(p.stage, {foobaz.GetPath()}):
+                foobaz.Load()
+            foobazgarply = p.stage.GetPrimAtPath('/Foo/Baz/Garply')
+            # Should have been loaded already in previous step
+            with _AssertObjectsChanged(p.stage, {}):
+                foobazgarply.Load()
+            p.CleanupOnDiskAssets(fmt)
+
+class _AssertObjectsChanged(object):
+    def __init__(self, stage, expectedResyncedPaths):
+        self.stage = stage
+        self.expectedResyncedPaths = set(expectedResyncedPaths)
+        self.resyncedPaths = set()
+
+    def __enter__(self):
+        self.listener = Tf.Notice.Register(
+            Usd.Notice.ObjectsChanged, self.callback, self.stage)
+
+    def callback(self, notice, sender):
+        assert sender == self.stage
+        self.resyncedPaths.update(notice.GetResyncedPaths())
+    
+    def __exit__(self, *args):
+        del self.listener
+        assert self.resyncedPaths == self.expectedResyncedPaths
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)
- Update the ancestral payload discovery code to more explicitly find prims that have payloads authored but have not been loaded. This prevents the issue where the parents of loaded prims were being unnecessarily flagged as needing a resync.
- Add basic test coverage to validate expected payload resync granularity

### Fixes Issue(s)
- #2286 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
