### PR TITLE
[usdviewq] Hide render frame when --norender is set

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1133,6 +1133,9 @@ class AppController(QtCore.QObject):
             # the viewer, which might take a long time.
             if self._stageView:
                 self._stageView.setUpdatesEnabled(False)
+                
+            if self._noRender:
+                self._ui.renderFrame.hide()
 
             self._mainWindow.update()
 


### PR DESCRIPTION
Strawman PR to hide render frame with --norender is set; happy to move this logic somewhere earlier in the function if desired and also avoid populating hidden UI contents...

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
