### PR TITLE
Replace boost hash usage with TfHash in pxr/base/gf

### DIFF
--- a/pxr/base/gf/bbox3d.h
+++ b/pxr/base/gf/bbox3d.h
@@ -210,10 +210,10 @@ class GfBBox3d {
 
     /// Hash.
     friend inline size_t hash_value(const GfBBox3d &b) {
-        size_t h = 0;
-        boost::hash_combine(h, b._box);
-        boost::hash_combine(h, b._matrix);
-        return h;
+        return TfHash::Combine(
+            b._box,
+            b._matrix
+        );
     }
     
     /// Component-wise equality test. The axis-aligned boxes and

--- a/pxr/base/gf/dualQuat.template.h
+++ b/pxr/base/gf/dualQuat.template.h
@@ -40,8 +40,7 @@
 {% endif %}
 
 #include "pxr/base/gf/quat{{ SUFFIX }}.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -175,10 +174,7 @@ class {{ DUALQUAT }} final
 
     /// Hash.
     friend inline size_t hash_value(const {{ DUALQUAT }} &dq) {
-        size_t h = 0;
-        boost::hash_combine(h, dq.GetReal());
-        boost::hash_combine(h, dq.GetDual());
-        return h;
+        return TfHash::Combine(dq.GetReal(), dq.GetDual());
     }
 
     /// Component-wise dual quaternion equality test. The real and dual parts

--- a/pxr/base/gf/dualQuatd.h
+++ b/pxr/base/gf/dualQuatd.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/traits.h"
 
 #include "pxr/base/gf/quatd.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -173,10 +172,7 @@ class GfDualQuatd final
 
     /// Hash.
     friend inline size_t hash_value(const GfDualQuatd &dq) {
-        size_t h = 0;
-        boost::hash_combine(h, dq.GetReal());
-        boost::hash_combine(h, dq.GetDual());
-        return h;
+        return TfHash::Combine(dq.GetReal(), dq.GetDual());
     }
 
     /// Component-wise dual quaternion equality test. The real and dual parts

--- a/pxr/base/gf/dualQuatf.h
+++ b/pxr/base/gf/dualQuatf.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/traits.h"
 
 #include "pxr/base/gf/quatf.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -173,10 +172,7 @@ class GfDualQuatf final
 
     /// Hash.
     friend inline size_t hash_value(const GfDualQuatf &dq) {
-        size_t h = 0;
-        boost::hash_combine(h, dq.GetReal());
-        boost::hash_combine(h, dq.GetDual());
-        return h;
+        return TfHash::Combine(dq.GetReal(), dq.GetDual());
     }
 
     /// Component-wise dual quaternion equality test. The real and dual parts

--- a/pxr/base/gf/dualQuath.h
+++ b/pxr/base/gf/dualQuath.h
@@ -38,8 +38,7 @@
 #include "pxr/base/gf/half.h"
 
 #include "pxr/base/gf/quath.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -174,10 +173,7 @@ class GfDualQuath final
 
     /// Hash.
     friend inline size_t hash_value(const GfDualQuath &dq) {
-        size_t h = 0;
-        boost::hash_combine(h, dq.GetReal());
-        boost::hash_combine(h, dq.GetDual());
-        return h;
+        return TfHash::Combine(dq.GetReal(), dq.GetDual());
     }
 
     /// Component-wise dual quaternion equality test. The real and dual parts

--- a/pxr/base/gf/frustum.h
+++ b/pxr/base/gf/frustum.h
@@ -38,8 +38,7 @@
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/api.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <array>
 #include <atomic>
@@ -190,14 +189,14 @@ class GfFrustum {
     }        
 
     friend inline size_t hash_value(const GfFrustum &f) {
-        size_t h = 0;
-        boost::hash_combine(h, f._position);
-        boost::hash_combine(h, f._rotation);
-        boost::hash_combine(h, f._window);
-        boost::hash_combine(h, f._nearFar);
-        boost::hash_combine(h, f._viewDistance);
-        boost::hash_combine(h, f._projectionType);
-        return h;
+        return TfHash::Combine(
+            f._position,
+            f._rotation,
+            f._window,
+            f._nearFar,
+            f._viewDistance,
+            f._projectionType
+        );
     }
 
     // Equality operator. true iff all parts match.

--- a/pxr/base/gf/interval.h
+++ b/pxr/base/gf/interval.h
@@ -29,9 +29,8 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/gf/math.h"
-#include "pxr/base/gf/api.h" 
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/gf/api.h"
+#include "pxr/base/tf/hash.h"
 
 #include <float.h>
 #include <iosfwd>
@@ -103,10 +102,7 @@ public:
     size_t Hash() const { return hash_value(*this); }
 
     friend inline size_t hash_value(GfInterval const &i) {
-        size_t h = 0;
-        boost::hash_combine(h, i._min);
-        boost::hash_combine(h, i._max);
-        return h;
+        return TfHash::Combine(i._min, i._max);
     }
 
     /// Minimum value
@@ -391,10 +387,7 @@ private:
             return _Bound( value * rhs.value, closed & rhs.closed );
         }
         friend inline size_t hash_value(const _Bound &b) {
-            size_t h = 0;
-            boost::hash_combine(h, b.value);
-            boost::hash_combine(h, b.closed);
-            return h;
+            return TfHash::Combine(b.value, b.closed);
         }
     };
 

--- a/pxr/base/gf/matrix.template.h
+++ b/pxr/base/gf/matrix.template.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/traits.h"
 {% block includes %}
 {% endblock %}
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -218,12 +217,9 @@ public:
 
     /// Hash.
     friend inline size_t hash_value({{ MAT }} const &m) {
-        int nElems = {{ DIM }} * {{ DIM }};
-        size_t h = 0;
-        const {{ SCL }} *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            {{ MATRIX("m._mtx[%(i)s][%(j)s]", sep=',\n            ') }}
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix2d.h
+++ b/pxr/base/gf/matrix2d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/matrixData.h"
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -224,12 +223,12 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix2d const &m) {
-        int nElems = 2 * 2;
-        size_t h = 0;
-        const double *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[1][0],
+            m._mtx[1][1]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix2f.h
+++ b/pxr/base/gf/matrix2f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/matrixData.h"
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -224,12 +223,12 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix2f const &m) {
-        int nElems = 2 * 2;
-        size_t h = 0;
-        const float *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[1][0],
+            m._mtx[1][1]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix3d.h
+++ b/pxr/base/gf/matrix3d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/matrixData.h"
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -263,12 +262,17 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix3d const &m) {
-        int nElems = 3 * 3;
-        size_t h = 0;
-        const double *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[0][2],
+            m._mtx[1][0],
+            m._mtx[1][1],
+            m._mtx[1][2],
+            m._mtx[2][0],
+            m._mtx[2][1],
+            m._mtx[2][2]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix3f.h
+++ b/pxr/base/gf/matrix3f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/matrixData.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -263,12 +262,17 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix3f const &m) {
-        int nElems = 3 * 3;
-        size_t h = 0;
-        const float *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[0][2],
+            m._mtx[1][0],
+            m._mtx[1][1],
+            m._mtx[1][2],
+            m._mtx[2][0],
+            m._mtx[2][1],
+            m._mtx[2][2]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix4d.h
+++ b/pxr/base/gf/matrix4d.h
@@ -41,8 +41,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/vec3d.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -303,12 +302,24 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix4d const &m) {
-        int nElems = 4 * 4;
-        size_t h = 0;
-        const double *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[0][2],
+            m._mtx[0][3],
+            m._mtx[1][0],
+            m._mtx[1][1],
+            m._mtx[1][2],
+            m._mtx[1][3],
+            m._mtx[2][0],
+            m._mtx[2][1],
+            m._mtx[2][2],
+            m._mtx[2][3],
+            m._mtx[3][0],
+            m._mtx[3][1],
+            m._mtx[3][2],
+            m._mtx[3][3]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/matrix4f.h
+++ b/pxr/base/gf/matrix4f.h
@@ -41,8 +41,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/vec3f.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 #include <vector>
@@ -303,12 +302,24 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfMatrix4f const &m) {
-        int nElems = 4 * 4;
-        size_t h = 0;
-        const float *p = m.GetArray();
-        while (nElems--)
-            boost::hash_combine(h, *p++);
-        return h;
+        return TfHash::Combine(
+            m._mtx[0][0],
+            m._mtx[0][1],
+            m._mtx[0][2],
+            m._mtx[0][3],
+            m._mtx[1][0],
+            m._mtx[1][1],
+            m._mtx[1][2],
+            m._mtx[1][3],
+            m._mtx[2][0],
+            m._mtx[2][1],
+            m._mtx[2][2],
+            m._mtx[2][3],
+            m._mtx[3][0],
+            m._mtx[3][1],
+            m._mtx[3][2],
+            m._mtx[3][3]
+        );
     }
 
     /// Tests for element-wise matrix equality. All elements must match

--- a/pxr/base/gf/multiInterval.cpp
+++ b/pxr/base/gf/multiInterval.cpp
@@ -52,10 +52,7 @@ GfMultiInterval::GfMultiInterval(const std::vector<GfInterval> &intervals)
 size_t
 GfMultiInterval::Hash() const
 {
-    size_t h = 0;
-    for (auto const &i: _set)
-        boost::hash_combine(h, i);
-    return h;
+    return TfHash()(_set);
 }
 
 GfInterval

--- a/pxr/base/gf/quat.template.h
+++ b/pxr/base/gf/quat.template.h
@@ -39,8 +39,7 @@
 {% if SCL == 'GfHalf' -%}
 #include "pxr/base/gf/half.h"
 {% endif %}
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -165,9 +164,7 @@ class {{ QUAT }}
 
     /// Hash.
     friend inline size_t hash_value(const {{ QUAT }} &q) {
-        size_t h = boost::hash<ScalarType>()(q.GetReal());
-        boost::hash_combine(h, q.GetImaginary());
-        return h;
+        return TfHash::Combine(q.GetReal(), q.GetImaginary());
     }
 
     /// Component-wise negation.

--- a/pxr/base/gf/quatd.h
+++ b/pxr/base/gf/quatd.h
@@ -36,8 +36,7 @@
 #include "pxr/base/gf/declare.h"
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -163,9 +162,7 @@ class GfQuatd
 
     /// Hash.
     friend inline size_t hash_value(const GfQuatd &q) {
-        size_t h = boost::hash<ScalarType>()(q.GetReal());
-        boost::hash_combine(h, q.GetImaginary());
-        return h;
+        return TfHash::Combine(q.GetReal(), q.GetImaginary());
     }
 
     /// Component-wise negation.

--- a/pxr/base/gf/quaternion.h
+++ b/pxr/base/gf/quaternion.h
@@ -30,8 +30,7 @@
 #include "pxr/pxr.h"
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/vec3d.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -125,10 +124,7 @@ class GfQuaternion
 
     /// Hash.
     friend inline size_t hash_value(const GfQuaternion &q) {
-        size_t h = 0;
-        boost::hash_combine(h, q.GetReal());
-        boost::hash_combine(h, q.GetImaginary());
-        return h;
+        return TfHash::Combine(q.GetReal(), q.GetImaginary());
     }
 
     /// Component-wise quaternion equality test. The real and imaginary parts

--- a/pxr/base/gf/quatf.h
+++ b/pxr/base/gf/quatf.h
@@ -36,8 +36,7 @@
 #include "pxr/base/gf/declare.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -163,9 +162,7 @@ class GfQuatf
 
     /// Hash.
     friend inline size_t hash_value(const GfQuatf &q) {
-        size_t h = boost::hash<ScalarType>()(q.GetReal());
-        boost::hash_combine(h, q.GetImaginary());
-        return h;
+        return TfHash::Combine(q.GetReal(), q.GetImaginary());
     }
 
     /// Component-wise negation.

--- a/pxr/base/gf/quath.h
+++ b/pxr/base/gf/quath.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/vec3h.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/half.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -164,9 +163,7 @@ class GfQuath
 
     /// Hash.
     friend inline size_t hash_value(const GfQuath &q) {
-        size_t h = boost::hash<ScalarType>()(q.GetReal());
-        boost::hash_combine(h, q.GetImaginary());
-        return h;
+        return TfHash::Combine(q.GetReal(), q.GetImaginary());
     }
 
     /// Component-wise negation.

--- a/pxr/base/gf/range.template.h
+++ b/pxr/base/gf/range.template.h
@@ -39,8 +39,7 @@
 #include "pxr/base/gf/vec{{ DIM }}f.h"
 {% endif %}
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -324,10 +323,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const {{ RNG }} &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range1d.h
+++ b/pxr/base/gf/range1d.h
@@ -35,8 +35,7 @@
 
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -296,10 +295,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange1d &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range1f.h
+++ b/pxr/base/gf/range1f.h
@@ -35,8 +35,7 @@
 
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -296,10 +295,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange1f &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range2d.h
+++ b/pxr/base/gf/range2d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -300,10 +299,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange2d &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range2f.h
+++ b/pxr/base/gf/range2f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/vec2d.h"
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -300,10 +299,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange2f &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range3d.h
+++ b/pxr/base/gf/range3d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -302,10 +301,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange3d &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/range3f.h
+++ b/pxr/base/gf/range3f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cfloat>
 #include <cstddef>
@@ -302,10 +301,7 @@ public:
 
     /// hash.
     friend inline size_t hash_value(const GfRange3f &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }
 
     /// The min and max points must match exactly for equality.

--- a/pxr/base/gf/rect2i.h
+++ b/pxr/base/gf/rect2i.h
@@ -31,8 +31,7 @@
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/gf/api.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -267,10 +266,7 @@ public:
     }
 
     friend inline size_t hash_value(const GfRect2i &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._min);
-        boost::hash_combine(h, r._max);
-        return h;
+        return TfHash::Combine(r._min, r._max);
     }        
 
     /// Returns true if \p r1 and \p r2 are equal.

--- a/pxr/base/gf/rotation.h
+++ b/pxr/base/gf/rotation.h
@@ -34,8 +34,7 @@
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/api.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iosfwd>
 
@@ -221,10 +220,7 @@ class GfRotation {
 
     /// Hash.
     friend inline size_t hash_value(const GfRotation &r) {
-        size_t h = 0;
-        boost::hash_combine(h, r._axis);
-        boost::hash_combine(h, r._angle);
-        return h;
+        return TfHash::Combine(r._axis, r._angle);
     }
 
     /// Component-wise rotation equality test. The axes and angles must match

--- a/pxr/base/gf/testenv/testGfBBox3d.py
+++ b/pxr/base/gf/testenv/testGfBBox3d.py
@@ -170,6 +170,15 @@ class TestGfBBox3d(unittest.TestCase):
 
         self.assertEqual(b4, eval(repr(b4)))
 
+    def test_Hash(self):
+        b = Gf.BBox3d(
+            Gf.Range3d((-1, -2, -3), (2, 3, 4)),
+            Gf.Matrix4d(1.0)
+        )
+
+        self.assertEqual(hash(b), hash(b))
+        self.assertEqual(hash(b), hash(Gf.BBox3d(b)))
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/pxr/base/gf/testenv/testGfDualQuaternion.py
+++ b/pxr/base/gf/testenv/testGfDualQuaternion.py
@@ -208,5 +208,14 @@ class TestGfDualQuaternion(unittest.TestCase):
                             Gf.IsClose(dq.Transform(vec3Type(0,1,0)), vec3Type(-0.4,-0.333333,-0.133333), closeVal) and
                             Gf.IsClose(dq.Transform(vec3Type(0,0,1)), vec3Type(0.2,0.666667,-0.933333), closeVal))
 
+    def test_Hash(self):
+        for DualQuatType, QuatType, Vec3Type, _ in testClasses:
+            dq = DualQuatType(
+                QuatType(1.0, Vec3Type(2.0, 3.0, 4.0)),
+                QuatType(2.0, Vec3Type(3.0, 4.0, 5.0))
+            )
+            self.assertEqual(hash(dq), hash(dq))
+            self.assertEqual(hash(dq), hash(DualQuatType(dq)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfFrustum.py
+++ b/pxr/base/gf/testenv/testGfFrustum.py
@@ -408,7 +408,19 @@ class TestGfFrustum(unittest.TestCase):
             self.assertTrue(
                 Gf.IsClose(corners[i], (results[i] + results[i+4]) / 2.0,
                            0.0001))
-        
+
+    def test_Hash(self):
+        frustum = Gf.Frustum(
+                Gf.Vec3d(1.0, 2.0, 3.0),
+                Gf.Rotation(Gf.Vec3d(1.0, 0.0, 0.0), 90.0),
+                Gf.Range2d(Gf.Vec2d(-0.5, 0.5), Gf.Vec2d(-1.0, 1.0)),
+                Gf.Range1d(1.0, 1000.0),
+                Gf.Frustum.Perspective,
+                10.0
+        )
+
+        self.assertEqual(hash(frustum), hash(frustum))
+        self.assertEqual(hash(frustum), hash(Gf.Frustum(frustum)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfInterval.py
+++ b/pxr/base/gf/testenv/testGfInterval.py
@@ -269,5 +269,11 @@ class TestGfInterval(unittest.TestCase):
 
         self.assertTrue(len(str(Gf.Interval())), ("str"))
 
+    def test_Hash(self):
+        interval = Gf.Interval(-1.5, 2.0, True, False)
+        self.assertEqual(hash(interval), hash(interval))
+        self.assertEqual(hash(interval), hash(Gf.Interval(interval)))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfMatrix.py
+++ b/pxr/base/gf/testenv/testGfMatrix.py
@@ -816,5 +816,20 @@ class TestGfMatrix(unittest.TestCase):
         with self.assertRaises(excType):
             int(Gf.Matrix3f(3))
 
+    def test_Hash(self):
+        MatrixTypes = [
+            Gf.Matrix2d,
+            Gf.Matrix2f,
+            Gf.Matrix3d,
+            Gf.Matrix3f,
+            Gf.Matrix4d,
+            Gf.Matrix4f
+        ]
+
+        for MatrixType in MatrixTypes:
+            m  = MatrixType(*(i * 2.0 for i in range(1, 1 + MatrixType.dimension[0] * MatrixType.dimension[1])))
+            self.assertEqual(hash(m), hash(m))
+            self.assertEqual(hash(m), hash(MatrixType(m)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfQuaternion.py
+++ b/pxr/base/gf/testenv/testGfQuaternion.py
@@ -225,5 +225,11 @@ class TestGfQuaternion(unittest.TestCase):
             self.assertTrue(Gf.IsClose(r1, vec3Type(0.0, 1.0, 0.0), closeVal) and
                             Gf.IsClose(r1, r2, closeVal))
 
+    def test_Hash(self):
+        for QuatType, Vec3Type, _ in testClasses:
+            q = QuatType(1.0, Vec3Type(2.0, 3.0, 4.0))
+            self.assertEqual(hash(q), hash(q))
+            self.assertEqual(hash(q), hash(QuatType(q)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfRange.py
+++ b/pxr/base/gf/testenv/testGfRange.py
@@ -328,5 +328,14 @@ class TestGfRange(unittest.TestCase):
             # Construct float from double type
             self.assertEqual(Rangef(r1d), r1f)
 
+    def test_Hash(self):
+        for RangeType, ValueType in self.Ranges:
+            r = RangeType(
+                makeValue(ValueType, [-1.0, -2.0, -3.0, -4.0]),
+                makeValue(ValueType, [4.0, 3.0, 2.0, 1.0])
+            )
+            self.assertEqual(hash(r), hash(r))
+            self.assertEqual(hash(r), hash(RangeType(r)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfRect2i.py
+++ b/pxr/base/gf/testenv/testGfRect2i.py
@@ -112,5 +112,14 @@ class TestGfRect2i(unittest.TestCase):
 
         self.assertTrue(len(str(Gf.Rect2i())))
 
+    def test_Hash(self):
+        r = Gf.Rect2i(
+            Gf.Vec2i(1, 2),
+            Gf.Vec2i(10, 20)
+        )
+
+        self.assertEqual(hash(r), hash(r))
+        self.assertEqual(hash(r), hash(Gf.Rect2i(r)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfRotation.py
+++ b/pxr/base/gf/testenv/testGfRotation.py
@@ -205,5 +205,10 @@ class TestGfRotation(unittest.TestCase):
         self.assertTrue(Gf.IsClose(rot.angle, -1.91983, 0.00001))
         self.assertEqual(rot.axis, axis.GetNormalized())
 
+    def test_Hash(self):
+        rot = Gf.Rotation(Gf.Vec3d(1.0, 0.0, 0.0), 40.0)
+        self.assertEqual(hash(rot), hash(rot))
+        self.assertEqual(hash(rot), hash(Gf.Rotation(rot)))
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/base/gf/testenv/testGfVec.py
+++ b/pxr/base/gf/testenv/testGfVec.py
@@ -287,6 +287,12 @@ class TestGfVec(unittest.TestCase):
             #
             v[:2] = [None, None]
 
+    def HashTest(self, Vec):
+        v1 = Vec()
+        SetVec(v1, [12, 1, 2, -4])
+        self.assertEqual(hash(v1), hash(v1))
+        self.assertEqual(hash(v1), hash(Vec(v1)))
+
     def MethodsTest(self, Vec):
         v1 = Vec()
         v2 = Vec()
@@ -544,6 +550,7 @@ class TestGfVec(unittest.TestCase):
             self.ConstructorsTest( Vec )
             self.OperatorsTest( Vec )
             self.MethodsTest( Vec )
+            self.HashTest( Vec )
 
 
     def test_TupleToVec(self):

--- a/pxr/base/gf/vec.template.h
+++ b/pxr/base/gf/vec.template.h
@@ -42,8 +42,7 @@
 #include "pxr/base/gf/half.h"
 {% endif %}
 {% endif %}
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 {% if IS_FLOATING_POINT(SCL) -%}
@@ -143,9 +142,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value({{ VEC }} const &vec) {
-        size_t h = 0;
-        {{ LIST("boost::hash_combine(h, vec[%(i)s]);", sep='\n        ') }}
-        return h;
+        return TfHash::Combine({{ LIST("vec[%(i)s]", sep=', ') }});
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec2d.h
+++ b/pxr/base/gf/vec2d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -143,10 +142,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec2d const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec2f.h
+++ b/pxr/base/gf/vec2f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -143,10 +142,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec2f const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec2h.h
+++ b/pxr/base/gf/vec2h.h
@@ -38,8 +38,7 @@
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/half.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -144,10 +143,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec2h const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec2i.h
+++ b/pxr/base/gf/vec2i.h
@@ -36,8 +36,7 @@
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 
@@ -132,10 +131,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec2i const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec3d.h
+++ b/pxr/base/gf/vec3d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -150,11 +149,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec3d const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec3f.h
+++ b/pxr/base/gf/vec3f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -150,11 +149,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec3f const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec3h.h
+++ b/pxr/base/gf/vec3h.h
@@ -38,8 +38,7 @@
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/half.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -151,11 +150,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec3h const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec3i.h
+++ b/pxr/base/gf/vec3i.h
@@ -36,8 +36,7 @@
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 
@@ -139,11 +138,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec3i const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec4d.h
+++ b/pxr/base/gf/vec4d.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -157,12 +156,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec4d const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        boost::hash_combine(h, vec[3]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2], vec[3]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec4f.h
+++ b/pxr/base/gf/vec4f.h
@@ -37,8 +37,7 @@
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -157,12 +156,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec4f const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        boost::hash_combine(h, vec[3]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2], vec[3]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec4h.h
+++ b/pxr/base/gf/vec4h.h
@@ -38,8 +38,7 @@
 #include "pxr/base/gf/traits.h"
 #include "pxr/base/gf/math.h"
 #include "pxr/base/gf/half.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 #include <cmath>
@@ -158,12 +157,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec4h const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        boost::hash_combine(h, vec[3]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2], vec[3]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/vec4i.h
+++ b/pxr/base/gf/vec4i.h
@@ -36,8 +36,7 @@
 #include "pxr/base/gf/api.h"
 #include "pxr/base/gf/limits.h"
 #include "pxr/base/gf/traits.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <cstddef>
 
@@ -146,12 +145,7 @@ public:
 
     /// Hash.
     friend inline size_t hash_value(GfVec4i const &vec) {
-        size_t h = 0;
-        boost::hash_combine(h, vec[0]);
-        boost::hash_combine(h, vec[1]);
-        boost::hash_combine(h, vec[2]);
-        boost::hash_combine(h, vec[3]);
-        return h;
+        return TfHash::Combine(vec[0], vec[1], vec[2], vec[3]);
     }
 
     /// Equality comparison.

--- a/pxr/base/gf/wrapBBox3d.cpp
+++ b/pxr/base/gf/wrapBBox3d.cpp
@@ -48,6 +48,10 @@ string _Repr(GfBBox3d const &self) {
         TfPyRepr(self.GetMatrix()) + ")";
 }
 
+static size_t __hash__(GfBBox3d const &self) {
+    return TfHash()(self);
+}
+
 } // anonymous namespace
 
 void wrapBBox3d()
@@ -128,6 +132,7 @@ void wrapBBox3d()
         .def(self != self)
 
         .def("__repr__", _Repr)
+        .def("__hash__", __hash__)
         
         ;
     to_python_converter<std::vector<This>,

--- a/pxr/base/gf/wrapFrustum.cpp
+++ b/pxr/base/gf/wrapFrustum.cpp
@@ -64,6 +64,10 @@ static std::string _Repr(GfFrustum const &self)
     return prefix + TfStringJoin(kwargs, seperator.c_str()) + ")";
 }
 
+static size_t __hash__(GfFrustum const &self) {
+    return TfHash()(self);
+}
+
 static object
 GetPerspectiveHelper( const GfFrustum &self, bool isFovVertical ) {
     double fov, aspect, nearDist, farDist;
@@ -257,6 +261,7 @@ void wrapFrustum()
         .def(self != self)
 
         .def("__repr__", _Repr)
+        .def("__hash__", __hash__)
         ;
 
     TfPyWrapEnum<This::ProjectionType>();

--- a/pxr/base/gf/wrapInterval.cpp
+++ b/pxr/base/gf/wrapInterval.cpp
@@ -68,6 +68,7 @@ void wrapInterval()
         .def(init<double, double>(
                  "Create a closed interval representing the range [v1,v2]."))
         .def(init<double, double, bool, bool>("Create the interval."))
+        .def(init<This>())
 
         .def( TfTypePythonClass() )
 

--- a/pxr/base/gf/wrapQuat.template.cpp
+++ b/pxr/base/gf/wrapQuat.template.cpp
@@ -69,6 +69,10 @@ static {{ QUAT }}& __itruediv__({{ QUAT }} &self, {{ SCL }} value)
     return self /= value;
 }
 
+static size_t __hash__({{ QUAT }} const &self) {
+    return TfHash()(self);
+}
+
 // Zero-initialized default ctor for python.
 static {{ QUAT }} *__init__() { return new {{ QUAT }}(0); }
 
@@ -157,7 +161,7 @@ void wrapQuat{{ SUFFIX }}()
         .def({{ SCL }}() * self)
         .def(self / {{ SCL }}())
         .def("__repr__", __repr__)
-
+        .def("__hash__", __hash__)
         ;
 
 {% for S in SCALARS if S != SCL and ALLOW_IMPLICIT_CONVERSION(S, SCL) %}

--- a/pxr/base/gf/wrapQuatd.cpp
+++ b/pxr/base/gf/wrapQuatd.cpp
@@ -69,6 +69,10 @@ static GfQuatd& __itruediv__(GfQuatd &self, double value)
     return self /= value;
 }
 
+static size_t __hash__(GfQuatd const &self) {
+    return TfHash()(self);
+}
+
 // Zero-initialized default ctor for python.
 static GfQuatd *__init__() { return new GfQuatd(0); }
 
@@ -154,7 +158,7 @@ void wrapQuatd()
         .def(double() * self)
         .def(self / double())
         .def("__repr__", __repr__)
-
+        .def("__hash__", __hash__)
         ;
 
     implicitly_convertible<GfQuatf, GfQuatd>();

--- a/pxr/base/gf/wrapQuaternion.cpp
+++ b/pxr/base/gf/wrapQuaternion.cpp
@@ -86,6 +86,8 @@ void wrapQuaternion()
 
         .def(init<double, const GfVec3d &>())
 
+        .def(init<This>())
+
         .def( TfTypePythonClass() )
 
         .def("GetZero", &This::GetZero)

--- a/pxr/base/gf/wrapQuatf.cpp
+++ b/pxr/base/gf/wrapQuatf.cpp
@@ -69,6 +69,10 @@ static GfQuatf& __itruediv__(GfQuatf &self, float value)
     return self /= value;
 }
 
+static size_t __hash__(GfQuatf const &self) {
+    return TfHash()(self);
+}
+
 // Zero-initialized default ctor for python.
 static GfQuatf *__init__() { return new GfQuatf(0); }
 
@@ -155,7 +159,7 @@ void wrapQuatf()
         .def(float() * self)
         .def(self / float())
         .def("__repr__", __repr__)
-
+        .def("__hash__", __hash__)
         ;
 
     implicitly_convertible<GfQuath, GfQuatf>();

--- a/pxr/base/gf/wrapQuath.cpp
+++ b/pxr/base/gf/wrapQuath.cpp
@@ -69,6 +69,10 @@ static GfQuath& __itruediv__(GfQuath &self, GfHalf value)
     return self /= value;
 }
 
+static size_t __hash__(GfQuath const &self) {
+    return TfHash()(self);
+}
+
 // Zero-initialized default ctor for python.
 static GfQuath *__init__() { return new GfQuath(0); }
 
@@ -156,7 +160,7 @@ void wrapQuath()
         .def(GfHalf() * self)
         .def(self / GfHalf())
         .def("__repr__", __repr__)
-
+        .def("__hash__", __hash__)
         ;
 
 

--- a/pxr/base/gf/wrapRect2i.cpp
+++ b/pxr/base/gf/wrapRect2i.cpp
@@ -48,6 +48,10 @@ static string _Repr(GfRect2i const &self) {
         TfPyRepr(self.GetMax()) + ")";
 }
 
+static size_t __hash__(GfRect2i const &self) {
+    return TfHash()(self);
+}
+
 } // anonymous namespace 
 
 void wrapRect2i()
@@ -115,7 +119,7 @@ void wrapRect2i()
         .def( self + self )
         
         .def("__repr__", _Repr)
-        
+        .def("__hash__", __hash__)
         ;
     to_python_converter<std::vector<This>,
         TfPySequenceToPython<std::vector<This> > >();

--- a/pxr/base/gf/wrapRotation.cpp
+++ b/pxr/base/gf/wrapRotation.cpp
@@ -166,6 +166,10 @@ static GfRotation __itruediv__(GfRotation &self, double value)
 
 } // anonymous namespace 
 
+static size_t __hash__(GfRotation const &self) {
+    return TfHash()(self);
+}
+
 void wrapRotation()
 {    
     typedef GfRotation This;
@@ -176,6 +180,7 @@ void wrapRotation()
         .def(init<const GfQuaternion &>())
         .def(init<const GfQuatd &>())
         .def(init<const GfVec3d &, const GfVec3d &>())
+        .def(init<const GfRotation &>())
 
         .def( TfTypePythonClass() )
 
@@ -258,7 +263,8 @@ void wrapRotation()
 #endif
 
        .def("__repr__", _Repr)
-        
+       .def("__hash__", __hash__)
+
         ;
     to_python_converter<std::vector<This>,
         TfPySequenceToPython<std::vector<This> > >();


### PR DESCRIPTION
### Description of Change(s)
This is a reconstruction #2175 which didn't get successfully merged.

Requires: #2173
To remove the dependency of pxr/base/gf on boost's hashing functions
* Copy constructor for python bindings added when missing to support test coverage (`Gf.Rotation`, `Gf.Quaternion`, `Gf.Interval`)
* `__hash__` operator overloads are added when missing to support test coverage (`Gf.BBox3d`, `Gf.Frustum`, `Gf.Quat{f,h,d}`, `Gf.Rect2i`, `Gf.Rotation`)  
* `__hash__` test coverage added to `testGfRotation`, `testGfVec`, `testGfRect2i`, `testGfRange`, `testGfQuarternion`, `testGfMatrix`, `testGfInterval`, `testGfFrustum`, `testGfDualQuaternion`, `testGfBBox3d`, and `testGfFrustum`.
* Replaced `boost::hash_combine` with `TfHash::Combine` in `hash_value` implementations.  Preserving `hash_value` allows `boost::hash` to still work with these types without the explicit dependency.  `TfHash` will use these `hash_value` implementations when no `TfHashAppend` overload has been provided.

### Fixes Issue(s)
-#2172 (more PRs forthcoming)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
