### PR TITLE
Replace `boost::in_place` with `emplace` method

### DIFF
--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -53,7 +53,6 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
-#include <boost/utility/in_place_factory.hpp>
 
 #include <atomic>
 #include <algorithm>
@@ -279,11 +278,11 @@ public:
         }
 
         if (!base->aliasToDerivedTypeMap)
-            base->aliasToDerivedTypeMap = boost::in_place(0);
+            base->aliasToDerivedTypeMap.emplace(0);
         (*base->aliasToDerivedTypeMap)[alias] = derived;
 
         if (!base->derivedTypeToAliasesMap)
-            base->derivedTypeToAliasesMap = boost::in_place(0);
+            base->derivedTypeToAliasesMap.emplace(0);
         (*base->derivedTypeToAliasesMap)[derived].push_back(alias);
     }
 

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -97,7 +97,6 @@
 
 #include <boost/optional.hpp>
 #include <boost/iterator/transform_iterator.hpp>
-#include <boost/utility/in_place_factory.hpp>
 
 #include <tbb/spin_rw_mutex.h>
 #include <tbb/spin_mutex.h>
@@ -852,7 +851,7 @@ _OpenLayer(
 {
     boost::optional<ArResolverContextBinder> binder;
     if (!resolverContext.IsEmpty())
-        binder = boost::in_place(resolverContext);
+        binder.emplace(resolverContext);
 
     SdfLayer::FileFormatArguments args;
     args[SdfFileFormatTokens->TargetArg] =
@@ -2952,7 +2951,7 @@ UsdStage::_ComposeSubtreesInParallel(
 
     // Begin a subtree composition in parallel.
     WorkWithScopedParallelism([this, &prims, &primIndexPaths]() {
-            _dispatcher = boost::in_place();
+            _dispatcher.emplace();
             // We populate the clip cache concurrently during composition, so we
             // need to enable concurrent population here.
             Usd_ClipCache::ConcurrentPopulationContext
@@ -3104,7 +3103,7 @@ UsdStage::_DestroyPrimsInParallel(const vector<SdfPath>& paths)
     TF_AXIOM(!_dispatcher);
 
     WorkWithScopedParallelism([&]() {
-        _dispatcher = boost::in_place();
+        _dispatcher.emplace();
         for (const auto& path : paths) {
             Usd_PrimDataPtr prim = _GetPrimDataAtPath(path);
             // We *expect* every prim in paths to be valid as we iterate,


### PR DESCRIPTION
### Description of Change(s)
- Replaces `boost::in_place` with `emplace` method in `TfType` and `UsdStage` usage

### Fixes Issue(s)
- #2290 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
