### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `Pcp_SdSiteRef`

### DIFF
--- a/pxr/usd/pcp/types.h
+++ b/pxr/usd/pcp/types.h
@@ -33,8 +33,6 @@
 #include <limits>
 #include <vector>
 
-#include <boost/operators.hpp>
-
 /// \file pcp/types.h
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -130,7 +128,7 @@ struct PcpSiteTrackerSegment {
 typedef std::vector<PcpSiteTrackerSegment> PcpSiteTracker;
 
 // Internal type for Sd sites.
-struct Pcp_SdSiteRef : boost::totally_ordered<Pcp_SdSiteRef> {
+struct Pcp_SdSiteRef {
     Pcp_SdSiteRef(const SdfLayerRefPtr& layer_, const SdfPath& path_) :
         layer(layer_), path(path_)
     {
@@ -142,10 +140,30 @@ struct Pcp_SdSiteRef : boost::totally_ordered<Pcp_SdSiteRef> {
         return layer == other.layer && path == other.path;
     }
 
+    bool operator!=(const Pcp_SdSiteRef& other) const
+    {
+        return !(*this == other);
+    }
+
     bool operator<(const Pcp_SdSiteRef& other) const
     {
         return layer < other.layer ||
                (!(other.layer < layer) && path < other.path);
+    }
+
+    bool operator<=(const Pcp_SdSiteRef& other) const
+    {
+        return !(other < *this);
+    }
+
+    bool operator>(const Pcp_SdSiteRef& other) const
+    {
+        return other < *this;
+    }
+
+    bool operator>=(const Pcp_SdSiteRef& other) const
+    {
+        return !(*this < other);
     }
 
     // These are held by reference for performance,


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `Pcp_SdSiteRef`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
