### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfPath`

### DIFF
--- a/pxr/usd/sdf/path.h
+++ b/pxr/usd/sdf/path.h
@@ -287,7 +287,7 @@ VT_TYPE_IS_CHEAP_TO_COPY(class SdfPath);
 /// the number of values created (since it requires synchronized access to
 /// this table) or copied (since it requires atomic ref-counting operations).
 ///
-class SdfPath : boost::totally_ordered<SdfPath>
+class SdfPath
 {
 public:
     /// The empty path value, equivalent to SdfPath().
@@ -881,9 +881,13 @@ public:
     /// @{
 
     /// Equality operator.
-    /// (Boost provides inequality from this.)
     inline bool operator==(const SdfPath &rhs) const {
         return _AsInt() == rhs._AsInt();
+    }
+
+    /// Inequality operator.
+    inline bool operator!=(const SdfPath &rhs) const {
+        return !(*this == rhs);
     }
 
     /// Comparison operator.
@@ -899,6 +903,24 @@ public:
         }
         // Valid prim parts -- must walk node structure, etc.
         return _LessThanInternal(*this, rhs);
+    }
+
+    /// Greater than operator.
+    /// \sa SdfPath::operator<(const SdfPath&)
+    inline bool operator>(const SdfPath& rhs) const {
+        return rhs < *this;
+    }
+
+    /// Less than or equal operator.
+    /// \sa SdfPath::operator<(const SdfPath&)
+    inline bool operator<=(const SdfPath& rhs) const {
+        return !(rhs < *this);
+    }
+
+    /// Greater than or equal operator.
+    /// \sa SdfPath::operator<(const SdfPath&)
+    inline bool operator>=(const SdfPath& rhs) const {
+        return !(*this < rhs);
     }
 
     template <class HashState>

--- a/pxr/usd/sdf/testenv/testSdfPath.py
+++ b/pxr/usd/sdf/testenv/testSdfPath.py
@@ -75,6 +75,20 @@ class TestSdfPath(unittest.TestCase):
         self.assertTrue(Sdf.Path('aaa') < Sdf.Path('aab'))
         self.assertTrue(not Sdf.Path('aaa') < Sdf.Path())
         self.assertTrue(Sdf.Path('/') < Sdf.Path('/a'))
+
+        # Test greaterthan
+        self.assertGreater(Sdf.Path('aab'), Sdf.Path('aaa'))
+        self.assertGreater(Sdf.Path('/a'), Sdf.Path.emptyPath)
+
+        # Test lessequal
+        self.assertLessEqual(Sdf.Path('aaa'), Sdf.Path('aab'))
+        self.assertLessEqual(Sdf.Path('aaa'), Sdf.Path('aaa'))
+        self.assertLessEqual(Sdf.Path.emptyPath, Sdf.Path('/a'))
+
+        # Test greaterequal
+        self.assertGreaterEqual(Sdf.Path('aab'), Sdf.Path('aaa'))
+        self.assertGreaterEqual(Sdf.Path('aaa'), Sdf.Path('aaa'))
+        self.assertGreaterEqual(Sdf.Path('/a'), Sdf.Path.emptyPath)
         
         # XXX test path from elements ['.prop'] when we have that wrapped?
         


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfPath`
- Add unit test coverage for `operator{>,>=,<=}`
- Update doxygen comments so `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
