### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfReference`

### DIFF
--- a/pxr/usd/sdf/reference.h
+++ b/pxr/usd/sdf/reference.h
@@ -34,8 +34,6 @@
 #include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 
-#include <boost/operators.hpp>
-
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -73,7 +71,7 @@ typedef std::vector<SdfReference> SdfReferenceVector;
 /// Custom data is for use by plugins or other non-tools supplied extensions
 /// that need to be able to store data associated with references.
 ///
-class SdfReference : boost::totally_ordered<SdfReference> {
+class SdfReference {
 public:
     /// Creates a reference with all its meta data.  The default reference is an
     /// internal reference to the default prim.  See SdfAssetPath for what
@@ -174,9 +172,29 @@ public:
     /// Returns whether this reference equals \a rhs.
     SDF_API bool operator==(const SdfReference &rhs) const;
 
+    /// \sa SdfReference::operator==(const SdfReference&)
+    bool operator!=(const SdfReference &rhs) const {
+        return !(*this == rhs);
+    }
+
     /// Returns whether this reference is less than \a rhs.  The meaning
     /// of less than is somewhat arbitrary.
     SDF_API bool operator<(const SdfReference &rhs) const;
+
+    /// \sa SdfReference::operator<(const SdfReference&)
+    bool operator>(const SdfReference &rhs) const {
+        return rhs < *this;
+    }
+
+    /// \sa SdfReference::operator<(const SdfReference&)
+    bool operator<=(const SdfReference &rhs) const {
+        return !(rhs < *this);
+    }
+
+    /// \sa SdfReference::operator<(const SdfReference&)
+    bool operator>=(const SdfReference &rhs) const {
+        return !(*this < rhs);
+    }
 
     /// Struct that defines equality of SdfReferences based on their
     /// identity (the asset path and prim path).


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfReference`
- Add doxygen comments so `operator!=` references `operator==` and `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
