### PR TITLE
Replace `boost::container::flat_map` with `robin_map`

### DIFF
--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -2624,7 +2624,7 @@ CrateFile::_AddDeferredSpecs()
 {
     // A map from sample time to VtValues within TimeSamples instances in
     // _deferredSpecs.
-    boost::container::flat_map<double, vector<VtValue *>> allValuesAtAllTimes;
+    pxr_tsl::robin_map<double, vector<VtValue *>> allValuesAtAllTimes;
 
     // Search for the TimeSamples, add to the allValuesAtAllTimes.
     for (auto &spec: _deferredSpecs) {
@@ -2638,12 +2638,22 @@ CrateFile::_AddDeferredSpecs()
         }
     }
 
+    // Create a sorted view of the underlying map keys.
+    std::vector<double> orderedTimes(allValuesAtAllTimes.size());
+    std::transform(std::cbegin(allValuesAtAllTimes),
+                   std::cend(allValuesAtAllTimes),
+                   std::begin(orderedTimes),
+                   [](const auto& element) { return element.first; });
+    std::sort(orderedTimes.begin(), orderedTimes.end());
+
     // Now walk through allValuesAtAllTimes in order and pack all the values,
     // swapping them out with the resulting reps.  This ensures that when we
     // pack the specs, which will re-pack the values, they'll be noops since
     // they are just holding value reps that point into the file.
-    for (auto const &p: allValuesAtAllTimes) {
-        for (VtValue *val: p.second)
+    for (auto const &t: orderedTimes) {
+        auto it = allValuesAtAllTimes.find(t);
+        TF_DEV_AXIOM(it != allValuesAtAllTimes.end());
+        for (VtValue *val: it->second)
             *val = _PackValue(*val);
     }
 

--- a/pxr/usd/usd/crateFile.h
+++ b/pxr/usd/usd/crateFile.h
@@ -32,6 +32,7 @@
 
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/tf/hash.h"
+#include "pxr/base/tf/pxrTslRobinMap/robin_map.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/array.h"
 #include "pxr/base/vt/value.h"
@@ -43,7 +44,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/usd/sdf/types.h"
 
-#include <boost/container/flat_map.hpp>
 #include <boost/intrusive_ptr.hpp>
 
 #include <tbb/concurrent_unordered_set.h>
@@ -1046,7 +1046,7 @@ private:
     mutable tbb::spin_rw_mutex _sharedTimesMutex;
 
     // functions to write VtValues to file by type.
-    boost::container::flat_map<
+    pxr_tsl::robin_map<
         std::type_index, std::function<ValueRep (VtValue const &)>>
         _packValueFunctions;
 


### PR DESCRIPTION
### Description of Change(s)
- Change `_packValueFunctions` to be a `robin_map` as it does not rely on the order provided by `boost::container::flat_map`
- Use `robin_map` to store `allValuesAtAllTimes` and create a sorted view of the map iterators for the subsequent order dependent operation

### Fixes Issue(s)
- #2296 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
