### PR TITLE
Specialize `TfHashAppend` for `std::vector<bool>`

### DIFF
--- a/pxr/base/tf/hash.h
+++ b/pxr/base/tf/hash.h
@@ -89,12 +89,20 @@ TfHashAppend(HashState &h, std::pair<T, U> const &p)
     h.Append(p.second);
 }
 
-// Support std::vector.
+// Support std::vector. std::vector<bool> specialized below.
 template <class HashState, class T>
-inline void
+inline std::enable_if_t<!std::is_same<std::remove_const_t<T>, bool>::value>
 TfHashAppend(HashState &h, std::vector<T> const &vec)
 {
     h.AppendContiguous(vec.data(), vec.size());
+}
+
+// Support std::vector<bool>.
+template <class HashState>
+inline void
+TfHashAppend(HashState &h, std::vector<bool> const &vec)
+{
+    h.Append(std::hash<std::vector<bool>>{}(vec));
 }
 
 // Support std::set.

--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -294,6 +294,9 @@ Test_TfHash()
     std::vector<int> vint = {1, 2, 3, 4, 5};
     printf("hash(vector<int>): %zu\n", h(vint));
 
+    std::vector<bool> vbool = {true, false, true};
+    printf("hash(vector<bool>): %zu\n", h(vbool));
+
     std::set<int> sint = {1, 2, 3, 4, 5};
     printf("hash(set<int>): %zu\n", h(sint));
 


### PR DESCRIPTION
### Description of Change(s)
The `TfHashAppend` specialization for `std::vector` uses the `.data()` method to hash contiguous elements. However, `std::vector<bool>` is not guaranteed to provide a `.data()` method and does not guarantee the underlying data's length is the container's `size() * sizeof(bool)`.

This change modifies the `TfHashAppend` specialization to not match against `std::vector<bool>` and provides a more explicit specialization that uses `std::hash` instead.

This issue was detected during testing of #2176 which changes `VtHash` to prefer `TfHash` over `hash_value` for hashing.

### Fixes Issue(s)
- #2172 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
