### PR TITLE
Specialize `TfHashAppend` for `std::shared_ptr` and `std::unique_ptr`

### DIFF
--- a/pxr/base/tf/hash.h
+++ b/pxr/base/tf/hash.h
@@ -34,6 +34,7 @@
 #include <cstring>
 #include <string>
 #include <map>
+#include <memory>
 #include <set>
 #include <typeindex>
 #include <type_traits>
@@ -140,6 +141,22 @@ template <class HashState, class T>
 inline void
 TfHashAppend(HashState &h, const T* ptr) {
     return h.Append(reinterpret_cast<uintptr_t>(ptr));
+}
+
+// Support for hashing std::shared_ptr. When TfHash support for std::hash is
+// enabled, this explicit specialization will no longer be necessary.
+template <class HashState, class T>
+inline void
+TfHashAppend(HashState &h, const std::shared_ptr<T>& ptr) {
+    h.Append(std::hash<std::shared_ptr<T>>{}(ptr));
+}
+
+// Support for hashing std::unique_ptr. When TfHash support for std::hash is
+// enabled, this explicit specialization will no longer be necessary.
+template <class HashState, class T>
+inline void
+TfHashAppend(HashState &h, const std::unique_ptr<T>& ptr) {
+    h.Append(std::hash<std::unique_ptr<T>>{}(ptr));
 }
 
 // We refuse to hash [const] char *.  You're almost certainly trying to hash the

--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -315,6 +315,12 @@ Test_TfHash()
     // Validate support for std::type_index
     printf("hash(type_index): %zu\n", h(std::type_index(typeid(int))));
 
+    // Validate support for std::shared_ptr
+    printf("hash(shared_ptr): %zu\n", h(std::make_shared<int>(5)));
+
+    // Validate support for std::unique_ptr
+    printf("hash(unique_ptr): %zu\n", h(std::make_unique<int>(7)));
+
     TfHasher tfh;
     //BoostHasher bh;
 


### PR DESCRIPTION
### Description of Change(s)
`TfHash` and `VtHash` may utilize ADL of `hash_value` for their hashing implementations. As usage of `boost::hash_value` is being phased out, it's possible for other `hash_value` implementations to be picked up. Specifically, while testing the removal of `boost::hash_value` from `pxr/base/vt/hash.h` (#2176), `stdext::hash_value` was getting discovered on certain Windows builds when hashing `std::shared_ptr`.  `boost::hash_value` was previously providing the `std::shared_ptr` specialization for `VtHash` but with #2176 `VtHash` prefers `TfHash` and `TfHash` may resolve to the `stdext::hash_value` implementation.

This PR provides an implementation of `TfHashAppend` for `std::shared_ptr` and `std::unique_ptr` which hash their underlying pointers and takes precedence over `hash_value`.

While providing a `TfHashAppend` implementation for `std::shared_ptr` and `std::unique_ptr` precludes `hash_value` ADL, it's worth noting that for user code using `VtHash` or `TfHash`, other types may be affected by this and additional specializations may be required.

This should not affect the specialization of `TfHashAppend` for `std::shared_ptr<_Untyped>` used in `pxr/usd/ar` which hashes the pointed to value instead of the pointer.

### Fixes Issue(s)
- #2172 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
