### PR TITLE
Replace `boost::iterator_facade` with explicit iterator for `TfDenseHashMap`

### DIFF
--- a/pxr/base/tf/denseHashMap.h
+++ b/pxr/base/tf/denseHashMap.h
@@ -33,8 +33,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/iterator/iterator_facade.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class TfDenseHashMap
@@ -141,30 +139,65 @@ private:
     //
     // Clearly not a good thing.
     //
-    // Therefore we use boost::iterator_facade to create an iterator that uses
-    // the map's value_type as externally visible type.
+    // Therefore we create an iterator that uses the map's value_type as
+    // externally visible type.
     //
     template <class ElementType, class UnderlyingIterator>
-    class _IteratorBase :
-        public boost::iterator_facade<
-            _IteratorBase<ElementType, UnderlyingIterator>,
-            ElementType,
-            boost::bidirectional_traversal_tag>
+    class _IteratorBase
     {
     public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = ElementType;
+        using reference = ElementType&;
+        using pointer = ElementType*;
+        using difference_type = typename UnderlyingIterator::difference_type;
 
         // Empty ctor.
-        _IteratorBase() {}
+        _IteratorBase() = default;
 
         // Allow conversion of an iterator to a const_iterator.
         template<class OtherIteratorType>
         _IteratorBase(const OtherIteratorType &rhs)
         :   _iter(rhs._GetUnderlyingIterator()) {}
 
+        reference operator*() const { return dereference(); }
+        pointer operator->() const { return &(dereference()); }
+
+        _IteratorBase& operator++() {
+            increment();
+            return *this;
+        }
+
+        _IteratorBase& operator--() {
+            decrement();
+            return *this;
+        }
+
+        _IteratorBase operator++(int) {
+            _IteratorBase result(*this);
+            increment();
+            return result;
+        }
+
+        _IteratorBase operator--(int) {
+            _IteratorBase result(*this);
+            decrement();
+            return result;
+        }
+
+        template <class OtherIteratorType>
+        bool operator==(const OtherIteratorType& other) const {
+            return equal(other);
+        }
+
+        template <class OtherIteratorType>
+        bool operator!=(const OtherIteratorType& other) const {
+            return !equal(other);
+        }
+
     private:
 
         friend class TfDenseHashMap;
-        friend class boost::iterator_core_access;
 
         // Ctor from an underlying iterator.
         _IteratorBase(const UnderlyingIterator &iter)

--- a/pxr/base/tf/denseHashSet.h
+++ b/pxr/base/tf/denseHashSet.h
@@ -33,8 +33,6 @@
 #include <memory>
 #include <vector>
 
-#include <boost/iterator/iterator_facade.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class TfDenseHashSet


### PR DESCRIPTION
### Description of Change(s)
- Remove spurious include of `boost/iterator/iterator_facade.hpp` in `pxr/base/tf/denseHashSet.h`
- Explicitly implement `_IteratorBase` for `TfDenseHashMap`
- Make empty `_IteratorBase` constructor `default` instead of empty

### Fixes Issue(s)
- #2305 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
