### PR TITLE
Remove unused `boost` headers

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -34,7 +34,6 @@
 #include "pxr/base/arch/systemInfo.h"
 #include "pxr/base/arch/errno.h"
 
-#include <boost/assign.hpp>
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/hashset.h"
 

--- a/pxr/base/tf/testenv/notice.cpp
+++ b/pxr/base/tf/testenv/notice.cpp
@@ -31,8 +31,6 @@
 #include "pxr/base/tf/weakPtr.h"
 #include "pxr/base/arch/systemInfo.h"
 
-#include <boost/function.hpp>
-
 #include <chrono>
 #include <cstdio>
 #include <iostream>

--- a/pxr/base/tf/wrapTestTfPython.cpp
+++ b/pxr/base/tf/wrapTestTfPython.cpp
@@ -52,8 +52,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 
-#include <boost/smart_ptr.hpp>
-
 #include <functional>
 #include <string>
 #include <vector>

--- a/pxr/base/tf/wrapType.cpp
+++ b/pxr/base/tf/wrapType.cpp
@@ -43,7 +43,6 @@
 #include <boost/python/has_back_reference.hpp>
 #include <boost/python/operators.hpp>
 #include <boost/python/overloads.hpp>
-#include <boost/preprocessor.hpp>
 
 #include <string>
 

--- a/pxr/base/vt/wrapArray.h
+++ b/pxr/base/vt/wrapArray.h
@@ -48,7 +48,6 @@
 #include "pxr/base/tf/tf.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 
-#include <boost/preprocessor/facilities/empty.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/repetition/repeat.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>

--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -30,7 +30,6 @@
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/stringUtils.h"
 
-#include <boost/ptr_container/ptr_map.hpp>
 #include <boost/ptr_container/ptr_set.hpp>
 #include <boost/variant.hpp>
 

--- a/pxr/usd/sdf/textFileFormat.cpp
+++ b/pxr/usd/sdf/textFileFormat.cpp
@@ -41,7 +41,6 @@
 #include "pxr/base/tf/staticData.h"
 #include "pxr/base/arch/fileSystem.h"
 
-#include <boost/assign.hpp>
 #include <ostream>
 
 using std::string;

--- a/pxr/usd/sdf/wrapPayload.cpp
+++ b/pxr/usd/sdf/wrapPayload.cpp
@@ -29,7 +29,6 @@
 #include "pxr/base/vt/valueFromPython.h"
 
 #include <boost/python.hpp>
-#include <boost/function.hpp>
 
 #include <string>
 

--- a/pxr/usd/sdf/wrapPrimSpec.cpp
+++ b/pxr/usd/sdf/wrapPrimSpec.cpp
@@ -42,7 +42,6 @@
 
 #include <boost/python.hpp>
 #include <boost/python/stl_iterator.hpp>
-#include <boost/function.hpp>
 
 using namespace boost::python;
 

--- a/pxr/usd/sdf/wrapReference.cpp
+++ b/pxr/usd/sdf/wrapReference.cpp
@@ -28,7 +28,6 @@
 #include "pxr/base/tf/pyUtils.h"
 
 #include <boost/python.hpp>
-#include <boost/function.hpp>
 
 #include <string>
 


### PR DESCRIPTION
### Description of Change(s)
* Remove unused headers `boost/ptr_container/ptr_map.hpp`, `boost/smart_ptr.hpp`, `boost/preprocessor/facilities/empty.hpp`, and `boost/assign.hpp` from the pxr code base.
* Removed `boost/preprocessor.hpp` from `wrapType.cpp`
* Removed `boost/function.hpp` from several unused sites, as the boost function `make_function` comes from `boost/python`, not `boost/function.hpp`.

### Fixes Issue(s)
- #2243 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
