### PR TITLE
Explicitly delete hashing of `float` via implicit conversion to `GfHalf`

### DIFF
--- a/pxr/base/gf/half.h
+++ b/pxr/base/gf/half.h
@@ -35,8 +35,6 @@
 #include "pxr/base/gf/ilmbase_halfLimits.h"
 #include "pxr/base/gf/traits.h"
 
-#include <type_traits>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// A 16-bit floating point data type.
@@ -44,10 +42,9 @@ using GfHalf = pxr_half::half;
 
 namespace pxr_half {
     /// Overload hash_value for half.
-    template<typename Half>
-    inline
-    typename std::enable_if<std::is_same<Half, half>::value, size_t>::type
-    hash_value(const Half& h) { return h.bits(); }
+    inline size_t hash_value(const half h) { return h.bits(); }
+    // Explicitly delete hashing via implicit conversion of half to float
+    size_t hash_value(float) = delete;
 }
 
 template <>

--- a/pxr/base/gf/testenv/testGfHardToReach.cpp
+++ b/pxr/base/gf/testenv/testGfHardToReach.cpp
@@ -180,6 +180,11 @@ main(int argc, char *argv[])
 
         float halfsNan = GfHalf::sNan();
         TF_AXIOM(std::isnan(halfsNan));
+
+        TF_AXIOM(pxr_half::hash_value(GfHalf(1.0f)) ==
+                 pxr_half::hash_value(GfHalf(1.0f)));
+        TF_AXIOM(pxr_half::hash_value(GfHalf(1.0f)) ==
+                 hash_value(GfHalf(1.0f)));
     }
 
     return 0;


### PR DESCRIPTION
### Description of Change(s)
During testing of #2175 (which removes boost's hashing from multiple code sites), it was observed that ADL was not resolving an implementation of `hash_value` for some qualifier variations of `GfHalf` under certain compiler conditions (specifically, on Windows when the `PXR_NS` has been disabled). SFINAE was being used to suppress hashing via implicit conversion of `float` to `GfHalf`. We can avoid SFINAE and suppress the implicit conversion by explicitly deleting `pxr_half::hash_value(float)`. With this change, ADL now works as expected in concert with #2175.

This change also makes the `half` input argument to `hash_value` passed by value under the principle of passing cheap to copy types by value.

Test coverage has been added for `hash_value`.

### Fixes Issue(s)
- #2172 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
