### PR TITLE
hdEmbree: add support for building against embree4

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1577,14 +1577,19 @@ MATERIALX = Dependency("MaterialX", InstallMaterialX, "include/MaterialXCore/Lib
 
 ############################################################
 # Embree
-# For MacOS we use version 3.13.3 to include a fix from Intel
-# to build on Apple Silicon.
-if MacOS():
-    EMBREE_URL = "https://github.com/RenderKit/embree/archive/v3.13.3.zip"
-else:
-    EMBREE_URL = "https://github.com/RenderKit/embree/archive/v3.2.2.zip"
+
+EMBREE_DEFAULT_MAJOR_VERSION = 3
 
 def InstallEmbree(context, force, buildArgs):
+    if context.embreeMajorVersion >= 4:
+        EMBREE_URL = "https://github.com/RenderKit/embree/archive/refs/tags/v4.4.0.zip"
+    elif MacOS():
+        # For MacOS we use version 3.13.3 to include a fix from Intel
+        # to build on Apple Silicon.
+        EMBREE_URL = "https://github.com/RenderKit/embree/archive/refs/tags/v3.13.3.zip"
+    else:
+        EMBREE_URL = "https://github.com/RenderKit/embree/archive/refs/tags/v3.2.2.zip"
+
     with CurrentWorkingDirectory(DownloadURL(EMBREE_URL, context, force)):
         extraArgs = [
             '-DTBB_ROOT="{instDir}"'.format(instDir=context.instDir),
@@ -1601,7 +1606,9 @@ def InstallEmbree(context, force, buildArgs):
 
         RunCMake(context, force, extraArgs)
 
-EMBREE = Dependency("Embree", InstallEmbree, "include/embree3/rtcore.h")
+EMBREE = Dependency("Embree", InstallEmbree,
+                    "include/embree3/rtcore.h",
+                    "include/embree4/rtcore.h")
 
 ############################################################
 # AnimX
@@ -2121,6 +2128,12 @@ subgroup.add_argument("--embree", dest="build_embree", action="store_true",
                       help="Build Embree sample imaging plugin")
 subgroup.add_argument("--no-embree", dest="build_embree", action="store_false",
                       help="Do not build Embree sample imaging plugin (default)")
+group.add_argument("--embree-major-version",
+                   default=EMBREE_DEFAULT_MAJOR_VERSION, type=int,
+                   choices=[3, 4],
+                   help=(
+                       "The major version of Embree to build "
+                       "(default: {})").format(EMBREE_DEFAULT_MAJOR_VERSION))
 subgroup = group.add_mutually_exclusive_group()
 subgroup.add_argument("--prman", dest="build_prman", action="store_true",
                       default=False,
@@ -2342,6 +2355,7 @@ class InstallContext:
 
         # - Imaging plugins
         self.buildEmbree = self.buildImaging and args.build_embree
+        self.embreeMajorVersion = args.embree_major_version
         self.buildPrman = self.buildImaging and args.build_prman
         self.prmanLocation = (os.path.abspath(args.prman_location)
                                if args.prman_location else None)                               
@@ -2656,6 +2670,7 @@ summaryMsg += """\
       OpenImageIO support:      {buildOIIO} 
       OpenColorIO support:      {buildOCIO} 
       Embree support:           {buildEmbree}
+        Embree major version:   {embreeMajorVersion}
       PRMan support:            {buildPrman}
       Vulkan support:           {enableVulkan}
     UsdImaging                  {buildUsdImaging}
@@ -2738,6 +2753,8 @@ summaryMsg = summaryMsg.format(
     buildOIIO=("On" if context.buildOIIO else "Off"),
     buildOCIO=("On" if context.buildOCIO else "Off"),
     buildEmbree=("On" if context.buildEmbree else "Off"),
+    embreeMajorVersion=(context.embreeMajorVersion if context.buildEmbree
+                        else "N/A"),
     buildPrman=("On" if context.buildPrman else "Off"),
     buildUsdImaging=("On" if context.buildUsdImaging else "Off"),
     buildUsdview=("On" if context.buildUsdview else "Off"),

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2473,9 +2473,10 @@ if context.buildDraco and context.buildMonolithic and Windows():
     PrintError("Draco plugin can not be enabled for monolithic build on Windows")
     sys.exit(1)
 
-# The versions of Embree we currently support do not support oneTBB.
-if context.buildOneTBB and context.buildEmbree:
-    PrintError("Embree support cannot be enabled when building against oneTBB")
+# When building with both oneTBB and Embree, a 4.x version of Embree must be
+# used.
+if context.buildOneTBB and (context.buildEmbree and context.embreeMajorVersion < 4):
+    PrintError("Embree 4.x or later must be selected when building against oneTBB")
     sys.exit(1)
 
 # Windows ARM64 requires oneTBB. Since oneTBB is a non-standard option for the

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1587,7 +1587,7 @@ else:
 def InstallEmbree(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(EMBREE_URL, context, force)):
         extraArgs = [
-            '-DTBB_ROOT={instDir}'.format(instDir=context.instDir),
+            '-DTBB_ROOT="{instDir}"'.format(instDir=context.instDir),
             '-DEMBREE_TUTORIALS=OFF',
             '-DEMBREE_ISPC_SUPPORT=OFF'
         ]

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1580,9 +1580,9 @@ MATERIALX = Dependency("MaterialX", InstallMaterialX, "include/MaterialXCore/Lib
 # For MacOS we use version 3.13.3 to include a fix from Intel
 # to build on Apple Silicon.
 if MacOS():
-    EMBREE_URL = "https://github.com/embree/embree/archive/v3.13.3.zip"
+    EMBREE_URL = "https://github.com/RenderKit/embree/archive/v3.13.3.zip"
 else:
-    EMBREE_URL = "https://github.com/embree/embree/archive/v3.2.2.zip"
+    EMBREE_URL = "https://github.com/RenderKit/embree/archive/v3.2.2.zip"
 
 def InstallEmbree(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(EMBREE_URL, context, force)):

--- a/cmake/modules/FindEmbree.cmake
+++ b/cmake/modules/FindEmbree.cmake
@@ -19,12 +19,30 @@
 #
 #=============================================================================
 
+find_path(EMBREE_INCLUDE_DIR
+    embree4/rtcore.h
+    embree3/rtcore.h
+HINTS
+    "${EMBREE_LOCATION}/include"
+    "$ENV{EMBREE_LOCATION}/include"
+DOC
+    "Embree headers path"
+)
+
+if (EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree4/rtcore.h")
+    set(EMBREE_VERSIONED_LIBRARY_NAME "embree4")
+    set(EMBREE_VERSION_HEADER_FILE_NAME "rtcore_config.h")
+else()
+    set(EMBREE_VERSIONED_LIBRARY_NAME "embree3")
+    set(EMBREE_VERSION_HEADER_FILE_NAME "rtcore_version.h")
+endif()
+
 if (APPLE)
-    set (EMBREE_LIB_NAME libembree3.dylib)
+    set (EMBREE_LIB_NAME "lib${EMBREE_VERSIONED_LIBRARY_NAME}.dylib")
 elseif (UNIX)
-    set (EMBREE_LIB_NAME libembree3.so)
+    set (EMBREE_LIB_NAME "lib${EMBREE_VERSIONED_LIBRARY_NAME}.so")
 elseif (WIN32)
-    set (EMBREE_LIB_NAME embree3.lib)
+    set (EMBREE_LIB_NAME "${EMBREE_VERSIONED_LIBRARY_NAME}.lib")
 endif()
 
 find_library(EMBREE_LIBRARY
@@ -38,21 +56,14 @@ find_library(EMBREE_LIBRARY
         "Embree library path"
 )
 
-find_path(EMBREE_INCLUDE_DIR
-    embree3/rtcore.h
-HINTS
-    "${EMBREE_LOCATION}/include"
-    "$ENV{EMBREE_LOCATION}/include"
-DOC
-    "Embree headers path"
-)
+set(EMBREE_VERSION_HEADER_FILE_PATH "${EMBREE_INCLUDE_DIR}/${EMBREE_VERSIONED_LIBRARY_NAME}/${EMBREE_VERSION_HEADER_FILE_NAME}")
 
-if (EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" )
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MAJOR.*$")
+if (EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_VERSION_HEADER_FILE_PATH}")
+    file(STRINGS "${EMBREE_VERSION_HEADER_FILE_PATH}" TMP REGEX "^#define RTC_VERSION_MAJOR.*$")
     string(REGEX MATCHALL "[0-9]+" MAJOR ${TMP})
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MINOR.*$")
+    file(STRINGS "${EMBREE_VERSION_HEADER_FILE_PATH}" TMP REGEX "^#define RTC_VERSION_MINOR.*$")
     string(REGEX MATCHALL "[0-9]+" MINOR ${TMP})
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_PATCH.*$")
+    file(STRINGS "${EMBREE_VERSION_HEADER_FILE_PATH}" TMP REGEX "^#define RTC_VERSION_PATCH.*$")
     string(REGEX MATCHALL "[0-9]+" PATCH ${TMP})
 
     set (EMBREE_VERSION ${MAJOR}.${MINOR}.${PATCH})

--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -11,6 +11,12 @@ if (NOT ${PXR_BUILD_GPU_SUPPORT})
     return()
 endif()
 
+if (EMBREE_VERSION VERSION_GREATER_EQUAL 4.0.0)
+    add_definitions(-DPXR_EMBREE_MAJOR_VERSION=4)
+else()
+    add_definitions(-DPXR_EMBREE_MAJOR_VERSION=3)
+endif()
+
 pxr_plugin(hdEmbree
    LIBRARIES
         plug

--- a/pxr/imaging/plugin/hdEmbree/context.h
+++ b/pxr/imaging/plugin/hdEmbree/context.h
@@ -14,7 +14,11 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/vt/array.h"
 
-#include <embree3/rtcore.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+#else
+    #include <embree3/rtcore.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/mesh.h
+++ b/pxr/imaging/plugin/hdEmbree/mesh.h
@@ -15,8 +15,13 @@
 
 #include "pxr/imaging/plugin/hdEmbree/meshSamplers.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+    #include <embree4/rtcore_ray.h>
+#else
+    #include <embree3/rtcore.h>
+    #include <embree3/rtcore_ray.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/meshSamplers.h
+++ b/pxr/imaging/plugin/hdEmbree/meshSamplers.h
@@ -12,8 +12,13 @@
 #include "pxr/imaging/hd/meshUtil.h"
 #include "pxr/base/vt/types.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_geometry.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+    #include <embree4/rtcore_geometry.h>
+#else
+    #include <embree3/rtcore.h>
+    #include <embree3/rtcore_geometry.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 
 #include <bitset>
 

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -76,9 +76,15 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_geometry.h>
+#include <embree4/rtcore_ray.h>
+#else
 #include <embree3/rtcore.h>
 #include <embree3/rtcore_geometry.h>
 #include <embree3/rtcore_ray.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.h
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.h
@@ -13,8 +13,13 @@
 #include "pxr/imaging/plugin/hdEmbree/renderer.h"
 #include "pxr/base/tf/staticTokens.h"
 
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+#else
+    #include <embree3/rtcore.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+
 #include <mutex>
-#include <embree3/rtcore.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/renderParam.h
+++ b/pxr/imaging/plugin/hdEmbree/renderParam.h
@@ -11,7 +11,11 @@
 #include "pxr/imaging/hd/renderDelegate.h"
 #include "pxr/imaging/hd/renderThread.h"
 
-#include <embree3/rtcore.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+#else
+    #include <embree3/rtcore.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -709,9 +709,13 @@ HdEmbreeRenderer::_TraceRay(unsigned int x, unsigned int y,
     rayHit.ray.flags = 0;
     _PopulateRayHit(&rayHit, origin, dir, 0.0f);
     {
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+      rtcIntersect1(_scene, &rayHit);
+#else
       RTCIntersectContext context;
       rtcInitIntersectContext(&context);
       rtcIntersect1(_scene, &context, &rayHit);
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
       //
       // there is something odd about how this is used in Embree. Is it reversed
       // here and then when it it used in
@@ -1047,9 +1051,13 @@ HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
         shadow.flags = 0;
         _PopulateRay(&shadow, position, shadowDir, 0.001f);
         {
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+          rtcOccluded1(_scene, &shadow);
+#else
           RTCIntersectContext context;
           rtcInitIntersectContext(&context);
           rtcOccluded1(_scene,&context,&shadow);
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
         }
 
         // Record this AO ray's contribution to the occlusion factor: a

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -28,8 +28,13 @@
 // oneTBB as a min spec. This applies the "Work" thread limit to the
 // render thread if "Work" is using old TBB, but won't affect other "Work"
 // implementations.  Note that it may affect Embree TBB usage as well.
+//
+// The header that provides version definitions moved between TBB
+// (tbb_stddef.h) and oneTBB (version.h), so we use the lowest level header
+// that is available at the same path in both and let it bring in the
+// definitions.
 // -------------------------------------------------------------------------
-#include <tbb/tbb_stddef.h>
+#include <tbb/blocked_range.h>
 
 #if TBB_INTERFACE_VERSION_MAJOR < 12
 

--- a/pxr/imaging/plugin/hdEmbree/renderer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderer.h
@@ -15,8 +15,13 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/rect2i.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+    #include <embree4/rtcore_ray.h>
+#else
+    #include <embree3/rtcore.h>
+    #include <embree3/rtcore_ray.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
 
 #include <random>
 #include <atomic>

--- a/pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
+++ b/pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
@@ -23,7 +23,12 @@
 
 #include "pxr/base/tf/errorMark.h"
 
-#include <embree3/rtcore.h>
+#if defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+    #include <embree4/rtcore.h>
+#else
+    #include <embree3/rtcore.h>
+#endif // defined(PXR_EMBREE_MAJOR_VERSION) && PXR_EMBREE_MAJOR_VERSION >= 4
+
 #include <iostream>
 
 PXR_NAMESPACE_USING_DIRECTIVE


### PR DESCRIPTION
Hello!

### Description of Change(s)

These changes allow building USD and the `hdEmbree` plugin against the recently released [4.0.0 version of Embree](https://github.com/embree/embree/releases/tag/v4.0.0). The upgrade from 3.x to 4.x of Embree involves a filename change of headers and libraries (`embree3` -> `embree4`), the renaming of the header file that contains the version information from `rtcore_version.h` to `rtcore_config.h`, and for the usage in `hdEmbree`, no longer providing an (unused) context to the `rtcIntersect1()` and `rtcOccluded1()` functions. See the notes for more detail on upgrading from Embree 4 to Embree 4 here:
https://github.com/RenderKit/embree/tree/v4.0.0?tab=readme-ov-file#upgrading-from-embree-3-to-embree-4

The last change in https://github.com/mattyjams/USD/commit/98b171aa83f27fa4cdb6ab74d241c1d1727e27ea isn't strictly necessary and may be overkill since there isn't really a precedent for being able to choose versions of dependencies from the command-line, so I wouldn't mind if that change needed to be culled. It does provide an easy way to select Embree 4 rather than Embree 3 though, so I included it in case it might be useful for others.

Many of the imaging tests still appear to be disabled by default on Windows which is the platform I'm currently on, so I have not been able to verify them, though the rest of the test suite passes. Manual testing in `usdview` has been successful so far as well.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
