### PR TITLE
usd: align Python UsdProperty property stack getter API with C++

### DIFF
--- a/pxr/usd/usd/testenv/testUsdCreateProperties.py
+++ b/pxr/usd/usd/testenv/testUsdCreateProperties.py
@@ -550,6 +550,11 @@ class TestUsdCreateProperties(unittest.TestCase):
                 (expectedPropertyStack[2], Sdf.LayerOffset(20.0, 2.0))
             ]
 
+            # ensure that fetching property stacks with and without providing
+            # the default timecode as an argument yields the same result.
+            self.assertEqual(attr.GetPropertyStack(), expectedPropertyStack)
+            self.assertEqual(attr.GetPropertyStackWithLayerOffsets(),
+                             expectedPropertyStackWithLayerOffsets)
             self.assertEqual(attr.GetPropertyStack(Usd.TimeCode.Default()), 
                                               expectedPropertyStack)
             self.assertEqual(attr.GetPropertyStackWithLayerOffsets(

--- a/pxr/usd/usd/wrapProperty.cpp
+++ b/pxr/usd/usd/wrapProperty.cpp
@@ -59,10 +59,10 @@ void wrapUsdProperty()
              arg("nestedGroups"))
 
         .def("GetPropertyStack", &UsdProperty::GetPropertyStack,
-             arg("time"))
+             arg("time")=UsdTimeCode::Default())
         .def("GetPropertyStackWithLayerOffsets", 
              &UsdProperty::GetPropertyStackWithLayerOffsets,
-             arg("time"),
+             arg("time")=UsdTimeCode::Default(),
              return_value_policy<TfPySequenceToList>())
 
         .def("IsCustom", &UsdProperty::IsCustom)


### PR DESCRIPTION
### Description of Change(s)

On the C++ side, the `GetPropertyStack()` and `GetPropertyStackWithLayerOffsets()` member functions of `UsdProperty` take a `UsdTimeCode` as an optional argument. This change makes that argument optional through the Python API as well.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
