### PR TITLE
Add missing HD_API in hdGp

### DIFF
--- a/pxr/imaging/hdGp/CMakeLists.txt
+++ b/pxr/imaging/hdGp/CMakeLists.txt
@@ -18,6 +18,9 @@ pxr_library(hdGp
         generativeProceduralPluginRegistry
         generativeProceduralResolvingSceneIndex
         sceneIndexPlugin
+        
+    PUBLIC_HEADERS
+        api.h
 
     RESOURCE_FILES
         plugInfo.json

--- a/pxr/imaging/hdGp/api.h
+++ b/pxr/imaging/hdGp/api.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pixar
+// Copyright 2023 Pixar
 //
 // Licensed under the Apache License, Version 2.0 (the "Apache License")
 // with the following modification; you may not use this file except in
@@ -21,41 +21,27 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#ifndef PXR_IMAGING_HD_GP_GENERATIVE_PROCEDURAL_PLUGIN_H
-#define PXR_IMAGING_HD_GP_GENERATIVE_PROCEDURAL_PLUGIN_H
+#ifndef PXR_IMAGING_HDGP_API_H
+#define PXR_IMAGING_HDGP_API_H
 
-#include "pxr/imaging/hdGp/generativeProcedural.h"
+#include "pxr/base/arch/export.h"
 
-#include "pxr/pxr.h"
-#include "pxr/imaging/hdGp/api.h"
-#include "pxr/imaging/hf/pluginBase.h"
-
-PXR_NAMESPACE_OPEN_SCOPE
-
-/// \class HdGpGenerativeProceduralPlugin
-/// 
-/// HdGpGenerativeProceduralPlugin represents an HdGpGenerativeProcedural for
-/// plug-in discovery via HdGpGenerativeProceduralPluginRegistry.
-///
-class HdGpGenerativeProceduralPlugin : public HfPluginBase
-{
-public:
-
-    /// Subclasses implement this to instantiate an HdGpGenerativeProcedural
-    /// at a given prim path.
-    HDGP_API
-    virtual HdGpGenerativeProcedural *Construct(
-        const SdfPath &proceduralPrimPath);
-
-protected:
-
-    HDGP_API
-    HdGpGenerativeProceduralPlugin();
-
-    HDGP_API
-    ~HdGpGenerativeProceduralPlugin() override;
-};
-
-PXR_NAMESPACE_CLOSE_SCOPE
-
+#if defined(PXR_STATIC)
+#   define HDGP_API
+#   define HDGP_API_TEMPLATE_CLASS(...)
+#   define HDGP_API_TEMPLATE_STRUCT(...)
+#   define HDGP_LOCAL
+#else
+#   if defined(HDGP_EXPORTS)
+#       define HDGP_API ARCH_EXPORT
+#       define HDGP_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#       define HDGP_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#   else
+#       define HDGP_API ARCH_IMPORT
+#       define HDGP_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#       define HDGP_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   endif
+#   define HDGP_LOCAL ARCH_HIDDEN
 #endif
+
+#endif // PXR_IMAGING_HDGP_API_H

--- a/pxr/imaging/hdGp/generativeProcedural.h
+++ b/pxr/imaging/hdGp/generativeProcedural.h
@@ -48,7 +48,10 @@ TF_DECLARE_PUBLIC_TOKENS(HdGpGenerativeProceduralTokens,
 class HdGpGenerativeProcedural
 {
 public:
+    HD_API
     HdGpGenerativeProcedural(const SdfPath &proceduralPrimPath);
+    
+    HD_API
     virtual ~HdGpGenerativeProcedural();
 
     using DependencyMap =
@@ -119,6 +122,7 @@ public:
         const SdfPath &childPrimPath) = 0;
 
 protected:
+    HD_API
     const SdfPath &_GetProceduralPrimPath();
 
 private:

--- a/pxr/imaging/hdGp/generativeProcedural.h
+++ b/pxr/imaging/hdGp/generativeProcedural.h
@@ -24,6 +24,7 @@
 #ifndef PXR_IMAGING_HD_GP_GENERATIVE_PROCEDURAL_H
 #define PXR_IMAGING_HD_GP_GENERATIVE_PROCEDURAL_H
 
+#include "pxr/imaging/hdGp/api.h"
 #include "pxr/imaging/hd/sceneIndex.h"
 #include "pxr/base/tf/denseHashMap.h"
 
@@ -48,10 +49,10 @@ TF_DECLARE_PUBLIC_TOKENS(HdGpGenerativeProceduralTokens,
 class HdGpGenerativeProcedural
 {
 public:
-    HD_API
+    HDGP_API
     HdGpGenerativeProcedural(const SdfPath &proceduralPrimPath);
     
-    HD_API
+    HDGP_API
     virtual ~HdGpGenerativeProcedural();
 
     using DependencyMap =
@@ -122,7 +123,7 @@ public:
         const SdfPath &childPrimPath) = 0;
 
 protected:
-    HD_API
+    HDGP_API
     const SdfPath &_GetProceduralPrimPath();
 
 private:

--- a/pxr/imaging/hdGp/generativeProceduralPlugin.h
+++ b/pxr/imaging/hdGp/generativeProceduralPlugin.h
@@ -49,6 +49,7 @@ public:
 
 protected:
 
+    HD_API
     HdGpGenerativeProceduralPlugin();
 
     HD_API

--- a/pxr/imaging/hdGp/generativeProceduralPluginRegistry.h
+++ b/pxr/imaging/hdGp/generativeProceduralPluginRegistry.h
@@ -27,7 +27,7 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/singleton.h"
 #include "pxr/imaging/hf/pluginRegistry.h"
-#include "pxr/imaging/hd/api.h"
+#include "pxr/imaging/hdGp/api.h"
 
 #include "pxr/imaging/hdGp/generativeProceduralPlugin.h"
 
@@ -39,7 +39,7 @@ public:
     ///
     /// Returns the singleton registry for \c HdSceneIndexPlugin
     ///
-    HD_API
+    HDGP_API
     static HdGpGenerativeProceduralPluginRegistry &GetInstance();
 
     ///
@@ -48,7 +48,7 @@ public:
     template<typename T, typename... Bases>
     static void Define();
 
-    HD_API
+    HDGP_API
     HdGpGenerativeProcedural *ConstructProcedural(
         const TfToken &proceduralTypeName,
         const SdfPath &proceduralPrimPath);


### PR DESCRIPTION
### Description of Change(s)
Missing HD_API prevents from inheriting from `HdGpGenerativeProcedural` and `HdGpGenerativeProceduralPlugin` on windows because symbols are not exported (for example in the case of an external plugin) . This PR simply adds the missing HD_API in generativeProcedural.h and generativeProceduralPlugin.h.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
