### PR TITLE
Remove preprocessor usage in macros in `pxr/base/tf`

### DIFF
--- a/pxr/base/tf/enum.h
+++ b/pxr/base/tf/enum.h
@@ -37,7 +37,6 @@
 #include "pxr/base/tf/api.h"
 
 #include <boost/operators.hpp>
-#include <boost/preprocessor/punctuation/comma_if.hpp>
 
 #include <iosfwd>
 #include <string>
@@ -447,10 +446,8 @@ TF_API std::ostream& operator<<(std::ostream& out, const TfEnum & e);
 /// \ingroup group_tf_RuntimeTyping
 /// \hideinitializer
 #define TF_ADD_ENUM_NAME(VAL, ...)                               \
-    TfEnum::_AddName(VAL,                                        \
-                     TF_PP_STRINGIZE(VAL)                        \
-                     BOOST_PP_COMMA_IF(TF_NUM_ARGS(__VA_ARGS__)) \
-                     __VA_ARGS__)
+    TfEnum::_AddName(VAL, TF_PP_STRINGIZE(VAL),                  \
+                     std::string{__VA_ARGS__});
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/base/tf/scopeDescription.h
+++ b/pxr/base/tf/scopeDescription.h
@@ -32,7 +32,6 @@
 #include "pxr/base/tf/api.h"
 
 #include <boost/optional.hpp>
-#include <boost/preprocessor/if.hpp>
 
 #include <vector>
 #include <string>
@@ -133,10 +132,27 @@ TfGetThisThreadScopeDescriptionStack();
 
 /// Macro that accepts either a single string, or printf-style arguments and
 /// creates a scope description local variable with the resulting string.
-#define TF_DESCRIBE_SCOPE(fmt, ...)                                            \
+#define TF_DESCRIBE_SCOPE(...)                                                 \
     TfScopeDescription __scope_description__                                   \
-    (BOOST_PP_IF(TF_NUM_ARGS(__VA_ARGS__),                                     \
-                 TfStringPrintf(fmt, __VA_ARGS__), fmt), TF_CALL_CONTEXT)
+    (Tf_DescribeScopeFormat(__VA_ARGS__), TF_CALL_CONTEXT);                    \
+
+template <typename... Args>
+inline std::string
+Tf_DescribeScopeFormat(const char* fmt, Args&&... args) {
+    return TfStringPrintf(fmt, std::forward<Args>(args)...);
+}
+
+// If there are no formatting arguments, the string can be forwarded to the
+// scope description constructor. In C++17, consider if std::string_view could
+// reduce the need for as many of these overloads
+inline const char*
+Tf_DescribeScopeFormat(const char* fmt) { return fmt; }
+
+inline std::string&&
+Tf_DescribeScopeFormat(std::string&& fmt) { return std::move(fmt); }
+
+inline const std::string&
+Tf_DescribeScopeFormat(const std::string& fmt) { return fmt; }
 
 PXR_NAMESPACE_CLOSE_SCOPE
 


### PR DESCRIPTION
### Description of Change(s)
- The boost preprocessor usage in `enum.h` are replaced by simply passing the variadic arguments as `std::string` arguments. If there are no arguments, the macro expands to `std::string{}` which is the empty string (and equivalent to the default argument). Otherwise, the variadic arguments will be passed to the `std::string` constructor.
- The boost preprocessor usage in `scopeDescription.h` are replaced with variadic templates. Forwarding overloads are provided for common string types to avoid needless construction of a new string when no formatting arguments are provided.

### Fixes Issue(s)
- #2318 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
