### PR TITLE
Use non-deprecated TBB headers in `pxr/base/work`

### DIFF
--- a/pxr/base/work/loops.h
+++ b/pxr/base/work/loops.h
@@ -32,7 +32,7 @@
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>
-#include <tbb/task.h>
+#include <tbb/task_group.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/base/work/reduce.h
+++ b/pxr/base/work/reduce.h
@@ -31,7 +31,7 @@
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_reduce.h>
-#include <tbb/task.h>
+#include <tbb/task_group.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
### Description of Change(s)
`tbb/task.h` is deprecated / removed in newer versions of TBB, but `tbb/task_group.h` is not. Using `tbb/task_group.h` when possible reduces the warning count when building with TBB 2020.3 and is a small step in making `pxr/base/work` compatible with oneAPI.

### Fixes Issue(s)
- #1600
- #1471 
This PR is related to the issues above, but does not fully address.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
