### PR TITLE
Use non-deprecated TBB headers in `pxr/usd/usd/instanceCache.h`

### DIFF
--- a/pxr/usd/usd/instanceCache.h
+++ b/pxr/usd/usd/instanceCache.h
@@ -30,7 +30,7 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/tf/hashmap.h"
 
-#include <tbb/mutex.h>
+#include <tbb/spin_mutex.h>
 #include <map>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
### Description of Change(s)
`tbb/mutex.h` is deprecated / removed in newer versions of TBB, but `tbb/spin_mutex.h` is not. Using `tbb/spin_mutex.h` when possible reduces the warning count when building with TBB 2020.3 and is a small step in making `pxr/usd/usd` compatible with oneAPI.

### Fixes Issue(s)
- #1600 
- #1471 
This PR is related to the issues above, but does not fully address.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
