### PR TITLE
Apple: MaterialX on Metal

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1574,11 +1574,12 @@ DRACO = Dependency("Draco", InstallDraco, "include/draco/compression/decode.h")
 ############################################################
 # MaterialX
 
-MATERIALX_URL = "https://github.com/materialx/MaterialX/archive/v1.38.4.zip"
+MATERIALX_URL = "https://github.com/apple/MaterialX/archive/refs/tags/v1.38.6_MetalShadingLaguage.zip"
 
 def InstallMaterialX(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(MATERIALX_URL, context, force)):
         cmakeOptions = ['-DMATERIALX_BUILD_SHARED_LIBS=ON']
+        cmakeOptions += ['-DMATERIALX_BUILD_TESTS=OFF']
 
         cmakeOptions += buildArgs;
 

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -20,6 +20,7 @@ if (${PXR_ENABLE_MATERIALX_SUPPORT})
         MaterialXCore
         MaterialXFormat
         MaterialXGenGlsl
+        MaterialXGenMsl
         hdMtlx
     )
     list(APPEND optionalPrivateClasses

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -27,6 +27,7 @@
 #include "pxr/imaging/hdSt/package.h"
 #include "pxr/imaging/hdSt/resourceRegistry.h"
 #include "pxr/imaging/hdMtlx/hdMtlx.h"
+#include "pxr/imaging/hgi/tokens.h"
 
 #include "pxr/usd/sdr/registry.h"
 #include "pxr/imaging/hio/glslfx.h"
@@ -103,16 +104,37 @@ R"(
 </materialx>
 )";
 
+mx::GenContext createMaterialXContext(
+                HdSt_MxShaderGenInfo const& mxHdInfo,
+                std::string const& apiName)
+{
+    if(apiName == HgiTokens->Metal)
+        return HdStMaterialXMslShaderGen::create(mxHdInfo);
+    if(apiName == HgiTokens->OpenGL)
+        return HdStMaterialXGlslShaderGen::create(mxHdInfo);
+    else
+    {
+        TF_CODING_ERROR(
+            "MaterialX Shader Generator doesn't support %s API.",
+            apiName.c_str());
+        //return mx::GenContext();
+    }
+}
+
 // Use the given mxDocument to generate the corresponding glsl shader
 // Based on MaterialXViewer Viewer::loadDocument()
 mx::ShaderPtr
 HdSt_GenMaterialXShader(
     mx::DocumentPtr const& mxDoc,
     mx::FileSearchPath const& searchPath,
-    HdSt_MxShaderGenInfo const& mxHdInfo)
+    HdSt_MxShaderGenInfo const& mxHdInfo,
+    std::string const& apiName)
 {
     // Initialize the Context for shaderGen. 
-    mx::GenContext mxContext = HdStMaterialXShaderGen::create(mxHdInfo);
+    mx::GenContext mxContext = createMaterialXContext(mxHdInfo, apiName);
+
+    // USD expects transmission Opacity. Default is changed to TRANSMISSION_REFRACTION
+    mxContext.getOptions().hwTransmissionRenderMethod = mx::TRANSMISSION_OPACITY;
 
 #if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 38 && MATERIALX_BUILD_VERSION == 3
     mxContext.registerSourceCodeSearchPath(searchPath);
@@ -122,6 +144,7 @@ HdSt_GenMaterialXShader(
     for (const mx::FilePath &path : searchPath) {
         if (path.getBaseName() == "libraries") {
             libSearchPaths.append(path.getParentPath());
+            libSearchPaths.append(path);
         }
         else {
             libSearchPaths.append(path);
@@ -863,6 +886,7 @@ _GenerateMaterialXShader(
     HdMaterialNode2 const& terminalNode,
     SdfPath const& terminalNodePath,
     TfToken const& materialTagToken,
+    TfToken const& apiName,
     bool const bindlessTexturesEnabled)
 {
     // Load Standard Libraries/setup SearchPaths (for mxDoc and mxShaderGen)
@@ -901,7 +925,7 @@ _GenerateMaterialXShader(
     mxHdInfo.bindlessTexturesEnabled = bindlessTexturesEnabled;
     
     // Generate the glslfx source code from the mtlxDoc
-    return HdSt_GenMaterialXShader(mtlxDoc, searchPath, mxHdInfo);
+    return HdSt_GenMaterialXShader(mtlxDoc, searchPath, mxHdInfo, apiName.GetString());
 }
 
 void
@@ -927,6 +951,8 @@ HdSt_ApplyMaterialXFilter(
             resourceRegistry->GetHgi()->GetCapabilities()->IsSet(
                 HgiDeviceCapabilitiesBitsBindlessTextures);
 
+        const TfToken apiName = resourceRegistry->GetHgi()->GetAPIName();
+
         // If the MaterialNetwork has just a terminal node, utilize the
         // Resource Registry to cache the generated MaterialX glslfx Shader
         if (hdNetwork->nodes.size() == 1) {
@@ -942,7 +968,7 @@ HdSt_ApplyMaterialXFilter(
                 // Generate the MaterialX glslfx ShaderPtr
                 glslfxShader = _GenerateMaterialXShader(
                     hdNetwork, materialPath, terminalNode, terminalNodePath, 
-                    materialTagToken, bindlessTexturesEnabled);
+                    materialTagToken, apiName, bindlessTexturesEnabled);
 
                 // Store the mx::ShaderPtr 
                 glslfxInstance.SetValue(glslfxShader);
@@ -965,8 +991,8 @@ HdSt_ApplyMaterialXFilter(
         else {
             // Process the network and generate the MaterialX glslfx ShaderPtr
             glslfxShader = _GenerateMaterialXShader(
-                hdNetwork, materialPath, terminalNode, terminalNodePath, 
-                materialTagToken, bindlessTexturesEnabled);
+                hdNetwork, materialPath, terminalNode, terminalNodePath,
+                materialTagToken, apiName, bindlessTexturesEnabled);
 
             // Add material parameters from the glslfxShader
             _AddMaterialXParams(glslfxShader, materialParams);

--- a/pxr/imaging/hdSt/materialXFilter.h
+++ b/pxr/imaging/hdSt/materialXFilter.h
@@ -66,7 +66,8 @@ void HdSt_ApplyMaterialXFilter(
 MaterialX::ShaderPtr HdSt_GenMaterialXShader(
     MaterialX::DocumentPtr const& mxDoc,
     MaterialX::FileSearchPath const& searchPath,
-    HdSt_MxShaderGenInfo const& mxHdInfo=HdSt_MxShaderGenInfo());
+    HdSt_MxShaderGenInfo const& mxHdInfo=HdSt_MxShaderGenInfo(),
+    std::string const& apiName="");
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -1189,6 +1189,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 

--- a/pxr/imaging/hdx/shaders/renderPass.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPass.glslfx
@@ -43,6 +43,7 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
         colorOut = vec4(color.rgb, 1);
     } else {
         discard;
+        return;
     }
 }
 
@@ -122,7 +123,7 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     // There are two render passes for ordinary OIT geometry.
     // Fragments with alpha >= 1.0 are handled in the first (opaque)
     // render pass.
-    if (color.a < 1.0 && color.a > 0.0001) {
+    if (color.a < 1.0 && color.a >= 0.0001) {
         RenderOutputImpl(Peye, Neye, color, patchCoord);
     }
 }

--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -444,31 +444,48 @@ HgiMetalBlitCmds::FillBuffer(HgiBufferHandle const& buffer, uint8_t value)
 }
 
 static bool
-_HgiCanBeFiltered(HgiFormat format)
+_HgiTextureCanBeFiltered(HgiTextureDesc descriptor)
 {
-    HgiFormat const componentFormat = HgiGetComponentBaseFormat(format);
+    HgiFormat const componentFormat =
+        HgiGetComponentBaseFormat(descriptor.format);
 
-    switch(componentFormat) {
-    case HgiFormatInt16:
-    case HgiFormatUInt16:
-    case HgiFormatInt32:
+    if (componentFormat == HgiFormatInt16 ||
+        componentFormat == HgiFormatUInt16 ||
+        componentFormat == HgiFormatInt32) {
         return false;
-    default:
-        return true;
     }
+
+    HgiTextureType const type = descriptor.type;
+    static_assert(HgiTextureTypeCount == (HgiTextureType2DArray+1),
+                  "New texture type is added that is not supported "
+                  "by GenerateMipMaps. Update GenerateMipMaps accordingly.");
+    GfVec3i const dims = descriptor.dimensions;
+    bool const is1DTex = (type == HgiTextureType1D ||
+                          type == HgiTextureType1DArray);
+    bool const is2DTex = (type == HgiTextureType2D ||
+                          type == HgiTextureType2DArray);
+    bool const is3DTex = (type == HgiTextureType3D);
+    bool const dimensionsCompatible =
+        (is1DTex && dims[0] > 1) ||
+        (is2DTex && dims[0] > 1 && dims[1] > 1) ||
+        (is3DTex && dims[0] > 1 && dims[1] > 1 && dims[2] > 1);
+
+    return dimensionsCompatible;
 }
 
 void
 HgiMetalBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
 {
     HgiMetalTexture* metalTex = static_cast<HgiMetalTexture*>(texture.Get());
-    if (metalTex) {
-        HgiFormat const format = metalTex->GetDescriptor().format;
-        if (_HgiCanBeFiltered(format)) {
-            _CreateEncoder();
-            // Can fail if the texture format is not filterable.
-            [_blitEncoder generateMipmapsForTexture:metalTex->GetTextureId()];
-        }
+
+    if(!metalTex) {
+        return;
+    }
+
+    if (_HgiTextureCanBeFiltered(metalTex->GetDescriptor())) {
+        _CreateEncoder();
+        
+        [_blitEncoder generateMipmapsForTexture:metalTex->GetTextureId()];
     }
 }
 

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -431,7 +431,7 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
     header  << _GetPackedTypeDefinitions();
 
     header << "#define in /*in*/\n"
-              "#define discard discard_fragment();\n"
+              "#define discard discard_fragment(); discarded_fragment = true;\n"
               "#define radians(d) (d * 0.01745329252)\n"
               "#define noperspective /*center_no_perspective MTL_FIXME*/\n"
               "#define dFdx    dfdx\n"
@@ -1394,6 +1394,10 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
         section->VisitScopeStructs(ss);
     }
     ss << "\n// //////// Scope Member Declarations ////////\n";
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << "bool discarded_fragment;\n";
+    }
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         section->VisitScopeMemberDeclarations(ss);
     }
@@ -1506,11 +1510,24 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
 
     // Execute all code that hooks into the entry point function
     ss << "\n// //////// Entry Point Function Executions ////////\n";
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << _generatorShaderSections->GetScopeInstanceName() << ".discarded_fragment = false;\n";
+    }
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         if (section->VisitEntryPointFunctionExecutions(
                 ss, _generatorShaderSections->GetScopeInstanceName())) {
             ss << "\n";
         }
+    }
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << "if(" << _generatorShaderSections->GetScopeInstanceName() << ".discarded_fragment)\n";
+        ss << "{\n";
+        ss << "return "
+           << (outputs ? "{}" : "")
+           << ";\n";
+        ss << "}\n";
     }
     //return the instance of the shader entrypoint output type
     if(outputs)

--- a/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
+++ b/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
@@ -78,6 +78,7 @@ surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (opacity < opacityThreshold) {
         discard;
+        return vec4(1.0);
     } 
     opacity = 1.0;
 #endif            


### PR DESCRIPTION
### Description of Change(s)
- Enables MaterialX support on Metal. Makes the MaterialX shader generator polymorphic and implements the Metal based functionality.
- Points to Apple's branched hosted version of MaterialX until official release of MaterialX with Metal
- Makes sure that on Metal we don't attempt to mipmap textures containing only one pixel.
- Metal versions 2.2 and earlier don't return upon usage of the discard keyword. Improve discard handling to pass MaterialX unit tests on Metal.

Co-authored by:
Morteza Mostajabodaveh
Jon Creighton

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
