### PR TITLE
APPLE: Explicitly return after discarding in shader programs where appropriate

### DIFF
--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -923,6 +923,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 
@@ -973,6 +974,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -1189,6 +1189,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 

--- a/pxr/imaging/hdSt/shaders/meshWire.glslfx
+++ b/pxr/imaging/hdSt/shaders/meshWire.glslfx
@@ -275,7 +275,10 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+        return vec4(1.0);
+    }
 
     vec4 wireColor = GetWireframeColor();
 
@@ -293,7 +296,10 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+        return vec4(1.0);
+    }
 
     Cfill.a = 1.0; // edges ignore input opacity and are opaque.
     return Cfill;
@@ -347,7 +353,10 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+        return vec4(1.0);
+    }
 
     Cfill.a = 1.0; // edges ignore input opacity and are opaque.
 

--- a/pxr/imaging/hdSt/shaders/points.glslfx
+++ b/pxr/imaging/hdSt/shaders/points.glslfx
@@ -111,6 +111,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 

--- a/pxr/imaging/hdSt/shaders/renderPass.glslfx
+++ b/pxr/imaging/hdSt/shaders/renderPass.glslfx
@@ -284,6 +284,7 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     // Allow alpha threshold discard for ID renders regardless of material tag
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 
     int primId = HdGet_primID();

--- a/pxr/imaging/hdSt/shaders/terminals.glslfx
+++ b/pxr/imaging/hdSt/shaders/terminals.glslfx
@@ -318,12 +318,13 @@ integrateLights(vec4 Peye, vec3 Neye, LightingInterfaceProperties props)
 ReprStyle GetReprStyle()
 {
     vec4 hullColor = vec4(vec3(0.18), 1.0);
-
+    ReprStyle reprStyle;
 #if defined(HD_HAS_selectedWeight)
     float weight = clamp(HdGet_selectedWeight(), 0.0, 1.0);
 
     if (weight <= 0.0) {
         discard;
+        return reprStyle;
     }
 
     // The three control points of the quadratic curve for the selection color
@@ -353,8 +354,6 @@ ReprStyle GetReprStyle()
     hullColor.a = HdGet_hullOpacity();
 #endif
 #endif
-
-    ReprStyle reprStyle;
     
     reprStyle.color                    = hullColor;
     reprStyle.usePrimvarColor          = false;

--- a/pxr/imaging/hdSt/shaders/volume.glslfx
+++ b/pxr/imaging/hdSt/shaders/volume.glslfx
@@ -621,6 +621,7 @@ void main(void)
     // near plane.
     if (gl_FrontFacing != (determinant(instanceModelViewInverse) < 0.0)) {
         discard;
+        return;
     }
 
     // camera facing.

--- a/pxr/imaging/hdx/shaders/boundingBox.glslfx
+++ b/pxr/imaging/hdx/shaders/boundingBox.glslfx
@@ -62,6 +62,7 @@ void main(void)
         const float pixelDist = distance(dashStart, gl_FragCoord.xy);
         if (mod(pixelDist, 2.0*dashSize) > dashSize) {
             discard;
+            return;
         }
     }
 

--- a/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
+++ b/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
@@ -78,6 +78,7 @@ surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (opacity < opacityThreshold) {
         discard;
+        return vec4(0.0);
     } 
     opacity = 1.0;
 #endif            


### PR DESCRIPTION
### Description of Change(s)
Metal 2.2 and older requires explicit returns for discards in order to stop shader execution.
Along with an improvement made in the MaterialX pull request https://github.com/PixarAnimationStudios/USD/pull/2324 , discards in the system on the used version of Metal are more correct and explicit, should increase performance and reduce risk of errors and should fix some errors as well.

### Fixes Issue(s)
- Not explicitly returning after discards on Metal 2.2

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
