### PR TITLE
Use `TfHash` in `__hash__` implementations in `pxr/base/gf`

### DIFF
--- a/pxr/base/gf/wrapDualQuat.template.cpp
+++ b/pxr/base/gf/wrapDualQuat.template.cpp
@@ -30,6 +30,7 @@
 #include "pxr/base/gf/dualQuat{{ SCALAR_SUFFIX(S) }}.h"
 {% endfor %}
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -70,7 +71,7 @@ static {{ DUALQUAT }}& __itruediv__({{ DUALQUAT }} &self, {{ SCL }} value)
 }
 
 static size_t __hash__({{ DUALQUAT }} const &self) {
-    return hash_value(self);
+    return TfHash{}(self);
 }
 
 // Zero-initialized default ctor for python.

--- a/pxr/base/gf/wrapDualQuatd.cpp
+++ b/pxr/base/gf/wrapDualQuatd.cpp
@@ -30,6 +30,7 @@
 #include "pxr/base/gf/dualQuatf.h"
 #include "pxr/base/gf/dualQuath.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -70,7 +71,7 @@ static GfDualQuatd& __itruediv__(GfDualQuatd &self, double value)
 }
 
 static size_t __hash__(GfDualQuatd const &self) {
-    return hash_value(self);
+    return TfHash{}(self);
 }
 
 // Zero-initialized default ctor for python.

--- a/pxr/base/gf/wrapDualQuatf.cpp
+++ b/pxr/base/gf/wrapDualQuatf.cpp
@@ -30,6 +30,7 @@
 #include "pxr/base/gf/dualQuatf.h"
 #include "pxr/base/gf/dualQuath.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -70,7 +71,7 @@ static GfDualQuatf& __itruediv__(GfDualQuatf &self, float value)
 }
 
 static size_t __hash__(GfDualQuatf const &self) {
-    return hash_value(self);
+    return TfHash{}(self);
 }
 
 // Zero-initialized default ctor for python.

--- a/pxr/base/gf/wrapDualQuath.cpp
+++ b/pxr/base/gf/wrapDualQuath.cpp
@@ -30,6 +30,7 @@
 #include "pxr/base/gf/dualQuatf.h"
 #include "pxr/base/gf/dualQuath.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -70,7 +71,7 @@ static GfDualQuath& __itruediv__(GfDualQuath &self, GfHalf value)
 }
 
 static size_t __hash__(GfDualQuath const &self) {
-    return hash_value(self);
+    return TfHash{}(self);
 }
 
 // Zero-initialized default ctor for python.

--- a/pxr/base/gf/wrapMatrix.template.cpp
+++ b/pxr/base/gf/wrapMatrix.template.cpp
@@ -33,6 +33,7 @@
 {% block customIncludes %}
 {% endblock customIncludes %}
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -267,7 +268,7 @@ struct {{ MAT }}_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__({{ MAT }} const &m) { return hash_value(m); }
+static size_t __hash__({{ MAT }} const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix2d.cpp
+++ b/pxr/base/gf/wrapMatrix2d.cpp
@@ -32,6 +32,7 @@
 #include "pxr/base/gf/pyBufferUtils.h"
 
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -264,7 +265,7 @@ struct GfMatrix2d_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix2d const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix2d const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix2f.cpp
+++ b/pxr/base/gf/wrapMatrix2f.cpp
@@ -32,6 +32,7 @@
 #include "pxr/base/gf/pyBufferUtils.h"
 
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -264,7 +265,7 @@ struct GfMatrix2f_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix2f const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix2f const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix3d.cpp
+++ b/pxr/base/gf/wrapMatrix3d.cpp
@@ -35,6 +35,7 @@
 #include "pxr/base/gf/quatd.h"
 #include "pxr/base/gf/rotation.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -270,7 +271,7 @@ struct GfMatrix3d_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix3d const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix3d const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix3f.cpp
+++ b/pxr/base/gf/wrapMatrix3f.cpp
@@ -35,6 +35,7 @@
 #include "pxr/base/gf/quatf.h"
 #include "pxr/base/gf/rotation.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -270,7 +271,7 @@ struct GfMatrix3f_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix3f const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix3f const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix4d.cpp
+++ b/pxr/base/gf/wrapMatrix4d.cpp
@@ -39,6 +39,7 @@
 #include "pxr/base/gf/quatd.h"
 #include "pxr/base/gf/rotation.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -294,7 +295,7 @@ struct GfMatrix4d_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix4d const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix4d const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapMatrix4f.cpp
+++ b/pxr/base/gf/wrapMatrix4f.cpp
@@ -39,6 +39,7 @@
 #include "pxr/base/gf/quatf.h"
 #include "pxr/base/gf/rotation.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -294,7 +295,7 @@ struct GfMatrix4f_Pickle_Suite : boost::python::pickle_suite
     }
 };
 
-static size_t __hash__(GfMatrix4f const &m) { return hash_value(m); }
+static size_t __hash__(GfMatrix4f const &m) { return TfHash{}(m); }
 
 static boost::python::tuple get_dimension()
 {

--- a/pxr/base/gf/wrapQuaternion.cpp
+++ b/pxr/base/gf/wrapQuaternion.cpp
@@ -24,6 +24,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/gf/quaternion.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static string _Repr(GfQuaternion const &self) {
         TfPyRepr(self.GetImaginary()) + ")";
 }
 
-static size_t __hash__(GfQuaternion const &self) { return hash_value(self); }
+static size_t __hash__(GfQuaternion const &self) { return TfHash{}(self); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange.template.cpp
+++ b/pxr/base/gf/wrapRange.template.cpp
@@ -31,6 +31,7 @@
 #include "pxr/base/gf/range{{ DIM }}{{ S[0] }}.h"
 {% endfor %}
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -67,7 +68,7 @@ static {{ RNG }}& __itruediv__({{ RNG }} &self, double value)
     return self /= value;
 }
 
-static size_t __hash__({{ RNG }} const &r) { return hash_value(r); }
+static size_t __hash__({{ RNG }} const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange1d.cpp
+++ b/pxr/base/gf/wrapRange1d.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range1d.h"
 #include "pxr/base/gf/range1f.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange1d& __itruediv__(GfRange1d &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange1d const &r) { return hash_value(r); }
+static size_t __hash__(GfRange1d const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange1f.cpp
+++ b/pxr/base/gf/wrapRange1f.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range1f.h"
 #include "pxr/base/gf/range1d.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange1f& __itruediv__(GfRange1f &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange1f const &r) { return hash_value(r); }
+static size_t __hash__(GfRange1f const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange2d.cpp
+++ b/pxr/base/gf/wrapRange2d.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range2d.h"
 #include "pxr/base/gf/range2f.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange2d& __itruediv__(GfRange2d &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange2d const &r) { return hash_value(r); }
+static size_t __hash__(GfRange2d const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange2f.cpp
+++ b/pxr/base/gf/wrapRange2f.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range2f.h"
 #include "pxr/base/gf/range2d.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange2f& __itruediv__(GfRange2f &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange2f const &r) { return hash_value(r); }
+static size_t __hash__(GfRange2f const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange3d.cpp
+++ b/pxr/base/gf/wrapRange3d.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range3d.h"
 #include "pxr/base/gf/range3f.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange3d& __itruediv__(GfRange3d &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange3d const &r) { return hash_value(r); }
+static size_t __hash__(GfRange3d const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapRange3f.cpp
+++ b/pxr/base/gf/wrapRange3f.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/gf/range3f.h"
 #include "pxr/base/gf/range3d.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/wrapTypeHelpers.h"
 #include "pxr/base/tf/pyContainerConversions.h"
@@ -65,7 +66,7 @@ static GfRange3f& __itruediv__(GfRange3f &self, double value)
     return self /= value;
 }
 
-static size_t __hash__(GfRange3f const &r) { return hash_value(r); }
+static size_t __hash__(GfRange3f const &r) { return TfHash{}(r); }
 
 } // anonymous namespace 
 

--- a/pxr/base/gf/wrapVec.template.cpp
+++ b/pxr/base/gf/wrapVec.template.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -52,8 +53,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -180,7 +179,7 @@ static string __repr__({{ VEC }} const &self) {
 }
 
 static size_t __hash__({{ VEC }} const &self) {
-    return boost::hash<{{ VEC }}>()(self);
+    return TfHash{}(self);
 }
 
 {% if IS_FLOATING_POINT(SCL) %}

--- a/pxr/base/gf/wrapVec2d.cpp
+++ b/pxr/base/gf/wrapVec2d.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec2d const &self) {
 }
 
 static size_t __hash__(GfVec2d const &self) {
-    return boost::hash<GfVec2d>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec2f.cpp
+++ b/pxr/base/gf/wrapVec2f.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec2f const &self) {
 }
 
 static size_t __hash__(GfVec2f const &self) {
-    return boost::hash<GfVec2f>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec2h.cpp
+++ b/pxr/base/gf/wrapVec2h.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec2h const &self) {
 }
 
 static size_t __hash__(GfVec2h const &self) {
-    return boost::hash<GfVec2h>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec2i.cpp
+++ b/pxr/base/gf/wrapVec2i.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -45,8 +46,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -173,7 +172,7 @@ static string __repr__(GfVec2i const &self) {
 }
 
 static size_t __hash__(GfVec2i const &self) {
-    return boost::hash<GfVec2i>()(self);
+    return TfHash{}(self);
 }
 
  

--- a/pxr/base/gf/wrapVec3d.cpp
+++ b/pxr/base/gf/wrapVec3d.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec3d const &self) {
 }
 
 static size_t __hash__(GfVec3d const &self) {
-    return boost::hash<GfVec3d>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec3f.cpp
+++ b/pxr/base/gf/wrapVec3f.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec3f const &self) {
 }
 
 static size_t __hash__(GfVec3f const &self) {
-    return boost::hash<GfVec3f>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec3h.cpp
+++ b/pxr/base/gf/wrapVec3h.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec3h const &self) {
 }
 
 static size_t __hash__(GfVec3h const &self) {
-    return boost::hash<GfVec3h>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec3i.cpp
+++ b/pxr/base/gf/wrapVec3i.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -45,8 +46,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -173,7 +172,7 @@ static string __repr__(GfVec3i const &self) {
 }
 
 static size_t __hash__(GfVec3i const &self) {
-    return boost::hash<GfVec3i>()(self);
+    return TfHash{}(self);
 }
 
  

--- a/pxr/base/gf/wrapVec4d.cpp
+++ b/pxr/base/gf/wrapVec4d.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec4d const &self) {
 }
 
 static size_t __hash__(GfVec4d const &self) {
-    return boost::hash<GfVec4d>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec4f.cpp
+++ b/pxr/base/gf/wrapVec4f.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec4f const &self) {
 }
 
 static size_t __hash__(GfVec4f const &self) {
-    return boost::hash<GfVec4f>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec4h.cpp
+++ b/pxr/base/gf/wrapVec4h.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -50,8 +51,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -178,7 +177,7 @@ static string __repr__(GfVec4h const &self) {
 }
 
 static size_t __hash__(GfVec4h const &self) {
-    return boost::hash<GfVec4h>()(self);
+    return TfHash{}(self);
 }
 
 

--- a/pxr/base/gf/wrapVec4i.cpp
+++ b/pxr/base/gf/wrapVec4i.cpp
@@ -30,6 +30,7 @@
 
 #include "pxr/base/gf/pyBufferUtils.h"
 
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/py3Compat.h"
 #include "pxr/base/tf/pyContainerConversions.h"
 #include "pxr/base/tf/pyUtils.h"
@@ -45,8 +46,6 @@
 #include <boost/python/return_arg.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/slice.hpp>
-
-#include <boost/functional/hash.hpp>
 
 #include <string>
 
@@ -173,7 +172,7 @@ static string __repr__(GfVec4i const &self) {
 }
 
 static size_t __hash__(GfVec4i const &self) {
-    return boost::hash<GfVec4i>()(self);
+    return TfHash{}(self);
 }
 
  


### PR DESCRIPTION
### Description of Change(s)
#2175 replaced usage of `boost::hash_value` and `boost::hash_combine` with their `TfHash` equivalents in C++. This completes the removal of `boost/functional/hash.hpp` from `pxr/base/gf` by exclusively using `TfHash` in the python bindings.

### Fixes Issue(s)
- #2172 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
