### PR TITLE
Provide adapter for `std::reverse_iterator` to replace `boost::reverse_iterator` for proxy reference iterators

### DIFF
--- a/pxr/usd/pcp/iterator.h
+++ b/pxr/usd/pcp/iterator.h
@@ -34,7 +34,6 @@
 
 #include "pxr/base/tf/iterator.h"
 
-#include <boost/iterator/reverse_iterator.hpp>
 #include <iterator>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -187,12 +186,12 @@ private:
 /// order.
 ///
 class PcpNodeReverseIterator
-    : public boost::reverse_iterator<PcpNodeIterator>
+    : public Tf_ProxyReferenceReverseIterator<PcpNodeIterator>
 {
 public:
     PcpNodeReverseIterator() { }
     explicit PcpNodeReverseIterator(const PcpNodeIterator& iter)
-        : boost::reverse_iterator<PcpNodeIterator>(iter) { }
+        : Tf_ProxyReferenceReverseIterator<PcpNodeIterator>(iter) {}
 };
 
 /// \class PcpPrimIterator
@@ -344,12 +343,12 @@ private:
 /// weak-to-strong order.
 ///
 class PcpPrimReverseIterator
-    : public boost::reverse_iterator<PcpPrimIterator>
+    : public Tf_ProxyReferenceReverseIterator<PcpPrimIterator>
 {
 public:
     PcpPrimReverseIterator() { }
     explicit PcpPrimReverseIterator(const PcpPrimIterator& iter)
-        : boost::reverse_iterator<PcpPrimIterator>(iter) { }
+        : Tf_ProxyReferenceReverseIterator<PcpPrimIterator>(iter) { }
         
     PcpNodeRef GetNode() const
     {

--- a/pxr/usd/sdf/childrenProxy.h
+++ b/pxr/usd/sdf/childrenProxy.h
@@ -33,7 +33,6 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/iterator.h"
 
-#include <boost/iterator/reverse_iterator.hpp>
 #include <iterator>
 #include <map>
 #include <utility>
@@ -207,9 +206,9 @@ private:
 public:
     typedef _ValueProxy reference;
     typedef _Iterator<This*, _inner_iterator, _PairProxy> iterator;
-    typedef boost::reverse_iterator<iterator> reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<iterator> reverse_iterator;
     typedef _Iterator<const This*, _inner_iterator, value_type> const_iterator;
-    typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<const_iterator> const_reverse_iterator;
 
     static const int CanSet    = 1;
     static const int CanInsert = 2;

--- a/pxr/usd/sdf/childrenView.h
+++ b/pxr/usd/sdf/childrenView.h
@@ -31,7 +31,6 @@
 #include "pxr/usd/sdf/children.h"
 #include "pxr/base/tf/iterator.h"
 
-#include <boost/iterator/reverse_iterator.hpp>
 #include <algorithm>
 #include <vector>
 
@@ -381,7 +380,7 @@ private:
 public:
     typedef Sdf_ChildrenViewTraits<This, _InnerIterator, Predicate> _Traits;
     typedef typename _Traits::const_iterator const_iterator;
-    typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<const_iterator> const_reverse_iterator;
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
 

--- a/pxr/usd/sdf/listProxy.h
+++ b/pxr/usd/sdf/listProxy.h
@@ -35,7 +35,6 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/errorMark.h"
 #include "pxr/base/tf/iterator.h"
-#include <boost/iterator/reverse_iterator.hpp>
 #include <boost/optional.hpp>
 
 #include <memory>
@@ -298,8 +297,8 @@ public:
     typedef _ItemProxy reference;
     typedef _Iterator<This*, _GetHelper> iterator;
     typedef _Iterator<const This*, _ConstGetHelper> const_iterator;
-    typedef boost::reverse_iterator<iterator> reverse_iterator;
-    typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<iterator> reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<const_iterator> const_reverse_iterator;
 
     /// Creates a default list proxy object for list operation vector specified
     /// \p op. This object evaluates to false in a boolean context and all

--- a/pxr/usd/sdf/mapEditProxy.h
+++ b/pxr/usd/sdf/mapEditProxy.h
@@ -35,8 +35,8 @@
 
 #include "pxr/base/vt/value.h"  // for Vt_DefaultValueFactory
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/iterator.h"
 #include "pxr/base/tf/mallocTag.h"
-#include <boost/iterator/reverse_iterator.hpp>
 #include <iterator>
 #include <utility>
 
@@ -363,8 +363,8 @@ public:
     typedef _Iterator<This*, inner_iterator, _PairProxy> iterator;
     typedef _Iterator<const This*, const_inner_iterator,
                                    const value_type&> const_iterator;
-    typedef boost::reverse_iterator<iterator> reverse_iterator;
-    typedef boost::reverse_iterator<const_iterator> const_reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<iterator> reverse_iterator;
+    typedef Tf_ProxyReferenceReverseIterator<const_iterator> const_reverse_iterator;
 
     explicit SdfMapEditProxy(const SdfSpecHandle& owner, const TfToken& field) :
         _editor(Sdf_CreateMapEditor<T>(owner, field))


### PR DESCRIPTION
### Description of Change(s)
Depends on #2205, #2328

#2205 replaces `std::reverse_iterator` in several but not all instances. The C++ standard states `std::reverse_iterator::operator->` should return the equivalent of `std::addressof(operator*())`. For iterators that return proxy types as references (say `PcpNodeRef`), taking the address of a temporary is a problematic operation. The C++20 standard modifies this specification to `std::prev(/*underlying iterator*/).operator->()`. Some compilers are already using the newer specification.

This change introduces `Tf_ProxyReferenceReverseIterator` as an adapter for `std::reverse_iterator` that specializes `operator->` to use the C++20 specification, deferring all other operations to `std::reverse_iterator`. When possible, this is explicitly done with `using` directives. However, in many cases, the return and argument types require wrapper methods and functions.

This change depends on #2328 due to a bug with the current implementation of `PcpNodeIterator` and `std::prev`.

### Fixes Issue(s)
- #2202 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
