### PR TITLE
Avoid implicit conversion to `TfWeakPtr` when iterating in `dynamicFileFormatContext.cpp`

### DIFF
--- a/pxr/usd/pcp/dynamicFileFormatContext.cpp
+++ b/pxr/usd/pcp/dynamicFileFormatContext.cpp
@@ -78,7 +78,7 @@ private:
     {
         // Search the node's layer stack in strength order for the field on
         // the spec.
-        for (const SdfLayerHandle &layer : node.GetLayerStack()->GetLayers()) {
+        for (const auto &layer : node.GetLayerStack()->GetLayers()) {
             VtValue value;
             if (layer->HasField(node.GetPath(), _fieldName, &value)) {
                 // Process the value and mark found


### PR DESCRIPTION
### Description of Change(s)
The return type of `PcpLayerStack::GetLayers` is a container of `SdfLayerRefPtr`. However, in `pxr/usd/pcp/dynamicFileFormatContext.cpp`, a range based for loop was iterating over this container using `const SdfLayerHandle&` (an alias of `TfWeakPtr`). This produced the following warning in GCC11.

```
dynamicFileFormatContext.cpp:81:36: warning: loop variable ‘layer’ of type ‘const SdfLayerHandle&’ {aka ‘const pxrInternal_v0_23__pxrReserved__::TfWeakPtr<pxrInternal_v0_23__pxrReserved__::SdfLayer>&’} binds to a temporary constructed from type ‘const pxrInternal_v0_23__pxrReserved__::TfRefPtr<pxrInternal_v0_23__pxrReserved__::SdfLayer>’ [-Wrange-loop-construct]
```

To avoid taking a reference to a copy via implicit conversion from `TfRefPtr` to `TfWeakPtr`, this changes the type of `layer` in this loop to `const auto&`.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
