### PR TITLE
Fix setting `VtArray` elements by index for `[-1]`

### DIFF
--- a/pxr/base/vt/testenv/testVtArray.py
+++ b/pxr/base/vt/testenv/testVtArray.py
@@ -60,6 +60,12 @@ class TestVtArray(unittest.TestCase):
         with self.assertRaises(TypeError):
             a = d['foo']
 
+    def test_SetNegativeIndices(self):
+        d = Vt.DoubleArray([1.0, 3.0, 5.0])
+        d[-1] = 2.0
+        d[-2] = 4.0
+        self.assertEqual(d, [1.0, 4.0, 2.0])
+
     def test_TooFewElements(self):
         d = Vt.DoubleArray(4)
         with self.assertRaises(ValueError):

--- a/pxr/base/vt/wrapArray.h
+++ b/pxr/base/vt/wrapArray.h
@@ -259,7 +259,12 @@ void
 setitem_index(VtArray<T> &self, int64_t idx, object value)
 {
     static const bool tile = true;
-    setArraySlice(self, slice(idx, idx + 1), value, tile);
+    // Converting index -1 to a slice by adding 1 results in
+    // the slice [-1:0] which is empty. Using 'slice_nil' allows
+    // the slice to behave like [-1:]
+    const auto indexAsSlice = (idx == -1) ?
+        slice{idx, slice_nil{}} : slice{idx, idx + 1};
+    setArraySlice(self, indexAsSlice, value, tile);
 }
 
 template <typename T>


### PR DESCRIPTION
### Description of Change(s)
The code path for setting `VtArray` elements by index converts the index into a slice by adding 1 to the index.  However, for index -1, this produces the slice `[-1:0]` which is empty.

This change fixes the behavior of setting elements with index equal to -1. `slice{-1, slice_nil}`  is now used to create a slice equivalent to to `[-1:]`. This is both non-empty and only contains the last element.

A test case has been added to exercise setting by negative indices.

### Fixes Issue(s)
- #2327 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
