### PR TITLE
Allow customizing the C++ standard used for building

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -25,8 +25,10 @@ include(CXXHelpers)
 include(Version)
 include(Options)
 
-# Require C++14
-set(CMAKE_CXX_STANDARD 14)
+# Default to C++14
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
### Description of Change(s)

Instead of hardcoding `CMAKE_CXX_STANDARD` to `14`, set it only if it isn't set already so that consuming projects can customize it, to build with a consistent standard.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
