### PR TITLE
Apple: Add clip plane handling on Metal in Storm

### DIFF
--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -2596,6 +2596,14 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
         if (!_geometricShader->IsFrustumCullingPass()) {
             HgiShaderFunctionAddStageOutput(
                 &vsDesc, "gl_Position", "vec4", "position");
+
+            HgiShaderFunctionParamDesc clipParam;
+            clipParam.nameInShader = "gl_ClipDistance";
+            clipParam.type = "float";
+            clipParam.role = "clip_distance";
+            clipParam.arraySize = "HD_NUM_clipPlanes";
+            HgiShaderFunctionAddStageOutput(
+                &vsDesc, clipParam);
             
             // For Metal, only set the role for the point size
             // if the primitive is a point list.
@@ -2869,8 +2877,15 @@ HdSt_CodeGen::_CompileWithGeneratedHgiResources(
             HgiShaderKeywordTokens->hdInstanceID);
 
         HgiShaderFunctionAddStageOutput(
-            &ptvsDesc, "gl_Position", "vec4",
-            "position");
+                &ptvsDesc, "gl_Position", "vec4",
+                "position");
+        HgiShaderFunctionParamDesc clipParam;
+        clipParam.nameInShader = "gl_ClipDistance";
+        clipParam.type = "float";
+        clipParam.role = "clip_distance";
+        clipParam.arraySize = "HD_NUM_clipPlanes";
+        HgiShaderFunctionAddStageOutput(
+            &ptvsDesc, clipParam);
 
         char const* pointRole =
             (_geometricShader->GetPrimitiveType() ==

--- a/pxr/imaging/hgi/shaderSection.h
+++ b/pxr/imaging/hgi/shaderSection.h
@@ -109,9 +109,9 @@ protected:
 
     HGI_API
     const std::string& _GetDefaultValue() const;
+    const std::string _identifierVar;
 
 private:
-    const std::string _identifierVar;
     const HgiShaderSectionAttributeVector _attributes;
     const std::string _defaultValue;
     const std::string _arraySize;

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -396,6 +396,8 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
             << "#pragma clang diagnostic ignored \"-Wunused-variable\"\n"
             << "#pragma clang diagnostic ignored \"-Wsign-compare\"\n"
             << "using namespace metal;\n";
+    //clip plane default size
+    header << "#define HD_NUM_clipPlanes 1\n";
 
     // Basic types
     header  << "#define double float\n"
@@ -1146,7 +1148,12 @@ HgiMetalShaderStageEntryPoint::_Init(
         /* members = */ stageInputs,
         generator,
         _inputsGenericWrapper);
-
+    
+    for (HgiMetalShaderSection *section : stageOutputs) {
+        if(section->GetIdentifier() == "gl_ClipDistance") {
+            section->writesArrayOutput = true;
+        }
+    }
     _outputs =
         _BuildStructInstance<HgiMetalStageOutputShaderSection>(
         GetOutputTypeName(),

--- a/pxr/imaging/hgiMetal/shaderSection.h
+++ b/pxr/imaging/hgiMetal/shaderSection.h
@@ -43,6 +43,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HgiMetalShaderSection: public HgiShaderSection
 {
 public:
+    
+    HGIMETAL_API
+    explicit HgiMetalShaderSection(
+            const std::string &identifier,
+            const HgiShaderSectionAttributeVector& attributes = {},
+            const std::string &defaultValue = std::string(),
+            const std::string &arraySize = std::string(),
+            const std::string &blockInstanceIdentifier = std::string());
     HGIMETAL_API
     ~HgiMetalShaderSection() override;
 
@@ -73,7 +81,10 @@ public:
     /// either exists
     HGIMETAL_API
     void WriteAttributesWithIndex(std::ostream& ss) const;
-
+    /// Returns the identifier
+    HGIMETAL_API
+    std::string GetIdentifier() const;
+    bool writesArrayOutput;
     using HgiShaderSection::HgiShaderSection;
 };
 

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -26,6 +26,21 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+HgiMetalShaderSection::HgiMetalShaderSection(
+        const std::string &identifier,
+        const HgiShaderSectionAttributeVector& attributes,
+        const std::string &defaultValue,
+        const std::string &arraySize,
+        const std::string &blockInstanceIdentifier)
+  : HgiShaderSection(identifier,
+                     attributes,
+                     defaultValue,
+                     arraySize,
+                     blockInstanceIdentifier),
+    writesArrayOutput(false)
+{
+}
+
 HgiMetalShaderSection::~HgiMetalShaderSection() = default;
 
 bool
@@ -99,6 +114,11 @@ HgiMetalShaderSection::WriteAttributesWithIndex(std::ostream& ss) const
     if (attributes.size() > 0) {
         ss << "]]";
     }
+}
+
+std::string
+HgiMetalShaderSection::GetIdentifier() const {
+    return _identifierVar;
 }
 
 HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
@@ -814,6 +834,9 @@ HgiMetalStructTypeDeclarationShaderSection::WriteDeclaration(
         member->WriteParameter(ss);
         if (!member->HasBlockInstanceIdentifier()) {
             member->WriteAttributesWithIndex(ss);
+            if(!member->GetArraySize().empty() && member->writesArrayOutput) {
+                ss << "[" << member->GetArraySize() << "]";
+            }
         }
         ss << ";\n";
     }
@@ -1103,17 +1126,38 @@ HgiMetalStageOutputShaderSection::VisitEntryPointFunctionExecutions(
         if (i > 0) {
             ss << "\n";
         }
-        HgiShaderSection *member = structTypeDeclMembers[i];
-        WriteIdentifier(ss);
-        ss << ".";
-        member->WriteIdentifier(ss);
-        ss << " = " << scopeInstanceName << ".";
-        if (member->HasBlockInstanceIdentifier()) {
-            member->WriteBlockInstanceIdentifier(ss);
+        HgiMetalShaderSection *member = structTypeDeclMembers[i];
+        if (member->GetArraySize().empty()) {
+            WriteIdentifier(ss);
             ss << ".";
+            member->WriteIdentifier(ss);
+            ss << " = " << scopeInstanceName << ".";
+            if (member->HasBlockInstanceIdentifier()) {
+                member->WriteBlockInstanceIdentifier(ss);
+                ss << ".";
+            }
+            member->WriteIdentifier(ss);
+            ss << ";";
+        } else if (member->writesArrayOutput){
+            std::istringstream arrSizeRead(member->GetArraySize());
+            size_t arrEnd;
+            arrSizeRead >> arrEnd;
+            for (size_t i = 0; i < arrEnd; i++) {
+                WriteIdentifier(ss);
+                ss << ".";
+                member->WriteIdentifier(ss);
+                ss << "[" << std::to_string(i) << "]";
+                ss << " = " << scopeInstanceName << ".";
+                if (member->HasBlockInstanceIdentifier()) {
+                    member->WriteBlockInstanceIdentifier(ss);
+                    ss << ".";
+                }
+                member->WriteIdentifier(ss);
+                ss << "[" << std::to_string(i) << "]";
+                ss << ";";
+            }
+            
         }
-        member->WriteIdentifier(ss);
-        ss << ";";
     }
     return true;
 }


### PR DESCRIPTION
### Description of Change(s)
- Adds clip plane outputs in vertex stages
- Adds ability to write arrays to Metal shader stage output
- Is selective about when to write out arrays as current assumptions about the array out are around the post tessellation stage, and we don't want those attributes to create array style outputs

### Fixes Issue(s)
- Clip plane distance having no effect on Metal

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
