### PR TITLE
Fix memory leak during framebuffer resize

### DIFF
--- a/pxr/imaging/hdx/aovInputTask.cpp
+++ b/pxr/imaging/hdx/aovInputTask.cpp
@@ -228,6 +228,10 @@ HdxAovInputTask::_UpdateTexture(
         _GetHgi()->SubmitCmds(blitCmds.get());
         buffer->Unmap();
     } else {
+        // Destroy old texture
+        if(texture) {
+            _GetHgi()->DestroyTexture(&texture);
+        }
         // Create a new texture
         HgiTextureDesc texDesc;
         texDesc.debugName = "AovInput Texture";


### PR DESCRIPTION
When the size of the framebuffer is updated, Hgi textures leak when Hydra delegates use a HdRenderBuffer.

### Description of Change(s)
Destroy the previous texture if applicable before creating a new one.

### Fixes Issue(s)
Memory leak leading to crash when resizing framebuffer.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement

### Note
I observed two tests failing when testing **both** the public USD release branch and my fix's branch:
348 - testUsdBugs (Failed)
658 - testUsdResolverExample (Failed)
