### PR TITLE
Remove `boost::recursive_wrapper` usage from `JsValue`

### DIFF
--- a/pxr/base/js/testenv/testJsConverter.cpp
+++ b/pxr/base/js/testenv/testJsConverter.cpp
@@ -335,6 +335,20 @@ int main(int argc, char const *argv[])
             indent << "checking null conversion" << std::endl;
             TF_AXIOM(object[p.first].IsNull());
             TF_AXIOM(IsEmpty(p.second));
+        } else if (p.first == "ArrayOfObjects") {
+            indent << "checking array of object conversion" << std::endl;
+            TF_AXIOM(object[p.first].IsArray());
+            TF_AXIOM(object[p.first].Is<JsArray>());
+            const auto arrayOfObjects = object[p.first].Get<JsArray>();
+            TF_AXIOM(arrayOfObjects.size() == 2);
+            TF_AXIOM(arrayOfObjects[0].IsObject());
+            TF_AXIOM(arrayOfObjects[1].IsObject());
+            // Test coverage for equivalence of nested structures
+            const static JsArray EXPECTED = {
+                JsObject({{"String", JsValue{"value1"}}}),
+                JsObject({{"Real", JsValue{5.0}}})
+            };
+            TF_AXIOM(arrayOfObjects == EXPECTED);
         }
     }
 

--- a/pxr/base/js/testenv/testJsConverter/values.json
+++ b/pxr/base/js/testenv/testJsConverter/values.json
@@ -12,6 +12,7 @@
         "Real" : 42.0,
         "BoolTrue" : true,
         "BoolFalse" : false,
-        "Null" : null
+        "Null" : null,
+        "ArrayOfObjects" : [{"String" : "value1"}, {"Real" : 5.0}]
     }
 }


### PR DESCRIPTION
### Description of Change(s)
It's expected that upon adoption of C++17, USD will replace `boost::variant` with `std::variant`.  However, `std::variant` does not support `boost::recursive_wrapper` and does not have an equivalent concept.

This PR introduces `Js_Wrapper`, internally leveraging `std::unique_ptr`, but adds the invariant that it is always dereferenceable (ie. always non-NULL) and implements equality operators via the dereferenced value not the pointer value.

`Js_Wrapper` can then be used to add a level of indirection to `JsValue::_Holder` for types (`JsObject` and `JsArray`) that may contain `JsValue`s.

This PR adds test coverage for an array of objects nested in an object to validate both conversion and equality testing for more complicated structures.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
