### PR TITLE
Fix ranged loop type in `SdfLayer`

### DIFF
--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -4096,8 +4096,7 @@ SdfLayer::_SetData(const SdfAbstractDataPtr &newData,
         if (!updater.unrecognizedFields.empty()) {
             vector<string> fieldDescrs;
             fieldDescrs.reserve(updater.unrecognizedFields.size());
-            for (std::pair<TfToken, SdfPath> const &tokenPath:
-                     updater.unrecognizedFields) {
+            for (auto const &tokenPath: updater.unrecognizedFields) {
                 fieldDescrs.push_back(
                     TfStringPrintf("'%s' first seen at <%s>",
                                    tokenPath.first.GetText(),


### PR DESCRIPTION
### Description of Change(s)
When building with GCC11, the following warning was observed.
```
 warning: loop variable ‘tokenPath’ of type ‘const std::pair<pxrInternal_v0_23__pxrReserved__::TfToken, pxrInternal_v0_23__pxrReserved__::SdfPath>&’ binds to a temporary constructed from type ‘std::pair<const pxrInternal_v0_23__pxrReserved__::TfToken, pxrInternal_v0_23__pxrReserved__::SdfPath>’ [-Wrange-loop-construct]
```
The value type of a `std::map<TfToken, SdfPath>` is `std::pair<const TfToken, SdfPath>` not `std::pair<TfToken, SdfPath>`. This change uses `auto` in the range loop to avoid the unnecessary temporary copy.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
