### PR TITLE
Replace `boost::multi_index_container` with custom container in `Sdf_LayerRegistry`

### DIFF
--- a/pxr/usd/sdf/layerRegistry.cpp
+++ b/pxr/usd/sdf/layerRegistry.cpp
@@ -38,7 +38,6 @@
 #include "pxr/base/tf/staticData.h"
 #include <ostream>
 
-using namespace boost::multi_index;
 using std::string;
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -57,69 +56,197 @@ Sdf_LayerDebugRepr(
         ;
 }
 
-const Sdf_LayerRegistry::layer_identifier::result_type&
-Sdf_LayerRegistry::layer_identifier::operator()(
-    const SdfLayerHandle& layer) const
-{
-    static string emptyString;
-    return layer ? layer->GetIdentifier() : emptyString;
-}
+struct Sdf_RegistryAliases {
+    std::string identifier;
+    std::string repositoryPath;
+    std::string realPath;
+};
 
-Sdf_LayerRegistry::layer_repository_path::result_type
-Sdf_LayerRegistry::layer_repository_path::operator()(
-    const SdfLayerHandle& layer) const
-{
-    if (!layer) {
-        return std::string();
-    }
-
-    const string repoPath = layer->GetRepositoryPath();
-    if (!repoPath.empty()) {
-        string layerPath, arguments;
-        TF_VERIFY(Sdf_SplitIdentifier(
-                layer->GetIdentifier(), &layerPath, &arguments));
-        return Sdf_CreateIdentifier(repoPath, arguments);
-    }
-
-    return std::string();
-}
-
-Sdf_LayerRegistry::layer_real_path::result_type
-Sdf_LayerRegistry::layer_real_path::operator()(
-    const SdfLayerHandle& layer) const
-{
-    if (!layer) {
-        return std::string();
-    }
-
-    if (layer->IsAnonymous()) {
-        // The layer_real_path index requires a unique key. As anonymous do
-        // not have a realPath, we use the (unique) identifier as the key.
-        return layer->GetIdentifier();
-    }
-
-    const string realPath = layer->GetRealPath();
-    if (!realPath.empty()) {
-        string layerPath, arguments;
-        TF_VERIFY(Sdf_SplitIdentifier(
-                layer->GetIdentifier(), &layerPath, &arguments));
-        return Sdf_CreateIdentifier(realPath, arguments);
-    }
-
-    return std::string();
+static Sdf_RegistryAliases
+_AssetInfoToAliases(const Sdf_AssetInfo& assetInfo) {
+    std::string identifierSansArguments, arguments;
+    TF_VERIFY(Sdf_SplitIdentifier(
+              assetInfo.identifier, &identifierSansArguments, &arguments));
+    // The identifier cannot be empty. If it is, GetLayers() will not function
+    // correctly.
+    TF_VERIFY(!assetInfo.identifier.empty());
+    return {
+        assetInfo.identifier,
+        assetInfo.assetInfo.repoPath.empty() ? "" :
+            Sdf_CreateIdentifier(assetInfo.assetInfo.repoPath, arguments),
+        assetInfo.resolvedPath.empty() ? "" :
+            Sdf_CreateIdentifier(assetInfo.resolvedPath, arguments)
+    };
 }
 
 Sdf_LayerRegistry::Sdf_LayerRegistry()
 {
 }
 
-struct update_index_only {
-    void operator()(const SdfLayerHandle&) { }
-};
+// Ideally, the lifetime of a layer should be synchronized with the registry.
+// However--
+//    a) Update operations can result in a "dangling layer" where a layer
+//       is evicted from the registry even though a user still retains
+//       a handle.
+//    b) There's a known race in expiring layers where a handle is evicted
+//       before the destructor completes.
+// For those two reasons _TryToRemove must "try" to remove and not error
+// or warn if an expected key is missing.
+static bool
+_TryToRemove(const std::string& key, const SdfLayerHandle& layer,
+             std::unordered_map<std::string, SdfLayerHandle, TfHash>* map) {
+    if (!key.empty()) {
+        if (const auto it = map->find(key);
+            it != std::end(*map) && it->second == layer) {
+            map->erase(it);
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool
+_TryToRemove(
+    const std::string& key, const SdfLayerHandle& layer,
+    std::unordered_multimap<std::string, SdfLayerHandle, TfHash>* map) {
+    const auto range = map->equal_range(key);
+    if (const auto it = std::find_if(range.first, range.second,
+                                [&layer](const auto& entry){
+                                    return entry.second == layer;
+                                }); it != range.second) {
+        map->erase(it);
+        return true;
+    }
+    return false;
+}
 
 void
-Sdf_LayerRegistry::InsertOrUpdate(
-    const SdfLayerHandle& layer)
+Sdf_LayerRegistry::_Layers::Update(const SdfLayerHandle& layer,
+                                   const Sdf_AssetInfo& oldInfo,
+                                   const Sdf_AssetInfo& newInfo) {
+    const auto oldAliases = _AssetInfoToAliases(oldInfo);
+    auto newAliases = _AssetInfoToAliases(newInfo);
+    if (oldAliases.realPath != newAliases.realPath) {
+        if (_TryToRemove(oldAliases.realPath, layer, &_byRealPath)) {
+            TF_DEBUG(SDF_LAYER).Msg("Removed realPath '%s' for update.\n",
+                                    oldAliases.realPath.c_str());
+        }
+        if (!newAliases.realPath.empty()) {
+            if (const auto insertion = _byRealPath.emplace(
+                    newAliases.realPath, layer);
+                insertion.second) {
+                TF_DEBUG(SDF_LAYER).Msg("Updated realPath '%s'.\n",
+                                        newAliases.realPath.c_str());
+            }
+            else {
+                // It is uncommon but possible for two distinct handles to have
+                // the same real path. If an update operation is going to
+                // generate a dangling layer, then ensure the identifier and
+                // repository path entries are removed as well by setting the
+                // identifier and repository path to the empty string so that
+                // their entries in the repository and identifier maps will be
+                // removed.
+                newAliases.repositoryPath = "";
+                newAliases.identifier = "";
+                TF_DEBUG(SDF_LAYER).Msg("Updated realPath '%s' would create "
+                                        "collision. Dangling layer created "
+                                        "instead.\n",
+                                        newAliases.realPath.c_str());
+            }
+        }
+    }
+    if (oldAliases.repositoryPath != newAliases.repositoryPath) {
+        if (_TryToRemove(oldAliases.repositoryPath, layer,
+                         &_byRepositoryPath)) {
+            TF_DEBUG(SDF_LAYER).Msg("Removed repositoryPath '%s' for "
+                                    "update.\n",
+                                    oldAliases.repositoryPath.c_str());
+        }
+        if (!newAliases.repositoryPath.empty()) {
+            _byRepositoryPath.emplace(newAliases.repositoryPath, layer);
+            TF_DEBUG(SDF_LAYER).Msg("Updated repositoryPath '%s'.\n",
+                                    newAliases.repositoryPath.c_str());
+        }
+    }
+    if (oldAliases.identifier != newAliases.identifier) {
+        if (_TryToRemove(oldAliases.identifier, layer,
+                         &_byIdentifier)) {
+            TF_DEBUG(SDF_LAYER).Msg("Removed identifier '%s' for "
+                                    "update.\n",
+                                    oldAliases.identifier.c_str());
+        }
+        if (!newAliases.identifier.empty()) {
+            _byIdentifier.emplace(newAliases.identifier, layer);
+            TF_DEBUG(SDF_LAYER).Msg("Updated identifier '%s'.\n",
+                                    newAliases.identifier.c_str());
+        }
+    }
+}
+
+std::pair<SdfLayerHandle, bool>
+Sdf_LayerRegistry::_Layers::Insert(const SdfLayerHandle& layer,
+                                   const Sdf_AssetInfo& assetInfo) {
+    const auto aliases = _AssetInfoToAliases(assetInfo);
+    if (const auto it = _byRealPath.find(aliases.realPath);
+        it != std::end(_byRealPath)) {
+        return std::make_pair(it->second, false);
+    }
+    if (!aliases.realPath.empty()) {
+        TF_VERIFY(_byRealPath.emplace(aliases.realPath, layer).second);
+        TF_DEBUG(SDF_LAYER).Msg("Inserted realPath '%s' into registry\n",
+                                aliases.realPath.c_str());
+    }
+    if (!aliases.repositoryPath.empty()) {
+        _byRepositoryPath.emplace(aliases.repositoryPath, layer);
+        TF_DEBUG(SDF_LAYER).Msg("Inserted repositoryPath '%s' into registry\n",
+                                aliases.repositoryPath.c_str());
+    }
+    if (!aliases.identifier.empty()) {
+        _byIdentifier.emplace(aliases.identifier, layer);
+        TF_DEBUG(SDF_LAYER).Msg("Inserted identifier '%s' into registry\n",
+                                aliases.identifier.c_str());
+    }
+    return std::make_pair(layer, true);
+}
+
+bool
+Sdf_LayerRegistry::_Layers::Erase(const SdfLayerHandle& layer,
+                                  const Sdf_AssetInfo& assetInfo) {
+    const auto aliases = _AssetInfoToAliases(assetInfo);
+    // Track whether any entries were actually erased. In general,
+    // It's the responsibility of the layer destructor to erase
+    // the entry from the registry, but trying to acquire an expiring
+    // layer may cause this eviction to happen early. This isn't an
+    // error, but we do want to track successful erases for TF_DEBUG
+    // info. Additionally, Update in rare circumstances could create
+    // a real path collisions due to asset resolver context updates
+    // and may lead to an early eviction of a layer from the registry.
+    bool erased = false;
+    if (_TryToRemove(aliases.realPath, layer, &_byRealPath)) {
+        erased = true;
+        TF_DEBUG(SDF_LAYER).Msg("Erased realPath '%s' from registry.\n",
+                                aliases.realPath.c_str());
+    }
+    if (_TryToRemove(aliases.repositoryPath, layer,
+                     &_byRepositoryPath)) {
+        erased = true;
+        TF_DEBUG(SDF_LAYER).Msg(
+            "Erased repositoryPath '%s' from registry.\n",
+            aliases.repositoryPath.c_str());
+    }
+    if (_TryToRemove(aliases.identifier, layer,
+                     &_byIdentifier)) {
+        erased = true;
+        TF_DEBUG(SDF_LAYER).Msg(
+            "Erased identifier '%s' from registry.\n",
+            aliases.repositoryPath.c_str());
+    }
+    return erased;
+}
+
+void
+Sdf_LayerRegistry::Insert(
+    const SdfLayerHandle& layer, const Sdf_AssetInfo& assetInfo)
 {
     TRACE_FUNCTION();
 
@@ -129,38 +256,50 @@ Sdf_LayerRegistry::InsertOrUpdate(
     }
 
     TF_DEBUG(SDF_LAYER).Msg(
-        "Sdf_LayerRegistry::InsertOrUpdate(%s)\n",
+        "Sdf_LayerRegistry::Insert(%s)\n",
         Sdf_LayerDebugRepr(layer).c_str());
 
-    // Attempt to insert the layer into the registry. This may fail because
-    // the new layer violates constraints of one of the registry indices.
-    std::pair<_Layers::iterator, bool> result = _layers.insert(layer);
+    // Attempt to insert the layer into the registry.
+    std::pair<SdfLayerHandle, bool> result = _layers.Insert(layer, assetInfo);
     if (!result.second) {
-        SdfLayerHandle existingLayer = *result.first;
-        if (layer == existingLayer) {
-            // We failed to insert the layer into the registry because this
-            // layer object is already in the registry. All we need to do is
-            // update the indices so it can be found.
-            _layers.modify(result.first, update_index_only());
-        } else {
-            // We failed to insert the layer into the registry because there
-            // is a realPath conflict. This can happen when the same layer is
-            // crated twice in the same location in the same session.
-            TF_CODING_ERROR("Cannot insert duplicate registry entry for "
-                "%s layer %s over existing entry for %s layer %s",
-                layer->GetFileFormat()->GetFormatId().GetText(),
-                Sdf_LayerDebugRepr(layer).c_str(),
-                existingLayer->GetFileFormat()->GetFormatId().GetText(),
-                Sdf_LayerDebugRepr(existingLayer).c_str());
-        }
+        // We failed to insert the layer into the registry because there
+        // is a realPath conflict. This can happen when the same layer is
+        // created twice in the same location in the same session.
+        TF_CODING_ERROR("Cannot insert duplicate registry entry for "
+            "%s layer %s over existing entry for %s layer %s",
+            layer->GetFileFormat()->GetFormatId().GetText(),
+            Sdf_LayerDebugRepr(layer).c_str(),
+            result.first->GetFileFormat()->GetFormatId().GetText(),
+            Sdf_LayerDebugRepr(result.first).c_str());
     }
 }
 
 void
-Sdf_LayerRegistry::Erase(
-    const SdfLayerHandle& layer)
+Sdf_LayerRegistry::Update(
+    const SdfLayerHandle& layer,
+    const Sdf_AssetInfo& oldInfo,
+    const Sdf_AssetInfo& newInfo)
 {
-    bool erased = _layers.erase(layer);
+    TRACE_FUNCTION();
+
+    if (!layer) {
+        TF_CODING_ERROR("Expired layer handle");
+        return;
+    }
+
+    TF_DEBUG(SDF_LAYER).Msg(
+        "Sdf_LayerRegistry::Update(%s)\n",
+        Sdf_LayerDebugRepr(layer).c_str());
+
+    _layers.Update(layer, oldInfo, newInfo);
+}
+
+void
+Sdf_LayerRegistry::Erase(
+    const SdfLayerHandle& layer,
+    const Sdf_AssetInfo& assetInfo)
+{
+    bool erased = _layers.Erase(layer, assetInfo);
 
     TF_DEBUG(SDF_LAYER).Msg(
         "Sdf_LayerRegistry::Erase(%s) => %s\n",
@@ -224,12 +363,11 @@ Sdf_LayerRegistry::_FindByIdentifier(
     TRACE_FUNCTION();
 
     SdfLayerHandle foundLayer;
-
-    const _LayersByIdentifier& byIdentifier = _layers.get<by_identifier>();
-    _LayersByIdentifier::const_iterator identifierIt =
-        byIdentifier.find(layerPath);
-    if (identifierIt != byIdentifier.end())
-        foundLayer = *identifierIt;
+    const auto& byIdentifier = _layers.ByIdentifier();
+    const auto identifierIt = byIdentifier.find(layerPath);
+    if (identifierIt != byIdentifier.end()) {
+        foundLayer = identifierIt->second;
+    }
 
     TF_DEBUG(SDF_LAYER).Msg(
         "Sdf_LayerRegistry::_FindByIdentifier('%s') => %s\n",
@@ -250,11 +388,11 @@ Sdf_LayerRegistry::_FindByRepositoryPath(
     if (layerPath.empty())
         return foundLayer;
 
-    const _LayersByRepositoryPath& byRepoPath = _layers.get<by_repository_path>();
-    _LayersByRepositoryPath::const_iterator repoPathIt =
-        byRepoPath.find(layerPath);
-    if (repoPathIt != byRepoPath.end())
-        foundLayer = *repoPathIt;
+    const auto& byRepoPath = _layers.ByRepositoryPath();
+    const auto repoPathIt = byRepoPath.find(layerPath);
+    if (repoPathIt != byRepoPath.end()) {
+        foundLayer = repoPathIt->second;
+    }
 
     TF_DEBUG(SDF_LAYER).Msg(
         "Sdf_LayerRegistry::_FindByRepositoryPath('%s') => %s\n",
@@ -305,11 +443,11 @@ Sdf_LayerRegistry::_FindByRealPath(
     }
     searchPath = Sdf_CreateIdentifier(searchPath, arguments);
 
-    const _LayersByRealPath& byRealPath = _layers.get<by_real_path>();
-    _LayersByRealPath::const_iterator realPathIt =
-        byRealPath.find(searchPath);
-    if (realPathIt != byRealPath.end())
-        foundLayer = *realPathIt;
+    const auto& byRealPath = _layers.ByRealPath();
+    const auto realPathIt = byRealPath.find(searchPath);
+    if (realPathIt != byRealPath.end()) {
+        foundLayer = realPathIt->second;
+    }
 
     TF_DEBUG(SDF_LAYER).Msg(
         "Sdf_LayerRegistry::_FindByRealPath('%s') => %s\n",
@@ -324,8 +462,8 @@ Sdf_LayerRegistry::GetLayers() const
 {
     SdfLayerHandleSet layers;
 
-    TF_FOR_ALL(i, _layers.get<by_identity>()) {
-        SdfLayerHandle layer = *i;
+    for (const auto& entry : _layers.ByIdentifier()) {
+        SdfLayerHandle layer = entry.second;
         if (TF_VERIFY(layer, "Found expired layer in registry")) {
             layers.insert(layer);
         }


### PR DESCRIPTION
### Description of Change(s)
To reduce the number of dependencies on boost, this PR introduces a custom container that synchronizes a set of unordered maps.  Internally, it leverages layer `Sdf_AssetInfo` as the generator of keys for `Insert`, `Update`, and `Erase` operations.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
