### PR TITLE
Apple: Dynamic state to no longer be a part of the pipeline

### DIFF
--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -1212,7 +1212,7 @@ _GetDrawPipeline(
     if (pipelineInstance.IsFirstInstance()) {
         HgiGraphicsPipelineDesc pipeDesc;
 
-        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,      
+        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,
                                                   state.geometricShader);
 
         pipeDesc.shaderProgram = state.glslProgram->GetProgram();
@@ -1250,6 +1250,10 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
     // execute it here.  Otherwise render with the normal graphicsCmd path.
     //
     if (_indirectCommands) {
+        renderPassState->UpdateDynamicState(
+                _indirectCommands.get(),
+                _drawItemInstances.front()->GetDrawItem()->
+                        GetGeometricShader());
         HgiIndirectCommandEncoder *encoder = hgi->GetIndirectCommandEncoder();
         encoder->ExecuteDraw(gfxCmds, _indirectCommands.get());
 
@@ -1269,12 +1273,16 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
                 program.GetComposedShaders(),
                 program.GetGeometricShader());
 
+
         HgiGraphicsPipelineSharedPtr pso =
             _GetDrawPipeline(
                 renderPassState,
                 resourceRegistry,
                 state);
-        
+
+        renderPassState->UpdateDynamicState(
+                gfxCmds,
+                state.geometricShader);
         HgiGraphicsPipelineHandle psoHandle = *pso.get();
         gfxCmds->BindPipeline(psoHandle);
 

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -1248,23 +1248,32 @@ HdStRenderPassState::_InitMultiSampleState(
 }
 
 void
+HdStRenderPassState::UpdateDynamicState(
+        HgiDynamicStateUpdatable * dynamicStateUpdatable,
+        HdSt_GeometricShaderSharedPtr const & geometricShader) const
+{
+    HgiDynamicState newDynamicState;
+    if (geometricShader->GetPolygonMode() == HdPolygonModeLine) {
+        newDynamicState.polygonMode = HgiPolygonModeLine;
+        float const gsLineWidth = geometricShader->GetLineWidth();
+        if (gsLineWidth > 0) {
+            newDynamicState.lineWidth = gsLineWidth;
+        }
+    } else {
+        newDynamicState.polygonMode = HgiPolygonModeFill;
+    }
+
+    newDynamicState.cullMode =
+            _ResolveCullMode(_cullStyle, geometricShader);
+    dynamicStateUpdatable->UpdateDynamicState(&newDynamicState);
+}
+
+
+void
 HdStRenderPassState::_InitRasterizationState(
     HgiRasterizationState * rasterizationState,
     HdSt_GeometricShaderSharedPtr const & geometricShader) const
 {
-    if (geometricShader->GetPolygonMode() == HdPolygonModeLine) {
-        rasterizationState->polygonMode = HgiPolygonModeLine;
-        float const gsLineWidth = geometricShader->GetLineWidth();
-        if (gsLineWidth > 0) {
-            rasterizationState->lineWidth = gsLineWidth;
-        }
-    } else {
-        rasterizationState->polygonMode = HgiPolygonModeFill;
-    }
-
-    rasterizationState->cullMode =
-        _ResolveCullMode(_cullStyle, geometricShader);
-
     if (GetEnableDepthClamp()) {
         rasterizationState->depthClampEnabled = true;
     }

--- a/pxr/imaging/hdSt/renderPassState.h
+++ b/pxr/imaging/hdSt/renderPassState.h
@@ -28,6 +28,7 @@
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hd/renderPassState.h"
 #include "pxr/imaging/hgi/graphicsCmdsDesc.h"
+#include "pxr/imaging/hgi/dynamicStateUpdatable.h"
 
 #include <memory>
 
@@ -195,6 +196,12 @@ public:
     void InitGraphicsPipelineDesc(
                 HgiGraphicsPipelineDesc * pipeDesc,
                 HdSt_GeometricShaderSharedPtr const & geometricShader) const;
+
+    // Helper to update a dynamic state from the render pass state
+    HDST_API
+    void UpdateDynamicState(
+            HgiDynamicStateUpdatable * dynamicStateUpdatable,
+            HdSt_GeometricShaderSharedPtr const & geometricShader) const;
 
     /// Generates the hash for the settings used to init the graphics pipeline.
     HDST_API

--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -401,6 +401,10 @@ HdSt_TextureTestDriver::Draw(HgiTextureHandle const &colorDst,
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
     gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
+    HgiDynamicState dynamicState;
+    dynamicState.cullMode = HgiCullModeBack;
+    dynamicState.polygonMode = HgiPolygonModeFill;
+    gfxCmds->UpdateDynamicState(&dynamicState);
     gfxCmds->SetViewport(viewport);
     gfxCmds->SetConstantValues(_pipeline, HgiShaderStageFragment, 0, 
         _constantsData.size(), _constantsData.data());
@@ -685,8 +689,6 @@ HdSt_TextureTestDriver::_CreatePipeline(HgiTextureHandle const& colorDst)
     desc.vertexBuffers = { _vboDesc };
     desc.depthState.depthWriteEnabled = false;
     desc.multiSampleState.alphaToCoverageEnable = false;
-    desc.rasterizationState.cullMode = HgiCullModeBack;
-    desc.rasterizationState.polygonMode = HgiPolygonModeFill;
     desc.rasterizationState.winding = HgiWindingCounterClockwise;
     desc.shaderProgram = _shaderProgram;
     desc.shaderConstantsDesc.byteSize = _constantsData.size();

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -966,8 +966,6 @@ HdxColorCorrectionTask::_CreatePipeline(HgiTextureHandle const& aovTexture)
     desc.multiSampleState.sampleCount = aovTexture->GetDescriptor().sampleCount;
 
     // Setup rasterization state
-    desc.rasterizationState.cullMode = HgiCullModeBack;
-    desc.rasterizationState.polygonMode = HgiPolygonModeFill;
     desc.rasterizationState.winding = HgiWindingCounterClockwise;
 
     // Setup attachment descriptor
@@ -1023,6 +1021,10 @@ HdxColorCorrectionTask::_ApplyColorCorrection(
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
     gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
+    HgiDynamicState dynamicState;
+    dynamicState.cullMode = HgiCullModeBack;
+    dynamicState.polygonMode = HgiPolygonModeFill;
+    gfxCmds->UpdateDynamicState(&dynamicState);
     const GfVec4i vp(0, 0, dimensions[0], dimensions[1]);
     _screenSize[0] = static_cast<float>(dimensions[0]);
     _screenSize[1] = static_cast<float>(dimensions[1]);

--- a/pxr/imaging/hdx/fullscreenShader.cpp
+++ b/pxr/imaging/hdx/fullscreenShader.cpp
@@ -527,8 +527,6 @@ HdxFullscreenShader::_CreatePipeline(
     }
 
     // Setup rasterization state
-    desc.rasterizationState.cullMode = HgiCullModeBack;
-    desc.rasterizationState.polygonMode = HgiPolygonModeFill;
     desc.rasterizationState.winding = HgiWindingCounterClockwise;
 
     // Set the shaders
@@ -708,6 +706,11 @@ HdxFullscreenShader::_Draw(
 
     // Begin rendering
     HgiGraphicsCmdsUniquePtr gfxCmds = _hgi->CreateGraphicsCmds(gfxDesc);
+
+    HgiDynamicState dynamicState;
+    dynamicState.cullMode = HgiCullModeBack;
+    dynamicState.polygonMode = HgiPolygonModeFill;
+    gfxCmds->UpdateDynamicState(&dynamicState);
     gfxCmds->PushDebugGroup(_debugName.c_str());
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);

--- a/pxr/imaging/hdx/visualizeAovTask.cpp
+++ b/pxr/imaging/hdx/visualizeAovTask.cpp
@@ -367,8 +367,6 @@ HdxVisualizeAovTask::_CreatePipeline(HgiTextureDesc const& outputTextureDesc)
     desc.multiSampleState.alphaToCoverageEnable = false;
 
     // Setup rasterization state
-    desc.rasterizationState.cullMode = HgiCullModeBack;
-    desc.rasterizationState.polygonMode = HgiPolygonModeFill;
     desc.rasterizationState.winding = HgiWindingCounterClockwise;
 
     // Setup attachment descriptor
@@ -512,6 +510,11 @@ HdxVisualizeAovTask::_ApplyVisualizationKernel(
     gfxCmds->BindResources(_resourceBindings);
     gfxCmds->BindPipeline(_pipeline);
     gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
+    // Setup dynamic state
+    HgiDynamicState dynamicState;
+    dynamicState.cullMode = HgiCullModeBack;
+    dynamicState.polygonMode = HgiPolygonModeFill;
+    gfxCmds->UpdateDynamicState(&dynamicState);
     const GfVec4i vp(0, 0, dimensions[0], dimensions[1]);
     _screenSize[0] = static_cast<float>(dimensions[0]);
     _screenSize[1] = static_cast<float>(dimensions[1]);

--- a/pxr/imaging/hgi/CMakeLists.txt
+++ b/pxr/imaging/hgi/CMakeLists.txt
@@ -38,4 +38,5 @@ pxr_library(hgi
         blitCmdsOps.h
         enums.h
         handle.h
+        dynamicStateUpdatable.h
 )

--- a/pxr/imaging/hgi/dynamicStateUpdatable.h
+++ b/pxr/imaging/hgi/dynamicStateUpdatable.h
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#ifndef PXR_IMAGING_HGI_DYNAMIC_STATE_UPDATABLE_H
+#define PXR_IMAGING_HGI_DYNAMIC_STATE_UPDATABLE_H
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+struct HgiDynamicState;
+
+class HgiDynamicStateUpdatable
+{
+public:
+    HGI_API
+    virtual void UpdateDynamicState(HgiDynamicState const *newDynamicState) = 0;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+#endif

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -31,6 +31,7 @@
 #include "pxr/imaging/hgi/graphicsPipeline.h"
 #include "pxr/imaging/hgi/resourceBindings.h"
 #include "pxr/imaging/hgi/cmds.h"
+#include "pxr/imaging/hgi/dynamicStateUpdatable.h"
 #include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -44,7 +45,7 @@ using HgiGraphicsCmdsUniquePtr = std::unique_ptr<class HgiGraphicsCmds>;
 /// HgiGraphicsCmds is a lightweight object that cannot be re-used after it has
 /// been submitted. A new cmds object should be acquired for each frame.
 ///
-class HgiGraphicsCmds : public HgiCmds
+class HgiGraphicsCmds : public HgiCmds, public HgiDynamicStateUpdatable
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/graphicsPipeline.cpp
+++ b/pxr/imaging/hgi/graphicsPipeline.cpp
@@ -98,11 +98,31 @@ bool operator!=(
     return !(lhs == rhs);
 }
 
+HgiDynamicState::HgiDynamicState()
+        : polygonMode(HgiPolygonModeFill)
+        , lineWidth(1.0f)
+        , cullMode(HgiCullModeBack)
+{
+}
+
+bool operator==(
+        const HgiDynamicState& lhs,
+        const HgiDynamicState& rhs)
+{
+    return lhs.polygonMode == rhs.polygonMode &&
+           lhs.lineWidth == rhs.lineWidth &&
+           lhs.cullMode == rhs.cullMode;
+}
+
+bool operator!=(
+        const HgiDynamicState& lhs,
+        const HgiDynamicState& rhs)
+{
+    return !(lhs == rhs);
+}
+
 HgiRasterizationState::HgiRasterizationState()
-    : polygonMode(HgiPolygonModeFill)
-    , lineWidth(1.0f)
-    , cullMode(HgiCullModeBack)
-    , winding(HgiWindingCounterClockwise)
+    : winding(HgiWindingCounterClockwise)
     , rasterizerEnabled(true)
     , depthClampEnabled(false)
     , depthRange(0.f, 1.f)
@@ -115,10 +135,7 @@ bool operator==(
     const HgiRasterizationState& lhs,
     const HgiRasterizationState& rhs)
 {
-    return lhs.polygonMode == rhs.polygonMode &&
-           lhs.lineWidth == rhs.lineWidth &&
-           lhs.cullMode == rhs.cullMode &&
-           lhs.winding == rhs.winding &&
+    return lhs.winding == rhs.winding &&
            lhs.rasterizerEnabled == rhs.rasterizerEnabled &&
            lhs.depthClampEnabled == rhs.depthClampEnabled &&
            lhs.depthRange == rhs.depthRange &&

--- a/pxr/imaging/hgi/graphicsPipeline.h
+++ b/pxr/imaging/hgi/graphicsPipeline.h
@@ -154,9 +154,9 @@ bool operator!=(
     const HgiMultiSampleState& rhs);
 
 
-/// \struct HgiRasterizationState
+/// \struct HgiDynamicState
 ///
-/// Properties to configure the rasterization state.
+/// Properties to configure the dynamic state.
 ///
 /// <ul>
 /// <li>polygonMode:
@@ -165,6 +165,33 @@ bool operator!=(
 ///   The width of lines when polygonMode is set to line drawing.</li>
 /// <li>cullMode:
 ///   Determines the culling rules for primitives (triangles).</li>
+/// </ul>
+///
+struct HgiDynamicState
+{
+    HGI_API
+    HgiDynamicState();
+
+    HgiPolygonMode polygonMode;
+    float lineWidth;
+    HgiCullMode cullMode;
+};
+
+HGI_API
+bool operator==(
+        const HgiDynamicState& lhs,
+        const HgiDynamicState& rhs);
+
+HGI_API
+bool operator!=(
+        const HgiDynamicState& lhs,
+        const HgiDynamicState& rhs);
+
+/// \struct HgiRasterizationState
+///
+/// Properties to configure the rasterization state.
+///
+/// <ul>
 /// <li>winding:
 ///   The rule that determines what makes a front-facing primitive.</li>
 /// <li>rasterizationEnabled:
@@ -185,10 +212,6 @@ struct HgiRasterizationState
 {
     HGI_API
     HgiRasterizationState();
-
-    HgiPolygonMode polygonMode;
-    float lineWidth;
-    HgiCullMode cullMode;
     HgiWinding winding;
     bool rasterizerEnabled;
     bool depthClampEnabled;

--- a/pxr/imaging/hgi/indirectCommandEncoder.h
+++ b/pxr/imaging/hgi/indirectCommandEncoder.h
@@ -29,6 +29,7 @@
 #include "pxr/imaging/hgi/cmds.h"
 #include "pxr/imaging/hgi/resourceBindings.h"
 #include "pxr/imaging/hgi/graphicsPipeline.h"
+#include "pxr/imaging/hgi/dynamicStateUpdatable.h"
 
 #include <memory>
 #include <stdint.h>
@@ -39,10 +40,11 @@ class Hgi;
 class HgiComputeCmds;
 class HgiGraphicsCmds;
 
-struct HgiIndirectCommands
+struct HgiIndirectCommands : public HgiDynamicStateUpdatable
 {
     HgiIndirectCommands(uint32_t drawCount,
                         HgiGraphicsPipelineHandle const &graphicsPipeline,
+                        HgiDynamicState const &dynamicState,
                         HgiResourceBindingsHandle const &resourceBindings)
         : drawCount(drawCount)
         , graphicsPipeline(graphicsPipeline)
@@ -54,6 +56,7 @@ struct HgiIndirectCommands
 
     uint32_t drawCount;
     HgiGraphicsPipelineHandle graphicsPipeline;
+    HgiDynamicState dynamicState;
     HgiResourceBindingsHandle resourceBindings;
 };
 

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -291,4 +291,24 @@ HgiGLGraphicsCmds::_AddResolveToOps(HgiGLDevice *device)
     _recording = false;
 }
 
+void
+HgiGLGraphicsCmds::UpdateDynamicState(HgiDynamicState const *newDynamicState)
+{
+    GLenum cullMode = HgiGLConversions::GetCullMode(
+            newDynamicState->cullMode);
+    if (cullMode == GL_NONE) {
+        glDisable(GL_CULL_FACE);
+    } else {
+        glEnable(GL_CULL_FACE);
+        glCullFace(cullMode);
+    }
+
+    GLenum polygonMode = HgiGLConversions::GetPolygonMode(
+            newDynamicState->polygonMode);
+    glPolygonMode(GL_FRONT_AND_BACK, polygonMode);
+    if (newDynamicState->lineWidth != 1.0f) {
+        glLineWidth(newDynamicState->lineWidth);
+    }
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -120,6 +120,9 @@ public:
     HGIGL_API
     void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
+    HGIGL_API
+    void UpdateDynamicState(HgiDynamicState const *newDynamicState) override;
+
 protected:
     friend class HgiGL;
 

--- a/pxr/imaging/hgiGL/graphicsPipeline.cpp
+++ b/pxr/imaging/hgiGL/graphicsPipeline.cpp
@@ -188,27 +188,11 @@ HgiGLGraphicsPipeline::BindPipeline()
     //
     // Rasterization state
     //
-    GLenum cullMode = HgiGLConversions::GetCullMode(
-        _descriptor.rasterizationState.cullMode);
-    if (cullMode == GL_NONE) {
-        glDisable(GL_CULL_FACE);
-    } else {
-        glEnable(GL_CULL_FACE);
-        glCullFace(cullMode);
-    }
-
-    GLenum polygonMode = HgiGLConversions::GetPolygonMode(
-        _descriptor.rasterizationState.polygonMode);
-    glPolygonMode(GL_FRONT_AND_BACK, polygonMode);
 
     if (_descriptor.rasterizationState.winding == HgiWindingClockwise) {
         glFrontFace(GL_CW);
     } else {
         glFrontFace(GL_CCW);
-    }
-
-    if (_descriptor.rasterizationState.lineWidth != 1.0f) {
-        glLineWidth(_descriptor.rasterizationState.lineWidth);
     }
 
     if (_descriptor.rasterizationState.rasterizerEnabled) {

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -118,6 +118,9 @@ public:
     HGIMETAL_API
     void EnableParallelEncoder(bool enable);
 
+    HGIMETAL_API
+    void UpdateDynamicState(HgiDynamicState const *newDynamicState) override;
+
     // Needs to be accessible from the Metal IndirectCommandEncoder
     id<MTLRenderCommandEncoder> GetEncoder(uint32_t encoderIndex = 0);
 

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -876,5 +876,16 @@ HgiMetalGraphicsCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
     
     return _hasWork;
 }
+void
+HgiMetalGraphicsCmds::UpdateDynamicState(HgiDynamicState const *newDynamicState)
+{
+    id<MTLRenderCommandEncoder> encoder = GetEncoder();
+    [encoder setCullMode:HgiMetalConversions::GetCullMode(
+            newDynamicState->cullMode)];
+    [encoder setTriangleFillMode:HgiMetalConversions::GetPolygonMode(
+            newDynamicState->polygonMode)];
+    TF_VERIFY(newDynamicState->lineWidth == 1.0f,
+              "Missing implementation buffers");
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiMetal/graphicsPipeline.mm
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.mm
@@ -373,10 +373,6 @@ HgiMetalGraphicsPipeline::BindPipeline(id<MTLRenderCommandEncoder> renderEncoder
     //
     // Rasterization state
     //
-    [renderEncoder setCullMode:HgiMetalConversions::GetCullMode(
-        _descriptor.rasterizationState.cullMode)];
-    [renderEncoder setTriangleFillMode:HgiMetalConversions::GetPolygonMode(
-        _descriptor.rasterizationState.polygonMode)];
     [renderEncoder setFrontFacingWinding:HgiMetalConversions::GetWinding(
         _descriptor.rasterizationState.winding)];
     [renderEncoder setDepthStencilState:_depthStencilState];
@@ -385,9 +381,6 @@ HgiMetalGraphicsPipeline::BindPipeline(id<MTLRenderCommandEncoder> renderEncoder
         [renderEncoder
             setDepthClipMode: MTLDepthClipModeClamp];     
     }
-
-    TF_VERIFY(_descriptor.rasterizationState.lineWidth == 1.0f,
-        "Missing implementation buffers");
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.h
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.h
@@ -122,6 +122,7 @@ private:
     MTLResourceOptions _bufferStorageMode;
     id<MTLBuffer> _triangleTessFactors;
     id<MTLBuffer> _quadTessFactors;
+    HgiDynamicState _dynamicState;
     
     using FreeCommandBuffers =
         std::multimap<uint32_t, id<MTLIndirectCommandBuffer>>;

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -46,17 +46,22 @@ struct HgiMetalIndirectCommands : public HgiIndirectCommands
     HgiMetalIndirectCommands(
         uint32_t drawCount,
         HgiGraphicsPipelineHandle const &graphicsPipeline,
+        HgiDynamicState const &dynamicState,
         HgiResourceBindingsHandle const &resourceBindings,
         id<MTLIndirectCommandBuffer> indirectCommandBuffer,
         id<MTLBuffer> argumentBuffer,
         id<MTLBuffer> mainArgumentBuffer)
-        : HgiIndirectCommands(drawCount, graphicsPipeline, resourceBindings)
+        : HgiIndirectCommands(drawCount, graphicsPipeline, dynamicState, resourceBindings)
         , indirectCommandBuffer(indirectCommandBuffer)
         , indirectArgumentBuffer(argumentBuffer)
         , mainArgumentBuffer(mainArgumentBuffer)
     {
     }
-    
+    HGIMETAL_API
+    void UpdateDynamicState(HgiDynamicState const *newDynamicState) override
+    {
+        dynamicState = *newDynamicState;
+    }
     id<MTLIndirectCommandBuffer> indirectCommandBuffer;
     id<MTLBuffer> indirectArgumentBuffer;
     id<MTLBuffer> mainArgumentBuffer;
@@ -570,6 +575,7 @@ HgiMetalIndirectCommandEncoder::_EncodeDraw(
         std::make_unique<HgiMetalIndirectCommands>(
             drawCount,
             pipeline,
+            _dynamicState,
             resourceBindings,
             _AllocateCommandBuffer(drawCount),
             _AllocateArgumentBuffer(function.argumentEncoder.encodedLength),
@@ -701,6 +707,7 @@ HgiMetalIndirectCommandEncoder::ExecuteDraw(
     HgiMetalGraphicsPipeline* graphicsPipeline =
         static_cast<HgiMetalGraphicsPipeline*>(metalCommands->graphicsPipeline.Get());
     graphicsPipeline->BindPipeline(encoder);
+    gfxCmds->UpdateDynamicState(&(commands->dynamicState));
 
     // Bind the resources.
     id<MTLBuffer> mainArgumentBuffer = metalCommands->mainArgumentBuffer;


### PR DESCRIPTION
### Description of Change(s)
- Moves cullStyle, polygonMode and lineWidth to a new Hgi type, HgiDynamicState and away from the GraphicsPipelineDesc
- Introduces an interface HgiDynamicStateUpdatable to allow passing of the various classes who want their dynamic state updated from the renderPassState -> the graphicsCmds and the indirectGraphicsCmds
- Update the dynamic state from the renderPass in Storm for PipelineDrawBatch which uses HGI resource generation
### Fixes Issue(s)
- Fixes issues where the initial pipeline state created and the dynamic state set during the first draw is not the same as later ones in a render or timeline.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
