### PR TITLE
Apple: Update dynamic state from render pass for pipelinedrawbatch

### DIFF
--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -1374,8 +1374,17 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
     // execute it here.  Otherwise render with the normal graphicsCmd path.
     //
     if (_indirectCommands) {
+        const std::function<void (HgiGraphicsCmds*)> dynamicStateCallback =
+            [this, &renderPassState](HgiGraphicsCmds* cmd) {
+                renderPassState->UpdateDynamicState(
+                        cmd,
+                        _drawItemInstances.front()->GetDrawItem()->
+                                GetGeometricShader());
+        };
         HgiIndirectCommandEncoder *encoder = hgi->GetIndirectCommandEncoder();
-        encoder->ExecuteDraw(gfxCmds, _indirectCommands.get());
+        encoder->ExecuteDraw(gfxCmds,
+                             _indirectCommands.get(),
+                             &dynamicStateCallback);
 
         hgi->DestroyResourceBindings(&(_indirectCommands->resourceBindings));
         _indirectCommands.reset();
@@ -1401,6 +1410,9 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
         
         HgiGraphicsPipelineHandle psoHandle = *pso.get();
         gfxCmds->BindPipeline(psoHandle);
+        renderPassState->UpdateDynamicState(
+                gfxCmds,
+                state.geometricShader);
 
         HgiResourceBindingsDesc bindingsDesc;
         state.GetBindingsForDrawing(&bindingsDesc,

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -1176,23 +1176,31 @@ HdStRenderPassState::_InitMultiSampleState(
 }
 
 void
+HdStRenderPassState::UpdateDynamicState(
+        HgiGraphicsCmds * gfxCmds,
+    HdSt_GeometricShaderSharedPtr const & geometricShader) const
+{
+    if (geometricShader->GetPolygonMode() == HdPolygonModeLine) {
+        gfxCmds->SetPolygonMode(HgiPolygonModeLine);
+        float const gsLineWidth = geometricShader->GetLineWidth();
+        if (gsLineWidth > 0) {
+            gfxCmds->SetLineWidth(gsLineWidth);
+        }
+    } else {
+        gfxCmds->SetPolygonMode(HgiPolygonModeFill);
+    }
+    gfxCmds->SetCullMode(
+       _ResolveCullMode(_cullStyle, geometricShader));
+}
+
+    rasterizationState->cullMode =
+        _ResolveCullMode(_cullStyle, geometricShader);
+
+void
 HdStRenderPassState::_InitRasterizationState(
     HgiRasterizationState * rasterizationState,
     HdSt_GeometricShaderSharedPtr const & geometricShader) const
 {
-    if (geometricShader->GetPolygonMode() == HdPolygonModeLine) {
-        rasterizationState->polygonMode = HgiPolygonModeLine;
-        float const gsLineWidth = geometricShader->GetLineWidth();
-        if (gsLineWidth > 0) {
-            rasterizationState->lineWidth = gsLineWidth;
-        }
-    } else {
-        rasterizationState->polygonMode = HgiPolygonModeFill;
-    }
-
-    rasterizationState->cullMode =
-        geometricShader->ResolveCullMode(_cullStyle);
-
     if (GetEnableDepthClamp()) {
         rasterizationState->depthClampEnabled = true;
     }

--- a/pxr/imaging/hdSt/renderPassState.h
+++ b/pxr/imaging/hdSt/renderPassState.h
@@ -27,7 +27,7 @@
 #include "pxr/pxr.h"
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hd/renderPassState.h"
-#include "pxr/imaging/hgi/graphicsCmdsDesc.h"
+#include "pxr/imaging/hgi/graphicsCmds.h"
 
 #include <memory>
 
@@ -195,6 +195,12 @@ public:
     void InitGraphicsPipelineDesc(
                 HgiGraphicsPipelineDesc * pipeDesc,
                 HdSt_GeometricShaderSharedPtr const & geometricShader) const;
+
+    // Helper to update a dynamic state from the render pass state
+    HDST_API
+    void UpdateDynamicState(
+            HgiGraphicsCmds * gfxCmds,
+            HdSt_GeometricShaderSharedPtr const & geometricShader) const;
 
     /// Generates the hash for the settings used to init the graphics pipeline.
     HDST_API

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -66,6 +66,18 @@ public:
     /// drawing commands.
     HGI_API
     virtual void SetScissor(GfVec4i const& sc) = 0;
+    
+    /// Set the cull mode dynamically
+    HGI_API
+    virtual void SetCullMode(HgiCullMode const cullMode) = 0;
+    
+    /// Set the polygon mode dynamically
+    HGI_API
+    virtual void SetPolygonMode(HgiPolygonMode const polygonMode) = 0;
+    
+    /// Set the line width dynamically
+    HGI_API
+    virtual void SetLineWidth(float const lineWidth) = 0;
 
     /// Bind a pipeline state object. Usually you call this right after calling
     /// CreateGraphicsCmds to set the graphics pipeline state.

--- a/pxr/imaging/hgi/indirectCommandEncoder.h
+++ b/pxr/imaging/hgi/indirectCommandEncoder.h
@@ -28,6 +28,7 @@
 #include "pxr/imaging/hgi/api.h"
 #include "pxr/imaging/hgi/cmds.h"
 #include "pxr/imaging/hgi/resourceBindings.h"
+#include "pxr/imaging/hgi/graphicsCmds.h"
 #include "pxr/imaging/hgi/graphicsPipeline.h"
 
 #include <memory>
@@ -111,7 +112,9 @@ public:
     HGI_API
     virtual void ExecuteDraw(
         HgiGraphicsCmds * gfxCmds,
-        HgiIndirectCommands const* commands) = 0;
+        HgiIndirectCommands const* commands,
+        const std::function<void (HgiGraphicsCmds*)>
+            *dynamicStateCallback = nullptr) = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -291,4 +291,33 @@ HgiGLGraphicsCmds::_AddResolveToOps(HgiGLDevice *device)
     _recording = false;
 }
 
+void
+HgiGLGraphicsCmds::SetCullMode(HgiCullMode const cullMode)
+{
+    GLenum glCullMode = HgiGLConversions::GetCullMode(
+            cullMode);
+    if (glCullMode == GL_NONE) {
+        glDisable(GL_CULL_FACE);
+    } else {
+        glEnable(GL_CULL_FACE);
+        glCullFace(glCullMode);
+    }
+}
+
+void
+HgiGLGraphicsCmds::SetPolygonMode(HgiPolygonMode const polygonMode)
+{
+    GLenum glPolyMode = HgiGLConversions::GetPolygonMode(
+            polygonMode);
+    glPolygonMode(GL_FRONT_AND_BACK, glPolyMode);
+}
+
+void
+HgiGLGraphicsCmds::SetLineWidth(float const lineWidth)
+{
+    if (lineWidth != 1.0f) {
+        glLineWidth(lineWidth);
+    }
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -120,6 +120,15 @@ public:
     HGIGL_API
     void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
 
+    HGIGL_API
+    void SetCullMode(HgiCullMode const cullMode) override;
+    
+    HGIGL_API
+    void SetPolygonMode(HgiPolygonMode const polygonMode) override;
+    
+    HGIGL_API
+    void SetLineWidth(float const lineWidth) override;
+
 protected:
     friend class HgiGL;
 

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -117,6 +117,15 @@ public:
     
     HGIMETAL_API
     void EnableParallelEncoder(bool enable);
+    
+    HGIMETAL_API
+    void SetCullMode(HgiCullMode const cullMode) override;
+    
+    HGIMETAL_API
+    void SetPolygonMode(HgiPolygonMode const polygonMode) override;
+    
+    HGIMETAL_API
+    void SetLineWidth(float const lineWidth) override;
 
     // Needs to be accessible from the Metal IndirectCommandEncoder
     id<MTLRenderCommandEncoder> GetEncoder(uint32_t encoderIndex = 0);

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -878,4 +878,22 @@ HgiMetalGraphicsCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
     return _hasWork;
 }
 
+void HgiMetalGraphicsCmds::SetCullMode(HgiCullMode const cullMode)
+{
+    [GetEncoder() setCullMode:HgiMetalConversions::GetCullMode(
+        cullMode)];
+}
+
+void HgiMetalGraphicsCmds::SetPolygonMode(
+      HgiPolygonMode const polygonMode)
+{
+    [GetEncoder() setTriangleFillMode:
+        HgiMetalConversions::GetPolygonMode(polygonMode)];
+}
+
+void HgiMetalGraphicsCmds::SetLineWidth(float const lineWidth)
+{
+    TF_VERIFY(lineWidth == 1.0f, "Missing implementation buffers");
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.h
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.h
@@ -81,7 +81,8 @@ public:
     HGIMETAL_API
     void ExecuteDraw(
         HgiGraphicsCmds * gfxCmds,
-        HgiIndirectCommands const* commands) override;
+        HgiIndirectCommands const* commands,
+        const std::function<void (HgiGraphicsCmds*)> *dynamicStateCallback = nullptr) override;
 
 private:
     HgiMetalIndirectCommandEncoder & operator=(const HgiMetalIndirectCommandEncoder&) = delete;

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -704,7 +704,8 @@ HgiMetalIndirectCommandEncoder::_EncodeDraw(
 void
 HgiMetalIndirectCommandEncoder::ExecuteDraw(
     HgiGraphicsCmds * gfxCmds,
-    HgiIndirectCommands const* commands)
+    HgiIndirectCommands const* commands,
+    const std::function<void (HgiGraphicsCmds*)> *dynamicStateCallback)
 {
     HgiMetalGraphicsCmds *metalGfxCmds = static_cast<HgiMetalGraphicsCmds*>(gfxCmds);
     id<MTLRenderCommandEncoder> encoder = metalGfxCmds->GetEncoder();
@@ -718,7 +719,9 @@ HgiMetalIndirectCommandEncoder::ExecuteDraw(
     HgiMetalGraphicsPipeline* graphicsPipeline =
         static_cast<HgiMetalGraphicsPipeline*>(metalCommands->graphicsPipeline.Get());
     graphicsPipeline->BindPipeline(encoder);
-
+    if (dynamicStateCallback != nullptr) {
+        dynamicStateCallback->operator()(gfxCmds);
+    }
     // Bind the resources.
     id<MTLBuffer> mainArgumentBuffer = metalCommands->mainArgumentBuffer;
     HgiMetalResourceBindings* resourceBindings =


### PR DESCRIPTION
### Description of Change(s)
- Lets the render pass state set the dynamic state on classes that use the pipelinedrawbatch and HGI resource generation
### Fixes Issue(s)
- Dynamic state not being updated from the renderpassstate for later frames / timecodes during a scene's playback

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
