### PR TITLE
[usdz, ar] Support ArAsset / ArWritableAsset for USDZ

### DIFF
--- a/pxr/usd/ar/filesystemWritableAsset.cpp
+++ b/pxr/usd/ar/filesystemWritableAsset.cpp
@@ -76,7 +76,17 @@ ArFilesystemWritableAsset::ArFilesystemWritableAsset(TfSafeOutputFile&& file)
     }
 }
 
-ArFilesystemWritableAsset::~ArFilesystemWritableAsset() = default;
+ArFilesystemWritableAsset::~ArFilesystemWritableAsset()
+{
+    // XXX: If Close() has not been explicitly called for replacing an asset
+    // we will discard it, so we don't overwrite that asset with invalid data.
+    // When an asset has been opened for update we will allow the destructor
+    // of TfSafeOutput to close it properly
+    if (!_file.IsOpenForUpdate())
+    {
+        _file.Discard();
+    }
+}
 
 bool
 ArFilesystemWritableAsset::Close()

--- a/pxr/usd/sdf/testenv/TestSdfStreamingFileFormat.cpp
+++ b/pxr/usd/sdf/testenv/TestSdfStreamingFileFormat.cpp
@@ -27,6 +27,7 @@
 #include "pxr/usd/sdf/fileFormat.h"
 
 #include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/writableAsset.h"
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/type.h"
@@ -99,8 +100,10 @@ public:
         const std::string& comment,
         const FileFormatArguments& args) const override
     {
-        return static_cast<bool>(ArGetResolver().OpenAssetForWrite(
-            ArResolvedPath(filePath), ArResolver::WriteMode::Replace));
+        std::shared_ptr<ArWritableAsset> asset =
+                ArGetResolver().OpenAssetForWrite(ArResolvedPath(filePath),
+                                                  ArResolver::WriteMode::Replace);
+        return asset->Close();
     }
 
 protected:

--- a/pxr/usd/usd/zipFile.cpp
+++ b/pxr/usd/usd/zipFile.cpp
@@ -27,13 +27,11 @@
 #include "pxr/usd/ar/writableAsset.h"
 #include "pxr/usd/ar/resolvedPath.h"
 #include "pxr/usd/ar/resolver.h"
-#include "pxr/usd/ar/resolverContextBinder.h"
 
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/errorMark.h"
 #include "pxr/base/tf/pathUtils.h"
-#include "pxr/base/tf/safeOutputFile.h"
 
 #include <boost/crc.hpp>
 
@@ -43,8 +41,6 @@
 #include <shared_mutex>
 #include <vector>
 #include <unordered_map>
-
-#include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/usd/usd/zipFile.h
+++ b/pxr/usd/usd/zipFile.h
@@ -228,13 +228,13 @@ private:
 class UsdZipFileWriter
 {
 public:
-    /// Create a new file writer with \p filePath as the destination file path
+    /// Create a new file writer with \p assetPath as the destination asset
     /// where the zip archive will be written. The zip file will not be written
-    /// to \p filePath until the writer is destroyed or Save() is called.
+    /// to \p assetPath until the writer is destroyed or Save() is called.
     ///
     /// Returns an invalid object on error.
     USD_API
-    static UsdZipFileWriter CreateNew(const std::string& filePath);
+    static UsdZipFileWriter CreateNew(const std::string& assetPath);
 
     /// Create an invalid UsdZipFileWriter object.
     USD_API


### PR DESCRIPTION
### Description of Change(s)

[usdz] USDZ zip files would always force the use of file system paths.
For asset management systems that don't directly rely on the file system this could be inconvenient. It would require downloading content to temp files, writing to a temp file, then uploading the temp zip file. With Ar 2.0, we can now use OpenAsset / OpenAssetForWrite so the underlying ArResolver can manage this directly. This change adds support so we can write directly to an ArWritableAsset to abstract the file system.

[ar] Required a change to ArFilesystemWritableAsset to discard the TfSafeOutput file if Close() was not explicitly called.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/2374

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
