### PR TITLE
Load plugins using LoadLibraryEx with LOAD_WITH_ALTERED_SEARCH_PATH on Windows

### DIFF
--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -32,6 +32,7 @@
 #include "pxr/base/arch/api.h"
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/inttypes.h"
+#include <algorithm>
 #include <memory>
 #include <cstdio>
 #include <string>
@@ -458,6 +459,14 @@ inline std::wstring ArchWindowsUtf8ToUtf16(const std::string &str)
         return std::wstring();
     }
     return wstr;
+}
+
+/// Converts all forward slashes to back slashes - Windows-only
+inline std::string ArchWindowsPreferredPath(const std::string& inPath)
+{
+    std::string path = inPath;
+    std::replace(path.begin(), path.end(), '/', '\\');
+    return path;
 }
 
 #endif

--- a/pxr/base/arch/library.cpp
+++ b/pxr/base/arch/library.cpp
@@ -44,7 +44,7 @@ void* ArchLibraryOpen(const std::string &filename, int flag)
 {
 #if defined(ARCH_OS_WINDOWS)
     arch_lastLibraryError = 0;
-    if (void* result = LoadLibrary(filename.c_str())) {
+    if (void* result = LoadLibraryEx(filename.c_str(), NULL, flag)) {
         return result;
     }
     else {

--- a/pxr/base/arch/library.h
+++ b/pxr/base/arch/library.h
@@ -30,18 +30,21 @@
 #include <string>
 
 #if defined(ARCH_OS_WINDOWS)
-#   define ARCH_LIBRARY_LAZY    0
-#   define ARCH_LIBRARY_NOW     0
-#   define ARCH_LIBRARY_LOCAL   0
-#   define ARCH_LIBRARY_GLOBAL  0
+#   include <Windows.h>
+#   define ARCH_LIBRARY_LAZY                0
+#   define ARCH_LIBRARY_NOW                 0
+#   define ARCH_LIBRARY_LOCAL               0
+#   define ARCH_LIBRARY_GLOBAL              0
+#   define ARCH_LIBRARY_ALTERED_SEARCH_PATH LOAD_WITH_ALTERED_SEARCH_PATH
 #   define ARCH_LIBRARY_SUFFIX  ".dll"
 #   define ARCH_STATIC_LIBRARY_SUFFIX ".lib"
 #else
 #   include <dlfcn.h>
-#   define ARCH_LIBRARY_LAZY    RTLD_LAZY
-#   define ARCH_LIBRARY_NOW     RTLD_NOW
-#   define ARCH_LIBRARY_LOCAL   RTLD_LOCAL
-#   define ARCH_LIBRARY_GLOBAL  RTLD_GLOBAL
+#   define ARCH_LIBRARY_LAZY                RTLD_LAZY
+#   define ARCH_LIBRARY_NOW                 RTLD_NOW
+#   define ARCH_LIBRARY_LOCAL               RTLD_LOCAL
+#   define ARCH_LIBRARY_GLOBAL              RTLD_GLOBAL
+#   define ARCH_LIBRARY_ALTERED_SEARCH_PATH 0
 #   if defined(ARCH_OS_DARWIN)
 #       define ARCH_LIBRARY_SUFFIX  ".dylib"
 #   else

--- a/pxr/base/plug/plugin.cpp
+++ b/pxr/base/plug/plugin.cpp
@@ -253,8 +253,12 @@ PlugPlugin::_Load()
         else {
             string dsoError;
             {
-                TRACE_FUNCTION_SCOPE("dlopen");
+                TRACE_FUNCTION_SCOPE("dlopen");   
+#if defined(ARCH_OS_WINDOWS)
+                _handle = TfDlopen(ArchWindowsPreferredPath(_path).c_str(), ARCH_LIBRARY_ALTERED_SEARCH_PATH, &dsoError);
+#else
                 _handle = TfDlopen(_path.c_str(), ARCH_LIBRARY_NOW, &dsoError);
+#endif
             }
             if (!_handle ) {
                 TF_CODING_ERROR("Failed to load plugin '%s': %s in '%s'",  


### PR DESCRIPTION
### Description of Change(s)

Search for USD plugin dependencies in the folder that the plugin is loaded from as well as the application's directory on Windows. This is to support situations where USD itself is a plugin for an application. See https://github.com/PixarAnimationStudios/USD/issues/2367 for more information.

I found when testing LoadLibraryEx that the LOAD_WITH_ALTERED_SEARCH_PATH flag only works when using back slashes instead of forward slashes, so I've added a ArchWindowsPreferredPath method to convert between them based off of [std::filesystem::path::make_preferred](https://en.cppreference.com/w/cpp/filesystem/path/make_preferred) in C++17.

This limitation is mentioned [here](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa):
> If the string specifies a fully qualified path, the function searches only that path for the module. When specifying a path, be sure to use backslashes (\\), not forward slashes (/).

I originally added ArchPreferredPath that simply returned the input path for MacOS/Linux but decided against the extra copy.

I also made converting to back slashes the responsibility of the caller (PlugPlugin::_Load) rather than ArchLibraryOpen in keeping with LoadLibraryEx.

Happy to revisit either of these decisions.

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/USD/issues/2367

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
