### PR TITLE
Add a helper function to add mtlx support to a scene delegate

### DIFF
--- a/pxr/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DIRS
     usdImaging
     usdImagingGL
+    usdImagingMtlx
     usdProcImaging
     usdRiImaging
     usdSkelImaging

--- a/pxr/usdImaging/usdImagingMtlx/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingMtlx/CMakeLists.txt
@@ -1,0 +1,37 @@
+set(PXR_PREFIX pxr/usdImaging)
+set(PXR_PACKAGE usdImagingMtlx)
+
+if(NOT ${PXR_ENABLE_MATERIALX_SUPPORT})
+    message(STATUS
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_MATERIALX_SUPPORT is OFF")
+    return()
+endif()
+
+pxr_library(usdImagingMtlx
+    LIBRARIES
+        usdMtlx
+        usdImaging
+
+    PUBLIC_CLASSES
+        adapter
+
+    PUBLIC_HEADERS
+        api.h
+
+    DISABLE_PRECOMPILED_HEADERS
+)
+
+pxr_build_test(testUsdImagingMtlxAdapter
+    LIBRARIES
+        usdImagingMtlx
+    CPPFILES
+        testenv/testUsdImagingMtlxAdapter.cpp
+)
+pxr_install_test_dir(
+    SRC testenv/testUsdImagingMtlxAdapter.testenv
+    DEST testUsdImagingMtlxAdapter
+)
+pxr_register_test(testUsdImagingMtlxAdapter
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingMtlxAdapter"
+    EXPECTED_RETURN_CODE 0
+)

--- a/pxr/usdImaging/usdImagingMtlx/adapter.cpp
+++ b/pxr/usdImaging/usdImagingMtlx/adapter.cpp
@@ -1,0 +1,82 @@
+#include "pxr/usdImaging/usdImagingMtlx/adapter.h"
+
+#include "pxr/usdImaging/usdImaging/materialParamUtils.h"
+
+#include "pxr/imaging/hd/material.h"
+#include "pxr/imaging/hd/tokens.h"
+
+#include "pxr/usd/usdMtlx/reader.h"
+#include "pxr/usd/usdMtlx/utils.h"
+
+#include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/resolverContextBinder.h"
+#include "pxr/usd/ar/resolverScopedCache.h"
+
+#include "pxr/usd/usdShade/material.h"
+#include "pxr/usd/usdShade/shader.h"
+
+#include "pxr/base/arch/fileSystem.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+void UsdImagingMtlxConvertMtlxToHdMaterialNetworkMap(
+    const std::string& mtlxPath,
+    const TfTokenVector& shaderSourceTypes,
+    const TfTokenVector& renderContexts,
+    HdMaterialNetworkMap* out)
+{
+    if (mtlxPath.empty()) {
+        return;
+    }
+
+    std::string basePath = TfGetPathName(mtlxPath);
+    if (basePath.empty()) {
+        basePath = ".";
+    }
+
+    ArResolver& resolver = ArGetResolver();
+    const ArResolverContext context = resolver.CreateDefaultContextForAsset(mtlxPath);
+    ArResolverContextBinder binder(context);
+    ArResolverScopedCache resolverCache;
+
+    std::string mtlxName = TfGetBaseName(mtlxPath);
+    std::string stage_id = TfStringPrintf(
+        "%s%s%s.usda", basePath.c_str(), ARCH_PATH_SEP, mtlxName.c_str());
+    UsdStageRefPtr stage = UsdStage::CreateInMemory(stage_id, context);
+
+    try {
+        MaterialX::DocumentPtr doc = UsdMtlxReadDocument(mtlxPath);
+        UsdMtlxRead(doc, stage);
+    } catch (MaterialX::ExceptionFoundCycle &x) {
+        Tf_PostErrorHelper(TF_CALL_CONTEXT,
+                           TF_DIAGNOSTIC_RUNTIME_ERROR_TYPE,
+                           "MaterialX cycle found: %s\n",
+                           x.what());
+        return;
+    } catch (MaterialX::Exception &x) {
+        Tf_PostErrorHelper(TF_CALL_CONTEXT,
+                           TF_DIAGNOSTIC_RUNTIME_ERROR_TYPE,
+                           "MaterialX error: %s\n",
+                           x.what());
+        return;
+    }
+
+    SdfPath materialsPath("/MaterialX/Materials");
+    if (UsdPrim materials = stage->GetPrimAtPath(materialsPath)) {
+        if (UsdPrimSiblingRange children = materials.GetChildren()) {
+            if (auto material = UsdShadeMaterial(*children.begin())) {
+                if (UsdShadeShader mtlxSurface = material.ComputeSurfaceSource(renderContexts)) {
+                    UsdImagingBuildHdMaterialNetworkFromTerminal(
+                        mtlxSurface.GetPrim(),
+                        HdMaterialTerminalTokens->surface,
+                        shaderSourceTypes,
+                        renderContexts,
+                        out,
+                        UsdTimeCode::Default());
+                }
+            }
+        }
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImagingMtlx/adapter.h
+++ b/pxr/usdImaging/usdImagingMtlx/adapter.h
@@ -1,0 +1,45 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//        names, trademarks, service marks, or product names of the Licensor
+//        and its affiliates, except as required to comply with Section 4(c) of
+//        the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_IMAGING_USD_IMAGING_MTLX_ADAPTER_H
+#define PXR_USD_IMAGING_USD_IMAGING_MTLX_ADAPTER_H
+
+#include "pxr/usdImaging/usdImagingMtlx/api.h"
+#include "pxr/base/tf/token.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+struct HdMaterialNetworkMap;
+
+/// Create a HdMaterialNetworkMap from the given MaterialX file.
+/// Can be used by a custom scene delegate to easily add MaterialX support.
+USDIMAGINGMTLX_API
+void UsdImagingMtlxConvertMtlxToHdMaterialNetworkMap(
+    const std::string& mtlxPath,
+    const TfTokenVector& shaderSourceTypes,
+    const TfTokenVector& renderContexts,
+    HdMaterialNetworkMap* out);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/usdImaging/usdImagingMtlx/api.h
+++ b/pxr/usdImaging/usdImagingMtlx/api.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_IMAGING_USD_IMAGING_MTLX_API_H
+#define PXR_USD_IMAGING_USD_IMAGING_MTLX_API_H
+
+#include "pxr/base/arch/export.h"
+
+#if defined(PXR_STATIC)
+#   define USDIMAGINGMTLX_API
+#   define USDIMAGINGMTLX_API_TEMPLATE_CLASS(...)
+#   define USDIMAGINGMTLX_API_TEMPLATE_STRUCT(...)
+#   define USDIMAGINGMTLX_LOCAL
+#else
+#   if defined(USDIMAGINGMTLX_EXPORTS)
+#       define USDIMAGINGMTLX_API ARCH_EXPORT
+#       define USDIMAGINGMTLX_API_TEMPLATE_CLASS(...) ARCH_EXPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDIMAGINGMTLX_API_TEMPLATE_STRUCT(...) ARCH_EXPORT_TEMPLATE(struct, __VA_ARGS__)
+#   else
+#       define USDIMAGINGMTLX_API ARCH_IMPORT
+#       define USDIMAGINGMTLX_API_TEMPLATE_CLASS(...) ARCH_IMPORT_TEMPLATE(class, __VA_ARGS__)
+#       define USDIMAGINGMTLX_API_TEMPLATE_STRUCT(...) ARCH_IMPORT_TEMPLATE(struct, __VA_ARGS__)
+#   endif
+#   define USDIMAGINGMTLX_LOCAL ARCH_HIDDEN
+#endif
+
+#endif // PXR_USD_IMAGING_USD_IMAGING_MTLX_API_H

--- a/pxr/usdImaging/usdImagingMtlx/testenv/testUsdImagingMtlxAdapter.cpp
+++ b/pxr/usdImaging/usdImagingMtlx/testenv/testUsdImagingMtlxAdapter.cpp
@@ -1,0 +1,96 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/usdImaging/usdImagingMtlx/adapter.h"
+#include "pxr/imaging/hd/material.h"
+#include "pxr/imaging/hd/tokens.h"
+#include "pxr/usd/usdShade/tokens.h"
+#include "pxr/base/tf/errorMark.h"
+
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static bool
+UsdImagingMtlxAdapterBasicTest()
+{
+    const std::string mtlxPath = "test.mtlx";
+    const TfTokenVector shaderSourceTypes = {TfToken("mtlx")};
+    const TfTokenVector renderContexts = {TfToken("mtlx")};
+    HdMaterialNetworkMap materialNetworkMap;
+    UsdImagingMtlxConvertMtlxToHdMaterialNetworkMap(
+        mtlxPath,
+        shaderSourceTypes,
+        renderContexts,
+        &materialNetworkMap);
+
+    if (!TF_VERIFY(materialNetworkMap.map.size() > 0) ||
+        !TF_VERIFY(materialNetworkMap.terminals.size() == 1)) {
+        return false;
+    }
+
+    bool isVolume = false;
+    HdMaterialNetwork2 network = HdConvertToHdMaterialNetwork2(materialNetworkMap, &isVolume);
+
+    if (!TF_VERIFY(!isVolume)) {
+        return false;
+    }
+
+    const std::vector<std::pair<SdfPath, std::string>> expectedNodes = {
+        {SdfPath("/MaterialX/Materials/surfacematerial_4/ND_standard_surface_surfaceshader"), "ND_standard_surface_surfaceshader"},
+        {SdfPath("/MaterialX/Materials/surfacematerial_4/NG/image_2"), "ND_image_color3"},
+        {SdfPath("/MaterialX/Materials/surfacematerial_4/NG/texcoord_1"), "ND_texcoord_vector2"},
+    };
+
+    if (!TF_VERIFY(network.nodes.size() == expectedNodes.size())) {
+        return false;
+    }
+
+    for (auto& entry : expectedNodes) {
+        auto it = network.nodes.find(entry.first);
+        if (!TF_VERIFY(it != network.nodes.end()) ||
+            !TF_VERIFY(it->second.nodeTypeId == entry.second)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int 
+main(int argc, char **argv)
+{
+    TfErrorMark mark;
+
+    bool success = UsdImagingMtlxAdapterBasicTest();
+
+    TF_VERIFY(mark.IsClean());
+
+    if (success && mark.IsClean()) {
+        std::cout << "OK" << std::endl;
+        return EXIT_SUCCESS;
+    } else {
+        std::cout << "FAILED" << std::endl;
+        return EXIT_FAILURE;
+    }
+}

--- a/pxr/usdImaging/usdImagingMtlx/testenv/testUsdImagingMtlxAdapter.testenv/test.mtlx
+++ b/pxr/usdImaging/usdImagingMtlx/testenv/testUsdImagingMtlxAdapter.testenv/test.mtlx
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<materialx version="1.38" xmlns:xi="http://www.w3.org/2001/XInclude">
+  <nodegraph name="NG">
+    <texcoord name="texcoord_1" type="vector2" />
+    <image name="image_2" type="color3">
+      <input name="file" type="filename" value="D:\blender\scenes\Untitled.bmp" />
+      <input name="texcoord" type="vector2" nodename="texcoord_1" />
+    </image>
+    <output name="out_image_2" type="color3" nodename="image_2" />
+  </nodegraph>
+  <standard_surface name="standard_surface_3" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="NG" output="out_image_2" />
+    <input name="diffuse_roughness" type="float" value="0" />
+    <input name="metalness" type="float" value="0.6" />
+  </standard_surface>
+  <surfacematerial name="surfacematerial_4" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface_3" />
+  </surfacematerial>
+</materialx>


### PR DESCRIPTION
### Description of Change(s)
This helper function provides an easy way of adding support of MaterialX to a custom HdSceneDelegate:
```
class CustomSceneDelegate : public HdSceneDelegate {
    // ...
    VtValue GetMaterialResource(SdfPath const& id) override {
        std::string mtlxPath = GetMaterialXForPrim(id);

        HdRenderDelegate* renderDelegate = GetRenderIndex().GetRenderDelegate();

        HdMaterialNetworkMap materialNetworkMap;
        UsdImagingMtlxConvertMtlxToHdMaterialNetworkMap(
            mtlxPath,
            renderDelegate->GetShaderSourceTypes(),
            renderDelegate->GetMaterialRenderContexts(),
            &materialNetworkMap);
        return VtValue(materialNetworkMap);
    }
};

```

### Fixes Issue(s)
- No easy way to pass MaterialX from a custom HdSceneDelegate in the standard way (MaterialX translated to HdMaterialNetwork as a UsdShade graph).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
