### PR TITLE
Disable shadows on the "simple" headlight

### DIFF
--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -857,6 +857,8 @@ HdxTaskController::_SetParameters(SdfPath const& pathName,
     if (light.IsDomeLight()) {
         _delegate.SetParameter(pathName, HdLightTokens->textureFile,
                                _GetDomeLightTexture(light));
+        _delegate.SetParameter(pathName, HdLightTokens->shadowEnable, 
+            VtValue(true));
     }
     // When not using storm, initialize the camera light transform based on
     // the SimpleLight position
@@ -871,6 +873,8 @@ HdxTaskController::_SetParameters(SdfPath const& pathName,
             VtValue(DISTANT_LIGHT_ANGLE));
         _delegate.SetParameter(pathName, HdLightTokens->intensity, 
             VtValue(DISTANT_LIGHT_INTENSITY));
+        _delegate.SetParameter(pathName, HdLightTokens->shadowEnable, 
+            VtValue(false));
     }
 }
 
@@ -901,6 +905,7 @@ HdxTaskController::_SetMaterialNetwork(SdfPath const& pathName,
         // For the domelight, add the domelight texture resource.
         node.parameters[HdLightTokens->textureFile] = 
             _GetDomeLightTexture(light);
+        node.parameters[HdLightTokens->shadowEnable] = true;
     }
     else {
         // For the camera light, initialize the transform based on the
@@ -913,6 +918,7 @@ HdxTaskController::_SetMaterialNetwork(SdfPath const& pathName,
         // Initialize distant light specific parameters
         node.parameters[HdLightTokens->angle] = DISTANT_LIGHT_ANGLE;
         node.parameters[HdLightTokens->intensity] = DISTANT_LIGHT_INTENSITY;
+        node.parameters[HdLightTokens->shadowEnable] = false;
     }
     lightNetwork.nodes.push_back(node);
 


### PR DESCRIPTION
When using a "simple" headlight, turn off shadows generated by this light.

Because it is a distant light, and not an actual "headlight" co-located with the camera, interior scenes will be entirely in shadow. Submitting this on behalf of @crydalch spawned from this discussion on usd-interest: https://groups.google.com/g/usd-interest/c/ShnbqGtpi_0

### Description of Change(s)

Changed the code in the TaskController that translates a GlfSimpleLight into explicit values stored in the task controller's custom scene delegate so that simple dome lights have shadows enabled, but simple distant light have shadows disabled.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
