### PR TITLE
Replace locale dependent `TfStringToLower` with `TfStringToLowerAscii`

### DIFF
--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -1201,4 +1201,16 @@ TfGetXmlEscapedString(const std::string &in)
     return result;
 }
 
+std::string
+TfStringToLowerAscii(const std::string& source)
+{
+    std::string folded;
+    folded.resize(source.size());
+    std::transform(source.begin(), source.end(), folded.begin(),
+                   [](char ch) {
+                       return ('A' <= ch && ch <= 'Z') ? ch - 'A' + 'a' : ch;
+                   });
+    return folded;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -277,6 +277,20 @@ std::string TfStringToUpper(const std::string& source);
 TF_API
 std::string TfStringCapitalize(const std::string& source);
 
+/// Locale-independent case folding of [A-Z] for ASCII or UTF-8 encoded
+/// \p source strings
+///
+/// This can be used for case insensitive matching where one of the strings
+/// being compared either known to be ASCII only by specification (like a URI
+/// scheme or an explicit token) or where the specification explicitly notes
+/// that only [A-Z] will be matched case insensitively.
+///
+/// \code
+/// TfStringEndsWith(TfStringToLowerAscii("ü.JPG"), ".jpg")
+/// \endcode
+TF_API
+std::string TfStringToLowerAscii(const std::string& source);
+
 /// Trims characters (by default, whitespace) from the left.
 ///
 /// Characters from the beginning of \p s are removed until a character not in

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -268,6 +268,13 @@ TestStrings()
     TF_AXIOM(TfStringCapitalize("@@@@") == "@@@@");
     TF_AXIOM(TfStringCapitalize("") == "");
 
+    TF_AXIOM(TfStringToLowerAscii("PIXAR") == TfStringToLowerAscii("pixar"));
+    TF_AXIOM(TfStringToLowerAscii("PiXaR") == TfStringToLowerAscii("pixar"));
+    // 'Pixar' in capital Greek letters is not case folded
+    TF_AXIOM(TfStringToLowerAscii("ΠΙΞΑΡ") == "ΠΙΞΑΡ");
+    // Mixture of symbols, capital non-ASCII letters, and ASCII letters
+    TF_AXIOM(TfStringToLowerAscii("ΠΙΞΑΡ ≈ PIXAR") == "ΠΙΞΑΡ ≈ pixar");
+
     TF_AXIOM(TfStringGetSuffix("file.ext") == "ext");
     TF_AXIOM(TfStringGetSuffix("here are some words", ' ') == "words");
     TF_AXIOM(TfStringGetSuffix("0words", '0') == "words");

--- a/pxr/imaging/hd/aov.cpp
+++ b/pxr/imaging/hd/aov.cpp
@@ -65,16 +65,21 @@ size_t hash_value(const HdRenderPassAovBinding &b) {
 bool HdAovHasDepthSemantic(TfToken const& aovName)
 {
     // Expect depth aov's to end with (case-insensitive) "depth".
+    // Because depth contains ASCII only characters, we can compare by only
+    // case folding [A-Z]
     return TfStringEndsWith(
-                TfStringToLower(aovName.GetString()), HdAovTokens->depth);
+                TfStringToLowerAscii(aovName.GetString()),
+                HdAovTokens->depth);
 }
 
 bool HdAovHasDepthStencilSemantic(TfToken const& aovName)
 {
     // Expect depthStencil aov's to end with (case-insensitive) "depthStencil".
+    // Because depthStencil contains ASCII only characters, we can compare by
+    // only case folding [A-Z]
     return TfStringEndsWith(
-                TfStringToLower(aovName.GetString()),
-                TfStringToLower(HdAovTokens->depthStencil));
+                TfStringToLowerAscii(aovName.GetString()),
+                TfStringToLowerAscii(HdAovTokens->depthStencil));
 }
 
 HdParsedAovToken::HdParsedAovToken()

--- a/pxr/imaging/hio/fieldTextureData.cpp
+++ b/pxr/imaging/hio/fieldTextureData.cpp
@@ -65,7 +65,7 @@ _FieldTextureDataFactoryRegistry::GetFactory(
         std::string const & filePath) const
 {
     TfToken const fileExtension(
-            TfStringToLower(ArGetResolver().GetExtension(filePath)));
+            TfStringToLowerAscii(ArGetResolver().GetExtension(filePath)));
 
     TfType const & pluginType = _typeMap.Find(fileExtension);
     if (!pluginType) {

--- a/pxr/imaging/hio/image.h
+++ b/pxr/imaging/hio/image.h
@@ -49,6 +49,8 @@ using HioImageSharedPtr = std::shared_ptr<class HioImage>;
 ///
 /// The class allows basic access to texture image file data.
 ///
+/// Texture paths are UTF-8 strings, resolvable by AR. Texture system dispatch
+/// is driven by extension, with [A-Z] (and no other characters) case folded.
 class HioImage
 {
 public:

--- a/pxr/imaging/hio/imageRegistry.cpp
+++ b/pxr/imaging/hio/imageRegistry.cpp
@@ -72,7 +72,7 @@ HioImageRegistry::_ConstructImage(std::string const & filename)
 
     // Lookup the plug-in type name based on the filename.
     const TfToken fileExtension(
-            TfStringToLower(ArGetResolver().GetExtension(filename)));
+            TfStringToLowerAscii(ArGetResolver().GetExtension(filename)));
 
     TfType const & pluginType = _typeMap->Find(fileExtension);
 

--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -543,7 +543,7 @@ std::string
 HioOIIO_Image::_GetFilenameExtension() const
 {
     std::string fileExtension = ArGetResolver().GetExtension(_filename);
-    return TfStringToLower(fileExtension);
+    return TfStringToLowerAscii(fileExtension);
 }
 
 #if OIIO_VERSION >= 20003

--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -1159,7 +1159,7 @@ private:
                 // Per RFC 3986 sec 3.1 / RFC 3987 sec 5.3.2.1 schemes are
                 // case-insensitive. Force all schemes to lower-case to support
                 // this.
-                uriScheme = TfStringToLower(uriScheme);
+                uriScheme = TfStringToLowerAscii(uriScheme);
 
                 if (const _ResolverSharedPtr* existingResolver =
                     TfMapLookupPtr(uriResolvers, uriScheme)) {
@@ -1339,7 +1339,7 @@ private:
         // stored in lower-case, so convert our candidate scheme to lower case
         // as well.
         const _ResolverSharedPtr* uriResolver = 
-            TfMapLookupPtr(_uriResolvers, TfStringToLower(scheme));
+            TfMapLookupPtr(_uriResolvers, TfStringToLowerAscii(scheme));
         if (uriResolver) {
             if (info) { 
                 *info = &((*uriResolver)->info);

--- a/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
@@ -55,8 +55,9 @@ protected:
         const ArResolvedPath& anchorAssetPath) const final
     {
         TF_AXIOM(
-            TfStringStartsWith(TfStringToLower(assetPath), _uriScheme) ||
-            TfStringStartsWith(TfStringToLower(anchorAssetPath), _uriScheme));
+            TfStringStartsWith(TfStringToLowerAscii(assetPath), _uriScheme) ||
+            TfStringStartsWith(TfStringToLowerAscii(anchorAssetPath),
+                               _uriScheme));
         return assetPath;
     }
 
@@ -65,15 +66,17 @@ protected:
         const ArResolvedPath& anchorAssetPath) const final
     {
         TF_AXIOM(
-            TfStringStartsWith(TfStringToLower(assetPath), _uriScheme) ||
-            TfStringStartsWith(TfStringToLower(anchorAssetPath), _uriScheme));
+            TfStringStartsWith(TfStringToLowerAscii(assetPath), _uriScheme) ||
+            TfStringStartsWith(TfStringToLowerAscii(anchorAssetPath),
+                               _uriScheme));
         return assetPath;
     }
 
     ArResolvedPath _Resolve(
         const std::string& assetPath) const final
     {
-        TF_AXIOM(TfStringStartsWith(TfStringToLower(assetPath), _uriScheme));
+        TF_AXIOM(TfStringStartsWith(TfStringToLowerAscii(assetPath),
+                                    _uriScheme));
 
         const _TestURIResolverContext* uriContext = _GetCurrentContextPtr();
         if (uriContext && !uriContext->data.empty()) {
@@ -105,7 +108,8 @@ protected:
     std::shared_ptr<ArAsset> _OpenAsset(
         const ArResolvedPath& resolvedPath) const final
     {
-        TF_AXIOM(TfStringStartsWith(TfStringToLower(resolvedPath), _uriScheme));
+        TF_AXIOM(TfStringStartsWith(TfStringToLowerAscii(resolvedPath),
+                                    _uriScheme));
         return nullptr;
     }
 
@@ -120,7 +124,8 @@ protected:
         const ArResolvedPath& resolvedPath,
         WriteMode writeMode) const final
     {
-        TF_AXIOM(TfStringStartsWith(TfStringToLower(resolvedPath), _uriScheme));
+        TF_AXIOM(TfStringStartsWith(TfStringToLowerAscii(resolvedPath),
+                                    _uriScheme));
         return nullptr;
     }
 

--- a/pxr/usd/bin/usdtree/usdtree.cpp
+++ b/pxr/usd/bin/usdtree/usdtree.cpp
@@ -176,7 +176,8 @@ std::vector<TfToken> GetPropertyNames(const SdfPrimSpecHandle &prim) {
 
 template<typename PrimType>
 std::string GetPrimLabel(const PrimType &prim) {
-    const std::string spec = TfStringToLower(GetSpecifier(prim));
+    // The display name of specifiers are known to be ASCII only.
+    const std::string spec = TfStringToLowerAscii(GetSpecifier(prim));
     const std::string typeName = GetTypeName(prim);
     std::string definition = spec;
     if (!typeName.empty()) {

--- a/pxr/usd/ndr/filesystemDiscoveryHelpers.cpp
+++ b/pxr/usd/ndr/filesystemDiscoveryHelpers.cpp
@@ -57,7 +57,7 @@ _FsHelpersExamineFiles(
     const NdrParseIdentifierFn &parseIdentifierFn)
 {
     for (const std::string& fileName : dirFileNames) {
-        std::string extension = TfStringToLower(TfGetExtension(fileName));
+        std::string extension = TfStringToLowerAscii(TfGetExtension(fileName));
 
         // Does the extension match one of the known-good extensions?
         NdrStringVec::const_iterator extIter = std::find(
@@ -267,7 +267,7 @@ NdrFsHelpersDiscoverFiles(
 
         for (const std::string& fileName : dirFileNames) {
             const std::string extension = 
-                TfStringToLower(TfGetExtension(fileName));
+                TfStringToLowerAscii(TfGetExtension(fileName));
 
             // Does the extension match one of the known-good extensions?
             if (std::find(allowedExtensions.begin(), allowedExtensions.end(), 

--- a/pxr/usd/sdf/layer.h
+++ b/pxr/usd/sdf/layer.h
@@ -83,6 +83,10 @@ struct Sdf_AssetInfo;
 /// the layer to a different location. You can use the GetIdentifier() method
 /// to get the layer's Id or GetRealPath() to get the resolved, full URI.
 ///
+/// Layer identifiers are UTF-8 encoded strings. A layer's file format is
+/// determined via the identifier's extension (as resolved by Ar) with [A-Z]
+/// (and no other characters) explicitly case folded.
+///
 /// Layers can have a timeCode range (startTimeCode and endTimeCode). This range
 /// represents the suggested playback range, but has no impact on the extent of 
 /// the animation data that may be stored in the layer. The metadatum 


### PR DESCRIPTION
### Description of Change(s)
Depends on #2751.

This replaces usage of the locale dependent `TfStringToLower` with `TfStringToLowerAscii`. This PR also updates comments and documentation to clarify the case folding rules for layer and texture dispatch.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
