### PR TITLE
APPLE: Protect IBL convolution from NaNs in textures

### DIFF
--- a/pxr/imaging/hdSt/shaders/domeLight.glslfx
+++ b/pxr/imaging/hdSt/shaders/domeLight.glslfx
@@ -64,7 +64,9 @@ vec2 GetTexCoords(ivec2 outCoords)
 vec3 SampleEnvMapLod(vec3 sampleVec, float sampleLod) {
     vec2 coord = vec2((atan(sampleVec.z, sampleVec.x) + PI) / (2.0 * PI),
                       acos(sampleVec.y) / PI);
-    return HgiTextureLod_inTexture(coord, sampleLod).rgb;
+    vec3 value = HgiTextureLod_inTexture(coord, sampleLod).rgb;
+
+    return mix(value, vec3(0.0, 0.0, 0.0), (vec3)isnan(value));
 }
 
 // compute world position from texture coords


### PR DESCRIPTION
### Description of Change(s)

On Apple platforms with the Metal port of Storm, any NaNs in the input dome light textures will propagate through the IBL convolution calculation and cause completely black lighting. on these channels.

This doesn't seem to be a problem with openGL, but it's a small change that shouldn't have a performance hit.

### Fixes Issue(s)
- Incorrect lighting when NaNs are present in input texture to dome lights.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
