### PR TITLE
APPLE: Turn off building tests for MaterialX on macOS

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1588,7 +1588,11 @@ def InstallMaterialX(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(MATERIALX_URL, context, force)):
         cmakeOptions = ['-DMATERIALX_BUILD_SHARED_LIBS=ON']
 
-        cmakeOptions += buildArgs;
+        # Disable MaterialX tests on macOS until it is upgraded to Catch2 due
+        # to Xcode 14.3 incompatibility with the RandomNumberGenerator
+        if MacOS():
+            cmakeOptions += ['-DMATERIALX_BUILD_TESTS=OFF']
+        cmakeOptions += buildArgs
 
         RunCMake(context, force, cmakeOptions)
 


### PR DESCRIPTION
### Description of Change(s)

With the recent change to turn on MaterialX by default, the macOS build will fail with Ventura 13.3 and Xcode 14.3 due to compatibility issues with the test framework, Catch.

Also there was a superfluous semicolon in the Python code.

### Fixes Issue(s)
- Fix macOS build.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
