### PR TITLE
APPLE: Fix for breaking API change in PySide 6.5.0

### DIFF
--- a/pxr/usdImaging/usdviewq/qt.py
+++ b/pxr/usdImaging/usdviewq/qt.py
@@ -38,7 +38,17 @@ def GetPySideModule():
             return module.__name__.split('.')[0]
 
     return None
-        
+
+def QObjectInit(self):
+    # In PySide 6.5.0 there was a breaking API change to the QObject __init__
+    if not hasattr(QObjectInit, 'QtVersion'):
+        QtVersion = [int(s) for s in QtCore.qVersion().split('.') if s.isdigit()]
+
+    if len(QtVersion) >= 2 and QtVersion[0] >= 6 and QtVersion[1] >= 5:
+        QtCore.QObject.__init__(self, parent=None, name=None)
+    else:
+        QtCore.QObject.__init__(self)
+
 PySideModule = GetPySideModule()
 if PySideModule == 'PySide':
     from PySide import QtCore, QtGui, QtOpenGL

--- a/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
+++ b/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from .qt import QtCore
+from .qt import QtCore, QObjectInit
 from pxr import UsdGeom, Sdf
 from pxr.UsdAppUtils.complexityArgs import RefinementComplexities
 
@@ -133,7 +133,7 @@ class ViewSettingsDataModel(QtCore.QObject, StateSource):
     signalStyleSettingsChanged = QtCore.Signal()
 
     def __init__(self, rootDataModel, parent):
-        QtCore.QObject.__init__(self)
+        QObjectInit(self)
         StateSource.__init__(self, parent, "model")
 
         self._rootDataModel = rootDataModel


### PR DESCRIPTION
### Description of Change(s)

The most recent version of PySide 6.5.0 appears to have introduced a breaking change in the initialiser of `QObject`.  Check for the Qt version number and pass in a null `parent` and `name` to handle it.

Small change: split the qVersion string only once and store it as a function attribute, to avoid perf hit.

### Fixes Issue(s)
- usdview crash on startup with PySide 6.5.0

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
