### PR TITLE
APPLE: Disable presentation in UsdAppUtilsFrameRecorder

### DIFF
--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -54,7 +54,11 @@ UsdAppUtilsFrameRecorder::UsdAppUtilsFrameRecorder(
     _complexity(1.0f),
     _colorCorrectionMode(HdxColorCorrectionTokens->disabled),
     _purposes({UsdGeomTokens->default_, UsdGeomTokens->proxy})
-{}
+{
+    // Disable presentation to avoid the need to create an OpenGL context when
+    // using other graphics APIs such as Metal and Vulkan.
+    _imagingEngine.SetEnablePresentation(false);
+}
 
 static bool
 _HasPurpose(const TfTokenVector& purposes, const TfToken& purpose)

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -51,8 +51,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// particular UsdTimeCode. The images generated will be effectively the same
 /// as what you would see in the viewer in usdview.
 ///
-/// Note that it is assumed that an OpenGL context has already been setup if
-/// the UsdAppUtilsFrameRecorder instance is created with the GPU enabled.
+/// Note that it is assumed that an OpenGL context has already been setup for
+/// the UsdAppUtilsFrameRecorder if OpenGL is being used as the underlying HGI
+/// device.  This is not required for Metal.
 class UsdAppUtilsFrameRecorder
 {
 public:
@@ -73,11 +74,16 @@ public:
     }
 
     /// Sets the Hydra renderer plugin to be used for recording.
+    /// This also resets the presentation flag on the HdxPresentTask to false,
+    /// to avoid the need for an OpenGL context.
     ///
     /// Note that the renderer plugins that may be set will be restricted if
     /// this UsdAppUtilsFrameRecorder instance has disabled the GPU.
     bool SetRendererPlugin(const TfToken& id) {
-        return _imagingEngine.SetRendererPlugin(id);
+        bool succeeded = _imagingEngine.SetRendererPlugin(id);
+        _imagingEngine.SetEnablePresentation(false);
+
+        return succeeded;
     }
 
     /// Sets the width of the recorded image.


### PR DESCRIPTION
### Description of Change(s)

The `UsdImagingGLEngine` in `UsdAppUtilsFrameRecorder` has `HdxPresentTask` presentation enabled by default.  When this is used in Metal this means that the openGL context is still required.  Since the frame recorder doesn't present to the viewport we should disable this.

Addendum: the presentation flag is also reset to enabled if the renderer plugin is changed after the frame recorder is created, so it is now set to disabled then too.

### Fixes Issue(s)
- Requirement for openGL context when using the UsdAppUtilsFrameRecorder on Metal.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
