### PR TITLE
APPLE: Fix for PySide 6.5.0 initialization order.

### DIFF
--- a/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
+++ b/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
@@ -104,7 +104,7 @@ class OCIOSettings():
     def colorSpace(self):
         return self._colorSpace
 
-class ViewSettingsDataModel(QtCore.QObject, StateSource):
+class ViewSettingsDataModel(StateSource, QtCore.QObject):
     """Data model containing settings related to the rendered view of a USD
     file.
     """


### PR DESCRIPTION
### Description of Change(s)

The recent change in Pyside 6.5.0 here:

https://github.com/pyside/pyside-setup/commit/e8095467f7d0332cc0987e7c541de9906e19fece

Introduced correct multiple inheritance through the use of the `super()` Method Resolution Order.  I checked the MRO of ViewSettingsDataModel, which was:

```
<class 'pxr.Usdviewq.viewSettingsDataModel.ViewSettingsDataModel'>
<class 'PySide6.QtCore.QObject'>
<class 'Shiboken.Object'>
<class 'pxr.Usdviewq.settings.StateSource'>
<class 'object'>
```

This meant that the `StateSource` object wasn't being initialised correctly.  With this change the MRO is:

```
<class 'pxr.Usdviewq.viewSettingsDataModel.ViewSettingsDataModel'>
<class 'pxr.Usdviewq.settings.StateSource'>
<class 'PySide6.QtCore.QObject'>
<class 'Shiboken.Object'>
<class 'object'>
```

And the initialisation works correctly.  Checked with PySide 6.5.0 and 6.4.3

### Fixes Issue(s)
- usdview runtime exception on startup.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
