### PR TITLE
Replace references to ASCII with Text in USD binaries to account for UTF-8 support

### DIFF
--- a/pxr/usd/bin/usddiff/usddiff.py
+++ b/pxr/usd/bin/usddiff/usddiff.py
@@ -40,7 +40,7 @@ def _exit(msg, exitCode):
     sys.exit(exitCode)
 
 # generates a command list representing a call which will generate
-# a temporary ascii file used during diffing. 
+# a temporary text file used during diffing.
 def _generateCatCommand(usdcatCmd, inPath, outPath, flatten=None, fmt=None):
     command = [usdcatCmd, inPath, '--out', outPath]
     if flatten:

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -2798,7 +2798,7 @@ class AppController(QtCore.QObject):
             caption,
             './' + recommendedFilename,
             'USD Files (*.usd)'
-            ';;USD ASCII Files (*.usda)'
+            ';;USD Text Files (*.usda)'
             ';;USD Crate Files (*.usdc)'
             ';;Any USD File (*.usd *.usda *.usdc)',
             'Any USD File (*.usd *.usda *.usdc)')


### PR DESCRIPTION
### Description of Change(s)
Utilities using `usda` historically reference it as the "ASCII" file format. However, for some time, strings can be UTF-8 encoded (#2055, #1331). Prim and property identifiers will be getting similar support soon as well (#2120).

For clarity, this PR changes references to ASCII in `usdview` and `usddiff` to the more general and accurate descriptor of "text".

### Fixes Issue(s)
- #2120 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
