### PR TITLE
Replace documentation references to "ASCII" with "text"

### DIFF
--- a/pxr/usd/sdf/overview.dox
+++ b/pxr/usd/sdf/overview.dox
@@ -4,13 +4,13 @@
 \mainpage Sdf : Scene Description Foundations
 \endif
 
-Sdf provides the foundations for serializing scene description to a reference ascii format, or a (multitude of) plugin-defined format.  It also provides the primitive abstractions for interacting with scene description, such as SdfPath, SdfLayer, SdfPrimSpec.
+Sdf provides the foundations for serializing scene description to a reference text format, or a (multitude of) plugin-defined format.  It also provides the primitive abstractions for interacting with scene description, such as SdfPath, SdfLayer, SdfPrimSpec.
 
 \section sdf_overview Overview
 
 Implements scene description \em layers in USD.  In USD, a complete scene description is composed from partial scene description stored in SdfLayer objects.  The primary unit of scene description within a layer is a \em prim \em spec, represented by the SdfPrimSpec class.  A complete UsdPrim on a stage is a composition of the prim's built-in fallback values and all of the prim spec objects specified in Sdf layers.  (For an overview of prims and stages, see the \ref usd_page_front "Usd library overview".) 
 
-Use methods on an SdfLayer object to export and save a layer to a file, or to load a file from disk.  Scene description files are stored in <c>.usd</c> format (one layer per file, ascii or binary).  Other features abstracted at the layer level include undo/redo functionality and logging, which can be customized by subclassing SdfLayerStateDelegateBase .
+Use methods on an SdfLayer object to export and save a layer to a file, or to load a file from disk.  Scene description files are stored in <c>.usd</c> format (one layer per file, text or binary).  Other features abstracted at the layer level include undo/redo functionality and logging, which can be customized by subclassing SdfLayerStateDelegateBase .
 
 You should primarily work with scene description using the classes in the Usd library.  The UsdStage object not only represents a complete scene; it also knows how each of the partial scene descriptions were combined to form the complete scene.  For example, the UsdStage object has the context to know how the path of a UsdPrim object on the stage relates to the paths of each SdfPrimSpec object in each layer that contributes a partial description to the complete prim.  SdfLayer objects do not have the context to know how they relate to other layers.
 

--- a/pxr/usd/usd/common.h
+++ b/pxr/usd/usd/common.h
@@ -74,7 +74,7 @@ USD_API
 std::string UsdDescribe(const UsdStageCache &);
 
 // XXX:
-// Currently used for querying composed values from ascii layers, so VtValue is
+// Currently used for querying composed values from text layers, so VtValue is
 // the optimal value-store, but this may not always be the case.
 typedef std::map<class TfToken, VtValue,
                  TfDictionaryLessThan

--- a/pxr/usd/usd/doxygen/propertiesOfSceneDescription.dox
+++ b/pxr/usd/usd/doxygen/propertiesOfSceneDescription.dox
@@ -76,7 +76,7 @@ consider the prim to be *deactivated*, which has two important consequences:
   scene complexity and cost.
 
 
-\section Usd_Filetypes Ascii, Binary, and Plugin Filetypes
+\section Usd_Filetypes Text, Binary, and Plugin Filetypes
      
 \section Usd_AssetResolution Resolving Asset References
 

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -130,7 +130,7 @@ SDF_DECLARE_HANDLES(SdfLayer);
 /// exercized with large scenes, as flattening defeats some of the benefits of
 /// referenced scene description, and may produce very large results, 
 /// especially in file formats that do not support data de-duplication, like
-/// the usda ASCII format!
+/// the usda text format!
 ///
 /// \section Usd_SessionLayer Stage Session Layers
 ///

--- a/pxr/usd/usd/usdFileFormat.cpp
+++ b/pxr/usd/usd/usdFileFormat.cpp
@@ -318,7 +318,7 @@ UsdUsdFileFormat::WriteToFile(
 
     // Otherwise, if we are saving a .usd layer (i.e., calling SdfLayer::Save),
     // we want to maintain that layer's underlying format. For example,
-    // calling Save() on an ASCII .usd file should produce an ASCII file
+    // calling Save() on a text .usd file should produce a text file
     // and not convert it to binary.
     // 
     // If we are exporting to a .usd layer (i.e., calling SdfLayer::Export),


### PR DESCRIPTION
### Description of Change(s)
Utilities using `usda` historically reference it as the "ASCII" file format. However, for some time, strings can be UTF-8 encoded (#2055, #1331). Prim and property identifiers will be getting similar support soon as well (#2120).

For clarity, this PR changes references to ASCII at several points in documentation to the more general and accurate descriptor of "text".

This PR does not update test case descriptions or file names.

### Fixes Issue(s)
- #2120 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
