### PR TITLE
Fix export of USD as a monolithic shared library.

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -1424,7 +1424,10 @@ function(_pxr_library NAME)
     endif()
 
     if(isObject)
-        # Nothing
+        install(
+            TARGETS ${NAME}
+            EXPORT pxrTargets
+        )
     else()
         # Do not include plugins libs in externally linkable targets
         if(isPlugin)

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1070,16 +1070,16 @@ function(pxr_toplevel_epilogue)
         # usd_m target.
         target_compile_definitions(usd_ms
             PUBLIC
-                $<BUILD_INTERFACE:$<TARGET_PROPERTY:usd_m,INTERFACE_COMPILE_DEFINITIONS>>
+                $<TARGET_PROPERTY:usd_m,INTERFACE_COMPILE_DEFINITIONS>
         )
         target_include_directories(usd_ms
             PUBLIC
-                $<BUILD_INTERFACE:$<TARGET_PROPERTY:usd_m,INTERFACE_INCLUDE_DIRECTORIES>>
+                $<TARGET_PROPERTY:usd_m,INTERFACE_INCLUDE_DIRECTORIES>
         )
         target_include_directories(usd_ms
             SYSTEM
             PUBLIC
-                $<BUILD_INTERFACE:$<TARGET_PROPERTY:usd_m,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>>
+                $<TARGET_PROPERTY:usd_m,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
         )
         foreach(lib ${PXR_OBJECT_LIBS})
             get_property(libs TARGET ${lib} PROPERTY INTERFACE_LINK_LIBRARIES)
@@ -1146,6 +1146,11 @@ function(pxr_monolithic_epilogue)
             POSITION_INDEPENDENT_CODE ON
             PREFIX "${libPrefix}"
             IMPORT_PREFIX "${libPrefix}"
+    )
+
+    install(
+        TARGETS usd_m
+        EXPORT pxrTargets
     )
 
     # Adding $<TARGET_OBJECTS:foo> will not bring along compile


### PR DESCRIPTION
### Description of Change(s)
Outside projects could not easily be built against USD as a monolithic shared library because of some usage requirements not set on the exported `usd_ms` target. For example, the `INTERFACE_INCLUDE_DIRECTORIES` target property was missing.

This is fixed by reverting the use of the `$<BUILD_INTERFACE:...>` export generator expression.

However, outside builds would still fail because the `usd_m` and other internal-to-monolithic targets were not exported. This is fixed too.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/2396

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
