### PR TITLE
APPLE: Buffer binding null pointer checks

### DIFF
--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -627,12 +627,15 @@ HgiMetalIndirectCommandEncoder::_EncodeDraw(
     for (const HgiBufferBindDesc &buffer :
          resourceBindings->GetDescriptor().buffers) {
         if (buffer.resourceType == HgiBindResourceTypeTessFactors) {
-            HgiMetalBuffer* mtlBuffer =
-                static_cast<HgiMetalBuffer*>(buffer.buffers[0].Get());
-            [function.argumentEncoder setBuffer:mtlBuffer->GetBufferId()
-                                         offset:buffer.offsets[0]
-                                        atIndex:ArgIndex_PatchFactorsBuffer];
-            usedExplicitTessFactorBuffer = true;
+            if (buffer.buffers[0].Get()) {
+                HgiMetalBuffer* mtlBuffer =
+                    static_cast<HgiMetalBuffer*>(buffer.buffers[0].Get());
+
+                [function.argumentEncoder setBuffer:mtlBuffer->GetBufferId()
+                                             offset:buffer.offsets[0]
+                                            atIndex:ArgIndex_PatchFactorsBuffer];
+                usedExplicitTessFactorBuffer = true;
+            }
         }
     }
     if (pipelineDesc.primitiveType == HgiPrimitiveTypePatchList &&
@@ -665,13 +668,15 @@ HgiMetalIndirectCommandEncoder::_EncodeDraw(
     uint32_t index = 0;
 
     for (auto const& binding : bindings) {
-        HgiMetalBuffer* mtlBuffer =
-            static_cast<HgiMetalBuffer*>(binding.buffer.Get());
-        [function.argumentEncoder setBuffer:mtlBuffer->GetBufferId()
-                                     offset:binding.byteOffset
-                                    atIndex:ArgIndex_Buffers + index];
-        [encoder useResource:mtlBuffer->GetBufferId()
-                       usage:(MTLResourceUsageRead | MTLResourceUsageWrite)];
+        if (binding.buffer.Get()) {
+            HgiMetalBuffer* mtlBuffer =
+                static_cast<HgiMetalBuffer*>(binding.buffer.Get());
+            [function.argumentEncoder setBuffer:mtlBuffer->GetBufferId()
+                                         offset:binding.byteOffset
+                                        atIndex:ArgIndex_Buffers + index];
+            [encoder useResource:mtlBuffer->GetBufferId()
+                           usage:(MTLResourceUsageRead | MTLResourceUsageWrite)];
+        }
         index++;
     }
 

--- a/pxr/imaging/hgiMetal/stepFunctions.mm
+++ b/pxr/imaging/hgiMetal/stepFunctions.mm
@@ -73,18 +73,20 @@ void
 HgiMetalStepFunctions::Bind(HgiVertexBufferBindingVector const &bindings)
 {
     for (HgiVertexBufferBinding const &binding : bindings) {
-        HgiBufferDesc const& desc = binding.buffer->GetDescriptor();
+        if (binding.buffer) {
+            HgiBufferDesc const& desc = binding.buffer->GetDescriptor();
 
-        TF_VERIFY(desc.usage & HgiBufferUsageVertex);
+            TF_VERIFY(desc.usage & HgiBufferUsageVertex);
 
-        for (auto & stepFunction : _vertexBufferDescs) {
-            if (stepFunction.bindingIndex == binding.index) {
-                stepFunction.byteOffset = binding.byteOffset;
+            for (auto & stepFunction : _vertexBufferDescs) {
+                if (stepFunction.bindingIndex == binding.index) {
+                    stepFunction.byteOffset = binding.byteOffset;
+                }
             }
-        }
-        for (auto & stepFunction : _patchBaseDescs) {
-            if (stepFunction.bindingIndex == binding.index) {
-                stepFunction.byteOffset = binding.byteOffset;
+            for (auto & stepFunction : _patchBaseDescs) {
+                if (stepFunction.bindingIndex == binding.index) {
+                    stepFunction.byteOffset = binding.byteOffset;
+                }
             }
         }
     }


### PR DESCRIPTION
### Description of Change(s)

If an empty USD file was loaded, a null buffer would be passed into the step function and indirect command buffer bindings, causing a segfault.  This protects against it.

### Fixes Issue(s)
- Segfault on binding null buffers

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
