### PR TITLE
usdBakeMtlx: absorb TextureBakerGlsl API change to fix compilation with MaterialX 1.38.7

### DIFF
--- a/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.cpp
+++ b/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.cpp
@@ -37,6 +37,7 @@
 #include "pxr/usd/usdShade/shader.h"
 
 #include <MaterialXCore/Document.h>
+#include <MaterialXCore/Generated.h>
 #include <MaterialXCore/Node.h>
 #include <MaterialXFormat/Util.h>
 #include <MaterialXFormat/XmlIo.h>
@@ -144,8 +145,15 @@ void _BakeMtlxDocument(
         : mx::Image::BaseType::UINT8;
 
     // Construct a Texture Baker.
+#if MATERIALX_MAJOR_VERSION <= 1 &&  \
+    MATERIALX_MINOR_VERSION <= 38 && \
+    MATERIALX_BUILD_VERSION <= 6
     mx::TextureBakerPtr baker = mx::TextureBaker::create(
         textureWidth, textureHeight, baseType);
+#else
+    mx::TextureBakerPtr baker = mx::TextureBakerGlsl::create(
+        textureWidth, textureHeight, baseType);
+#endif
     baker->setupUnitSystem(stdLibraries);
     baker->setAverageImages(bakeAverage);
 


### PR DESCRIPTION
### Description of Change(s)

As part of the work to support Metal in MaterialX, the API for creating a GLSL-based texture baker was modified in 1.38.7. This change ensures that the correct type name is used based on the MaterialX version being used.

See more detail in the MaterialX commit here:
https://github.com/AcademySoftwareFoundation/MaterialX/commit/6f8b3bdb57390687ec1bea00a0551ac6bef3aed6

I've verified that the unit tests pass when USD is built against MaterialX 1.38.7, but I've admittedly not done any other correctness verification. This change only addresses the compilation failure.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
