### PR TITLE
Allow instancing of bounding boxes drawn on prims with unloaded payloads

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -232,10 +232,11 @@ UsdImagingDelegate::_AdapterLookup(UsdPrim const& prim, bool ignoreInstancing)
     //    threads.
 
     TfToken adapterKey;
-    if (_displayUnloadedPrimsWithBounds && !prim.IsLoaded()) {
-        adapterKey = UsdImagingAdapterKeyTokens->drawModeAdapterKey;
-    } else if (!ignoreInstancing && prim.IsInstance()) {
+
+    if (!ignoreInstancing && prim.IsInstance()) {
         adapterKey = UsdImagingAdapterKeyTokens->instanceAdapterKey;
+    } else if (_displayUnloadedPrimsWithBounds && !prim.IsLoaded()) {
+        adapterKey = UsdImagingAdapterKeyTokens->drawModeAdapterKey;
     } else if (_hasDrawModeAdapter && _enableUsdDrawModes &&
                _IsDrawModeApplied(prim)) {
         adapterKey = UsdImagingAdapterKeyTokens->drawModeAdapterKey;

--- a/pxr/usdImaging/usdImaging/drawModeAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/drawModeAdapter.cpp
@@ -1561,11 +1561,7 @@ UsdImagingDrawModeAdapter::GetTransform(UsdPrim const& prim,
     // the instance prim, but we want to ignore transforms on that
     // prim since the instance adapter will incorporate it into the per-instance
     // transform and we don't want to double-transform the prim.
-    //
-    // Note: if the prim is unloaded (because unloaded prims are drawing as
-    // bounds), we skip the normal instancing machinery and need to handle
-    // the transform ourselves.
-    if (prim.IsInstance() && prim.IsLoaded()) {
+    if (prim.IsInstance()) {
         return GfMatrix4d(1.0);
     } else {
         return BaseAdapter::GetTransform(


### PR DESCRIPTION
Allow instancing of bounding boxes drawn on prims with unloaded payloads.

### Description of Change(s)
Reordered code in UsdImagingDelegate::_AdapterLookup to check for IsInstanceable _before_ checking for IsLoaded. This allows the instancer adapter to instance the bounding box rprims created for instanceable prims with unloaded payloads. Previously even with the instanceable flag set, every unloaded payload prim would create a separate rprim for its bounding box.

This change also required changing the draw mode adapter because that code was explicitly compensating for the fact that unloaded payload prims were not being instanced properly.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
