### PR TITLE
Make sure add_dll_directory is always called with an absolute path.

### DIFF
--- a/pxr/base/tf/__init__.py
+++ b/pxr/base/tf/__init__.py
@@ -44,7 +44,8 @@ if sys.version_info >= (3, 8) and platform.system() == "Windows":
             # Calling add_dll_directory raises an exception if paths don't
             # exist, or if you pass in dot
             if os.path.exists(path) and path != '.':
-                dirs.append(os.add_dll_directory(path))
+                abs_path = os.path.abspath(path)
+                dirs.append(os.add_dll_directory(abs_path))
         # This block guarantees we clear the dll directories if an exception
         # is raised in the with block.
         try:


### PR DESCRIPTION
Make sure add_dll_directory is always called with an absolute path.
Calling it with a relative path on Windows raises an exception.
This would happen if the PATH variable contains a relative path.

### Description of Change(s)
In the Tf __init__.py module, get the absolute path of each component of the PATH variable before calling add_dll_directory.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
