### PR TITLE
[usdImaging] add array include to drawModeStandin.cpp

### DIFF
--- a/pxr/usdImaging/usdImaging/drawModeStandin.cpp
+++ b/pxr/usdImaging/usdImaging/drawModeStandin.cpp
@@ -55,6 +55,7 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/range3d.h"
 
+#include <array>
 #include <functional>
 #include <bitset>
 


### PR DESCRIPTION
### Description of Change(s)

Changes in https://github.com/PixarAnimationStudios/USD/commit/bbd0b53f510b45790ee3e91942dd35f5fbdab613 introduced `std::array` but did not add `#include <array>`. Including `array` fixes an issue where GCC 12 would exit with an error about an incomplete return type. Such errors looked like:


```console
usd> FAILED: pxr/usdImaging/usdImaging/CMakeFiles/usdImaging.dir/drawModeStandin.cpp.o
usd> /nix/store/nlgyw2fv0cm8rkz8qm1jyw78vyif1bl9-gcc-wrapper-12.2.0/bin/g++ -DBOOST_PYTHON_NO_PY_SIGNATURES -DGLX_GLXEXT_PROTOTYPES -DGL_GLEXT_PROTOTYPES -DMFB_ALT_PACKAGE_NAME=usdImaging -DMFB_PACKAGE_MODULE=UsdImaging -DMFB_PACKAGE_NAME=usdImaging -DPXR_BUILD_LOCATION=usd -DPXR_OCIO_PLUGIN_ENABLED -DPXR_OIIO_PLUGIN_ENABLED -DPXR_OPENVDB_SUPPORT_ENABLED -DPXR_PLUGIN_BUILD_LOCATION=../plugin/usd -DPXR_PTEX_SUPPORT_ENABLED -DUSDIMAGING_EXPORTS=1 -DusdImaging_EXPORTS -I/build/source/build/pxr/usdImaging/usdImaging -I/build/source/pxr/usdImaging/usdImaging -I/build/source/build/include -Wall -Wformat-security -pthread -Wno-deprecated -Wno-deprecated-declarations -Wno-unused-local-typedefs -Wno-placement-new  -O3 -DNDEBUG -fPIC -std=c++14 -MD -MT pxr/usdImaging/usdImaging/CMakeFiles/usdImaging.dir/drawModeStandin.cpp.o -MF pxr/usdImaging/usdImaging/CMakeFiles/usdImaging.dir/drawModeStandin.cpp.o.d -o pxr/usdImaging/usdImaging/CMakeFiles/usdImaging.dir/drawModeStandin.cpp.o -c /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp:936:70: error: return type 'struct std::array<pxrInternal_v0_23__pxrReserved__::TfToken, 6>' is incomplete
usd>   936 | _AddAxesToNames(const std::string &prefix, const std::string &postfix) {
usd>       |                                                                      ^
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp: In static member function 'static pxrInternal_v0_23__pxrReserved__::HdContainerDataSourceHandle pxrInternal_v0_23__pxrReserved__::{anonymous}::_CardsDrawMode::_CardsDataCache::_CardsData::_ComputeGeomSubsets(const pxrInternal_v0_23__pxrReserved__::{anonymous}::_CardsDrawMode::_CardsDataCache::_SchemaValues&, const pxrInternal_v0_23__pxrReserved__::SdfPath&)':
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp:1384:41: error: variable 'const std::array<pxrInternal_v0_23__pxrReserved__::TfToken, 6> subsetNameTokens' has initializer but incomplete type
usd>  1384 |     static const std::array<TfToken, 6> subsetNameTokens =
usd>       |                                         ^~~~~~~~~~~~~~~~
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp:1386:41: error: variable 'const std::array<pxrInternal_v0_23__pxrReserved__::TfToken, 6> materialNameTokens' has initializer but incomplete type
usd>  1386 |     static const std::array<TfToken, 6> materialNameTokens =
usd>       |                                         ^~~~~~~~~~~~~~~~~~
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp: In static member function 'static const pxrInternal_v0_23__pxrReserved__::{anonymous}::_CardsDrawMode::_MaterialsDict pxrInternal_v0_23__pxrReserved__::{anonymous}::_CardsDrawMode::_CardsDataCache::_CardsData::_ComputeMaterials(const pxrInternal_v0_23__pxrReserved__::{anonymous}::_CardsDrawMode::_CardsDataCache::_SchemaValues&)':
usd> /build/source/pxr/usdImaging/usdImaging/drawModeStandin.cpp:1667:41: error: variable 'const std::array<pxrInternal_v0_23__pxrReserved__::TfToken, 6> materialNameTokens' has initializer but incomplete type
usd>  1667 |     static const std::array<TfToken, 6> materialNameTokens =
usd>       |                                         ^~~~~~~~~~~~~~~~~~
```

### Fixes Issue(s)
- GCC 12 `incomplete type` errors

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
