### PR TITLE
Fix VtArray declaraions of extern template instantiations so that the…

### DIFF
--- a/pxr/base/vt/array.cpp
+++ b/pxr/base/vt/array.cpp
@@ -47,7 +47,7 @@ Vt_ArrayBase::_DetachCopyHook(char const *funcName) const
 
 // Instantiate basic array templates.
 #define VT_ARRAY_EXPLICIT_INST(r, unused, elem) \
-    template class VtArray< VT_TYPE(elem) >;
+    template class VT_API VtArray< VT_TYPE(elem) >;
 BOOST_PP_SEQ_FOR_EACH(VT_ARRAY_EXPLICIT_INST, ~, VT_SCALAR_VALUE_TYPES)
 
 

--- a/pxr/base/vt/array.h
+++ b/pxr/base/vt/array.h
@@ -919,7 +919,7 @@ class VtArray : public Vt_ArrayBase {
 // Declare basic array instantiations as extern templates.  They are explicitly
 // instantiated in array.cpp.
 #define VT_ARRAY_EXTERN_TMPL(r, unused, elem) \
-    extern template class VtArray< VT_TYPE(elem) >;
+    VT_API_TEMPLATE_CLASS(VtArray< VT_TYPE(elem) >);
 BOOST_PP_SEQ_FOR_EACH(VT_ARRAY_EXTERN_TMPL, ~, VT_SCALAR_VALUE_TYPES)
 
 template <class HashState, class ELEM>


### PR DESCRIPTION
Fix VtArray declaraions of extern template instantiations so that the code in array.cpp will actually instantiate and export the templates as expected. Currently the templates are marked as extern even while compiling array.cpp so the compiler isn't actually instantiating anything. This problem seems to only apply to Windows builds.

### Description of Change(s)
The existing code in vt/array.cpp doesn't actually generate exported symbols for some compilers as demonstrated here: https://godbolt.org/z/Gz1vc5eEe

The array.h file should be using the VT_API_TEMPLATE_CLASS macro so that when compiling array.cpp there is no confusion about whether code should be generated to instantiate the templates. In array.cpp VT_API must be added explicitly to the instantiation macro to ensure the generated symbols are exported.

Note that for many compilers there are many configurations here that all seem to work okay, either because of inlining of VtArry functions, or different interpretations of classes defined first as extern in the header, then non-extern in the cpp.

Thanks go to @e4lam for pointing this out.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
