### PR TITLE
APPLE: Add the option to disable camera light in usdRecord

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -153,6 +153,9 @@ def main():
             'Width of the output image. The height will be computed from this '
             'value and the camera\'s aspect ratio (default=%(default)s)'))
 
+    parser.add_argument('--disableCameraLight', action='store_true', default=False,
+        help='Disables the default camera light.')
+    
     args = parser.parse_args()
 
     UsdAppUtils.framesArgs.ValidateCmdlineArgs(parser, args,
@@ -197,9 +200,13 @@ def main():
     frameRecorder.SetComplexity(args.complexity.value)
     frameRecorder.SetColorCorrectionMode(args.colorCorrectionMode)
     frameRecorder.SetIncludedPurposes(purposes)
+    frameRecorder.SetEnableCameraLight(not args.disableCameraLight)
 
     _Msg('Camera: %s' % usdCamera.GetPath().pathString)
     _Msg('Renderer plugin: %s' % frameRecorder.GetCurrentRendererId())
+
+    if args.disableCameraLight:
+        _Msg('Camera light disabled')
 
     for timeCode in args.frames:
         _Msg('Recording time code: %s' % timeCode)

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -122,6 +122,16 @@ public:
     USDAPPUTILS_API
     void SetIncludedPurposes(const TfTokenVector& purposes);
 
+    /// Turns the build-in camera light on and off.
+    ///
+    /// When on, Storm will make a direct light at the camera's origin facing
+    /// the same direction as the camera. This is sometimes called a 
+    /// "headlight."
+    USDAPPUTILS_API
+    void SetEnableCameraLight(const bool enabled) {
+        _cameraLightEnabled = enabled;
+    }
+
     /// Records an image and writes the result to \p outputImagePath.
     ///
     /// The recorded image will represent the view from \p usdCamera looking at
@@ -145,6 +155,7 @@ private:
     float _complexity;
     TfToken _colorCorrectionMode;
     TfTokenVector _purposes;
+    bool _cameraLightEnabled;
 };
 
 

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -50,6 +50,7 @@ wrapFrameRecorder()
         .def("SetColorCorrectionMode", &This::SetColorCorrectionMode)
         .def("SetIncludedPurposes", &This::SetIncludedPurposes,
              (arg("purposes")))
+        .def("SetEnableCameraLight", &This::SetEnableCameraLight)
         .def(
             "Record",
             &This::Record,


### PR DESCRIPTION
### Description of Change(s)

Provide an option in usdRecord to disable the camera light.  This is useful when using the IBL (see https://github.com/PixarAnimationStudios/USD/pull/2352 and https://github.com/PixarAnimationStudios/USD/pull/2383)

Thanks to the wider team at Apple for this.

### Fixes Issue(s)
- Over brightening of output from usdRecord when using IBL

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
