### PR TITLE
APPLE: Fix for primID rendering in AOVs

### DIFF
--- a/pxr/imaging/hdSt/shaders/renderPass.glslfx
+++ b/pxr/imaging/hdSt/shaders/renderPass.glslfx
@@ -276,12 +276,22 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
 // with AoVs.  We generate "primId" and "instanceId", and depending on how
 // the client called glDrawBuffers, they will get one or both.
 
+// Note: This code originally packed the 32-bit ID into all 4 channels, which
+// will correspond to RGBA. However, using A for the top 8 bits causes problems.
+// First, somewhere downstream RGB will be premultiplied by A and information will
+// be lost. Second, when these end up in an output image, there is no way to know
+// what pixels have valid IDs, unless we pick a specifc RGBA like (0,0,0,0) to mean 
+// "no object", but I think that is a valid primId.
+//
+// So, while this means we can only handle 16 million IDs, this is the safest option
+// right now. See similar code in frameRecorder.cpp which interprets these values.
+
 vec4 IntToVec4(int id)
 {
     return vec4(((id >>  0) & 0xff) / 255.0,
                 ((id >>  8) & 0xff) / 255.0,
                 ((id >> 16) & 0xff) / 255.0,
-                ((id >> 24) & 0xff) / 255.0);
+                1.0);
 }
 
 void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)


### PR DESCRIPTION
### Description of Change(s)

When rendering primID as an AOV, the `IntToVec4` function originally packed the 32-bit ID into all 4 channels, which will correspond to RGBA. However, using A for the top 8 bits causes problems.  First, somewhere downstream RGB will be premultiplied by A and information will be lost. Second, when these end up in an output image, there is no way to know what pixels have valid IDs, unless we pick a specific RGBA like (0,0,0,0) to mean "no object".

While this means we can only handle 16 million IDs, this seems to be the safest option right now. See similar code in frameRecorder.cpp which interprets these values.

Thanks to the wider team at Apple for this.

### Fixes Issue(s)
- Incorrect output in primID AOV

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
