### PR TITLE
APPLE: Move ResolveCullMode to geometry shader and remove accessors.

### DIFF
--- a/pxr/imaging/hdSt/geometricShader.cpp
+++ b/pxr/imaging/hdSt/geometricShader.cpp
@@ -101,6 +101,66 @@ HdSt_GeometricShader::_GetGlslfx() const
     return _glslfx.get();
 }
 
+// Note: The geometric shader may override the state if necessary, including
+// disabling h/w culling altogether.  This is required to handle instancing
+// since instanceScale / instanceTransform can flip the xform handedness.
+HgiCullMode
+HdSt_GeometricShader::ResolveCullMode(
+    HdCullStyle const renderStateCullStyle) const
+{
+    if (!_useHardwareFaceCulling) {
+        // Use fragment shader culling via discard.
+        return HgiCullModeNone;
+    }
+
+    // If the Rprim has an opinion, that wins, else use the render state style.
+    HdCullStyle const resolvedCullStyle =
+        _cullStyle == HdCullStyleDontCare ? renderStateCullStyle : _cullStyle;
+
+    HgiCullMode resolvedCullMode = HgiCullModeNone;
+
+    switch (resolvedCullStyle) {
+        case HdCullStyleFront:
+            if (_hasMirroredTransform) {
+                resolvedCullMode = HgiCullModeBack;
+            } else {
+                resolvedCullMode = HgiCullModeFront;
+            }
+            break;
+        case HdCullStyleFrontUnlessDoubleSided:
+            if (!_doubleSided) {
+                if (_hasMirroredTransform) {
+                    resolvedCullMode = HgiCullModeBack;
+                } else {
+                    resolvedCullMode = HgiCullModeFront;
+                }
+            }
+            break;
+        case HdCullStyleBack:
+            if (_hasMirroredTransform) {
+                resolvedCullMode = HgiCullModeFront;
+            } else {
+                resolvedCullMode = HgiCullModeBack;
+            }
+            break;
+        case HdCullStyleBackUnlessDoubleSided:
+            if (!_doubleSided) {
+                if (_hasMirroredTransform) {
+                    resolvedCullMode = HgiCullModeFront;
+                } else {
+                    resolvedCullMode = HgiCullModeBack;
+                }
+            }
+            break;
+        case HdCullStyleNothing:
+        default:
+            resolvedCullMode = HgiCullModeNone;
+            break;
+    }
+
+    return resolvedCullMode;
+}
+
 /* virtual */
 HdStShaderCode::ID
 HdSt_GeometricShader::ComputeHash() const

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -186,22 +186,6 @@ public:
         return _primType;
     }
 
-    HdCullStyle GetCullStyle() const {
-        return _cullStyle;
-    }
-
-    bool GetUseHardwareFaceCulling() const {
-        return _useHardwareFaceCulling;
-    }
-
-    bool GetHasMirroredTransform() const {
-        return _hasMirroredTransform;
-    }
-
-    bool GetDoubleSided() const {
-        return _doubleSided;
-    }
-
     bool GetUseMetalTessellation() const {
         return _useMetalTessellation;
     }
@@ -269,6 +253,10 @@ public:
     // Returns the HgiPrimitiveType for the primitive type.
     HDST_API
     HgiPrimitiveType GetHgiPrimitiveType() const;
+
+    // Resolve the cull mode from the cull style in the render state.
+    HDST_API
+    HgiCullMode ResolveCullMode(HdCullStyle const renderStateCullStyle) const;
 
     // Factory for convenience.
     static HdSt_GeometricShaderSharedPtr Create(

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -642,7 +642,7 @@ HdStRenderPassState::ApplyStateFromGeometricShader(
         HdSt_ResourceBinder const &binder,
         HdSt_GeometricShaderSharedPtr const &geometricShader)
 {
-    _SetGLCullState(geometricShader.ResolveCullMode(_cullStyle));
+    _SetGLCullState(geometricShader->ResolveCullMode(_cullStyle));
     _SetGLPolygonMode(_lineWidth, geometricShader);
 }
 
@@ -1200,7 +1200,7 @@ HdStRenderPassState::_InitRasterizationState(
     }
 
     rasterizationState->cullMode =
-        _ResolveCullMode(_cullStyle, geometricShader);
+        geometricShader->ResolveCullMode(_cullStyle);
 
     if (GetEnableDepthClamp()) {
         rasterizationState->depthClampEnabled = true;

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -548,73 +548,6 @@ HdStRenderPassState::GetShaders() const
 
 namespace {
 
-// Note: The geometric shader may override the state if necessary,
-// including disabling h/w culling altogether.
-// Disabling h/w culling is required to handle instancing wherein
-// instanceScale/instanceTransform can flip the xform handedness.
-HgiCullMode
-_ResolveCullMode(
-        HdCullStyle const rsCullStyle,
-        HdSt_GeometricShaderSharedPtr const &geometricShader)
-{
-    if (!geometricShader->GetUseHardwareFaceCulling()) {
-        // Use fragment shader culling via discard.
-        return HgiCullModeNone;
-    }
-
-
-    // If the Rprim has an opinion, that wins. Else use the render pass.
-    HdCullStyle const gsCullStyle = geometricShader->GetCullStyle();
-    HdCullStyle const resolvedCullStyle =
-        gsCullStyle == HdCullStyleDontCare? rsCullStyle : gsCullStyle;
-    
-    bool const hasMirroredTransform =
-                        geometricShader->GetHasMirroredTransform();
-    bool const doubleSided = geometricShader->GetDoubleSided();
-
-    HgiCullMode resolvedCullMode = HgiCullModeNone;
-
-    switch (resolvedCullStyle) {
-        case HdCullStyleFront:
-            if (hasMirroredTransform) {
-                resolvedCullMode = HgiCullModeBack;
-            } else {
-                resolvedCullMode = HgiCullModeFront;
-            }
-            break;
-        case HdCullStyleFrontUnlessDoubleSided:
-            if (!doubleSided) {
-                if (hasMirroredTransform) {
-                    resolvedCullMode = HgiCullModeBack;
-                } else {
-                    resolvedCullMode = HgiCullModeFront;
-                }
-            }
-            break;
-        case HdCullStyleBack:
-            if (hasMirroredTransform) {
-                resolvedCullMode = HgiCullModeFront;
-            } else {
-                resolvedCullMode = HgiCullModeBack;
-            }
-            break;
-        case HdCullStyleBackUnlessDoubleSided:
-            if (!doubleSided) {
-                if (hasMirroredTransform) {
-                    resolvedCullMode = HgiCullModeFront;
-                } else {
-                    resolvedCullMode = HgiCullModeBack;
-                }
-            }
-            break;
-        case HdCullStyleNothing:
-        default:
-            resolvedCullMode = HgiCullModeNone;
-            break;
-    }
-
-    return resolvedCullMode;
-}
 
 void
 _SetGLCullState(HgiCullMode const resolvedCullMode)
@@ -709,7 +642,7 @@ HdStRenderPassState::ApplyStateFromGeometricShader(
         HdSt_ResourceBinder const &binder,
         HdSt_GeometricShaderSharedPtr const &geometricShader)
 {
-    _SetGLCullState(_ResolveCullMode(_cullStyle, geometricShader));
+    _SetGLCullState(geometricShader.ResolveCullMode(_cullStyle));
     _SetGLPolygonMode(_lineWidth, geometricShader);
 }
 


### PR DESCRIPTION
### Description of Change(s)
The `_ResolveCullMode` method in `hdSt/renderPassState.cpp` requires a number of accessors on the `HdSt_GeometricShader`, specifically:

- `GetCullStyle`
- `GetUseHardwareFaceCulling`
- `GetHasMirroredTransform`
- `GetDoubleSided`
- 
It seems to make more sense to move this function into the geometric shader and remove these accessors entirely.

### Fixes Issue(s)
- General cleanup

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
