### PR TITLE
Using the correct integer compression to get decompression working space size

### DIFF
--- a/pxr/usd/usd/integerCoding.cpp
+++ b/pxr/usd/usd/integerCoding.cpp
@@ -389,9 +389,14 @@ template <class Int>
 size_t _DecompressIntegers(char const *compressed, size_t compressedSize,
                            Int *ints, size_t numInts, char *workingSpace)
 {
+    using Compressor = typename std::conditional<
+            sizeof(Int) == 4,
+            Usd_IntegerCompression,
+            Usd_IntegerCompression64>::type;
+
     // Working space.
     size_t workingSpaceSize =
-        Usd_IntegerCompression::GetDecompressionWorkingSpaceSize(numInts);
+        Compressor::GetDecompressionWorkingSpaceSize(numInts);
     std::unique_ptr<char[]> tmpSpace;
     if (!workingSpace) {
         tmpSpace.reset(new char[workingSpaceSize]);


### PR DESCRIPTION
### Description of Change(s)
There is an issue in `_DecompressIntegers` function regarding dealing with integers bigger than 4 bytes. When dealing with integers bigger than 4 bytes, it is still using `Usd_IntegerCompression::GetDecompressionWorkingSpaceSize` to calculate the output buffer size where it should have used `Usd_IntegerCompression64::GetDecompressionWorkingSpaceSize` instead. 

This is the fix for this issue https://github.com/PixarAnimationStudios/USD/issues/2434

### Fixes Issue(s)
- Fixed an error at https://github.com/PixarAnimationStudios/USD/blob/release/pxr/base/tf/fastCompression.cpp#L116 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
