### PR TITLE
APPLE: Replace bitwise with logical operators

### DIFF
--- a/pxr/usd/usdSkel/animation.cpp
+++ b/pxr/usd/usdSkel/animation.cpp
@@ -282,8 +282,8 @@ UsdSkelAnimation::SetTransforms(const VtMatrix4dArray& xforms,
     VtVec3hArray scales;
     if (UsdSkelDecomposeTransforms(xforms, &translations,
                                    &rotations, &scales)) {
-        return GetTranslationsAttr().Set(translations, time) &
-               GetRotationsAttr().Set(rotations, time) &
+        return GetTranslationsAttr().Set(translations, time) &&
+               GetRotationsAttr().Set(rotations, time) &&
                GetScalesAttr().Set(scales, time);
     }
     return false;


### PR DESCRIPTION
### Description of Change(s)

The predicates of the if statements should use logical rather than bitwise operators.

### Fixes Issue(s)
- Warnings in the build.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
