### PR TITLE
[usdAbc] Reenable USD_ABC_READ_ARCHIVE_USE_MMAP

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -90,7 +90,7 @@ TF_DEFINE_ENV_SETTING(
 
 #if ALEMBIC_LIBRARY_VERSION >= 10709
 TF_DEFINE_ENV_SETTING(
-    USD_ABC_READ_ARCHIVE_USE_MMAP, false,
+    USD_ABC_READ_ARCHIVE_USE_MMAP, true,
     "Use mmap when reading from an Ogawa archive.");
 #endif
 
@@ -915,6 +915,13 @@ _ReaderContext::Open(const std::string& filePath, std::string* errorLog,
     IFactory::CoreType abcType;
     factory.setPolicy(Abc::ErrorHandler::Policy::kQuietNoopPolicy);
     factory.setOgawaNumStreams(_GetNumOgawaStreams());
+
+#if ALEMBIC_LIBRARY_VERSION >= 10709
+    if (!TfGetEnvSetting(USD_ABC_READ_ARCHIVE_USE_MMAP)) {
+        factory.setOgawaReadStrategy(Alembic::AbcCoreFactory::IFactory::kFileStreams);
+    }
+#endif
+
     IArchive archive = factory.getArchive(layeredABC, abcType);
 
 #if PXR_HDF5_SUPPORT_ENABLED && !H5_HAVE_THREADSAFE


### PR DESCRIPTION
With this change a user may set USD_ABC_READ_ARCHIVE_USE_MMAP=0 to disable memory map read support.

### Description of Change(s)

The USD_ABC_READ_ARCHIVE_USE_MMAP TfGetEnvSetting was defined but had no effect when set. Originally intended to allow for the user to choose between pread and mmap, the functionality was lost in commit 5a795b2cb.

We restore that functionality and change USD_ABC_READ_ARCHIVE_USE_MMAP's default from 'false' to 'true' to match the current behavior of Alembic 1.7.9+ and the usdAbc plugin.

### Fixes Issue(s)
- n/a

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
