### PR TITLE
Report the path of the invalid spec (not the inducing spec) in `SdfCopySpec`

### DIFF
--- a/pxr/usd/sdf/copyUtils.cpp
+++ b/pxr/usd/sdf/copyUtils.cpp
@@ -552,7 +552,7 @@ SdfCopySpec(
         const SdfSpecType specType = srcLayer->GetSpecType(toCopy.srcPath);
         if (specType == SdfSpecTypeUnknown) {
             TF_CODING_ERROR("Cannot copy unknown spec at <%s> from layer <%s>",
-                srcPath.GetText(), srcLayer->GetIdentifier().c_str());
+                toCopy.srcPath.GetText(), srcLayer->GetIdentifier().c_str());
             return false;
         }
 


### PR DESCRIPTION
### Description of Change(s)
`SdfCopySpec` iterates over child specs when copying.  If any of those specs is invalid (`GetSpecType() == SdfSpecTypeUnknown`), a coding error is reported.  However, the error message reports the path to the inducing spec (the source path argument to `SdfCopySpec`) as invalid when a child is invalid.

This PR fixes the error message so that the right spec is reported as being invalid.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
