### PR TITLE
APPLE: Fix for missing implicitSurfaceSceneIndexPlugin in Embree

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -30,6 +30,7 @@ pxr_plugin(hdEmbree
 
     PUBLIC_CLASSES
         config
+        implicitSurfaceSceneIndexPlugin
         instancer
         mesh
         meshSamplers


### PR DESCRIPTION
### Description of Change(s)

Embree was reporting the error:

```
Plugin HdEmbree_ImplicitSurfaceSceneIndexPlugin is missing TfType registration
```

Because it wasn't in the CMakeLists.txt

### Fixes Issue(s)
- Embree on usdrecord and usdview

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
