### PR TITLE
Set correct aspect for depth buffers with HgiVulkan

### DIFF
--- a/pxr/imaging/hgiVulkan/texture.cpp
+++ b/pxr/imaging/hgiVulkan/texture.cpp
@@ -464,7 +464,8 @@ HgiVulkanTexture::CopyBufferToTexture(
 
         const HgiMipInfo &mipInfo = mipInfos[mip];
         VkBufferImageCopy bufferCopyRegion = {};
-        bufferCopyRegion.imageSubresource.aspectMask= VK_IMAGE_ASPECT_COLOR_BIT;
+        const bool isDepthBuffer = _descriptor.usage & HgiTextureUsageBitsDepthTarget;
+        bufferCopyRegion.imageSubresource.aspectMask= isDepthBuffer ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
         bufferCopyRegion.imageSubresource.mipLevel = (uint32_t) mip;
         bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
         bufferCopyRegion.imageSubresource.layerCount = _descriptor.layerCount;


### PR DESCRIPTION
### Description of Change(s)
Set the correct region aspect when dealing with depth buffers so that Vulkan copies the data correctly

### Fixes Issue(s)
aovInputTask does not correctly copy depth buffers from hydra delegate when running Hgi Vulkan.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
