### PR TITLE
APPLE: Add clip distance handling on Metal

### DIFF
--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -56,6 +56,7 @@ FORWARD_DECL(void ProcessPointId(int));
 
 void main(void)
 {
+    InitClipPlanes();
     ProcessPrimvarsIn();
 
     MAT4 transform    = ApplyInstanceTransform(HdGet_transform());
@@ -108,6 +109,7 @@ FORWARD_DECL(void ProcessPointId(int));
 
 void main(void)
 {
+    InitClipPlanes();
     MAT4 transform = ApplyInstanceTransform(HdGet_transform());
 
     int pointId = GetPointId();
@@ -181,6 +183,7 @@ FORWARD_DECL(void ProcessPointId(int));
 
 void main(void)
 {
+    InitClipPlanes();
     MAT4 transform = ApplyInstanceTransform(HdGet_transform());
 
     int pointId = GetPointId();
@@ -263,6 +266,7 @@ FORWARD_DECL(void ProcessPointId(int));
 
 void main(void)
 {
+    InitClipPlanes();
     MAT4 transform = ApplyInstanceTransform(HdGet_transform());
 
     int pointId = GetPointId();

--- a/pxr/imaging/hgi/shaderSection.h
+++ b/pxr/imaging/hgi/shaderSection.h
@@ -109,9 +109,9 @@ protected:
 
     HGI_API
     const std::string& _GetDefaultValue() const;
+    const std::string _identifierVar;
 
 private:
-    const std::string _identifierVar;
     const HgiShaderSectionAttributeVector _attributes;
     const std::string _defaultValue;
     const std::string _arraySize;

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -396,6 +396,8 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
             << "#pragma clang diagnostic ignored \"-Wunused-variable\"\n"
             << "#pragma clang diagnostic ignored \"-Wsign-compare\"\n"
             << "using namespace metal;\n";
+    //clip plane default size
+    header << "#define HD_NUM_clipPlanes 1\n";
 
     // Basic types
     header  << "#define double float\n"
@@ -1146,7 +1148,12 @@ HgiMetalShaderStageEntryPoint::_Init(
         /* members = */ stageInputs,
         generator,
         _inputsGenericWrapper);
-
+    
+    for (HgiMetalShaderSection *section : stageOutputs) {
+        if(section->GetIdentifier() == "gl_ClipDistance") {
+            section->writesArrayOutput = true;
+        }
+    }
     _outputs =
         _BuildStructInstance<HgiMetalStageOutputShaderSection>(
         GetOutputTypeName(),

--- a/pxr/imaging/hgiMetal/shaderSection.h
+++ b/pxr/imaging/hgiMetal/shaderSection.h
@@ -43,6 +43,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HgiMetalShaderSection: public HgiShaderSection
 {
 public:
+    
+    HGIMETAL_API
+    explicit HgiMetalShaderSection(
+            const std::string &identifier,
+            const HgiShaderSectionAttributeVector& attributes = {},
+            const std::string &defaultValue = std::string(),
+            const std::string &arraySize = std::string(),
+            const std::string &blockInstanceIdentifier = std::string());
     HGIMETAL_API
     ~HgiMetalShaderSection() override;
 
@@ -73,7 +81,10 @@ public:
     /// either exists
     HGIMETAL_API
     void WriteAttributesWithIndex(std::ostream& ss) const;
-
+    /// Returns the identifier
+    HGIMETAL_API
+    std::string GetIdentifier() const;
+    bool writesArrayOutput;
     using HgiShaderSection::HgiShaderSection;
 };
 


### PR DESCRIPTION
Replacement for an older PR. This one includes more robust support for out handling and initialisation

### Description of Change(s)
- Add clip distance support on Meta
- We always put a stub in for clip plane handling of size 1.
- This is done as having a size of 0 clip planes is hard to handle in the generated code that does not otherwise know if it should be there or not
### Fixes Issue(s)
- Metal respects explicit clip planes

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
