### PR TITLE
Add strict validation mode for AR resource identifier schemes

### DIFF
--- a/pxr/usd/ar/testenv/TestArURIResolver_plugInfo.json
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugInfo.json
@@ -18,7 +18,23 @@
                     },
                     "_TestOtherURIResolver": {
                         "bases": ["_TestURIResolverBase"],
+                        "uriSchemes": ["test-other"]
+                    },
+                    "_TestInvalidUnderbarURIResolver": {
+                        "bases": ["_TestURIResolverBase"],
                         "uriSchemes": ["test_other"]
+                    },
+                    "_TestInvalidColonURIResolver": {
+                        "bases": ["_TestURIResolverBase"],
+                        "uriSchemes": ["other:test"]
+                    },
+                    "_TestInvalidNonAsciiURIResolver": {
+                        "bases": ["_TestURIResolverBase"],
+                        "uriSchemes": ["test-π-utf8"]
+                    },
+                    "_TestInvalidNumericPrefixResolver": {
+                        "bases": ["_TestURIResolverBase"],
+                        "uriSchemes": ["113-test"]
                     }
                 }
             }

--- a/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugin.cpp
@@ -144,13 +144,59 @@ public:
     }
 };
 
-// Test resolver that handles asset paths of the form "test_other://...."
+// Test resolver that handles asset paths of the form "test-other://...."
 class _TestOtherURIResolver
     : public _TestURIResolverBase
 {
 public:
     _TestOtherURIResolver()
+        : _TestURIResolverBase("test-other")
+    {
+    }
+};
+
+// Underbar characters should cause a failure to register under strict mode
+class _TestInvalidUnderbarURIResolver
+    : public _TestURIResolverBase
+{
+public:
+    _TestInvalidUnderbarURIResolver()
         : _TestURIResolverBase("test_other")
+    {
+    }
+};
+
+// A colon in the scheme could cause problems when parsing an asset path.
+// This should cause a failure to register under strict mode.
+class _TestInvalidColonURIResolver
+    : public _TestURIResolverBase
+{
+public:
+    _TestInvalidColonURIResolver()
+        : _TestURIResolverBase("other:test")
+    {
+    }
+};
+
+// UTF-8 characters should cause a failure to register under strict mode
+class _TestInvalidNonAsciiURIResolver
+    : public _TestURIResolverBase
+{
+public:
+    _TestInvalidNonAsciiURIResolver()
+        : _TestURIResolverBase("test-π-utf8")
+    {
+    }
+};
+
+// Schemes starting with numeric characters should cause a failure to
+// register under strict mode
+class _TestInvalidNumericPrefixResolver
+    : public _TestURIResolverBase
+{
+public:
+    _TestInvalidNumericPrefixResolver()
+        : _TestURIResolverBase("113-test")
     {
     }
 };
@@ -165,3 +211,7 @@ TF_REGISTRY_FUNCTION(TfType)
 
 AR_DEFINE_RESOLVER(_TestURIResolver, _TestURIResolverBase);
 AR_DEFINE_RESOLVER(_TestOtherURIResolver, _TestURIResolverBase);
+AR_DEFINE_RESOLVER(_TestInvalidUnderbarURIResolver, _TestURIResolverBase);
+AR_DEFINE_RESOLVER(_TestInvalidColonURIResolver, _TestURIResolverBase);
+AR_DEFINE_RESOLVER(_TestInvalidNonAsciiURIResolver, _TestURIResolverBase);
+AR_DEFINE_RESOLVER(_TestInvalidNumericPrefixResolver, _TestURIResolverBase);

--- a/pxr/usd/ar/testenv/testArURIResolver.py
+++ b/pxr/usd/ar/testenv/testArURIResolver.py
@@ -79,24 +79,46 @@ class TestArURIResolver(unittest.TestCase):
         self.assertEqual(resolver.Resolve("test://foo.package[bar.file]"), 
                          "test://foo.package[bar.file]")
 
-        self.assertEqual(resolver.Resolve("test_other://foo"), 
-                         "test_other://foo")
+        self.assertEqual(resolver.Resolve("test-other://foo"),
+                         "test-other://foo")
         self.assertEqual(
-            resolver.Resolve("test_other://foo.package[bar.file]"), 
-            "test_other://foo.package[bar.file]")
+            resolver.Resolve("test-other://foo.package[bar.file]"),
+            "test-other://foo.package[bar.file]")
 
         # These calls should hit the URI resolver since schemes are
         # case-insensitive.
-        self.assertEqual(resolver.Resolve("TEST://foo"), 
+        self.assertEqual(resolver.Resolve("TEST://foo"),
                          "TEST://foo")
-        self.assertEqual(resolver.Resolve("TEST://foo.package[bar.file]"), 
+        self.assertEqual(resolver.Resolve("TEST://foo.package[bar.file]"),
                          "TEST://foo.package[bar.file]")
 
-        self.assertEqual(resolver.Resolve("TEST_OTHER://foo"), 
-                         "TEST_OTHER://foo")
+        self.assertEqual(resolver.Resolve("TEST-OTHER://foo"),
+                         "TEST-OTHER://foo")
         self.assertEqual(
-            resolver.Resolve("TEST_OTHER://foo.package[bar.file]"), 
-            "TEST_OTHER://foo.package[bar.file]")
+            resolver.Resolve("TEST-OTHER://foo.package[bar.file]"),
+            "TEST-OTHER://foo.package[bar.file]")
+
+    def test_InvalidScheme(self):
+        resolver = Ar.GetResolver()
+        invalid_underbar_path = "test_other:/abc.xyz"
+        invalid_utf8_path = "test-π-utf8:/abc.xyz"
+        invalid_numeric_prefix_path = "113-test:/abc.xyz"
+        invalid_colon_path = "other:test:/abc.xyz"
+        if Tf.GetEnvSetting("PXR_AR_DISABLE_STRICT_SCHEME_VALIDATION"):
+            self.assertEqual(resolver.Resolve(invalid_underbar_path),
+                             invalid_underbar_path)
+            self.assertEqual(resolver.Resolve(invalid_utf8_path),
+                             invalid_utf8_path)
+            self.assertEqual(resolver.Resolve(invalid_numeric_prefix_path),
+                             invalid_numeric_prefix_path)
+            # Even when strict scheme validation mode is disabled
+            # schemes with colons in them may fail to resolve
+            self.assertFalse(resolver.Resolve(invalid_colon_path))
+        else:
+            self.assertFalse(resolver.Resolve(invalid_underbar_path))
+            self.assertFalse(resolver.Resolve(invalid_utf8_path))
+            self.assertFalse(resolver.Resolve(invalid_numeric_prefix_path))
+            self.assertFalse(resolver.Resolve(invalid_colon_path))
 
     def test_ResolveForNewAsset(self):
         resolver = Ar.GetResolver()


### PR DESCRIPTION
### Description of Change(s)
The current implementation of AR resource identifiers (URI/IRI) allows any string to be registered as the scheme component.  The URI/IRI specification restricts the character set of the scheme component to ASCII alphanumeric characters plus `+`, `.`, and `-`.  Consider handling of a scheme which contains `:` as an example of where an unrestricted character set for scheme can go awry.  This change adds validation, warning the user when a scheme is not valid under the specification.  By default, the scheme is ignored, but users can set `PXR_AR_DISABLE_STRICT_SCHEME_VALIDATION` to be more permissive.

Validation could be implemented as a regular expression match, but was done with explicit checks to produce clearer error messages for users.  A note is left to output the invalid characters once #2120 has been accepted.

The `test_output` scheme currently used in some of the testing is an example of an invalid scheme per the URI/IRI specifications.  This scheme has been added to a list of invalid test cases and been replaced with `test-output`.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
