### PR TITLE
geomUtil: use Tf.PreparePythonModule() in __init__.py

### DIFF
--- a/pxr/imaging/geomUtil/__init__.py
+++ b/pxr/imaging/geomUtil/__init__.py
@@ -25,15 +25,6 @@
 Utilities to help image common geometry.
 """
 
-from . import _geomUtil
 from pxr import Tf
-Tf.PrepareModule(_geomUtil, locals())
-del _geomUtil, Tf
-
-try:
-    import __DOC
-    __DOC.Execute(locals())
-    del __DOC
-except Exception:
-    pass
-
+Tf.PreparePythonModule()
+del Tf


### PR DESCRIPTION
### Description of Change(s)

This follows the pattern used by other library Python modules and ensures that the `pxr.GeomUtil` Python module can be imported correctly on all platforms.

In particular, this fixes an issue on Windows where the `pxr.GeomUtil` Python module fails to import:

```
C:\Users\MattJohnson\Developer>python
Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from pxr import GeomUtil
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\USD_dev\lib\python\pxr\GeomUtil\__init__.py", line 28, in <module>
    from . import _geomUtil
ImportError: DLL load failed while importing _geomUtil: The specified module could not be found.
>>>
```

In my case, I wasn't actually trying to use anything out of `GeomUtil` in Python, but because the module is included in the `__all__` list in the top-level `pxr` module's `__init__.py`, you'll see the same failure-to-import when doing `from pxr import *`.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ X ] I have submitted a signed Contributor License Agreement
