### PR TITLE
oneTBB: tbb::atomic to std::atomic in sdf

### DIFF
--- a/pxr/usd/sdf/changeManager.cpp
+++ b/pxr/usd/sdf/changeManager.cpp
@@ -34,7 +34,7 @@
 #include "pxr/base/tf/instantiateSingleton.h"
 #include "pxr/base/tf/stackTrace.h"
 
-#include <tbb/atomic.h>
+#include <atomic>
 
 using std::string;
 using std::vector;
@@ -150,9 +150,9 @@ Sdf_ChangeManager::_ProcessRemoveIfInert(_Data *data)
     TF_VERIFY(data->outermostBlock);
 }
 
-static tbb::atomic<size_t> &
+static std::atomic<size_t> &
 _InitChangeSerialNumber() {
-    static tbb::atomic<size_t> value;
+    static std::atomic<size_t> value;
     value = 1;
     return value;
 }
@@ -191,8 +191,8 @@ Sdf_ChangeManager::_SendNotices(_Data *data)
     }
 
     // Obtain a serial number for this round of change processing.
-    static tbb::atomic<size_t> &changeSerialNumber = _InitChangeSerialNumber();
-    size_t serialNumber = changeSerialNumber.fetch_and_increment();
+    static std::atomic<size_t> &changeSerialNumber = _InitChangeSerialNumber();
+    size_t serialNumber = changeSerialNumber.fetch_add(1);
 
     // Send global notice.
     SdfNotice::LayersDidChange(changes, serialNumber).Send();

--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -214,7 +214,7 @@ SdfLayer::SdfLayer(
     _MarkCurrentStateAsClean();
 }
 
-SdfLayer::~SdfLayer()
+SdfLayer::~SdfLayer() noexcept
 {
     TF_PY_ALLOW_THREADS_IN_SCOPE();
 

--- a/pxr/usd/sdf/layer.h
+++ b/pxr/usd/sdf/layer.h
@@ -98,7 +98,7 @@ class SdfLayer
 public:
     /// Destructor
     SDF_API
-    virtual ~SdfLayer(); 
+    virtual ~SdfLayer() noexcept; // noexcept needed for std::atomic member
 
     /// Noncopyable
     SdfLayer(const SdfLayer&) = delete;

--- a/pxr/usd/sdf/pch.h
+++ b/pxr/usd/sdf/pch.h
@@ -225,7 +225,6 @@
 #include <boost/variant.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>


### PR DESCRIPTION
### Description of Change(s)
Swaps out tbb::atomic with std::atomic.

Split off from #1908

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement