### PR TITLE
oneTBB: tbb::atomic to std::atomic in usdGeom

### DIFF
--- a/pxr/usd/usdGeom/pch.h
+++ b/pxr/usd/usdGeom/pch.h
@@ -181,7 +181,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>


### PR DESCRIPTION
### Description of Change(s)
Swaps out tbb::atomic with std::atomic.

Split off from #1908

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement