### PR TITLE
oneTBB: tbb::atomic to std::atomic in pcp

### DIFF
--- a/pxr/usd/pcp/mapExpression.cpp
+++ b/pxr/usd/pcp/mapExpression.cpp
@@ -238,7 +238,7 @@ PcpMapExpression::_Node::New( _Op op_,
         // Check for existing instance to re-use
         _NodeMap::accessor accessor;
         if (_nodeRegistry->map.insert(accessor, key) ||
-            accessor->second->_refCount.fetch_and_increment() == 0) {
+            accessor->second->_refCount.fetch_add(1) == 0) {
             // Either there was no node in the table, or there was but it had
             // begun dying (another client dropped its refcount to 0).  We have
             // to create a new node in the table.  When the client that is
@@ -388,7 +388,7 @@ intrusive_ptr_add_ref(PcpMapExpression::_Node* p)
 void
 intrusive_ptr_release(PcpMapExpression::_Node* p)
 {
-    if (p->_refCount.fetch_and_decrement() == 1)
+    if (p->_refCount.fetch_sub(1) == 1)
         delete p;
 }
 

--- a/pxr/usd/pcp/mapExpression.h
+++ b/pxr/usd/pcp/mapExpression.h
@@ -30,7 +30,6 @@
 
 #include <boost/intrusive_ptr.hpp>
 
-#include <tbb/atomic.h>
 #include <tbb/spin_mutex.h>
 
 #include <atomic>
@@ -267,7 +266,7 @@ private: // data
         struct _NodeMap;
         static TfStaticData<_NodeMap> _nodeRegistry;
 
-        mutable tbb::atomic<int> _refCount;
+        mutable std::atomic<int> _refCount;
         mutable Value _cachedValue;
         mutable std::set<_Node*> _dependentExpressions;
         Value _valueForVariable;

--- a/pxr/usd/pcp/pch.h
+++ b/pxr/usd/pcp/pch.h
@@ -194,7 +194,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>


### PR DESCRIPTION
### Description of Change(s)
Swaps out tbb::atomic with std::atomic.

Split off from #1908

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement