### PR TITLE
oneTBB: remove tbb atomic includes in precompiled headers

### DIFF
--- a/extras/usd/examples/usdObj/pch.h
+++ b/extras/usd/examples/usdObj/pch.h
@@ -166,7 +166,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/extras/usd/examples/usdSchemaExamples/pch.h
+++ b/extras/usd/examples/usdSchemaExamples/pch.h
@@ -168,7 +168,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/base/plug/pch.h
+++ b/pxr/base/plug/pch.h
@@ -183,7 +183,6 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_vector.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/base/tf/pch.h
+++ b/pxr/base/tf/pch.h
@@ -242,7 +242,6 @@
 #include <boost/variant.hpp>
 #include <boost/variant/get.hpp>
 #include <boost/variant/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/base/trace/pch.h
+++ b/pxr/base/trace/pch.h
@@ -178,7 +178,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/base/vt/pch.h
+++ b/pxr/base/vt/pch.h
@@ -171,7 +171,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/base/work/pch.h
+++ b/pxr/base/work/pch.h
@@ -110,7 +110,6 @@
 #include <boost/type_traits/is_enum.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_vector.h>

--- a/pxr/imaging/garch/pch.h
+++ b/pxr/imaging/garch/pch.h
@@ -145,7 +145,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/glf/pch.h
+++ b/pxr/imaging/glf/pch.h
@@ -199,7 +199,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hd/pch.h
+++ b/pxr/imaging/hd/pch.h
@@ -152,7 +152,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdGp/pch.h
+++ b/pxr/imaging/hdGp/pch.h
@@ -120,7 +120,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/imaging/hdMtlx/pch.h
+++ b/pxr/imaging/hdMtlx/pch.h
@@ -139,7 +139,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdSt/pch.h
+++ b/pxr/imaging/hdSt/pch.h
@@ -170,7 +170,6 @@
 #include <opensubdiv/osd/cpuVertexBuffer.h>
 #include <opensubdiv/osd/mesh.h>
 #include <opensubdiv/version.h>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hdar/pch.h
+++ b/pxr/imaging/hdar/pch.h
@@ -131,7 +131,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/spin_mutex.h>

--- a/pxr/imaging/hdsi/pch.h
+++ b/pxr/imaging/hdsi/pch.h
@@ -119,7 +119,6 @@
 #include <boost/utility/enable_if.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/concurrent_queue.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"

--- a/pxr/imaging/hdx/pch.h
+++ b/pxr/imaging/hdx/pch.h
@@ -152,7 +152,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/hgiMetal/pch.h
+++ b/pxr/imaging/hgiMetal/pch.h
@@ -141,7 +141,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/spin_mutex.h>

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -154,7 +154,6 @@
 #include <embree3/rtcore.h>
 #include <embree3/rtcore_geometry.h>
 #include <embree3/rtcore_ray.h>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/imaging/plugin/hdStorm/pch.h
+++ b/pxr/imaging/plugin/hdStorm/pch.h
@@ -141,7 +141,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/spin_mutex.h>

--- a/pxr/imaging/plugin/hioOiio/pch.h
+++ b/pxr/imaging/plugin/hioOiio/pch.h
@@ -199,7 +199,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/weak_ptr.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/ar/pch.h
+++ b/pxr/usd/ar/pch.h
@@ -166,7 +166,6 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/spin_rw_mutex.h>

--- a/pxr/usd/ndr/pch.h
+++ b/pxr/usd/ndr/pch.h
@@ -198,7 +198,6 @@
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/enumerable_thread_specific.h>

--- a/pxr/usd/plugin/usdAbc/pch.h
+++ b/pxr/usd/plugin/usdAbc/pch.h
@@ -206,7 +206,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/plugin/usdDraco/pch.h
+++ b/pxr/usd/plugin/usdDraco/pch.h
@@ -169,7 +169,6 @@
 #include <draco/compression/encode.h>
 #include <draco/mesh/mesh.h>
 #include <draco/mesh/mesh_misc_functions.h>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usd/pch.h
+++ b/pxr/usd/usd/pch.h
@@ -228,7 +228,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/utility/in_place_factory.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>

--- a/pxr/usd/usdHydra/pch.h
+++ b/pxr/usd/usdHydra/pch.h
@@ -162,7 +162,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdLux/pch.h
+++ b/pxr/usd/usdLux/pch.h
@@ -177,7 +177,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdMedia/pch.h
+++ b/pxr/usd/usdMedia/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdMtlx/pch.h
+++ b/pxr/usd/usdMtlx/pch.h
@@ -193,7 +193,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>

--- a/pxr/usd/usdPhysics/pch.h
+++ b/pxr/usd/usdPhysics/pch.h
@@ -181,7 +181,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdProc/pch.h
+++ b/pxr/usd/usdProc/pch.h
@@ -165,7 +165,6 @@
 #include <boost/variant.hpp>
 #include <boost/vmd/is_empty.hpp>
 #include <boost/vmd/is_tuple.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdRender/pch.h
+++ b/pxr/usd/usdRender/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdRi/pch.h
+++ b/pxr/usd/usdRi/pch.h
@@ -173,7 +173,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdShade/pch.h
+++ b/pxr/usd/usdShade/pch.h
@@ -179,7 +179,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdSkel/pch.h
+++ b/pxr/usd/usdSkel/pch.h
@@ -180,7 +180,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdUI/pch.h
+++ b/pxr/usd/usdUI/pch.h
@@ -168,7 +168,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>

--- a/pxr/usd/usdUtils/pch.h
+++ b/pxr/usd/usdUtils/pch.h
@@ -215,7 +215,6 @@
 #include <boost/unordered_map.hpp>
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <tbb/atomic.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>

--- a/pxr/usd/usdVol/pch.h
+++ b/pxr/usd/usdVol/pch.h
@@ -170,7 +170,6 @@
 #include <boost/utility.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-#include <tbb/atomic.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_set.h>


### PR DESCRIPTION
### Description of Change(s)
Split off from #1908

Requires landing the other pull requests to remove tbb atomic first.

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement