### PR TITLE
oneTBB: change tbb::tbb_thread to std::thread

### DIFF
--- a/pxr/base/tf/testenv/error.cpp
+++ b/pxr/base/tf/testenv/error.cpp
@@ -29,7 +29,7 @@
 
 #include "pxr/base/arch/functionLite.h"
 
-#include <tbb/tbb_thread.h>
+#include <thread>
 
 #define FILENAME   "error.cpp"
 
@@ -195,7 +195,7 @@ Test_TfErrorThreadTransport()
     printf("Creating TfErrorMark\n");
     TfErrorMark m;
     printf("Launching thread\n");
-    tbb::tbb_thread t([&transport]() { _ThreadTask(&transport); });
+    std::thread t([&transport]() { _ThreadTask(&transport); });
     TF_AXIOM(m.IsClean());
     t.join();
     printf("Thread completed, posting error.\n");


### PR DESCRIPTION
### Description of Change(s)
The only place where tbb::thread was still used.

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement