### PR TITLE
oneTBB: change tbb::mutex to std::mutex

### DIFF
--- a/pxr/usd/usd/clipCache.cpp
+++ b/pxr/usd/usd/clipCache.cpp
@@ -218,10 +218,9 @@ Usd_ClipCache::PopulateClipsForPrim(
     const bool primHasClips = !allClips.empty();
     if (primHasClips) {
         TRACE_SCOPE("Usd_ClipCache::PopulateClipsForPrim (primHasClips)");
-        tbb::mutex::scoped_lock lock;
-        if (_concurrentPopulationContext) {
-            lock.acquire(_concurrentPopulationContext->_mutex);
-        }
+        std::unique_lock<std::mutex> lock = (_concurrentPopulationContext) ?
+            std::unique_lock<std::mutex>(_concurrentPopulationContext->_mutex) :
+            std::unique_lock<std::mutex>();
 
         // Find nearest ancestor with clips specified.
         const std::vector<Usd_ClipSetRefPtr>* ancestralClips = nullptr;
@@ -260,10 +259,10 @@ Usd_ClipCache::PopulateClipsForPrim(
 SdfLayerHandleSet
 Usd_ClipCache::GetUsedLayers() const
 {
-    tbb::mutex::scoped_lock lock;
-    if (_concurrentPopulationContext) {
-        lock.acquire(_concurrentPopulationContext->_mutex);
-    }
+    std::unique_lock<std::mutex> lock = (_concurrentPopulationContext) ?
+        std::unique_lock<std::mutex>(_concurrentPopulationContext->_mutex) :
+        std::unique_lock<std::mutex>();
+
     SdfLayerHandleSet layers;
     for (_ClipTable::iterator::value_type const &clipsListIter : _table){
         for (Usd_ClipSetRefPtr const &clipSet : clipsListIter.second){
@@ -342,10 +341,9 @@ const std::vector<Usd_ClipSetRefPtr>&
 Usd_ClipCache::GetClipsForPrim(const SdfPath& path) const
 {
     TRACE_FUNCTION();
-    tbb::mutex::scoped_lock lock;
-    if (_concurrentPopulationContext) {
-        lock.acquire(_concurrentPopulationContext->_mutex);
-    }
+    std::unique_lock<std::mutex> lock = (_concurrentPopulationContext) ?
+        std::unique_lock<std::mutex>(_concurrentPopulationContext->_mutex) :
+        std::unique_lock<std::mutex>();
     return _GetClipsForPrim_NoLock(path);
 }
 

--- a/pxr/usd/usd/clipCache.h
+++ b/pxr/usd/usd/clipCache.h
@@ -30,7 +30,7 @@
 #include "pxr/usd/usd/clipSet.h"
 #include "pxr/usd/sdf/pathTable.h"
 
-#include <tbb/mutex.h>
+#include <mutex>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -61,7 +61,7 @@ public:
         explicit ConcurrentPopulationContext(Usd_ClipCache &cache);
         ~ConcurrentPopulationContext();
         Usd_ClipCache &_cache;
-        tbb::mutex _mutex;
+        std::mutex _mutex;
     };
 
     /// Populate the cache with clips for \p prim. Returns true if clips

--- a/pxr/usd/usd/instanceCache.h
+++ b/pxr/usd/usd/instanceCache.h
@@ -30,7 +30,7 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/tf/hashmap.h"
 
-#include <tbb/mutex.h>
+#include <tbb/spin_mutex.h>
 #include <map>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
### Description of Change(s)
Don't rely on removed `tbb::mutex`.

### Fixes Issue(s)

Part of #1471, adding oneTBB support.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement