### PR TITLE
Nominally reference the IRI specification in documentation

### DIFF
--- a/pxr/usd/ar/overview.dox
+++ b/pxr/usd/ar/overview.dox
@@ -94,15 +94,20 @@ that will search for an asset in a specified list of directories.
 See documentation on ArDefaultResolver for more information on configuring
 this behavior.
 
-\subsection ar_uri_resolvers URI Resolvers
+\subsection ar_uri_resolvers URI/IRI Resolvers
 
-URI resolvers are ArResolver subclasses that are associated with particular
-URI schemes.
+URI/IRI resolvers are ArResolver subclasses that are associated with particular
+resource identifier schemes.
+
+\note IRIs are URIs which support unicode characters in certain components of
+the identifier. All URIs are IRIs, and compliant IRIs can be idempotently
+converted to URIs through percent encoding.
 
 When Ar encounters an asset path or resolved path of the form "<scheme>:...", it
 will check if any ArResolver subclasses have been registered for the scheme. If
 so, it will dispatch the path to that subclass for handling. If not, it will
-dispatch the path to the primary resolver for handling.
+dispatch the path to the primary resolver for handling. Schemes should adhere to
+the URI/IRI specification and are ASCII only.
 
 For example, if there were an HTTPResolver subclass of ArResolver that was
 registered to handle the "http" scheme. If the following was called:
@@ -116,13 +121,13 @@ Ar would inspect the given path, find the "http" scheme and determine that
 HTTPResolver (if one had not already been created), then call
 HTTPResolver::Resolve on that instance with the given path.
 
-To create a URI resolver:
+To create a URI/IRI resolver:
 
 - Implement a subclass of ArResolver as described in the 
   \ref ar_primary_resolver "Primary Resolver" section above.
 
 - In the entry for the subclass in the plugin's plugInfo.json file,
-  add a "uriSchemes" key with a list of URI schemes associated with the
+  add a "uriSchemes" key with a list of schemes associated with the
   resolver.
 \code{.json}
 {
@@ -141,6 +146,16 @@ To create a URI resolver:
     ]
 }
 \endcode
+
+`uriSchemes` may be used to register resolvers which support non-percent
+encoded IRIs. Unicode characters in asset path strings should be UTF-8 encoded.
+
+Resolvers are ultimately responsible for validation, normalization, and parsing
+of asset paths. USD does not attempt to validate or parse resource identifiers
+beyond what's needed for dispatching via 'scheme'. When a resolver is working
+with a protocol that strictly requires percent-encoded URIs, it's acceptable
+for the resolver to accept UTF-8 encoded IRIs and internally handle percent
+encoding.
 
 \section ar_resolution Asset Path Resolution
 
@@ -267,11 +282,11 @@ Ar reserves trailing bracket-enclosed paths as syntax for package-relative
 asset paths. For example, paths like:
 
 - "/foo/baz.usdz[file.usd]"
-- "my_uri://foo/baz.usdz[file.usd]" 
+- "my-uri://foo/baz.usdz[file.usd]" 
 
 will be recognized by Ar as a package-relative asset path and will be split
 so that  ArResolver subclasses will only see the path "/foo/baz.usdz" or 
-"my_uri://foo/baz.usdz". For more details, see 
+"my-uri://foo/baz.usdz". For more details, see 
 \ref Ar_packagePaths "Package Relative Paths"
 
 */

--- a/pxr/usd/ar/resolver.h
+++ b/pxr/usd/ar/resolver.h
@@ -166,7 +166,7 @@ public:
     /// to resolve assets when no other context is explicitly specified.
     ///
     /// The returned ArResolverContext will contain the default context 
-    /// returned by the primary resolver and all URI resolvers.
+    /// returned by the primary resolver and all URI/IRI resolvers.
     AR_API
     ArResolverContext CreateDefaultContext() const;
 
@@ -175,7 +175,8 @@ public:
     /// that asset when no other context is explicitly specified.
     ///
     /// The returned ArResolverContext will contain the default context 
-    /// for \p assetPath returned by the primary resolver and all URI resolvers.
+    /// for \p assetPath returned by the primary resolver and all URI/IRI
+    /// resolvers.
     AR_API
     ArResolverContext CreateDefaultContextForAsset(
         const std::string& assetPath) const;
@@ -194,6 +195,8 @@ public:
     ///
     /// If no resolver is registered for \p uriScheme, returns an empty
     /// ArResolverContext.
+    ///
+    /// \note 'uriScheme' can be used to register IRI resolvers
     AR_API
     ArResolverContext CreateContextFromString(
         const std::string& uriScheme, const std::string& contextStr) const;
@@ -202,25 +205,25 @@ public:
     /// objects created from the given \p contextStrs.
     ///
     /// \p contextStrs is a list of pairs of strings. The first element in the
-    /// pair is the URI scheme for the ArResolver that will be used to create
-    /// the ArResolverContext from the second element in the pair. An empty
-    /// URI scheme indicates the primary resolver.
+    /// pair is the URI/IRI scheme for the ArResolver that will be used to
+    /// create the ArResolverContext from the second element in the pair. An
+    /// empty resource identifier scheme indicates the primary resolver.
     ///
     /// For example:
     ///
     /// \code
     /// ArResolverContext ctx = ArGetResolver().CreateContextFromStrings(
     ///    { {"", "context str 1"}, 
-    ///      {"my_scheme", "context str 2"} });
+    ///      {"my-scheme", "context str 2"} });
     /// \endcode
     /// 
     /// This will use the primary resolver to create an ArResolverContext
     /// using the string "context str 1" and use the resolver registered for
-    /// the "my_scheme" URI scheme to create an ArResolverContext using
+    /// the "my-scheme" URI/IRI scheme to create an ArResolverContext using
     /// "context str 2". These contexts will be combined into a single
     /// ArResolverContext and returned.
     ///
-    /// If no resolver is registered for a URI scheme in an entry in
+    /// If no resolver is registered for a URI/IRI scheme in an entry in
     /// \p contextStrs, that entry will be ignored.
     AR_API
     ArResolverContext CreateContextFromStrings(
@@ -453,9 +456,9 @@ protected:
     /// same asset, so implementations should take care to canonicalize and
     /// normalize the returned identifier to a consistent format.
     ///
-    /// If either \p assetPath or \p anchorAssetPath have a URI scheme, this
-    /// function will be called on the resolver associated with that URI scheme,
-    /// if any.
+    /// If either \p assetPath or \p anchorAssetPath have a URI/IRI scheme,
+    /// this function will be called on the resolver associated with that
+    /// URI/IRI scheme, if any.
     ///
     /// Example uses:
     /// - When opening a layer via SdfLayer::FindOrOpen or Find,
@@ -563,9 +566,9 @@ protected:
     /// to resolve assets when no other context is explicitly specified.
     ///
     /// When CreateDefaultContext is called on the configured asset resolver,
-    /// Ar will call this method on the primary resolver and all URI resolvers
-    /// and merge the results into a single ArResolverContext that will be
-    /// returned to the consumer.
+    /// Ar will call this method on the primary resolver and all URI/IRI
+    /// resolvers and merge the results into a single ArResolverContext that
+    /// will be returned to the consumer.
     ///
     /// This function should not automatically bind this context, but should
     /// create one that may be used later.
@@ -585,16 +588,16 @@ protected:
     /// that asset when no other context is explicitly specified.
     ///
     /// When CreateDefaultContextForAsset is called on the configured asset
-    /// resolver, Ar will call this method on the primary resolver and all URI
-    /// resolvers and merge the results into a single ArResolverContext that
-    /// will be returned to the consumer.
+    /// resolver, Ar will call this method on the primary resolver and all
+    /// URI/IRI resolvers and merge the results into a single ArResolverContext
+    /// that will be returned to the consumer.
     ///
     /// Note that this means this method may be called with asset paths that
     /// are not associated with this resolver. For example, this method may
-    /// be called on a URI resolver with a non-URI asset path. This is to
-    /// support cases where the asset at \p assetPath references other
-    /// assets with URI schemes that differ from the URI scheme (if any)
-    /// in \p assetPath.
+    /// be called on a URI/IRI resolver with a non-URI/IRI asset path. This is
+    /// to support cases where the asset at \p assetPath references other
+    /// assets with URI/IRI schemes that differ from the URI/IRI scheme
+    /// (if any) in \p assetPath.
     ///
     /// This function should not automatically bind this context, but should
     /// create one that may be used later.


### PR DESCRIPTION
### Description of Change(s)
The URI specification nominally referenced throughout the `Ar` documentation restricts the character set to ASCII characters. This update to documentation clarifies that--
* Resolvers registered via `uriSchemes` may also accept UTF-8 encoded IRIs (a unicode supporting resource identifier specification)
* Resolvers working with protocols that only accept URIs may (but are not required to) support IRIs encoded in layers and handle percent encoding idempotently at the resolver level
* USD does not validate URI or IRI paths beyond what's needed to dispatch via a resource identifier's scheme component. Resolvers handle their own parsing, validation, and normalization of asset paths.

This change also converts the invalid `my_scheme` URI/IRI scheme to `my-scheme`.

### Fixes Issue(s)
- #2120 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
