### PR TITLE
usdBakeMtlx, usdrecord: skip building usdImaging tools if GPU and/or OpenGL are unavailable

### DIFF
--- a/pxr/usdImaging/bin/usdBakeMtlx/CMakeLists.txt
+++ b/pxr/usdImaging/bin/usdBakeMtlx/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdBakeMtlx)
 
+# MaterialX's MaterialXRenderGlsl library, which is used by usdBakeMtlx,
+# requires OpenGL.
+if (NOT ${PXR_ENABLE_GL_SUPPORT})
+    message(STATUS
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
+    return()
+endif()
+
 pxr_library(usdBakeMtlx
     LIBRARIES
         tf

--- a/pxr/usdImaging/bin/usdrecord/CMakeLists.txt
+++ b/pxr/usdImaging/bin/usdrecord/CMakeLists.txt
@@ -1,6 +1,14 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdrecord)
 
+# usdrecord has usdAppUtils as a dependency, which is only built when GPU
+# support is enabled.
+if (NOT ${PXR_BUILD_GPU_SUPPORT})
+    message(STATUS
+        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT is OFF")
+    return()
+endif()
+
 pxr_python_bin(usdrecord
     DEPENDENCIES
         usd


### PR DESCRIPTION
This fixes two issues when building USD with `PXR_BUILD_USD_IMAGING` **enabled** but `PXR_ENABLE_GPU_SUPPORT` and/or `PXR_ENABLE_GL_SUPPORT` **disabled**.

The build of `usdAppUtils` is gated on `PXR_BUILD_GPU_SUPPORT` being enabled, but there was no such check for `usdrecord`, so the build would be aborted when CMake goes to build `usdrecord` but discovers the dependency is missing.

The `usdBakeMtlx` change might be slightly more contentious, but in environments where OpenGL is not supported, it's likely that building MaterialX will yield an installation that is missing the `MaterialXRenderGlsl` library. Attempting to then build USD in that environment against such an installation of MaterialX with `PXR_ENABLE_GL_SUPPORT` disabled would be aborted when CMake goes to build `usdBakeMtlx` but discovers the dependency is missing.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
