### PR TITLE
Apple: Mesh shader stage - high level

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -233,6 +233,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (tessEvalShader)                            \
     (postTessControlShader)                     \
     (postTessVertexShader)                      \
+    (meshObjectShader)                          \
+    (meshletShader)                             \
     (tessLevel)                                 \
     (viewport)                                  \
     (vertexShader)                              \

--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -1482,6 +1482,8 @@ HdSt_CodeGen::_GetShaderResourceLayouts(
         HdShaderTokens->fragmentShader,
         HdShaderTokens->postTessControlShader,
         HdShaderTokens->postTessVertexShader,
+        HdShaderTokens->meshObjectShader,
+        HdShaderTokens->meshletShader,
         HdShaderTokens->computeShader,
     };
 

--- a/pxr/imaging/hdSt/codeGen.h
+++ b/pxr/imaging/hdSt/codeGen.h
@@ -127,6 +127,15 @@ public:
         return _ptvsSource;
     }
 
+    /// Return the generated mesh object shader source
+    const std::string &GetMeshObjectShaderSource() const {
+        return _mosSource;
+    }
+
+    const std::string &GetMeshletShaderSource() const {
+        return _msSource;
+    }
+
     /// Return the pointer of metadata to be populated by resource binder.
     HdSt_ResourceBinder::MetaData *GetMetaData() { return &_metaData; }
 
@@ -203,6 +212,8 @@ private:
     std::string _csSource;
     std::string _ptcsSource;
     std::string _ptvsSource;
+    std::string _mosSource;
+    std::string _msSource;
 
     bool _hasVS;
     bool _hasTCS;

--- a/pxr/imaging/hdSt/geometricShader.cpp
+++ b/pxr/imaging/hdSt/geometricShader.cpp
@@ -47,6 +47,7 @@ HdSt_GeometricShader::HdSt_GeometricShader(std::string const &glslfxString,
                                        bool hasMirroredTransform,
                                        bool doubleSided,
                                        bool useMetalTessellation,
+                                       bool useMeshShaders,
                                        HdPolygonMode polygonMode,
                                        bool cullingPass,
                                        FvarPatchType fvarPatchType,
@@ -59,6 +60,7 @@ HdSt_GeometricShader::HdSt_GeometricShader(std::string const &glslfxString,
     , _hasMirroredTransform(hasMirroredTransform)
     , _doubleSided(doubleSided)
     , _useMetalTessellation(useMetalTessellation)
+    , _useMeshShaders(useMeshShaders)
     , _polygonMode(polygonMode)
     , _lineWidth(lineWidth)
     , _frustumCullingPass(cullingPass)
@@ -370,6 +372,7 @@ HdSt_GeometricShader::GetHgiPrimitiveType() const
                 shaderKey.HasMirroredTransform(),
                 shaderKey.IsDoubleSided(),
                 shaderKey.UseMetalTessellation(),
+                shaderKey.UseMeshShaders(),
                 shaderKey.GetPolygonMode(),
                 shaderKey.IsFrustumCullingPass(),
                 shaderKey.GetFvarPatchType(),

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -129,7 +129,7 @@ public:
                primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES ||
                primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES;
     }
-
+    
     static inline bool IsPrimTypeCompute(PrimitiveType primType) {
         return primType == PrimitiveType::PRIM_COMPUTE;
     }
@@ -153,6 +153,7 @@ public:
                        bool hasMirroredTransform,
                        bool doubleSided,
                        bool useMetalTessellation,
+                       bool useMeshShaders,
                        HdPolygonMode polygonMode,
                        bool cullingPass,
                        FvarPatchType fvarPatchType,
@@ -188,6 +189,12 @@ public:
 
     bool GetUseMetalTessellation() const {
         return _useMetalTessellation;
+    }
+    
+    bool GetUseMeshShaders() const {
+        return _useMeshShaders &&
+            (_primType == PrimitiveType::PRIM_MESH_COARSE_TRIANGLES  ||
+            _primType == PrimitiveType::PRIM_MESH_REFINED_TRIANGLES);
     }
 
     float GetLineWidth() const {
@@ -274,6 +281,7 @@ private:
     bool _hasMirroredTransform;
     bool _doubleSided;
     bool _useMetalTessellation;
+    bool _useMeshShaders;
     HdPolygonMode _polygonMode;
     float _lineWidth;
 

--- a/pxr/imaging/hdSt/glslProgram.cpp
+++ b/pxr/imaging/hdSt/glslProgram.cpp
@@ -145,6 +145,10 @@ _GetShaderType(HgiShaderStage stage)
             return "POST_TESS_CONTROL_SHADER";
         case HgiShaderStagePostTessellationVertex:
             return "POST_TESS_VERTEX_SHADER";
+        case HgiShaderStageMeshObject:
+            return "MESH_OBJECT_SHADER";
+        case HgiShaderStageMeshlet:
+            return "MESHLET_SHADER";
         default:
             return nullptr;
     }

--- a/pxr/imaging/hdSt/shaderKey.cpp
+++ b/pxr/imaging/hdSt/shaderKey.cpp
@@ -44,6 +44,8 @@ HdSt_ShaderKey::ComputeHash() const
     TfToken const *VS = GetVS();
     TfToken const *TCS = GetTCS();
     TfToken const *TES = GetTES();
+    TfToken const *MOS = GetMOS();
+    TfToken const *MS = GetMS();
     TfToken const *PTCS = GetPTCS();
     TfToken const *PTVS = GetPTVS();
     TfToken const *GS = GetGS();
@@ -151,6 +153,8 @@ HdSt_ShaderKey::GetGlslfxString() const
     ss << _JoinTokens("tessEvalShader",    GetTES(), &firstStage);
     ss << _JoinTokens("postTessControlShader",  GetPTCS(), &firstStage);
     ss << _JoinTokens("postTessVertexShader",   GetPTVS(), &firstStage);
+    ss << _JoinTokens("meshObjectShader",  GetMOS(), &firstStage);
+    ss << _JoinTokens("meshletShader",   GetMS(), &firstStage);
     ss << _JoinTokens("geometryShader",    GetGS(),  &firstStage);
     ss << _JoinTokens("fragmentShader",    GetFS(),  &firstStage);
     ss << "}}}\n";
@@ -189,6 +193,20 @@ HdSt_ShaderKey::GetPTCS() const
 /*virtual*/
 TfToken const*
 HdSt_ShaderKey::GetPTVS() const
+{
+    return nullptr;
+}
+
+/*virtual*/
+TfToken const*
+HdSt_ShaderKey::GetMOS() const
+{
+    return nullptr;
+}
+
+/*virtual*/
+TfToken const*
+HdSt_ShaderKey::GetMS() const
 {
     return nullptr;
 }

--- a/pxr/imaging/hdSt/shaderKey.h
+++ b/pxr/imaging/hdSt/shaderKey.h
@@ -76,6 +76,10 @@ struct HdSt_ShaderKey {
     HDST_API
     virtual TfToken const *GetPTVS() const;
     HDST_API
+    virtual TfToken const *GetMOS() const;
+    HDST_API
+    virtual TfToken const *GetMS() const;
+    HDST_API
     virtual TfToken const *GetGS() const;
     HDST_API
     virtual TfToken const *GetFS() const;
@@ -104,6 +108,8 @@ struct HdSt_ShaderKey {
     virtual bool IsDoubleSided() const;
     HDST_API
     virtual bool UseMetalTessellation() const;
+    HDST_API
+    virtual bool UseMeshShaders() const {return false;};
     HDST_API
     virtual HdPolygonMode GetPolygonMode() const;
     HDST_API

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -97,6 +97,7 @@ enum HgiDeviceCapabilitiesBits : HgiBits
     HgiDeviceCapabilitiesBitsBasePrimitiveOffset     = 1 << 15,
     HgiDeviceCapabilitiesBitsPrimitiveIdEmulation    = 1 << 16,
     HgiDeviceCapabilitiesBitsIndirectCommandBuffers  = 1 << 17,
+    HgiDeviceCapabilitiesBitsMeshShading             = 1 << 18,
 };
 
 using HgiDeviceCapabilities = HgiBits;
@@ -365,7 +366,9 @@ enum HgiShaderStageBits : HgiBits
     HgiShaderStageGeometry               = 1 << 5,
     HgiShaderStagePostTessellationControl = 1 << 6,
     HgiShaderStagePostTessellationVertex = 1 << 7,
-    HgiShaderStageCustomBitsBegin        = 1 << 8,
+    HgiShaderStageMeshObject             = 1 << 8,
+    HgiShaderStageMeshlet                = 1 << 9,
+    HgiShaderStageCustomBitsBegin        = 1 << 10,
 };
 using HgiShaderStage = HgiBits;
 

--- a/pxr/imaging/hgi/resourceBindings.cpp
+++ b/pxr/imaging/hgi/resourceBindings.cpp
@@ -40,7 +40,8 @@ HgiResourceBindings::GetDescriptor() const
 
 HgiBufferBindDesc::HgiBufferBindDesc()
     : bindingIndex(0)
-    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex)
+    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex |
+                 HgiShaderStageMeshObject | HgiShaderStageMeshlet)
     , writable(false)
 {
 }
@@ -68,7 +69,7 @@ bool operator!=(
 HgiTextureBindDesc::HgiTextureBindDesc()
     : resourceType(HgiBindResourceTypeCombinedSamplerImage)
     , bindingIndex(0)
-    , stageUsage(HgiShaderStageFragment)
+    , stageUsage(HgiShaderStageFragment | HgiShaderStagePostTessellationVertex | HgiShaderStageMeshlet)
     , writable(false)
 {
 }

--- a/pxr/imaging/hgi/shaderFunctionDesc.cpp
+++ b/pxr/imaging/hgi/shaderFunctionDesc.cpp
@@ -394,6 +394,7 @@ HgiShaderFunctionAddConstantParam(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
     
     desc->constantParams.push_back(std::move(paramDesc));
 }
@@ -409,6 +410,7 @@ HgiShaderFunctionAddStageInput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
 
     desc->stageInputs.push_back(std::move(paramDesc));
 }
@@ -419,6 +421,25 @@ HgiShaderFunctionAddStageInput(
         HgiShaderFunctionParamDesc const &paramDesc)
 {
     functionDesc->stageInputs.push_back(paramDesc);
+}
+
+/// Adds a field to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
+    const uint32_t arraySize) {
+    HgiShaderFunctionParamDesc paramDesc;
+    paramDesc.nameInShader = nameInShader;
+    paramDesc.type = type;
+    paramDesc.arraySize = std::to_string(arraySize);
+    if (arraySize < 1) {
+        paramDesc.arraySize = "";
+    }
+    paramDesc.isPointerToValue = false;
+    desc->payloadMembers.push_back(std::move(paramDesc));
 }
 
 void
@@ -432,6 +453,7 @@ HgiShaderFunctionAddGlobalVariable(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.arraySize = arraySize;
+    paramDesc.isPointerToValue = false;
     desc->stageGlobalMembers.push_back(std::move(paramDesc));
 }
 
@@ -446,6 +468,7 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }
@@ -461,6 +484,7 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.location = location;
+    paramDesc.isPointerToValue = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -174,6 +174,7 @@ struct HgiShaderFunctionParamDesc
     HgiStorageType storage;
     std::string role;
     std::string arraySize;
+    bool isPointerToValue = false;
 };
 
 using HgiShaderFunctionParamDescVector =
@@ -324,7 +325,49 @@ bool operator!=(
         const HgiShaderFunctionTessellationDesc& lhs,
         const HgiShaderFunctionTessellationDesc& rhs);
 
-/// \struct HgiShaderFunctionGeometryDesc
+/// \struct HgiShaderFunctionMeshDesc
+///
+/// Describes a mesh shader's function description
+///
+/// <ul>
+/// <li>meshTopology:
+///   The type of topology</li>
+/// <li>maxMeshletVertexCount
+///   Max number of vertices per meshlet in shader</li>
+/// <li>maxPrimitiveCount
+///   Max number of primitives in shader</li>
+/// <li>maxTotalThreadsPerObjectThreadgroup
+///   Max number of threads per object threadgroup</li>
+/// <li>maxTotalThreadsPerMeshletThreadgroup:
+///   Maximum total threads per meshlet threadgroup</li>
+/// <li>maxTotalThreadgroupsPerMeshObject:
+///   Maximum total threadgroups per mesh object shader</li>
+/// <li>maxTotalThreadgroupsPerMeshlet:
+///   Max total threadgroups per meshlet shader</li>
+/// </ul>
+///
+struct HgiShaderFunctionMeshDesc
+{
+    enum class MeshTopology { Point, Line, Triangle, None };
+    MeshTopology meshTopology = MeshTopology::None;
+    uint32_t maxMeshletVertexCount;
+    uint32_t maxPrimitiveCount;
+    uint32_t maxTotalThreadsPerObjectThreadgroup;
+    uint32_t maxTotalThreadsPerMeshletThreadgroup;
+    uint32_t maxTotalThreadgroupsPerMeshObject;
+    uint32_t maxTotalThreadgroupsPerMeshlet;
+};
+
+HGI_API
+bool operator==(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
+HGI_API
+bool operator!=(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
 ///
 /// Describes a geometry function's description
 ///
@@ -448,10 +491,13 @@ struct HgiShaderFunctionDesc
     std::vector<HgiShaderFunctionParamDesc> constantParams;
     std::vector<HgiShaderFunctionParamDesc> stageGlobalMembers;
     std::vector<HgiShaderFunctionParamDesc> stageInputs;
+    std::vector<HgiShaderFunctionParamDesc> stagePayload;
     std::vector<HgiShaderFunctionParamDesc> stageOutputs;
+    std::vector<HgiShaderFunctionParamDesc> payloadMembers;
     std::vector<HgiShaderFunctionParamBlockDesc> stageInputBlocks;
     std::vector<HgiShaderFunctionParamBlockDesc> stageOutputBlocks;
     HgiShaderFunctionComputeDesc computeDescriptor;
+    HgiShaderFunctionMeshDesc meshDescriptor;
     HgiShaderFunctionTessellationDesc tessellationDescriptor;
     HgiShaderFunctionGeometryDesc geometryDescriptor;
     HgiShaderFunctionFragmentDesc fragmentDescriptor;
@@ -513,6 +559,15 @@ HgiShaderFunctionAddBuffer(
     const std::string &type,
     const uint32_t bindIndex,
     HgiBindingType binding,
+    const uint32_t arraySize = 0);
+
+/// Adds a member to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
     const uint32_t arraySize = 0);
 
 /// Adds buffer descriptor to given shader function descriptor.

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -51,7 +51,7 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         options.fastMathEnabled = YES;
 
         if (@available(macOS 10.15, ios 13.0, *)) {
-            options.languageVersion = MTLLanguageVersion2_2;
+            options.languageVersion = MTLLanguageVersion3_0;
         } else {
             options.languageVersion = MTLLanguageVersion2_1;
         }
@@ -65,6 +65,10 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             [hgi->GetPrimaryDevice() newLibraryWithSource:@(shaderCode)
                                                         options:options
                                                         error:&error];
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
+        }
 
         [options release];
         options = nil;
@@ -86,6 +90,12 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             case HgiShaderStagePostTessellationVertex:
                 entryPoint = @"vertexEntryPoint";
                 break;
+            case HgiShaderStageMeshObject:
+                entryPoint = @"meshObjectEntryPoint";
+                break;
+            case HgiShaderStageMeshlet:
+                entryPoint = @"meshletEntryPoint";
+                break;
             case HgiShaderStageTessellationControl:
             case HgiShaderStageTessellationEval:
             case HgiShaderStageGeometry:
@@ -101,6 +111,11 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         }
         else {
             HGIMETAL_DEBUG_LABEL(_shaderId, _descriptor.debugName.c_str());
+        }
+        
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
         }
         
         [library release];

--- a/pxr/imaging/hgiMetal/shaderProgram.h
+++ b/pxr/imaging/hgiMetal/shaderProgram.h
@@ -86,6 +86,16 @@ public:
         return _postTessControlFunction;
     }
 
+    HGIMETAL_API
+            id<MTLFunction> GetMeshObjectFunction() const {
+        return _meshObjectFunction;
+    }
+
+    HGIMETAL_API
+            id<MTLFunction> GetMeshletFunction() const {
+        return _meshletFunction;
+    }
+
 protected:
     friend class HgiMetal;
 
@@ -105,6 +115,8 @@ private:
     id<MTLFunction> _computeFunction;
     id<MTLFunction> _postTessVertexFunction;
     id<MTLFunction> _postTessControlFunction;
+    id<MTLFunction> _meshObjectFunction;
+    id<MTLFunction> _meshletFunction;
 };
 
 

--- a/pxr/imaging/hio/glslfx.h
+++ b/pxr/imaging/hio/glslfx.h
@@ -56,6 +56,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (tessEvalShader)            \
     (postTessControlShader)     \
     (postTessVertexShader)      \
+    (meshObjectShader)          \
+    (meshletShader)             \
     (vertexShader)              \
     (vertexShaderInjection)     \
                                 \


### PR DESCRIPTION
### Description of Change(s)
- Adds a mesh shader stage to HGI and Storm
- Minimal changes that should allow us getting the stage in, with shader generator, binding, codegen, geometric shader and mesh shader itself to follow.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
