### PR TITLE
Fix bug where ResolveParameter doesn't support type conversion

### DIFF
--- a/pxr/imaging/hdSt/materialNetwork.cpp
+++ b/pxr/imaging/hdSt/materialNetwork.cpp
@@ -551,6 +551,12 @@ _ResolveParameter(
         if (value.IsHolding<T>()) {
             return value.UncheckedGet<T>();
         }
+        else if (value.CanCast<T>())
+        {
+            VtValue castResult = value;
+            castResult.Cast<T>();
+            return castResult.UncheckedGet<T>();
+        }
     }
 
     // Then fallback to SdrNode.
@@ -560,6 +566,12 @@ _ResolveParameter(
             const VtValue &value = input->GetDefaultValue();
             if (value.IsHolding<T>()) {
                 return value.UncheckedGet<T>();
+            }
+            else if (value.CanCast<T>())
+            {
+                VtValue castResult = value;
+                castResult.Cast<T>();
+                return castResult.UncheckedGet<T>();
             }
         }
     }


### PR DESCRIPTION
Currently it is required that the type of the value must match the type of the parameter. However sometimes we still want to convert the value. For example, the Wrap parameter of the sampler requires a TfToken type, which can be TfToken(“repeat”), TfToken(“clamp”) and so on. But in the USD file, it is common that we just write a string as the value. When we resolve the parameter, we need to cast from a string to token. This fix enables us to get the value from the usd file for the parameters, by casting to the type of parameter.

### Description of Change(s)

When the type of the node is different from the required type, we try to cast the value of the node to the required type.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
