### PR TITLE
Autodesk: Fix for shader compile error with mx::heighttonormal nodes

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -689,12 +689,12 @@ HdStMaterialXShaderGen<Base>::_EmitConstantsUniformsAndTypeDefs(
     Base::emitLineBreak(mxStage);
     Base::emitTypeDefinitions(mxContext, mxStage);
 
-    // Add all constants
+    // Add all constants and ensure that values are initialized
     const mx::VariableBlock& constants = mxStage.getConstantBlock();
     if (!constants.empty()) {
         emitVariableDeclarations(constants, constQualifier,
                                  mx::Syntax::SEMICOLON,
-                                 mxContext, mxStage, false);
+                                 mxContext, mxStage, true);
         Base::emitLineBreak(mxStage);
     }
 


### PR DESCRIPTION
When we use MaterialX heighttonormal node to convert a height map to normal map, Storm reports a shader error. error C7522: OpenGL requires constants to be initialized

The root cause is that the filter kernels are uninitialized

const float c_box_filter_weights[84];
const float c_gaussian_filter_weights[84];

Also logged as USD github issue https://github.com/PixarAnimationStudios/USD/issues/2281

### Description of Change(s)
Ensure blur filters are initialized correctly by MaterialX glslfx codegen

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/USD/issues/2281

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
