### PR TITLE
APPLE: Keep the color target as an FP16 format in hgiInterop

### DIFF
--- a/pxr/imaging/hgiInterop/metal.mm
+++ b/pxr/imaging/hgiInterop/metal.mm
@@ -549,7 +549,7 @@ HgiInteropMetal::_SetAttachmentSize(int width, int height)
         kCFAllocatorDefault,
         width,
         height,
-        kCVPixelFormatType_32BGRA,
+        kCVPixelFormatType_64RGBAHalf,
         (__bridge CFDictionaryRef)cvBufferProperties,
         &_pixelBuffer);
     
@@ -598,7 +598,7 @@ HgiInteropMetal::_SetAttachmentSize(int width, int height)
         _cvmtlTextureCache,
         _pixelBuffer,
         (__bridge CFDictionaryRef)metalTextureProperties,
-        MTLPixelFormatBGRA8Unorm,
+        MTLPixelFormatRGBA16Float,
         width,
         height,
         0,


### PR DESCRIPTION
### Description of Change(s)

Keep the colour target as an FP16 in HgiInteropMetal, which allows openGL clients to use EDR.  This doesn't change the behaviour in usdview, we'll have to add some changes into the Python code to create the right final target.

### Fixes Issue(s)
- [Allow for 16bit colour targets in Metal->openGL applications](https://github.com/PixarAnimationStudios/USD/issues/2481)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
