### PR TITLE
Autodesk: Fix bug where Creation of HgiGLSampler will always set GL_TEXTURE_MAX_ANISOTROPY_EXT to 16

### DIFF
--- a/pxr/imaging/hgiGL/sampler.cpp
+++ b/pxr/imaging/hgiGL/sampler.cpp
@@ -61,26 +61,34 @@ HgiGLSampler::HgiGLSampler(HgiSamplerDesc const& desc)
         GL_TEXTURE_WRAP_R,
         HgiGLConversions::GetSamplerAddressMode(desc.addressModeW));
 
+    GLenum minFilter =
+        HgiGLConversions::GetMinFilter(desc.minFilter, desc.mipFilter);
     glSamplerParameteri(
         _samplerId,
-        GL_TEXTURE_MIN_FILTER,
-        HgiGLConversions::GetMinFilter(desc.minFilter, desc.mipFilter));
+        GL_TEXTURE_MIN_FILTER, 
+        minFilter);
 
+    GLenum magFilter =
+        HgiGLConversions::GetMagFilter(desc.magFilter);
     glSamplerParameteri(
         _samplerId,
-        GL_TEXTURE_MAG_FILTER,
-        HgiGLConversions::GetMagFilter(desc.magFilter));
+        GL_TEXTURE_MAG_FILTER, 
+        magFilter);
 
     glSamplerParameterfv(
         _samplerId,
         GL_TEXTURE_BORDER_COLOR,
         HgiGLConversions::GetBorderColor(desc.borderColor).GetArray());
 
-    static const float maxAnisotropy = 16.0;
-    glSamplerParameterf(
-        _samplerId,
-        GL_TEXTURE_MAX_ANISOTROPY_EXT,
-        maxAnisotropy);
+    if (minFilter != GL_NEAREST && magFilter != GL_NEAREST)
+    {
+        // If the filter is nearest, we will not set GL_TEXTURE_MAX_ANISOTROPY_EXT.
+        static const float maxAnisotropy = 16.0;
+        glSamplerParameterf(
+            _samplerId,
+            GL_TEXTURE_MAX_ANISOTROPY_EXT,
+            maxAnisotropy);
+    }
 
     glSamplerParameteri(
         _samplerId, 


### PR DESCRIPTION
### Description of Change(s)

HgiGLSampler will always enable ANISOTROPY. But when the filter is nearest, we should disable anisotropy. In this branch we fix this issue. In the constructor of HgiGLSampler, we will check if the minFilter or magFilter is nearest. If yes, we will not set GL_TEXTURE_MAX_ANISOTROPY_EXT. When GL_TEXTURE_MAX_ANISOTROPY_EXT is set, it will ignore the minFilter and magFilter on some platform. This means that we will never create a nearest sampler.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
