### PR TITLE
Autodesk: Add support for input/output qualifiers

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -207,6 +207,7 @@ pxr_library(hdSt
         shaders/visibility.glslfx
         shaders/volume.glslfx
         textures/fallbackBlackDomeLight.png
+        testenv/testHdstQualifiers/testQualifiers.glslfx
 
     DOXYGEN_FILES
         overview.dox
@@ -221,5 +222,26 @@ pxr_build_test(testHdStBasicDrawing
         glf
     CPPFILES
         testenv/testHdStBasicDrawing.cpp
+)
+endif()
+
+if (WIN32 OR APPLE)
+pxr_install_test_dir(
+    SRC testenv/testHdStQualifiers
+    DEST testHdStQualifiers
+)
+
+pxr_build_test(testHdStQualifiers
+    LIBRARIES
+        hdSt
+        hd
+        garch
+        glf
+    CPPFILES
+        testenv/testHdStQualifiers.cpp
+)
+
+pxr_register_test(testHdStQualifiers
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStQualifiers --offscreen --flatQF FlatMember --nopersQF NoPerspectiveMember --centroidQF CentroidMember --sampleQF SampleMember"
 )
 endif()

--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -766,6 +766,7 @@ _ResourceGenerator::_GenerateHgiResources(
                 HgiShaderFunctionParamBlockDesc::Member paramMember;
                 paramMember.name = member.name;
                 paramMember.type = _ConvertBoolType(member.dataType);
+                paramMember.qualifiers = member.qualifiers;
                 paramBlock.members.push_back(paramMember);
             }
             if (element.inOut == InOut::STAGE_IN) {
@@ -1018,8 +1019,20 @@ _ResourceGenerator::_GenerateGLSLResources(
                 }
                 str << element.aggregateName << " {\n";
                 for (auto const & member : element.members) {
-                    str << "    " << member.dataType << " "
-                                        << member.name;
+                    str << "    ";
+                    if (member.qualifiers == _tokens->flat) {
+                        str << "flat ";
+                    }
+                    else if (member.qualifiers == _tokens->noperspective) {
+                        str << "noperspective ";
+                    }
+                    else if (member.qualifiers == _tokens->centroid) {
+                        str << "centroid ";
+                    }
+                    else if (member.qualifiers == _tokens->sample) {
+                        str << "sample ";
+                    }
+                    str << member.dataType << " " << member.name;
                     if (member.arraySize.IsEmpty()) {
                         str << ";\n";
                     } else {

--- a/pxr/imaging/hdSt/resourceLayout.cpp
+++ b/pxr/imaging/hdSt/resourceLayout.cpp
@@ -66,17 +66,23 @@ _GetInputValueVector(InputValue const & input)
 }
 
 // e.g. ["vec4", "Peye"]
+// e.g. ["float", "length", "3"] The member is a float array with 3 elements.
+// e.g. ["vec3", "color", "", "flat"] The member type is vec3, and there is no interpolation across the face.
 MemberVector
 _ParseMembers(InputValueVector const & input, int fromElement)
 {
     MemberVector result;
     for (auto const & inputValue : input) {
         InputValueVector memberInput = _GetInputValueVector(inputValue);
-        if (memberInput.size() != 2 && memberInput.size() != 3) continue;
+        if (memberInput.size() != 2 && memberInput.size() != 3 && memberInput.size() != 4) continue;
         result.emplace_back(/*dataType=*/_Token(memberInput[0]),
                             /*name=*/_Token(memberInput[1]));
-        if (input.size() == 3) {
-            result.back().arraySize = _Token(input[2]);
+        if (memberInput.size() == 3) {
+            result.back().arraySize = _Token(memberInput[2]);
+        }
+        // The support for member qualifiers.
+        if (memberInput.size() == 4) {
+            result.back().qualifiers = _Token(memberInput[3]);
         }
     }
     return result;

--- a/pxr/imaging/hdSt/resourceLayout.h
+++ b/pxr/imaging/hdSt/resourceLayout.h
@@ -107,7 +107,8 @@ public:
     struct Member {
         Member(TfToken const & dataType,
                TfToken const & name,
-               TfToken const & arraySize = TfToken())
+               TfToken const & arraySize = TfToken(),
+               TfToken qualifiers = TfToken())
             : dataType(dataType)
             , name(name)
             , arraySize(arraySize)
@@ -115,6 +116,7 @@ public:
         TfToken dataType;
         TfToken name;
         TfToken arraySize;
+        TfToken qualifiers;
     };
     using MemberVector = std::vector<Member>;
 

--- a/pxr/imaging/hdSt/testenv/testHdstQualifiers.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdstQualifiers.cpp
@@ -1,0 +1,405 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include <algorithm>
+#include <iostream>
+#include <unordered_set>
+
+#include "pxr/imaging/hdst/codeGen.h"
+#include "pxr/imaging/hdst/glslProgram.h"
+#include "pxr/imaging/hdst/shaderKey.h"
+#include "pxr/imaging/hdst/tokens.h"
+#include "pxr/imaging/hdSt/unitTestGLDrawing.h"
+#include "pxr/imaging/hdSt/unitTestHelper.h"
+#include "pxr/imaging/hgi/hgi.h"
+
+#include "pxr/base/plug/plugin.h"
+#include "pxr/base/plug/registry.h"
+#include "pxr/base/tf/envSetting.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TF_DEFINE_ENV_SETTING(HGI_ENABLE_VULKAN, 0,
+    "Enable Vulkan as platform default Hgi backend (WIP)");
+
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+    ((baseGLSLFX, "../testenv/testHdstQualifiers/testQualifiers.glslfx"))
+
+    ((qualifiersVertex, "Qualifiers.Vertex"))
+    ((qualifiersFragment, "Qualifiers.Fragment"))
+);
+
+// The shaderKey for testQualifiers.glslfx.
+struct HdSt_TestQualifiersShaderKey : public HdSt_ShaderKey
+{
+    HdSt_TestQualifiersShaderKey()
+    {
+        VS[0] = _tokens->qualifiersVertex;
+        VS[1] = TfToken();
+        FS[0] = _tokens->qualifiersFragment;
+        FS[1] = TfToken();
+    }
+    ~HdSt_TestQualifiersShaderKey() = default;
+
+    TfToken const& GetGlslfxFilename() const override { return _tokens->baseGLSLFX; }
+    TfToken const* GetVS() const override { return VS; }
+    TfToken const* GetFS() const override { return FS; }
+    HdSt_GeometricShader::PrimitiveType GetPrimitiveType() const override {
+        return HdSt_GeometricShader::PrimitiveType::PRIM_MESH_COARSE_TRIANGLES;
+    }
+
+private:
+    TfToken VS[2];
+    TfToken FS[2];
+};
+
+// Custom CodeGen which can verify if the qualifiers are correctly generated.
+class My_CodeGen : public HdSt_CodeGen
+{
+public:
+    My_CodeGen(HdSt_GeometricShaderPtr const& geometricShader,
+        HdStShaderCodeSharedPtrVector const& shaders,
+        TfToken const& materialTag) 
+        : HdSt_CodeGen(geometricShader, shaders, materialTag)
+    {}
+
+    ~My_CodeGen() = default;
+
+    bool VerifyQualifiers(TfToken const& shaderStage, std::string const& member,
+        std::string const& qualifier, bool qualifierBeforeMember, int offsetOfQualifier)
+    {
+        // Get the shader source.
+        std::string shaderSource;
+        if (shaderStage == HdShaderTokens->vertexShader)
+        {
+            shaderSource = GetVertexShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->fragmentShader)
+        {
+            shaderSource = GetFragmentShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->tessControlShader)
+        {
+            shaderSource = GetTessControlShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->tessEvalShader)
+        {
+            shaderSource = GetTessEvalShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->geometryShader)
+        {
+            shaderSource = GetGeometryShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->computeShader)
+        {
+            shaderSource = GetComputeShaderSource();
+        }
+        else if (shaderStage == HdShaderTokens->postTessControlShader)
+        {
+            shaderSource = GetPostTessControlShaderSource();
+        }
+
+        // Find the member that should have qualifiers.
+        size_t index = shaderSource.find(member, 0);
+        if (index < qualifier.length() + 1)
+            return false;
+        else
+        {
+            if (qualifierBeforeMember)
+            {
+                // Check if the correct qualifier is before the member.
+                // In GLSL, the syntax for a qualifier is like "flat float dataFlat,".
+                // So the position for the qualifier is the start of the member type 
+                // minus the length of the qualifier and offset. Here, offsetQualifer 
+                // should be -1 for the space before the member.
+                // First find the index of the start of member type.
+                index = shaderSource.find_last_not_of(' ', index - 1);
+                index = shaderSource.find_last_of(' ', index) + 1;
+                if (shaderSource.compare(index - qualifier.length() + offsetOfQualifier,
+                    qualifier.length(), qualifier) == 0)
+                    return true;
+                else
+                    return false;
+            }
+            else
+            {
+                // Check if the correct qualifier is after the member.
+                // In MSL, the syntax for a qualifier is like "float dataFlat [[flat]];".
+                // So the position for the qualifier is the start of the member plus the
+                // length of the member and offset. Here, offsetQualifer should be 3 for
+                // " [[" after the member.
+                if (shaderSource.compare(index + member.length() + offsetOfQualifier,
+                    qualifier.length(), qualifier) == 0)
+                    return true;
+                else
+                    return false;
+            }
+        }
+    }
+};
+
+// Custom Drawing class.
+class My_TestGLDrawing : public HdSt_UnitTestGLDrawing {
+public:
+    My_TestGLDrawing() : _testResult(false) {}
+
+    // HdSt_UnitTestGLDrawing overrides
+    void InitTest() override;
+    void DrawTest() override;
+    void OffscreenTest() override;
+    void Present(uint32_t framebuffer) override;
+
+    bool TestResult() const { return _testResult; }
+
+    struct MemberWithQualifiers
+    {
+        std::string _memberName;
+        std::string _qualifiers;
+    };
+
+protected:
+    void ParseArgs(int argc, char* argv[]) override;
+
+private:
+    bool _testResult;
+    HdSt_TestDriver* _driver;
+    std::string _outputFilePath;
+    std::vector<MemberWithQualifiers> _testMembers;
+};
+
+////////////////////////////////////////////////////////////
+
+void
+My_TestGLDrawing::InitTest()
+{
+    std::cout << "My_TestGLDrawing::InitTest() " << "\n";
+
+    _driver = new HdSt_TestDriver();
+    GfVec3f center(0);
+
+    // center camera
+    SetCameraTranslate(GetCameraTranslate() - center);
+
+    _driver->SetClearColor(GfVec4f(0.1f, 0.1f, 0.1f, 1.0f));
+    _driver->SetClearDepth(1.0f);
+    _driver->SetupAovs(GetWidth(), GetHeight());
+}
+
+// Get the language specified qualifier string.
+std::string _GetInterpolationString(const TfToken& API, const std::string& qualifiers)
+{
+    if (API == HgiTokens->OpenGL)
+    {
+        return qualifiers;
+    }
+    else if (API == HgiTokens->Metal)
+    {
+        if (qualifiers == "flat") {
+            return qualifiers;
+        }
+        else if (qualifiers == "noperspective") {
+            return "center_no_perspective";
+        }
+        else if (qualifiers == "centroid") {
+            return "centroid_perspective";
+        }
+        else if (qualifiers == "sample") {
+            return "sample_perspective";
+        }
+        else {
+            return "";
+        }
+    }
+    else {
+        return "";
+    }
+}
+
+
+void
+My_TestGLDrawing::DrawTest()
+{
+    HdRenderIndex& renderIndex = _driver->GetDelegate().GetRenderIndex();
+    HdStResourceRegistrySharedPtr const& registryPtr =
+        std::static_pointer_cast<HdStResourceRegistry>(renderIndex.GetResourceRegistry());
+
+    HdSt_TestQualifiersShaderKey shaderKey;
+    HdStShaderCodeSharedPtrVector shaders;
+
+    // Create the geometric shader.
+    HdInstance<HdSt_GeometricShaderSharedPtr> geometricShaderInstance =
+        registryPtr->RegisterGeometricShader(shaderKey.ComputeHash());
+
+    if (geometricShaderInstance.IsFirstInstance()) {
+        geometricShaderInstance.SetValue(
+            std::make_shared<HdSt_GeometricShader>(
+                shaderKey.GetGlslfxString(),
+                shaderKey.GetPrimitiveType(),
+                shaderKey.GetCullStyle(),
+                shaderKey.UseHardwareFaceCulling(),
+                shaderKey.HasMirroredTransform(),
+                shaderKey.IsDoubleSided(),
+                shaderKey.UseMetalTessellation(),
+                shaderKey.GetPolygonMode(),
+                shaderKey.IsFrustumCullingPass(),
+                shaderKey.GetFvarPatchType(),
+                /*debugId=*/SdfPath(),
+                shaderKey.GetLineWidth()));
+    }
+    HdSt_GeometricShaderSharedPtr geometricShader = geometricShaderInstance.GetValue();
+
+    // Initialize the codeGen.
+    My_CodeGen codeGen(geometricShader, shaders, HdStMaterialTagTokens->defaultMaterialTag);
+
+    // Resolve bindings.
+    HdSt_ResourceBinder::MetaData::DrawingCoordBufferBinding _drawingCoordBufferBinding;
+    HdStBindingRequestVector customBindings;
+    HdRprimSharedData sharedData(1);
+    std::unique_ptr<HdStDrawItem> drawItem =
+        std::make_unique<HdStDrawItem>(&sharedData);
+    HdSt_ResourceBinder resourceBinder;
+    // let resourcebinder resolve bindings and populate metadata
+    // which is owned by codegen.
+    resourceBinder.ResolveBindings(drawItem.get(),
+        shaders,
+        codeGen.GetMetaData(),
+        _drawingCoordBufferBinding,
+        false,
+        customBindings,
+        registryPtr->GetHgi()->GetCapabilities());
+
+    // Compile the program.
+    HdStGLSLProgramSharedPtr glslProgram = codeGen.Compile(registryPtr.get());
+
+    // If we fail to compile or link the program, return failure.
+    if (!glslProgram || !glslProgram->Link()) {
+        // Failed to compile and link a valid glsl program.
+        return;
+    }
+
+    Hgi* hgi = registryPtr->GetHgi();
+    bool qualifierBeforeMember = true;
+    int offset = 0;
+    // In GLSL, the syntax for a qualifier is like "flat float dataFlat,". So qualifier is before
+    // the member and the extra offset is 1 for the white space.
+    if (hgi->GetAPIName() == HgiTokens->OpenGL)
+        offset = -1;
+    // In MSL, the syntax for a qualifier is like "float dataFlat [[flat]];". So qualifier is after
+    // the member and the extra offset is 3 for " [[".
+    else if (hgi->GetAPIName() == HgiTokens->Metal)
+    {
+        qualifierBeforeMember = false;
+        offset = 3;
+    }
+
+    // Verify if the qualifiers are correctly added before the member.
+    for (auto member : _testMembers)
+    {
+        if (!codeGen.VerifyQualifiers(HdShaderTokens->vertexShader, member._memberName, 
+            _GetInterpolationString(hgi->GetAPIName(), member._qualifiers),
+            qualifierBeforeMember, offset))
+            return;
+        if (!codeGen.VerifyQualifiers(HdShaderTokens->fragmentShader, member._memberName, 
+            _GetInterpolationString(hgi->GetAPIName(), member._qualifiers),
+            qualifierBeforeMember, offset))
+            return;
+    }
+
+    _driver->Draw();
+    _testResult = true;
+}
+
+void
+My_TestGLDrawing::OffscreenTest()
+{
+    DrawTest();
+
+    if (!_outputFilePath.empty()) {
+        _driver->WriteToFile("color", _outputFilePath);
+    }
+}
+
+void
+My_TestGLDrawing::Present(uint32_t framebuffer)
+{
+    _driver->Present(GetWidth(), GetHeight(), framebuffer);
+}
+
+/* virtual */
+void
+My_TestGLDrawing::ParseArgs(int argc, char* argv[])
+{
+    for (int i = 0; i < argc; ++i) {
+        std::string arg(argv[i]);
+        if (arg == "--write") {
+            _outputFilePath = argv[++i];
+        }
+        else if (arg == "--flatQF") {
+            MemberWithQualifiers member;
+            member._memberName = argv[++i];
+            member._qualifiers = "flat";
+            _testMembers.emplace_back(member);
+        }
+        else if (arg == "--nopersQF") {
+            MemberWithQualifiers member;
+            member._memberName = argv[++i];
+            member._qualifiers = "noperspective";
+            _testMembers.emplace_back(member);
+        }
+        else if (arg == "--centroidQF") {
+            MemberWithQualifiers member;
+            member._memberName = argv[++i];
+            member._qualifiers = "centroid";
+            _testMembers.emplace_back(member);
+        }
+        else if (arg == "--sampleQF") {
+            MemberWithQualifiers member;
+            member._memberName = argv[++i];
+            member._qualifiers = "sample";
+            _testMembers.emplace_back(member);
+        }
+    }
+}
+
+bool BasicTest(int argc, char* argv[])
+{
+    My_TestGLDrawing driver;
+    driver.RunTest(argc, argv);
+    return driver.TestResult();
+}
+
+
+int main(int argc, char* argv[])
+{
+    if (BasicTest(argc, argv))
+    {
+        std::cout << "OK" << std::endl;
+            return EXIT_SUCCESS;
+    }
+    else
+    {
+        std::cout << "FAILED" << std::endl;
+            return EXIT_FAILURE;
+    }
+}

--- a/pxr/imaging/hdSt/testenv/testHdstQualifiers/testQualifiers.glslfx
+++ b/pxr/imaging/hdSt/testenv/testHdstQualifiers/testQualifiers.glslfx
@@ -1,0 +1,73 @@
+-- glslfx version 0.1
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+--- --------------------------------------------------------------------------
+-- layout Qualifiers.Vertex
+
+[
+    ["out block", "VertexData", "outData",
+        ["float", "NormalMember"],
+        ["float", "FlatMember", "", "flat"],
+        ["float", "NoPerspectiveMember", "", "noperspective"],
+        ["float", "CentroidMember", "", "centroid"],
+        ["float", "SampleMember", "", "sample"]
+    ]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Qualifiers.Vertex
+
+void main(void)
+{
+    gl_Position = vec4(1.0, 1.0, 1.0, 1.0);
+    outData.NormalMember = 1.0;
+    outData.FlatMember = 1.0;
+    outData.NoPerspectiveMember = 1.0;
+    outData.CentroidMember = 1.0;
+    outData.SampleMember = 1.0;
+}
+
+--- --------------------------------------------------------------------------
+-- layout Qualifiers.Fragment
+
+[
+    ["in block", "VertexData", "inData",
+        ["float", "NormalMember"],
+        ["float", "FlatMember", "", "flat"],
+        ["float", "NoPerspectiveMember", "", "noperspective"],
+        ["float", "CentroidMember", "", "centroid"],
+        ["float", "SampleMember", "", "sample"]
+    ],
+    ["out", "vec4", "colorOut"]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Qualifiers.Fragment
+
+void main(void)
+{
+    colorOut = vec4(inData.NormalMember + inData.FlatMember,
+        inData.NoPerspectiveMember, inData.CentroidMember, inData.SampleMember);
+}

--- a/pxr/imaging/hdSt/unitTestHelper.h
+++ b/pxr/imaging/hdSt/unitTestHelper.h
@@ -58,9 +58,10 @@
 #include <memory>
 #include <vector>
 
-class HdSt_ResourceBinder;
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+class HdSt_ResourceBinder;
 
 using HgiUniquePtr = std::unique_ptr<class Hgi>;
 
@@ -502,19 +503,24 @@ HdSt_TestDriverBase<SceneDelegate>::Present(
 class HdSt_DrawTask final : public HdTask
 {
 public:
+    HDST_API
     HdSt_DrawTask(HdRenderPassSharedPtr const &renderPass,
                   HdStRenderPassStateSharedPtr const &renderPassState,
                   const TfTokenVector &renderTags);
     
+    HDST_API
     void Sync(HdSceneDelegate*,
               HdTaskContext*,
               HdDirtyBits*) override;
 
+    HDST_API
     void Prepare(HdTaskContext* ctx,
                  HdRenderIndex* renderIndex) override;
 
+    HDST_API
     void Execute(HdTaskContext* ctx) override;
 
+    HDST_API
     const TfTokenVector &GetRenderTags() const override
     {
         return _renderTags;
@@ -539,20 +545,27 @@ private:
 class HdSt_TestDriver final : public HdSt_TestDriverBase<HdUnitTestDelegate>
 {
 public:
+    HDST_API
     HdSt_TestDriver();
+    HDST_API
     HdSt_TestDriver(TfToken const &reprName);
+    HDST_API
     HdSt_TestDriver(HdReprSelector const &reprSelector);
 
     /// Draw
+    HDST_API
     void Draw(bool withGuides=false);
 
     /// Draw with external renderPass
+    HDST_API
     void Draw(HdRenderPassSharedPtr const &renderPass, bool withGuides);
 
+    HDST_API
     const HdStRenderPassStateSharedPtr &GetRenderPassState() const {
         return _renderPassStates[0];
     }
 
+    HDST_API
     const HdRenderPassSharedPtr &GetRenderPass();
 
 private:
@@ -617,16 +630,21 @@ private:
 class HdSt_TextureTestDriver
 {
 public:
+    HDST_API
     HdSt_TextureTestDriver();
+    HDST_API
     ~HdSt_TextureTestDriver();
 
-    void Draw(HgiTextureHandle const &colorDst, 
+    HDST_API
+    void Draw(HgiTextureHandle const &colorDst,
               HgiTextureHandle const &inputTexture,
               HgiSamplerHandle const &inputSampler);
 
-    bool WriteToFile(HgiTextureHandle const &dstTexture, 
+    HDST_API
+    bool WriteToFile(HgiTextureHandle const &dstTexture,
                      std::string filename) const;
 
+    HDST_API
     Hgi * GetHgi() { return _hgi.get(); }
 
 private:

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -215,6 +215,7 @@ struct HgiShaderFunctionParamBlockDesc
     struct Member {
         std::string name;
         std::string type;
+        std::string qualifiers;
     };
     using MemberVector = std::vector<Member>;
 

--- a/pxr/imaging/hgiMetal/shaderSection.h
+++ b/pxr/imaging/hgiMetal/shaderSection.h
@@ -121,6 +121,7 @@ public:
     HgiMetalMemberShaderSection(
         const std::string &identifier,
         const std::string &type,
+        const std::string &qualifiers,
         const HgiShaderSectionAttributeVector &attributes = {},
         const std::string arraySize = std::string(),
         const std::string &blockInstanceIdentifier = std::string());
@@ -130,12 +131,15 @@ public:
 
     HGIMETAL_API
     void WriteType(std::ostream &ss) const override;
+    HGIMETAL_API
+    void WriteParameter(std::ostream& ss) const override;
 
     HGIMETAL_API
     bool VisitScopeMemberDeclarations(std::ostream &ss) override;
 
 private:
     const std::string _type;
+    const std::string _qualifiers;
 };
 
 /// \class HgiMetalSamplerShaderSection

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -104,13 +104,14 @@ HgiMetalShaderSection::WriteAttributesWithIndex(std::ostream& ss) const
 HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
     const std::string &identifier,
     const std::string &type,
+    const std::string &qualifiers,
     const HgiShaderSectionAttributeVector &attributes,
     const std::string arraySize,
     const std::string &blockInstanceIdentifier)
   : HgiMetalShaderSection(identifier, attributes,
                           std::string(), arraySize,
                           blockInstanceIdentifier)
-  , _type{type}
+    , _type{ type }, _qualifiers{qualifiers}
 {
 }
 
@@ -120,6 +121,19 @@ void
 HgiMetalMemberShaderSection::WriteType(std::ostream &ss) const
 {
     ss << _type;
+}
+
+void
+HgiMetalMemberShaderSection::WriteParameter(std::ostream& ss) const
+{
+    WriteType(ss);
+    ss << " ";
+    WriteIdentifier(ss);
+    // Write the qualifiers, such as "flat" and "center_no_perspective".
+    if (!_qualifiers.empty())
+    {
+        ss << " [[" << _qualifiers << "]]";
+    }
 }
 
 bool


### PR DESCRIPTION
### Description of Change(s)

Summary: Add support for input/output qualifiers for input/output layout. "flat", "noperspective", "centroid" and "sample" are supported.

Currently USD doesn’t support interpolation qualifiers in the shader input/output layout. USD uses the “layout” structure as the shader input/output, which can be parsed into platform-dependent code. One example is:
```
-- layout Curves.Vertex.Patch

[
    ["out block", "CurveVertexData", "outData",
        ["vec4", "Peye"],                                                          
        ["vec3", "Neye"]
    ]
]
```
But you can not add “flat” qualifier to the member. The HdSt_ResourceLayout class can not identify it. This will block any feature that requires flat interpolation. 
This code change adds interpolation support to the layout. It can be correctly translated to GLSL or MSL. The layout will be like this:
```
-- layout Curves.Vertex.Patch

[
    ["out block", "CurveVertexData", "outData",
        ["vec4", "Peye"],                                                          
        ["vec3", "Neye"]
        ["float", "flatData", "", "flat"] // The third string is already defined by pixar as array size.
    ]
]
```

Currently we support “flat”, “noperspective”, “centroid”, and “sample” interpolation, as these are the interpolations that are supported in global value.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
