### PR TITLE
Replace `boost::lexical_cast` with `pxr/base/tf/stringUtils.h` in `UsdStageCache`

### DIFF
--- a/pxr/usd/usd/stageCache.h
+++ b/pxr/usd/usd/stageCache.h
@@ -28,8 +28,7 @@
 #include "pxr/usd/usd/api.h"
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/base/tf/declarePtrs.h"
-
-#include <boost/lexical_cast.hpp>
+#include "pxr/base/tf/stringUtils.h"
 
 #include <string>
 #include <memory>
@@ -107,7 +106,15 @@ public:
         /// Create an Id from a string value.  The supplied \p val must have
         /// been obtained by calling ToString() previously.
         static Id FromString(const std::string &s) {
-            return FromLongInt(boost::lexical_cast<long int>(s));
+            bool overflow = false;
+            const long int result = TfStringToLong(s, &overflow);
+            if (overflow) {
+                TF_CODING_ERROR(
+                    "'%s' overflowed during conversion to int64_t.",
+                    s.c_str()
+                );
+            }
+            return FromLongInt(result);
         }
 
         /// Convert this Id to an integral representation.
@@ -115,7 +122,7 @@ public:
 
         /// Convert this Id to a string representation.
         std::string ToString() const {
-            return boost::lexical_cast<std::string>(ToLongInt());
+            return TfStringify(ToLongInt());
         }
 
         /// Return true if this Id is valid.


### PR DESCRIPTION
### Description of Change(s)
To reduce the dependency on boost, replace usage of `boost::lexical_cast` with `TfStringify` and `TfStringToLong`.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
