### PR TITLE
Improve UsdLux->Sdr translation

### DIFF
--- a/pxr/usd/usd/usdGenSchema.py
+++ b/pxr/usd/usd/usdGenSchema.py
@@ -1643,7 +1643,7 @@ def GenerateRegistry(codeGenPath, filePath, classes, validate, env):
             #   'specifier' - This is a required field and will always exist.
             # Any other metadata is an error.
             allowedAPIMetadata = [
-                'specifier', 'customData', 'documentation']
+                'specifier', 'customData', 'documentation', 'propertyOrder']
             # Single apply API schemas are also allowed to specify 'apiSchemas'
             # metadata to include other API schemas.
             if apiSchemaType == SINGLE_APPLY or apiSchemaType == MULTIPLE_APPLY:

--- a/pxr/usd/usdLux/generatedSchema.usda
+++ b/pxr/usd/usdLux/generatedSchema.usda
@@ -34,6 +34,7 @@ class "LightAPI" (
     """
 )
 {
+    reorder properties = ["inputs:intensity", "inputs:exposure", "inputs:diffuse", "inputs:specular", "inputs:normalize", "inputs:color", "inputs:enableColorTemperature", "inputs:colorTemperature"]
     uniform bool collection:lightLink:includeRoot = 1
     uniform bool collection:shadowLink:includeRoot = 1
     color3f inputs:color = (1, 1, 1) (
@@ -360,6 +361,7 @@ class "ShapingAPI" (
     doc = "Controls for shaping a light's emission."
 )
 {
+    reorder properties = ["inputs:shaping:focus", "inputs:shaping:focusTint", "inputs:shaping:cone:angle", "inputs:shaping:cone:softness", "inputs:shaping:ies:file", "inputs:shaping:ies:angleScale", "inputs:shaping:ies:normalize"]
     float inputs:shaping:cone:angle = 90 (
         displayGroup = "Shaping"
         displayName = "Cone Angle"
@@ -412,6 +414,7 @@ class "ShadowAPI" (
     non-physical controls that are valuable for visual lighting work."""
 )
 {
+    reorder properties = ["inputs:shadow:enable", "inputs:shadow:color", "inputs:shadow:distance", "inputs:shadow:falloff", "inputs:shadow:falloffGamma"]
     color3f inputs:shadow:color = (0, 0, 0) (
         displayGroup = "Shadows"
         displayName = "Shadow Color"
@@ -691,6 +694,7 @@ class DistantLight "DistantLight" (
     Also known as a directional light."""
 )
 {
+    reorder properties = ["inputs:angle", "inputs:intensity"]
     float inputs:angle = 0.53 (
         displayGroup = "Basic"
         displayName = "Angle Extent"
@@ -855,6 +859,7 @@ class RectLight "RectLight" (
     max coordinates at (-X, -Y)."""
 )
 {
+    reorder properties = ["inputs:width", "inputs:height", "inputs:texture:file"]
     float3[] extent (
         doc = """Extent is a three dimensional range measuring the geometric
         extent of the authored gprim in its own local space (i.e. its own
@@ -1046,6 +1051,7 @@ class CylinderLight "CylinderLight" (
     """
 )
 {
+    reorder properties = ["inputs:length", "inputs:radius"]
     float3[] extent (
         doc = """Extent is a three dimensional range measuring the geometric
         extent of the authored gprim in its own local space (i.e. its own
@@ -1234,6 +1240,7 @@ class DomeLight "DomeLight" (
 """
 )
 {
+    reorder properties = ["inputs:texture:file", "inputs:texture:format"]
     float guideRadius = 100000 (
         displayGroup = "Guides"
         displayName = "Radius"

--- a/pxr/usd/usdLux/lightDefParser.cpp
+++ b/pxr/usd/usdLux/lightDefParser.cpp
@@ -136,6 +136,15 @@ _CopyPropertiesFromSchema(
             return false;
         }
     }
+
+    // Append the schema's property order to the destination.
+    std::vector<TfToken> propertyOrder = destPrimSpec->GetPropertyOrder();
+    for( const auto &name : schemaSpec->GetPropertyOrder() )
+    {
+        propertyOrder.push_back( name );
+    }
+    destPrimSpec->SetPropertyOrder( propertyOrder );
+
     return true;
 }
 

--- a/pxr/usd/usdLux/schema.usda
+++ b/pxr/usd/usdLux/schema.usda
@@ -81,6 +81,7 @@ class "LightAPI" (
     }
     prepend apiSchemas = ["CollectionAPI:lightLink", "CollectionAPI:shadowLink"]
 ) {
+    reorder properties = [ "inputs:intensity", "inputs:exposure", "inputs:diffuse", "inputs:specular", "inputs:normalize", "inputs:color", "inputs:enableColorTemperature", "inputs:colorTemperature" ]
     uniform bool collection:lightLink:includeRoot = 1 (
         customData = {
             bool apiSchemaOverride = true
@@ -466,6 +467,7 @@ class "ShapingAPI" (
     }
 
 ) {
+    reorder properties = [ "inputs:shaping:focus", "inputs:shaping:focusTint", "inputs:shaping:cone:angle", "inputs:shaping:cone:softness", "inputs:shaping:ies:file", "inputs:shaping:ies:angleScale", "inputs:shaping:ies:normalize" ]
     float inputs:shaping:focus = 0 (
         displayGroup = "Shaping"
         displayName = "Emission Focus"
@@ -545,6 +547,7 @@ class "ShadowAPI" (
     }
 
 ) {
+    reorder properties = [ "inputs:shadow:enable", "inputs:shadow:color", "inputs:shadow:distance", "inputs:shadow:falloff", "inputs:shadow:falloffGamma" ]
     bool inputs:shadow:enable = true (
         displayGroup = "Shadows"
         displayName = "Enable Shadows"
@@ -684,6 +687,7 @@ class DistantLight "DistantLight" (
     doc = """Light emitted from a distant source along the -Z axis.
     Also known as a directional light."""
 ) {
+    reorder properties = [ "inputs:angle", "inputs:intensity" ]
     uniform token light:shaderId = "DistantLight" (
         customData = {
             bool apiSchemaOverride = true
@@ -720,6 +724,7 @@ class DiskLight "DiskLight" (
     doc = """Light emitted from one side of a circular disk.
     The disk is centered in the XY plane and emits light along the -Z axis."""
 ) {
+    reorder properties = [ "inputs:radius" ]
     uniform token light:shaderId = "DiskLight"  (
         customData = {
             bool apiSchemaOverride = true
@@ -748,6 +753,7 @@ class RectLight "RectLight" (
     position, a texture file's min coordinates should be at (+X, +Y) and 
     max coordinates at (-X, -Y)."""
 ) {
+    reorder properties = [ "inputs:width", "inputs:height", "inputs:texture:file" ]
     uniform token light:shaderId = "RectLight"  (
         customData = {
             bool apiSchemaOverride = true
@@ -789,6 +795,7 @@ class SphereLight "SphereLight" (
     inherits = </BoundableLightBase>
     doc = """Light emitted outward from a sphere."""
 ) {
+    reorder properties = [ "inputs:radius" ]
     uniform token light:shaderId = "SphereLight"  (
         customData = {
             bool apiSchemaOverride = true
@@ -824,6 +831,7 @@ class CylinderLight "CylinderLight" (
     The cylinder does not emit light from the flat end-caps.
     """
 ) {
+    reorder properties = [ "inputs:length", "inputs:radius" ]
     uniform token light:shaderId = "CylinderLight"  (
         customData = {
             bool apiSchemaOverride = true
@@ -898,6 +906,7 @@ class DomeLight "DomeLight" (
     -------------------------------------------------------------------------
 """
 ) {
+    reorder properties = [ "inputs:texture:file", "inputs:texture:format" ]
     uniform token light:shaderId = "DomeLight"  (
         customData = {
             bool apiSchemaOverride = true

--- a/pxr/usd/usdShade/shaderDefUtils.cpp
+++ b/pxr/usd/usdShade/shaderDefUtils.cpp
@@ -407,6 +407,19 @@ UsdShadeShaderDefUtils::GetShaderProperties(
             metadata.erase(implementationName);
         }
 
+        // Translate DisplayGroup/DisplayName to Page/Label.
+        const std::string displayGroup = shaderInput.GetAttr().GetDisplayGroup();
+        if( !displayGroup.empty() )
+        {
+            metadata[SdrPropertyMetadata->Page] = displayGroup;
+        }
+
+        const std::string displayName = shaderInput.GetAttr().GetDisplayName();
+        if( !displayName.empty() )
+        {
+            metadata[SdrPropertyMetadata->Label] = displayName;
+        }
+
         result.emplace_back(
             _CreateSdrShaderProperty(
                 /* shaderProperty */ shaderInput,


### PR DESCRIPTION
It may be that this would be better as a query on `usd-interest`, but I thought it might be worth having a stab at coding it so that there's something concrete to talk about. My goal is to be able to use `Sdr` as a source of shader and light definitions that can be loaded onto nodes in Gaffer, for presentation to the user via Gaffer's UI. The UsdLux `schema.usda` defines light inputs in a user-friendly order and with useful metadata for `displayGroup` and `displayName`, but that is currently lost when the schema is parsed into the `SdrRegistry`. This results in things like `RectLight.width` and `RectLight.height` being separated, and `enableColorTemperature` no longer being alongside `colorTemperature`. In this PR I've attempted to preserve this information during parsing to Sdr so that the user is presented with a well organised UI in Gaffer.

Questions in my mind : Was this a reasonable expectation to have from Sdr in the first place? Does whitelisting `propertyOrder` like this in `usdGenSchema` have unwanted side-effects I don't know about?

### Description of Change(s)

- Preserve property order in UsdLux_LightDefParserPlugin.
- Translate Usd displayGroup/displayName to Sdr page/label.

- [ ] I have verified that all unit tests pass with the proposed changes (`ctest` reports `No tests were found!!!`, so clearly I did something wrong)
- [x] I have submitted a signed Contributor License Agreement (via Cinesite)
