### PR TITLE
Validating UsdCollectionAPI before accessing in UsdShadeMaterialBindingAPI::ComputeBoundMaterial

### DIFF
--- a/pxr/usd/usdShade/materialBindingAPI.cpp
+++ b/pxr/usd/usdShade/materialBindingAPI.cpp
@@ -791,6 +791,9 @@ UsdShadeMaterialBindingAPI::ComputeBoundMaterial(
 
                 const UsdCollectionAPI &collection = 
                     collBinding.GetCollection();
+                if (!collection) {
+                    continue;
+                }
                 const SdfPath &collectionPath = collBinding.GetCollectionPath();
 
                 auto collIt = collectionQueryCache->find(collectionPath);


### PR DESCRIPTION
### Description of Change(s)
Validating UsdCollectionAPI before accessing in UsdShadeMaterialBindingAPI::ComputeBoundMaterial.

This is a quick proposal to fix #2500 , but I'm unsure if this is the right place to do so. I.e. should we validate collections earlier, like in `UsdShadeMaterialBindingAPI::_GetCollectionBindings` or a similar place?

### Fixes Issue(s)
- #2500

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
