### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfPayload`

### DIFF
--- a/pxr/usd/sdf/payload.h
+++ b/pxr/usd/sdf/payload.h
@@ -33,8 +33,6 @@
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/tf/hash.h"
 
-#include <boost/operators.hpp>
-
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -57,7 +55,7 @@ typedef std::vector<SdfPayload> SdfPayloadVector;
 /// system behaviors will not traverse across, providing a user-visible
 /// way to manage the working set of the scene.
 ///
-class SdfPayload : boost::totally_ordered<SdfPayload> {
+class SdfPayload {
 public:
     /// Create a payload. See SdfAssetPath for what characters are valid in \p
     /// assetPath.  If \p assetPath contains invalid characters, issue an error
@@ -107,9 +105,29 @@ public:
     /// Returns whether this payload equals \a rhs.
     SDF_API bool operator==(const SdfPayload &rhs) const;
 
+    /// \sa SdfPayload::operator==
+    bool operator!=(const SdfPayload& rhs) const {
+        return !(*this == rhs);
+    }
+
     /// Returns whether this payload is less than \a rhs.
     /// The meaning of less than is arbitrary but stable.
     SDF_API bool operator<(const SdfPayload &rhs) const;
+
+    /// \sa SdfPayload::operator<
+    bool operator>(const SdfPayload& rhs) const {
+        return rhs < *this;
+    }
+
+    /// \sa SdfPayload::operator<
+    bool operator<=(const SdfPayload& rhs) const {
+        return !(rhs < *this);
+    }
+
+    /// \sa SdfPayload::operator<
+    bool operator>=(const SdfPayload& rhs) const {
+        return !(*this < rhs);
+    }
 
 private:
     friend inline size_t hash_value(const SdfPayload &p) {


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfPayload`
- Add doxygen comments so `operator!=` references `operator==` and `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
