### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfSite`

### DIFF
--- a/pxr/usd/sdf/site.h
+++ b/pxr/usd/sdf/site.h
@@ -30,7 +30,6 @@
 
 #include <set>
 #include <vector>
-#include <boost/operators.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -40,8 +39,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// opinions may possibly be found. It is simply a pair of layer and path
 /// within that layer.
 ///
-class SdfSite 
-    : public boost::totally_ordered<SdfSite>
+class SdfSite
 {
 public:
     SdfSite() { }
@@ -55,10 +53,30 @@ public:
         return layer == other.layer && path == other.path;
     }
 
+    bool operator!=(const SdfSite& other) const
+    {
+        return !(*this == other);
+    }
+
     bool operator<(const SdfSite& other) const
     {
         return layer < other.layer ||
                (!(other.layer < layer) && path < other.path);
+    }
+
+    bool operator>(const SdfSite& other) const
+    {
+        return other < *this;
+    }
+
+    bool operator<=(const SdfSite& other) const
+    {
+        return !(other < *this);
+    }
+
+    bool operator>=(const SdfSite& other) const
+    {
+        return !(*this < other);
     }
 
     /// Explicit bool conversion operator. A site object converts to \c true iff 


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfSite`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
