### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfMapEditProxy`

### DIFF
--- a/pxr/usd/sdf/mapEditProxy.h
+++ b/pxr/usd/sdf/mapEditProxy.h
@@ -38,7 +38,6 @@
 #include "pxr/base/tf/mallocTag.h"
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
-#include <boost/operators.hpp>
 #include <iterator>
 #include <utility>
 
@@ -117,8 +116,7 @@ public:
 /// \sa SdfIdentityMapEditProxyValuePolicy
 ///
 template <class T, class _ValuePolicy = SdfIdentityMapEditProxyValuePolicy<T> >
-class SdfMapEditProxy :
-    boost::totally_ordered<SdfMapEditProxy<T, _ValuePolicy>, T> {
+class SdfMapEditProxy {
 public:
     typedef T Type;
     typedef _ValuePolicy ValuePolicy;
@@ -578,6 +576,21 @@ public:
         return _Validate() ? _CompareEqual(other) : false;
     }
 
+    bool operator!=(const Type& other) const
+    {
+        return !(*this == other);
+    }
+
+    friend bool operator==(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs == lhs;
+    }
+
+    friend bool operator!=(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs != lhs;
+    }
+
     bool operator<(const Type& other) const
     {
         return _Validate() ? _Compare(other) < 0 : false;
@@ -586,6 +599,36 @@ public:
     bool operator>(const Type& other) const
     {
         return _Validate() ? _Compare(other) > 0 : false;
+    }
+
+    bool operator>=(const Type& other) const
+    {
+        return !(*this < other);
+    }
+
+    bool operator<=(const Type& other) const
+    {
+        return !(*this > other);
+    }
+
+    friend bool operator<(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs > lhs;
+    }
+
+    friend bool operator>(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs < lhs;
+    }
+
+    friend bool operator<=(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs >= lhs;
+    }
+
+    friend bool operator>=(const Type& lhs, const SdfMapEditProxy& rhs)
+    {
+        return rhs <= lhs;
     }
 
     template <class U, class UVP>


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>=,!=}` to `SdfMapEditProxy` when compared against its `Type` template parameter
- #2502 documents some inconsistencies between operator overloads that should be looked at in a future change. This PR attempts to preserve the existing behavior.

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
