### PR TITLE
Apple: Fix floating point error caused by FMA conversion

### DIFF
--- a/cmake/defaults/clangdefaults.cmake
+++ b/cmake/defaults/clangdefaults.cmake
@@ -26,6 +26,12 @@ include(gccclangshareddefaults)
 
 set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")
 
+# Prevent floating point result discrepancies on Apple platforms
+# due to multiplication+additions being converted to FMA
+if (APPLE)
+    add_compile_options(-ffp-contract=off)
+endif()
+
 # clang annoyingly warns about the -pthread option if it's only linking.
 if(CMAKE_USE_PTHREADS_INIT)
     _disable_warning("unused-command-line-argument")


### PR DESCRIPTION
### Description of Change(s)
Adds a compile flag that prevents FMA conversion for floating points due to additions and multiplications which changed behaviour of unit tests.
-ffp-contract specifically controls fused multiply-add operations
https://clang.llvm.org/docs/UsersManual.html#cmdoption-ffp-contract

### Fixes Issue(s)
The following tests FAILED:
111 - testGfCamera (Failed)
433 - testUsdGeomPointInstancer (Failed)
472 - testUsdSkelBakeSkinning (Failed)

When building on Xcode 14.3 and newer.
With the change, they now pass.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
