### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfLayerOffset`

### DIFF
--- a/pxr/usd/sdf/layerOffset.h
+++ b/pxr/usd/sdf/layerOffset.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
 
-#include <boost/operators.hpp>
 #include <iosfwd>
 #include <vector>
 
@@ -58,7 +57,7 @@ class SdfTimeCode;
 /// GetReferenceLayerOffset() methods (the latter is the referenceLayerOffset 
 /// property in Python) of the SdfPrimSpec class.
 ///
-class SdfLayerOffset : public boost::totally_ordered<SdfLayerOffset>
+class SdfLayerOffset
 {
 public:
     /// \name Constructors
@@ -127,10 +126,30 @@ public:
     SDF_API
     bool operator==(const SdfLayerOffset &rhs) const;
 
+    /// \sa SdfLayerOffset::operator==
+    bool operator!=(const SdfLayerOffset &rhs) const {
+        return !(*this == rhs);
+    }
+
     /// Returns whether this offset is less than another.  The meaning
     /// of less than is somewhat arbitrary.
     SDF_API
     bool operator<(const SdfLayerOffset &rhs) const;
+
+    /// \sa SdfLayerOffset::operator<
+    bool operator>(const SdfLayerOffset& rhs) const {
+        return rhs < *this;
+    }
+
+    /// \sa SdfLayerOffset::operator<
+    bool operator>=(const SdfLayerOffset& rhs) const {
+        return !(*this < rhs);
+    }
+
+    /// \sa SdfLayerOffset::operator<
+    bool operator<=(const SdfLayerOffset& rhs) const {
+        return !(*this > rhs);
+    }
 
     /// Composes this with the offset \e rhs, such that the resulting
     /// offset is equivalent to first applying \e rhs and then \e *this.


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfLayerOffset`
- Add doxygen comments so `operator!=` references `operator==` and `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
