### PR TITLE
Replace `boost::totally_ordered` with explicit operator overloads for `SdfHandle`

### DIFF
--- a/pxr/usd/sdf/declareHandles.h
+++ b/pxr/usd/sdf/declareHandles.h
@@ -135,9 +135,9 @@ public:
     }
 
     /// \sa SdfHandle::operator==
-    bool operator!=(const SdfHandle& other) const
+    friend bool operator!=(const SdfHandle& lhs, const SdfHandle& rhs)
     {
-        return !(*this == other);
+        return !(lhs == rhs);
     }
 
     /// Arranges handles in an arbitrary strict weak ordering.  Note that
@@ -149,21 +149,21 @@ public:
     }
 
     /// \sa SdfHandle::operator<
-    bool operator>(const SdfHandle& other) const
+    friend bool operator>(const SdfHandle& lhs, const SdfHandle& rhs)
     {
-        return other < *this;
+        return rhs < lhs;
     }
 
     /// \sa SdfHandle::operator<
-    bool operator<=(const SdfHandle& other) const
+    friend bool operator<=(const SdfHandle& lhs, const SdfHandle& rhs)
     {
-        return !(other < *this);
+        return !(rhs < lhs);
     }
 
     /// \sa SdfHandle::operator<
-    bool operator>=(const SdfHandle& other) const
+    friend bool operator>=(const SdfHandle& lhs, const SdfHandle& rhs)
     {
-        return !(*this < other);
+        return !(lhs < rhs);
     }
 
     /// Hash.

--- a/pxr/usd/sdf/declareHandles.h
+++ b/pxr/usd/sdf/declareHandles.h
@@ -39,7 +39,6 @@
 #include <type_traits>
 #include <vector>
 #include <boost/intrusive_ptr.hpp>
-#include <boost/operators.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -60,7 +59,7 @@ typedef boost::intrusive_ptr<Sdf_Identity> Sdf_IdentityRefPtr;
 /// be expired.
 ///
 template <class T>
-class SdfHandle : private boost::totally_ordered<SdfHandle<T> > {
+class SdfHandle {
 public:
     typedef SdfHandle<T> This;
     typedef T SpecType;
@@ -135,12 +134,36 @@ public:
         return _spec == other._spec;
     }
 
+    /// \sa SdfHandle::operator==
+    bool operator!=(const SdfHandle& other) const
+    {
+        return !(*this == other);
+    }
+
     /// Arranges handles in an arbitrary strict weak ordering.  Note that
     /// this ordering is stable across path changes.
     template <class U>
     bool operator<(const SdfHandle<U>& other) const
     {
         return _spec < other._spec;
+    }
+
+    /// \sa SdfHandle::operator<
+    bool operator>(const SdfHandle& other) const
+    {
+        return other < *this;
+    }
+
+    /// \sa SdfHandle::operator<
+    bool operator<=(const SdfHandle& other) const
+    {
+        return !(other < *this);
+    }
+
+    /// \sa SdfHandle::operator<
+    bool operator>=(const SdfHandle& other) const
+    {
+        return !(*this < other);
     }
 
     /// Hash.


### PR DESCRIPTION
### Description of Change(s)
- Add explicit implementations of `operator{<=,>,>=,!=}` to `SdfHandle` when the template parameters match.  This mirrors the current behavior inherited from `boost::totally_ordered` even though `operator==` and `operator<` are parameterized to be more general.
- Add doxygen comments so `operator!=` references `operator==` and `operator{<=,>,>=}` reference `operator<`

### Fixes Issue(s)
- #2250 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
