### PR TITLE
Autodesk: Fix issue where ResolveParameter doesn't support type conversion

### DIFF
--- a/pxr/imaging/hd/material.cpp
+++ b/pxr/imaging/hd/material.cpp
@@ -149,7 +149,7 @@ _ResolveParameter(
     if (sdrNode) {
         if (const SdrShaderPropertyConstPtr input =
                                         sdrNode->GetShaderInput(name)) {
-            const VtValue& value = input->GetDefaultValue();
+            const VtValue& value = input->GetDefaultValueAsSdfType();
             if (value.IsHolding<T>()) {
                 return value.UncheckedGet<T>();
             }


### PR DESCRIPTION
### Description of Change(s)

When resolving the parameter for wrapSampler, minSampler, and magSampler, if the value got is not a token, we try to get the value as a string, and construct the token from the string.

Related: Prior approach/discussion in https://github.com/PixarAnimationStudios/OpenUSD/pull/2473 

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
