### PR TITLE
Support asset primvars on native instances.

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -1129,6 +1129,9 @@ UsdImagingInstanceAdapter::_ComputeInheritedPrimvar(UsdPrim const& instancer,
     } else if (dv.IsHolding<std::string>()) {
         return _ComputeInheritedPrimvar<std::string>(
                 instancer, primvarName, result, time);
+    } else if (dv.IsHolding<SdfAssetPath>()) {
+        return _ComputeInheritedPrimvar<SdfAssetPath>(
+                instancer, primvarName, result, time);
     } else {
         TF_WARN("Native instancing: unrecognized inherited primvar type '%s' "
                 "for primvar '%s'", 


### PR DESCRIPTION
### Description of Change(s)
Add a handler for "asset"-type primvars to the native instancer primvar handling method.

### Fixes Issue(s)
- #2518 

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
