### PR TITLE
Revise removal of `boost::compressed_pair` to better preserve object layout

### DIFF
--- a/pxr/base/tf/denseHashMap.h
+++ b/pxr/base/tf/denseHashMap.h
@@ -56,12 +56,7 @@ template <
     unsigned Threshold = 128
 >
 
-class ARCH_EMPTY_BASES TfDenseHashMap :
-    // Since sizeof(EqualKey) == 0 and sizeof(HashFn) == 0 in many cases
-    // we use the empty base optimization to not pay a size penalty.
-    // In C++20, explore using [[no_unique_address]] as an alternative
-    // way to get this optimization.
-    private HashFn, private EqualKey
+class TfDenseHashMap
 {
 public:
 
@@ -224,9 +219,11 @@ public:
     ///
     explicit TfDenseHashMap(
         const HashFn   &hashFn   = HashFn(),
-        const EqualKey &equalKey = EqualKey()) :
-            HashFn(hashFn),
-            EqualKey(equalKey) {}
+        const EqualKey &equalKey = EqualKey())
+    {
+        _hash() = hashFn;
+        _equ()  = equalKey;
+    }
 
     /// Construct with range.
     ///
@@ -244,11 +241,11 @@ public:
     /// Copy Ctor.
     ///
     TfDenseHashMap(const TfDenseHashMap &rhs)
-    :   HashFn(rhs),
-        EqualKey(rhs),
-        _vector(rhs._vector),
-        _h(rhs._h ? std::make_unique<_HashMap>(*rhs._h) : nullptr) {}
-
+    :   _storage(rhs._storage) {
+        if (rhs._h) {
+            _h = std::make_unique<_HashMap>(*rhs._h);
+        }
+    }
     /// Move Ctor.
     ///
     TfDenseHashMap(TfDenseHashMap &&rhs) = default;
@@ -310,10 +307,7 @@ public:
     /// Swaps the contents of two maps.
     ///
     void swap(TfDenseHashMap &rhs) {
-        using std::swap;
-        swap(_hash(), rhs._hash());
-        swap(_equ(), rhs._equ());
-        _vector.swap(rhs._vector);
+        _storage.swap(rhs._storage);
         _h.swap(rhs._h);
     }
 
@@ -548,32 +542,32 @@ private:
 
     // Helper to access the storage vector.
     _Vector &_vec() {
-        return _vector;
+        return _storage.vector;
     }
 
     // Helper to access the hash functor.
     HashFn &_hash() {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the equality functor.
     EqualKey &_equ() {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the storage vector.
     const _Vector &_vec() const {
-        return _vector;
+        return _storage.vector;
     }
 
     // Helper to access the hash functor.
     const HashFn &_hash() const {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the equality functor.
     const EqualKey &_equ() const {
-        return *this;
+        return _storage;
     }
 
     // Helper to linear-search the vector for a key.
@@ -617,8 +611,28 @@ private:
         }
     }
 
-    // Vector holding all elements
-    _Vector _vector;
+    // Since sizeof(EqualKey) == 0 and sizeof(HashFn) == 0 in many cases
+    // we use the empty base optimization to not pay a size penalty.
+    // In C++20, explore using [[no_unique_address]] as an alternative
+    // way to get this optimization.
+    struct ARCH_EMPTY_BASES _CompressedStorage :
+        private EqualKey, private HashFn {
+        static_assert(!std::is_same<EqualKey, HashFn>::value,
+                      "EqualKey and HashFn must be distinct types.");
+        _CompressedStorage() = default;
+        _CompressedStorage(const EqualKey& equalKey, const HashFn& hashFn)
+            : EqualKey(equalKey), HashFn(hashFn) {}
+
+        void swap(_CompressedStorage& other) {
+            using std::swap;
+            vector.swap(other.vector);
+            swap(static_cast<EqualKey&>(*this), static_cast<EqualKey&>(other));
+            swap(static_cast<HashFn&>(*this), static_cast<HashFn&>(other));
+        }
+        _Vector vector;
+        friend class TfDenseHashMap;
+    };
+    _CompressedStorage _storage;
 
     // Optional hash map that maps from keys to vector indices.
     std::unique_ptr<_HashMap> _h;

--- a/pxr/base/tf/denseHashSet.h
+++ b/pxr/base/tf/denseHashSet.h
@@ -54,12 +54,7 @@ template <
     class    EqualElement  = std::equal_to<Element>,
     unsigned Threshold = 128
 >
-class ARCH_EMPTY_BASES TfDenseHashSet :
-    // Since sizeof(EqualElement) == 0 and sizeof(HashFn) == 0 in many cases
-    // we use the empty base optimization to not pay a size penalty.
-    // In C++20, explore using [[no_unique_address]] as an alternative
-    // way to get this optimization.
-    private HashFn, private EqualElement
+class TfDenseHashSet
 {
 public:
 
@@ -96,17 +91,20 @@ public:
     ///
     explicit TfDenseHashSet(
         const HashFn       &hashFn       = HashFn(),
-        const EqualElement &equalElement = EqualElement()) :
-        HashFn(hashFn),
-        EqualElement(equalElement) {}
+        const EqualElement &equalElement = EqualElement())
+    {
+        _hash() = hashFn;
+        _equ()  = equalElement;
+    }
 
     /// Copy Ctor.
     ///
     TfDenseHashSet(const TfDenseHashSet &rhs)
-    :   HashFn(rhs),
-        EqualElement(rhs),
-        _vector(rhs._vector),
-        _h(rhs._h ? std::make_unique<_HashMap>(*rhs._h) : nullptr) {}
+    :   _storage(rhs._storage) {
+        if (rhs._h) {
+            _h = std::make_unique<_HashMap>(*rhs._h);
+        }
+    }
 
     /// Move Ctor.
     ///
@@ -179,10 +177,7 @@ public:
     /// Swaps the contents of two sets.
     ///
     void swap(TfDenseHashSet &rhs) {
-        using std::swap;
-        swap(_hash(), rhs._hash());
-        swap(_equ(), rhs._equ());
-        _vector.swap(rhs._vector);
+        _storage.swap(rhs._storage);
         _h.swap(rhs._h);
     }
 
@@ -393,32 +388,32 @@ private:
 
     // Helper to access the storage vector.
     _Vector &_vec() {
-        return _vector;
+        return _storage.vector;
     }
 
     // Helper to access the hash functor.
     HashFn &_hash() {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the equality functor.
     EqualElement &_equ() {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the storage vector.
     const _Vector &_vec() const {
-        return _vector;
+        return _storage.vector;
     }
 
     // Helper to access the hash functor.
     const HashFn &_hash() const {
-        return *this;
+        return _storage;
     }
 
     // Helper to access the equality functor.
     const EqualElement &_equ() const {
-        return *this;
+        return _storage;
     }
 
     // Helper to create the acceleration table if size dictates.
@@ -438,8 +433,29 @@ private:
         }
     }
 
-    // Vector holding all elements
-    _Vector _vector;
+    // Since sizeof(EqualElement) == 0 and sizeof(HashFn) == 0 in many cases
+    // we use the empty base optimization to not pay a size penalty.
+    // In C++20, explore using [[no_unique_address]] as an alternative
+    // way to get this optimization.
+    struct ARCH_EMPTY_BASES _CompressedStorage :
+        private EqualElement, private HashFn {
+        static_assert(!std::is_same<EqualElement, HashFn>::value,
+                      "EqualElement and HashFn must be distinct types.");
+        _CompressedStorage() = default;
+        _CompressedStorage(const EqualElement& equal, const HashFn& hashFn)
+            : EqualElement(equal), HashFn(hashFn) {}
+
+        void swap(_CompressedStorage& other) {
+            using std::swap;
+            vector.swap(other.vector);
+            swap(static_cast<EqualElement&>(*this),
+                 static_cast<EqualElement&>(other));
+            swap(static_cast<HashFn&>(*this), static_cast<HashFn&>(other));
+        }
+        _Vector vector;
+        friend class TfDenseHashSet;
+    };
+    _CompressedStorage _storage;
 
     // Optional hash map that maps from keys to vector indices.
     std::unique_ptr<_HashMap> _h;


### PR DESCRIPTION
### Description of Change(s)
Some minor performance regressions were observed in the initial removal of `boost::compressed_pair` (#2259) . This PR restores the order of inheritance of the equality and hash function objects which were inadvertently switched as well as some of the original initialization logic.

### Fixes Issue(s)
- #2257 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
