### PR TITLE
Remove unneeded boost dependencies from python bindings

### DIFF
--- a/pxr/base/vt/wrapArray.h
+++ b/pxr/base/vt/wrapArray.h
@@ -444,7 +444,7 @@ ARCH_PRAGMA_POP
 template <typename T>
 static std::string _VtStr(T const &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 template <typename T>

--- a/pxr/usd/sdf/wrapAssetPath.cpp
+++ b/pxr/usd/sdf/wrapAssetPath.cpp
@@ -28,7 +28,6 @@
 #include "pxr/base/tf/pyResultConversions.h"
 #include "pxr/base/vt/wrapArray.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/implicit.hpp>

--- a/pxr/usd/sdf/wrapTimeCode.cpp
+++ b/pxr/usd/sdf/wrapTimeCode.cpp
@@ -28,7 +28,6 @@
 #include "pxr/base/tf/pyResultConversions.h"
 #include "pxr/base/vt/wrapArray.h"
 
-#include <boost/functional/hash.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/implicit.hpp>


### PR DESCRIPTION
### Description of Change(s)
Several usages of boost in the python bindings can be easily removed.

* Remove unused header references to `boost/functional/hash.hpp`
* Introduce a simple pair and range-like struct for iterators to remove `boost::begin` and `boost::end` in favor of `std::begin` and `std::end`
* Replace `boost::lexical_cast` with `TfStringify`

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
