### PR TITLE
Fix inconsistent units used in documentation string

### DIFF
--- a/pxr/usd/usdPhysics/driveAPI.h
+++ b/pxr/usd/usdPhysics/driveAPI.h
@@ -328,7 +328,7 @@ public:
     // --------------------------------------------------------------------- //
     /// Damping of the drive. Units: 
     /// if linear drive: mass/second
-    /// If angular drive: mass*DIST_UNITS*DIST_UNITS/second/second/degrees.
+    /// If angular drive: mass*DIST_UNITS*DIST_UNITS/second/degrees.
     ///
     /// | ||
     /// | -- | -- |
@@ -352,7 +352,7 @@ public:
     // --------------------------------------------------------------------- //
     /// Stiffness of the drive. Units:
     /// if linear drive: mass/second/second
-    /// if angular drive: mass*DIST_UNITS*DIST_UNITS/degree/second/second.
+    /// if angular drive: mass*DIST_UNITS*DIST_UNITS/degrees/second/second.
     ///
     /// | ||
     /// | -- | -- |

--- a/pxr/usd/usdPhysics/generatedSchema.usda
+++ b/pxr/usd/usdPhysics/generatedSchema.usda
@@ -890,7 +890,7 @@ class "PhysicsDriveAPI" (
     float drive:__INSTANCE_NAME__:physics:damping = 0 (
         doc = """Damping of the drive. Units: 
 \t\tif linear drive: mass/second
-\t\tIf angular drive: mass*DIST_UNITS*DIST_UNITS/second/second/degrees."""
+\t\tIf angular drive: mass*DIST_UNITS*DIST_UNITS/second/degrees."""
     )
     float drive:__INSTANCE_NAME__:physics:maxForce = inf (
         displayName = "Max Force"
@@ -903,7 +903,7 @@ class "PhysicsDriveAPI" (
     float drive:__INSTANCE_NAME__:physics:stiffness = 0 (
         doc = """Stiffness of the drive. Units:
 \t\tif linear drive: mass/second/second
-\t\tif angular drive: mass*DIST_UNITS*DIST_UNITS/degree/second/second."""
+\t\tif angular drive: mass*DIST_UNITS*DIST_UNITS/degrees/second/second."""
     )
     float drive:__INSTANCE_NAME__:physics:targetPosition = 0 (
         displayName = "Target Position"

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -821,7 +821,7 @@ class "PhysicsDriveAPI"
         }
         doc = """Damping of the drive. Units: 
 		if linear drive: mass/second
-		If angular drive: mass*DIST_UNITS*DIST_UNITS/second/second/degrees."""
+		If angular drive: mass*DIST_UNITS*DIST_UNITS/second/degrees."""
     )
 
     float physics:stiffness = 0.0 (
@@ -830,7 +830,7 @@ class "PhysicsDriveAPI"
         }
         doc = """Stiffness of the drive. Units:
 		if linear drive: mass/second/second
-		if angular drive: mass*DIST_UNITS*DIST_UNITS/degree/second/second."""
+		if angular drive: mass*DIST_UNITS*DIST_UNITS/degrees/second/second."""
     )
 }
 


### PR DESCRIPTION
### Description of Change(s)

Discussed this with @eberled - just noticed a minor issue with the units in the documentation for UsdPhysicsDriveAPI's damping.

### Fixes Issue(s)

The motor force equation is given by:

> Force or acceleration = stiffness * (targetPosition - position) + damping * (targetVelocity - velocity)

The stiffness term is correct. However, for angular motors, the documentation for the damping term uses incorrect units:

```
        doc = """Damping of the drive. Units: 
		if linear drive: mass/second
		If angular drive: mass*DIST_UNITS*DIST_UNITS/second/second/degrees."""
```

i.e. kg m^2 s^-2 deg^-1
So the term "damping * (targetVelocity - velocity)" has units of "kg m^2 s^-3" which is not the units of torque (kg m^2 s^-2)


While in the area, I changed the stiffness term to use the word "degrees" rather than "degree," which is more consistent with the surrounding documentation. I'll also note that the file "wp_rigid_body_physics.rst" has a copy of the physics schema from when it was a proposal, but it's out of date (and has a warning to that effect) and I have not updated it.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
