### PR TITLE
convertDoxygen: Add docstrings to more python objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .p4*
 .DS_Store
 .AppleDouble
-
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .p4*
 .DS_Store
 .AppleDouble
-*.pyc

--- a/docs/python/convertDoxygen.py
+++ b/docs/python/convertDoxygen.py
@@ -106,11 +106,13 @@ if ',' in modules:
     # Loop through module list and create a Writer for each module to 
     # load and generate the doc strings for the specific module
     for moduleName in moduleList:
+        if not moduleName:
+            continue
         writer = Writer(packageName, moduleName)
         # Parser.traverse builds the docElement tree for all the 
         # doxygen XML files, so we only need to call it once if we're
         # processing multiple modules
-        if (docList == None):
+        if (docList is None):
             docList = parser.traverse(writer)
             Debug("Processed %d DocElements from doxygen XML" % len(docList))
         Debug("Processing module %s" % moduleName)
@@ -120,8 +122,12 @@ if ',' in modules:
         module_output_file = os.path.join(module_output_dir, "__DOC.py")
         writer.generate(module_output_file, docList)
 else:
+    moduleName = modules
     # Processing a single module. Writer's constructor will sanity
     # check module and verify it can be loaded
-    writer = Writer()
+    if not output_file.endswith(".py"):
+        module_output_dir = os.path.join(output_file, moduleName)
+        output_file = os.path.join(module_output_dir, "__DOC.py")
+    writer = Writer(packageName, moduleName)
     docList = parser.traverse(writer)
     writer.generate(output_file, docList)

--- a/docs/python/doxygenlib/cdParser.py
+++ b/docs/python/doxygenlib/cdParser.py
@@ -387,7 +387,10 @@ class Parser:
             prot = ''
             doc = self.__getAllDocStrings(node, name)
             location = node.getLocation()
-            ret = DocElement(name, kind, prot, doc, location)
+            if location != ('', ''):
+                # These elements shadow class elements of the same name, but they 
+                # lack any valuable information, and thus create empty docstrings.
+                ret = DocElement(name, kind, prot, doc, location)
         elif node.name == 'compounddef':
             kind = node.getKind()
             if kind == 'class' or kind == 'struct':

--- a/docs/python/doxygenlib/cdParser.py
+++ b/docs/python/doxygenlib/cdParser.py
@@ -42,12 +42,17 @@ class XMLNode:
     """
     Rrepresent a single node in the XML tree.
     """
+    __slots__ = ("parent", "name", "attrs", "text", "childNodes")
+
     def __init__(self, parent, name, attrs, text):
         self.parent = parent
         self.name = name
         self.attrs = attrs
         self.text = text
         self.childNodes = []
+
+    def __repr__(self) -> str:
+        return "XMLNode(%s, %s, ...)" % (self.name, self.attrs.items())
 
     def addChildNode(self, node):
         """Append the specifed node to the children of this node."""
@@ -221,8 +226,7 @@ class Parser:
                     continue
                 if (kind == "dir"):
                     continue
-                if (kind == "file"):
-                    continue
+                # we need to keep kind == "file" because this holds info on functions
                 refid = compound_element.get('refid')
                 # Individual entity XML generated XML files are <refid>.xml
                 entity_file_name = refid + ".xml"
@@ -357,7 +361,8 @@ class Parser:
             if child.name == 'param':
                 pname = child.getText('declname')
                 ptype = child.getText('type')
-                params.append((ptype, pname))
+                pdefault = child.getText('defval') or None
+                params.append(Param(ptype, pname, pdefault))
         return params
 
     def __createDocElement(self, node):


### PR DESCRIPTION
### Description of Change(s)

With these changes, the `convertDoxgen` build script adds docstrings for many additional python objects.  

For example, from Sdf these objects are now documented:

```
SpecType
Specifier
Permission
Variability
AuthoringError
GetNameForUnit
GetUnitFromName
ValueHasValidType
GetTypeForValueTypeName
GetValueTypeNameForValue
ConvertToValidMetadataDictionary
JustCreatePrimAttributeInLayer
CopySpec
ComputeAssetPathRelativeToLayer
ListOpType
CreatePrimInLayer
JustCreatePrimInLayer
CreateVariantInLayer
```

The primary change is that we no longer filter "file" xml type: these are necessary to find info on non-class functions.

In addition, this PR also provides a change necessary to support creation of [python type stubs](https://github.com/PixarAnimationStudios/OpenUSD/issues/196):  the parser now captures function default arguments. 

### Performance impact

Casting a wider net during parsing increased parse time from 25s to 1m45s.  The addition of slots shaved off ~10s and reduced memory usage. 

I've run this through a profiler, and the majority of the time is spent in the xml parsing, with about half of the parsing-time spent in pxr code and the other half in the parser base class.  I think there's room to make this more efficient if we can avoid instantiating `XMLNode` unnecessarily.  I noticed that for every class/function there is a useless "doxygen" root node, so I tried collapsing that down to a single root, but it only saved 10s and it creates some other problems.  

I also tried using `multiprocessing` to speed up parsing, but even distributing the parsing of files across 16 processes did not speed it up -- I suspect this was due to the amount of `DocElement` instances that needed to be serialized and marshaled across to the primary process after parsing, due to the way that the `multiprocessing` module works in python.   If that inference is correct, this approach could be improved by filtering the resulting `DocElement` classes while parsing, as there are many extraneous functions being captured. 

tl;dr  with this change, the doc generation process takes longer, but there's not a simple solution.

