### PR TITLE
Replace `boost::call_traits` in `pxr/usd/sdf/accessorHelpers.h`

### DIFF
--- a/pxr/usd/sdf/accessorHelpers.h
+++ b/pxr/usd/sdf/accessorHelpers.h
@@ -173,6 +173,13 @@ SDF_ACCESSOR_CLASS::name_(                                                     \
 
 // Convenience macros to provide common combinations of value accessors
 
+// Convert non-trivial types like `std::string` to `const std::string&` while
+// preserving the type for `int`, `bool`, `char`, etc.
+template <typename T>
+using Sdf_SetParameter = std::conditional<
+    std::is_arithmetic<T>::value, std::add_const_t<T>,
+    std::add_lvalue_reference_t<std::add_const_t<T>>>;
+
 #define SDF_DEFINE_TYPED_GET_SET(name_, key_, getType_, setType_)              \
 SDF_DEFINE_GET(name_, key_, getType_)                                          \
 SDF_DEFINE_SET(name_, key_, setType_)
@@ -184,11 +191,11 @@ SDF_DEFINE_CLEAR(name_, key_)
 
 #define SDF_DEFINE_GET_SET(name_, key_, type_)                                 \
 SDF_DEFINE_TYPED_GET_SET(name_, key_, type_,                                   \
-                         boost::call_traits<type_>::param_type)
+                         Sdf_SetParameter<type_>::type)
 
 #define SDF_DEFINE_GET_SET_HAS_CLEAR(name_, key_, type_)                       \
 SDF_DEFINE_TYPED_GET_SET_HAS_CLEAR(name_, key_, type_,                         \
-                                   boost::call_traits<type_>::param_type)
+                                   Sdf_SetParameter<type_>::type)
 
 #define SDF_DEFINE_IS_SET(name_, key_)                                         \
 SDF_DEFINE_IS(name_, key_)                                                     \


### PR DESCRIPTION
### Description of Change(s)

The macros in `pxr/usd/sdf/accessorHelpers.h` use `boost::call_traits` to convert the parameter `T` to `const T` if `T` is a primitive type and the cost of the reference outweighs the cost of the copy (`const T&` otherwise).

This replaces that macro with a templated `using` statement and standard STL traits.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
