### PR TITLE
Remove unused boost header from `pxr/usd/sdf/path.h`

### DIFF
--- a/pxr/usd/sdf/path.h
+++ b/pxr/usd/sdf/path.h
@@ -33,7 +33,6 @@
 #include "pxr/base/vt/traits.h"
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/operators.hpp>
 
 #include <algorithm>
 #include <iterator>


### PR DESCRIPTION
### Description of Change(s)
#2294 removed the usage of `boost/operators.hpp` but didn't remove the header.  This follow up PR cleans up the header usage.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
