### PR TITLE
Move `TF_EAT_PARENS` to `tf/preprocessorUtilsLite.h`

### DIFF
--- a/pxr/base/tf/preprocessorUtils.h
+++ b/pxr/base/tf/preprocessorUtils.h
@@ -33,6 +33,7 @@
 
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/pragmas.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/arithmetic/sub.hpp>
 #include <boost/preprocessor/cat.hpp>
@@ -141,7 +142,7 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
 // 0.  No other values of c are allowed.  We can't use BOOST_PP_IFF() because
 // it won't expand during stringizing under MSVC.
 #define _TF_PP_EAT_PARENS_IFF(c, t, f) \
-    BOOST_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
+    TF_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
 #define _TF_PP_EAT_PARENS_IFF_0(t, f) f
 #define _TF_PP_EAT_PARENS_IFF_1(t, f) t
 

--- a/pxr/base/tf/preprocessorUtils.h
+++ b/pxr/base/tf/preprocessorUtils.h
@@ -33,7 +33,6 @@
 
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/pragmas.h"
-#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include <boost/preprocessor/arithmetic/inc.hpp>
 #include <boost/preprocessor/arithmetic/sub.hpp>
 #include <boost/preprocessor/cat.hpp>
@@ -109,81 +108,6 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
     (__VA_ARGS__ BOOST_PP_REPEAT(BOOST_PP_INC(TF_MAX_ARITY), \
     _TF_NUM_ARGS_REP, _TF))
 #endif
-
-
-/// Return the arguments as is except if the first argument starts with a
-/// matched parenthesis then remove those parentheses.
-/// \ingroup group_tf_Preprocessor
-/// \hideinitializer
-//
-// If the arguments satisfy _TF_PP_EAT_PARENS_IS_PARENS() then we expand to
-// _TF_PP_EAT_PARENS_EXPAND1, otherwise to _TF_PP_EAT_PARENS_EXPAND.  The
-// former eats the parentheses while the latter passes the arguments
-// unchanged.
-// 
-// We add the ~ after the first __VA_ARGS__ in case there are zero
-// arguments. MSVC will complain about insufficient arguments otherwise. 
-// The ~ will be discarded in any case.
-#define TF_PP_EAT_PARENS(...) \
-    _TF_PP_EAT_PARENS_IFF(_TF_PP_EAT_PARENS_IS_PARENS(__VA_ARGS__ ~),\
-        _TF_PP_EAT_PARENS_EXPAND1,_TF_PP_EAT_PARENS_EXPAND)(__VA_ARGS__)
-
-/// Expand the arguments and make the result a string.
-// We can't use
-// BOOST_PP_STRINGIZE because on MSVC passing no arguments will report "not
-// enough actual parameters" and yield nothing.  We want no warnings and an
-// empty string.  We do that by passing an unused first argument to the inner
-// macro (we need an inner macro to cause expansion).  This causes MSVC to
-// yield "" for an empty __VA_ARGS__ list.
-#define TF_PP_EAT_PARENS_STR(...) _TF_PP_EAT_PARENS_STR2(~, __VA_ARGS__)
-#define _TF_PP_EAT_PARENS_STR2(x, ...) #__VA_ARGS__
-
-// Expands to the second argument if c is 1 and the third argument if c is
-// 0.  No other values of c are allowed.  We can't use BOOST_PP_IFF() because
-// it won't expand during stringizing under MSVC.
-#define _TF_PP_EAT_PARENS_IFF(c, t, f) \
-    TF_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
-#define _TF_PP_EAT_PARENS_IFF_0(t, f) f
-#define _TF_PP_EAT_PARENS_IFF_1(t, f) t
-
-// Force expansion of the arguments.
-#define _TF_PP_EAT_PARENS_EXPAND(...) __VA_ARGS__
-
-// Similar to expand except it will eat the first matching pair of
-// parentheses. For example, _TF_PP_EAT_PARENS_EXPAND1((x)(y)) yields x(y). 
-// The outer _TF_PP_EAT_PARENS_EXPAND() is needed for MSVC, which otherwise
-// would stringizing to "_TF_PP_EAT_PARENS_EXPAND " plus the literal
-// substitution of the arguments.
-#define _TF_PP_EAT_PARENS_EXPAND1(...) \
-    _TF_PP_EAT_PARENS_EXPAND(_TF_PP_EAT_PARENS_EXPAND __VA_ARGS__)
-
-// This works around a MSVC bug.  When a macro expands to FOO(__VA_ARGS__,bar),
-// MSVC will separate the arguments of __VA_ARGS__ even if they're inside
-// matching parentheses. So, for example, if __VA_ARGS__ is (x,y) then we'll
-// expand to FOO(x,y,bar) instead of FOO((x,y),bar).  This macro works around
-// that.  Use: _TF_PP_EAT_PARENS_CALL(FOO,(__VA_ARGS__,bar)).
-//
-// We need the _TF_PP_EAT_PARENS_EXPAND() here otherwise stringizing will
-// stringize the literal replacements, not the result of the expansion of x y. 
-// If FOO(x,y) expands to x+y then we'd get "FOO ((x,y),bar)" without
-// _TF_PP_EAT_PARENS_EXPAND() instead of the correct "(x,y)+bar".
-#define _TF_PP_EAT_PARENS_CALL(x, y) _TF_PP_EAT_PARENS_EXPAND(x y)
-
-// Expands to 1 if x starts with a matched parenthesis, otherwise expands to
-// 0. "_TF_PP_EAT_PARENS_IS_PARENS2 x" eats the parentheses if they exist and
-// expands to "x, 1,", otherwise it expands to _TF_PP_EAT_PARENS_IS_PARENS2
-// and the literal expansion of x.  This result goes to
-// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N() which extracts the 1 expanded from
-// _TF_PP_EAT_PARENS_IS_PARENS2 or a 0 passed as a final argument.  In either
-// case the desired result is the second argument to
-// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N.
-#define _TF_PP_EAT_PARENS_IS_PARENS(x) \
-    _TF_PP_EAT_PARENS_IS_PARENS_CHECK(_TF_PP_EAT_PARENS_IS_PARENS2 x)
-#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK(...) \
-    _TF_PP_EAT_PARENS_CALL(_TF_PP_EAT_PARENS_IS_PARENS_CHECK_N,(__VA_ARGS__,0,))
-#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N(x, n, ...) n
-#define _TF_PP_EAT_PARENS_IS_PARENS_TRUE(x) x, 1,
-#define _TF_PP_EAT_PARENS_IS_PARENS2(...) _TF_PP_EAT_PARENS_IS_PARENS_TRUE(~)
 
 /// Exapnds to 1 if the argument is a tuple, and 0 otherwise.
 /// \ingroup group_tf_Preprocessor

--- a/pxr/base/tf/preprocessorUtilsLite.h
+++ b/pxr/base/tf/preprocessorUtilsLite.h
@@ -319,4 +319,78 @@
 
 #endif
 
+/// Return the arguments as is except if the first argument starts with a
+/// matched parenthesis then remove those parentheses.
+/// \ingroup group_tf_Preprocessor
+/// \hideinitializer
+//
+// If the arguments satisfy _TF_PP_EAT_PARENS_IS_PARENS() then we expand to
+// _TF_PP_EAT_PARENS_EXPAND1, otherwise to _TF_PP_EAT_PARENS_EXPAND.  The
+// former eats the parentheses while the latter passes the arguments
+// unchanged.
+//
+// We add the ~ after the first __VA_ARGS__ in case there are zero
+// arguments. MSVC will complain about insufficient arguments otherwise.
+// The ~ will be discarded in any case.
+#define TF_PP_EAT_PARENS(...) \
+    _TF_PP_EAT_PARENS_IFF(_TF_PP_EAT_PARENS_IS_PARENS(__VA_ARGS__ ~),\
+        _TF_PP_EAT_PARENS_EXPAND1,_TF_PP_EAT_PARENS_EXPAND)(__VA_ARGS__)
+
+/// Expand the arguments and make the result a string.
+// We can't use
+// BOOST_PP_STRINGIZE because on MSVC passing no arguments will report "not
+// enough actual parameters" and yield nothing.  We want no warnings and an
+// empty string.  We do that by passing an unused first argument to the inner
+// macro (we need an inner macro to cause expansion).  This causes MSVC to
+// yield "" for an empty __VA_ARGS__ list.
+#define TF_PP_EAT_PARENS_STR(...) _TF_PP_EAT_PARENS_STR2(~, __VA_ARGS__)
+#define _TF_PP_EAT_PARENS_STR2(x, ...) #__VA_ARGS__
+
+// Expands to the second argument if c is 1 and the third argument if c is
+// 0.  No other values of c are allowed.  We can't use BOOST_PP_IFF() because
+// it won't expand during stringizing under MSVC.
+#define _TF_PP_EAT_PARENS_IFF(c, t, f) \
+    TF_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
+#define _TF_PP_EAT_PARENS_IFF_0(t, f) f
+#define _TF_PP_EAT_PARENS_IFF_1(t, f) t
+
+// Force expansion of the arguments.
+#define _TF_PP_EAT_PARENS_EXPAND(...) __VA_ARGS__
+
+// Similar to expand except it will eat the first matching pair of
+// parentheses. For example, _TF_PP_EAT_PARENS_EXPAND1((x)(y)) yields x(y).
+// The outer _TF_PP_EAT_PARENS_EXPAND() is needed for MSVC, which otherwise
+// would stringizing to "_TF_PP_EAT_PARENS_EXPAND " plus the literal
+// substitution of the arguments.
+#define _TF_PP_EAT_PARENS_EXPAND1(...) \
+    _TF_PP_EAT_PARENS_EXPAND(_TF_PP_EAT_PARENS_EXPAND __VA_ARGS__)
+
+// This works around a MSVC bug.  When a macro expands to FOO(__VA_ARGS__,bar),
+// MSVC will separate the arguments of __VA_ARGS__ even if they're inside
+// matching parentheses. So, for example, if __VA_ARGS__ is (x,y) then we'll
+// expand to FOO(x,y,bar) instead of FOO((x,y),bar).  This macro works around
+// that.  Use: _TF_PP_EAT_PARENS_CALL(FOO,(__VA_ARGS__,bar)).
+//
+// We need the _TF_PP_EAT_PARENS_EXPAND() here otherwise stringizing will
+// stringize the literal replacements, not the result of the expansion of x y.
+// If FOO(x,y) expands to x+y then we'd get "FOO ((x,y),bar)" without
+// _TF_PP_EAT_PARENS_EXPAND() instead of the correct "(x,y)+bar".
+#define _TF_PP_EAT_PARENS_CALL(x, y) _TF_PP_EAT_PARENS_EXPAND(x y)
+
+// Expands to 1 if x starts with a matched parenthesis, otherwise expands to
+// 0. "_TF_PP_EAT_PARENS_IS_PARENS2 x" eats the parentheses if they exist and
+// expands to "x, 1,", otherwise it expands to _TF_PP_EAT_PARENS_IS_PARENS2
+// and the literal expansion of x.  This result goes to
+// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N() which extracts the 1 expanded from
+// _TF_PP_EAT_PARENS_IS_PARENS2 or a 0 passed as a final argument.  In either
+// case the desired result is the second argument to
+// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N.
+#define _TF_PP_EAT_PARENS_IS_PARENS(x) \
+    _TF_PP_EAT_PARENS_IS_PARENS_CHECK(_TF_PP_EAT_PARENS_IS_PARENS2 x)
+#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK(...) \
+    _TF_PP_EAT_PARENS_CALL(_TF_PP_EAT_PARENS_IS_PARENS_CHECK_N,(__VA_ARGS__,0,))
+#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N(x, n, ...) n
+#define _TF_PP_EAT_PARENS_IS_PARENS_TRUE(x) x, 1,
+#define _TF_PP_EAT_PARENS_IS_PARENS2(...) _TF_PP_EAT_PARENS_IS_PARENS_TRUE(~)
+
 #endif // PXR_BASE_TF_PREPROCESSOR_UTILS_LITE_H

--- a/pxr/base/tf/testenv/meta.cpp
+++ b/pxr/base/tf/testenv/meta.cpp
@@ -26,7 +26,7 @@
 
 #include "pxr/base/tf/functionTraits.h"
 #include "pxr/base/tf/meta.h"
-#include "pxr/base/tf/preprocessorUtils.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 
 #include <string>
 #include <tuple>

--- a/pxr/base/vt/traits.h
+++ b/pxr/base/vt/traits.h
@@ -28,7 +28,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/vt/api.h"
-#include "pxr/base/tf/preprocessorUtils.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 
 #include <boost/type_traits/has_trivial_assign.hpp>
 


### PR DESCRIPTION
### Description of Change(s)
Depends on #2241 

- Move `TF_EAT_PARENS` to `pxr/base/tf/preprocessUtilsLite.h` now that it's not dependent on boost
- Update `pxr/base/vt/traits.h` and `pxr/base/tf/testenv/meta.cpp` dependencies

### Fixes Issue(s)
- #2240 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
