### PR TITLE
Replace `boost::iterator_facade` with explicit iterator definition in `childrenProxy.h`

### DIFF
--- a/pxr/usd/sdf/children.h
+++ b/pxr/usd/sdf/children.h
@@ -29,7 +29,6 @@
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
### Description of Change(s)
- Replace `iterator_facade` with explicit implementation for `SdfChildrenProxy`'s internal iterator

### Fixes Issue(s)
- #2305 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
