### PR TITLE
Remove spurious include of `boost/iterator_adaptors.hpp` in `vt/array.h`

### DIFF
--- a/pxr/base/vt/array.h
+++ b/pxr/base/vt/array.h
@@ -38,8 +38,6 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/mallocTag.h"
 
-#include <boost/iterator_adaptors.hpp>
-
 #include <algorithm>
 #include <atomic>
 #include <cstddef>


### PR DESCRIPTION
### Description of Change(s)
- `boost/iterator_adaptors.hpp` is unused by `vt/array.h` and can be removed.

### Fixes Issue(s)
- #2309 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
