### PR TITLE
Remove spurious include of boost header in `sdf/types.h`

### DIFF
--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -68,7 +68,6 @@
 
 #include <boost/preprocessor/list/for_each.hpp>
 #include <boost/preprocessor/list/size.hpp>
-#include <boost/preprocessor/punctuation/comma.hpp>
 #include <boost/preprocessor/selection/max.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/seq.hpp>


### PR DESCRIPTION
### Description of Change(s)

`boost/preprocessor/punctuation/comma.hpp` is not being used by `sdf/types.h` and can be removed

### Fixes Issue(s)
- #2243 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
