### PR TITLE
Remove support for `TfToken` arrays in `tf/staticTokens.h` macros

### DIFF
--- a/pxr/base/tf/pyStaticTokens.h
+++ b/pxr/base/tf/pyStaticTokens.h
@@ -39,12 +39,9 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-// TODO: Should wrap token arrays to Python.
-
 /// Macro to wrap static tokens defined with \c TF_DEFINE_PUBLIC_TOKENS to
 /// Python.  It creates a class of name \p name in the current scope
 /// containing just the tokens in \p seq in the static tokens named by \p key.
-/// Arrays are not wrapped but their components are.
 ///
 /// \hideinitializer
 #define TF_PY_WRAP_PUBLIC_TOKENS(name, key, seq)                            \
@@ -54,8 +51,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 /// Macro to wrap static tokens defined with \c TF_DEFINE_PUBLIC_TOKENS to
 /// Python. This wraps tokens in \p seq in the static tokens named by \p key
-/// as attributes on the current boost python scope. Arrays are not wrapped
-/// but their components are.
+/// as attributes on the current boost python scope.
 ///
 /// \hideinitializer
 #define TF_PY_WRAP_PUBLIC_TOKENS_IN_CURRENT_SCOPE(key, seq)                 \
@@ -90,9 +86,7 @@ private:
                 boost::python::return_by_value>(),                          \
             boost::mpl::vector1<std::string>()))
 
-#define _TF_PY_TOKENS_EXPAND(seq)                                           \
-    BOOST_PP_SEQ_FILTER(_TF_TOKENS_IS_NOT_ARRAY, ~, seq)                    \
-    _TF_TOKENS_EXPAND_ARRAY_ELEMENTS(seq)
+#define _TF_PY_TOKENS_EXPAND(seq) seq
 
 // Private macros to wrap a single element in a sequence.
 #define _TF_PY_TOKENS_WRAP_ELEMENT(r, key, elem)                            \

--- a/pxr/base/tf/testenv/staticTokens.cpp
+++ b/pxr/base/tf/testenv/staticTokens.cpp
@@ -36,8 +36,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 #define TFTEST_TOKENS \
     (foo) \
-    ((bar, "bar_value")) \
-    ((array, ((array_0) (array_1))))
+    ((bar, "bar_value"))
 
 // Public tokens.
 // Normally only in .h file:
@@ -52,10 +51,6 @@ TF_DEFINE_PRIVATE_TOKENS( TfTestPrivateTokens, TFTEST_TOKENS );
 #define TEST(holder)                                                \
     TF_AXIOM( holder->foo == TfToken("foo") );                        \
     TF_AXIOM( holder->bar == TfToken("bar_value") );                  \
-    TF_AXIOM( holder->array[0] == TfToken("array_0") );               \
-    TF_AXIOM( holder->array[1] == TfToken("array_1") );               \
-    TF_AXIOM( holder->array_0 == TfToken("array_0") );                \
-    TF_AXIOM( holder->array_1 == TfToken("array_1") );               \
     TF_AXIOM( holder->allTokens == expectedAllTokens );               \
     ;
 
@@ -67,8 +62,6 @@ Test_TfStaticTokens()
     // Expected contents of allTokens
     expectedAllTokens.push_back( TfToken("foo") );
     expectedAllTokens.push_back( TfToken("bar_value") );
-    expectedAllTokens.push_back( TfToken("array_0") );
-    expectedAllTokens.push_back( TfToken("array_1") );
 
     TEST(TfTestPublicTokens);
     TEST(TfTestPrivateTokens);

--- a/pxr/base/tf/testenv/testTfPyStaticTokens.py
+++ b/pxr/base/tf/testenv/testTfPyStaticTokens.py
@@ -32,9 +32,6 @@ class TestTfPyStaticTokens(unittest.TestCase):
         testTokens = (
             ('orange', 'orange'),
             ('pear', "d'Anjou"),
-            ('Fuji', 'Fuji'),
-            ('Pippin', 'Pippin'),
-            ('McIntosh', 'McIntosh'),
             )
 
         for scope in (Tf._testStaticTokens, Tf._TestStaticTokens):

--- a/pxr/base/tf/wrapTestPyStaticTokens.cpp
+++ b/pxr/base/tf/wrapTestPyStaticTokens.cpp
@@ -32,7 +32,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define TF_TEST_TOKENS                  \
     (orange)                            \
     ((pear, "d'Anjou"))                 \
-    ((apple, ( (Fuji) (Pippin) (McIntosh) )))
 
 TF_DECLARE_PUBLIC_TOKENS(tfTestStaticTokens, TF_API, TF_TEST_TOKENS);
 TF_DEFINE_PUBLIC_TOKENS(tfTestStaticTokens, TF_TEST_TOKENS);


### PR DESCRIPTION
### Description of Change(s)
The macros in `tf/staticTokens.h` currently allow the following syntax.
```
((myArray, ((value1) (value2) (value3))))
```
which will add `value1`, `value2`, and `value3` as tokens as well as `TfToken myArray[3]` to token static data structure with references to `value1`, `value2`, and `value3`. This feature is unused in the OpenUSD code base and brings in a lot of additional boost dependencies to support.

Future refinements will be required to completely remove the boost dependency from this file, but removing the array support is a first step.

This feature can be replaced by simply declaring the values of the array as tokens.
```
(value1)
(value2)
(value3)
```
The `allTokens` vector would have the same contents (though the order may change).  Usage which benefits from having a static array of tokens can be replaced in the scopes they're needed.
```
void function() {
    static const std::array<TfToken, 3> myArray = {{Tokens->value1, Tokens->value2, Tokens->value3}};
    ...
}
```
### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
