### PR TITLE
Replace `boost::iterator_facade` with explicit implementation for `SdfMapProxy`

### DIFF
--- a/pxr/usd/sdf/mapEditProxy.h
+++ b/pxr/usd/sdf/mapEditProxy.h
@@ -36,7 +36,6 @@
 #include "pxr/base/vt/value.h"  // for Vt_DefaultValueFactory
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/mallocTag.h"
-#include <boost/iterator/iterator_facade.hpp>
 #include <boost/iterator/reverse_iterator.hpp>
 #include <boost/operators.hpp>
 #include <iterator>
@@ -232,12 +231,26 @@ private:
     };
 
     template <class Owner, class I, class R>
-    class _Iterator :
-        public boost::iterator_facade<_Iterator<Owner, I, R>, R,
-                                      std::bidirectional_iterator_tag, R> {
+    class _Iterator {
+        class _PtrProxy {
+        public:
+            std::add_pointer_t<R> operator->() {
+                return std::addressof(_result);
+            }
+        private:
+            friend class _Iterator;
+            explicit _PtrProxy(const R& result) : _result(result) {}
+            R _result;
+        };
     public:
-        _Iterator() :
-            _owner(NULL), _data(NULL) { }
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = R;
+        using reference = R;
+        using pointer = std::conditional_t<std::is_lvalue_reference<R>::value,
+                                           std::add_pointer_t<R>, _PtrProxy>;
+        using difference_type = std::ptrdiff_t;
+
+        _Iterator() = default;
 
         _Iterator(Owner owner, const Type* data, I i) :
             _owner(owner), _data(data), _pos(i)
@@ -252,9 +265,57 @@ private:
             // Do nothing
         }
 
+        reference operator*() const { return dereference(); }
+
+        // In C++20, when pointer can be `void` and `operator->` elided,
+        // this conditional behavior may be deprecated. The `operator->`
+        // implementation is keyed off of whether the underlying pointer
+        // requires a proxy type
+        template <typename PointerType=pointer,
+                  typename std::enable_if_t<
+                    std::is_pointer<PointerType>::value, int> = 0>
+        pointer operator->() const { return std::addressof(dereference()); }
+        template <typename PointerType=pointer,
+                  typename std::enable_if_t<
+                    !std::is_pointer<PointerType>::value, int> = 0>
+        pointer operator->() const { return pointer(dereference()); }
+
+
         const I& base() const
         {
             return _pos;
+        }
+
+        _Iterator& operator++() {
+            increment();
+            return *this;
+        }
+
+        _Iterator& operator--() {
+            decrement();
+            return *this;
+        }
+
+        _Iterator operator++(int) {
+            _Iterator result(*this);
+            increment();
+            return result;
+        }
+
+        _Iterator operator--(int) {
+            _Iterator result(*this);
+            decrement();
+            return result;
+        }
+
+        template <class Owner2, class I2, class R2>
+        bool operator==(const _Iterator<Owner2, I2, R2>& other) const {
+            return equal(other);
+        }
+
+        template <class Owner2, class I2, class R2>
+        bool operator!=(const _Iterator<Owner2, I2, R2>& other) const {
+            return !equal(other);
         }
 
     private:
@@ -289,11 +350,10 @@ private:
         }
 
     private:
-        Owner _owner;
-        const Type* _data;
+        Owner _owner = nullptr;
+        const Type* _data = nullptr;
         I _pos;
 
-        friend class boost::iterator_core_access;
         template <class Owner2, class I2, class R2> friend class _Iterator;
     };
 


### PR DESCRIPTION
### Description of Change(s)
- Replace `iterator_facade` with explicit implementation for `SdfMapProxy`
- Uses type traits / SFINAE to provide two implementations of `operator->` depending on whether the reference type is a true reference and can be safely converted to a pointer or if it's a proxy type and needs a pointer proxy to manage lifetime. Added a comment to recommend deprecating usage of `operator->` for C++20 to avoid this complexity.

### Fixes Issue(s)
- #2305 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
