### PR TITLE
Bailp/emsusd 239/corrupted file read crash

### DIFF
--- a/pxr/usd/usd/crateData.cpp
+++ b/pxr/usd/usd/crateData.cpp
@@ -804,16 +804,21 @@ private:
                     
             dispatcher.Run(
                 [this, fsBegin, fsEnd, &fields, &fieldValuePairs]() mutable {
-                    // XXX Won't need first two tags when bug #132031 is
-                    // addressed
-                    TfAutoMallocTag tag(
-                        "Usd", "Usd_CrateDataImpl::Open", "field data");
-                    auto &pairs = fieldValuePairs.GetMutable();
-                    pairs.resize(fsEnd-fsBegin);
-                    for (size_t i = 0; fsBegin != fsEnd; ++fsBegin, ++i) {
-                        auto const &field = fields[fsBegin->value];
-                        pairs[i].first = _crateFile->GetToken(field.tokenIndex);
-                        pairs[i].second = _UnpackForField(field.valueRep);
+                    try {
+                        // XXX Won't need first two tags when bug #132031 is
+                        // addressed
+                        TfAutoMallocTag tag(
+                            "Usd", "Usd_CrateDataImpl::Open", "field data");
+                        auto &pairs = fieldValuePairs.GetMutable();
+                        pairs.resize(fsEnd-fsBegin);
+                        for (size_t i = 0; fsBegin != fsEnd; ++fsBegin, ++i) {
+                            auto const &field = fields[fsBegin->value];
+                            pairs[i].first = _crateFile->GetToken(field.tokenIndex);
+                            pairs[i].second = _UnpackForField(field.valueRep);
+                        }
+                    } catch (const std::exception&) {
+                        // Don't let exceptions from individual reader out,
+                        // otherwise it will crash in some destructors.
                     }
                 });
         }

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -4008,7 +4008,7 @@ CrateFile::_UnpackValue(ValueRep rep, T *out) const
                          "%s, returning a value-initialized object",
                          GetAssetPath().c_str(),
                          ArchGetDemangled<T>().c_str());
-        *out = T();
+        throw;
     }
 }
 
@@ -4032,7 +4032,7 @@ CrateFile::_UnpackValue(ValueRep rep, VtArray<T> *out) const {
                          "VtArray<%s>, returning an empty array",
                          GetAssetPath().c_str(),
                          ArchGetDemangled<T>().c_str());
-        *out = VtArray<T>();
+        throw;
     }
 }
 
@@ -4059,7 +4059,7 @@ CrateFile::_UnpackValue(ValueRep rep, VtValue *result) const {
         TF_RUNTIME_ERROR("Corrupt asset <%s>: exception raised unpacking a "
                          "value, returning an empty VtValue",
                          GetAssetPath().c_str());
-        *result = VtValue();
+        throw;
     }
 }
 

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -92,6 +92,7 @@
 #include <mutex>
 #include <tuple>
 #include <type_traits>
+#include <exception>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -595,8 +596,7 @@ struct _MmapStream {
                     "Read out-of-bounds: %zd bytes at offset %td in "
                     "a mapping of length %zd",
                     nBytes, offset, mapLen);
-                memset(dest, 0x99, nBytes);
-                return;
+                throw std::runtime_error("Read out of bounds");
             }
         }
 


### PR DESCRIPTION
### Description of Change(s)
- Throw an exception when detecting an out-of-bound read instead of returning random data.
- CrateFile helpers re-throw the exceptions they caught.
- Catch exception in the parallel read dispatcher, otherwise the dispatcher destructors that run afterwards cause double-exception termination or read invalid memory.
- CreateData remembers that exceptions were thrown during I/O and returns an error. Cratedata cannot throw an exception because it is invoked in parallel code that crash when exceptions are thrown. Error return are used instead.
- With this, the error propagates to the caller that tried to load the layer or stage.

### Fixes Issue(s)
- Crash when reading corrupted USD files.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
