### PR TITLE
Autodesk: Provide enough information to allow matrix33 default values

### DIFF
--- a/pxr/usd/usdMtlx/parser.cpp
+++ b/pxr/usd/usdMtlx/parser.cpp
@@ -242,10 +242,11 @@ ShaderBuilder::AddProperty(
         if (converted.valueTypeName) {
             type = converted.valueTypeName.GetAsToken();
             // Do not use GetAsToken for comparison as recommended in the API
-            if (converted.valueTypeName == SdfValueTypeNames->Bool) {
+            if (converted.valueTypeName == SdfValueTypeNames->Bool ||
+                converted.valueTypeName == SdfValueTypeNames->Matrix3d) {
                  defaultValue = UsdMtlxGetUsdValue(element, isOutput);
                  metadata.emplace(SdrPropertyMetadata->SdrUsdDefinitionType,
-                           converted.valueTypeName.GetType().GetTypeName());
+                           converted.valueTypeName.GetAliasesAsTokens().front());
             }
         }
         else {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.py
@@ -25,7 +25,7 @@
 import os
 os.environ['PXR_MTLX_PLUGIN_SEARCH_PATHS'] = os.getcwd()
 
-from pxr import Tf, Ndr, Sdr
+from pxr import Ndr, Sdr, Gf
 import unittest
 
 class TestDiscovery(unittest.TestCase):
@@ -42,6 +42,7 @@ class TestDiscovery(unittest.TestCase):
             ['pxr_nd_boolean',
              'pxr_nd_float',
              'pxr_nd_integer',
+             'pxr_nd_matrix33',
              'pxr_nd_string',
              'pxr_nd_vector',
              'pxr_nd_vector_2',
@@ -54,6 +55,7 @@ class TestDiscovery(unittest.TestCase):
             ['pxr_nd_boolean',
              'pxr_nd_float',
              'pxr_nd_integer',
+             'pxr_nd_matrix33',
              'pxr_nd_string',
              'pxr_nd_vector'])
 
@@ -68,6 +70,7 @@ class TestDiscovery(unittest.TestCase):
             ['pxr_nd_boolean',
              'pxr_nd_float',
              'pxr_nd_integer',
+             'pxr_nd_matrix33',
              'pxr_nd_string',
              'pxr_nd_vector_2',
              'pxr_nd_vector_noversion'])
@@ -88,6 +91,7 @@ class TestDiscovery(unittest.TestCase):
              Ndr.Version(),
              Ndr.Version(),
              Ndr.Version(),
+             Ndr.Version(),
              Ndr.Version(1),
              Ndr.Version(2, 0),
              Ndr.Version(2, 1),
@@ -103,6 +107,7 @@ class TestDiscovery(unittest.TestCase):
              'pxr_nd_booleanDefaults',
              'pxr_nd_float',
              'pxr_nd_integer',
+             'pxr_nd_matrix33',
              'pxr_nd_string',
              'pxr_nd_vector_2',
              'pxr_nd_vector_noversion'])
@@ -110,6 +115,7 @@ class TestDiscovery(unittest.TestCase):
         versions = [node.GetVersion() for node in nodes]
         self.assertEqual(versions,
             [Ndr.Version(),
+             Ndr.Version(),
              Ndr.Version(),
              Ndr.Version(),
              Ndr.Version(),
@@ -126,6 +132,13 @@ class TestDiscovery(unittest.TestCase):
         falseInput = node.GetInput("inFalse")
         self.assertFalse(falseInput.GetDefaultValue())
         self.assertFalse(falseInput.GetDefaultValueAsSdfType())
+
+        # Check default values of matrix33 inputs:
+        node = registry.GetNodeByIdentifier("pxr_nd_matrix33")
+        self.assertTrue(node)
+        matrixInput = node.GetInput("in")
+        self.assertEqual(matrixInput.GetDefaultValue(), Gf.Matrix3d(1,2,3,4,5,6,7,8,9))
+        self.assertEqual(matrixInput.GetDefaultValueAsSdfType(), Gf.Matrix3d(1,2,3,4,5,6,7,8,9))
 
 
 if __name__ == '__main__':

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.testenv/test.mtlx
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxDiscovery.testenv/test.mtlx
@@ -10,6 +10,11 @@
     <input name="inFalse" type="boolean" value="false" />
     <output name="out" type="boolean" />
   </nodedef>
+  <nodedef name="pxr_nd_matrix33" node="UsdMtlxTestNode">
+    <input name="in" type="matrix33" value="1.0,2.0,3.0, 4.0,5.0,6.0, 7.0,8.0,9.0" />
+    <input name="note" type="string" value="" uniform="true" />
+    <output name="out" type="matrix33" />
+  </nodedef>
   <nodedef name="pxr_nd_integer" node="UsdMtlxTestNode">
     <input name="in" type="integer" />
     <input name="note" type="string" value="" uniform="true" />
@@ -41,6 +46,7 @@
   </nodedef>
   <implementation name="im_boolean" nodedef="pxr_nd_boolean" file="mx_boolean.osl" function="mx_boolean" />
   <implementation name="im_booleanDefaults" nodedef="pxr_nd_booleanDefaults" file="mx_boolean.osl" function="mx_booleanDefaults" />
+  <implementation name="im_matrix33" nodedef="pxr_nd_matrix33" file="mx_matrix33.osl" function="mx_matrix33" />
   <implementation name="im_integer" nodedef="pxr_nd_integer" file="mx_integer.osl" function="mx_integer" />
   <implementation name="im_float" nodedef="pxr_nd_float" file="mx_float.osl" function="mx_float" />
   <implementation name="im_string" nodedef="pxr_nd_string" file="mx_string.osl" function="mx_string" />


### PR DESCRIPTION
### Description of Change(s)

Remembers default values of matrix33 inputs in Sdr.

This follows the fix done for Boolean inputs done in https://github.com/PixarAnimationStudios/OpenUSD/pull/1789

(Previously closed [PR-2545](https://github.com/PixarAnimationStudios/OpenUSD/pull/2545))

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/2523

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
