### PR TITLE
Autodesk: Add access to depthStencil AOV

### DIFF
--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -1003,11 +1003,13 @@ HdxTaskController::SetRenderOutputs(TfTokenVector const& outputs)
     // complete with depth-compositing and selection, so we in-line add
     // some extra buffers if they weren't already requested.
     if (_IsStormRenderingBackend(GetRenderIndex())) {
-		TfToken depthToken = _depthStencilEnabled ? HdAovTokens->depthStencil : HdAovTokens->depth;
+        TfToken depthToken = _depthStencilEnabled
+            ? HdAovTokens->depthStencil
+            : HdAovTokens->depth;
         if (std::find(localOutputs.begin(), 
                       localOutputs.end(), depthToken) == localOutputs.end())
-		{
-			localOutputs.push_back(depthToken);
+        {
+            localOutputs.push_back(depthToken);
         }
     } else {
         std::set<TfToken> mainRenderTokens;
@@ -1103,8 +1105,9 @@ HdxTaskController::SetRenderOutputs(TfTokenVector const& outputs)
         aovBindingsNoClear[i] = aovBindingsClear[i];
         aovBindingsNoClear[i].clearValue = VtValue();
 
-        if (localOutputs[i] == HdAovTokens->depth || localOutputs[i] == HdAovTokens->depthStencil)
-		{
+        if (localOutputs[i] == HdAovTokens->depth ||
+            localOutputs[i] == HdAovTokens->depthStencil)
+        {
             aovInputBindings.push_back(aovBindingsNoClear[i]);
         }
     }
@@ -1166,7 +1169,9 @@ HdxTaskController::SetViewportRenderOutput(TfToken const& name)
             params.depthBufferPath = SdfPath::EmptyPath();
         } else if (name == HdAovTokens->color) {
             params.aovBufferPath = _GetAovPath(HdAovTokens->color);
-			params.depthBufferPath = _depthStencilEnabled ? _GetAovPath(HdAovTokens->depthStencil) : _GetAovPath(HdAovTokens->depth);
+            params.depthBufferPath = _depthStencilEnabled
+                                   ? _GetAovPath(HdAovTokens->depthStencil)
+                                   : _GetAovPath(HdAovTokens->depth);
         } else {
             params.aovBufferPath = _GetAovPath(name);
             params.depthBufferPath = SdfPath::EmptyPath();
@@ -1218,9 +1223,9 @@ HdxTaskController::SetViewportRenderOutput(TfToken const& name)
                 _GetAovPath(HdAovTokens->instanceId);
             pickParams.elementIdBufferPath =
                 _GetAovPath(HdAovTokens->elementId);
-			pickParams.depthBufferPath =
-				_depthStencilEnabled ? _GetAovPath(HdAovTokens->depthStencil) : 
-                _GetAovPath(HdAovTokens->depth);
+            pickParams.depthBufferPath = _depthStencilEnabled 
+                ? _GetAovPath(HdAovTokens->depthStencil)
+                : _GetAovPath(HdAovTokens->depth);
         } else {
             pickParams.primIdBufferPath = SdfPath::EmptyPath();
             pickParams.instanceIdBufferPath = SdfPath::EmptyPath();

--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -269,6 +269,17 @@ public:
     HDX_API
     void SetEnablePresentation(bool enabled);
 
+    /// -------------------------------------------------------
+    /// Enable / disable depth stencil.
+    /// An application may choose to use depth AOV, or depthStencil AOV.
+	HDX_API
+	void SetDepthStencilEnabled(bool enabled);
+
+    /// Returns true if the render index use depthStencil AOV.
+    /// Returns flase if the render index use depth AOV.
+    HDX_API
+    bool GetDepthStencilEnabled();
+
 private:
     ///
     /// This class is not intended to be copied.
@@ -428,6 +439,7 @@ private:
     std::pair<bool, CameraUtilConformWindowPolicy> _overrideWindowPolicy;
 
     GfVec4d _viewport;
+	bool _depthStencilEnabled{false};
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -272,8 +272,8 @@ public:
     /// -------------------------------------------------------
     /// Enable / disable depth stencil.
     /// An application may choose to use depth AOV, or depthStencil AOV.
-	HDX_API
-	void SetDepthStencilEnabled(bool enabled);
+    HDX_API
+    void SetDepthStencilEnabled(bool enabled);
 
     /// Returns true if the render index use depthStencil AOV.
     /// Returns flase if the render index use depth AOV.
@@ -439,7 +439,7 @@ private:
     std::pair<bool, CameraUtilConformWindowPolicy> _overrideWindowPolicy;
 
     GfVec4d _viewport;
-	bool _depthStencilEnabled{false};
+    bool _depthStencilEnabled{false};
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -1579,6 +1579,26 @@ UsdImagingGLEngine::GetHgi()
     return _hgi.get();
 }
 
+void
+UsdImagingGLEngine::SetDepthStencilEnabled(bool enabled)
+{
+    if (ARCH_UNLIKELY(!_renderDelegate)) {
+        return;
+    }
+
+    _taskController->SetDepthStencilEnabled(enabled);
+}
+
+bool
+UsdImagingGLEngine::GetDepthStencilEnabled()
+{
+    if (ARCH_UNLIKELY(!_renderDelegate)) {
+        return false;
+    }
+    
+    return _taskController->GetDepthStencilEnabled();
+}
+
 //----------------------------------------------------------------------------
 // Private/Protected
 //----------------------------------------------------------------------------

--- a/pxr/usdImaging/usdImagingGL/engine.h
+++ b/pxr/usdImaging/usdImagingGL/engine.h
@@ -581,6 +581,27 @@ public:
 
     /// @}
     
+    // ---------------------------------------------------------------------
+    /// \name DepthStencil
+    /// @{
+    // ---------------------------------------------------------------------
+
+    /// Enable / disable depth stencil.
+    /// An application may choose to use depth AOV, or depthStencil AOV.
+    /// Depth AOV represents the clip-space depth of the final fragment, while
+    /// depthStencil AOV represent the clip-space depth plus 8-bit stencil of 
+    /// the final fragment.
+    /// 
+    USDIMAGINGGL_API
+    void SetDepthStencilEnabled(bool enabled);
+
+    /// Returns true if the Engine use depthStencil AOV.
+    /// Returns flase if the Engine use depth AOV.
+    USDIMAGINGGL_API
+    bool GetDepthStencilEnabled();
+
+    /// @}
+    
 protected:
 
     /// Open some protected methods for whitebox testing.


### PR DESCRIPTION
### Description of Change(s)

Add interface in UsdImagingGLEngine to set & get the use of depthStencil AOV.

- An application may choose to use depth AOV, or depthStencil AOV.
- By default, the render index use the color AOV and the depth AOV.
- If we want to use the depthstencil AOV, we could call engine->SetDepthStencilEnabled(true) before engine->SetRendererAov().
- Users can use the depth stencil AOV for stencil testing.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
