### PR TITLE
Autodesk: Fix for MSAA configuration on macOS

### DIFF
--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -1315,9 +1315,6 @@ _GetPTCSPipeline(
     if (pipelineInstance.IsFirstInstance()) {
         HgiGraphicsPipelineDesc pipeDesc;
 
-        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,
-                                                  state.geometricShader);
-
         pipeDesc.rasterizationState.rasterizerEnabled = false;
         pipeDesc.multiSampleState.sampleCount = HgiSampleCount1;
         pipeDesc.multiSampleState.alphaToCoverageEnable = false;
@@ -1326,6 +1323,9 @@ _GetPTCSPipeline(
         pipeDesc.depthState.stencilTestEnabled = false;
         pipeDesc.primitiveType = HgiPrimitiveTypePatchList;
         pipeDesc.multiSampleState.multiSampleEnable = false;
+        
+        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,
+                                                  state.geometricShader);
 
         pipeDesc.shaderProgram = state.glslProgram->GetProgram();
         pipeDesc.vertexBuffers = _GetVertexBuffersForDrawing(state);


### PR DESCRIPTION
### Description of Change(s)

Here's the issue:

Most of our apps use an MSAA configuration, and on macOS we are getting the error:

* [MTLDebugRenderCommandEncoder setRenderPipelineState]:1598: failed assertion 'Set Render Pipeline State Validation
the sample count (4) does not match the renderPipelineState's sample count (1).

The issue is that the PSO does not have the correct (MSAA) sample count for the target.

I tracked this down to some code in pxr/imaging/hdSt/pipelineDrawBatch.cpp, in _GetDrawPipeline() where the correct state configured by a call to InitGraphicsPipelineDesc() is later overwritten. The fix here simply moves the call to InitGraphicsPipelineDesc() a few rows down, after the hardcoded initialization.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
