### PR TITLE
Support both OpenGL and Vulkan Hgi from single build.

### DIFF
--- a/pxr/imaging/hgiInterop/CMakeLists.txt
+++ b/pxr/imaging/hgiInterop/CMakeLists.txt
@@ -26,6 +26,12 @@ else()
     list(APPEND optionalPrivateHeaders opengl.h)
 endif()
 
+if (PXR_ENABLE_VULKAN_SUPPORT)
+    list(APPEND optionalCppFiles vulkan.cpp)
+    list(APPEND optionalPrivateHeaders vulkan.h)
+    list(APPEND optionalLibraries hgiVulkan)
+endif()
+
 pxr_library(hgiInterop
     LIBRARIES
         gf

--- a/pxr/imaging/hgiInterop/hgiInterop.cpp
+++ b/pxr/imaging/hgiInterop/hgiInterop.cpp
@@ -29,11 +29,12 @@
 #if defined(PXR_METAL_SUPPORT_ENABLED)
     #include "pxr/imaging/hgiMetal/hgi.h"
     #include "pxr/imaging/hgiInterop/metal.h"
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
-    #include "pxr/imaging/hgiVulkan/hgi.h"
-    #include "pxr/imaging/hgiInterop/vulkan.h"
 #else
     #include "pxr/imaging/hgiInterop/opengl.h"
+#endif
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
+    #include "pxr/imaging/hgiVulkan/hgi.h"
+    #include "pxr/imaging/hgiInterop/vulkan.h"
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -52,40 +53,43 @@ void HgiInterop::TransferToApp(
 {
     TfToken const& srcApi = srcHgi->GetAPIName();
 
+    if (dstApi != HgiTokens->OpenGL) {
+        TF_CODING_ERROR("Unsupported destination Hgi backend: %s", dstApi.GetText());
+        return;
+    }
+
 #if defined(PXR_METAL_SUPPORT_ENABLED)
-    if (srcApi==HgiTokens->Metal && dstApi==HgiTokens->OpenGL) {
+    if (srcApi==HgiTokens->Metal) {
         // Transfer Metal textures to OpenGL application
         if (!_metalToOpenGL) {
             _metalToOpenGL = std::make_unique<HgiInteropMetal>(srcHgi);
         }
-        _metalToOpenGL->CompositeToInterop(
+        return _metalToOpenGL->CompositeToInterop(
             srcColor, srcDepth, dstFramebuffer, dstRegion);
-    } else {
-        TF_CODING_ERROR("Unsupported Hgi backend: %s", srcApi.GetText());
-    }
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
-    if (srcApi==HgiTokens->Vulkan && dstApi==HgiTokens->OpenGL) {
-        // Transfer Vulkan textures to OpenGL application
-        if (!_vulkanToOpenGL) {
-            _vulkanToOpenGL = std::make_unique<HgiInteropVulkan>(srcHgi);
-        }
-        _vulkanToOpenGL->CompositeToInterop(
-            srcColor, srcDepth, dstFramebuffer, dstRegion);
-    } else {
-        TF_CODING_ERROR("Unsupported Hgi backend: %s", srcApi.GetText());
     }
 #else
-    if (srcApi==HgiTokens->OpenGL && dstApi==HgiTokens->OpenGL) {
+    if (srcApi==HgiTokens->OpenGL) {
         // Transfer OpenGL textures to OpenGL application
         if (!_openGLToOpenGL) {
             _openGLToOpenGL = std::make_unique<HgiInteropOpenGL>();
         }
-        _openGLToOpenGL->CompositeToInterop(
+        return _openGLToOpenGL->CompositeToInterop(
             srcColor, srcDepth, dstFramebuffer, dstRegion);
-    } else {
-        TF_CODING_ERROR("Unsupported Hgi backend: %s", srcApi.GetText());
     }
 #endif
+
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
+    if (srcApi==HgiTokens->Vulkan) {
+        // Transfer Vulkan textures to OpenGL application
+        if (!_vulkanToOpenGL) {
+            _vulkanToOpenGL = std::make_unique<HgiInteropVulkan>(srcHgi);
+        }
+        return _vulkanToOpenGL->CompositeToInterop(
+            srcColor, srcDepth, dstFramebuffer, dstRegion);
+    }
+#endif
+
+    TF_CODING_ERROR("Unsupported source Hgi backend: %s", srcApi.GetText());
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiInterop/hgiInterop.h
+++ b/pxr/imaging/hgiInterop/hgiInterop.h
@@ -102,10 +102,11 @@ private:
 
 #if defined(PXR_METAL_SUPPORT_ENABLED)
     std::unique_ptr<HgiInteropMetal> _metalToOpenGL;
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
-    std::unique_ptr<HgiInteropVulkan> _vulkanToOpenGL;
 #else
     std::unique_ptr<HgiInteropOpenGL> _openGLToOpenGL;
+#endif
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
+    std::unique_ptr<HgiInteropVulkan> _vulkanToOpenGL;
 #endif
 };
 


### PR DESCRIPTION
### Description of Change(s)
Makes it possible to use hgiOpenGL or hgiVulkan from a single USD distribution, with the choice to use which happening at runtime.

### Fixes Issue(s)
Currently only a single OpenGL, Vulkan, or Metal backend is built with USD.  While the exclusionary nature of OpenGL/Metal makes sense for macOS, this is less true for Window or Linux and means an app cannot choose which to use at runtime in addition to making updating a render-delegate to be aware of hgiVulkan a bit more difficult than it needs to be.

Additionally, with [proposals such as Autodesk DirectX backend](https://github.com/autodesk-forks/USD-proposals/tree/adsk/feature/DirectX12Hgi), it makes sense to think of these interop plug-ins as a matrix where multiple backends can transfer to one-another as needed.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
