### PR TITLE
Remove unused `boost/call_traits.h` header

### DIFF
--- a/pxr/usd/sdf/accessorHelpers.h
+++ b/pxr/usd/sdf/accessorHelpers.h
@@ -31,7 +31,6 @@
 #include "pxr/usd/sdf/spec.h"
 #include "pxr/usd/sdf/types.h"
 
-#include <boost/call_traits.hpp>
 #include <type_traits>
 
 // This file defines macros intended to reduce the amount of boilerplate code


### PR DESCRIPTION
### Description of Change(s)
`boost::call_traits` was removed from `pxr/usd/sdf/accessorHelpers.h` in #2527 but the header was not removed. This change removes the now unused header.

### Fixes Issue(s)
N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
