### PR TITLE
[docs] convertDoxygen.py: print stack trace on errors if debug mode on

### DIFF
--- a/docs/python/doxygenlib/cdUtils.py
+++ b/docs/python/doxygenlib/cdUtils.py
@@ -32,7 +32,7 @@
 import os
 import sys
 import inspect
-import re
+import traceback
 
 __debugMode = True
 
@@ -43,7 +43,10 @@ LABEL_STATIC = '**static** '
 
 def Error(msg):
     """Output a fatal error message and exit the program."""
-    print("Error: %s" % msg)
+    print("Error: %s" % msg, flush=True)
+    if __debugMode:
+        traceback.print_stack()
+        sys.stderr.flush()
     sys.exit(1)
 
 def Warn(msg):


### PR DESCRIPTION
### Description of Change(s)

If there's an error while running convertDoxygen.py, there's currently no easy way to get a stacktrace - this change makes it so that if debug prints are on, it also prints the full python stack trace.

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
