### PR TITLE
[docs] raise cmake error if converting python docstrings fails

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1270,12 +1270,18 @@ function(pxr_build_python_documentation)
     string(REPLACE ";" "," pxrPythonModulesStr "${pxrPythonModules}")
     # Run convertDoxygen on the module list, setting PYTHONPATH 
     # to the install path for the USD Python modules
-    install(CODE "execute_process(\
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/cmake \
-        COMMAND ${PYTHON_EXECUTABLE} ${CONVERT_DOXYGEN_TO_PYTHON_DOCS_SCRIPT} \
-        --package pxr --module ${pxrPythonModulesStr} \
-        --inputIndex ${BUILT_XML_DOCS}/index.xml \
-        --pythonPath ${CMAKE_INSTALL_PREFIX}/lib/python \
-        --output ${INSTALL_PYTHON_PXR_ROOT})")
+    install(CODE "\
+        execute_process(\
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/cmake \
+            RESULT_VARIABLE convert_doxygen_return_code
+            COMMAND ${PYTHON_EXECUTABLE} ${CONVERT_DOXYGEN_TO_PYTHON_DOCS_SCRIPT} \
+                --package pxr --module ${pxrPythonModulesStr} \
+                --inputIndex ${BUILT_XML_DOCS}/index.xml \
+                --pythonPath ${CMAKE_INSTALL_PREFIX}/lib/python \
+                --output ${INSTALL_PYTHON_PXR_ROOT})
+        if (NOT \${convert_doxygen_return_code} EQUAL \"0\")
+            message( FATAL_ERROR \"Error generating python docstrings - ${CONVERT_DOXYGEN_TO_PYTHON_DOCS_SCRIPT} return code: \${convert_doxygen_return_code} \")
+        endif()
+    ")
 
 endfunction() # pxr_build_python_documentation


### PR DESCRIPTION
### Description of Change(s)

Currently, if there is an error during python docstring generation, CMake will continue without erroring, and it is very easy to miss that there was an error.

Since python docstring generation is off by default, if it's on, the user likely wants to be know if there was a problem, so this change makes CMake error if docstring generation fails.

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
