### PR TITLE
[docs] cdWriterDocstring - don't word-wrap inside CODE sections

### DIFF
--- a/docs/python/doxygenlib/cdWriterDocstring.py
+++ b/docs/python/doxygenlib/cdWriterDocstring.py
@@ -228,11 +228,17 @@ class Writer:
         # following lines of a list item are indented at the same
         # level. We word wrap the text, but don't break long words
         # as we don't want to word wrap code sections.
+        # Take extra care with doxygen lifted CODE block lines.
         textWrapper = textwrap.TextWrapper(width=70, break_long_words=False)
-        newlines = list(map(textWrapper.fill, newlines))
+        wrapped_lines = []
+        for line in newlines:
+            if line.startswith("CODE_START"): # skip line wrapping on codeblock - manually unwrapped below
+                wrapped_lines.append(line)
+            else:
+                wrapped_lines.append(textWrapper.fill(line))
         lines = []
         inlistitem = False
-        for curline in newlines:
+        for curline in wrapped_lines:
             # the textwrap.fill call adds \n's at line breaks
             for line in curline.split('\n'):
                 if line.startswith("   - "):


### PR DESCRIPTION
### Description of Change(s)

Avoid applying word-wrapping line break inside of literal CODE chunks.

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
