### PR TITLE
[docs] py docstrings: fix docstring injection for pxr.GeomUtil

### DIFF
--- a/pxr/imaging/geomUtil/__init__.py
+++ b/pxr/imaging/geomUtil/__init__.py
@@ -25,15 +25,7 @@
 Utilities to help image common geometry.
 """
 
-from . import _geomUtil
 from pxr import Tf
-Tf.PrepareModule(_geomUtil, locals())
-del _geomUtil, Tf
-
-try:
-    import __DOC
-    __DOC.Execute(locals())
-    del __DOC
-except Exception:
-    pass
+Tf.PreparePythonModule()
+del Tf
 


### PR DESCRIPTION
### Description of Change(s)

For some reason, pxr.GeomUtil had non-standard code for handling it's python module setup; this code wasn't properly ported to python 3, as it does `import __DOC` instead of `from . import __DOC`, as relative imports are no longer default

However, replacing the non-standard code with the normal Tf.PreparePythonModule() works fine, so I just went with that approach

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
