### PR TITLE
[docs] py docstrings:  when generating docstrings, ignore old __DOC.py

### DIFF
--- a/docs/python/convertDoxygen.py
+++ b/docs/python/convertDoxygen.py
@@ -33,6 +33,7 @@
 # getDocString() and generate(). See cdWriterDocstring.py for an example.
 #
 
+import importlib
 import os
 import sys
 
@@ -71,8 +72,12 @@ if dll_path != None and os.name == "nt":
 #
 # Try to import the plugin module that creates the desired output
 #
-if not Import("from doxygenlib.cdWriter"+output_format+" import Writer as Writer"):
+try:
+    cdWriterModule = importlib.import_module(".cdWriter" + output_format, package="doxygenlib")
+except ImportError:
     Error("No writer plugin exists for format '%s'" % output_format)
+else:
+    Writer = cdWriterModule.Writer
 
 print("Converting Doxygen comments to %s format..." % output_format)
 

--- a/docs/python/doxygenlib/cdUtils.py
+++ b/docs/python/doxygenlib/cdUtils.py
@@ -63,32 +63,6 @@ def SetDebugMode(debugOn):
     global __debugMode
     __debugMode = debugOn
 
-def Import(cmd):
-    """Perform an import, inserting into the calling module's global scope."""
-
-    # find the global frame for the calling module
-    frame = inspect.currentframe()
-    module = frame.f_code.co_filename
-    modcount = 0
-    while frame and frame.f_back:
-        parent_module = frame.f_back.f_code.co_filename
-        if parent_module != module:
-            module = parent_module
-            modcount += 1
-            if modcount > 1:
-                break
-        frame = frame.f_back
-
-    # try to execute the import command (really, any command)
-    try:
-        globals = frame.f_globals
-        locals = frame.f_locals
-        exec(compile(cmd, '<string>', 'single'), globals, locals)
-        return True
-    except Exception as e:
-        print("Error: %s" % e)
-        return False
-
 def GetArg(optnames, default=False):
     """Return True if any of the args exist in sys.argv."""
     if not isinstance(optnames, type([])):

--- a/docs/python/doxygenlib/cdWriterDocstring.py
+++ b/docs/python/doxygenlib/cdWriterDocstring.py
@@ -130,9 +130,10 @@ class Writer:
         if packageName == "pxr":
             self.module = pxrModules[moduleName]
         else:
-            if not Import("from " +packageName+ " import " +moduleName+ " as " +moduleName):
-                Error("Could not import %s" % (moduleName))
-            self.module = eval(moduleName)
+            try:
+                self.module = importlib.import_module("." + moduleName, package=packageName)
+            except ImportError:
+                Error("Could not import %s.%s" % (packageName, moduleName))
         self.prefix = self.module.__name__.split('.')[-1]
         self.seenPaths = {}
         self.propertyTable = {}


### PR DESCRIPTION
### Description of Change(s)

py docstrings:  when generating docstrings, ignore old __DOC.py

...otherwise, the old generated python docstrings will cause new docstring generation to be skipped... but the new docstrings are still written out as empty

The result was that, before this change, every other run of docstring generation would wipe most of the docstrings

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
