### PR TITLE
[docs] py docstrings: use "classmethod" not "static"

### DIFF
--- a/docs/python/doxygenlib/cdUtils.py
+++ b/docs/python/doxygenlib/cdUtils.py
@@ -39,7 +39,7 @@ __debugMode = True
 ATTR_NOT_IN_PYTHON = 'notinpython'
 ATTR_STATIC_METHOD = 'staticmethod'
 
-LABEL_STATIC = '**static** '
+LABEL_STATIC = '**classmethod** '
 
 def Error(msg):
     """Output a fatal error message and exit the program."""


### PR DESCRIPTION
### Description of Change(s)

Since `static` is a C++ term, not a python one, use `classmethod` in python documentation instead.

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
