### PR TITLE
[docs] py docstrings: get rid of, ie "USD_API" type name prefixes

### DIFF
--- a/docs/python/doxygenlib/cdWriterDocstring.py
+++ b/docs/python/doxygenlib/cdWriterDocstring.py
@@ -42,6 +42,11 @@ import re
 
 from .cdUtils import *
 
+
+API_RE_FIND = re.compile(r"""\b[A-Z]+_API(?:\s+|$)""")
+API_RE_REPLACE = ""
+
+
 class Writer:
     """
     Manage the formatting of Python docstrings and output file generation.
@@ -483,6 +488,7 @@ class Writer:
         ret = ret.replace('boost::', '')
         ret = ret.replace('vector', 'sequence')
         ret = ret.replace('::', '.')
+        ret = API_RE_FIND.sub(API_RE_REPLACE, ret)
         ret = ret.strip()
         if ret.startswith(self.prefix):
             ret = ret[len(self.prefix):]


### PR DESCRIPTION
### Description of Change(s)

The python function signatures still had the X_API modifiers in them.  Since this is a C++ only concept, strip them when going from C++ to python.

**NOTE:**
This PR is one of several targeting the python docstring generation process.  To see all these PRs in a branch, see [here](https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...pmolodo:USD:pr/python-docstring-tweaks).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
