### PR TITLE
Implement `TF_PP_IS_TUPLE` with `tf/preprocessorUtilsLite.h`

### DIFF
--- a/pxr/base/tf/preprocessorUtils.h
+++ b/pxr/base/tf/preprocessorUtils.h
@@ -47,7 +47,6 @@
 #if defined(ARCH_COMPILER_MSVC)
 #include <boost/preprocessor/variadic/size.hpp>
 #include <boost/vmd/is_empty.hpp>
-#include <boost/vmd/is_tuple.hpp>
 ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
 #endif
 
@@ -108,27 +107,6 @@ ARCH_PRAGMA_MACRO_TOO_FEW_ARGUMENTS
     (__VA_ARGS__ BOOST_PP_REPEAT(BOOST_PP_INC(TF_MAX_ARITY), \
     _TF_NUM_ARGS_REP, _TF))
 #endif
-
-/// Exapnds to 1 if the argument is a tuple, and 0 otherwise.
-/// \ingroup group_tf_Preprocessor
-/// \hideinitializer
-#if defined(ARCH_COMPILER_MSVC)
-    #define TF_PP_IS_TUPLE(sequence) \
-        BOOST_VMD_IS_TUPLE(sequence)
-#else
-
-#define TF_PP_IS_TUPLE(arg) \
-    BOOST_PP_CAT(_TF_PP_IS_TUPLE, BOOST_PP_EXPAND(_TF_PP_IS_TUPLE arg)) )
-
-#define _TF_PP_IS_TUPLE(...) _TF
-
-#define _TF_PP_IS_TUPLE_TF _TF_PP_IS_TUPLE_TRUE(
-#define _TF_PP_IS_TUPLE_TF_PP_IS_TUPLE _TF_PP_IS_TUPLE_FALSE(
-
-#define _TF_PP_IS_TUPLE_TRUE() 1
-#define _TF_PP_IS_TUPLE_FALSE(arg) 0
-
-#endif 
 
 /// Count the number of elements in a preprocessor tuple.
 /// \ingroup group_tf_Preprocessor

--- a/pxr/base/tf/preprocessorUtilsLite.h
+++ b/pxr/base/tf/preprocessorUtilsLite.h
@@ -324,8 +324,8 @@
 /// \ingroup group_tf_Preprocessor
 /// \hideinitializer
 //
-// If the arguments satisfy _TF_PP_EAT_PARENS_IS_PARENS() then we expand to
-// _TF_PP_EAT_PARENS_EXPAND1, otherwise to _TF_PP_EAT_PARENS_EXPAND.  The
+// If the arguments satisfy _TF_PP_IS_PARENS() then we expand to
+// _TF_PP_PARENS_EXPAND1, otherwise to _TF_PP_PARENS_EXPAND.  The
 // former eats the parentheses while the latter passes the arguments
 // unchanged.
 //
@@ -333,8 +333,8 @@
 // arguments. MSVC will complain about insufficient arguments otherwise.
 // The ~ will be discarded in any case.
 #define TF_PP_EAT_PARENS(...) \
-    _TF_PP_EAT_PARENS_IFF(_TF_PP_EAT_PARENS_IS_PARENS(__VA_ARGS__ ~),\
-        _TF_PP_EAT_PARENS_EXPAND1,_TF_PP_EAT_PARENS_EXPAND)(__VA_ARGS__)
+    _TF_PP_EAT_PARENS_IFF(_TF_PP_IS_PARENS(__VA_ARGS__ ~),\
+        _TF_PP_PARENS_EXPAND1,_TF_PP_PARENS_EXPAND)(__VA_ARGS__)
 
 /// Expand the arguments and make the result a string.
 // We can't use
@@ -355,42 +355,47 @@
 #define _TF_PP_EAT_PARENS_IFF_1(t, f) t
 
 // Force expansion of the arguments.
-#define _TF_PP_EAT_PARENS_EXPAND(...) __VA_ARGS__
+#define _TF_PP_PARENS_EXPAND(...) __VA_ARGS__
 
 // Similar to expand except it will eat the first matching pair of
-// parentheses. For example, _TF_PP_EAT_PARENS_EXPAND1((x)(y)) yields x(y).
-// The outer _TF_PP_EAT_PARENS_EXPAND() is needed for MSVC, which otherwise
-// would stringizing to "_TF_PP_EAT_PARENS_EXPAND " plus the literal
+// parentheses. For example, _TF_PP_PARENS_EXPAND1((x)(y)) yields x(y).
+// The outer _TF_PP_PARENS_EXPAND() is needed for MSVC, which otherwise
+// would stringizing to "_TF_PP_PARENS_EXPAND " plus the literal
 // substitution of the arguments.
-#define _TF_PP_EAT_PARENS_EXPAND1(...) \
-    _TF_PP_EAT_PARENS_EXPAND(_TF_PP_EAT_PARENS_EXPAND __VA_ARGS__)
+#define _TF_PP_PARENS_EXPAND1(...) \
+    _TF_PP_PARENS_EXPAND(_TF_PP_PARENS_EXPAND __VA_ARGS__)
 
 // This works around a MSVC bug.  When a macro expands to FOO(__VA_ARGS__,bar),
 // MSVC will separate the arguments of __VA_ARGS__ even if they're inside
 // matching parentheses. So, for example, if __VA_ARGS__ is (x,y) then we'll
 // expand to FOO(x,y,bar) instead of FOO((x,y),bar).  This macro works around
-// that.  Use: _TF_PP_EAT_PARENS_CALL(FOO,(__VA_ARGS__,bar)).
+// that.  Use: _TF_PP_PARENS_CALL(FOO,(__VA_ARGS__,bar)).
 //
-// We need the _TF_PP_EAT_PARENS_EXPAND() here otherwise stringizing will
+// We need the _TF_PP_PARENS_EXPAND() here otherwise stringizing will
 // stringize the literal replacements, not the result of the expansion of x y.
 // If FOO(x,y) expands to x+y then we'd get "FOO ((x,y),bar)" without
-// _TF_PP_EAT_PARENS_EXPAND() instead of the correct "(x,y)+bar".
-#define _TF_PP_EAT_PARENS_CALL(x, y) _TF_PP_EAT_PARENS_EXPAND(x y)
+// _TF_PP_PARENS_EXPAND() instead of the correct "(x,y)+bar".
+#define _TF_PP_PARENS_CALL(x, y) _TF_PP_PARENS_EXPAND(x y)
 
 // Expands to 1 if x starts with a matched parenthesis, otherwise expands to
-// 0. "_TF_PP_EAT_PARENS_IS_PARENS2 x" eats the parentheses if they exist and
-// expands to "x, 1,", otherwise it expands to _TF_PP_EAT_PARENS_IS_PARENS2
+// 0. "_TF_PP_IS_PARENS2 x" eats the parentheses if they exist and
+// expands to "x, 1,", otherwise it expands to _TF_PP_IS_PARENS2
 // and the literal expansion of x.  This result goes to
-// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N() which extracts the 1 expanded from
-// _TF_PP_EAT_PARENS_IS_PARENS2 or a 0 passed as a final argument.  In either
+// _TF_PP_IS_PARENS_CHECK_N() which extracts the 1 expanded from
+// _TF_PP_IS_PARENS2 or a 0 passed as a final argument.  In either
 // case the desired result is the second argument to
-// _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N.
-#define _TF_PP_EAT_PARENS_IS_PARENS(x) \
-    _TF_PP_EAT_PARENS_IS_PARENS_CHECK(_TF_PP_EAT_PARENS_IS_PARENS2 x)
-#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK(...) \
-    _TF_PP_EAT_PARENS_CALL(_TF_PP_EAT_PARENS_IS_PARENS_CHECK_N,(__VA_ARGS__,0,))
-#define _TF_PP_EAT_PARENS_IS_PARENS_CHECK_N(x, n, ...) n
-#define _TF_PP_EAT_PARENS_IS_PARENS_TRUE(x) x, 1,
-#define _TF_PP_EAT_PARENS_IS_PARENS2(...) _TF_PP_EAT_PARENS_IS_PARENS_TRUE(~)
+// _TF_PP_IS_PARENS_CHECK_N.
+#define _TF_PP_IS_PARENS(x) \
+    _TF_PP_IS_PARENS_CHECK(_TF_PP_IS_PARENS2 x)
+#define _TF_PP_IS_PARENS_CHECK(...) \
+    _TF_PP_PARENS_CALL(_TF_PP_IS_PARENS_CHECK_N,(__VA_ARGS__,0,))
+#define _TF_PP_IS_PARENS_CHECK_N(x, n, ...) n
+#define _TF_PP_IS_PARENS_TRUE(x) x, 1,
+#define _TF_PP_IS_PARENS2(...) _TF_PP_IS_PARENS_TRUE(~)
+
+/// Exapnds to 1 if the argument is a tuple, and 0 otherwise.
+/// \ingroup group_tf_Preprocessor
+/// \hideinitializer
+#define TF_PP_IS_TUPLE(arg) _TF_PP_IS_PARENS(arg)
 
 #endif // PXR_BASE_TF_PREPROCESSOR_UTILS_LITE_H

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -76,7 +76,6 @@
 /// PRIVATE, you only need to use the DEFINE macro.
 
 #include "pxr/pxr.h"
-#include "pxr/base/tf/preprocessorUtils.h"
 #include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/staticData.h"
 #include "pxr/base/tf/token.h"


### PR DESCRIPTION
### Description of Change(s)
`TF_PP_EAT_PARENS` was recently made boost independent (#2241, #2532). `TF_PP_IS_TUPLE` can be implemented in terms of some of `TF_PP_EAT_PARENS` utilities. This PR removes the `EAT_PARENS` prefix from the now shared utility functions and moves `TF_PP_IS_TUPLE` to `preprocessorUtilsLite.h`.

With this PR, OpenUSD no longer depends on on `tf/preprocessorUtils.h` (except in its test).

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
