### PR TITLE
Replace `BOOST_PP_CAT` with `TF_PP_CAT`

### DIFF
--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -83,7 +83,6 @@
 
 #include <vector>
 
-#include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/control/iif.hpp>
 #include <boost/preprocessor/control/expr_iif.hpp>
 #include <boost/preprocessor/logical/and.hpp>

--- a/pxr/base/vt/types.h
+++ b/pxr/base/vt/types.h
@@ -33,9 +33,9 @@
 #include "pxr/base/arch/inttypes.h"
 #include "pxr/base/gf/declare.h"
 #include "pxr/base/gf/half.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/token.h"
 
-#include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/tuple/elem.hpp>
@@ -173,14 +173,14 @@ VT_SCALAR_CLASS_VALUE_TYPES VT_BUILTIN_VALUE_TYPES
 template<typename T> class VtArray;
 #define VT_ARRAY_TYPEDEF(r, unused, elem) \
 typedef VtArray< VT_TYPE(elem) > \
-BOOST_PP_CAT(Vt, BOOST_PP_CAT(VT_TYPE_NAME(elem), Array)) ;
+TF_PP_CAT(Vt, TF_PP_CAT(VT_TYPE_NAME(elem), Array)) ;
 BOOST_PP_SEQ_FOR_EACH(VT_ARRAY_TYPEDEF, ~, VT_SCALAR_VALUE_TYPES)
 
 // The following preprocessor code generates the boost pp sequence for
 // all array value types (VT_ARRAY_VALUE_TYPES)
 #define VT_ARRAY_TYPE_TUPLE(r, unused, elem) \
-(( BOOST_PP_CAT(Vt, BOOST_PP_CAT(VT_TYPE_NAME(elem), Array)) , \
-   BOOST_PP_CAT(VT_TYPE_NAME(elem), Array) ))
+(( TF_PP_CAT(Vt, TF_PP_CAT(VT_TYPE_NAME(elem), Array)) , \
+   TF_PP_CAT(VT_TYPE_NAME(elem), Array) ))
 #define VT_ARRAY_VALUE_TYPES \
 BOOST_PP_SEQ_FOR_EACH(VT_ARRAY_TYPE_TUPLE, ~, VT_SCALAR_VALUE_TYPES)
 

--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -171,7 +171,7 @@ static void _AddToUnitsMaps(_UnitsInfo &info,
 
 #define _ADD_UNIT_ENUM(r, category, elem)                               \
     TF_ADD_ENUM_NAME(                                                   \
-        BOOST_PP_CAT(Sdf ## category ## Unit, _SDF_UNIT_TAG(elem)),     \
+        TF_PP_CAT(Sdf ## category ## Unit, _SDF_UNIT_TAG(elem)),        \
         _SDF_UNIT_NAME(elem));
 
 #define _REGISTRY_FUNCTION(r, unused, elem)                          \
@@ -187,7 +187,7 @@ BOOST_PP_LIST_FOR_EACH(_REGISTRY_FUNCTION, ~, _SDF_UNITS)
 #define _ADD_UNIT_TO_MAPS(r, category, elem)                            \
     _AddToUnitsMaps(                                                    \
         *info,                                                          \
-        BOOST_PP_CAT(Sdf ## category ## Unit, _SDF_UNIT_TAG(elem)),     \
+        TF_PP_CAT(Sdf ## category ## Unit, _SDF_UNIT_TAG(elem)),        \
         _SDF_UNIT_NAME(elem),                                           \
         _SDF_UNIT_SCALE(elem), #category);
 
@@ -211,11 +211,11 @@ static _UnitsInfo &_GetUnitsInfo() {
 #undef _PROCESS_ENUMERANT
 
 #define _REGISTRY_FUNCTION(r, unused, elem)                          \
-TF_REGISTRY_FUNCTION_WITH_TAG(TfType, BOOST_PP_CAT(Type, _SDF_UNITSLIST_CATEGORY(elem))) \
+TF_REGISTRY_FUNCTION_WITH_TAG(TfType, TF_PP_CAT(Type, _SDF_UNITSLIST_CATEGORY(elem))) \
 {                                                                    \
     TfType::Define<_SDF_UNITSLIST_ENUM(elem)>();                     \
 }                                                                    \
-TF_REGISTRY_FUNCTION_WITH_TAG(VtValue, BOOST_PP_CAT(Value, _SDF_UNITSLIST_CATEGORY(elem))) \
+TF_REGISTRY_FUNCTION_WITH_TAG(VtValue, TF_PP_CAT(Value, _SDF_UNITSLIST_CATEGORY(elem))) \
 {                                                                    \
     _RegisterEnumWithVtValue<_SDF_UNITSLIST_ENUM(elem)>();           \
 }

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -59,6 +59,7 @@
 #include "pxr/base/gf/vec4h.h"
 #include "pxr/base/gf/vec4i.h"
 #include "pxr/base/tf/enum.h"
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/type.h"
@@ -247,11 +248,11 @@ enum SdfAuthoringError
 
 #define _SDF_UNITSLIST_CATEGORY(tup) BOOST_PP_TUPLE_ELEM(2, 0, tup)
 #define _SDF_UNITSLIST_TUPLES(tup) BOOST_PP_TUPLE_ELEM(2, 1, tup)
-#define _SDF_UNITSLIST_ENUM(elem) BOOST_PP_CAT(BOOST_PP_CAT(Sdf, \
+#define _SDF_UNITSLIST_ENUM(elem) TF_PP_CAT(TF_PP_CAT(Sdf, \
                                     _SDF_UNITSLIST_CATEGORY(elem)), Unit)
 
 #define _SDF_DECLARE_UNIT_ENUMERANT(r, tag, elem) \
-    BOOST_PP_CAT(Sdf ## tag ## Unit, _SDF_UNIT_TAG(elem)),
+    TF_PP_CAT(Sdf ## tag ## Unit, _SDF_UNIT_TAG(elem)),
 
 #define _SDF_DECLARE_UNIT_ENUM(r, unused, elem)          \
 enum _SDF_UNITSLIST_ENUM(elem) {                         \


### PR DESCRIPTION
### Description of Change(s)
`BOOST_PP_CAT` can be replaced with `TF_PP_CAT` in many places, reducing the dependency of OpenUSD on boost.

### Fixes Issue(s)
- 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
