### PR TITLE
Make `Sdf_LayerRegistry::FindByIdentifier` private

### DIFF
--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -3328,8 +3328,8 @@ SdfLayer::_OpenLayerAndUnlockRegistry(
     // initialization.  But now that the layer is in the registry, we release
     // the registry lock to avoid blocking progress of threads working with
     // other layers.
-    TF_VERIFY(_layerRegistry->
-              FindByIdentifier(layer->GetIdentifier()) == layer,
+    TF_VERIFY(_layerRegistry->Find(layer->GetIdentifier(),
+                                   layer->GetResolvedPath()) == layer,
               "Could not find %s", layer->GetIdentifier().c_str());
 
     lock.release();

--- a/pxr/usd/sdf/layerRegistry.cpp
+++ b/pxr/usd/sdf/layerRegistry.cpp
@@ -178,7 +178,7 @@ Sdf_LayerRegistry::Find(
     SdfLayerHandle foundLayer;
 
     if (Sdf_IsAnonLayerIdentifier(inputLayerPath)) {
-        foundLayer = FindByIdentifier(inputLayerPath);
+        foundLayer = _FindByIdentifier(inputLayerPath);
     } else {
         ArResolver& resolver = ArGetResolver();
 
@@ -190,7 +190,7 @@ Sdf_LayerRegistry::Find(
         string assetPath, args;
         Sdf_SplitIdentifier(inputLayerPath, &assetPath, &args);
         if (!resolver.IsContextDependentPath(assetPath)) {
-            foundLayer = FindByIdentifier(layerPath);
+            foundLayer = _FindByIdentifier(layerPath);
         }
 
         // If the layer path is in repository form and we haven't yet
@@ -218,7 +218,7 @@ Sdf_LayerRegistry::Find(
 }
 
 SdfLayerHandle
-Sdf_LayerRegistry::FindByIdentifier(
+Sdf_LayerRegistry::_FindByIdentifier(
     const string& layerPath) const
 {
     TRACE_FUNCTION();
@@ -232,7 +232,7 @@ Sdf_LayerRegistry::FindByIdentifier(
         foundLayer = *identifierIt;
 
     TF_DEBUG(SDF_LAYER).Msg(
-        "Sdf_LayerRegistry::FindByIdentifier('%s') => %s\n",
+        "Sdf_LayerRegistry::_FindByIdentifier('%s') => %s\n",
         layerPath.c_str(),
         foundLayer ? "Found" : "Not Found");
 

--- a/pxr/usd/sdf/layerRegistry.h
+++ b/pxr/usd/sdf/layerRegistry.h
@@ -71,15 +71,14 @@ public:
     SdfLayerHandle Find(const std::string &layerPath,
                         const std::string &resolvedPath=std::string()) const;
 
-    /// Returns a layer from the registry, consulting the by_identifier index
-    /// with the \p layerPath as provided.
-    SdfLayerHandle FindByIdentifier(const std::string& layerPath) const;
-
     /// Returns all valid layers held in the registry as a set.
     SdfLayerHandleSet GetLayers() const;
 
 private:
-    
+    // Returns a layer from the registry, consulting the by_identifier index
+    // with the \p layerPath as provided.
+    SdfLayerHandle _FindByIdentifier(const std::string& layerPath) const;
+
     // Returns a layer from the registry, consulting the by_repository_path
     // index with the \p layerPath as provided.
     SdfLayerHandle _FindByRepositoryPath(const std::string& layerPath) const;


### PR DESCRIPTION
### Description of Change(s)
Layer identifiers when multiple contexts are bound are not guaranteed to be unique. As such, `FindByIdentifier` may not return the intended result.  It's only used once externally (in a `TF_VERIFY` statement).  This updates that statement to use `Find` with an explicitly resolved path and makes `FindByIdentifier` private.

Simplifying the public API for `Sdf_LayerRegistry` will help the boost removal effort by scoping what kind of queries the replacement data structure needs to support.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
