### PR TITLE
Fix Windows dll-interface warnings (C4251) for clients of `TfSingleton`

### DIFF
--- a/pxr/base/tf/singleton.h
+++ b/pxr/base/tf/singleton.h
@@ -195,7 +195,12 @@ public:
 private:
     static T *_CreateInstance(std::atomic<T *> &instance);
     
+    // Suppress dll-interface warnings from MSVC; _instance
+    // is an inaccessible implementation detail of TfSingleton.
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_NEEDS_EXPORT_INTERFACE
     static std::atomic<T *> _instance;
+    ARCH_PRAGMA_POP
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

The `std::atomic` is a private implementation detail and is inaccessible by clients of `TfSingleton`.

This pragma was originally included in `TfSingleton` on a private `std::mutex`, but was removed when it was refactored in 7899a94edb41a7b4d08d065a6f971f048bf1597c. That commit also removed `ARCH_PRAGMA_UNDEFINED_VAR_TEMPLATE` from `GetInstance()`. However, that one was added back in 4cec3635bc4b11e6ba5ce3d372ff6e4703c06391, while `ARCH_PRAGMA_NEEDS_EXPORT_INTERFACE` was never re-introduced.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
