### PR TITLE
[sdrOsl] Support building plugin against OSL builds that use Imath

### DIFF
--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -5,6 +5,14 @@ if(NOT PXR_ENABLE_OSL_SUPPORT)
     return()
 endif()
 
+# Use the import targets set by Imath's package config
+if (Imath_FOUND)
+    set(__OSL_IMATH_LIBS "Imath::Imath")
+else()
+    set(__OSL_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
+    set(__OSL_IMATH_LIBS ${OPENEXR_LIBRARIES})
+endif()
+
 pxr_plugin(sdrOsl
     LIBRARIES
         gf
@@ -15,11 +23,12 @@ pxr_plugin(sdrOsl
         sdr
         ${OSL_QUERY_LIBRARY}
         ${OIIO_LIBRARIES}
+        ${__OSL_IMATH_LIBS}
 
     INCLUDE_DIRS
-        ${OPENEXR_INCLUDE_DIR}
         ${OSL_INCLUDE_DIR}
         ${OIIO_INCLUDE_DIRS}
+        ${__OSL_IMATH_INCLUDE}
 
     PUBLIC_CLASSES
         oslParser


### PR DESCRIPTION
### Description of Change(s)

Simple change to fix the build of the `sdrOsl` plugin when using an OSL build that depends on `Imath` rather than `IlmBase`.

The changes use the same pattern as the `hioOiio` plugin build.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
