### PR TITLE
Fix compilation issues when building USD using the C++20 standard

### DIFF
--- a/pxr/imaging/hd/instanceRegistry.h
+++ b/pxr/imaging/hd/instanceRegistry.h
@@ -177,7 +177,7 @@ public:
 private:
     template <typename T>
     static bool _IsUnique(std::shared_ptr<T> const &value) {
-        return value.unique();
+        return value.use_count() == 1;
     }
 
     typename InstanceType::Dictionary _dictionary;

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -551,8 +551,9 @@ HdStResourceRegistry::GarbageCollectDispatchBuffers()
     _dispatchBufferRegistry.erase(
         std::remove_if(
             _dispatchBufferRegistry.begin(), _dispatchBufferRegistry.end(),
-            std::bind(&HdStDispatchBufferSharedPtr::unique,
-                      std::placeholders::_1)),
+            [](const HdStDispatchBufferSharedPtr& ptr) {
+                return ptr.use_count() == 1;
+            }),
         _dispatchBufferRegistry.end());
 }
 
@@ -564,8 +565,9 @@ HdStResourceRegistry::GarbageCollectBufferResources()
     _bufferResourceRegistry.erase(
         std::remove_if(
             _bufferResourceRegistry.begin(), _bufferResourceRegistry.end(),
-            std::bind(&HdStBufferResourceSharedPtr::unique,
-                      std::placeholders::_1)),
+            [](const HdStBufferResourceSharedPtr& ptr) {
+                return ptr.use_count() == 1;
+            }),
         _bufferResourceRegistry.end());
 }
 

--- a/pxr/imaging/hdSt/samplerObjectRegistry.cpp
+++ b/pxr/imaging/hdSt/samplerObjectRegistry.cpp
@@ -129,13 +129,13 @@ HdSt_SamplerObjectRegistry::GarbageCollect()
     size_t last = _samplerObjects.size();
 
     for (size_t i = 0; i < last; i++) {
-        if (_samplerObjects[i].unique()) {
+        if (_samplerObjects[i].use_count() == 1) {
             while(true) {
                 last--;
                 if (i == last) {
                     break;
                 }
-                if (!_samplerObjects[last].unique()) {
+                if (_samplerObjects[last].use_count() != 1) {
                     _samplerObjects[i] = _samplerObjects[last];
                     break;
                 }

--- a/pxr/imaging/hio/stb/stb_image.h
+++ b/pxr/imaging/hio/stb/stb_image.h
@@ -4626,7 +4626,7 @@ static int stbi__check_png_header(stbi__context *s)
    return 1;
 }
 
-typedef struct
+typedef struct stbi__png_type
 {
    stbi__context *s;
    stbi_uc *idata, *expanded, *out;

--- a/pxr/imaging/hio/stb/stb_image.patch
+++ b/pxr/imaging/hio/stb/stb_image.patch
@@ -1,5 +1,5 @@
---- original/stb_image.h	2024-05-21 15:30:18.887733957 -0700
-+++ stb_image.h	2024-05-21 15:17:49.371401403 -0700
+--- original/stb_image.h	2024-12-09 08:40:54
++++ stb_image.h	2024-12-09 08:41:15
 @@ -490,14 +490,14 @@
  STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
  
@@ -28,7 +28,13 @@
  static int      stbi__png_is16(stbi__context *s);
  #endif
  
-@@ -4631,6 +4631,7 @@
+@@ -4626,11 +4626,12 @@
+    return 1;
+ }
+ 
+-typedef struct
++typedef struct stbi__png_type
+ {
     stbi__context *s;
     stbi_uc *idata, *expanded, *out;
     int depth;

--- a/pxr/usd/pcp/primIndex_Graph.cpp
+++ b/pxr/usd/pcp/primIndex_Graph.cpp
@@ -613,7 +613,7 @@ PcpPrimIndex_Graph::_InsertChildInStrengthOrder(
 void 
 PcpPrimIndex_Graph::_DetachSharedNodePool()
 {
-    if (!_nodes.unique()) {
+    if (_nodes.use_count() != 1) {
         TRACE_FUNCTION();
         TfAutoMallocTag tag("_DetachSharedNodePool");
         _nodes = std::make_shared<_NodePool>(*_nodes);
@@ -623,7 +623,7 @@ PcpPrimIndex_Graph::_DetachSharedNodePool()
 void 
 PcpPrimIndex_Graph::_DetachSharedNodePoolForNewNodes(size_t numAddedNodes)
 {
-    if (!_nodes.unique()) {
+    if (_nodes.use_count() != 1) {
         TRACE_FUNCTION();
         TfAutoMallocTag tag("_DetachSharedNodePoolForNewNodes");
         // Create a new copy, but with some extra capacity since we are adding


### PR DESCRIPTION
Hello! :)

This may be a ways out on the road map still since the VFX reference platform hasn't made it there yet, but I took an initial crack at addressing some C++20 compilation issues and wanted to offer this small handful of changes that worked for me and still maintains compatibility with the currently chosen standard (C++14).

With the changes here, I was able to build USD with the C++ standard set forward to C++20 using the following patch:

```
diff --git a/cmake/defaults/CXXDefaults.cmake b/cmake/defaults/CXXDefaults.cmake
index e970dfbe2..48c132ff7 100644
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -25,8 +25,8 @@ include(CXXHelpers)
 include(Version)
 include(Options)

-# Require C++14
-set(CMAKE_CXX_STANDARD 14)
+# Require C++20
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
```

I tested on the following configurations:
- Windows 10, Visual Studio 2022 v17.6.5/msvc 19.36.32537, Python 3.9.13
- macOS 13.5, Apple clang 14.0.3, Python 3.9.6

I unfortunately don't have a Linux environment I can test this with at the moment. Interestingly, I did **not** need to incorporate #2242 (which aims to address #2183), so that particular issue may be specific to using gcc.

Here are some details about the changes:

---

The first three commits replace the use of `std::shared_ptr`'s `unique()` with `use_count() == 1` instead. `unique()` was deprecated in C++17 and removed in C++20, and should be equivalent to `use_count() == 1` which is available back to C++11. I broke them out into individual commits updating `hd`, `hdSt`, and `pcp`, but I'm also happy to create separate pull requests for each if that's preferable.

I did want to flag the note on [cppreference.com](https://en.cppreference.com/w/cpp/memory/shared_ptr/unique) though:

> This function was deprecated in C++17 and removed in C++20 because use_count is only an approximation in multithreaded environment (see Notes in use_count).

I'm not sure whether that's of concern for the instances of `unique()` currently in place, but switching to `use_count()` at least shouldn't be any less safe.

---

The change in `hio/stb` addresses an issue where unnamed classes used in typedefs can no longer have a default member initializer. This is specific to the `gamma` field in `stb__png` which the `hio` version adds. Since the affected file is sourced externally, I also updated the `.patch` file used to produce `hio`'s version from the original.

---

The last change in `sdf` is somewhat perplexing, but the Boost Python wrapping for `SdfPredicateExpression`'s `GetParseError()` seems to fail to deduce properly when C++20 is enabled. I was able to get around this by adding an explicit static function to call the appropriate version, but I'd be curious to see whether anyone with stronger Boost and/or type deduction debugging-fu has a better idea. I tried bumping Boost to the latest version (1.82.0) as well, but that didn't seem to make a difference.

I'll post the wall-of-text compilation error that was generated prompting the change separately so as not to (further) muddy the description here.

---

Hope these are helpful! Thanks!


- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement


