### PR TITLE
fix VisualStudio find fail

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -116,7 +116,8 @@ def GetXcodeDeveloperDirectory():
 def GetVisualStudioCompilerAndVersion():
     """Returns a tuple containing the path to the Visual Studio compiler
     and a tuple for its version, e.g. (14, 0). If the compiler is not found
-    or version number cannot be determined, returns None."""
+    or version number cannot be determined, returns None.
+    NOTE: path possibly to be None, please don't depend on it"""
     if not Windows():
         return None
 
@@ -129,6 +130,19 @@ def GetVisualStudioCompilerAndVersion():
             os.environ.get("VisualStudioVersion", ""))
         if match:
             return (msvcCompiler, tuple(int(v) for v in match.groups()))
+
+    # if VisualStudioVersion environment variable was not set, which happened
+    # for most users, CMake was used to search. A python version of CMake
+    # search method also provided on github PyVisualStudioSetupConfiguration,
+    # but unnecessary.
+    # Exact path of cl is never be used, so left to be None here.
+    output = subprocess.getoutput("cmake --help")
+    if output:
+        m = re.search('\* *(Visual Studio (\d+) (\d+))', output)
+        if m:
+            msvcMajorVersion    = int(m.group(2))
+            msvcMinorVerson     = 0   # no minor version info
+            return (None, (msvcMajorVersion, msvcMinorVerson))
     return None
 
 def IsVisualStudioVersionOrGreater(desiredVersion):


### PR DESCRIPTION
### Description of Change(s)

Visual Studio finding will fail if user not set environment variable, which happened to most users.

And if clang or g++ was installed, build will continue with MSBuild but with -j cpu_count, not /M:cpu_cout. This makes users confused and don't known how to build.

This fix use CMake to find visual studio,  cmake use sophisticated approach to find visual studio.

A python implement of this sophisticated finding algorithm also provided on my github [PyVisualStudioSetupConfiguration](https://github.com/AndrewChan2022/PyVisualStudioSetupConfiguration), but I think it is unnecessary, cmake should be good enough.

### Fixes Issue(s)
- Visual Studio finding fails

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes


431 - testUsdZipFile (Failed)
677 - testUsdviewNavigationKeys (Failed)
693 - testUsdResolverExample (Failed)

the 3 cases also failed before my change, should unrelated to this change.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
