### PR TITLE
Autodesk: Fix C4273 warning from Sdf_PathExpressionEvalBase

### DIFF
--- a/pxr/usd/sdf/pathExpressionEval.h
+++ b/pxr/usd/sdf/pathExpressionEval.h
@@ -69,7 +69,7 @@ Sdf_MakePathExpressionEvalImpl(
 class Sdf_PathExpressionEvalBase
 {
 public:
-    friend bool
+    friend SDF_API bool
     Sdf_MakePathExpressionEvalImpl(
         Sdf_PathExpressionEvalBase &eval,
         SdfPathExpression const &expr,


### PR DESCRIPTION
### Description of Change(s)

The declaration of the function Sdf_MakePathExpressionEvalImpl has SDF_API prefix, but when it is used as a friend function in Sdf_PathExpressionEvalBase, the SDF_APL prefix is missing. This will cause C4273 warning if this header is included in an external project. This small change fixes the warning.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
