### PR TITLE
Autodesk: Fix C3861 error for std::sort in base/tf

### DIFF
--- a/pxr/base/tf/testenv/notice.cpp
+++ b/pxr/base/tf/testenv/notice.cpp
@@ -110,6 +110,7 @@ vector<string> mainThreadList;
 std::mutex workerThreadLock;
 std::mutex mainThreadLock;
 
+// Helper to lock and print the list of log strings alphabetically; then clear the list
 static void 
 _DumpLog(ostream *log, vector<string> *li, std::mutex *mutex) {
     std::lock_guard<std::mutex> lock(*mutex);

--- a/pxr/base/tf/testenv/notice.cpp
+++ b/pxr/base/tf/testenv/notice.cpp
@@ -31,6 +31,7 @@
 #include "pxr/base/tf/weakPtr.h"
 #include "pxr/base/arch/systemInfo.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdio>
 #include <iostream>
@@ -112,7 +113,7 @@ std::mutex mainThreadLock;
 static void 
 _DumpLog(ostream *log, vector<string> *li, std::mutex *mutex) {
     std::lock_guard<std::mutex> lock(*mutex);
-    sort(li->begin(), li->end());
+    std::sort(li->begin(), li->end());
     for(vector<string>::const_iterator n = li->begin(); 
         n != li->end(); ++ n) {
         *log << *n << endl;


### PR DESCRIPTION
### Description of Change(s)

Adding include to address error C3861: 'sort': identifier not found.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
