### PR TITLE
APPLE: OIT issue fix for MaterialX

### DIFF
--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -1510,6 +1510,7 @@ void main(void)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
         discard;
+        return;
     }
 #endif
 

--- a/pxr/imaging/hdx/shaders/renderPass.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPass.glslfx
@@ -43,6 +43,7 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
         colorOut = vec4(color.rgb, 1);
     } else {
         discard;
+        return;
     }
 }
 
@@ -122,7 +123,7 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     // There are two render passes for ordinary OIT geometry.
     // Fragments with alpha >= 1.0 are handled in the first (opaque)
     // render pass.
-    if (color.a < 1.0 && color.a > 0.0001) {
+    if (color.a < 1.0 && color.a >= 0.0001) {
         RenderOutputImpl(Peye, Neye, color, patchCoord);
     }
 }

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -434,7 +434,7 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
     header  << _GetPackedTypeDefinitions();
 
     header << "#define in /*in*/\n"
-              "#define discard discard_fragment();\n"
+              "#define discard discard_fragment(); discarded_fragment = true;\n"
               "#define radians(d) (d * 0.01745329252)\n"
               "#define noperspective /*center_no_perspective MTL_FIXME*/\n"
               "#define dFdx    dfdx\n"
@@ -1413,6 +1413,10 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
         section->VisitScopeStructs(ss);
     }
     ss << "\n// //////// Scope Member Declarations ////////\n";
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << "bool discarded_fragment;\n";
+    }
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         section->VisitScopeMemberDeclarations(ss);
     }
@@ -1526,11 +1530,24 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
 
     // Execute all code that hooks into the entry point function
     ss << "\n// //////// Entry Point Function Executions ////////\n";
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << _generatorShaderSections->GetScopeInstanceName() << ".discarded_fragment = false;\n";
+    }
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         if (section->VisitEntryPointFunctionExecutions(
                 ss, _generatorShaderSections->GetScopeInstanceName())) {
             ss << "\n";
         }
+    }
+    if(this->_GetShaderStage() == HgiShaderStageFragment)
+    {
+        ss << "if(" << _generatorShaderSections->GetScopeInstanceName() << ".discarded_fragment)\n";
+        ss << "{\n";
+        ss << "return "
+           << (outputs ? "{}" : "")
+           << ";\n";
+        ss << "}\n";
     }
     //return the instance of the shader entrypoint output type
     if (outputs &&

--- a/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
+++ b/pxr/usdImaging/plugin/usdShaders/shaders/previewSurface.glslfx
@@ -78,6 +78,7 @@ surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (opacity < opacityThreshold) {
         discard;
+        return vec4(1.0);
     } 
     opacity = 1.0;
 #endif            


### PR DESCRIPTION
### Description of Change(s)
- Explicit returns for discards for Metal shading language version less than 2_4
- Parts of our earlier MaterialX PR which couldn't be included in last release are explicitly put out in PR, for discussion and hopeful landing in next release

### Fixes Issue(s)
- OIT buffer invalidly written into when the intention was to stop shader execution due to discard
- When one such asset is included, especially with MaterialX, the whole frame buffer becomes noisy and glitchy

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
