### PR TITLE
Autodesk: Remove include of "dispatcher.h" which introduces tbb headers

### DIFF
--- a/pxr/imaging/hdx/colorCorrectionTask.h
+++ b/pxr/imaging/hdx/colorCorrectionTask.h
@@ -36,8 +36,8 @@
 #include "pxr/imaging/hgi/resourceBindings.h"
 #include "pxr/imaging/hgi/shaderProgram.h"
 #include "pxr/imaging/hgi/texture.h"
-#include "pxr/base/work/dispatcher.h"
 
+#include <memory>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -218,7 +218,8 @@ private: // data
     HgiGraphicsPipelineHandle _pipeline;
     float _screenSize[2];
 
-    WorkDispatcher _workDispatcher;
+    class _Impl;
+    std::unique_ptr<_Impl> _impl;
 };
 
 // VtValue requirements


### PR DESCRIPTION
### Description of Change(s)

Currently, TBB header is directly included in dispatcher.h. And when someone includes the header file colorCorrectionTask.h or taskController.h in their application, dispatcher.h is included in colorCorrectionTask.h and the TBB headers will be leaked to end users causing some compatibility issues. 

In this commit, the unnecessary dispatcher.h included in colorCorrectionTask.h is removed to reduce the risk of such problems.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
