### PR TITLE
Apple: Make C++ CLI apps linkable with python plugins

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -100,10 +100,15 @@ if(PXR_ENABLE_PYTHON_SUPPORT)
 
         # This option indicates that we don't want to explicitly link to the
         # python libraries. See BUILDING.md for details.
+        # Note: If the libraries dont link with python, that means the
+        # applications using them must do so. We define APP_PYTHON_LIBRARIES
+        # for the applications built with USD, such as usdcat, to use.
         if(PXR_PY_UNDEFINED_DYNAMIC_LOOKUP AND NOT WIN32)
             set(PYTHON_LIBRARIES "")
+            set(BIN_PYTHON_LIBRARIES "${package}::Python")
         else()
             set(PYTHON_LIBRARIES "${package}::Python")
+            set(BIN_PYTHON_LIBRARIES "")
         endif()
     endmacro()
 

--- a/pxr/usd/bin/sdfdump/CMakeLists.txt
+++ b/pxr/usd/bin/sdfdump/CMakeLists.txt
@@ -7,4 +7,5 @@ pxr_cpp_bin(sdfdump
         plug
         tf
         sdf
+        ${BIN_PYTHON_LIBRARIES}
 )

--- a/pxr/usd/bin/sdffilter/CMakeLists.txt
+++ b/pxr/usd/bin/sdffilter/CMakeLists.txt
@@ -8,4 +8,5 @@ pxr_cpp_bin(sdffilter
         arch
         tf
         sdf
+        ${BIN_PYTHON_LIBRARIES}
 )

--- a/pxr/usd/bin/usdcat/CMakeLists.txt
+++ b/pxr/usd/bin/usdcat/CMakeLists.txt
@@ -7,6 +7,7 @@ pxr_cpp_bin(usdcat
         sdf
         usd
         usdUtils
+        ${BIN_PYTHON_LIBRARIES}
         )
 
 pxr_install_test_dir(

--- a/pxr/usd/bin/usdtree/CMakeLists.txt
+++ b/pxr/usd/bin/usdtree/CMakeLists.txt
@@ -9,6 +9,7 @@ pxr_cpp_bin(usdtree
         tf
         usd
         usdUtils
+        ${BIN_PYTHON_LIBRARIES}
         )
 
 pxr_install_test_dir(


### PR DESCRIPTION
### Description of Change(s)
- Expose the ability to allow external CLIs to link with Python

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
