### PR TITLE
Apple: Allow toggling visualization

### DIFF
--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -210,6 +210,7 @@ HdxTaskController::HdxTaskController(HdRenderIndex *renderIndex,
     , _renderBufferSize(0, 0)
     , _overrideWindowPolicy{false, CameraUtilFit}
     , _viewport(0, 0, 1, 1)
+    , _enableVisualization(true)
 {
     _CreateRenderGraph();
 }
@@ -692,7 +693,7 @@ bool
 HdxTaskController::_VisualizeAovEnabled() const
 {
     // Only non-color AOVs need special colorization for viz.
-    if (_viewportAov != HdAovTokens->color) {
+    if (_enableVisualization && _viewportAov != HdAovTokens->color) {
         return true;
     }
     return false;
@@ -1982,6 +1983,14 @@ HdxTaskController::SetBBoxParams(
         GetRenderIndex()->GetChangeTracker().MarkTaskDirty(
             _boundingBoxTaskId, HdChangeTracker::DirtyParams);
     }
+}
+
+void 
+HdxTaskController::SetEnableVisualization(bool status)
+{
+    // This controls whether or not to run visualization passes or output the
+    // raw unvisualized data.
+    _enableVisualization = status;
 }
 
 void 

--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -261,6 +261,13 @@ public:
     void SetBBoxParams(const HdxBoundingBoxTaskParams& params);
 
     /// -------------------------------------------------------
+    /// Visualization API
+
+    /// Configure visualization passes.
+    HDX_API
+    void SetEnableVisualization(bool status);
+    
+    /// -------------------------------------------------------
     /// Present API
 
     /// Enable / disable presenting the render to bound framebuffer.
@@ -428,6 +435,8 @@ private:
     std::pair<bool, CameraUtilConformWindowPolicy> _overrideWindowPolicy;
 
     GfVec4d _viewport;
+
+    bool _enableVisualization;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -428,6 +428,8 @@ UsdImagingGLEngine::RenderBatch(
 
     _SetBBoxParams(params.bboxes, params.bboxLineColor, params.bboxLineDashSize);
 
+    _taskController->SetEnableVisualization(params.enableVisualization);
+    
     // XXX App sets the clear color via 'params' instead of setting up Aovs 
     // that has clearColor in their descriptor. So for now we must pass this
     // clear color to the color AOV.

--- a/pxr/usdImaging/usdImagingGL/renderParams.h
+++ b/pxr/usdImaging/usdImagingGL/renderParams.h
@@ -112,6 +112,8 @@ public:
     BBoxVector bboxes;
     GfVec4f bboxLineColor;
     float bboxLineDashSize;
+    // Visualization control
+    bool enableVisualization;
 
     inline UsdImagingGLRenderParams();
 
@@ -149,7 +151,8 @@ UsdImagingGLRenderParams::UsdImagingGLRenderParams() :
     clearColor(0,0,0,1),
     lut3dSizeOCIO(65),
     bboxLineColor(1),
-    bboxLineDashSize(3)
+    bboxLineDashSize(3),
+    enableVisualization(true)
 {
 }
 
@@ -188,7 +191,8 @@ UsdImagingGLRenderParams::operator==(const UsdImagingGLRenderParams &other)
         && lut3dSizeOCIO               == other.lut3dSizeOCIO
         && bboxes                      == other.bboxes
         && bboxLineColor               == other.bboxLineColor
-        && bboxLineDashSize            == other.bboxLineDashSize;
+        && bboxLineDashSize            == other.bboxLineDashSize
+        && enableVisualization         == other.enableVisualization;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
- Storm applies a "visualization" to some passes so they appear nicer in usdview, some users prefer not to have that option on. This is a contribution that allows us to toggle that easily on or off
### Fixes Issue(s)
- Can't toggle visualization on or off

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
