### PR TITLE
Replace deprecated QFontMetrics.width with horizontalAdvance 

### DIFF
--- a/pxr/usdImaging/usdviewq/pythonInterpreter.py
+++ b/pxr/usdImaging/usdviewq/pythonInterpreter.py
@@ -433,7 +433,7 @@ class Controller(QtCore.QObject):
     def _GetStringLengthInPixels(cf, string):
         font = cf.font()
         fm = QtGui.QFontMetrics(font)
-        strlen = fm.width(string)
+        strlen = fm.horizontalAdvance(string)
         return strlen
 
     def _CompleteSlot(self):


### PR DESCRIPTION
### Description of Change(s)

usdview was using a deprecated `width` method on `QFontMetrics` that was finally dropped in Qt6.
This PR (thanks to John Hood for the fix) replaces it with  `horizontalAdvance`

This method has been available since Qt 5.11 and is the recommended replacement per https://doc.qt.io/qt-5/qfontmetrics-obsolete.html#width

Since this encompasses every version of the VFX Platform setup, I haven't tried to maintain compatibility behind 5.11

### Fixes Issue(s)
- Allows python auto-complete again with Qt 6

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
