### PR TITLE
extras: make the build of extras/imaging/examples conditional on PXR_BUILD_EXAMPLES

### DIFF
--- a/extras/imaging/CMakeLists.txt
+++ b/extras/imaging/CMakeLists.txt
@@ -1,2 +1,3 @@
-add_subdirectory(examples)
-
+if (PXR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()


### PR DESCRIPTION
The `extras/imaging/examples` directory currently contains `hdTiny` and `hdui`, and since `hdui` (intentionally) does not build as part of the open source distribution, this makes it so that specifying `PXR_BUILD_EXAMPLES=OFF` prevents `hdTiny` from being built.

This mimics the pattern already in use in `extras/usd/CMakeLists.txt`.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
