### PR TITLE
Remove assumption in UsdUtils_FileAnalyzer that USDZ files are fully self contained

### DIFF
--- a/pxr/usd/usdUtils/assetLocalization.cpp
+++ b/pxr/usd/usdUtils/assetLocalization.cpp
@@ -80,12 +80,6 @@ UsdUtils_FileAnalyzer::UsdUtils_FileAnalyzer(const std::string &referencePath,
             return;
         }
 
-        // If the newly opened layer is a package, it we do not need to traverse
-        // into it as the entire package will be included as a dependency.
-        if (_layer->GetFileFormat()->IsPackage()) {
-            return;
-        }
-
         _AnalyzeDependencies();
     }
 


### PR DESCRIPTION
### Description of Change(s)

`UsdUtils_FileAnalyzer` assumed that USDZ files are fully self contained.
I'm removing this assumption because:

1. According to prior discussion, USDZ files *may perhaps* refer to external files,  even if that's not ideal
2. This was skipping validation in files that did have missing references, thereby not catching incorrect files

### Fixes Issue(s)
[2636](https://github.com/PixarAnimationStudios/OpenUSD/issues/2636)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
