### PR TITLE
Fix typo in hgiInterop CMakeLists.txt

### DIFF
--- a/pxr/imaging/hgiInterop/CMakeLists.txt
+++ b/pxr/imaging/hgiInterop/CMakeLists.txt
@@ -22,7 +22,7 @@ if (PXR_ENABLE_METAL_SUPPORT)
     list(APPEND optionalPrivateHeaders metal.h)
 elseif(PXR_ENABLE_VULKAN_SUPPORT)
     list(APPEND optionalLibraries hgiVulkan)
-    list(APPEND optionalCppFiles vulkan.mm)
+    list(APPEND optionalCppFiles vulkan.cpp)
     list(APPEND optionalPrivateHeaders vulkan.h)
 else()
     # No OpenGL-to-OpenGL interop when using Vulkan or Metal.


### PR DESCRIPTION
### Description of Change(s)
The line was copied over from the metal if-branch, but the file extension was not adjusted.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
