### PR TITLE
Avoid conversion of `SdfLayerRefPtr` to `SdfLayerHandle` in `pcp/cache.cpp`

### DIFF
--- a/pxr/usd/pcp/cache.cpp
+++ b/pxr/usd/pcp/cache.cpp
@@ -1229,7 +1229,7 @@ PcpCache::ReloadReferences(PcpChanges* changes, const SdfPath& primPath)
     // local layers.
     SdfLayerHandleSet layersToReload;
     for (const PcpLayerStackPtr& layerStack: layerStacksAtOrUnderPrim) {
-        for (const SdfLayerHandle& layer: layerStack->GetLayers()) {
+        for (const auto& layer: layerStack->GetLayers()) {
             if (!_layerStack->HasLayer(layer)) {
                 layersToReload.insert(layer);
             }


### PR DESCRIPTION
### Description of Change(s)

The following warning was observed in GCC 11.

```
warning: loop variable ‘layer’ of type ‘const SdfLayerHandle&’ {aka ‘const pxrInternal_v0_23__pxrReserved__::TfWeakPtr<pxrInternal_v0_23__pxrReserved__::SdfLayer>&’} binds to a temporary constructed from type ‘const pxrInternal_v0_23__pxrReserved__::TfRefPtr<pxrInternal_v0_23__pxrReserved__::SdfLayer>’ [-Wrange-loop-construct]
 1232 |         for (const SdfLayerHandle& layer: layerStack->GetLayers()) {
```

`GetLayers()` returns a vector of `SdfLayerRefPtr`s.  Iterating using a handle will trigger an implicit conversion to a temporary `SdfLayerHandle`.  This PR uses `auto` to preserve the type of the vector contents and avoid any implicit conversions.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
