### PR TITLE
Replace `BOOST_PP_CAT` with `TF_PP_CAT` in `tf/staticTokens.h`

### DIFF
--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -150,14 +150,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 // Note that this needs to be a unique struct name for each translation unit. 
 //
 #define _TF_TOKENS_STRUCT_NAME_PRIVATE(key) \
-    BOOST_PP_CAT(key, _PrivateStaticTokenType)
+    TF_PP_CAT(key, _PrivateStaticTokenType)
 
 // Private macro to generate struct name from key.  This version is used
 // by the public token declarations, and so key must be unique for the entire
 // namespace.
 //
 #define _TF_TOKENS_STRUCT_NAME(key) \
-    BOOST_PP_CAT(key, _StaticTokenType)
+    TF_PP_CAT(key, _StaticTokenType)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Declaration Macros


### PR DESCRIPTION
### Description of Change(s)

#2585 removed the header include of `boost/preprocessor/cat.hpp` but didn't remove the usage of the `BOOST_PP_CAT` macro from `tf/staticTokens.h`.  This PR completes that change.

### Fixes Issue(s)
- #2247 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
