### PR TITLE
Avoid `TfToken` copy while iterating in `usd/primDefinition.cpp`

### DIFF
--- a/pxr/usd/usd/primDefinition.cpp
+++ b/pxr/usd/usd/primDefinition.cpp
@@ -520,7 +520,7 @@ UsdPrimDefinition::_ComposeOverAndReplaceExistingProperty(
     // get the property spec with the overrides applied. Any fields that
     // are defined in the override spec are stronger so we copy the defined
     // spec fields that aren't already in the override spec.
-    for (const TfToken srcField : defProp.ListMetadataFields()) {
+    for (const TfToken &srcField : defProp.ListMetadataFields()) {
         if (!overLayerAndPath.HasField<VtValue>(srcField, nullptr)) {
             VtValue value;
             if (defLayerAndPath->HasField(srcField, &value)) {


### PR DESCRIPTION
### Description of Change(s)

The following warning was observed in GCC 11

```
warning: loop variable ‘srcField’ creates a copy from type ‘const pxrInternal_v0_23__pxrReserved__::TfToken’ [-Wrange-loop-construct]
  523 |     for (const TfToken srcField : defProp.ListMetadataFields()) {
      |                        ^~~~~~~~
note: use reference type to prevent copying
  523 |     for (const TfToken srcField : defProp.ListMetadataFields()) {
      |                        ^~~~~~~~
      |                        &
```

Making `srcField` a reference type avoids the copy of the `TfToken`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
