### PR TITLE
Apple: Mesh shaders - shader generator modifications

### DIFF
--- a/pxr/imaging/hgi/shaderFunctionDesc.cpp
+++ b/pxr/imaging/hgi/shaderFunctionDesc.cpp
@@ -394,6 +394,8 @@ HgiShaderFunctionAddConstantParam(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
     
     desc->constantParams.push_back(std::move(paramDesc));
 }
@@ -409,6 +411,8 @@ HgiShaderFunctionAddStageInput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageInputs.push_back(std::move(paramDesc));
 }
@@ -421,17 +425,40 @@ HgiShaderFunctionAddStageInput(
     functionDesc->stageInputs.push_back(paramDesc);
 }
 
+/// Adds a field to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
+    const uint32_t arraySize) {
+    HgiShaderFunctionParamDesc paramDesc;
+    paramDesc.nameInShader = nameInShader;
+    paramDesc.type = type;
+    paramDesc.arraySize = std::to_string(arraySize);
+    if (arraySize < 1) {
+        paramDesc.arraySize = "";
+    }
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
+    desc->payloadMembers.push_back(std::move(paramDesc));
+}
+
 void
 HgiShaderFunctionAddGlobalVariable(
    HgiShaderFunctionDesc *desc,
    const std::string &nameInShader,
    const std::string &type,
-   const std::string &arraySize)
+   const std::string &arraySize,
+   const bool isThreadGroupParam)
 {
     HgiShaderFunctionParamDesc paramDesc;
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.arraySize = arraySize;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = isThreadGroupParam;
     desc->stageGlobalMembers.push_back(std::move(paramDesc));
 }
 
@@ -446,6 +473,8 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }
@@ -461,6 +490,8 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.location = location;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -174,6 +174,8 @@ struct HgiShaderFunctionParamDesc
     HgiStorageType storage;
     std::string role;
     std::string arraySize;
+    bool isThreadGroupParam = false;
+    bool isPointerToValue = false;
 };
 
 using HgiShaderFunctionParamDescVector =
@@ -324,7 +326,50 @@ bool operator!=(
         const HgiShaderFunctionTessellationDesc& lhs,
         const HgiShaderFunctionTessellationDesc& rhs);
 
-/// \struct HgiShaderFunctionGeometryDesc
+/// \struct HgiShaderFunctionMeshDesc
+///
+/// Describes a mesh shader's function description
+///
+/// <ul>
+/// <li>meshTopology:
+///   The type of topology</li>
+/// <li>maxMeshletVertexCount
+///   Max number of vertices per meshlet in shader</li>
+/// <li>maxPrimitiveCount
+///   Max number of primitives in shader</li>
+/// <li>maxTotalThreadsPerObjectThreadgroup
+///   Max number of threads per object threadgroup</li>
+/// <li>maxTotalThreadsPerMeshletThreadgroup:
+///   Maximum total threads per meshlet threadgroup</li>
+/// <li>maxTotalThreadgroupsPerMeshObject:
+///   Maximum total threadgroups per mesh object shader</li>
+/// <li>maxTotalThreadgroupsPerMeshlet:
+///   Max total threadgroups per meshlet shader</li>
+/// </ul>
+///
+struct HgiShaderFunctionMeshDesc
+{
+    enum class MeshTopology { Point, Line, Triangle, None };
+    MeshTopology meshTopology = MeshTopology::None;
+    uint32_t maxMeshletVertexCount;
+    uint32_t maxPrimitiveCount;
+    uint32_t maxTotalThreadsPerObjectThreadgroup;
+    uint32_t maxTotalThreadsPerMeshletThreadgroup;
+    uint32_t maxTotalThreadgroupsPerMeshObject;
+    uint32_t maxTotalThreadgroupsPerMeshlet;
+    bool meshUser = false;
+};
+
+HGI_API
+bool operator==(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
+HGI_API
+bool operator!=(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
 ///
 /// Describes a geometry function's description
 ///
@@ -448,10 +493,13 @@ struct HgiShaderFunctionDesc
     std::vector<HgiShaderFunctionParamDesc> constantParams;
     std::vector<HgiShaderFunctionParamDesc> stageGlobalMembers;
     std::vector<HgiShaderFunctionParamDesc> stageInputs;
+    std::vector<HgiShaderFunctionParamDesc> stagePayload;
     std::vector<HgiShaderFunctionParamDesc> stageOutputs;
+    std::vector<HgiShaderFunctionParamDesc> payloadMembers;
     std::vector<HgiShaderFunctionParamBlockDesc> stageInputBlocks;
     std::vector<HgiShaderFunctionParamBlockDesc> stageOutputBlocks;
     HgiShaderFunctionComputeDesc computeDescriptor;
+    HgiShaderFunctionMeshDesc meshDescriptor;
     HgiShaderFunctionTessellationDesc tessellationDescriptor;
     HgiShaderFunctionGeometryDesc geometryDescriptor;
     HgiShaderFunctionFragmentDesc fragmentDescriptor;
@@ -515,6 +563,15 @@ HgiShaderFunctionAddBuffer(
     HgiBindingType binding,
     const uint32_t arraySize = 0);
 
+/// Adds a member to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
+    const uint32_t arraySize = 0);
+
 /// Adds buffer descriptor to given shader function descriptor.
 HGI_API
 void
@@ -560,7 +617,8 @@ HgiShaderFunctionAddGlobalVariable(
    HgiShaderFunctionDesc *desc,
    const std::string &nameInShader,
    const std::string &type,
-   const std::string &arraySize);
+   const std::string &arraySize,
+   const bool isThreadGroupParam = false);
 
 /// Adds stage output function param descriptor to given shader function
 /// descriptor.

--- a/pxr/imaging/hgi/shaderGenerator.h
+++ b/pxr/imaging/hgi/shaderGenerator.h
@@ -57,7 +57,7 @@ public:
     // Return generated shader source.
     HGI_API
     const char *GetGeneratedShaderCode() const;
-
+    const HgiShaderFunctionDesc &_descriptor;
 protected:
     HGI_API
     explicit HgiShaderGenerator(const HgiShaderFunctionDesc &descriptor);
@@ -73,9 +73,8 @@ protected:
 
     HGI_API
     HgiShaderStage _GetShaderStage() const;
-
+    
 private:
-    const HgiShaderFunctionDesc &_descriptor;
 
     // This is used if the descriptor does not specify a string
     // to be used as the destination for generated output.

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -49,9 +49,12 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
 
         MTLCompileOptions *options = [[MTLCompileOptions alloc] init];
         options.fastMathEnabled = YES;
-
-        if (@available(macOS 10.15, ios 13.0, *)) {
-            options.languageVersion = MTLLanguageVersion2_2;
+        
+        if (@available(macOS 14.0, *)){
+            options.languageVersion = MTLLanguageVersion3_0;
+        }
+        else if (@available(macOS 10.15, ios 13.0, *)) {
+            options.languageVersion = MTLLanguageVersion2_1;
         } else {
             options.languageVersion = MTLLanguageVersion2_1;
         }
@@ -65,6 +68,10 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             [hgi->GetPrimaryDevice() newLibraryWithSource:@(shaderCode)
                                                         options:options
                                                         error:&error];
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
+        }
 
         [options release];
         options = nil;
@@ -86,6 +93,12 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             case HgiShaderStagePostTessellationVertex:
                 entryPoint = @"vertexEntryPoint";
                 break;
+            case HgiShaderStageMeshObject:
+                entryPoint = @"meshObjectEntryPoint";
+                break;
+            case HgiShaderStageMeshlet:
+                entryPoint = @"meshletEntryPoint";
+                break;
             case HgiShaderStageTessellationControl:
             case HgiShaderStageTessellationEval:
             case HgiShaderStageGeometry:
@@ -101,6 +114,11 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         }
         else {
             HGIMETAL_DEBUG_LABEL(_shaderId, _descriptor.debugName.c_str());
+        }
+        
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
         }
         
         [library release];

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -28,6 +28,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 HgiMetalShaderSection::~HgiMetalShaderSection() = default;
 
+HgiMetalShaderSection::HgiMetalShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector& attributes,
+    const std::string &defaultValue,
+    const std::string &arraySize,
+    const std::string &blockInstanceIdentifier)
+  : HgiShaderSection(identifier
+  , attributes
+  , defaultValue
+  , arraySize
+  , blockInstanceIdentifier)
+{
+}
+
 bool
 HgiMetalShaderSection::VisitScopeStructs(std::ostream &ss)
 {
@@ -54,6 +68,12 @@ HgiMetalShaderSection::VisitScopeConstructorDeclarations(std::ostream &ss)
 
 bool
 HgiMetalShaderSection::VisitScopeConstructorInitialization(std::ostream &ss)
+{
+    return false;
+}
+
+bool
+HgiMetalShaderSection::VisitPreScopeConstructorInstantiation(std::ostream &ss)
 {
     return false;
 }
@@ -101,9 +121,40 @@ HgiMetalShaderSection::WriteAttributesWithIndex(std::ostream& ss) const
     }
 }
 
+void
+HgiMetalShaderSection::WriteAttributesOnlyWithoutIndex(std::ostream& ss) const
+{
+    const HgiShaderSectionAttributeVector &att = GetAttributes();
+    HgiShaderSectionAttributeVector attributes;
+    for (size_t i = 0; i < att.size(); i++) {
+        const HgiShaderSectionAttribute &a = att[i];
+        if (a.identifier.find("user") == std::string::npos) {
+            attributes.push_back(a);
+        }
+    }
+    if (attributes.size() > 0) {
+        ss << "[[";
+    }
+    for (size_t i = 0; i < attributes.size(); i++) {
+        if (i > 0) {
+            ss << ", ";
+        }
+        
+        const HgiShaderSectionAttribute &a = attributes[i];
+        ss << a.identifier;
+        if (!a.index.empty()) {
+            ss << "(" << a.index << ")";
+        }
+    }
+    if (attributes.size() > 0) {
+        ss << "]]";
+    }
+}
+
 HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
     const std::string &identifier,
     const std::string &type,
+    const bool isThreadGroupGlobal,
     const HgiShaderSectionAttributeVector &attributes,
     const std::string arraySize,
     const std::string &blockInstanceIdentifier)
@@ -111,6 +162,7 @@ HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
                           std::string(), arraySize,
                           blockInstanceIdentifier)
   , _type{type}
+  , _isThreadGroupGlobal{isThreadGroupGlobal}
 {
 }
 
@@ -126,9 +178,165 @@ bool
 HgiMetalMemberShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
 {
     if (!HasBlockInstanceIdentifier()) {
-        WriteDeclaration(ss);
+        if (_isThreadGroupGlobal) {
+            ss << "threadgroup ";
+        }
+        WriteType(ss);
+        ss << " ";
+        if (_isThreadGroupGlobal) {
+            ss << "(&";
+        }
+        WriteIdentifier(ss);
+        if (_isThreadGroupGlobal) {
+            ss << ")";
+        }
+        WriteArraySize(ss);
+        ss << ";";
         ss << std::endl;
     }
+    return true;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitPreScopeConstructorInstantiation(std::ostream &ss)
+{
+    if (_isThreadGroupGlobal) {
+        ss << "threadgroup ";
+        WriteDeclaration(ss);
+        ss << std::endl;
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorInstantiation(std::ostream &ss)
+{
+    
+    if (_isThreadGroupGlobal) {
+        ss << "";
+        WriteIdentifier(ss);
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    if (_isThreadGroupGlobal) {
+        ss << "threadgroup ";
+        WriteType(ss);
+        ss << " (&_";
+        WriteIdentifier(ss);
+        ss << ")";
+        WriteArraySize(ss);
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    if(_isThreadGroupGlobal) {
+        WriteIdentifier(ss);
+        ss << "(_";
+        WriteIdentifier(ss);
+        ss << ")";
+        return true;
+    }
+    return false;
+}
+
+HgiMetalRawShaderSection::HgiMetalRawShaderSection(
+    const std::string &identifier,
+    const std::string &type,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string arraySize,
+    const std::string &blockInstanceIdentifier)
+  : HgiMetalShaderSection(identifier, attributes,
+                          std::string(), arraySize,
+                          blockInstanceIdentifier)
+  , _type{type}
+{
+}
+
+HgiMetalRawShaderSection::~HgiMetalRawShaderSection() = default;
+
+void
+HgiMetalRawShaderSection::WriteType(std::ostream &ss) const
+{
+    ss << _type;
+}
+
+HgiMetalMeshShaderSection::HgiMetalMeshShaderSection(
+    const std::string &identifier,
+    const std::string &type)
+  : HgiMetalShaderSection(identifier, {},
+                          std::string(), std::string(),
+                          std::string())
+  , _type{type}
+{
+}
+
+HgiMetalMeshShaderSection::~HgiMetalMeshShaderSection() = default;
+
+void
+HgiMetalMeshShaderSection::WriteType(std::ostream &ss) const
+{
+    ss << _type;
+}
+
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    ss << "thread ";
+    WriteType(ss);
+    ss << " &_";
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    ss << "(_";
+    WriteIdentifier(ss);
+    ss << ")";
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorInstantiation(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
+{
+    ss << "thread ";
+    WriteType(ss);
+    ss << " &";
+    WriteIdentifier(ss);
+    ss << ";\n";
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    WriteParameter(ss);
     return true;
 }
 
@@ -637,7 +845,8 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
     const std::string &type,
     const HgiBindingType binding,
     const bool writable,
-    const HgiShaderSectionAttributeVector &attributes)
+    const HgiShaderSectionAttributeVector &attributes,
+    const bool canUseConstantSpace)
   : HgiMetalShaderSection(
       samplerSharedIdentifier,
       attributes,
@@ -646,6 +855,7 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
   , _binding(binding)
   , _writable(writable)
   , _unused(false)
+  , _canUseConstantSpace(canUseConstantSpace)
   , _samplerSharedIdentifier(samplerSharedIdentifier)
   , _parentScopeIdentifier(parentScopeIdentifier)
 {
@@ -662,6 +872,7 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
   , _binding(HgiBindingTypePointer)
   , _writable(false)
   , _unused(true)
+  , _canUseConstantSpace(false)
 {
 }
 
@@ -674,7 +885,8 @@ HgiMetalBufferShaderSection::WriteType(std::ostream& ss) const
 void
 HgiMetalBufferShaderSection::WriteParameter(std::ostream& ss) const
 {
-    if (!_writable) {
+    //TODO resolve -> meshlet shader buffers can't be declared in constant space
+    if (!_writable && _canUseConstantSpace) {
         ss << "constant ";
     } else {
         ss << "device ";
@@ -701,7 +913,7 @@ HgiMetalBufferShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
 {
     if (_unused) return false;
 
-    if (!_writable) {
+    if (!_writable && _canUseConstantSpace) {
         ss << "constant ";
     } else {
         ss << "device ";
@@ -730,8 +942,8 @@ HgiMetalBufferShaderSection::VisitScopeConstructorDeclarations(
     std::ostream &ss)
 {
     if (_unused) return false;
-
-    if (!_writable) {
+    
+    if (!_writable && _canUseConstantSpace) {
         ss << "const ";
         ss << "constant ";
     } else {
@@ -788,11 +1000,13 @@ HgiMetalStructTypeDeclarationShaderSection::HgiMetalStructTypeDeclarationShaderS
     const std::string &identifier,
     const HgiMetalShaderSectionPtrVector &members,
     const std::string &templateWrapper,
-    const std::string &templateWrapperParameters)
+    const std::string &templateWrapperParameters,
+    const bool useAttributes)
   : HgiMetalShaderSection(identifier)
   , _members(members)
   , _templateWrapper(templateWrapper)
   , _templateWrapperParameters(templateWrapperParameters)
+  , _useAttributes(useAttributes)
 {
 }
 
@@ -813,8 +1027,13 @@ HgiMetalStructTypeDeclarationShaderSection::WriteDeclaration(
     for (HgiMetalShaderSection* member : _members) {
         member->WriteParameter(ss);
         if (!member->HasBlockInstanceIdentifier()) {
-            member->WriteAttributesWithIndex(ss);
+            if (_useAttributes) {
+                member->WriteAttributesWithIndex(ss);
+            } else {
+                member->WriteAttributesOnlyWithoutIndex(ss);
+            }
         }
+        member->WriteArraySize(ss);
         ss << ";\n";
     }
     ss << "};\n";
@@ -963,6 +1182,115 @@ HgiMetalParameterInputShaderSection::VisitGlobalMemberDeclarations(
     return true;
 }
 
+HgiMetalParameterMeshInputShaderSection::HgiMetalParameterMeshInputShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string &addressSpace,
+    const bool isPointer,
+    HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration)
+  : HgiMetalStructInstanceShaderSection(
+      identifier,
+      attributes,
+      structTypeDeclaration)
+  , _addressSpace(addressSpace)
+  , _isPointer(isPointer)
+{
+}
+
+void
+HgiMetalParameterMeshInputShaderSection::WriteParameter(std::ostream& ss) const
+{
+    GetStructTypeDeclaration()->WriteTemplateWrapper(ss);
+    ss << " ";
+    if(_isPointer) {
+        ss << "*";
+    }
+    WriteIdentifier(ss);
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    if(!_addressSpace.empty()) {
+        ss << _addressSpace << " ";
+    }
+    
+    WriteParameter(ss);
+    WriteAttributesWithIndex(ss);
+    return true;
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitEntryPointFunctionExecutions(
+    std::ostream& ss,
+    const std::string &scopeInstanceName)
+{
+    const auto &structDeclMembers = GetStructTypeDeclaration()->GetMembers();
+    for (size_t i = 0; i < structDeclMembers.size(); ++i) {
+        if (i > 0) {
+            ss << "\n";
+        }
+        HgiShaderSection *member = structDeclMembers[i];
+        const std::string &arraySize = member->GetArraySize();
+        if (!arraySize.empty()) {
+            ss << "for (int arrInd = 0; arrInd < ";
+            ss << arraySize;
+            ss << "; arrInd++) {\n";
+            ss << scopeInstanceName << ".";
+            member->WriteIdentifier(ss);
+            ss << "[arrInd] = ";
+            WriteIdentifier(ss);
+            ss << "[arrInd]"
+               << (_isPointer ? "->" : ".");
+            member->WriteIdentifier(ss);
+            ss << ";\n}";
+        } else {
+            ss << scopeInstanceName << ".";
+            if (member->HasBlockInstanceIdentifier()) {
+                member->WriteBlockInstanceIdentifier(ss);
+                ss << ".";
+            }
+            member->WriteIdentifier(ss);
+            ss << " = ";
+            WriteIdentifier(ss);
+            ss << (_isPointer ? "->" : ".");
+            ss << "vertexOut.";
+            member->WriteIdentifier(ss);
+            ss << ";";
+        }
+    }
+    return true;
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    ss << "struct PrimOut {\n";
+    ss << "uint primitive_id_ms;\n";
+    ss << "};\n";
+    ss << "struct VertexOut {\n";
+    
+    for (auto &member : GetStructTypeDeclaration()->GetMembers()) {
+        //member->WriteParameter(ss);
+        member->WriteType(ss);
+        ss << " ";
+        member->WriteIdentifier(ss);
+        ss << ";\n";
+    }
+    ss << "};\n";
+    
+    ss << "struct ";
+    GetStructTypeDeclaration()->WriteIdentifier(ss);
+    ss << "{\n";
+    ss << "VertexOut vertexOut;\n";
+    ss << "PrimOut primOut;\n";
+    ss << "};\n";
+    return true;
+}
+
+
 HgiMetalArgumentBufferInputShaderSection::HgiMetalArgumentBufferInputShaderSection(
     const std::string &identifier,
     const HgiShaderSectionAttributeVector &attributes,
@@ -1011,15 +1339,114 @@ HgiMetalArgumentBufferInputShaderSection::VisitGlobalMemberDeclarations(
     return true;
 }
 
+HgiMetalPayloadShaderSection::HgiMetalPayloadShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string &addressSpace,
+    const bool isPointer,
+    const bool isConstParameter,
+    HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration)
+  : HgiMetalStructInstanceShaderSection(
+      identifier,
+      attributes,
+      structTypeDeclaration)
+  , _addressSpace(addressSpace)
+  , _isConstParameter(isConstParameter)
+{
+}
+
+void
+HgiMetalPayloadShaderSection::WriteParameter(std::ostream& ss) const
+{
+    WriteType(ss);
+    ss << " &";
+    WriteIdentifier(ss);
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    if(!_addressSpace.empty()) {
+        if (_isConstParameter) {
+            ss << "const ";
+        }
+        ss << _addressSpace << " ";
+    }
+    
+    WriteParameter(ss);
+    WriteAttributesWithIndex(ss);
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    GetStructTypeDeclaration()->WriteDeclaration(ss);
+    ss << "\n";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeMemberDeclarations(
+    std::ostream &ss)
+{
+    if (_isConstParameter) {
+        ss << "const ";
+    }
+    ss << "object_data ";
+    WriteType(ss);
+    ss << "& ";
+    WriteIdentifier(ss);
+    ss << ";\n";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    if (_isConstParameter) {
+        ss << "const ";
+    }
+    ss << "object_data ";
+        WriteType(ss);
+        ss << "& _";
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    ss << "(_";
+    WriteIdentifier(ss);
+    ss << ")";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorInstantiation(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    return true;
+}
+
 HgiMetalKeywordInputShaderSection::HgiMetalKeywordInputShaderSection(
     const std::string &identifier,
     const std::string &type,
-    const HgiShaderSectionAttributeVector &attributes)
+    const HgiShaderSectionAttributeVector &attributes,
+    const bool isPointerToValue)
   : HgiMetalShaderSection(
       identifier,
       attributes,
       "")
   , _type(type)
+  , _isPointerToValue(isPointerToValue)
 {
 }
 
@@ -1032,9 +1459,14 @@ HgiMetalKeywordInputShaderSection::WriteType(std::ostream& ss) const
 bool
 HgiMetalKeywordInputShaderSection::VisitScopeMemberDeclarations(
     std::ostream &ss)
-{
+{   if (_isPointerToValue) {
+        ss << "thread ";
+    }
     WriteType(ss);
     ss << " ";
+    if (_isPointerToValue) {
+        ss << "* ";
+    }
     WriteIdentifier(ss);
     ss << ";\n";
     return true;
@@ -1060,6 +1492,9 @@ HgiMetalKeywordInputShaderSection::VisitEntryPointFunctionExecutions(
     ss << scopeInstanceName << ".";
     WriteIdentifier(ss);
     ss << " = ";
+    if (_isPointerToValue) {
+        ss << "&";
+    }
     WriteIdentifier(ss);
     ss << ";";
     return true;
@@ -1123,6 +1558,25 @@ HgiMetalStageOutputShaderSection::VisitGlobalMemberDeclarations(
     std::ostream &ss)
 {
     GetStructTypeDeclaration()->WriteDeclaration(ss);
+    ss << "\n";
+    return true;
+}
+
+HgiMetalStageOutputMeshShaderSection::HgiMetalStageOutputMeshShaderSection(
+    HgiMetalStructTypeDeclarationShaderSection * const structTypeDeclaration)
+  : HgiMetalShaderSection("")
+, _structTypeDeclaration(structTypeDeclaration)
+{
+}
+
+bool
+HgiMetalStageOutputMeshShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    ss << "struct PrimOut {\n";
+    ss << "uint primitive_id_ms;\n";
+    ss << "};\n";
+    _structTypeDeclaration->WriteDeclaration(ss);
     ss << "\n";
     return true;
 }


### PR DESCRIPTION
### Description of Change(s)
- Extend shader generator to support
    - Mesh shader payload
    - Mesh shader per primitive in out
    - Mesh shader style handling of in outs
    - Handling of threadgroup locals that need to be declared in the entry point function
- Add new metadata to handle shader descriptions for mesh shaders

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
