### PR TITLE
hdx: update color correction task to support building against OpenColorIO 2.3.0

### DIFF
--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -409,8 +409,16 @@ HdxColorCorrectionTask::_CreateOpenColorIOResourcesImpl(
         uint32_t width, height;
         OCIO::GpuShaderCreator::TextureType channel;
         OCIO::Interpolation interpolation;
+
+#if OCIO_VERSION_HEX >= 0x02030000
+        OCIO::GpuShaderCreator::TextureDimensions dimensions;
+        shaderDesc->getTexture(i, textureName, samplerName, width, height,
+                                channel, dimensions, interpolation);
+#else
         shaderDesc->getTexture(i, textureName, samplerName, width, height,
                                 channel, interpolation);
+#endif // OCIO_VERSION_HEX >= 0x02030000
+
         shaderDesc->getTextureValues(i, lutValues);
 
         int channelPerPix =
@@ -432,7 +440,16 @@ HdxColorCorrectionTask::_CreateOpenColorIOResourcesImpl(
         // Texture description
         HgiTextureDesc texDesc;
         texDesc.debugName = textureName;
-        texDesc.type = height == 1 ? HgiTextureType1D : HgiTextureType2D;
+
+        texDesc.type =
+#if OCIO_VERSION_HEX >= 0x02030000
+            dimensions == OCIO::GpuShaderCreator::TextureDimensions::TEXTURE_1D ?
+                HgiTextureType1D :
+                HgiTextureType2D;
+#else
+            height == 1 ? HgiTextureType1D : HgiTextureType2D;
+#endif // OCIO_VERSION_HEX >= 0x02030000
+
         texDesc.dimensions = GfVec3i(width, height, 1);
         texDesc.format = fmt;
         texDesc.layerCount = 1;


### PR DESCRIPTION
[OpenColorIO version 2.3.0](https://github.com/AcademySoftwareFoundation/OpenColorIO/releases/tag/v2.3.0) introduced a `TextureDimensions` enum parameter to `GpuShaderCreator::getTexture()`. This directly determines the dimensions (1D vs 2D) of the texture rather than inferring it from whether the height of the texture is one.

More detail about this change is available from the OpenColorIO commit here:
https://github.com/AcademySoftwareFoundation/OpenColorIO/commit/929d5364c458cffffb3f4694f1786cbd999ed49b
