### PR TITLE
Implement `TF_PP_TUPLE_ELEM` using `tf/preprocessorUtilsLite.h`

### DIFF
--- a/pxr/base/tf/preprocessorUtilsLite.h
+++ b/pxr/base/tf/preprocessorUtilsLite.h
@@ -397,4 +397,8 @@
 /// \hideinitializer
 #define TF_PP_IS_TUPLE(arg) _TF_PP_IS_PARENS(arg)
 
+/// Expands to the 'index' element of a non-empty 'tuple'.
+#define TF_PP_TUPLE_ELEM(index, tuple) \
+    TF_PP_VARIADIC_ELEM(index, TF_PP_EAT_PARENS(tuple))
+
 #endif // PXR_BASE_TF_PREPROCESSOR_UTILS_LITE_H

--- a/pxr/base/tf/pyStaticTokens.h
+++ b/pxr/base/tf/pyStaticTokens.h
@@ -103,7 +103,7 @@ private:
 
 #define _TF_PY_TOKEN_GET_ELEM(elem)                                         \
     BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                                      \
-        BOOST_PP_TUPLE_ELEM(2, 0, elem), elem)
+        TF_PP_TUPLE_ELEM(0, elem), elem)
 
 // Private macros to wrap a sequence.
 #define _TF_PY_TOKENS_WRAP_SEQ(key, seq)                                    \

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -89,7 +89,6 @@
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/seq/size.hpp>
-#include <boost/preprocessor/tuple/elem.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -165,10 +164,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 //
 #define _TF_TOKENS_DECLARE_MEMBER(r, data, elem)                            \
     TfToken BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                              \
-        BOOST_PP_TUPLE_ELEM(2, 0, elem), elem)                              \
-        BOOST_PP_EXPR_IIF(TF_PP_IS_TUPLE(BOOST_PP_TUPLE_ELEM(2, 1, elem)),  \
-        [BOOST_PP_SEQ_SIZE(BOOST_PP_TUPLE_ELEM(1, 0,                        \
-            BOOST_PP_TUPLE_ELEM(2, 1, elem)))]);
+        TF_PP_TUPLE_ELEM(0, elem), elem)                                    \
+        BOOST_PP_EXPR_IIF(TF_PP_IS_TUPLE(TF_PP_TUPLE_ELEM(1, elem)),        \
+        [BOOST_PP_SEQ_SIZE(TF_PP_TUPLE_ELEM(0,                              \
+            TF_PP_TUPLE_ELEM(1, elem)))]);
 
 // Private macro used to declare the list of members as TfTokens
 //
@@ -208,27 +207,26 @@ PXR_NAMESPACE_OPEN_SCOPE
 //
 #define _TF_TOKENS_DEFINE_MEMBER(r, data, i, elem)                          \
     BOOST_PP_COMMA_IF(i)                                                    \
-    BOOST_PP_TUPLE_ELEM(1, 0, BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),            \
+    TF_PP_TUPLE_ELEM(0, BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                  \
         (_TF_TOKENS_INITIALIZE_MEMBER_TUPLE(elem)),                         \
         (_TF_TOKENS_INITIALIZE_MEMBER(elem))))
 
 #define _TF_TOKENS_INITIALIZE_MEMBER_TUPLE(elem)                            \
-    BOOST_PP_TUPLE_ELEM(2, 0, elem)(BOOST_PP_TUPLE_ELEM(2, 1, elem),        \
-                                        TfToken::Immortal)                  \
+    TF_PP_TUPLE_ELEM(0, elem)(TF_PP_TUPLE_ELEM(1, elem), TfToken::Immortal)
 
 #define _TF_TOKENS_INITIALIZE_MEMBER(elem)                                  \
     elem(TF_PP_STRINGIZE(elem), TfToken::Immortal)
 
 #define _TF_TOKENS_DEFINE_ARRAY_MEMBER(r, data, i, elem)                    \
     data[i] = BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                            \
-        BOOST_PP_TUPLE_ELEM(2, 0, elem), elem);
+        TF_PP_TUPLE_ELEM(0, elem), elem);
 
 // Private macros to append tokens to the allTokens vector.
 //
 #define _TF_TOKENS_APPEND_MEMBER(r, data, i, elem)                          \
     BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                                      \
         _TF_TOKENS_APPEND_MEMBER_BODY(~, ~,                                 \
-                                      BOOST_PP_TUPLE_ELEM(2, 0, elem)),     \
+                                      TF_PP_TUPLE_ELEM(0, elem)),           \
         _TF_TOKENS_APPEND_MEMBER_BODY(~, ~, elem))
 
 #define _TF_TOKENS_APPEND_MEMBER_BODY(r, data, elem)                        \
@@ -247,15 +245,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define _TF_TOKENS_DEFINE_ARRAY_MEMBERS(r, data, elem)                      \
     BOOST_PP_SEQ_FOR_EACH_I(_TF_TOKENS_DEFINE_ARRAY_MEMBER,                 \
-        BOOST_PP_TUPLE_ELEM(2, 0, elem),                                    \
-        BOOST_PP_TUPLE_ELEM(1, 0, BOOST_PP_TUPLE_ELEM(2, 1, elem)))
+        TF_PP_TUPLE_ELEM(0, elem),                                          \
+        TF_PP_TUPLE_ELEM(0, TF_PP_TUPLE_ELEM(1, elem)))
 
 // Private predicate macros to be used by SEQ_FILTER that determine if an
 // element of a sequence is an array of tokens or not.
 //
 #define _TF_TOKENS_IS_ARRAY(s, data, elem)                                  \
     _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                        \
-               TF_PP_IS_TUPLE(BOOST_PP_TUPLE_ELEM(2, 1, elem)), 0)
+               TF_PP_IS_TUPLE(TF_PP_TUPLE_ELEM(1, elem)), 0)
 
 #define _TF_TOKENS_IS_NOT_ARRAY(s, data, elem)                              \
     _TF_PP_IFF(_TF_TOKENS_IS_ARRAY(s, data, elem), 0, 1)
@@ -263,7 +261,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // Private macro to append all array elements to a sequence.
 //
 #define _TF_TOKENS_APPEND_ARRAY_ELEMENTS(r, data, elem)                     \
-    BOOST_PP_TUPLE_ELEM(1, 0, BOOST_PP_TUPLE_ELEM(2, 1, elem))
+    TF_PP_TUPLE_ELEM(0, TF_PP_TUPLE_ELEM(1, elem))
 
 // Private macro to define the struct of tokens. 
 //

--- a/pxr/base/tf/testenv/preprocessorUtils.cpp
+++ b/pxr/base/tf/testenv/preprocessorUtils.cpp
@@ -193,6 +193,27 @@ TestTF_PP_IS_TUPLE()
     return true;
 }
 
+static bool
+TestTF_PP_TUPLE_ELEM()
+{
+    #define _STR(value) std::string(TF_PP_STRINGIZE(value))
+
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, ())) == "");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, (a))) == "a");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, ((a)))) == "(a)");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, (((a))))) == "((a))");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, (a, b, c))) == "a");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(1, (a, b, c))) == "b");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(0, ((a, b, c)))) == "(a, b, c)");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(1, ((a, b, c)))) == "");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(1, (a, (b), c))) == "(b)");
+    TF_AXIOM(_STR(TF_PP_TUPLE_ELEM(2, (a, b, c))) == "c");
+
+    #undef _STR
+
+    return true;
+}
+
 
 static bool
 Test_TfPreprocessorUtils()
@@ -203,7 +224,8 @@ Test_TfPreprocessorUtils()
         TestTF_PP_IS_TUPLE() &&
         TestTF_PP_VARIADIC_SIZE() &&
         TestTF_PP_VARIADIC_ELEM() &&
-        TestTF_PP_FOR_EACH()
+        TestTF_PP_FOR_EACH() &&
+        TestTF_PP_TUPLE_ELEM()
         ;
 }
 

--- a/pxr/base/trace/testenv/testTraceData.cpp
+++ b/pxr/base/trace/testenv/testTraceData.cpp
@@ -79,8 +79,8 @@ TraceScopeAuto TF_PP_CAT(TraceScopeAuto_, instance)(\
         _TRACE_ARGS_TO_FUNC_PARAMS(TF_PP_CAT(TraceKeyData_, instance), \
             __VA_ARGS__));
 
-#define _TRACE_KEY_FROM_TUPLE(r, data, elem) BOOST_PP_TUPLE_ELEM(2, 0, elem)
-#define _TRACE_VALUE_FROM_TUPLE(r, data, elem) BOOST_PP_TUPLE_ELEM(2, 1, elem)
+#define _TRACE_KEY_FROM_TUPLE(r, data, elem) TF_PP_TUPLE_ELEM(0, elem)
+#define _TRACE_VALUE_FROM_TUPLE(r, data, elem) TF_PP_TUPLE_ELEM(1, elem)
 
 #define _TRACE_ARGS_TO_KEY_SEQ(...) \
     BOOST_PP_SEQ_TRANSFORM(\

--- a/pxr/base/vt/types.h
+++ b/pxr/base/vt/types.h
@@ -38,7 +38,6 @@
 
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
-#include <boost/preprocessor/tuple/elem.hpp>
 
 #include <cstddef>
 #include <cstring>
@@ -142,9 +141,9 @@ VT_TYPE_IS_CHEAP_TO_COPY(TfToken);
 
 // Helper macros for extracting bits from a type tuple.
 #define VT_TYPE(elem) \
-BOOST_PP_TUPLE_ELEM(2, 0, elem)
+TF_PP_TUPLE_ELEM(0, elem)
 #define VT_TYPE_NAME(elem) \
-BOOST_PP_TUPLE_ELEM(2, 1, elem)   
+TF_PP_TUPLE_ELEM(1, elem)
 
 
 // Composite groups of types.

--- a/pxr/usd/sdf/schemaTypeRegistration.h
+++ b/pxr/usd/sdf/schemaTypeRegistration.h
@@ -117,8 +117,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 ((SdfChildrenKeys->VariantChildren,            std::vector<TfToken>))    \
 ((SdfChildrenKeys->VariantSetChildren,         std::vector<TfToken>))
 
-#define _SDF_FIELDS_NAME(tup) BOOST_PP_TUPLE_ELEM(2, 0, tup)
-#define _SDF_FIELDS_TYPE(tup) BOOST_PP_TUPLE_ELEM(2, 1, tup)
+#define _SDF_FIELDS_NAME(tup) TF_PP_TUPLE_ELEM(0, tup)
+#define _SDF_FIELDS_TYPE(tup) TF_PP_TUPLE_ELEM(1, tup)
 
 /// Registers each built-in Sd field along with its C++ value type with
 /// \p reg. \p reg can be any type that has a member function:

--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -77,7 +77,7 @@ TF_REGISTRY_FUNCTION(TfType)
 #define _SDF_UNIT_MAX_UNITS_IMPL(seq)                    \
     BOOST_PP_SEQ_SIZE(seq),
 #define _SDF_UNIT_MAX_UNITS_OP(elem)                     \
-    _SDF_UNIT_MAX_UNITS_IMPL(BOOST_PP_TUPLE_ELEM(1, elem))
+    _SDF_UNIT_MAX_UNITS_IMPL(TF_PP_TUPLE_ELEM(1, elem))
 
 constexpr size_t _Sdf_UnitMaxUnits =
     std::max(

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -236,12 +236,12 @@ enum SdfAuthoringError
 (Angular, _SDF_ANGULAR_UNITS),              \
 (Dimensionless, _SDF_DIMENSIONLESS_UNITS))
 
-#define _SDF_UNIT_TAG(tup) BOOST_PP_TUPLE_ELEM(3, 0, tup)
-#define _SDF_UNIT_NAME(tup) BOOST_PP_TUPLE_ELEM(3, 1, tup)
-#define _SDF_UNIT_SCALE(tup) BOOST_PP_TUPLE_ELEM(3, 2, tup)
+#define _SDF_UNIT_TAG(tup) TF_PP_TUPLE_ELEM(0, tup)
+#define _SDF_UNIT_NAME(tup) TF_PP_TUPLE_ELEM(1, tup)
+#define _SDF_UNIT_SCALE(tup) TF_PP_TUPLE_ELEM(2, tup)
 
-#define _SDF_UNITSLIST_CATEGORY(tup) BOOST_PP_TUPLE_ELEM(2, 0, tup)
-#define _SDF_UNITSLIST_TUPLES(tup) BOOST_PP_TUPLE_ELEM(2, 1, tup)
+#define _SDF_UNITSLIST_CATEGORY(tup) TF_PP_TUPLE_ELEM(0, tup)
+#define _SDF_UNITSLIST_TUPLES(tup) TF_PP_TUPLE_ELEM(1, tup)
 #define _SDF_UNITSLIST_ENUM(elem) TF_PP_CAT(TF_PP_CAT(Sdf, \
                                     _SDF_UNITSLIST_CATEGORY(elem)), Unit)
 
@@ -366,8 +366,8 @@ SDF_API TfToken SdfGetRoleNameForValueTypeName(TfToken const &typeName);
 #define SDF_VALUE_TYPES _SDF_SCALAR_VALUE_TYPES _SDF_DIMENSIONED_VALUE_TYPES
 
 // Accessors for individual elements in the value types tuples.
-#define SDF_VALUE_CPP_TYPE(tup) BOOST_PP_TUPLE_ELEM(4, 2, tup)
-#define SDF_VALUE_CPP_ARRAY_TYPE(tup) VtArray<BOOST_PP_TUPLE_ELEM(4, 2, tup)> 
+#define SDF_VALUE_CPP_TYPE(tup) TF_PP_TUPLE_ELEM(2, tup)
+#define SDF_VALUE_CPP_ARRAY_TYPE(tup) VtArray<TF_PP_TUPLE_ELEM(2, tup)>
 
 template <class T>
 struct SdfValueTypeTraits {


### PR DESCRIPTION
### Description of Change(s)

`BOOST_PP_TUPLE_ELEM` can be replaced with a combination of `TF_PP_EAT_PARENS` and `TF_PP_VARIADIC_ELEM` from `tf/preprocessorUtilsLite.h`.  This replacement macro has been packaged as `TF_PP_TUPLE_ELEM` and all usage of the boost macro has been removed.  The replacement macro no longer supports the `size` parameter, but the boost documentation suggests this parameter has been deprecated and is unused.

Test cases have been added to `tf/testenv/preprocessorUtils.cpp` for `TF_PP_TUPLE_ELEM`.  The behavior matches the size-less version of `BOOST_PP_TUPLE_ELEM` for the provided test cases.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
