### PR TITLE
Use `memcpy` from `cstring` in `tf/fastCompression.cpp`

### DIFF
--- a/pxr/base/tf/fastCompression.cpp
+++ b/pxr/base/tf/fastCompression.cpp
@@ -30,6 +30,8 @@
 // XXX: Need to isolate symbols here?
 #include "pxrLZ4/lz4.h"
 
+#include <cstring>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 using namespace pxr_lz4;
@@ -86,7 +88,7 @@ TfFastCompression::CompressToBuffer(
             output += sizeof(int32_t);
             int32_t n = LZ4_compress_default(
                 input, output, size, LZ4_compressBound(size));
-            memcpy(o, &n, sizeof(n));
+            std::memcpy(o, &n, sizeof(n));
             output += n;
             input += size;
         };
@@ -123,7 +125,7 @@ TfFastCompression::DecompressFromBuffer(
         size_t totalDecompressed = 0;
         for (int i = 0; i != nChunks; ++i) {
             int32_t chunkSize = 0;
-            memcpy(&chunkSize, compressed, sizeof(chunkSize));
+            std::memcpy(&chunkSize, compressed, sizeof(chunkSize));
             compressed += sizeof(chunkSize);
             int nDecompressed = LZ4_decompress_safe(
                 compressed, output, chunkSize,


### PR DESCRIPTION
### Description of Change(s)

A future change that removes some boost headers will remove a transitive include of `memcpy`'s header.  This PR explicitly includes `cstring` to make the dependency explicit.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
