### PR TITLE
Replace boost type traits from python bindings

### DIFF
--- a/pxr/base/tf/pyEnum.h
+++ b/pxr/base/tf/pyEnum.h
@@ -112,8 +112,8 @@ class Tf_PyEnumRegistry {
             // In the case of producing a TfEnum or an integer, any
             // registered enum type is fine.  In all other cases, the
             // enum types must match.
-            if (boost::is_same<T, TfEnum>::value ||
-                (boost::is_integral<T>::value && !boost::is_enum<T>::value))
+            if (std::is_same<T, TfEnum>::value ||
+                (std::is_integral<T>::value && !std::is_enum<T>::value))
                 return i != o2e.end() ? obj : 0;
             else
                 return (i != o2e.end() && i->second.IsA<T>()) ? obj : 0;


### PR DESCRIPTION
### Description of Change(s)

#2213 replaced boost's type traits with the STL equivalents but excluded the python bindings.  This PR extends the replacement to the usage in python bindings.

### Fixes Issue(s)
- #2211 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
