### PR TITLE
Replace `boost::lexical_cast` with `TfStringify` in python bindings

### DIFF
--- a/pxr/usd/sdf/pyListEditorProxy.h
+++ b/pxr/usd/sdf/pyListEditorProxy.h
@@ -200,8 +200,7 @@ private:
 
     static std::string _GetStr(const Type& x)
     {
-        return x._listEditor ? 
-            boost::lexical_cast<std::string>(*x._listEditor) : std::string();
+        return x._listEditor ? TfStringify(*x._listEditor) : std::string();
     }
 
     static void _SetExplicitProxy(Type& x, const value_vector_type& v)

--- a/pxr/usd/sdf/wrapAssetPath.cpp
+++ b/pxr/usd/sdf/wrapAssetPath.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/vt/valueFromPython.h"
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyResultConversions.h"
+#include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/vt/wrapArray.h"
 
 #include <boost/python/class.hpp>
@@ -48,7 +49,7 @@ namespace {
 
 static std::string _Str(SdfAssetPath const &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 static std::string

--- a/pxr/usd/sdf/wrapTimeCode.cpp
+++ b/pxr/usd/sdf/wrapTimeCode.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/vt/valueFromPython.h"
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyResultConversions.h"
+#include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/vt/wrapArray.h"
 
 #include <boost/python/class.hpp>
@@ -48,7 +49,7 @@ namespace {
 
 static std::string _Str(SdfTimeCode const &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 static std::string

--- a/pxr/usd/usd/wrapStageLoadRules.cpp
+++ b/pxr/usd/usd/wrapStageLoadRules.cpp
@@ -33,6 +33,7 @@
 #include "pxr/base/tf/pyEnum.h"
 #include "pxr/base/tf/pyResultConversions.h"
 #include "pxr/base/tf/pyUtils.h"
+#include "pxr/base/tf/stringUtils.h"
 
 using std::string;
 
@@ -44,7 +45,7 @@ namespace {
 
 static std::string __str__(UsdStageLoadRules const &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 static string __repr__(UsdStageLoadRules const &self)

--- a/pxr/usd/usd/wrapStagePopulationMask.cpp
+++ b/pxr/usd/usd/wrapStagePopulationMask.cpp
@@ -29,6 +29,7 @@
 #include "pxr/usd/usd/stagePopulationMask.h"
 #include "pxr/base/tf/pyUtils.h"
 #include "pxr/base/tf/pyResultConversions.h"
+#include "pxr/base/tf/stringUtils.h"
 
 using std::string;
 
@@ -40,7 +41,7 @@ namespace {
 
 static std::string __str__(UsdStagePopulationMask const &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 static string __repr__(UsdStagePopulationMask const &self)

--- a/pxr/usd/usd/wrapTimeCode.cpp
+++ b/pxr/usd/usd/wrapTimeCode.cpp
@@ -46,7 +46,7 @@ static size_t __hash__(const UsdTimeCode &self) { return hash_value(self); }
 
 static std::string _Str(const UsdTimeCode &self)
 {
-    return boost::lexical_cast<std::string>(self);
+    return TfStringify(self);
 }
 
 static string __repr__(const UsdTimeCode &self)


### PR DESCRIPTION
### Description of Change(s)
#2496 replaced `boost::lexical_cast` with `TfStringify` for its non-python usage.  This PR extends that replacement to all usage in python bindings.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
