### PR TITLE
Material-X: flatten filenames upon read  #974

### DIFF
--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
@@ -248,5 +248,26 @@ class TestFileFormat(unittest.TestCase):
         self.assertFalse(Sdf.FileFormat.FormatSupportsWriting('.mtlx'))
         self.assertFalse(Sdf.FileFormat.FormatSupportsEditing('.mtlx'))
 
+    def test_ExpandFilePrefix(self):
+        """
+        Test active file prefix defined by the fileprefix attribute
+        in a parent tag.
+        """
+        stage = UsdMtlx._TestFile('ExpandFilePrefix.mtlx')
+
+        for nodeName, expectedResult in [
+            ('image_base', 'outer_scope/textures/base.tif'),
+            ('image_spec', 'inner_scope/textures/spec.tif')
+        ]:
+            primPath = f'/MaterialX/Materials/test_material/test_nodegraph/{nodeName}'
+            shader = UsdShade.Shader.Get(stage, primPath)
+            self.assertTrue(shader)
+
+            fileInput = shader.GetInput('file')
+            self.assertTrue(fileInput)
+
+            actualResult = fileInput.Get().path
+            self.assertEqual(actualResult, expectedResult)
+
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/ExpandFilePrefix.mtlx
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/ExpandFilePrefix.mtlx
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<materialx version="1.36">
+  <nodegraph name="test_nodegraph" fileprefix="outer_scope/textures/">
+    <image name="image_base" type="color3" nodedef="ND_image_color3">
+      <input name="file" type="filename" value="base.tif"/>
+    </image>
+    <image name="image_spec" type="float" nodedef="ND_image_float">
+      <input name="file" type="filename"  fileprefix="inner_scope/textures/" value="spec.tif"/>
+    </image>
+    <output name="base_out" type="color3" nodename="image_base" />
+    <output name="spec_out" type="float" nodename="image_spec" />
+  </nodegraph>
+  <standard_surface name="Surface" type="surfaceshader">
+    <input name="base_color" type="color3" output="base_out" nodegraph="test_nodegraph" />
+    <input name="specular" type="float" output="spec_out" nodegraph="test_nodegraph" />
+  </standard_surface>
+  <surfacematerial name="test_material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surface" />
+  </surfacematerial>
+</materialx>

--- a/pxr/usd/usdMtlx/utils.h
+++ b/pxr/usd/usdMtlx/utils.h
@@ -154,7 +154,7 @@ UsdMtlxGetUsdType(const std::string& mtlxTypeName);
 /// that silently returns an empty VtValue.
 USDMTLX_API
 VtValue
-UsdMtlxGetUsdValue(const MaterialX::ConstTypedElementPtr& mtlx,
+UsdMtlxGetUsdValue(const MaterialX::ConstElementPtr& mtlx,
                    bool getDefaultValue = false);
 
 /// Return the MaterialX values in \p values assuming it contains an

--- a/pxr/usd/usdMtlx/utils.h
+++ b/pxr/usd/usdMtlx/utils.h
@@ -154,7 +154,7 @@ UsdMtlxGetUsdType(const std::string& mtlxTypeName);
 /// that silently returns an empty VtValue.
 USDMTLX_API
 VtValue
-UsdMtlxGetUsdValue(const MaterialX::ConstElementPtr& mtlx,
+UsdMtlxGetUsdValue(const MaterialX::ConstTypedElementPtr& mtlx,
                    bool getDefaultValue = false);
 
 /// Return the MaterialX values in \p values assuming it contains an


### PR DESCRIPTION
### Description of Change(s)
1. Call mx::flattenFilenames() anytime a mx::read* function is called.  This results in a document in which all of the 'fileprefix' attributes have been fully resolved and prepended to any inputs of type 'filename'
2. Add `test_ExpandFilePrefix` to `TestFileFormat` to test `fileprefix` resolution at various scopes in the MaterialX document.

### Fixes Issue(s)
- #974 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
