### PR TITLE
usdMtlx: set a default prim

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -2612,6 +2612,9 @@ UsdMtlxRead(
     // Translate all materials.
     ReadMaterials(mtlx, context);
 
+    // Set the default prim.
+    stage->SetDefaultPrim(stage->GetPrimAtPath(internalPath));
+
     // If there are no looks then we're done.
     if (mtlx->getLooks().empty()) {
         return;

--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -2613,7 +2613,9 @@ UsdMtlxRead(
     ReadMaterials(mtlx, context);
 
     // Set the default prim.
-    stage->SetDefaultPrim(stage->GetPrimAtPath(internalPath));
+    if (auto internalPrim = stage->GetPrimAtPath(internalPath)) {
+        stage->SetDefaultPrim(internalPrim);
+    }
 
     // If there are no looks then we're done.
     if (mtlx->getLooks().empty()) {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/CustomNodeDef.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/CustomNodeDef.usda
@@ -1,4 +1,7 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+)
 
 def "MaterialX"
 {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/GraphlessNodes.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/GraphlessNodes.usda
@@ -1,4 +1,7 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+)
 
 def "MaterialX"
 {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include.usda
@@ -4,6 +4,7 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include_From_Usdz.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include_From_Usdz.usda
@@ -4,6 +4,7 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
@@ -4,6 +4,7 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/usd_preview_surface_gold.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/usd_preview_surface_gold.usda
@@ -1,4 +1,7 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+)
 
 def "MaterialX"
 {


### PR DESCRIPTION
### Description of Change(s)

Having to specify `</MaterialX>` when referencing MaterialX files was annoying me and it has tripped other people up in the past. There's no reason not to set a default prim for these files so I thought I'd just do that.

I haven't ran the tests yet simply because I haven't found the right directory to run `ctest` in.

Before:
`usdcat test.mtlx`
```
#usda 1.0
(
    customLayerData = {
        string colorSpace = "lin_rec709"
    }
)

def "MaterialX"
{
    def "Materials"
    {
...
```
After:
`usdcat test.mtlx`
```
#usda 1.0
(
    customLayerData = {
        string colorSpace = "lin_rec709"
    }
    defaultPrim = "MaterialX"
)

def "MaterialX"
{
    def "Materials"
    {
...
```

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/1544 (https://github.com/PixarAnimationStudios/OpenUSD/issues/1544#issuecomment-867162857 specifically)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
