### PR TITLE
Autodesk: Enable Trace macros for materialX interface in hdMtlx

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -36,6 +36,7 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/trace/trace.h"
 
 #include "pxr/usd/usdMtlx/utils.h"
 
@@ -520,6 +521,7 @@ HdMtlxCreateMtlxDocumentFromHdMaterialNetworkInterface(
     MaterialX::DocumentPtr const& libraries,
     HdMtlxTexturePrimvarData *mxHdData)
 {
+    TRACE_FUNCTION_SCOPE("Create Mtlx Document from HdMaterialNetwork")
     if (!netInterface) {
         return nullptr;
     }
@@ -550,12 +552,14 @@ HdMtlxCreateMtlxDocumentFromHdMaterialNetworkInterface(
         mxShaderNode);
 
     // Validate the MaterialX Document.
-    std::string message;
-    if (!mxDoc->validate(&message)) {
-        TF_WARN("Validation warnings for generated MaterialX file.\n%s", 
+    {
+	TRACE_FUNCTION_SCOPE("Validate created Mtlx Document")
+        std::string message;
+        if (!mxDoc->validate(&message)) {
+            TF_WARN("Validation warnings for generated MaterialX file.\n%s\n", 
                 message.c_str());
+        }
     }
-
     return mxDoc;
 }
 

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -145,6 +145,7 @@ HdSt_GenMaterialXShader(
     HdSt_MxShaderGenInfo const& mxHdInfo,
     TfToken const& apiName)
 {
+    TRACE_FUNCTION_SCOPE("Create GlslShader from MtlxDocument")
     // Initialize the Context for shaderGen. 
     mx::GenContext mxContext = _CreateHdStMaterialXContext(mxHdInfo, apiName);
 
@@ -765,6 +766,7 @@ _AddMaterialXParams(
     mx::ShaderPtr const& glslfxShader,
     HdSt_MaterialParamVector* materialParams)
 {
+    TRACE_FUNCTION_SCOPE("Collect Mtlx params from glslfx shader.")
     if (!glslfxShader) {
         return;
     }
@@ -957,6 +959,7 @@ HdSt_ApplyMaterialXFilter(
                                                      _tokens->mtlx);
 
     if (mtlxSdrNode) {
+        TRACE_FUNCTION_SCOPE("ApplyMaterialXFilter: Found Mtlx Node.")
 
         mx::ShaderPtr glslfxShader;
         const TfToken materialTagToken(_GetMaterialTag(terminalNode));


### PR DESCRIPTION
### Description of Change(s)

This is to enable one to get a breakdown of time taken when processing MaterialX for a hdMaterialNetwork. The trace macros are used widely in pxr code.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
