### PR TITLE
Autodesk: Cache materialX::LoadLibraries step to be done once

### DIFF
--- a/pxr/imaging/hdMtlx/CMakeLists.txt
+++ b/pxr/imaging/hdMtlx/CMakeLists.txt
@@ -16,6 +16,7 @@ pxr_library(hdMtlx
 
     PUBLIC_CLASSES
         hdMtlx
+        hdMtlxLibsRegistry
 
     PUBLIC_HEADERS
         api.h

--- a/pxr/imaging/hdMtlx/hdMtlx.h
+++ b/pxr/imaging/hdMtlx/hdMtlx.h
@@ -26,6 +26,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/usd/sdf/path.h"
 #include "pxr/imaging/hdMtlx/api.h"
 #include <memory>
 #include <set>

--- a/pxr/imaging/hdMtlx/hdMtlxLibsRegistry.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlxLibsRegistry.cpp
@@ -1,0 +1,50 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "hdMtlxLibsRegistry.h"
+#include "hdMtlx.h"
+#include "pxr/base/tf/instantiateSingleton.h"
+#include "pxr/usd/usdMtlx/utils.h"
+#include <MaterialXCore/Document.h>
+#include <MaterialXFormat/Util.h>
+
+
+
+PXR_NAMESPACE_OPEN_SCOPE
+TF_INSTANTIATE_SINGLETON(MtlxLibsRegistry);
+
+MtlxLibsRegistry::MtlxLibsRegistry()
+{
+	_stdLibraries = MaterialX::createDocument();
+	_searchPaths = HdMtlxSearchPaths();
+
+	mx::FilePathVec libraryFolders;
+	mx::loadLibraries(libraryFolders, _searchPaths, _stdLibraries);
+};
+
+MtlxLibsRegistry::~MtlxLibsRegistry()
+{
+}
+PXR_NAMESPACE_CLOSE_SCOPE
+
+

--- a/pxr/imaging/hdMtlx/hdMtlxLibsRegistry.h
+++ b/pxr/imaging/hdMtlx/hdMtlxLibsRegistry.h
@@ -1,0 +1,68 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_HD_MTLX_HDMTLXLIBSREGISTRY_H
+#define PXR_IMAGING_HD_MTLX_HDMTLXLIBSREGISTRY_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/singleton.h"
+#include <boost/noncopyable.hpp>
+
+#include "pxr/imaging/hdMtlx/api.h"
+
+#include <MaterialXCore/Library.h>
+#include <MaterialXFormat/File.h>
+#include <cstddef>
+
+MATERIALX_NAMESPACE_BEGIN
+    class FileSearchPath;
+    using DocumentPtr = std::shared_ptr<class Document>;
+MATERIALX_NAMESPACE_END
+
+PXR_NAMESPACE_OPEN_SCOPE
+namespace mx = MaterialX;
+class MtlxLibsRegistry : boost::noncopyable
+{
+	public:
+                 HDMTLX_API
+		 static MtlxLibsRegistry& GetInstance() { 
+			 return TfSingleton<MtlxLibsRegistry>::GetInstance();
+		 };
+	 
+                 HDMTLX_API
+		 MaterialX::DocumentPtr stdLibraries() const { return _stdLibraries; };
+		 HDMTLX_API
+		 const MaterialX::FileSearchPath& searchPaths() const {return _searchPaths;};
+	 private:
+		  
+		 MtlxLibsRegistry();
+		 ~MtlxLibsRegistry();
+		 friend class TfSingleton<MtlxLibsRegistry>;
+	private:
+		 MaterialX::FileSearchPath _searchPaths;
+		 MaterialX::DocumentPtr _stdLibraries = NULL;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -28,6 +28,7 @@
 #include "pxr/imaging/hdSt/resourceRegistry.h"
 #include "pxr/imaging/hdMtlx/hdMtlx.h"
 #include "pxr/imaging/hgi/tokens.h"
+#include "pxr/imaging/hdMtlx/hdMtlxLibsRegistry.h"
 
 #include "pxr/usd/sdr/registry.h"
 #include "pxr/imaging/hio/glslfx.h"
@@ -903,10 +904,10 @@ _GenerateMaterialXShader(
     bool const bindlessTexturesEnabled)
 {
     // Load Standard Libraries/setup SearchPaths (for mxDoc and mxShaderGen)
-    mx::FilePathVec libraryFolders;
-    mx::FileSearchPath searchPath = HdMtlxSearchPaths();
-    mx::DocumentPtr stdLibraries = mx::createDocument();
-    mx::loadLibraries(libraryFolders, searchPath, stdLibraries);
+    //
+    MtlxLibsRegistry& mtlxLibsRegistry = MtlxLibsRegistry::GetInstance();
+    mx::DocumentPtr stdLibraries = mtlxLibsRegistry.stdLibraries();
+    mx::FileSearchPath searchPath = mtlxLibsRegistry.searchPaths();
 
     // Create the MaterialX Document from the HdMaterialNetwork
     HdSt_MxShaderGenInfo mxHdInfo;


### PR DESCRIPTION
### Description of Change(s)

Cache the materialX::LoadLibraries step to be done once. Use pxr's thread safe singleton class.

When processing hdMaterialNetwork for Materialx, the mx::loadLibraries step could be done once and cached. This step improves performance when applying MaterialX shader networks on prims. We use pxr's thread-safe singleton class to do the loadLibraries step once.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
