### PR TITLE
Remove unused units table in `pxr/usd/sdf/types.cpp`

### DIFF
--- a/pxr/usd/sdf/types.cpp
+++ b/pxr/usd/sdf/types.cpp
@@ -160,8 +160,6 @@ struct _UnitsInfo {
     map<string, TfEnum> _DefaultUnitsMap;
     map<string, TfEnum> _UnitCategoryToDefaultUnitMap;
     map<string, string> _UnitTypeNameToUnitCategoryMap;
-    std::array<std::array<TfEnum, _Sdf_UnitMaxUnits>,
-               _Sdf_UnitNumTypes> _UnitIndicesTable;
     std::array<std::array<std::string, _Sdf_UnitMaxUnits>,
                _Sdf_UnitNumTypes> _UnitNameTable;
     map<string, TfEnum> _UnitNameToUnitMap;
@@ -197,7 +195,6 @@ static void _AddToUnitsMaps(_UnitsInfo &info,
     else {
         typeIndex = i->second;
     }
-    info._UnitIndicesTable[typeIndex][unit.GetValueAsInt()] = unit;
     info._UnitNameTable[typeIndex][unit.GetValueAsInt()] = unitName;
     info._UnitNameToUnitMap[unitName] = unit;
 }


### PR DESCRIPTION
### Description of Change(s)
While testing #2590, it was observed that one of the tables is unused. This followup PR removes the unused table.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
