### PR TITLE
Fixes from warning generation in Clang(windows) and MSVC

### DIFF
--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -102,6 +102,12 @@
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND \
         _Pragma("clang diagnostic ignored \"-Wobjc-method-access\"")
 
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+        _Pragma("clang diagnostic ignored \"-Wimplicit-const-int-float-conversion\"")
+
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+        _Pragma("clang diagnostic ignored \"-Wpotentially-evaluated-expression\"")
+
 #elif defined(ARCH_COMPILER_MSVC)
 
     #define ARCH_PRAGMA_PUSH \
@@ -138,6 +144,9 @@
 
     #define ARCH_PRAGMA_CONVERSION_FROM_SIZET \
         __pragma(warning(disable:4267)) 
+
+    #define ARCH_PRAGMA_NON_DLL_INTERFACE_CLASS_USED_AS_BASE_FOR_DLL_INTERFACE_CLASS \
+        __pragma(warning(disable:4275))
 
     #define ARCH_PRAGMA_MAY_NOT_BE_ALIGNED \
         __pragma(warning(disable:4316)) 
@@ -260,6 +269,18 @@
 
 #if !defined ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
+#endif
+
+#if !defined ARCH_PRAGMA_INT_FLOAT_CONVERSION
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+#endif
+
+#if !defined ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+#endif
+
+#if !defined ARCH_PRAGMA_NON_DLL_INTERFACE_CLASS_USED_AS_BASE_FOR_DLL_INTERFACE_CLASS
+    #define ARCH_PRAGMA_NON_DLL_INTERFACE_CLASS_USED_AS_BASE_FOR_DLL_INTERFACE_CLASS
 #endif
 
 #endif // PXR_BASE_ARCH_PRAGMAS_H

--- a/pxr/base/arch/stackTrace.cpp
+++ b/pxr/base/arch/stackTrace.cpp
@@ -1462,7 +1462,7 @@ Arch_DefaultStackTraceCallback(uintptr_t address)
         Arch_DemangleFunctionName(&symbolName);
         const uintptr_t symbolOffset =
             (uint64_t)(address - (uintptr_t)symbolAddress);
-        return ArchStringPrintf("%s+%#0lx", symbolName.c_str(), symbolOffset);
+        return ArchStringPrintf("%s+%#0zx", symbolName.c_str(), symbolOffset);
     }
     else {
         return "<unknown>";
@@ -1531,7 +1531,7 @@ Arch_GetStackTrace(const vector<uintptr_t> &frames,
         if (skipUnknownFrames && symbolic == "<unknown>") {
             continue;
         }
-        rv.push_back(ArchStringPrintf(" #%-3i 0x%016lx in %s",
+        rv.push_back(ArchStringPrintf(" #%-3i 0x%016zx in %s",
                                       n++, frames[i], symbolic.c_str()));
     }
 

--- a/pxr/base/arch/symbols.cpp
+++ b/pxr/base/arch/symbols.cpp
@@ -128,7 +128,7 @@ ArchGetAddressInfo(
         }
 
         if (symbolName) {
-            *symbolName = symbol->Name ? symbol->Name : "";
+            *symbolName = symbol->Name[0] ? symbol->Name : "";
         }
 
         if (symbolAddress) {

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -358,7 +358,7 @@ TfReadDir(
     if((hFind = FindFirstFileW(szPath, &fdFile)) == INVALID_HANDLE_VALUE)
     {
         if (errMsg) {
-            *errMsg = TfStringPrintf("Path not found: %s", szPath);
+            *errMsg = TfStringPrintf("Path not found: %ls", szPath);
         }
         return false;
     }

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -1231,7 +1231,7 @@ _GetAsCommaSeparatedString(size_t number)
 {
     string result;
 
-    string str = TfStringPrintf("%ld", number);
+    string str = TfStringPrintf("%zu", number);
     size_t n = str.size();
 
     TF_FOR_ALL(it, str) {
@@ -1361,7 +1361,7 @@ _PrintMallocCallSites(
     const size_t maxPercentageWidth = 15;
 
     string fmt = TfStringPrintf(
-        "%%-%lds %%%lds %%%lds\n",
+        "%%-%zus %%%zus %%%zus\n",
         maxNameWidth, maxBytesWidth, maxPercentageWidth);
 
     *rpt += TfStringPrintf(fmt.c_str(), "NAME", "BYTES", "%ROOT");
@@ -1442,7 +1442,7 @@ _ReportMallocNode(
     }
 
     out << TfStringPrintf(
-        "%13s B %13s B %7ld samples    ",
+        "%13s B %13s B %7zu samples    ",
         _GetAsCommaSeparatedString(node.nBytes).c_str(),
         _GetAsCommaSeparatedString(node.nBytesDirect).c_str(),
         node.nAllocations);

--- a/pxr/base/tf/singleton.h
+++ b/pxr/base/tf/singleton.h
@@ -194,8 +194,10 @@ public:
     
 private:
     static T *_CreateInstance(std::atomic<T *> &instance);
-    
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_NEEDS_EXPORT_INTERFACE
     static std::atomic<T *> _instance;
+    ARCH_PRAGMA_POP
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -806,8 +806,8 @@ TfDictionaryLessThan::_LessImpl(const string& lstr, const string& rstr) const
             // Add 5 mod 32 makes '_' sort before all letters.
             return ((l + 5) & 31) < ((r + 5) & 31);
         }
-        else if (IsDigit(l) | IsDigit(r)) {
-            if (IsDigit(l) & IsDigit(r)) {
+        else if (IsDigit(l) || IsDigit(r)) {
+            if (IsDigit(l) && IsDigit(r)) {
                 // We backtrack to find the start of each digit string, then we
                 // scan each digit string, ignoring leading zeros to put the two
                 // strings into alignment with their most significant digits.
@@ -869,7 +869,7 @@ TfDictionaryLessThan::_LessImpl(const string& lstr, const string& rstr) const
                 curEnd = lcur + std::min(std::distance(lcur, lend),
                                          std::distance(rcur, rend));
             }
-            else if (IsDigit(l) | IsDigit(r)) {
+            else if (IsDigit(l) || IsDigit(r)) {
                 if (lcur == lstr.c_str()) {
                     return l < r;
                 }

--- a/pxr/base/vt/value.cpp
+++ b/pxr/base/vt/value.cpp
@@ -94,6 +94,8 @@ _NumericCast(VtValue const &val)
 {
     const From x = val.UncheckedGet<From>();
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_UNSAFE_USE_OF_BOOL
     // Use 'x == x' to check that x is not NaN.  NaNs don't compare equal to
     // themselves.
     if (x == x) {
@@ -104,6 +106,7 @@ _NumericCast(VtValue const &val)
             return VtValue(-std::numeric_limits<To>::infinity());
         }
     }
+    ARCH_PRAGMA_POP
 
     return _BoostNumericCast<From, To>(x);
 }

--- a/pxr/imaging/hd/flattenedDataSourceProvider.h
+++ b/pxr/imaging/hd/flattenedDataSourceProvider.h
@@ -45,6 +45,8 @@ using HdFlattenedDataSourceProviderSharedPtr =
 class HdFlattenedDataSourceProvider
 {
 public:
+    virtual ~HdFlattenedDataSourceProvider() {};
+
     class Context
     {
     public:

--- a/pxr/imaging/hd/flattenedMaterialBindingsDataSourceProvider.cpp
+++ b/pxr/imaging/hd/flattenedMaterialBindingsDataSourceProvider.cpp
@@ -52,7 +52,7 @@ public:
     TfTokenVector GetNames() override {
         TfDenseHashSet<TfToken, TfToken::HashFunctor> allNames;
         {
-            for (const TfTokenVector names : { _primBindings->GetNames(),
+            for (const TfTokenVector &names : { _primBindings->GetNames(),
                                                _parentBindings->GetNames() } ) {
                 allNames.insert(names.begin(), names.end());
             }

--- a/pxr/imaging/hd/materialNetwork2Interface.cpp
+++ b/pxr/imaging/hd/materialNetwork2Interface.cpp
@@ -74,7 +74,7 @@ HdMaterialNetwork2Interface::GetNodeNames() const
     TfTokenVector result;
     if (_materialNetwork) {
         result.reserve(_materialNetwork->nodes.size());
-        for (const auto nameNodePair : _materialNetwork->nodes) {
+        for (const auto &nameNodePair : _materialNetwork->nodes) {
             result.push_back(TfToken(nameNodePair.first.GetString()));
         }
     }
@@ -112,7 +112,7 @@ HdMaterialNetwork2Interface::GetAuthoredNodeParameterNames(
     TfTokenVector result;
     if (HdMaterialNode2 *node = _GetNode(nodeName)) {
         result.reserve(node->parameters.size());
-        for (const auto nameValuePair : node->parameters) {
+        for (const auto &nameValuePair : node->parameters) {
             result.push_back(nameValuePair.first);
         }
     }
@@ -141,7 +141,7 @@ HdMaterialNetwork2Interface::GetNodeInputConnectionNames(
     TfTokenVector result;
     if (HdMaterialNode2 *node = _GetNode(nodeName)) {
         result.reserve(node->inputConnections.size());
-        for (const auto nameConnectionsPair : node->inputConnections) {
+        for (const auto &nameConnectionsPair : node->inputConnections) {
             result.push_back(nameConnectionsPair.first);
         }
     }
@@ -239,7 +239,7 @@ HdMaterialNetwork2Interface::GetTerminalNames() const
     TfTokenVector result;
     if (_materialNetwork) {
         result.reserve(_materialNetwork->terminals.size());
-        for (const auto nameConnectionPair : _materialNetwork->terminals) {
+        for (const auto &nameConnectionPair : _materialNetwork->terminals) {
             result.push_back(nameConnectionPair.first);
         }
     }

--- a/pxr/imaging/hd/perfLog.cpp
+++ b/pxr/imaging/hd/perfLog.cpp
@@ -63,7 +63,7 @@ HdPerfLog::AddCacheHit(TfToken const& name,
         return;
     _Lock lock(_mutex);
     _cacheMap[name].AddHit();
-    TF_DEBUG(HD_CACHE_HITS).Msg("Cache hit: %s %s %s hits: %lu\n",
+    TF_DEBUG(HD_CACHE_HITS).Msg("Cache hit: %s %s %s hits: %zu\n",
             name.GetText(),
             id.GetText(),
             tag.GetText(),
@@ -79,7 +79,7 @@ HdPerfLog::AddCacheMiss(TfToken const& name,
         return;
     _Lock lock(_mutex);
     _cacheMap[name].AddMiss();
-    TF_DEBUG(HD_CACHE_MISSES).Msg("Cache miss: %s %s %s Total misses: %lu\n",
+    TF_DEBUG(HD_CACHE_MISSES).Msg("Cache miss: %s %s %s Total misses: %zu\n",
             name.GetText(),
             id.GetText(),
             tag.GetText(),

--- a/pxr/imaging/hdsi/coordSysPrimSceneIndex.cpp
+++ b/pxr/imaging/hdsi/coordSysPrimSceneIndex.cpp
@@ -302,7 +302,7 @@ HdsiCoordSysPrimSceneIndex::GetChildPrimPaths(const SdfPath &primPath) const
     if (it == _targetedPrimToNameToRefCount.end()) {
         return result;
     }
-    for (const std::pair<TfToken, size_t> &nameAndRefCount : it->second) {
+    for (const std::pair<TfToken, size_t> nameAndRefCount : it->second) {
         const TfToken &coordSysName = nameAndRefCount.first;
         result.push_back(_PathForCoordSysPrim(primPath, coordSysName));
     }

--- a/pxr/imaging/hio/OpenEXR/OpenEXRCore/chunk.c
+++ b/pxr/imaging/hio/OpenEXR/OpenEXRCore/chunk.c
@@ -39,7 +39,7 @@ atomic_compare_exchange_strong (
     uint64_t volatile* object, uint64_t* expected, uint64_t desired)
 {
     uint64_t prev =
-        (uint64_t) InterlockedCompareExchange64 (object, desired, *expected);
+        (uint64_t) InterlockedCompareExchange64 ((volatile int64_t *)object, desired, *expected);
     if (prev == *expected) return 1;
     *expected = prev;
     return 0;

--- a/pxr/imaging/hio/OpenEXR/OpenEXRCore/encoding.c
+++ b/pxr/imaging/hio/OpenEXR/OpenEXRCore/encoding.c
@@ -31,7 +31,7 @@ default_compress_chunk (exr_encode_pipeline_t* encode)
         return pctxt->print_error (
             pctxt,
             rv,
-            "error allocating buffer %lu",
+            "error allocating buffer %zu",
             exr_compress_max_buffer_size (encode->packed_bytes));
     //return rv;
 

--- a/pxr/imaging/hio/OpenEXR/deflate/lib/deflate_decompress.c
+++ b/pxr/imaging/hio/OpenEXR/deflate/lib/deflate_decompress.c
@@ -1081,9 +1081,9 @@ typedef enum libdeflate_result (*decompress_func_t)
 
 #ifdef arch_select_decompress_func
 static enum libdeflate_result
-dispatch_decomp(struct libdeflate_decompressor *d,
-		const void *in, size_t in_nbytes,
-		void *out, size_t out_nbytes_avail,
+dispatch_decomp(struct libdeflate_decompressor * restrict d,
+		const void * restrict in, size_t in_nbytes,
+		void * restrict out, size_t out_nbytes_avail,
 		size_t *actual_in_nbytes_ret, size_t *actual_out_nbytes_ret);
 
 static volatile decompress_func_t decompress_impl = dispatch_decomp;

--- a/pxr/imaging/hio/fieldTextureData.h
+++ b/pxr/imaging/hio/fieldTextureData.h
@@ -103,7 +103,7 @@ private:
 ///
 /// A base class to make HioFieldTextureData objects, implemented by plugins.
 ///
-class HIO_API HioFieldTextureDataFactoryBase : public TfType::FactoryBase
+class HioFieldTextureDataFactoryBase : public TfType::FactoryBase
 {
 protected:
     friend class HioFieldTextureData;

--- a/pxr/imaging/hio/glslfxConfig.cpp
+++ b/pxr/imaging/hio/glslfxConfig.cpp
@@ -310,7 +310,7 @@ HioGlslfxConfig::_GetSourceKeyMap(VtDictionary const & dict,
 
     const VtDictionary& specDict = techniqueSpec.UncheckedGet<VtDictionary>();
     // get all of the shader stages specified in the spec
-    for (const std::pair<std::string, VtValue>& p : specDict) {
+    for (const std::pair<std::string, VtValue> p : specDict) {
         const string& shaderStageKey = p.first;
         const VtValue& shaderStageSpec = p.second;
 
@@ -438,7 +438,7 @@ HioGlslfxConfig::_GetParameters(VtDictionary const & dict,
 
     const VtDictionary& paramsDict = params.UncheckedGet<VtDictionary>();
     // pre-process the paramsDict in order to get the merged ordering
-    for (const std::pair<std::string, VtValue>& p : paramsDict) {
+    for (const std::pair<std::string, VtValue> p : paramsDict) {
         string paramName = p.first;
         if (std::find(paramOrder.begin(), paramOrder.end(), paramName) ==
                 paramOrder.end()) {
@@ -546,7 +546,7 @@ HioGlslfxConfig::_GetTextures(VtDictionary const & dict,
     }
 
     const VtDictionary& texturesDict = textures.UncheckedGet<VtDictionary>();
-    for (const std::pair<std::string, VtValue>& p : texturesDict) {
+    for (const std::pair<std::string, VtValue> p : texturesDict) {
         const string& textureName = p.first;
         const VtValue& textureData = p.second;
         if (!textureData.IsHolding<VtDictionary>()) {
@@ -617,7 +617,7 @@ HioGlslfxConfig::_GetAttributes(VtDictionary const & dict,
 
     const VtDictionary& attributesDict =
         attributes.UncheckedGet<VtDictionary>();
-    for (const std::pair<std::string, VtValue>& p : attributesDict) {
+    for (const std::pair<std::string, VtValue> p : attributesDict) {
         const string& attributeName = p.first;
         const VtValue& attributeData = p.second;
         if (!attributeData.IsHolding<VtDictionary>()) {

--- a/pxr/imaging/hio/image.h
+++ b/pxr/imaging/hio/image.h
@@ -199,7 +199,7 @@ HioImage::GetMetadata(TfToken const & key, T * value) const
     return true;
 }
 
-class HIO_API HioImageFactoryBase : public TfType::FactoryBase {
+class HioImageFactoryBase : public TfType::FactoryBase {
 public:
     virtual HioImageSharedPtr New() const = 0;
 };

--- a/pxr/imaging/hio/stb/stb_image.h
+++ b/pxr/imaging/hio/stb/stb_image.h
@@ -4554,7 +4554,7 @@ typedef struct
    stbi__context *s;
    stbi_uc *idata, *expanded, *out;
    int depth;
-   float gamma = 0;
+   float gamma;
 } stbi__png;
 
 

--- a/pxr/usd/pcp/cache.cpp
+++ b/pxr/usd/pcp/cache.cpp
@@ -1229,7 +1229,7 @@ PcpCache::ReloadReferences(PcpChanges* changes, const SdfPath& primPath)
     // local layers.
     SdfLayerHandleSet layersToReload;
     for (const PcpLayerStackPtr& layerStack: layerStacksAtOrUnderPrim) {
-        for (const SdfLayerHandle& layer: layerStack->GetLayers()) {
+        for (const SdfLayerHandle layer: layerStack->GetLayers()) {
             if (!_layerStack->HasLayer(layer)) {
                 layersToReload.insert(layer);
             }

--- a/pxr/usd/sdf/textFileFormat.cpp
+++ b/pxr/usd/sdf/textFileFormat.cpp
@@ -189,7 +189,7 @@ SdfTextFileFormat::_ReadFromAsset(
     const size_t toMB = 1048576;
 
     if (fileSizeWarning > 0 && asset->GetSize() > (fileSizeWarning * toMB)) {
-        TF_WARN("Performance warning: reading %lu MB text-based layer <%s>.",
+        TF_WARN("Performance warning: reading %zu MB text-based layer <%s>.",
                 asset->GetSize() / toMB,
                 resolvedPath.c_str());
     }

--- a/pxr/usd/sdf/textFileFormat.tab.cpp
+++ b/pxr/usd/sdf/textFileFormat.tab.cpp
@@ -3197,13 +3197,6 @@ yydestruct (yymsg, yytype, yyvaluep, context)
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
-
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
 }
 
 /* Prevent warnings from -Wmissing-prototypes.  */

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -1725,6 +1725,8 @@ _WritePossiblyCompressedArray(
         return _WriteUncompressedArray(w, array, ver);
     }
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_INT_FLOAT_CONVERSION
     // Check to see if all the floats are exactly represented as integers.
     auto isIntegral = [](T fp) {
         constexpr int32_t max = std::numeric_limits<int32_t>::max();
@@ -1732,6 +1734,7 @@ _WritePossiblyCompressedArray(
         return min <= fp && fp <= max &&
             static_cast<T>(static_cast<int32_t>(fp)) == fp;
     };    
+    ARCH_PRAGMA_POP
     if (std::all_of(array.cdata(), array.cdata() + array.size(), isIntegral)) {
         // Encode as integers.
         auto result = ValueRepForArray<T>(w.Tell());

--- a/pxr/usd/usd/primDefinition.cpp
+++ b/pxr/usd/usd/primDefinition.cpp
@@ -397,8 +397,8 @@ UsdPrimDefinition::_FindOrCreatePropertySpecForComposition(
     // we create a new layer for this prim definition to write its composed
     // properties.
     if (_composedPropertyLayer) {
-        if (destProp = _composedPropertyLayer->GetPropertyAtPath(
-                primPath.AppendProperty(propName))) {
+        if ((destProp = _composedPropertyLayer->GetPropertyAtPath(
+                primPath.AppendProperty(propName)))) {
             return destProp;
         }
     } else {
@@ -520,7 +520,7 @@ UsdPrimDefinition::_ComposeOverAndReplaceExistingProperty(
     // get the property spec with the overrides applied. Any fields that
     // are defined in the override spec are stronger so we copy the defined
     // spec fields that aren't already in the override spec.
-    for (const TfToken srcField : defProp.ListMetadataFields()) {
+    for (const TfToken &srcField : defProp.ListMetadataFields()) {
         if (!overLayerAndPath.HasField<VtValue>(srcField, nullptr)) {
             VtValue value;
             if (defLayerAndPath->HasField(srcField, &value)) {

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -5282,7 +5282,7 @@ _GenerateFlattenedPrototypePath(const std::vector<UsdPrim>& prototypes)
     size_t primPrototypeId = 1;
 
     const auto generatePathName = [&primPrototypeId]() {
-        return SdfPath(TfStringPrintf("/Flattened_Prototype_%lu", 
+        return SdfPath(TfStringPrintf("/Flattened_Prototype_%zu",
                                       primPrototypeId++));
     };
 

--- a/pxr/usd/usdGeom/primvar.h
+++ b/pxr/usd/usdGeom/primvar.h
@@ -865,8 +865,8 @@ UsdGeomPrimvar::_ComputeFlattenedHelper(const VtArray<ScalarType> &authored,
 
         if (errString) {
             *errString = TfStringPrintf(
-                "Found %ld invalid indices at positions [%s%s] that are out of "
-                "range [0,%ld).", invalidIndexPositions.size(), 
+                "Found %zu invalid indices at positions [%s%s] that are out of "
+                "range [0,%zu).", invalidIndexPositions.size(),
                 TfStringJoin(invalidPositionsStrVec, ", ").c_str(), 
                 invalidIndexPositions.size() > 5 ? ", ..." : "",
                 authored.size());

--- a/pxr/usd/usdGeom/subset.cpp
+++ b/pxr/usd/usdGeom/subset.cpp
@@ -518,7 +518,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Number of unique indices at time %s "
-                    "does not match the element count %ld.", 
+                    "does not match the element count %zu.",
                     TfStringify(t).c_str(), elementCount);
             }
         }
@@ -529,7 +529,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the element count %ld at time %s.\n", 
+                    "greater than the element count %zu at time %s.\n",
                     elementCount, TfStringify(t).c_str());
             }
         }
@@ -629,7 +629,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Number of unique indices at time %s "
-                    "does not match the face count %ld.", 
+                    "does not match the face count %zu.",
                     TfStringify(t).c_str(), faceCount);
             }
         }
@@ -640,7 +640,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the face-count %ld at time %s.\n", 
+                    "greater than the face-count %zu at time %s.\n",
                     faceCount, TfStringify(t).c_str());
             }
         }

--- a/pxr/usd/usdSkel/animation.cpp
+++ b/pxr/usd/usdSkel/animation.cpp
@@ -282,8 +282,8 @@ UsdSkelAnimation::SetTransforms(const VtMatrix4dArray& xforms,
     VtVec3hArray scales;
     if (UsdSkelDecomposeTransforms(xforms, &translations,
                                    &rotations, &scales)) {
-        return GetTranslationsAttr().Set(translations, time) &
-               GetRotationsAttr().Set(rotations, time) &
+        return GetTranslationsAttr().Set(translations, time) &&
+               GetRotationsAttr().Set(rotations, time) &&
                GetScalesAttr().Set(scales, time);
     }
     return false;

--- a/pxr/usd/usdUtils/pipeline.cpp
+++ b/pxr/usd/usdUtils/pipeline.cpp
@@ -319,7 +319,7 @@ _GetPipelineIdentifierTokens(const TfTokenVector& identifierKeys)
 
     const PlugPluginPtrVector plugs =
         PlugRegistry::GetInstance().GetAllPlugins();
-    for (const PlugPluginPtr plug : plugs) {
+    for (const PlugPluginPtr &plug : plugs) {
         JsObject metadata = plug->GetMetadata();
         JsValue metadataDictValue;
         if (!TfMapLookup(metadata, metadataDictKey, &metadataDictValue)) {

--- a/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
@@ -207,15 +207,13 @@ public:
 private:
     _UsdImagingDataSourceShadingNodeInputs(
         UsdShadeShader shaderNode,
-        const UsdImagingDataSourceStageGlobals &stageGlobals,
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals,
         const SdfPath &materialPrefix)
     : _shaderNode(shaderNode)
-    , _stageGlobals(stageGlobals)
     , _materialPrefix(materialPrefix)
     {}
 
     UsdShadeShader _shaderNode;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
     const SdfPath _materialPrefix;
 };
 

--- a/pxr/usdImaging/usdImaging/dataSourceVolume.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceVolume.cpp
@@ -33,9 +33,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 UsdImagingDataSourceVolumeFieldBindings
 ::UsdImagingDataSourceVolumeFieldBindings(
         UsdVolVolume usdVolume,
-        const UsdImagingDataSourceStageGlobals &stageGlobals)
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals)
     : _usdVolume(usdVolume)
-    , _stageGlobals(stageGlobals)
 {
 }
 

--- a/pxr/usdImaging/usdImaging/dataSourceVolume.h
+++ b/pxr/usdImaging/usdImaging/dataSourceVolume.h
@@ -55,7 +55,6 @@ private:
 
 private:
     UsdVolVolume _usdVolume;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceVolumeFieldBindings);

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -995,7 +995,7 @@ UsdImagingDelegate::_GatherDependencies(
     if (it != cache.end()) {
         TF_DEBUG(USDIMAGING_CHANGES).Msg(
             "[_GatherDependencies] Found entry in flattened cache for %s with "
-            "%lu paths\n", subtree.GetText(), it->second.size());
+            "%zu paths\n", subtree.GetText(), it->second.size());
 
         *affectedCachePaths = it->second;
         return;

--- a/pxr/usdImaging/usdImaging/drawModeSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/drawModeSceneIndex.cpp
@@ -118,7 +118,7 @@ UsdImagingDrawModeSceneIndex::_FindStandinForPrimOrAncestor(
     const auto it = std::lower_bound(
         _prims.rbegin(), _prims.rend(),
         path, 
-        [](const value_type &a, const SdfPath &b) { return a.first > b; });
+        [](value_type &a, const SdfPath &b) { return a.first > b; });
     if (it == _prims.rend()) {
         return nullptr;
     }

--- a/pxr/usdImaging/usdImaging/gprimAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.cpp
@@ -908,7 +908,7 @@ UsdImagingGprimAdapter::GetColor(UsdPrim const& prim,
 
                     if (colorInterp == UsdGeomTokens->constant &&
                         result.size() > 1) {
-                        TF_WARN("Prim %s has %lu element(s) for %s even "
+                        TF_WARN("Prim %s has %zu element(s) for %s even "
                                 "though it is marked constant.",
                                 prim.GetPath().GetText(), result.size(),
                                 primvar.GetName().GetText());
@@ -921,7 +921,7 @@ UsdImagingGprimAdapter::GetColor(UsdPrim const& prim,
 
                 if (colorInterp == UsdGeomTokens->constant &&
                     result.size() > 1) {
-                    TF_WARN("Prim %s has %lu element(s) for %s even "
+                    TF_WARN("Prim %s has %zu element(s) for %s even "
                             "though it is marked constant.",
                             prim.GetPath().GetText(), result.size(),
                             primvar.GetName().GetText());
@@ -1021,7 +1021,7 @@ UsdImagingGprimAdapter::GetOpacity(UsdPrim const& prim,
 
                     if (opacityInterp == UsdGeomTokens->constant &&
                         result.size() > 1) {
-                        TF_WARN("Prim %s has %lu element(s) for %s even "
+                        TF_WARN("Prim %s has %zu element(s) for %s even "
                                 "though it is marked constant.",
                                 prim.GetPath().GetText(), result.size(),
                                 primvar.GetName().GetText());
@@ -1034,7 +1034,7 @@ UsdImagingGprimAdapter::GetOpacity(UsdPrim const& prim,
 
                 if (opacityInterp == UsdGeomTokens->constant &&
                     result.size() > 1) {
-                    TF_WARN("Prim %s has %lu element(s) for %s even "
+                    TF_WARN("Prim %s has %zu element(s) for %s even "
                             "though it is marked constant.",
                             prim.GetPath().GetText(), result.size(),
                             primvar.GetName().GetText());

--- a/pxr/usdImaging/usdImaging/indexProxy.cpp
+++ b/pxr/usdImaging/usdImaging/indexProxy.cpp
@@ -57,10 +57,13 @@ UsdImagingIndexProxy::_AddHdPrimInfo(SdfPath const &cachePath,
         }
     }
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
     TF_DEBUG(USDIMAGING_CHANGES).Msg(
         "[Add HdPrim Info] <%s> adapter=%s\n",
         cachePath.GetText(),
         TfType::GetCanonicalTypeName(typeid(*(adapterToInsert.get()))).c_str());
+    ARCH_PRAGMA_POP
 
     // Currently, we don't support more than one adapter dependency per usd
     // prim, but we could relax this restriction if it's useful.

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -238,7 +238,6 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
         // prototypes.
         UsdPrimRange range(prototypePrim, _GetDisplayPredicate());
         int protoID = 0;
-        int primCount = 0;
 
         for (auto iter = range.begin(); iter != range.end(); ++iter) {
             // If we encounter an instance in this USD prototype, save it aside
@@ -329,7 +328,6 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 proto.path = iter->GetPath();
             }
             proto.adapter = primAdapter;
-            ++primCount;
 
             if (!isLeafInstancer) {
                 instancerData.childPointInstancers.insert(protoPath);
@@ -342,6 +340,8 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 }
             }
 
+            ARCH_PRAGMA_PUSH
+            ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
             TF_DEBUG(USDIMAGING_INSTANCER).Msg(
                 "[Add Instance NI] <%s>  %s (%s), adapter = %s\n",
                 instancerPath.GetText(), protoPath.GetText(),
@@ -349,6 +349,7 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 primAdapter ?
                     TfType::GetCanonicalTypeName(typeid(*primAdapter)).c_str() :
                     "none");
+            ARCH_PRAGMA_POP
         }
 
         UsdPrim instancerPrim = _GetPrim(instancerPath);

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -475,7 +475,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
     }
 
     TF_DEBUG(USDIMAGING_POINT_INSTANCER_PROTO_CREATED).Msg(
-        "Prototype[%d]: <%s>, primCount: %lu, instantiatedPrimCount: %lu\n",
+        "Prototype[%d]: <%s>, primCount: %zu, instantiatedPrimCount: %zu\n",
         protoIndex,
         protoRootPrim.GetPath().GetText(),
         primCount,
@@ -2219,8 +2219,8 @@ UsdImagingPointInstancerAdapter::GetInstanceIndices(
                         instancerPrim, time);
 
                 if (pathIndex >= indices.size()) {
-                    TF_WARN("ProtoIndex %lu out of bounds "
-                            "(prototypes size = %lu) for (%s, %s)",
+                    TF_WARN("ProtoIndex %zu out of bounds "
+                            "(prototypes size = %zu) for (%s, %s)",
                                     pathIndex,
                                     indices.size(),
                                     instancerCachePath.GetText(),


### PR DESCRIPTION
### Description of Change(s)
Small fixes to address warnings while working to get clang/ninja build working on Windows. Some warnings from MSVC most recent update.

### Fixes Issue(s)
- Multiple cases of printf semantics referring to size_t variables using a "l" semantic instead of "z". For example "lu" instead of "zu".
- A few cases of a boolean bit operator instead of the logical operator.
- A few cases of for_each resulting in a copy instead of a const reference in the loop control.
- A few cases where a reference was created on a temporary value (return in the loop control).

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
