### PR TITLE
Fix for git bash on windows using cp 1252 instead of Unicode for stdout

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2270,6 +2270,13 @@ except Exception as e:
 
 verbosity = args.verbosity
 
+if os.name == "nt" and sys.version_info > (3, 6):
+    # fix for git-bash on Windows using code page 1252 as default instead
+    # of unicode - functions like e.g. PrintCommandOutput fail writing
+    # unicode characters for filenames containing them
+    # `reconfigure` only exists in versions greater than Python 3.6
+    sys.stdout.reconfigure(encoding='utf-8')
+
 # Augment PATH on Windows so that 3rd-party dependencies can find libraries
 # they depend on. In particular, this is needed for building IlmBase/OpenEXR.
 extraPaths = []

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2270,7 +2270,7 @@ except Exception as e:
 
 verbosity = args.verbosity
 
-if os.name == "nt" and sys.version_info > (3, 6):
+if os.name == "nt" and sys.version_info >= (3, 7):
     # fix for git-bash on Windows using code page 1252 as default instead
     # of unicode - functions like e.g. PrintCommandOutput fail writing
     # unicode characters for filenames containing them

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2270,7 +2270,7 @@ except Exception as e:
 
 verbosity = args.verbosity
 
-if sys.version_info[0] >= 3 and sys.version_info[1] > 6:
+if (sys.version_info[0] == 3 and sys.version_info[1] > 6) or sys.version_info[0] > 3:
     # fix for git-bash on Windows using code page 1252 as default instead
     # of unicode - functions like e.g. PrintCommandOutput fail writing
     # unicode characters for filenames containing them

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2270,10 +2270,12 @@ except Exception as e:
 
 verbosity = args.verbosity
 
-# fix for git-bash on Windows using code page 1252 as default instead
-# of unicode - functions like e.g. PrintCommandOutput fail writing
-# unicode characters for filenames containing them
-sys.stdout.reconfigure(encoding='utf-8')
+if sys.version_info[0] >= 3 and sys.version_info[1] > 6:
+    # fix for git-bash on Windows using code page 1252 as default instead
+    # of unicode - functions like e.g. PrintCommandOutput fail writing
+    # unicode characters for filenames containing them
+    # `reconfigure` only exists in versions greater than Python 3.6
+    sys.stdout.reconfigure(encoding='utf-8')
 
 # Augment PATH on Windows so that 3rd-party dependencies can find libraries
 # they depend on. In particular, this is needed for building IlmBase/OpenEXR.

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2270,6 +2270,11 @@ except Exception as e:
 
 verbosity = args.verbosity
 
+# fix for git-bash on Windows using code page 1252 as default instead
+# of unicode - functions like e.g. PrintCommandOutput fail writing
+# unicode characters for filenames containing them
+sys.stdout.reconfigure(encoding='utf-8')
+
 # Augment PATH on Windows so that 3rd-party dependencies can find libraries
 # they depend on. In particular, this is needed for building IlmBase/OpenEXR.
 extraPaths = []


### PR DESCRIPTION
### Description of Change(s)

git bash on Windows uses cp 1252 for terminal encoding by default.  In newer OpenUSD builds, there are file name that contain Unicode characters that will cause functions in the build script like e.g. `PrintCommandOutput` to raise a `UnicodeEncodeError` when attempting to write the names of these files to `stdout`.  This fix reconfigures `stdout` in the build script to use `utf-8` explicitly.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
[X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
[X] I have submitted a signed Contributor License Agreement
