### PR TITLE
Replace `BOOST_PP_AND` and `BOOST_PP_NOT` with `tf/preprocessorUtilsLite.h`

### DIFF
--- a/pxr/base/tf/preprocessorUtilsLite.h
+++ b/pxr/base/tf/preprocessorUtilsLite.h
@@ -333,7 +333,7 @@
 // arguments. MSVC will complain about insufficient arguments otherwise.
 // The ~ will be discarded in any case.
 #define TF_PP_EAT_PARENS(...) \
-    _TF_PP_EAT_PARENS_IFF(_TF_PP_IS_PARENS(__VA_ARGS__ ~),\
+    _TF_PP_IFF(_TF_PP_IS_PARENS(__VA_ARGS__ ~),\
         _TF_PP_PARENS_EXPAND1,_TF_PP_PARENS_EXPAND)(__VA_ARGS__)
 
 /// Expand the arguments and make the result a string.
@@ -347,12 +347,11 @@
 #define _TF_PP_EAT_PARENS_STR2(x, ...) #__VA_ARGS__
 
 // Expands to the second argument if c is 1 and the third argument if c is
-// 0.  No other values of c are allowed.  We can't use BOOST_PP_IFF() because
-// it won't expand during stringizing under MSVC.
-#define _TF_PP_EAT_PARENS_IFF(c, t, f) \
-    TF_PP_CAT(_TF_PP_EAT_PARENS_IFF_, c)(t, f)
-#define _TF_PP_EAT_PARENS_IFF_0(t, f) f
-#define _TF_PP_EAT_PARENS_IFF_1(t, f) t
+// 0.  No other values of c are allowed.
+#define _TF_PP_IFF(c, t, f) \
+    TF_PP_CAT(_TF_PP_IFF_, c)(t, f)
+#define _TF_PP_IFF_0(t, f) f
+#define _TF_PP_IFF_1(t, f) t
 
 // Force expansion of the arguments.
 #define _TF_PP_PARENS_EXPAND(...) __VA_ARGS__

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -84,8 +84,6 @@
 
 #include <boost/preprocessor/control/iif.hpp>
 #include <boost/preprocessor/control/expr_iif.hpp>
-#include <boost/preprocessor/logical/and.hpp>
-#include <boost/preprocessor/logical/not.hpp>
 #include <boost/preprocessor/punctuation/comma_if.hpp>
 #include <boost/preprocessor/seq/filter.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
@@ -256,11 +254,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 // element of a sequence is an array of tokens or not.
 //
 #define _TF_TOKENS_IS_ARRAY(s, data, elem)                                  \
-    BOOST_PP_AND(TF_PP_IS_TUPLE(elem),                                      \
-                 TF_PP_IS_TUPLE(BOOST_PP_TUPLE_ELEM(2, 1, elem)))
+    _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                        \
+               TF_PP_IS_TUPLE(BOOST_PP_TUPLE_ELEM(2, 1, elem)), 0)
 
 #define _TF_TOKENS_IS_NOT_ARRAY(s, data, elem)                              \
-    BOOST_PP_NOT(_TF_TOKENS_IS_ARRAY(s, data, elem))
+    _TF_PP_IFF(_TF_TOKENS_IS_ARRAY(s, data, elem), 0, 1)
 
 // Private macro to append all array elements to a sequence.
 //


### PR DESCRIPTION
### Description of Change(s)

`tf/preprocessorUtilsLite.h` provides a macro `_TF_PP_EAT_PARENS_IFF`. This renames that internal macro to `_TF_PP_IFF` and replaces `tf/staticTokens.h` usage of `BOOST_PP_AND` and `BOOST_PP_NOT` with it.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
