### PR TITLE
Fixes from warning generation in Clang(windows) and MSVC

### DIFF
--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -102,6 +102,24 @@
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND \
         _Pragma("clang diagnostic ignored \"-Wobjc-method-access\"")
 
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+        _Pragma("clang diagnostic ignored \"-Wimplicit-const-int-float-conversion\"")
+
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+        _Pragma("clang diagnostic ignored \"-Wpotentially-evaluated-expression\"")
+
+    #define ARCH_PRAGMA_REINTERPRET_BASE_CLASS
+        _Pragma("clang diagnostic ignored \"-Wreinterpret-base-class\"")
+
+    #define ARCH_PRAGMA_MICROSOFT_CAST
+        _Pragma("clang diagnostic ignored \"-Wmicrosoft-cast\"")
+
+    #define ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE
+        _Pragma("clang diagnostic ignored \"-Wunused-lambda-capture\"")
+
+    #define ARCH_PRAGMA_UNUSED_VARIABLE
+        _Pragma("clang diagnostic ignored \"-Wunused-variable\"")
+
 #elif defined(ARCH_COMPILER_MSVC)
 
     #define ARCH_PRAGMA_PUSH \
@@ -260,6 +278,30 @@
 
 #if !defined ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
+#endif
+
+#if !defined ARCH_PRAGMA_INT_FLOAT_CONVERSION
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+#endif
+
+#if !defined ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+#endif
+
+#if !defined(ARCH_PRAGMA_REINTERPRET_BASE_CLASS)
+    #define ARCH_PRAGMA_REINTERPRET_BASE_CLASS
+#endif
+
+#if !defined(ARCH_PRAGMA_MICROSOFT_CAST)
+    #define ARCH_PRAGMA_MICROSOFT_CAST
+#endif
+
+#if !defined(ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE)
+    #define ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE
+#endif
+
+#if !defined(ARCH_PRAGMA_UNUSED_VARIABLE)
+    #define ARCH_PRAGMA_UNUSED_VARIABLE
 #endif
 
 #endif // PXR_BASE_ARCH_PRAGMAS_H

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -358,7 +358,7 @@ TfReadDir(
     if((hFind = FindFirstFileW(szPath, &fdFile)) == INVALID_HANDLE_VALUE)
     {
         if (errMsg) {
-            *errMsg = TfStringPrintf("Path not found: %s", szPath);
+            *errMsg = TfStringPrintf("Path not found: %ls", szPath);
         }
         return false;
     }

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -1231,7 +1231,7 @@ _GetAsCommaSeparatedString(size_t number)
 {
     string result;
 
-    string str = TfStringPrintf("%ld", number);
+    string str = TfStringPrintf("%zu", number);
     size_t n = str.size();
 
     TF_FOR_ALL(it, str) {
@@ -1361,7 +1361,7 @@ _PrintMallocCallSites(
     const size_t maxPercentageWidth = 15;
 
     string fmt = TfStringPrintf(
-        "%%-%lds %%%lds %%%lds\n",
+        "%%-%zus %%%zus %%%zus\n",
         maxNameWidth, maxBytesWidth, maxPercentageWidth);
 
     *rpt += TfStringPrintf(fmt.c_str(), "NAME", "BYTES", "%ROOT");
@@ -1442,7 +1442,7 @@ _ReportMallocNode(
     }
 
     out << TfStringPrintf(
-        "%13s B %13s B %7ld samples    ",
+        "%13s B %13s B %7zu samples    ",
         _GetAsCommaSeparatedString(node.nBytes).c_str(),
         _GetAsCommaSeparatedString(node.nBytesDirect).c_str(),
         node.nAllocations);

--- a/pxr/base/tf/pyClassMethod.h
+++ b/pxr/base/tf/pyClassMethod.h
@@ -36,6 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 namespace Tf_PyClassMethod {
 
 using namespace boost::python;
+namespace bp = boost::python;
 
 // Visitor for wrapping functions as Python class methods.
 // See typedef below for docs.
@@ -43,7 +44,7 @@ using namespace boost::python;
 // except it uses PyClassMethod_New() instead of PyStaticMethod_New().
 struct _TfPyClassMethod : def_visitor<_TfPyClassMethod>
 {
-    friend class def_visitor_access;
+    friend class bp::def_visitor_access;
 
     _TfPyClassMethod(const std::string &methodName) :
         _methodName(methodName) {}

--- a/pxr/base/tf/pyPtrHelpers.h
+++ b/pxr/base/tf/pyPtrHelpers.h
@@ -110,6 +110,7 @@ struct TfMakePyPtr {
 namespace Tf_PyDefHelpers {
 
 using namespace boost::python;
+namespace bp = boost::python;
 
 template <typename Ptr>
 struct _PtrInterface {
@@ -309,7 +310,7 @@ converter::to_python_function_t
 _PtrToPythonWrapper<T>::_originalConverter = 0;
 
 struct WeakPtr : def_visitor<WeakPtr> {
-    friend class def_visitor_access;
+    friend class bp::def_visitor_access;
 
     template <typename WrapperPtrType, typename Wrapper, typename T>
     static void _RegisterConversions(Wrapper *, T *) {
@@ -405,7 +406,7 @@ struct WeakPtr : def_visitor<WeakPtr> {
 };
 
 struct RefAndWeakPtr : def_visitor<RefAndWeakPtr> {
-    friend class def_visitor_access;
+    friend class bp::def_visitor_access;
 
     template <typename CLS, typename Wrapper, typename T>
     static void _AddAPI(Wrapper *, T *) {

--- a/pxr/base/tf/refPtr.h
+++ b/pxr/base/tf/refPtr.h
@@ -425,6 +425,7 @@
 ///
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/pragmas.h"
 
 #include "pxr/base/tf/diagnosticLite.h"
 #include "pxr/base/tf/hash.h"
@@ -1079,9 +1080,12 @@ private:
     // not the first base class of T then the resulting pointer may
     // not point to a T.  Nevertheless, it should be consistent to
     // all calls to the tracking functions.
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_REINTERPRET_BASE_CLASS
     T* _GetObjectForTracking() const {
         return reinterpret_cast<T*>(const_cast<TfRefBase*>(_refBase));
     }
+    ARCH_PRAGMA_POP
 
     /// Call \c typeid on the object pointed to by a \c TfRefPtr.
     ///

--- a/pxr/base/tf/singleton.h
+++ b/pxr/base/tf/singleton.h
@@ -194,8 +194,13 @@ public:
     
 private:
     static T *_CreateInstance(std::atomic<T *> &instance);
-    
+
+    // Disabling for strict builds. However, this is concerning and care
+    // should be taken on not having singletons cross DLL boundaries.
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_NEEDS_EXPORT_INTERFACE
     static std::atomic<T *> _instance;
+    ARCH_PRAGMA_POP
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -806,6 +806,7 @@ TfDictionaryLessThan::_LessImpl(const string& lstr, const string& rstr) const
             // Add 5 mod 32 makes '_' sort before all letters.
             return ((l + 5) & 31) < ((r + 5) & 31);
         }
+        // Intentionally using bitwise operators due to performance critical code path.
         else if (IsDigit(l) | IsDigit(r)) {
             if (IsDigit(l) & IsDigit(r)) {
                 // We backtrack to find the start of each digit string, then we

--- a/pxr/base/tf/testenv/notice.cpp
+++ b/pxr/base/tf/testenv/notice.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <algorithm>
 
 using std::cout;
 using std::endl;
@@ -112,7 +113,7 @@ std::mutex mainThreadLock;
 static void 
 _DumpLog(ostream *log, vector<string> *li, std::mutex *mutex) {
     std::lock_guard<std::mutex> lock(*mutex);
-    sort(li->begin(), li->end());
+    std::sort(li->begin(), li->end());
     for(vector<string>::const_iterator n = li->begin(); 
         n != li->end(); ++ n) {
         *log << *n << endl;

--- a/pxr/base/tf/testenv/scopeDescription.cpp
+++ b/pxr/base/tf/testenv/scopeDescription.cpp
@@ -102,6 +102,7 @@ TestOverhead()
     } while (sw.GetSeconds() < 0.5);
     // printf("%zd rand calls in %f seconds: %u\n",
     //        count, sw.GetSeconds(), val);
+    (void)val;
     double baseSecsPerCall = sw.GetSeconds() / double(count);
 
     count = 0;

--- a/pxr/base/tf/wrapTestPyStaticTokens.cpp
+++ b/pxr/base/tf/wrapTestPyStaticTokens.cpp
@@ -34,7 +34,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((pear, "d'Anjou"))                 \
     ((apple, ( (Fuji) (Pippin) (McIntosh) )))
 
-TF_DECLARE_PUBLIC_TOKENS(tfTestStaticTokens, TF_API, TF_TEST_TOKENS);
+TF_DECLARE_PUBLIC_TOKENS(tfTestStaticTokens, TF_TEST_TOKENS);
 TF_DEFINE_PUBLIC_TOKENS(tfTestStaticTokens, TF_TEST_TOKENS);
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/wrapTypeHelpers.h
+++ b/pxr/base/tf/wrapTypeHelpers.h
@@ -38,10 +38,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 namespace TfType_WrapHelpers {
 
     using namespace boost::python;
+    namespace bp = boost::python;
 
     struct _PythonClass : def_visitor<_PythonClass>
     {
-        friend class def_visitor_access;
+        friend class bp::def_visitor_access;
             
     private:
         template <class CLS, class T>

--- a/pxr/base/vt/value.cpp
+++ b/pxr/base/vt/value.cpp
@@ -94,6 +94,11 @@ _NumericCast(VtValue const &val)
 {
     const From x = val.UncheckedGet<From>();
 
+    // Fix for strict builds. Somce bools do not have an infinity, this function
+    // should not be compiled. However, that is not the case currently on MSVC.
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_UNSAFE_USE_OF_BOOL
+
     // Use 'x == x' to check that x is not NaN.  NaNs don't compare equal to
     // themselves.
     if (x == x) {
@@ -104,6 +109,7 @@ _NumericCast(VtValue const &val)
             return VtValue(-std::numeric_limits<To>::infinity());
         }
     }
+    ARCH_PRAGMA_POP
 
     return _BoostNumericCast<From, To>(x);
 }


### PR DESCRIPTION
### Description of Change(s)
 - Fix for using "long" type in printf format strings when paired with a size_t argument. Change from "l" to "z".
 - Fix for not using the "long" type when referring to a wchat_t in a print format string. Change from "s" to "ls".
 - Added a comment for using a bitwise operator in performance-critical code.
 - Template that will SFINAE throws a warning during the first pass compilation. Pragma ignored the warning not to break strict builds.
 - Wrapping the static atomic in singleton.h with an ignore compilation warning due to lack of export symbols (DLL export). This is theoretically safe as long as care is taken about access of singletons across DLL boundaries.

### Fixes Issue(s)
- Compile warnings

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement