### PR TITLE
Fixes from warning generation in Clang(windows) and MSVC

### DIFF
--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -102,6 +102,24 @@
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND \
         _Pragma("clang diagnostic ignored \"-Wobjc-method-access\"")
 
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+        _Pragma("clang diagnostic ignored \"-Wimplicit-const-int-float-conversion\"")
+
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+        _Pragma("clang diagnostic ignored \"-Wpotentially-evaluated-expression\"")
+
+    #define ARCH_PRAGMA_REINTERPRET_BASE_CLASS
+        _Pragma("clang diagnostic ignored \"-Wreinterpret-base-class\"")
+
+    #define ARCH_PRAGMA_MICROSOFT_CAST
+        _Pragma("clang diagnostic ignored \"-Wmicrosoft-cast\"")
+
+    #define ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE
+        _Pragma("clang diagnostic ignored \"-Wunused-lambda-capture\"")
+
+    #define ARCH_PRAGMA_UNUSED_VARIABLE
+        _Pragma("clang diagnostic ignored \"-Wunused-variable\"")
+
 #elif defined(ARCH_COMPILER_MSVC)
 
     #define ARCH_PRAGMA_PUSH \
@@ -260,6 +278,30 @@
 
 #if !defined ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
     #define ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND
+#endif
+
+#if !defined ARCH_PRAGMA_INT_FLOAT_CONVERSION
+    #define ARCH_PRAGMA_INT_FLOAT_CONVERSION
+#endif
+
+#if !defined ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+    #define ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
+#endif
+
+#if !defined(ARCH_PRAGMA_REINTERPRET_BASE_CLASS)
+    #define ARCH_PRAGMA_REINTERPRET_BASE_CLASS
+#endif
+
+#if !defined(ARCH_PRAGMA_MICROSOFT_CAST)
+    #define ARCH_PRAGMA_MICROSOFT_CAST
+#endif
+
+#if !defined(ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE)
+    #define ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE
+#endif
+
+#if !defined(ARCH_PRAGMA_UNUSED_VARIABLE)
+    #define ARCH_PRAGMA_UNUSED_VARIABLE
 #endif
 
 #endif // PXR_BASE_ARCH_PRAGMAS_H

--- a/pxr/usd/pcp/cache.cpp
+++ b/pxr/usd/pcp/cache.cpp
@@ -1229,7 +1229,7 @@ PcpCache::ReloadReferences(PcpChanges* changes, const SdfPath& primPath)
     // local layers.
     SdfLayerHandleSet layersToReload;
     for (const PcpLayerStackPtr& layerStack: layerStacksAtOrUnderPrim) {
-        for (const SdfLayerHandle& layer: layerStack->GetLayers()) {
+        for (const SdfLayerHandle layer: layerStack->GetLayers()) {
             if (!_layerStack->HasLayer(layer)) {
                 layersToReload.insert(layer);
             }

--- a/pxr/usd/sdf/pathExpressionEval.h
+++ b/pxr/usd/sdf/pathExpressionEval.h
@@ -70,7 +70,7 @@ class Sdf_PathExpressionEvalBase
 {
 public:
     friend bool
-    Sdf_MakePathExpressionEvalImpl(
+    SDF_API Sdf_MakePathExpressionEvalImpl(
         Sdf_PathExpressionEvalBase &eval,
         SdfPathExpression const &expr,
         TfFunctionRef<

--- a/pxr/usd/sdf/predicateExpression.cpp
+++ b/pxr/usd/sdf/predicateExpression.cpp
@@ -177,6 +177,8 @@ SdfPredicateExpression::GetText() const
 
     std::vector<Op> opStack;
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_UNUSED_LAMBDA_CAPTURE
     auto printLogic = [&opName, &opStack, &result](
         std::vector<std::pair<Op, int>> const &stack) {
 
@@ -206,6 +208,7 @@ SdfPredicateExpression::GetText() const
             result += ')';
         }                
     };
+    ARCH_PRAGMA_POP
 
     auto printCall = [&result](FnCall const &call) {
         result += call.funcName;

--- a/pxr/usd/sdf/textFileFormat.cpp
+++ b/pxr/usd/sdf/textFileFormat.cpp
@@ -189,7 +189,7 @@ SdfTextFileFormat::_ReadFromAsset(
     const size_t toMB = 1048576;
 
     if (fileSizeWarning > 0 && asset->GetSize() > (fileSizeWarning * toMB)) {
-        TF_WARN("Performance warning: reading %lu MB text-based layer <%s>.",
+        TF_WARN("Performance warning: reading %zu MB text-based layer <%s>.",
                 asset->GetSize() / toMB,
                 resolvedPath.c_str());
     }

--- a/pxr/usd/sdf/textFileFormat.tab.cpp
+++ b/pxr/usd/sdf/textFileFormat.tab.cpp
@@ -3197,13 +3197,6 @@ yydestruct (yymsg, yytype, yyvaluep, context)
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
-
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
 }
 
 /* Prevent warnings from -Wmissing-prototypes.  */
@@ -3259,6 +3252,7 @@ YYSTYPE yylval;
 
     /* Number of syntax errors so far.  */
     int yynerrs;
+    (void)yynerrs;
 
     int yystate;
     /* Number of tokens to shift before error messages enabled.  */

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -1725,6 +1725,8 @@ _WritePossiblyCompressedArray(
         return _WriteUncompressedArray(w, array, ver);
     }
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_INT_FLOAT_CONVERSION
     // Check to see if all the floats are exactly represented as integers.
     auto isIntegral = [](T fp) {
         constexpr int32_t max = std::numeric_limits<int32_t>::max();
@@ -1732,6 +1734,7 @@ _WritePossiblyCompressedArray(
         return min <= fp && fp <= max &&
             static_cast<T>(static_cast<int32_t>(fp)) == fp;
     };    
+    ARCH_PRAGMA_POP
     if (std::all_of(array.cdata(), array.cdata() + array.size(), isIntegral)) {
         // Encode as integers.
         auto result = ValueRepForArray<T>(w.Tell());

--- a/pxr/usd/usd/primDefinition.cpp
+++ b/pxr/usd/usd/primDefinition.cpp
@@ -397,8 +397,8 @@ UsdPrimDefinition::_FindOrCreatePropertySpecForComposition(
     // we create a new layer for this prim definition to write its composed
     // properties.
     if (_composedPropertyLayer) {
-        if (destProp = _composedPropertyLayer->GetPropertyAtPath(
-                primPath.AppendProperty(propName))) {
+        if ((destProp = _composedPropertyLayer->GetPropertyAtPath(
+                primPath.AppendProperty(propName)))) {
             return destProp;
         }
     } else {
@@ -520,7 +520,7 @@ UsdPrimDefinition::_ComposeOverAndReplaceExistingProperty(
     // get the property spec with the overrides applied. Any fields that
     // are defined in the override spec are stronger so we copy the defined
     // spec fields that aren't already in the override spec.
-    for (const TfToken srcField : defProp.ListMetadataFields()) {
+    for (const TfToken &srcField : defProp.ListMetadataFields()) {
         if (!overLayerAndPath.HasField<VtValue>(srcField, nullptr)) {
             VtValue value;
             if (defLayerAndPath->HasField(srcField, &value)) {

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -5282,7 +5282,7 @@ _GenerateFlattenedPrototypePath(const std::vector<UsdPrim>& prototypes)
     size_t primPrototypeId = 1;
 
     const auto generatePathName = [&primPrototypeId]() {
-        return SdfPath(TfStringPrintf("/Flattened_Prototype_%lu", 
+        return SdfPath(TfStringPrintf("/Flattened_Prototype_%zu",
                                       primPrototypeId++));
     };
 

--- a/pxr/usd/usdGeom/primvar.h
+++ b/pxr/usd/usdGeom/primvar.h
@@ -865,8 +865,8 @@ UsdGeomPrimvar::_ComputeFlattenedHelper(const VtArray<ScalarType> &authored,
 
         if (errString) {
             *errString = TfStringPrintf(
-                "Found %ld invalid indices at positions [%s%s] that are out of "
-                "range [0,%ld).", invalidIndexPositions.size(), 
+                "Found %zu invalid indices at positions [%s%s] that are out of "
+                "range [0,%zu).", invalidIndexPositions.size(),
                 TfStringJoin(invalidPositionsStrVec, ", ").c_str(), 
                 invalidIndexPositions.size() > 5 ? ", ..." : "",
                 authored.size());

--- a/pxr/usd/usdGeom/subset.cpp
+++ b/pxr/usd/usdGeom/subset.cpp
@@ -518,7 +518,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Number of unique indices at time %s "
-                    "does not match the element count %ld.", 
+                    "does not match the element count %zu.",
                     TfStringify(t).c_str(), elementCount);
             }
         }
@@ -529,7 +529,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the element count %ld at time %s.\n", 
+                    "greater than the element count %zu at time %s.\n",
                     elementCount, TfStringify(t).c_str());
             }
         }
@@ -629,7 +629,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Number of unique indices at time %s "
-                    "does not match the face count %ld.", 
+                    "does not match the face count %zu.",
                     TfStringify(t).c_str(), faceCount);
             }
         }
@@ -640,7 +640,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the face-count %ld at time %s.\n", 
+                    "greater than the face-count %zu at time %s.\n",
                     faceCount, TfStringify(t).c_str());
             }
         }

--- a/pxr/usd/usdUtils/pipeline.cpp
+++ b/pxr/usd/usdUtils/pipeline.cpp
@@ -319,7 +319,7 @@ _GetPipelineIdentifierTokens(const TfTokenVector& identifierKeys)
 
     const PlugPluginPtrVector plugs =
         PlugRegistry::GetInstance().GetAllPlugins();
-    for (const PlugPluginPtr plug : plugs) {
+    for (const PlugPluginPtr &plug : plugs) {
         JsObject metadata = plug->GetMetadata();
         JsValue metadataDictValue;
         if (!TfMapLookup(metadata, metadataDictKey, &metadataDictValue)) {

--- a/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
@@ -207,15 +207,13 @@ public:
 private:
     _UsdImagingDataSourceShadingNodeInputs(
         UsdShadeShader shaderNode,
-        const UsdImagingDataSourceStageGlobals &stageGlobals,
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals,
         const SdfPath &materialPrefix)
     : _shaderNode(shaderNode)
-    , _stageGlobals(stageGlobals)
     , _materialPrefix(materialPrefix)
     {}
 
     UsdShadeShader _shaderNode;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
     const SdfPath _materialPrefix;
 };
 

--- a/pxr/usdImaging/usdImaging/dataSourcePrim.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourcePrim.cpp
@@ -108,9 +108,8 @@ UsdImagingDataSourceVisibility::Get(const TfToken &name)
 
 UsdImagingDataSourcePurpose::UsdImagingDataSourcePurpose(
         const UsdAttributeQuery &purposeQuery,
-        const UsdImagingDataSourceStageGlobals &stageGlobals)
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals)
     : _purposeQuery(purposeQuery)
-    , _stageGlobals(stageGlobals)
 {
 }
 
@@ -328,9 +327,8 @@ UsdImagingDataSourceExtentsHint::Get(const TfToken &name)
 
 UsdImagingDataSourceXformResetXformStack::UsdImagingDataSourceXformResetXformStack(
         const UsdGeomXformable::XformQuery &xformQuery,
-        const UsdImagingDataSourceStageGlobals &stageGlobals)
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals)
     : _xformQuery(xformQuery)
-    , _stageGlobals(stageGlobals)
 {
 }
 

--- a/pxr/usdImaging/usdImaging/dataSourcePrim.h
+++ b/pxr/usdImaging/usdImaging/dataSourcePrim.h
@@ -111,7 +111,6 @@ private:
 
 private:
     UsdAttributeQuery _purposeQuery;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourcePurpose);
@@ -289,7 +288,6 @@ private:
 
 private:
     UsdGeomXformable::XformQuery _xformQuery;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceXformResetXformStack);

--- a/pxr/usdImaging/usdImaging/dataSourceVolume.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceVolume.cpp
@@ -33,9 +33,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 UsdImagingDataSourceVolumeFieldBindings
 ::UsdImagingDataSourceVolumeFieldBindings(
         UsdVolVolume usdVolume,
-        const UsdImagingDataSourceStageGlobals &stageGlobals)
+        ARCH_UNUSED_ARG const UsdImagingDataSourceStageGlobals &stageGlobals)
     : _usdVolume(usdVolume)
-    , _stageGlobals(stageGlobals)
 {
 }
 

--- a/pxr/usdImaging/usdImaging/dataSourceVolume.h
+++ b/pxr/usdImaging/usdImaging/dataSourceVolume.h
@@ -55,7 +55,6 @@ private:
 
 private:
     UsdVolVolume _usdVolume;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceVolumeFieldBindings);

--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -995,7 +995,7 @@ UsdImagingDelegate::_GatherDependencies(
     if (it != cache.end()) {
         TF_DEBUG(USDIMAGING_CHANGES).Msg(
             "[_GatherDependencies] Found entry in flattened cache for %s with "
-            "%lu paths\n", subtree.GetText(), it->second.size());
+            "%zu paths\n", subtree.GetText(), it->second.size());
 
         *affectedCachePaths = it->second;
         return;

--- a/pxr/usdImaging/usdImaging/drawModeSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/drawModeSceneIndex.cpp
@@ -118,7 +118,7 @@ UsdImagingDrawModeSceneIndex::_FindStandinForPrimOrAncestor(
     const auto it = std::lower_bound(
         _prims.rbegin(), _prims.rend(),
         path, 
-        [](const value_type &a, const SdfPath &b) { return a.first > b; });
+        [](value_type &a, const SdfPath &b) { return a.first > b; });
     if (it == _prims.rend()) {
         return nullptr;
     }

--- a/pxr/usdImaging/usdImaging/gprimAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.cpp
@@ -908,7 +908,7 @@ UsdImagingGprimAdapter::GetColor(UsdPrim const& prim,
 
                     if (colorInterp == UsdGeomTokens->constant &&
                         result.size() > 1) {
-                        TF_WARN("Prim %s has %lu element(s) for %s even "
+                        TF_WARN("Prim %s has %zu element(s) for %s even "
                                 "though it is marked constant.",
                                 prim.GetPath().GetText(), result.size(),
                                 primvar.GetName().GetText());
@@ -921,7 +921,7 @@ UsdImagingGprimAdapter::GetColor(UsdPrim const& prim,
 
                 if (colorInterp == UsdGeomTokens->constant &&
                     result.size() > 1) {
-                    TF_WARN("Prim %s has %lu element(s) for %s even "
+                    TF_WARN("Prim %s has %zu element(s) for %s even "
                             "though it is marked constant.",
                             prim.GetPath().GetText(), result.size(),
                             primvar.GetName().GetText());
@@ -1021,7 +1021,7 @@ UsdImagingGprimAdapter::GetOpacity(UsdPrim const& prim,
 
                     if (opacityInterp == UsdGeomTokens->constant &&
                         result.size() > 1) {
-                        TF_WARN("Prim %s has %lu element(s) for %s even "
+                        TF_WARN("Prim %s has %zu element(s) for %s even "
                                 "though it is marked constant.",
                                 prim.GetPath().GetText(), result.size(),
                                 primvar.GetName().GetText());
@@ -1034,7 +1034,7 @@ UsdImagingGprimAdapter::GetOpacity(UsdPrim const& prim,
 
                 if (opacityInterp == UsdGeomTokens->constant &&
                     result.size() > 1) {
-                    TF_WARN("Prim %s has %lu element(s) for %s even "
+                    TF_WARN("Prim %s has %zu element(s) for %s even "
                             "though it is marked constant.",
                             prim.GetPath().GetText(), result.size(),
                             primvar.GetName().GetText());

--- a/pxr/usdImaging/usdImaging/indexProxy.cpp
+++ b/pxr/usdImaging/usdImaging/indexProxy.cpp
@@ -57,10 +57,13 @@ UsdImagingIndexProxy::_AddHdPrimInfo(SdfPath const &cachePath,
         }
     }
 
+    ARCH_PRAGMA_PUSH
+    ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
     TF_DEBUG(USDIMAGING_CHANGES).Msg(
         "[Add HdPrim Info] <%s> adapter=%s\n",
         cachePath.GetText(),
         TfType::GetCanonicalTypeName(typeid(*(adapterToInsert.get()))).c_str());
+    ARCH_PRAGMA_POP
 
     // Currently, we don't support more than one adapter dependency per usd
     // prim, but we could relax this restriction if it's useful.

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -238,7 +238,6 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
         // prototypes.
         UsdPrimRange range(prototypePrim, _GetDisplayPredicate());
         int protoID = 0;
-        int primCount = 0;
 
         for (auto iter = range.begin(); iter != range.end(); ++iter) {
             // If we encounter an instance in this USD prototype, save it aside
@@ -329,7 +328,6 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 proto.path = iter->GetPath();
             }
             proto.adapter = primAdapter;
-            ++primCount;
 
             if (!isLeafInstancer) {
                 instancerData.childPointInstancers.insert(protoPath);
@@ -342,6 +340,8 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 }
             }
 
+            ARCH_PRAGMA_PUSH
+            ARCH_PRAGMA_POTENTIALLY_EVALUATED_EXPRESSION
             TF_DEBUG(USDIMAGING_INSTANCER).Msg(
                 "[Add Instance NI] <%s>  %s (%s), adapter = %s\n",
                 instancerPath.GetText(), protoPath.GetText(),
@@ -349,6 +349,7 @@ UsdImagingInstanceAdapter::_Populate(UsdPrim const& prim,
                 primAdapter ?
                     TfType::GetCanonicalTypeName(typeid(*primAdapter)).c_str() :
                     "none");
+            ARCH_PRAGMA_POP
         }
 
         UsdPrim instancerPrim = _GetPrim(instancerPath);

--- a/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/pointInstancerAdapter.cpp
@@ -475,7 +475,7 @@ UsdImagingPointInstancerAdapter::_PopulatePrototype(
     }
 
     TF_DEBUG(USDIMAGING_POINT_INSTANCER_PROTO_CREATED).Msg(
-        "Prototype[%d]: <%s>, primCount: %lu, instantiatedPrimCount: %lu\n",
+        "Prototype[%d]: <%s>, primCount: %zu, instantiatedPrimCount: %zu\n",
         protoIndex,
         protoRootPrim.GetPath().GetText(),
         primCount,
@@ -2219,8 +2219,8 @@ UsdImagingPointInstancerAdapter::GetInstanceIndices(
                         instancerPrim, time);
 
                 if (pathIndex >= indices.size()) {
-                    TF_WARN("ProtoIndex %lu out of bounds "
-                            "(prototypes size = %lu) for (%s, %s)",
+                    TF_WARN("ProtoIndex %zu out of bounds "
+                            "(prototypes size = %zu) for (%s, %s)",
                                     pathIndex,
                                     indices.size(),
                                     instancerCachePath.GetText(),


### PR DESCRIPTION
### Description of Change(s)
 - Fix for the use of "long" type in printf format strings when paired with a size_t argument. Change from "l" to "z".
 - Fix for for loop iterators using non-reference types, causing a full object copy to occur. Change to use const reference.
 - Fix for an int to float conversion warning. Change to disable the warning.
 - Fix for using the result of an assignment as an if condition. Change to wrap assignment in parentheses.
 - Removed an unused variable from a _UsdImagingDataSourceShadingNodeInputs and UsdImagingDataSourceVolumeFieldBindings
 - Fix for an issue when using typeid. A warning is thrown when the parameter expression may have side effects. Disabled the compilation warning.

### Fixes Issue(s)
- Compile warnings

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement