### PR TITLE
Replace `boost::unordered_map` with `robin_map` in `usdImaging/usdImaging`

### DIFF
--- a/pxr/usdImaging/usdImaging/delegate.cpp
+++ b/pxr/usdImaging/usdImaging/delegate.cpp
@@ -65,6 +65,7 @@
 #include "pxr/base/work/loops.h"
 
 #include "pxr/base/tf/envSetting.h"
+#include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pyLock.h"
 #include "pxr/base/tf/fileUtils.h"
 #include "pxr/base/tf/ostreamMethods.h"

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -56,9 +56,9 @@
 #include "pxr/base/gf/vec4i.h"
 #include "pxr/base/gf/vec4h.h"
 
+#include "pxr/base/tf/hash.h"
+#include "pxr/base/tf/pxrTslRobinMap/robin_map.h"
 #include "pxr/base/tf/type.h"
-
-#include <boost/unordered_map.hpp>
 
 #include <limits>
 #include <queue>
@@ -953,7 +953,7 @@ struct UsdImagingInstanceAdapter::_IsInstanceTransformVaryingFn
 
     // We keep a simple cache directly on _IsInstanceTransformVaryingFn because
     // we only need it during initialization and resyncs (not in UpdateForTime).
-    boost::unordered_map<UsdPrim, bool, boost::hash<UsdPrim>> cache;
+    pxr_tsl::robin_map<UsdPrim, bool, TfHash> cache;
 };
 
 bool 
@@ -2414,7 +2414,7 @@ struct UsdImagingInstanceAdapter::_ComputeInstanceMapVariabilityFn
     // We keep a simple cache of visibility varying states directly on
     // _ComputeInstanceMapVariabilityFn because we only need it for the
     // variability calculation and during resyncs.
-    boost::unordered_map<UsdPrim, bool, boost::hash<UsdPrim>> varyingCache;
+    pxr_tsl::robin_map<UsdPrim, bool, TfHash> varyingCache;
     const UsdImagingInstanceAdapter* adapter;
     std::vector<_InstancerData::Visibility>* visibility;
 };

--- a/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
+++ b/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
@@ -36,6 +36,8 @@
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/work/utils.h"
 
+#include "pxr/base/tf/hash.h"
+
 #include <tbb/concurrent_unordered_map.h>
 #include <functional>
 

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
@@ -36,7 +36,6 @@
 #include "pxr/usd/usdSkel/skeleton.h"
 #include "pxr/usd/usdSkel/skeletonQuery.h"
 
-#include <boost/unordered_map.hpp>
 #include <unordered_map>
 
 


### PR DESCRIPTION
### Description of Change(s)
This continues the replacement of `boost::unordered_map` in `usdImaging` and cleans up some headers and usage of `boost::hash` in favor `TfHash`.  Performance testing suggested a performance impact using `std::unordered_map` so `robin_map` is used instead.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
