### PR TITLE
Replace `boost::any` with `std::any` in `pxr/base/tf`

### DIFF
--- a/pxr/base/tf/diagnosticBase.h
+++ b/pxr/base/tf/diagnosticBase.h
@@ -38,13 +38,13 @@
 #include "pxr/base/arch/attributes.h"
 #include "pxr/base/arch/function.h"
 
-#include <boost/any.hpp>
+#include <any>
 #include <cstdarg>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::any TfDiagnosticInfo;
+typedef std::any TfDiagnosticInfo;
 
 class TfDiagnosticMgr;
 
@@ -160,7 +160,7 @@ public:
     /// then GetInfo() returns NULL.
     template <typename T>
     const T* GetInfo() const {
-        return boost::any_cast<T>(&_info);
+        return std::any_cast<T>(&_info);
     }
 
     /// Set the info object associated with this diagnostic message.

--- a/pxr/base/tf/diagnosticHelper.h
+++ b/pxr/base/tf/diagnosticHelper.h
@@ -27,17 +27,29 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/api.h"
 #include "pxr/base/arch/attributes.h"
+#include "pxr/base/arch/defines.h"
 
 // XXX: This include is a hack to avoid build errors due to
 // incompatible macro definitions in pyport.h on macOS.
 #include <locale>
 
-#include <boost/any.hpp>
+#include <any>
 #include <string>
+
+// Follow up changes should more tightly scope these to just where it's needed
+// in pxr.
+#if defined(ARCH_OS_LINUX) || defined(ARCH_OS_DARWIN)
+// Include <unistd.h> to provide _exit for tf/debugger.cpp and dependencies
+// that were previously transitively getting this from boost
+#include <unistd.h>
+// Include <cstring> to provide memset, memcmp, and memcpy for dependencies
+// that were previously transitively getting them from boost
+#include <cstring>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef boost::any TfDiagnosticInfo;
+typedef std::any TfDiagnosticInfo;
 class TfCallContext;
 enum TfDiagnosticType : int;
 class TfEnum;

--- a/pxr/base/tf/diagnosticMgr.cpp
+++ b/pxr/base/tf/diagnosticMgr.cpp
@@ -42,11 +42,10 @@
 #include "pxr/base/arch/stackTrace.h"
 #include "pxr/base/arch/threads.h"
 
-#include <boost/utility.hpp>
-
 #include <signal.h>
 #include <stdlib.h>
 
+#include <any>
 #include <thread>
 #include <memory>
 
@@ -673,7 +672,7 @@ TfDiagnosticMgr::FormatDiagnostic(const TfEnum &code,
 
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
     if (const TfPyExceptionState* exc =
-            boost::any_cast<TfPyExceptionState>(&info)) {
+            std::any_cast<TfPyExceptionState>(&info)) {
         output += TfStringPrintf("%s\n", exc->GetExceptionString().c_str());
     }
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -26,6 +26,7 @@
 #include "pxr/imaging/hgiMetal/resourceBindings.h"
 #include "pxr/imaging/hgi/tokens.h"
 
+#include <sstream>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
### Description of Change(s)

C++17 provides `std::any` and `std::any_cast` which can replace `boost::any` and `boost::any_cast`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
