### PR TITLE
Replace `boost::shared_array` with `std::shared_ptr` of C-style array

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -1205,7 +1205,7 @@ UsdGeomBBoxCache::_ResolvePrim(_BBoxTask* task,
     const UsdPrim &prim = primContext.prim;
     const bool useExtentsHintForPrim = _UseExtentsHintForPrim(prim);
 
-    boost::shared_array<UsdAttributeQuery> &queries = entry->queries;
+    std::shared_ptr<UsdAttributeQuery[]> &queries = entry->queries;
     if (!queries) {
         // If this cache doesn't use extents hints, we don't need the
         // corresponding query.

--- a/pxr/usd/usdGeom/bboxCache.h
+++ b/pxr/usd/usdGeom/bboxCache.h
@@ -35,7 +35,6 @@
 #include "pxr/base/work/dispatcher.h"
 
 #include <boost/optional.hpp>
-#include <boost/shared_array.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -487,7 +486,7 @@ private:
 
         // Queries for attributes that need to be re-computed at each
         // time for this entry. This will be invalid for non-varying entries.
-        boost::shared_array<UsdAttributeQuery> queries;
+        std::shared_ptr<UsdAttributeQuery[]> queries;
 
         // Computed purpose info of the prim that's associated with the entry.
         // This data includes the prim's actual computed purpose as well as


### PR DESCRIPTION
### Description of Change(s)
In C++17, `std::shared_ptr` can manage C-style arrays without a custom deleter. This uses that feature to replace the `UsdGeomBBoxCache`'s usage of `boost::shared_array`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
