### PR TITLE
fix: add long path support when calling ArchAbsPath on Windows 10

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -413,11 +413,22 @@ ArchAbsPath(const string& path)
     // @TODO support 32,767 long paths on windows by prepending "\\?\" to the
     // path
     wchar_t buffer[ARCH_PATH_MAX];
-    if (GetFullPathNameW(ArchWindowsUtf8ToUtf16(path).c_str(),
-                         ARCH_PATH_MAX, buffer, nullptr)) {
+    const auto bufferSize = GetFullPathNameW(ArchWindowsUtf8ToUtf16(path).c_str(),
+        ARCH_PATH_MAX, buffer, nullptr);
+
+    if (bufferSize > 0 && bufferSize <= ARCH_PATH_MAX) {
         return ArchWindowsUtf16ToUtf8(buffer);
-    }
-    else {
+    } else if (bufferSize > 0) {
+        // If the provided buffer is too small, GetFullPathNameW returns the
+        // required buffer size.  We can use this to dynamically allocate a
+        // buffer of the correct size.
+        std::unique_ptr<wchar_t[]> largerBuffer(new wchar_t[bufferSize]);
+        if (GetFullPathNameW(ArchWindowsUtf8ToUtf16(path).c_str(), bufferSize, largerBuffer, nullptr)) {
+            return ArchWindowsUtf16ToUtf8(largerBuffer.get());
+        } else {
+            return path;
+        }
+    } else {
         return path;
     }
 #else


### PR DESCRIPTION
### Description of Change(s)

According to MSDN, starting with Windows 10, Version 1607, `GetFullPathNameW` now support get paths which has no limitation with MAX_PATH 

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfullpathnamew

![image](https://github.com/PixarAnimationStudios/OpenUSD/assets/4926092/d457e365-c957-475f-a44a-e05cefcc3930)


### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
