### PR TITLE
usd: add a UsdSchemaRegistry function for identifying schematics layers

### DIFF
--- a/pxr/usd/usd/schemaRegistry.cpp
+++ b/pxr/usd/usd/schemaRegistry.cpp
@@ -51,6 +51,7 @@
 #include "pxr/base/work/loops.h"
 #include "pxr/base/work/withScopedParallelism.h"
 
+#include <algorithm>
 #include <cctype>
 #include <set>
 #include <utility>
@@ -1976,6 +1977,14 @@ Usd_GetAPISchemaPluginApplyToInfoForType(
             }
         }
     }
+}
+
+bool
+UsdSchemaRegistry::IsSchematicsLayer(const SdfLayerRefPtr& layer) const
+{
+    return std::find(
+        _schematicsLayers.cbegin(), _schematicsLayers.cend(),
+        layer) != _schematicsLayers.cend();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usd/schemaRegistry.h
+++ b/pxr/usd/usd/schemaRegistry.h
@@ -558,6 +558,11 @@ public:
         return _fallbackPrimTypes;
     }
 
+    /// Returns true if the given layer is a schematics layer stored in the
+    /// registry, or false otherwise.
+    USD_API
+    bool IsSchematicsLayer(const SdfLayerRefPtr& layer) const;
+
 private:
     friend class TfSingleton<UsdSchemaRegistry>;
 

--- a/pxr/usd/usd/testenv/testUsdSchemaRegistry.py
+++ b/pxr/usd/usd/testenv/testUsdSchemaRegistry.py
@@ -880,5 +880,27 @@ class TestUsdSchemaRegistry(unittest.TestCase):
         self.assertEqual(Usd.SchemaRegistry.MakeMultipleApplyNameInstance(
             "foo:__INSTANCE_NAME__:bar", ""), "foo::bar")
 
+    def test_SchematicsLayers(self):
+        '''
+        Tests that schematics layers can be identified and differentiated from
+        non-schematics layers.
+        '''
+        # Instantiating the schema registry causes all schematics layers to be
+        # loaded, so make sure that has been done in case this test happens to
+        # run first.
+        schemaRegistry = Usd.SchemaRegistry()
+        self.assertGreater(len(Sdf.Layer.GetLoadedLayers()), 0)
+
+        # Create a new, non-schematics layer.
+        contentLayer = Sdf.Layer.CreateAnonymous(tag='ContentLayer')
+
+        for layer in Sdf.Layer.GetLoadedLayers():
+            isSchematicsLayer = schemaRegistry.IsSchematicsLayer(layer)
+
+            if layer == contentLayer:
+                self.assertFalse(isSchematicsLayer)
+            else:
+                self.assertTrue(isSchematicsLayer)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pxr/usd/usd/wrapSchemaRegistry.cpp
+++ b/pxr/usd/usd/wrapSchemaRegistry.cpp
@@ -244,6 +244,8 @@ void wrapUsdSchemaRegistry()
 
         .def("GetFallbackPrimTypes", &This::GetFallbackPrimTypes, 
              return_value_policy<return_by_value>())
+
+        .def("IsSchematicsLayer", &This::IsSchematicsLayer, arg("layer"))
         ;
 
     // Need to convert TfToken properties of SchemaInfo to string


### PR DESCRIPTION
Hello!

Following https://github.com/PixarAnimationStudios/USD/commit/a32872440a542d5ef16b7be610a7a7f5a10f0294 that landed in v23.05, schematics layers read by the schema registry are no longer aggregated into a single `registry.usda` layer as they were in v23.02 and earlier. This has made it a bit more cumbersome for unit testing and other layer lifetime debugging as there isn't really a clean way to differentiate these now anonymous schematics layers from other layers that contain user content when using `SdfLayer::GetLoadedLayers()`, for example.

I added a `IsSchematicsLayer()` function to `UsdSchemaRegistry` that can be used to make that distinction and help filter out any of these schematics layers.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
