### PR TITLE
Fix incorrectly transformed points for GPU blendshapes with no skinning.

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/shaders/skinning.glslfx
+++ b/pxr/usdImaging/usdSkelImaging/shaders/skinning.glslfx
@@ -23,9 +23,6 @@ const float EPS = 1e-5;
 
 void compute(int index)
 {
-    // model space -> bind space
-    mat4 geomBindXform = HdGet_geomBindXform();
-
     vec3 restP = HdGet_restPoints(index);
 
     // apply blend shapes
@@ -39,11 +36,14 @@ void compute(int index)
             restP += offset.xyz * weight;
         }
     }
-    vec4 initP = geomBindXform * vec4(restP, 1);
-    
+
     int numInfluencesPerComponent = HdGet_numInfluencesPerComponent();
     vec3 p;
     if (numInfluencesPerComponent > 0) {
+        // model space -> bind space
+        mat4 geomBindXform = HdGet_geomBindXform();
+        vec4 initP = geomBindXform * vec4(restP, 1);
+
         p = vec3(0,0,0);
 
         bool constantPointInfluence = HdGet_hasConstantInfluences();
@@ -60,16 +60,16 @@ void compute(int index)
                 p += ((skinningXform * initP) * jointWeight).xyz;
             }
         }
-    } else {
-        p = initP.xyz;
-    }
 
-    // skel space -> world space -> model space
-    // XXX: Casts to mat4 below are necessary because the matrices passed
-    // down use doubles and not floats.
-    mat4 skelToPrimLocal = mat4( HdGet_primWorldToLocal() ) *
-                           mat4( HdGet_skelLocalToWorld() );
-    p = (skelToPrimLocal * vec4(p,1)).xyz;
+        // skel space -> world space -> model space
+        // XXX: Casts to mat4 below are necessary because the matrices passed
+        // down use doubles and not floats.
+        mat4 skelToPrimLocal = mat4( HdGet_primWorldToLocal() ) *
+                               mat4( HdGet_skelLocalToWorld() );
+        p = (skelToPrimLocal * vec4(p,1)).xyz;
+    } else {
+        p = restP;
+    }
 
     HdSet_skinnedPoints(index, p);
 }
@@ -135,9 +135,6 @@ vec3 GetDualQuaternionTranslation(vec4 real, vec4 dual)
 
 void compute(int index)
 {
-    // model space -> bind space
-    mat4 geomBindXform = HdGet_geomBindXform();
-
     vec3 restP = HdGet_restPoints(index);
 
     // apply blend shapes
@@ -151,11 +148,13 @@ void compute(int index)
             restP += offset.xyz * weight;
         }
     }
-    vec3 initP = (geomBindXform * vec4(restP, 1)).xyz;
 
     int numInfluencesPerComponent = HdGet_numInfluencesPerComponent();
     vec3 p;
     if (numInfluencesPerComponent > 0) {
+        // model space -> bind space
+        mat4 geomBindXform = HdGet_geomBindXform();
+        vec3 initP = (geomBindXform * vec4(restP, 1)).xyz;
 
 #ifdef HD_HAS_skinningScaleXforms
         vec3 scaledP = vec3(0, 0, 0);
@@ -220,16 +219,16 @@ void compute(int index)
         p = TransformByQuaternion(weightedSumDQReal, initP)
             + GetDualQuaternionTranslation(weightedSumDQReal, weightedSumDQDual);
 #endif
-    } else {
-        p = initP;
-    }
 
-    // skel space -> world space -> model space
-    // XXX: Casts to mat4 below are necessary because the matrices passed
-    // down use doubles and not floats.
-    mat4 skelToPrimLocal = mat4(HdGet_primWorldToLocal()) *
-                           mat4(HdGet_skelLocalToWorld());
-    p = (skelToPrimLocal * vec4(p,1)).xyz;
+        // skel space -> world space -> model space
+        // XXX: Casts to mat4 below are necessary because the matrices passed
+        // down use doubles and not floats.
+        mat4 skelToPrimLocal = mat4(HdGet_primWorldToLocal()) *
+                               mat4(HdGet_skelLocalToWorld());
+        p = (skelToPrimLocal * vec4(p,1)).xyz;
+    } else {
+        p = restP;
+    }
 
     HdSet_skinnedPoints(index, p);
 }


### PR DESCRIPTION
### Description of Change(s)
When the mesh only has blendshapes (no skinning), the deformed point positions are already in the prim's local space so it's simplest to just skip applying any additional transforms.

The previous behaviour was incorrect because the final skel space -> world space -> model space transform expected the points to be in skel space, which was not the case when only blendshapes were present. Similarly, the bind transform is only required when skinning is enabled.

The results are now consistent with the CPU skinning computation.
### Fixes Issue(s)
- #2425


- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
