### PR TITLE
Use unqualified calls to `get_pointer` for `Tf{Ref,Weak}Ptr`

### DIFF
--- a/pxr/usd/ndr/wrapFilesystemDiscoveryHelpers.cpp
+++ b/pxr/usd/ndr/wrapFilesystemDiscoveryHelpers.cpp
@@ -45,7 +45,7 @@ _WrapFsHelpersDiscoverNodes(
     return NdrFsHelpersDiscoverNodes(searchPaths,
                                      allowedExtensions,
                                      followSymlinks,
-                                     boost::get_pointer(context));
+                                     get_pointer(context));
 }
 
 static object

--- a/pxr/usd/pcp/mapExpression.cpp
+++ b/pxr/usd/pcp/mapExpression.cpp
@@ -364,8 +364,8 @@ PcpMapExpression::_Node::Key::GetHash() const
 {
     return TfHash::Combine(
         op,
-        boost::get_pointer(arg1),
-        boost::get_pointer(arg2),
+        get_pointer(arg1),
+        get_pointer(arg2),
         valueForConstant
     );
 }

--- a/pxr/usd/sdf/abstractData.cpp
+++ b/pxr/usd/sdf/abstractData.cpp
@@ -188,7 +188,7 @@ SdfAbstractData::Equals(const SdfAbstractDataRefPtr &rhs) const
 
     // Check that the set of specs matches.
     SdfAbstractData_CheckAllSpecsExist 
-        rhsHasAllSpecsInThis(*boost::get_pointer(rhs));
+        rhsHasAllSpecsInThis(*get_pointer(rhs));
     VisitSpecs(&rhsHasAllSpecsInThis);
     if (!rhsHasAllSpecsInThis.passed)
         return false;
@@ -200,7 +200,7 @@ SdfAbstractData::Equals(const SdfAbstractDataRefPtr &rhs) const
 
     // Check that every spec matches.
     SdfAbstractData_CheckAllSpecsMatch 
-        thisSpecsMatchRhsSpecs(*boost::get_pointer(rhs));
+        thisSpecsMatchRhsSpecs(*get_pointer(rhs));
     VisitSpecs(&thisSpecsMatchRhsSpecs);
     return thisSpecsMatchRhsSpecs.passed;
 }

--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -3971,7 +3971,7 @@ SdfLayer::_SetData(const SdfAbstractDataPtr &newData,
             std::set<SdfPath> paths;
         };
 
-        _SpecsToCreate specsToCreate(*boost::get_pointer(_data));
+        _SpecsToCreate specsToCreate(*get_pointer(_data));
         newData->VisitSpecs(&specsToCreate);
 
         SdfPath unrecognizedSpecTypePaths[SdfNumSpecTypes];
@@ -4520,7 +4520,7 @@ SdfLayer::_PrimDeleteSpec(const SdfPath &path, bool inert, bool useDelegate)
     Sdf_ChangeManager::Get().DidRemoveSpec(_self, path, inert);
 
     TraversalFunction eraseFunc = 
-        std::bind(&_EraseSpecAtPath, boost::get_pointer(_data), ph::_1);
+        std::bind(&_EraseSpecAtPath, get_pointer(_data), ph::_1);
     Traverse(path, eraseFunc);
 }
 

--- a/pxr/usd/usd/usdFileFormat.cpp
+++ b/pxr/usd/usd/usdFileFormat.cpp
@@ -374,7 +374,7 @@ UsdUsdFileFormat::WriteToStream(
     size_t indent) const
 {
     return _GetUnderlyingFileFormatForLayer(
-        *boost::get_pointer(spec->GetLayer()))->WriteToStream(
+        *get_pointer(spec->GetLayer()))->WriteToStream(
             spec, out, indent);
 }
 


### PR DESCRIPTION
### Description of Change(s)

Rely on ADL to pick up on the `get_pointer` implementations for `Tf` pointer types in the `PXR_NS` without using `boost::get_pointer` as an intermediary.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
