### PR TITLE
Replace `boost::{add,remove}_const` with STL in `pyPtrHelpers.h`

### DIFF
--- a/pxr/base/tf/pyPtrHelpers.h
+++ b/pxr/base/tf/pyPtrHelpers.h
@@ -53,6 +53,7 @@
 #include <boost/python/to_python_converter.hpp>
 
 #include <memory>
+#include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -114,8 +115,8 @@ using namespace boost::python;
 template <typename Ptr>
 struct _PtrInterface {
     typedef typename Ptr::DataType Pointee;
-    typedef typename boost::add_const<Pointee>::type ConstPointee;
-    typedef typename boost::remove_const<Pointee>::type NonConstPointee;
+    using ConstPointee = std::add_const_t<Pointee>;
+    using NonConstPointee = std::remove_const_t<Pointee>;
     
     template <typename U>
     struct Rebind {


### PR DESCRIPTION
### Description of Change(s)

#2656 cleaned up some usage of boost type traits in the python bindings but missed the usage of `boost::{add,remove}_const` from `pyPtrHelpers.h`.  This PR addresses the remaining usage.

### Fixes Issue(s)
- #2211 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
