### PR TITLE
Replace `boost::totally_ordered` and `boost::equality_comparable` in python bindings

### DIFF
--- a/pxr/base/tf/pyAnnotatedBoolResult.h
+++ b/pxr/base/tf/pyAnnotatedBoolResult.h
@@ -29,7 +29,6 @@
 #include "pxr/base/tf/pyLock.h"
 #include "pxr/base/tf/pyUtils.h"
 
-#include <boost/operators.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/operators.hpp>
 #include <boost/python/return_by_value.hpp>
@@ -39,8 +38,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 template <class Annotation>
-struct TfPyAnnotatedBoolResult :
-    boost::equality_comparable<TfPyAnnotatedBoolResult<Annotation>, bool>
+struct TfPyAnnotatedBoolResult
 {
     TfPyAnnotatedBoolResult() {}
     
@@ -63,6 +61,18 @@ struct TfPyAnnotatedBoolResult :
     /// Returns \c true if the result is the same as \p rhs.
     bool operator==(bool rhs) const {
         return _val == rhs;
+    }
+
+    friend bool operator==(bool lhs, const TfPyAnnotatedBoolResult& rhs) {
+        return rhs == lhs;
+    }
+
+    friend bool operator!=(const TfPyAnnotatedBoolResult& lhs, bool rhs) {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator!=(bool lhs, const TfPyAnnotatedBoolResult& rhs) {
+        return !(lhs == rhs);
     }
 
     template <class Derived>

--- a/pxr/base/tf/pyEnum.h
+++ b/pxr/base/tf/pyEnum.h
@@ -168,8 +168,7 @@ std::string Tf_PyEnumRepr(boost::python::object const &self);
 
 // Private base class for types which are instantiated and exposed to python
 // for each registered enum type.
-struct Tf_PyEnumWrapper
-    : public Tf_PyEnum, boost::totally_ordered<Tf_PyEnumWrapper>
+struct Tf_PyEnumWrapper : public Tf_PyEnum
 {
     typedef Tf_PyEnumWrapper This;
 
@@ -197,6 +196,11 @@ struct Tf_PyEnumWrapper
         return lhs.value == rhs.value;
     }
 
+    friend bool operator !=(Tf_PyEnumWrapper const &lhs,
+                            Tf_PyEnumWrapper const &rhs) {
+        return !(lhs == rhs);
+    }
+
     friend bool operator <(Tf_PyEnumWrapper const &lhs,
                            Tf_PyEnumWrapper const &rhs)
     {
@@ -210,7 +214,25 @@ struct Tf_PyEnumWrapper
         // If types do match, numerically compare values.
         return lhs.GetValue() < rhs.GetValue();
     }
-    
+
+    friend bool operator >(Tf_PyEnumWrapper const& lhs,
+                           Tf_PyEnumWrapper const& rhs)
+    {
+        return rhs < lhs;
+    }
+
+    friend bool operator <=(Tf_PyEnumWrapper const& lhs,
+                            Tf_PyEnumWrapper const& rhs)
+    {
+        return !(lhs > rhs);
+    }
+
+    friend bool operator >=(Tf_PyEnumWrapper const& lhs,
+                            Tf_PyEnumWrapper const& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
     //
     // XXX Bitwise operators for Enums are a temporary measure to support the
     // use of Enums as Bitmasks in libSd.  It should be noted that Enums are


### PR DESCRIPTION
### Description of Change(s)
`boost::totally_ordered` and `boost::equality_comparable` have been removed from non-python binding related usage in several previous changes (such as #2251). This extends their replacement with explicit operator overloads for the python bindings.

### Fixes Issue(s)
- #2250
- #2236 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
