### PR TITLE
Replace `boost::optional` with `std::optional` for `SdfCopySpec`

### DIFF
--- a/pxr/usd/bin/sdffilter/sdffilter.cpp
+++ b/pxr/usd/bin/sdffilter/sdffilter.cpp
@@ -491,7 +491,7 @@ FilterLayer(SdfLayerHandle const &inLayer,
         SdfSpecType specType, TfToken const &field,
         SdfLayerHandle const &srcLayer, const SdfPath& srcPath, bool fieldInSrc,
         const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-        boost::optional<VtValue> *valueToCopy) {
+        std::optional<VtValue> *valueToCopy) {
 
         if (!p.fieldMatcher || p.fieldMatcher->Match(field.GetString())) {
             *valueToCopy = GetReportFieldValue(

--- a/pxr/usd/sdf/copyUtils.cpp
+++ b/pxr/usd/sdf/copyUtils.cpp
@@ -174,7 +174,7 @@ _ProcessChildField(
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool childrenInDst,
     const SdfShouldCopyChildrenFn& shouldCopyChildren, _CopyStack* copyStack)
 {
-    boost::optional<VtValue> srcChildrenToCopy, dstChildrenToCopy;
+    std::optional<VtValue> srcChildrenToCopy, dstChildrenToCopy;
     if (!shouldCopyChildren(
             childField, 
             srcLayer, srcPath, childrenInSrc, dstLayer, dstPath, childrenInDst,
@@ -428,7 +428,7 @@ _AddFieldValueToCopy(
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
     const SdfShouldCopyValueFn& shouldCopyValue, _FieldValueList* valueList)
 {
-    boost::optional<VtValue> value;
+    std::optional<VtValue> value;
     if (shouldCopyValue(
             specType, field, 
             srcLayer, srcPath, fieldInSrc, dstLayer, dstPath, fieldInDst, 
@@ -699,7 +699,7 @@ SdfShouldCopyValue(
     SdfSpecType specType, const TfToken& field,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* valueToCopy)
+    std::optional<VtValue>* valueToCopy)
 {
     if (fieldInSrc) {
         if (field == SdfFieldKeys->ConnectionPaths || 
@@ -784,8 +784,8 @@ SdfShouldCopyChildren(
     const TfToken& childrenField,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* srcChildren, 
-    boost::optional<VtValue>* dstChildren)
+    std::optional<VtValue>* srcChildren,
+    std::optional<VtValue>* dstChildren)
 {
     if (fieldInSrc) {
         if (childrenField == SdfChildrenKeys->ConnectionChildren ||

--- a/pxr/usd/sdf/copyUtils.h
+++ b/pxr/usd/sdf/copyUtils.h
@@ -32,8 +32,8 @@
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/usd/sdf/types.h"
 
-#include <boost/optional.hpp>
 #include <functional>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -100,7 +100,7 @@ using SdfShouldCopyValueFn = std::function<
     bool(SdfSpecType specType, const TfToken& field,
          const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
          const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-         boost::optional<VtValue>* valueToCopy)>;
+         std::optional<VtValue>* valueToCopy)>;
 
 /// \class SdfCopySpecsValueEdit
 /// Value containing an editing operation for SdfCopySpecs.
@@ -152,8 +152,8 @@ using SdfShouldCopyChildrenFn = std::function<
     bool(const TfToken& childrenField,
          const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
          const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-         boost::optional<VtValue>* srcChildren, 
-         boost::optional<VtValue>* dstChildren)>;
+         std::optional<VtValue>* srcChildren,
+         std::optional<VtValue>* dstChildren)>;
 
 /// SdfShouldCopyValueFn used by the simple version of SdfCopySpec.
 ///
@@ -170,7 +170,7 @@ SdfShouldCopyValue(
     SdfSpecType specType, const TfToken& field,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* valueToCopy);
+    std::optional<VtValue>* valueToCopy);
 
 /// SdfShouldCopyChildrenFn used by the simple version of SdfCopySpec.
 ///
@@ -187,8 +187,8 @@ SdfShouldCopyChildren(
     const TfToken& childrenField,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* srcChildren, 
-    boost::optional<VtValue>* dstChildren);
+    std::optional<VtValue>* srcChildren,
+    std::optional<VtValue>* dstChildren);
 
 /// Utility function for copying spec data at \p srcPath in \p srcLayer to
 /// \p destPath in \p destLayer. Various behaviors (such as which parts of the

--- a/pxr/usd/sdf/wrapCopyUtils.cpp
+++ b/pxr/usd/sdf/wrapCopyUtils.cpp
@@ -87,7 +87,7 @@ _ShouldCopyValue(
     SdfSpecType specType, const TfToken& field,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* value)
+    std::optional<VtValue>* value)
 {
     object result = pyFunc(
         specType, field, 
@@ -117,8 +117,8 @@ _ShouldCopyChildren(
     const TfToken& field,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* srcChildren, 
-    boost::optional<VtValue>* dstChildren)
+    std::optional<VtValue>* srcChildren,
+    std::optional<VtValue>* dstChildren)
 {
     object result = pyFunc(
         field, srcLayer, srcPath, fieldInSrc, dstLayer, dstPath, fieldInDst);

--- a/pxr/usd/usdUtils/stitch.cpp
+++ b/pxr/usd/usdUtils/stitch.cpp
@@ -107,7 +107,7 @@ _MergeValue(
     const TfToken& field, const VtValue& fallback,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath,
-    boost::optional<VtValue>* valueToCopy)
+    std::optional<VtValue>* valueToCopy)
 {
     if (!fallback.IsHolding<T>()) {
         return false;
@@ -134,7 +134,7 @@ _MergeValueFn(
     SdfSpecType specType, const TfToken& field,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-    boost::optional<VtValue>* valueToCopy,
+    std::optional<VtValue>* valueToCopy,
     const UsdUtilsStitchValueFn& stitchFn)
 {
     TF_VERIFY(srcPath == dstPath);
@@ -292,8 +292,8 @@ _DontCopyChildrenFn(
     const TfToken& childrenField,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool childrenInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool childrenInDst,
-    boost::optional<VtValue>* srcChildren, 
-    boost::optional<VtValue>* dstChildren)
+    std::optional<VtValue>* srcChildren,
+    std::optional<VtValue>* dstChildren)
 {
     return false;
 }
@@ -304,8 +304,8 @@ _MergeChildren(
     const TfToken& field, const VtValue& fallback,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath,
-    boost::optional<VtValue>* finalSrcValue, 
-    boost::optional<VtValue>* finalDstValue)
+    std::optional<VtValue>* finalSrcValue,
+    std::optional<VtValue>* finalDstValue)
 {
     if (!fallback.IsHolding<T>()) {
         return false;
@@ -344,8 +344,8 @@ _MergeChildrenFn(
     const TfToken& childrenField,
     const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool childrenInSrc,
     const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool childrenInDst,
-    boost::optional<VtValue>* finalSrcChildren, 
-    boost::optional<VtValue>* finalDstChildren)
+    std::optional<VtValue>* finalSrcChildren,
+    std::optional<VtValue>* finalDstChildren)
 {
     if (!childrenInSrc) {
         // Children on the destination spec are never cleared if the


### PR DESCRIPTION
### Description of Change(s)
This updates `SdfCopySpec` to use `std::optional` instead of `boost::optional` as well as its usage in `usdUtils` and `sdffilter`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
