### PR TITLE
Replace `boost::optional` with `std::optional` in `usdSkel`

### DIFF
--- a/pxr/usd/usdSkel/skinningQuery.h
+++ b/pxr/usd/usdSkel/skinningQuery.h
@@ -37,6 +37,7 @@
 
 #include "pxr/usd/usdSkel/animMapper.h"
 
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -283,8 +284,8 @@ private:
     UsdRelationship _blendShapeTargets;
     UsdSkelAnimMapperRefPtr _jointMapper;
     UsdSkelAnimMapperRefPtr _blendShapeMapper;
-    boost::optional<VtTokenArray> _jointOrder;
-    boost::optional<VtTokenArray> _blendShapeOrder;
+    std::optional<VtTokenArray> _jointOrder;
+    std::optional<VtTokenArray> _blendShapeOrder;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
This replaces `boost::optional` with `std::optional` in `skinningQuery.h`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
