### PR TITLE
Replace `boost::variant` with `std::variant` in `pxr/base/tf`

### DIFF
--- a/pxr/base/tf/envSetting.cpp
+++ b/pxr/base/tf/envSetting.cpp
@@ -40,9 +40,8 @@
 #include "pxr/base/tf/pyUtils.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
-#include <boost/variant/get.hpp>
-#include <boost/variant/variant.hpp>
 #include <mutex>
+#include <variant>
 
 using std::string;
 
@@ -119,7 +118,7 @@ public:
         TfRegistryManager::GetInstance().SubscribeTo<Tf_EnvSettingRegistry>();
     }
 
-    using VariantType = boost::variant<int, bool, std::string>;
+    using VariantType = std::variant<int, bool, std::string>;
 
     template <typename U>
     bool Define(string const& varName,
@@ -141,7 +140,7 @@ public:
             TfHashMap<string, VariantType, TfHash>::iterator it;
             std::tie(it, inserted) = _valuesByName.insert({varName, value});
 
-            U* entryPointer = boost::get<U>(&(it->second));
+            U* entryPointer = std::get_if<U>(std::addressof(it->second));
             cachedValue->store(entryPointer);
         }
 
@@ -228,7 +227,7 @@ template void TF_API Tf_InitializeEnvSetting(TfEnvSetting<int> *);
 template void TF_API Tf_InitializeEnvSetting(TfEnvSetting<string> *);
 
 TF_API
-boost::variant<int, bool, std::string> const *
+std::variant<int, bool, std::string> const *
 Tf_GetEnvSettingByName(std::string const& name)
 {
     return Tf_EnvSettingRegistry::GetInstance().LookupByName(name);

--- a/pxr/base/tf/wrapEnvSetting.cpp
+++ b/pxr/base/tf/wrapEnvSetting.cpp
@@ -27,31 +27,31 @@
 
 #include <boost/python/def.hpp>
 #include <boost/python/object.hpp>
-#include <boost/variant.hpp>
 
 #include <string>
+#include <variant>
 
 #include "pxr/base/tf/envSetting.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-extern boost::variant<int, bool, std::string> const *
+extern std::variant<int, bool, std::string> const *
 Tf_GetEnvSettingByName(std::string const&);
 
 static boost::python::object
 _GetEnvSettingByName(std::string const& name) {
-    boost::variant<int, bool, std::string> const *
+    std::variant<int, bool, std::string> const *
         variantValue = Tf_GetEnvSettingByName(name);
 
     if (!variantValue) {
         return boost::python::object();
     } 
 
-    if (std::string const *value = boost::get<std::string>(variantValue)) {
+    if (std::string const *value = std::get_if<std::string>(variantValue)) {
         return boost::python::object(*value);
-    } else if (bool const *value = boost::get<bool>(variantValue)) {
+    } else if (bool const *value = std::get_if<bool>(variantValue)) {
         return boost::python::object(*value);
-    } else if (int const *value = boost::get<int>(variantValue)) {
+    } else if (int const *value = std::get_if<int>(variantValue)) {
         return boost::python::object(*value); 
     } 
             


### PR DESCRIPTION
### Description of Change(s)

This replaces `boost::variant` and `boost::get` with `std::variant` and `std::get{,_if}` for `TfEnvSetting`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
