### PR TITLE
Replace `boost::any` with `std::any` in `base/js`

### DIFF
--- a/pxr/base/js/testenv/testJsConverter.cpp
+++ b/pxr/base/js/testenv/testJsConverter.cpp
@@ -31,8 +31,7 @@
 #include "pxr/base/tf/diagnosticLite.h"
 #include "pxr/base/tf/staticData.h"
 
-#include <boost/any.hpp>
-
+#include <any>
 #include <iostream>
 #include <fstream>
 #include <map>
@@ -45,7 +44,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 namespace {
 
 // Generic types and functions.
-typedef boost::any _Any;
+typedef std::any _Any;
 typedef std::vector<_Any> _AnyVector;
 typedef std::map<string, _Any> _Dictionary;
 inline const std::type_info* GetType(const _Any& any)
@@ -54,17 +53,17 @@ inline const std::type_info* GetType(const _Any& any)
 }
 bool IsEmpty(const _Any& any)
 {
-    return any.empty();
+    return !any.has_value();
 }
 template <class T>
 bool IsHolding(const _Any& any)
 {
-    return boost::any_cast<T>(&any) != 0;
+    return std::any_cast<T>(&any) != 0;
 }
 template <class T>
 T Get(const _Any& any)
 {
-    return boost::any_cast<const T&>(any);
+    return std::any_cast<const T&>(any);
 }
 
 // This is a simplified version of TfIndenter.


### PR DESCRIPTION
### Description of Change(s)
This replaces `boost::any` and `boost::any_cast` with `std::any` and `std::any_cast` for `testJsConverter`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
