### PR TITLE
Replace `boost::variant` with `std::variant` in `pxr/base/trace`

### DIFF
--- a/pxr/base/trace/eventData.cpp
+++ b/pxr/base/trace/eventData.cpp
@@ -31,8 +31,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
-// Boost variant visitor to convert TraceEventData to JsValue
-class JsValue_visitor : public boost::static_visitor<void>
+// Variant visitor to convert TraceEventData to JsValue
+class JsValue_visitor
 {
 public:
     JsValue_visitor(JsWriter& writer)
@@ -67,8 +67,8 @@ private:
     JsWriter& _writer;
 };
 
-// Boost variant visitor to convert TraceEventData to TraceEvent::DataType
-class Type_visitor : public boost::static_visitor<TraceEvent::DataType>
+// Variant visitor to convert TraceEventData to TraceEvent::DataType
+class Type_visitor
 {
 public:
     TraceEvent::DataType operator()(int64_t i) const {
@@ -101,42 +101,42 @@ public:
 
 TraceEvent::DataType TraceEventData::GetType() const
 {
-    return boost::apply_visitor(Type_visitor(), _data);
+    return std::visit(Type_visitor(), _data);
 }
 
 const int64_t* TraceEventData::GetInt() const
 {
     return GetType() == TraceEvent::DataType::Int ?
-        &boost::get<int64_t>(_data) : nullptr;
+        &std::get<int64_t>(_data) : nullptr;
 }
 
 const uint64_t* TraceEventData::GetUInt() const
 {
     return GetType() == TraceEvent::DataType::UInt ?
-        &boost::get<uint64_t>(_data) : nullptr;
+        &std::get<uint64_t>(_data) : nullptr;
 }
 
 const double* TraceEventData::GetFloat() const
 {
     return GetType() == TraceEvent::DataType::Float ?
-        &boost::get<double>(_data) : nullptr;
+        &std::get<double>(_data) : nullptr;
 }
 
 const bool* TraceEventData::GetBool() const
 {
     return GetType() == TraceEvent::DataType::Boolean ?
-        &boost::get<bool>(_data) : nullptr;
+        &std::get<bool>(_data) : nullptr;
 }
 
 const std::string* TraceEventData::GetString() const
 {
     return GetType() == TraceEvent::DataType::String ?
-        &boost::get<std::string>(_data) : nullptr;
+        &std::get<std::string>(_data) : nullptr;
 }
 
 void TraceEventData::WriteJson(JsWriter& writer) const
 {
-    boost::apply_visitor(JsValue_visitor(writer), _data);
+    std::visit(JsValue_visitor(writer), _data);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/trace/eventData.h
+++ b/pxr/base/trace/eventData.h
@@ -30,8 +30,8 @@
 #include "pxr/base/trace/api.h"
 #include "pxr/base/trace/event.h"
 
-#include <boost/variant.hpp>
 #include <string>
+#include <variant>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -88,7 +88,7 @@ private:
     struct _NoData {};
 
     using Variant = 
-        boost::variant<_NoData, std::string, bool, int64_t, uint64_t, double>;
+        std::variant<_NoData, std::string, bool, int64_t, uint64_t, double>;
     Variant _data;
 };
 


### PR DESCRIPTION
### Description of Change(s)
This replaces `boost::variant`, `boost::apply_visitor`, and `boost::get` with `std::variant`, std::visit`, and `std::get`.  This also removes `boost::static_visitor` as it's not required for `std::visit`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
