### PR TITLE
Replace `boost::optional` with `std::optional` in `usdGeom`

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.h
+++ b/pxr/usd/usdGeom/bboxCache.h
@@ -34,7 +34,7 @@
 #include "pxr/base/tf/hashmap.h"
 #include "pxr/base/work/dispatcher.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -370,13 +370,13 @@ public:
     /// Return the base time if set, otherwise GetTime().  Use HasBaseTime() to
     /// observe if a base time has been set.
     UsdTimeCode GetBaseTime() const {
-        return _baseTime.get_value_or(GetTime());
+        return _baseTime.value_or(GetTime());
     }
 
     /// Clear this cache's baseTime if one has been set.  After calling this,
     /// the cache will use its time as the baseTime value.
     void ClearBaseTime() {
-        _baseTime = boost::none;
+        _baseTime = std::nullopt;
     }
 
     /// Return true if this cache has a baseTime that's been explicitly set,
@@ -570,7 +570,7 @@ private:
 
     WorkDispatcher _dispatcher;
     UsdTimeCode _time;
-    boost::optional<UsdTimeCode> _baseTime;
+    std::optional<UsdTimeCode> _baseTime;
     TfTokenVector _includedPurposes;
     UsdGeomXformCache _ctmCache;
     _PrimBBoxHashMap _bboxCache;


### PR DESCRIPTION
### Description of Change(s)
This replaces `boost::optional` with `std::optional` in `bboxCache.h`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
