### PR TITLE
Replace `boost::optional` with `std::optional` in `tf`

### DIFF
--- a/pxr/base/tf/scopeDescription.cpp
+++ b/pxr/base/tf/scopeDescription.cpp
@@ -379,7 +379,7 @@ TfScopeDescription::SetDescription(std::string const &msg)
         tbb::spin_mutex::scoped_lock lock(stack.mutex);
         _description = msg.c_str();
     }
-    _ownedString = boost::none;
+    _ownedString = std::nullopt;
 }
 
 void
@@ -399,7 +399,7 @@ TfScopeDescription::SetDescription(char const *msg)
         tbb::spin_mutex::scoped_lock lock(stack.mutex);
         _description = msg;
     }
-    _ownedString = boost::none;
+    _ownedString = std::nullopt;
 }
 
 static

--- a/pxr/base/tf/scopeDescription.h
+++ b/pxr/base/tf/scopeDescription.h
@@ -30,8 +30,7 @@
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/api.h"
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <vector>
 #include <string>
 
@@ -109,7 +108,7 @@ private:
     inline void _Push();
     inline void _Pop() const;
     
-    boost::optional<std::string> _ownedString;
+    std::optional<std::string> _ownedString;
     char const *_description;
     TfCallContext _context;
     void *_localStack;

--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -51,13 +51,12 @@
 #include "pxr/base/tf/pyUtils.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 
-#include <boost/optional.hpp>
-
 #include <atomic>
 #include <algorithm>
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <thread>
@@ -128,9 +127,9 @@ struct TfType::_TypeInfo {
     std::unique_ptr<TfType::FactoryBase> factory;
 
     // Map of derived type aliases to derived types.
-    boost::optional<NameToTypeMap> aliasToDerivedTypeMap;
+    std::optional<NameToTypeMap> aliasToDerivedTypeMap;
     // Reverse map of derived types to their aliases.
-    boost::optional<TypeToNamesMap> derivedTypeToAliasesMap;
+    std::optional<TypeToNamesMap> derivedTypeToAliasesMap;
 
     // Map of functions for converting to other types.
     // This map is keyed by type_info and not TfType because the TfTypes


### PR DESCRIPTION
### Description of Change(s)

Replace `boost::optional` with `std::optional` for `TfScopeDescription` and `TfType`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
