### PR TITLE
Make `sstream` dependency explicit in `hgiMetal`

### DIFF
--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -26,6 +26,7 @@
 #include "pxr/imaging/hgiMetal/resourceBindings.h"
 #include "pxr/imaging/hgi/tokens.h"
 
+#include <sstream>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
### Description of Change(s)
`hgiMetal` is transitively including `sstream` through one of the headers slated for removal in #2684. Making the dependency explicit will unblock #2684.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
