### PR TITLE
Replace `boost::optional` with `std::optional` for `sdf` list operations

### DIFF
--- a/pxr/usd/pcp/composeSite.cpp
+++ b/pxr/usd/pcp/composeSite.cpp
@@ -105,7 +105,7 @@ _PcpComposeSiteReferencesOrPayloads(
         // relative to the layer where they were expressed.
         curListOp.ApplyOperations(result,
             [&](SdfListOpType opType, const RefOrPayloadType& refOrPayload)
-            -> boost::optional<RefOrPayloadType>
+            -> std::optional<RefOrPayloadType>
             {
                 // Fill in the result reference or payload with the anchored
                 // asset path instead of the authored asset path. This 
@@ -126,7 +126,7 @@ _PcpComposeSiteReferencesOrPayloads(
                     // layer. If the empty result was due to an error, that
                     // will have already been saved to the errors list above.
                     if (authoredAssetPath.empty()) {
-                        return boost::none;
+                        return std::nullopt;
                     }
 
                     assetPath = SdfComputeAssetPathRelativeToLayer(

--- a/pxr/usd/pcp/targetIndex.cpp
+++ b/pxr/usd/pcp/targetIndex.cpp
@@ -37,9 +37,8 @@
 
 #include "pxr/base/trace/trace.h"
 
-#include <boost/optional.hpp>
-
 #include <functional>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -319,7 +318,7 @@ _RemoveTargetPathErrorsForPath(
 
 // Callback used to translate paths as path list operations from
 // various nodes are applied.
-static boost::optional<SdfPath>
+static std::optional<SdfPath>
 _PathTranslateCallback(
     SdfListOpType opType,
     const PcpSite &propSite,
@@ -352,7 +351,7 @@ _PathTranslateCallback(
             _RemoveTargetPathErrorsForPath(translatedPath, targetPathErrors);
             return translatedPath;
         }
-        return boost::optional<SdfPath>();
+        return std::optional<SdfPath>();
     }
     
     if (!pathIsMappable) {
@@ -367,11 +366,11 @@ _PathTranslateCallback(
         err->layer = owningProp->GetLayer();
         err->composedTargetPath = SdfPath();
         targetPathErrors->push_back(err);
-        return boost::optional<SdfPath>();
+        return std::optional<SdfPath>();
     }
 
     if (translatedPath.IsEmpty()) {
-        return boost::optional<SdfPath>();
+        return std::optional<SdfPath>();
     }
 
     if (cacheForValidation) {
@@ -390,7 +389,7 @@ _PathTranslateCallback(
             err->layer = owningProp->GetLayer();
             err->composedTargetPath = translatedPath;
             targetPathErrors->push_back(err);
-            return boost::optional<SdfPath>();
+            return std::optional<SdfPath>();
         }
 
         // Check if the connection is invalid due to permissions or
@@ -410,7 +409,7 @@ _PathTranslateCallback(
                 err->layer = owningProp->GetLayer();
                 err->composedTargetPath = translatedPath;
                 targetPathErrors->push_back(err);
-                return boost::optional<SdfPath>();
+                return std::optional<SdfPath>();
             }
 
             case InvalidTarget:
@@ -424,7 +423,7 @@ _PathTranslateCallback(
                 err->layer = owningProp->GetLayer();
                 err->composedTargetPath = translatedPath;
                 targetPathErrors->push_back(err);
-                return boost::optional<SdfPath>();
+                return std::optional<SdfPath>();
             }
 
             case NoError:

--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -76,6 +76,7 @@
 #include <functional>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <thread>
 #include <vector>
@@ -3204,7 +3205,7 @@ SdfLayer::GetExternalAssetDependencies() const
 // ModifyItemEdits() callback that updates a reference's or payload's
 // asset path for SdfReferenceListEditor and SdfPayloadListEditor.
 template <class RefOrPayloadType>
-static boost::optional<RefOrPayloadType>
+static std::optional<RefOrPayloadType>
 _UpdateRefOrPayloadPath(
     const string &oldLayerPath,
     const string &newLayerPath,
@@ -3213,7 +3214,7 @@ _UpdateRefOrPayloadPath(
     if (refOrPayload.GetAssetPath() == oldLayerPath) {
         // Delete if new layer path is empty, otherwise rename.
         if (newLayerPath.empty()) {
-            return boost::optional<RefOrPayloadType>();
+            return std::optional<RefOrPayloadType>();
         } else {
             RefOrPayloadType updatedRefOrPayload = refOrPayload;
             updatedRefOrPayload.SetAssetPath(newLayerPath);

--- a/pxr/usd/sdf/listEditor.h
+++ b/pxr/usd/sdf/listEditor.h
@@ -33,9 +33,8 @@
 #include "pxr/usd/sdf/schema.h"
 #include "pxr/usd/sdf/spec.h"
 
-#include <boost/optional.hpp>
-
 #include <functional>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -119,7 +118,7 @@ public:
     virtual bool ClearEditsAndMakeExplicit() = 0;
 
     typedef std::function<
-                boost::optional<value_type>(const value_type&)
+                std::optional<value_type>(const value_type&)
             >
         ModifyCallback;
 
@@ -132,7 +131,7 @@ public:
     virtual void ModifyItemEdits(const ModifyCallback& cb) = 0;
 
     typedef std::function<
-                boost::optional<value_type>(SdfListOpType, const value_type&)
+                std::optional<value_type>(SdfListOpType, const value_type&)
             >
         ApplyCallback;
 

--- a/pxr/usd/sdf/listEditorProxy.h
+++ b/pxr/usd/sdf/listEditorProxy.h
@@ -33,10 +33,9 @@
 
 #include "pxr/base/vt/value.h"  // for Vt_DefaultValueFactory
 
-#include <boost/optional.hpp>
-
 #include <functional>
 #include <memory>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -63,11 +62,11 @@ public:
     typedef std::vector<value_type> value_vector_type;
 
     // ApplyEdits types.
-    typedef std::function<boost::optional<value_type>
+    typedef std::function<std::optional<value_type>
                         (SdfListOpType, const value_type&)> ApplyCallback;
 
     // ModifyEdits types.
-    typedef std::function<boost::optional<value_type>
+    typedef std::function<std::optional<value_type>
                         (const value_type&)> ModifyCallback;
 
     /// Creates a default proxy object. The object evaluates to \c false in a 

--- a/pxr/usd/sdf/listOp.cpp
+++ b/pxr/usd/sdf/listOp.cpp
@@ -36,8 +36,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/trace/trace.h"
 
-#include <boost/optional.hpp>
-
 #include <ostream>
 
 using std::string;
@@ -344,7 +342,7 @@ SdfListOp<T>::ApplyOperations(ItemVector* vec, const ApplyCallback& cb) const
 }
 
 template <typename T>
-boost::optional<SdfListOp<T>>
+std::optional<SdfListOp<T>>
 SdfListOp<T>::ApplyOperations(const SdfListOp<T> &inner) const
 {
     if (IsExplicit()) {
@@ -422,7 +420,7 @@ SdfListOp<T>::ApplyOperations(const SdfListOp<T> &inner) const
     // and there is no way to express the relative order dependency
     // between 0 and 1.
     //
-    return boost::optional<SdfListOp<T>>();
+    return std::optional<SdfListOp<T>>();
 }
 
 template <class ItemType, class ListType, class MapType>
@@ -468,7 +466,7 @@ SdfListOp<T>::_AddKeys(
 {
     TF_FOR_ALL(i, GetItems(op)) {
         if (callback) {
-            if (boost::optional<T> item = callback(op, *i)) {
+            if (std::optional<T> item = callback(op, *i)) {
                 // Only append if the item isn't already present.
                 _InsertIfUnique(*item, result, search);
             }
@@ -490,7 +488,7 @@ SdfListOp<T>::_PrependKeys(
     const ItemVector& items = GetItems(op);
     if (callback) {
         for (auto i = items.rbegin(), iEnd = items.rend(); i != iEnd; ++i) {
-            if (boost::optional<T> mappedItem = callback(op, *i)) {
+            if (std::optional<T> mappedItem = callback(op, *i)) {
                 _InsertOrMove(*mappedItem, result->begin(), result, search);
             }
         }
@@ -512,7 +510,7 @@ SdfListOp<T>::_AppendKeys(
     const ItemVector& items = GetItems(op);
     if (callback) {
         for (const T& item: items) {
-            if (boost::optional<T> mappedItem = callback(op, item)) {
+            if (std::optional<T> mappedItem = callback(op, item)) {
                 _InsertOrMove(*mappedItem, result->end(), result, search);
             }
         }
@@ -533,7 +531,7 @@ SdfListOp<T>::_DeleteKeys(
 {
     TF_FOR_ALL(i, GetItems(op)) {
         if (callback) {
-            if (boost::optional<T> item = callback(op, *i)) {
+            if (std::optional<T> item = callback(op, *i)) {
                 _RemoveIfPresent(*item, result, search);
             }
         }
@@ -556,7 +554,7 @@ SdfListOp<T>::_ReorderKeys(
     std::set<ItemType, _ItemComparator> orderSet;
     TF_FOR_ALL(i, GetItems(op)) {
         if (callback) {
-            if (boost::optional<T> item = callback(op, *i)) {
+            if (std::optional<T> item = callback(op, *i)) {
                 if (orderSet.insert(*item).second) {
                     order.push_back(*item);
                 }
@@ -612,10 +610,10 @@ _ModifyCallbackHelper(const typename SdfListOp<T>::ModifyCallback& cb,
     TfDenseHashSet<T, TfHash> existingSet;
 
     for (const T& item : *itemVector) {
-        boost::optional<T> modifiedItem = cb(item);
+        std::optional<T> modifiedItem = cb(item);
         if (removeDuplicates && modifiedItem) {
             if (!existingSet.insert(*modifiedItem).second) {
-                modifiedItem = boost::none;
+                modifiedItem = std::nullopt;
             }
         }
 

--- a/pxr/usd/sdf/listOp.h
+++ b/pxr/usd/sdf/listOp.h
@@ -29,12 +29,11 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/hash.h"
 
-#include <boost/optional/optional_fwd.hpp>
-
 #include <functional>
 #include <iosfwd>
 #include <list>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -188,7 +187,7 @@ public:
 
     /// Callback type for ApplyOperations.
     typedef std::function<
-        boost::optional<ItemType>(SdfListOpType, const ItemType&)
+        std::optional<ItemType>(SdfListOpType, const ItemType&)
     > ApplyCallback;
 
     /// Applies edit operations to the given ItemVector.
@@ -211,12 +210,12 @@ public:
     /// the explicit, prepended, appended, and deleted portions of
     /// SdfListOp are closed under composition with ApplyOperations().
     SDF_API 
-    boost::optional<SdfListOp<T>>
+    std::optional<SdfListOp<T>>
     ApplyOperations(const SdfListOp<T> &inner) const;
 
     /// Callback type for ModifyOperations.
     typedef std::function<
-        boost::optional<ItemType>(const ItemType&)
+        std::optional<ItemType>(const ItemType&)
     > ModifyCallback;
 
     /// Modifies operations specified in this object.

--- a/pxr/usd/sdf/listOpListEditor.h
+++ b/pxr/usd/sdf/listOpListEditor.h
@@ -91,12 +91,12 @@ protected:
 
 private:
     static 
-    boost::optional<value_type> 
+    std::optional<value_type>
     _ModifyCallbackHelper(const ModifyCallback& cb,
                           const TypePolicy& typePolicy,
                           const value_type& v)
     {
-        boost::optional<value_type> value = cb(v);
+        std::optional<value_type> value = cb(v);
         return value ? typePolicy.Canonicalize(*value) : value;
     }
 

--- a/pxr/usd/sdf/listProxy.h
+++ b/pxr/usd/sdf/listProxy.h
@@ -35,9 +35,9 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/errorMark.h"
 #include "pxr/base/tf/iterator.h"
-#include <boost/optional.hpp>
 
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -663,10 +663,10 @@ public:
     /// Modify all edits in this list. 
     ///
     /// \p callback must be a callable that accepts an argument of type
-    /// value_type and returns a boost::optional<value_type>. 
+    /// value_type and returns a std::optional<value_type>.
     ///
     /// \p callback is called with every item in the list. If an invalid
-    /// boost::optional is returned, the item is removed. Otherwise it's
+    /// std::optional is returned, the item is removed. Otherwise it's
     /// replaced with the returned item. If a returned item matches an
     /// item that was previously returned, the returned item will be
     /// removed.

--- a/pxr/usd/sdf/pyListEditorProxy.h
+++ b/pxr/usd/sdf/pyListEditorProxy.h
@@ -54,7 +54,7 @@ public:
             // Do nothing
         }
 
-        boost::optional<V> operator()(SdfListOpType op, const V& value)
+        std::optional<V> operator()(SdfListOpType op, const V& value)
         {
             using namespace boost::python;
 
@@ -63,14 +63,14 @@ public:
             if (! TfPyIsNone(result)) {
                 extract<V> e(result);
                 if (e.check()) {
-                    return boost::optional<V>(e());
+                    return std::optional<V>(e());
                 }
                 else {
                     TF_CODING_ERROR("ApplyEditsToList callback has "
                                     "incorrect return type.");
                 }
             }
-            return boost::optional<V>();
+            return std::optional<V>();
         }
 
     private:
@@ -87,7 +87,7 @@ public:
             // Do nothing
         }
 
-        boost::optional<V> operator()(const V& value)
+        std::optional<V> operator()(const V& value)
         {
             using namespace boost::python;
 
@@ -96,14 +96,14 @@ public:
             if (! TfPyIsNone(result)) {
                 extract<V> e(result);
                 if (e.check()) {
-                    return boost::optional<V>(e());
+                    return std::optional<V>(e());
                 }
                 else {
                     TF_CODING_ERROR("ModifyItemEdits callback has "
                                     "incorrect return type.");
                 }
             }
-            return boost::optional<V>();
+            return std::optional<V>();
         }
 
     private:

--- a/pxr/usd/sdf/pyListOp.h
+++ b/pxr/usd/sdf/pyListOp.h
@@ -61,7 +61,7 @@ private:
     }
     static boost::python::object
     _ApplyOperations2(const T& outer, const T& inner) {
-        if (boost::optional<T> r = outer.ApplyOperations(inner)) {
+        if (std::optional<T> r = outer.ApplyOperations(inner)) {
             return boost::python::object(*r);
         } else {
             return boost::python::object();

--- a/pxr/usd/sdf/relationshipSpec.cpp
+++ b/pxr/usd/sdf/relationshipSpec.cpp
@@ -39,6 +39,7 @@
 #include "pxr/base/trace/trace.h"
 
 #include <functional>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -145,7 +146,7 @@ SdfRelationshipSpec::ClearTargetPathList() const
     GetTargetPathList().ClearEdits();
 }
 
-static boost::optional<SdfPath>
+static std::optional<SdfPath>
 _ReplacePath(
     const SdfPath &oldPath, const SdfPath &newPath, const SdfPath &path)
 {
@@ -155,7 +156,7 @@ _ReplacePath(
         return newPath;
     }
     if (path == newPath) {
-        return boost::none;
+        return std::nullopt;
     }
     return path;
 }

--- a/pxr/usd/sdf/vectorListEditor.h
+++ b/pxr/usd/sdf/vectorListEditor.h
@@ -127,12 +127,12 @@ protected:
 
 private:
     static 
-    boost::optional<value_type> 
+    std::optional<value_type>
     _ModifyCallbackHelper(const ModifyCallback& cb,
                           const TypePolicy& typePolicy,
                           const value_type& v)
     {
-        boost::optional<value_type> value = cb(v);
+        std::optional<value_type> value = cb(v);
         return value ? typePolicy.Canonicalize(*value) : value;
     }
 

--- a/pxr/usd/usd/flattenUtils.cpp
+++ b/pxr/usd/usd/flattenUtils.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <optional>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -127,7 +128,7 @@ VtValue
 _Reduce(const SdfListOp<T> &lhs, const SdfListOp<T> &rhs)
 {
     // We assume the caller has already applied _FixListOp()
-    if (boost::optional<SdfListOp<T>> r = lhs.ApplyOperations(rhs)) {
+    if (std::optional<SdfListOp<T>> r = lhs.ApplyOperations(rhs)) {
         return VtValue(*r);
     }
     // The approximation used should always be composable,
@@ -244,13 +245,13 @@ _ApplyLayerOffsetToClipInfo(
 }
 
 template <class RefOrPayloadType>
-static boost::optional<RefOrPayloadType>
+static std::optional<RefOrPayloadType>
 _ApplyLayerOffsetToRefOrPayload(const SdfLayerOffset &offset,
                                 const RefOrPayloadType &refOrPayload)
 {
     RefOrPayloadType result = refOrPayload;
     result.SetLayerOffset(offset * refOrPayload.GetLayerOffset());
-    return boost::optional<RefOrPayloadType>(result);
+    return std::optional<RefOrPayloadType>(result);
 }
 
 // Apply layer offsets (time remapping) to time-keyed metadata.
@@ -312,7 +313,7 @@ using _ResolveAssetPathFn = std::function<
                 const std::string& assetPath)>;
 
 template <class RefOrPayloadType>
-static boost::optional<RefOrPayloadType>
+static std::optional<RefOrPayloadType>
 _FixReferenceOrPayload(const _ResolveAssetPathFn& resolveAssetPathFn,
                        const SdfLayerHandle &sourceLayer,
                        const RefOrPayloadType &refOrPayload)
@@ -320,7 +321,7 @@ _FixReferenceOrPayload(const _ResolveAssetPathFn& resolveAssetPathFn,
     RefOrPayloadType result = refOrPayload;
     result.SetAssetPath(
         resolveAssetPathFn(sourceLayer, refOrPayload.GetAssetPath()));
-    return boost::optional<RefOrPayloadType>(result);
+    return std::optional<RefOrPayloadType>(result);
 }
 
 static void

--- a/pxr/usd/usdUtils/assetLocalizationDelegate.cpp
+++ b/pxr/usd/usdUtils/assetLocalizationDelegate.cpp
@@ -135,7 +135,7 @@ UsdUtils_WritableLocalizationDelegate::_ProcessReferencesOrPayloads(
 }
 
 template <class RefOrPayloadType, UsdUtils_DependencyType DEP_TYPE>
-boost::optional<RefOrPayloadType>
+std::optional<RefOrPayloadType>
 UsdUtils_WritableLocalizationDelegate::_ProcessRefOrPayload(
     const SdfLayerRefPtr &layer,
     const RefOrPayloadType& refOrPayload,
@@ -145,7 +145,7 @@ UsdUtils_WritableLocalizationDelegate::_ProcessRefOrPayload(
     // these since they refer to the same layer where the payload was
     // authored.
     if (refOrPayload.GetAssetPath().empty()) {
-        return boost::optional<RefOrPayloadType>(refOrPayload);
+        return std::optional<RefOrPayloadType>(refOrPayload);
     }
 
     UsdUtilsDependencyInfo depInfo(refOrPayload.GetAssetPath());
@@ -153,7 +153,7 @@ UsdUtils_WritableLocalizationDelegate::_ProcessRefOrPayload(
         layer, depInfo, DEP_TYPE);
 
     if (info.GetAssetPath().empty()) {
-        return boost::none;
+        return std::nullopt;
     }
 
     RefOrPayloadType processedRefOrPayload = refOrPayload;
@@ -165,7 +165,7 @@ UsdUtils_WritableLocalizationDelegate::_ProcessRefOrPayload(
     dependencies->insert(dependencies->end(), 
         info.GetDependencies().begin(), info.GetDependencies().end());
 
-    return boost::optional<RefOrPayloadType>(processedRefOrPayload);
+    return std::optional<RefOrPayloadType>(processedRefOrPayload);
 }
 
 // When beginning to process a value, if the value is a dictionary, explicitly

--- a/pxr/usd/usdUtils/assetLocalizationDelegate.h
+++ b/pxr/usd/usdUtils/assetLocalizationDelegate.h
@@ -204,7 +204,7 @@ private:
         const TfToken &listOpToken);
 
     template <class RefOrPayloadType, UsdUtils_DependencyType DEP_TYPE>
-    boost::optional<RefOrPayloadType> _ProcessRefOrPayload(
+    std::optional<RefOrPayloadType> _ProcessRefOrPayload(
         const SdfLayerRefPtr &layer,
         const RefOrPayloadType& refOrPayload,
         std::vector<std::string>* dependencies);

--- a/pxr/usd/usdUtils/stitch.cpp
+++ b/pxr/usd/usdUtils/stitch.cpp
@@ -82,7 +82,7 @@ template <typename T>
 VtValue
 _Reduce(const SdfListOp<T> &stronger, const SdfListOp<T> &weaker)
 {
-    boost::optional<SdfListOp<T>> r = stronger.ApplyOperations(weaker);
+    std::optional<SdfListOp<T>> r = stronger.ApplyOperations(weaker);
     if (r) {
         return VtValue(*r);
     }


### PR DESCRIPTION
### Description of Change(s)
This PR replaces `boost::optional` with `std::optional` for list operations in `sdf` and its downstream dependencies in `usd/flattenUtils.cpp` and `usdUtils/stitch.cpp`.

### Fixes Issue(s)


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
