### PR TITLE
Remove unused `boost/optional.hpp` header from `usdSkel` and `trace`

### DIFF
--- a/pxr/base/trace/eventTree.cpp
+++ b/pxr/base/trace/eventTree.cpp
@@ -30,8 +30,6 @@
 
 #include "pxr/base/js/json.h"
 
-#include <boost/optional.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 TraceEventTreeRefPtr

--- a/pxr/usd/usdSkel/cacheImpl.h
+++ b/pxr/usd/usdSkel/cacheImpl.h
@@ -38,8 +38,6 @@
 #include "pxr/usd/usdSkel/skeletonQuery.h"
 #include "pxr/usd/usdSkel/skinningQuery.h"
 
-#include <boost/optional.hpp>
-
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/queuing_rw_mutex.h>
 


### PR DESCRIPTION
### Description of Change(s)
#2703 removed usage of `boost::optional` but didn't remove the header include in `cacheImpl.h`.  This completes that change.

This also removes the optional header from `trace/eventTree.cpp` as it is currently unused.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
