### PR TITLE
[usdview] Add the option to step through authored samples in usdview.

### DIFF
--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -9110,6 +9110,30 @@ UsdStage::SetFramesPerSecond(double framesPerSecond) const
     SetMetadata(SdfFieldKeys->FramesPerSecond, framesPerSecond);
 }
 
+std::vector<double>
+UsdStage::GetTimeSamplesFromPrims()
+{
+    // Since we are doing tons of lookups and relatively small amounts of pushes
+    // a sorted vector and lower_bound is way more efficient
+    // than push_backs and std::finds or std::sets or anything
+    std::vector<double> ret;
+    for (auto prim: Traverse()) {
+        for (const auto& attr: prim.GetAuthoredAttributes()) {
+            static thread_local std::vector<double> samples;
+            attr.GetTimeSamples(&samples);
+            for (const auto& sample: samples) {
+                const auto it = std::lower_bound(ret.begin(), ret.end(), sample);
+                if (it == ret.end() || *it != sample) {
+                    ret.push_back(sample);
+                    std::sort(ret.begin(), ret.end());
+                }
+            }
+        }
+    }
+    return ret;
+}
+
+
 void 
 UsdStage::SetColorConfiguration(const SdfAssetPath &colorConfig) const
 {

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -1449,7 +1449,11 @@ public:
     /// \sa GetFramesPerSecond()
     USD_API
     void SetFramesPerSecond(double framesPerSecond) const;
-    
+
+    /// Returns the union of all the time samples from the prims in the scene.
+    USD_API
+    std::vector<double> GetTimeSamplesFromPrims();
+
     /// @}
 
     // --------------------------------------------------------------------- //

--- a/pxr/usd/usd/wrapStage.cpp
+++ b/pxr/usd/usd/wrapStage.cpp
@@ -535,6 +535,8 @@ void wrapUsdStage()
 
         .def("GetFramesPerSecond", &UsdStage::GetFramesPerSecond)
         .def("SetFramesPerSecond", &UsdStage::SetFramesPerSecond)
+        .def("GetTimeSamplesFromPrims", &UsdStage::GetTimeSamplesFromPrims,
+             return_value_policy<TfPySequenceToList>())
 
         .def("GetColorConfiguration", &UsdStage::GetColorConfiguration)
         .def("SetColorConfiguration", &UsdStage::SetColorConfiguration)

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -31,6 +31,7 @@ from __future__ import print_function
 from .qt import QtCore, QtGui, QtWidgets, QtActionWidgets
 
 # Stdlib components
+import bisect
 import re, sys, os, cProfile, pstats, traceback
 from itertools import groupby
 from time import time, sleep
@@ -834,6 +835,8 @@ class AppController(QtCore.QObject):
 
             self._ui.redrawOnScrub.toggled.connect(self._redrawOptionToggled)
 
+            self._ui.authoredStepsOnly.toggled.connect(self._authoredOptionToggled)
+
             if self._stageView:
                 self._ui.actionAuto_Compute_Clipping_Planes.triggered.connect(
                     self._toggleAutoComputeClippingPlanes)
@@ -1353,17 +1356,27 @@ class AppController(QtCore.QObject):
 
 
     def _UpdateTimeSamples(self, resetStageDataOnly=False):
-        if self.realStartTimeCode is not None and self.realEndTimeCode is not None:
-            if self.realStartTimeCode > self.realEndTimeCode:
-                sys.stderr.write('Warning: Invalid frame range (%s, %s)\n'
-                % (self.realStartTimeCode, self.realEndTimeCode))
-                self._timeSamples = []
+        def _setTimeSamplesFromRange():
+            if self.realStartTimeCode is not None and self.realEndTimeCode is not None:
+                if self.realStartTimeCode > self.realEndTimeCode:
+                    sys.stderr.write('Warning: Invalid frame range (%s, %s)\n'
+                                     % (self.realStartTimeCode, self.realEndTimeCode))
+                    self._timeSamples = []
+                else:
+                    self._timeSamples = Drange(self.realStartTimeCode,
+                                               self.realEndTimeCode,
+                                               self.step)
             else:
-                self._timeSamples = Drange(self.realStartTimeCode,
-                                           self.realEndTimeCode,
-                                           self.step)
+                self._timeSamples = []
+
+        if self._dataModel.viewSettings.authoredStepsOnly:
+            samples = self._dataModel.authoredSamples
+            if samples:
+                self._timeSamples = samples
+            else:
+                _setTimeSamplesFromRange()
         else:
-            self._timeSamples = []
+            _setTimeSamplesFromRange()
 
         self._geomCounts = dict()
         self._hasTimeSamples = (len(self._timeSamples) > 0)
@@ -2049,6 +2062,13 @@ class AppController(QtCore.QObject):
         self._ui.frameSlider.setTracking(
             self._dataModel.viewSettings.redrawOnScrub)
 
+    def _authoredOptionToggled(self, checked):
+        self._dataModel.viewSettings.authoredStepsOnly = checked
+        # give an indication when step size is not taken into account:
+        self._ui.stepSize.setVisible(not checked)
+        self._ui.stepSizeLabel.setVisible(not checked)
+        self._UpdateTimeSamples(resetStageDataOnly=False)
+
     # Frame-by-frame/Playback functionality ===================================
 
     def _setPlaybackAvailability(self, enabled = True):
@@ -2070,6 +2090,7 @@ class AppController(QtCore.QObject):
         self._ui.redrawOnScrub.setEnabled(isEnabled)
         self._ui.stepSizeLabel.setEnabled(isEnabled)
         self._ui.stepSize.setEnabled(isEnabled)
+        self._ui.authoredStepsOnly.setEnabled(isEnabled)
 
 
     def _playClicked(self):
@@ -2139,7 +2160,18 @@ class AppController(QtCore.QObject):
             int: The closest matching frame index or 0 if one cannot be
             found.
         """
-        closestIndex = int(round((timeSample - self._timeSamples[0]) / self.step))
+        if self._dataModel.viewSettings.authoredStepsOnly:
+            # Since the authored samples could be unevenly distributed, we need to
+            # search for the closest one. This index's value will be >= timeSample.
+            closestIndex = bisect.bisect(self._timeSamples, timeSample)
+            # if applicable, check if previous sample is closer
+            if (closestIndex > 0 and closestIndex < len(self._timeSamples) and
+                    (abs(timeSample - self._timeSamples[closestIndex - 1]) <
+                     abs(timeSample - self._timeSamples[closestIndex]))):
+                closestIndex = closestIndex -1
+        else:
+            # If we can assume even samples, we can avoid bisect search...
+            closestIndex = int(round((timeSample - self._timeSamples[0]) / self.step))
 
         # Bounds checking
         # 0 <= closestIndex <= number of time samples - 1
@@ -5191,6 +5223,7 @@ class AppController(QtCore.QObject):
         self._refreshRolloverPrimInfoMenu()
         self._refreshSelectionHighlightingMenu()
         self._refreshSelectionHighlightColorMenu()
+        self._refreshAuthoredStepsOnly()
 
     def _refreshRenderModeMenu(self):
         for action in self._renderModeActions:
@@ -5340,6 +5373,10 @@ class AppController(QtCore.QObject):
             action.setChecked(
                 str(action.text())
                 == self._dataModel.viewSettings.highlightColorName)
+
+    def _refreshAuthoredStepsOnly(self):
+        self._ui.authoredStepsOnly.setChecked(
+            self._dataModel.viewSettings.authoredStepsOnly)
 
     def _displayPurposeChanged(self):
         self._updatePropertyView()

--- a/pxr/usdImaging/usdviewq/mainWindowUI.ui
+++ b/pxr/usdImaging/usdviewq/mainWindowUI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1145</width>
+    <width>1351</width>
     <height>1002</height>
    </rect>
   </property>
@@ -1390,6 +1390,32 @@
             <property name="sizeHint" stdset="0">
              <size>
               <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="authoredStepsOnly">
+            <property name="text">
+             <string>Authored Steps Only</string>
+            </property>
+            <property name="toolTip">
+             <string>If checked, only authored time samples will be used for playback and scrubbing</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
               <height>20</height>
              </size>
             </property>

--- a/pxr/usdImaging/usdviewq/rootDataModel.py
+++ b/pxr/usdImaging/usdviewq/rootDataModel.py
@@ -47,6 +47,8 @@ class RootDataModel(QtCore.QObject):
 
         self._stage = None
         self._makeTimer = makeTimer if makeTimer is not None else Timer
+        
+        self._authoredSamples = None
 
         self._currentFrame = Usd.TimeCode.Default()
         self._playing = False
@@ -74,6 +76,7 @@ class RootDataModel(QtCore.QObject):
             raise ValueError("Expected USD Stage, got: {}".format(repr(value)))
 
         if value is not self._stage:
+            self._authoredSamples = None
 
             if self._pcListener:
                 self._pcListener.Revoke()
@@ -114,6 +117,15 @@ class RootDataModel(QtCore.QObject):
                     propertyChange = ChangeNotice.INFOCHANGES
 
         self._emitPrimsChanged(primChange, propertyChange)
+
+    @property
+    def authoredSamples(self):
+        if self._authoredSamples is None:
+            if self._stage is None:
+                return []
+            else:
+                self._authoredSamples = self._stage.GetTimeSamplesFromPrims()
+        return self._authoredSamples
 
     @property
     def currentFrame(self):

--- a/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
+++ b/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
@@ -143,6 +143,7 @@ class ViewSettingsDataModel(StateSource, QtCore.QObject):
         self._defaultMaterialAmbient = self.stateProperty("defaultMaterialAmbient", default=DEFAULT_AMBIENT)
         self._defaultMaterialSpecular = self.stateProperty("defaultMaterialSpecular", default=DEFAULT_SPECULAR)
         self._redrawOnScrub = self.stateProperty("redrawOnScrub", default=True)
+        self._authoredStepsOnly = False
         self._renderMode = self.stateProperty("renderMode", default=RenderModes.SMOOTH_SHADED)
         self._freeCameraFOV = self.stateProperty("freeCameraFOV", default=60.0)
         self._freeCameraAspect = self.stateProperty("freeCameraAspect", default=1.0)
@@ -822,6 +823,14 @@ class ViewSettingsDataModel(StateSource, QtCore.QObject):
     @visibleViewSetting
     def redrawOnScrub(self, value):
         self._redrawOnScrub = value
+
+    @property
+    def authoredStepsOnly(self):
+        return self._authoredStepsOnly
+
+    @authoredStepsOnly.setter
+    def authoredStepsOnly(self, value):
+        self._authoredStepsOnly = value
 
     @property
     def freeCamera(self):


### PR DESCRIPTION
### Description of Change(s)
+ Adds a new feature to `usdview` that allows users to step through authored samples instead of a fixed time step
+ Adds a utility method to `UsdStage` to get all of the authored samples across all prims of a stage. A wrapped command is also made available to python.

Credit to @sirpalee for the original implementation :)

### Use Cases
This has been an essential feature at our studio for debugging sample related issues in caches. The feature really shines when using renderers with "frame relative samples". 
- If artists need to troubleshoot any motion blur issues, they can use this mode to play through an export and quickly determine if the issue has to do with a bad cache sample or the interpolation between samples. 
- It is also a very handy way to quickly determine where the samples exist in a cache using the timeline. This can be a lot more fluid and intuitive for artists than inspecting the attribute data.

### Example Screenshots
![Screenshot 2023-09-19 at 5 55 34 PM](https://github.com/PixarAnimationStudios/OpenUSD/assets/14878394/2745c40f-abb6-473d-bd6f-87d1ba737493)
Here I am loading in a cache with frame relative samples at -.25, 0, and +.25. 
With the feature disabled (default), you can scrub by a constant frame step and see the .5 frame (which does not have an actual sample). 

![Screenshot 2023-09-19 at 5 56 12 PM](https://github.com/PixarAnimationStudios/OpenUSD/assets/14878394/e5104288-0f8d-40ca-8347-9adeec11ade5)
With the feature enabled, you can scrub through and only see authored frames (If you input 1005.5 it will be rounded to 1005.75). 

Let me know what you think, and whether we can contribute this back to the core.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
