### PR TITLE
Replace `boost::variant` with `std::variant` in `sdf`

### DIFF
--- a/pxr/usd/sdf/namespaceEdit.cpp
+++ b/pxr/usd/sdf/namespaceEdit.cpp
@@ -31,10 +31,10 @@
 #include "pxr/base/tf/stringUtils.h"
 
 #include <boost/ptr_container/ptr_set.hpp>
-#include <boost/variant.hpp>
 
 #include <memory>
 #include <ostream>
+#include <variant>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -91,7 +91,7 @@ private:
     // A key for a _Node.  _RootKey is for the root, SdfPath is for attribute
     // connections and relationship targets, and TfToken for prim and property
     // children.
-    typedef boost::variant<_RootKey, TfToken, SdfPath> _Key;
+    using _Key = std::variant<_RootKey, TfToken, SdfPath>;
 
     struct _TargetKey {
         _TargetKey(const SdfPath& path) : key(path) { }
@@ -161,7 +161,7 @@ private:
         // Test if the node was removed.  This returns true for key nodes.
         bool IsRemoved() const
         {
-            return !_parent && _key.which() != 0;
+            return !_parent && _key.index() != 0;
         }
 
         // Remove the node from its parent.  After this call returns \c true
@@ -567,7 +567,7 @@ SdfNamespaceEdit_Namespace::_FixBackpointers(
     for (_BackpointerMap::iterator j = i; j != n; ++j) {
         for (auto node : j->second) {
             node->SetKey(
-                boost::get<SdfPath>(node->GetKey()).
+                std::get<SdfPath>(node->GetKey()).
                     ReplacePrefix(currentPath, newPath, !fixTargetPaths));
         }
     }

--- a/pxr/usd/sdf/parserValueContext.cpp
+++ b/pxr/usd/sdf/parserValueContext.cpp
@@ -30,7 +30,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-struct Sdf_ToStringVisitor : boost::static_visitor<std::string>
+struct Sdf_ToStringVisitor
 {
     template <typename T>
     std::string operator () (const T &value)


### PR DESCRIPTION
### Description of Change(s)
This replaces `boost::variant` with `std::variant` in `sdf`.  The API uses `boost::bad_get` to communicate a failure to parse due to a bad variant access or an out of range error.  This change remaps the STL `std::bad_variant_access` to a `boost::bad_get` to preserve this behavior.  As visitors used via `std::visit` do not specify `result_type`, the return type for several helper methods has been converted to `auto`.

One or more follow up changes will be needed to remove a spurious include of `boost/variant.hpp` from the parser logic and replace `boost::bad_get` with a new proposed `Sdf_BadGet` exception.

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
