### PR TITLE
Autodesk: Support float type matrix (GfMatrix4f) for instanceTransform

### DIFF
--- a/pxr/imaging/hdSt/instancer.cpp
+++ b/pxr/imaging/hdSt/instancer.cpp
@@ -83,19 +83,30 @@ HdStInstancer::_SyncPrimvars(HdSceneDelegate *sceneDelegate,
         VtValue value = sceneDelegate->Get(instancerId, primvar.name);
         if (!value.IsEmpty()) {
             HdBufferSourceSharedPtr source;
-            if (primvar.name == HdInstancerTokens->instanceTransform &&
-                TF_VERIFY(value.IsHolding<VtArray<GfMatrix4d> >())) {
-                // Explicitly invoke the c'tor taking a
-                // VtArray<GfMatrix4d> to ensure we properly convert to
-                // the appropriate floating-point matrix type.
-                HgiCapabilities const * capabilities =
-                    resourceRegistry->GetHgi()->GetCapabilities();
-                bool const doublesSupported = capabilities->IsSet(
-                    HgiDeviceCapabilitiesBitsShaderDoublePrecision);
-                source.reset(new HdVtBufferSource(primvar.name,
-                            value.UncheckedGet<VtArray<GfMatrix4d>>(),
-                            1,
-                            doublesSupported));
+            if (primvar.name == HdInstancerTokens->instanceTransform) {
+                if (value.IsHolding<VtArray<GfMatrix4d> >()) {
+                    // Explicitly invoke the c'tor taking a
+                    // VtArray<GfMatrix4d> to ensure we properly convert to
+                    // the appropriate floating-point matrix type.
+                    HgiCapabilities const * capabilities =
+                        resourceRegistry->GetHgi()->GetCapabilities();
+                    bool const doublesSupported = capabilities->IsSet(
+                            HgiDeviceCapabilitiesBitsShaderDoublePrecision);
+                    source.reset(new HdVtBufferSource(primvar.name,
+                                value.UncheckedGet<VtArray<GfMatrix4d>>(),
+                                1,
+                                doublesSupported));
+                }
+                else if (value.IsHolding<VtArray<GfMatrix4f> >()) {
+                    source.reset(new HdVtBufferSource(primvar.name,
+                                value,
+                                1,
+                                false));
+                }
+                else {
+                    TF_VERIFY(false);
+                    source.reset(new HdVtBufferSource(primvar.name, value));
+                }
             }
             else {
                 source.reset(new HdVtBufferSource(primvar.name, value));


### PR DESCRIPTION
### Description of Change(s)

Support VtArray<GfMatrix4f> as the value type for token instanceTransform

A instancer may contain huge number of matrices and occupy lots of memory. Some data models only need float precision
matrices for instancers, however USD only accepts VtArray<GfMatrix4d>, doubling the memory size needed.
To save the memory, this fix allows USD to accept instancer matrices of type VtArray<GfMatrix4f> directly.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
