### PR TITLE
Autodesk: Fix testUsdImagingGLMaterialXCustomNodes_customColor failure

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -874,8 +874,7 @@ _NodeGraphBuilder::_AddNode(
                 usdParent.GetPath().GetText());
         // Nodegraphs associated with locally defined custom nodes are added 
         // before reading materials, and therefore get-able here 
-        auto nodeGraphPath = usdParent.GetParent().GetPath().AppendChild(
-            TfToken(mtlxNodeDef->getName()));
+        auto nodeGraphPath =usdParent.GetParent().GetPath().AppendChild(_MakeName(mtlxNodeDef));
         auto usdNodeGraph = UsdShadeNodeGraph::Get(usdStage, nodeGraphPath);
         connectable = usdNodeGraph.ConnectableAPI();
         _SetCoreUIAttributes(usdNodeGraph.GetPrim(), mtlxNode);


### PR DESCRIPTION
### Description of Change(s)

Fix testcase by changing way of getting prim path. 
Related commit: https://github.com/PixarAnimationStudios/OpenUSD/commit/1d2f18b540079dececa879c8515ccaac5c4161c6

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
