### PR TITLE
Fix timeVaryingBits for lights, light filters, and cameras for timesampled transform attribute

### DIFF
--- a/pxr/usdImaging/usdImaging/cameraAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/cameraAdapter.cpp
@@ -145,7 +145,7 @@ UsdImagingCameraAdapter::TrackVariability(UsdPrim const& prim,
         // Don't double-count clipping-plane or transform attrs.
         if (attr.GetBaseName() == UsdGeomTokens->clippingPlanes) { continue; }
         if (UsdGeomXformable::IsTransformationAffectedByAttrNamed(
-                attr.GetBaseName())) {
+                attr.GetName())) {
             continue;
         }
         if (_IsVarying(prim,

--- a/pxr/usdImaging/usdImaging/lightAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightAdapter.cpp
@@ -167,7 +167,7 @@ UsdImagingLightAdapter::TrackVariability(UsdPrim const& prim,
     for (UsdAttribute const& attr : attrs) {
         // Don't double-count transform attrs.
         if (UsdGeomXformable::IsTransformationAffectedByAttrNamed(
-                attr.GetBaseName())) {
+                attr.GetName())) {
             continue;
         }
         if (attr.GetNumTimeSamples()>1){

--- a/pxr/usdImaging/usdImaging/lightFilterAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightFilterAdapter.cpp
@@ -101,7 +101,7 @@ UsdImagingLightFilterAdapter::TrackVariability(UsdPrim const& prim,
     for (UsdAttribute const& attr : attrs) {
         // Don't double-count transform attrs.
         if (UsdGeomXformable::IsTransformationAffectedByAttrNamed(
-                attr.GetBaseName())) {
+                attr.GetName())) {
             continue;
         }
         if (attr.GetNumTimeSamples()>1){


### PR DESCRIPTION
### Description of Change(s)

Change calls to `UsdGeomXformable::IsTransformationAffectedByAttrNamed` to use `GetName` instead of `GetBaseName` so the namespace can be checked against.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
Tested on Windows, these tests fail:
The following tests FAILED:
        430 - testUsdZipFile (Failed)
        678 - testUsdviewNavigationKeys (Failed)
        694 - testUsdResolverExample (Failed)
Errors while running CTest
Based on other issues, these seem to be failing for a while, on windows. testUsdZipFile fails as an example due to windows line endings vs unix line endings in the write portion of the test (crc doesn't match the expected value).

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
