### PR TITLE
usdUtils: add a GeomSubsetsChecker for validating UsdGeomSubsets with usdchecker

### DIFF
--- a/pxr/usd/bin/usdchecker/CMakeLists.txt
+++ b/pxr/usd/bin/usdchecker/CMakeLists.txt
@@ -154,3 +154,15 @@ pxr_register_test(testUsdChecker13
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/cleanNormalMapReader.usda"
     EXPECTED_RETURN_CODE 0
 )
+
+pxr_install_test_dir(
+    SRC testenv/testUsdChecker
+    DEST testUsdChecker_GeomSubsets
+)
+
+pxr_register_test(testUsdChecker_GeomSubsets
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker bad/subsets.usda -o subsets_failedChecks.txt"
+    DIFF_COMPARE subsets_failedChecks.txt
+    EXPECTED_RETURN_CODE 1
+)

--- a/pxr/usd/bin/usdchecker/testenv/testUsdChecker/bad/subsets.usda
+++ b/pxr/usd/bin/usdchecker/testenv/testUsdChecker/bad/subsets.usda
@@ -1,0 +1,168 @@
+#usda 1.0
+(
+    defaultPrim = "SubsetsTest"
+    metersPerUnit = 0.01
+    upAxis = "Z"
+)
+
+def Xform "SubsetsTest" (
+    kind = "component"
+)
+{
+    def Xform "Geom"
+    {
+        def Mesh "Cube"
+        {
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+
+            uniform token subsetFamily:incompletePartition:familyType = "partition"
+            uniform token subsetFamily:materialBind:familyType = "unrestricted"
+            uniform token subsetFamily:nonOverlappingWithDuplicates:familyType = "nonOverlapping"
+
+            def GeomSubset "emptyIndicesAtAllTimes"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "emptyIndicesAtAllTimes"
+            }
+
+            def GeomSubset "incompletePartition_1"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "incompletePartition"
+                int[] indices = [0, 1]
+            }
+
+            def GeomSubset "incompletePartition_2"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "incompletePartition"
+                int[] indices = [4, 5]
+            }
+
+            def GeomSubset "materialBindShouldNotBeUnrestricted" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "materialBind"
+                int[] indices = [0, 2, 4]
+                rel material:binding = </SubsetsTest/Materials/TestMaterial>
+            }
+
+            def GeomSubset "materialBindMissingElementType" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                uniform token familyName = "materialBind"
+                int[] indices = [1, 3, 5]
+                rel material:binding = </SubsetsTest/Materials/TestMaterial>
+            }
+
+            def GeomSubset "materialBindMissingFamilyName" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                uniform token elementType = "face"
+                int[] indices = [1, 3, 5]
+                rel material:binding = </SubsetsTest/Materials/TestMaterial>
+            }
+
+            def GeomSubset "materialBindShouldBeFaceElementType" (
+                prepend apiSchemas = ["MaterialBindingAPI"]
+            )
+            {
+                uniform token elementType = "point"
+                uniform token familyName = "materialBind"
+                int[] indices = [0, 2, 4]
+                rel material:binding = </SubsetsTest/Materials/TestMaterial>
+            }
+
+            def GeomSubset "nonOverlappingWithDuplicates_1"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "nonOverlappingWithDuplicates"
+                int[] indices = [0, 3]
+            }
+
+            def GeomSubset "nonOverlappingWithDuplicates_2"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "nonOverlappingWithDuplicates"
+                int[] indices = [3, 5]
+            }
+
+            def GeomSubset "onlyNegativeIndices"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "onlyNegativeIndices"
+                int[] indices = [-1, -2, -3, -4, -5]
+            }
+
+            def GeomSubset "outOfRangeIndices"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "outOfRangeIndices"
+                int[] indices = [3, 4, 5, 6, 7]
+            }
+        }
+
+        def Mesh "NullMesh"
+        {
+            def GeomSubset "noElementsInGeometry"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "noElementsInGeometry"
+                int[] indices = [0, 1, 2, 3]
+            }
+        }
+
+        def Mesh "VaryingMesh"
+        {
+            int[] faceVertexCounts.timeSamples = {
+                1: [4],
+                2: [4, 4],
+                3: [4, 4, 4]
+            }
+
+            def GeomSubset "noDefaultTimeElementsInGeometry"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "noDefaultTimeElementsInGeometry"
+                int[] indices = [0]
+                int[] indices.timeSamples = {
+                    1: [0],
+                    2: [1],
+                    3: [2]
+                }
+            }
+        }
+
+        def Material "NonImageable"
+        {
+            def GeomSubset "parentIsNotImageable"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "parentIsNotImageable"
+                int[] indices = [0]
+            }
+        }
+    }
+
+    def Scope "Materials"
+    {
+        def Material "TestMaterial"
+        {
+            token outputs:surface.connect = </SubsetsTest/Materials/TestMaterial/PreviewSurface.outputs:surface>
+
+            def Shader "PreviewSurface"
+            {
+                uniform token info:id = "UsdPreviewSurface"
+                color3f inputs:diffuseColor = (1.0, 0.0, 0.0)
+                token outputs:surface
+            }
+        }
+    }
+}

--- a/pxr/usd/bin/usdchecker/testenv/testUsdChecker/baseline/baseRules.txt
+++ b/pxr/usd/bin/usdchecker/testenv/testUsdChecker/baseline/baseRules.txt
@@ -49,4 +49,19 @@ Specifically:
 [SkelBindingAPIAppliedChecker]:
  A prim providing skelBinding properties, must have SkelBindingAPI applied on the prim.
 ------------------------------
-Success!
+[GeomSubsetsChecker]:
+ Validates various aspects of UsdGeomSubsets:
+   - GeomSubsets must be authored as direct children of an Imageable prim
+   - The set of all subset family names is fetched for each subset parent
+     Imageable, and each family is checked for validity
+   - If the "materialBind" subset family is authored on an Imageable, it is
+     checked to ensure that it is of a restricted type (either "nonOverlapping"
+     or "partition"), since it is invalid for an element of geometry to be
+     bound to multiple materials.
+   - All subsets belonging to the "materialBind" family must be of element type "face",
+     since material bindings may only be applied to geometric faces.
+   - If a subset has authored material bindings but no authored subset
+     family name, it is suggested that the family name should be set to
+     "materialBind" to ensure that the material bindings are visible to
+     renderers. The material bindings will have no effect otherwise.
+------------------------------

--- a/pxr/usd/bin/usdchecker/testenv/testUsdChecker/baseline/subsets_failedChecks.txt
+++ b/pxr/usd/bin/usdchecker/testenv/testUsdChecker/baseline/subsets_failedChecks.txt
@@ -1,0 +1,18 @@
+Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'emptyIndicesAtAllTimes': No indices in family at any time.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'incompletePartition': Number of unique indices at time DEFAULT does not match the element count 6.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'nonOverlappingWithDuplicates': Found duplicate index 3 in GeomSubset at path </SubsetsTest/Geom/Cube/nonOverlappingWithDuplicates_2>.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'onlyNegativeIndices': Found one or more indices that are less than 0 at time DEFAULT.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'outOfRangeIndices': Found one or more indices that are greater than the element count 6 at time DEFAULT.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/Cube> has 'materialBind' subset family with invalid family type 'unrestricted'. Family type should be 'nonOverlapping' or 'partition' instead. (fails 'GeomSubsetsChecker')
+GeomSubset </SubsetsTest/Geom/Cube/materialBindShouldBeFaceElementType> belongs to family 'materialBind' but has non-face element type 'point'. Subsets belonging to family 'materialBind' should be of element type 'face'. (fails 'GeomSubsetsChecker')
+GeomSubset prim </SubsetsTest/Geom/Cube/materialBindMissingFamilyName> with material bindings applied but no authored family name should set familyName to 'materialBind'. (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/NullMesh> has invalid subset family 'noElementsInGeometry': Unable to determine element count at earliest time for geom </SubsetsTest/Geom/NullMesh>.
+ (fails 'GeomSubsetsChecker')
+Imageable prim </SubsetsTest/Geom/VaryingMesh> has invalid subset family 'noDefaultTimeElementsInGeometry': Geometry </SubsetsTest/Geom/VaryingMesh> has no elements at time DEFAULT, but the "noDefaultTimeElementsInGeometry" GeomSubset family contains indices.
+ (fails 'GeomSubsetsChecker')
+GeomSubset </SubsetsTest/Geom/NonImageable/parentIsNotImageable> has direct parent prim </SubsetsTest/Geom/NonImageable> that is not Imageable. (fails 'GeomSubsetsChecker')

--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -1118,7 +1118,8 @@ class ComplianceChecker(object):
         return [ByteAlignmentChecker, CompressionChecker, ShaderPropertyTypeConformanceChecker,
                 MissingReferenceChecker, StageMetadataChecker, TextureChecker, 
                 PrimEncapsulationChecker, NormalMapTextureChecker,
-                MaterialBindingAPIAppliedChecker, SkelBindingAPIAppliedChecker]
+                MaterialBindingAPIAppliedChecker, SkelBindingAPIAppliedChecker,
+                GeomSubsetsChecker]
 
     @staticmethod
     def GetARKitRules(skipARKitRootLayerCheck=False):


### PR DESCRIPTION
This new rule checker can be used to validate various aspects of `UsdGeomSubset`s:
- `GeomSubset`s must be authored as direct children of an `Imageable` prim.
- The set of all subset family names is fetched for each subset parent `Imageable`, and each family is checked for validity (using `UsdGeomSubset::ValidateFamily()`).
- If the `materialBind` subset family is authored on an `Imageable`, it is checked to ensure that it is of a restricted type (either `nonOverlapping` or `partition`), since it is invalid for an element of geometry to be bound to multiple materials.
- If a subset has authored material bindings but no authored subset family name, it is suggested that the family name should be set to `materialBind` to ensure that the material bindings are visible to renderers. The material bindings will have no effect otherwise.

I have run the unit tests successfully with the changes here, but they depend on fixes and improvements to `UsdGeomSubset::ValidateFamily()` from #2733.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
