### PR TITLE
Replace `BOOST_PP_SEQ` defined stream overloads in `vt/wrapArray.h`

### DIFF
--- a/pxr/base/vt/testenv/testVtArray.py
+++ b/pxr/base/vt/testenv/testVtArray.py
@@ -156,6 +156,10 @@ class TestVtArray(unittest.TestCase):
         self.assertGreater(da[0], 1.0)
         self.assertEqual(da, eval(repr(da)))
 
+        ha = Vt.HalfArray((1.0001, 1e39, float('-inf')))
+        self.assertGreater(da[0], 1.0)
+        self.assertEqual(ha, eval(repr(ha)))
+
     def test_Overflows(self):
         overflows = [
             # (array type, (largest negative number to overflow,


### PR DESCRIPTION
### Description of Change(s)
`wrapArray.h` provided overloads for `streamValue` so that integral and floating point values don't have to go through `TfPyRepr` as an optimization. Overloads were defined by `BOOST_PP_SEQ` operating on a list of floating point and integral type sequences.

This PR uses `if constexpr` and `TfMetaList` to provide a boost free implementation without SFINAE.

This additionally changes `_IsFinite` to be `inline`, as the `static` `GfHalf` overload was generating unused function warnings.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
