### PR TITLE
Remove unused `boost/functional/hash.hpp` includes from `imaging` and `usdImaging`

### DIFF
--- a/pxr/imaging/hdSt/drawItemsCache.cpp
+++ b/pxr/imaging/hdSt/drawItemsCache.cpp
@@ -32,7 +32,6 @@
 #include "pxr/imaging/hd/drawItem.h"
 #include "pxr/imaging/hd/perfLog.h"
 
-#include <boost/functional/hash.hpp>
 #include <sstream>
 #include <string>
 

--- a/pxr/imaging/hdSt/fallbackLightingShader.cpp
+++ b/pxr/imaging/hdSt/fallbackLightingShader.cpp
@@ -29,8 +29,6 @@
 
 #include "pxr/imaging/hio/glslfx.h"
 
-#include <boost/functional/hash.hpp>
-
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hdSt/shaderCode.cpp
+++ b/pxr/imaging/hdSt/shaderCode.cpp
@@ -35,8 +35,6 @@
 
 #include "pxr/base/vt/dictionary.h"
 
-#include <boost/functional/hash.hpp>
-
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hdSt/vboSimpleMemoryManager.cpp
+++ b/pxr/imaging/hdSt/vboSimpleMemoryManager.cpp
@@ -44,8 +44,6 @@
 
 #include <atomic>
 
-#include <boost/functional/hash.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 

--- a/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
+++ b/pxr/usdImaging/usdImaging/resolvedAttributeCache.h
@@ -36,7 +36,6 @@
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/work/utils.h"
 
-#include <boost/functional/hash.hpp>
 #include <tbb/concurrent_unordered_map.h>
 #include <functional>
 


### PR DESCRIPTION
### Description of Change(s)

Several files in `imaging` and `usdImaging` are including `boost/functional/hash.hpp` unnecessarily. This removes their usage.

### Fixes Issue(s)
- #2172 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
