### PR TITLE
Add locale independent `TfStringToLowerAscii`

### DIFF
--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -1201,4 +1201,16 @@ TfGetXmlEscapedString(const std::string &in)
     return result;
 }
 
+std::string
+TfStringToLowerAscii(const std::string& source)
+{
+    std::string folded;
+    folded.resize(source.size());
+    std::transform(source.begin(), source.end(), folded.begin(),
+                   [](char ch) {
+                       return ('A' <= ch && ch <= 'Z') ? ch - 'A' + 'a' : ch;
+                   });
+    return folded;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -277,6 +277,20 @@ std::string TfStringToUpper(const std::string& source);
 TF_API
 std::string TfStringCapitalize(const std::string& source);
 
+/// Locale-independent case folding of [A-Z] for ASCII or UTF-8 encoded
+/// \p source strings
+///
+/// This can be used for case insensitive matching where one of the strings
+/// being compared either known to be ASCII only by specification (like a URI
+/// scheme or an explicit token) or where the specification explicitly notes
+/// that only [A-Z] will be matched case insensitively.
+///
+/// \code
+/// TfStringEndsWith(TfStringToLowerAscii("ü.JPG"), ".jpg")
+/// \endcode
+TF_API
+std::string TfStringToLowerAscii(const std::string& source);
+
 /// Trims characters (by default, whitespace) from the left.
 ///
 /// Characters from the beginning of \p s are removed until a character not in

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -268,6 +268,13 @@ TestStrings()
     TF_AXIOM(TfStringCapitalize("@@@@") == "@@@@");
     TF_AXIOM(TfStringCapitalize("") == "");
 
+    TF_AXIOM(TfStringToLowerAscii("PIXAR") == TfStringToLowerAscii("pixar"));
+    TF_AXIOM(TfStringToLowerAscii("PiXaR") == TfStringToLowerAscii("pixar"));
+    // 'Pixar' in capital Greek letters is not case folded
+    TF_AXIOM(TfStringToLowerAscii("ΠΙΞΑΡ") == "ΠΙΞΑΡ");
+    // Mixture of symbols, capital non-ASCII letters, and ASCII letters
+    TF_AXIOM(TfStringToLowerAscii("ΠΙΞΑΡ ≈ PIXAR") == "ΠΙΞΑΡ ≈ pixar");
+
     TF_AXIOM(TfStringGetSuffix("file.ext") == "ext");
     TF_AXIOM(TfStringGetSuffix("here are some words", ' ') == "words");
     TF_AXIOM(TfStringGetSuffix("0words", '0') == "words");


### PR DESCRIPTION
### Description of Change(s)
To more robustly support UTF-8 encoding of strings, this promotes a utility function from `fileFormatRegistry.cpp` used for locale independent case folding to `pixar/base/tf/stringUtils.h` as `TfStringToLowerAscii`. This will replace `TfStringToLower` in many cases where one of the strings is known to be ASCII (or UTF-8 where a specification explicitly callouts of only casefolding of `[A-Z]`).

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
