### PR TITLE
Replace `std::is_trivially_assignable` with `std::is_trivially_copy_assignable`

### DIFF
--- a/pxr/base/vt/traits.h
+++ b/pxr/base/vt/traits.h
@@ -44,10 +44,8 @@ struct VtIsArray : public std::false_type {};
 // space but do not have a trivial assignment are not cheap to copy.  E.g. std::
 // containers.  Clients can specialize this template for their own types that
 // aren't trivially assignable but are cheap to copy to enable local storage.
-// In C++17, std::is_trivially_copy_assignable<T> could be used in place of
-// std::is_trivially_assignable
 template <class T>
-struct VtValueTypeHasCheapCopy : std::is_trivially_assignable<T&, const T&> {};
+struct VtValueTypeHasCheapCopy : std::is_trivially_copy_assignable<T> {};
 
 #define VT_TYPE_IS_CHEAP_TO_COPY(T)                                            \
     template <> struct VtValueTypeHasCheapCopy<TF_PP_EAT_PARENS(T)>            \

--- a/pxr/base/vt/value.h
+++ b/pxr/base/vt/value.h
@@ -197,14 +197,12 @@ class VtValue
     typedef std::aligned_storage<
         /* size */_MaxLocalSize, /* alignment */_MaxLocalSize>::type _Storage;
 
-    // In C++17, std::is_trivially_copy_assignable<T> could be used in place of
-    // std::is_trivially_assignable
     template <class T>
     using _IsTriviallyCopyable = std::integral_constant<bool,
-        std::is_trivially_default_constructible<T>::value &&
-        std::is_trivially_copyable<T>::value &&
-        std::is_trivially_assignable<T&, const T&>::value &&
-        std::is_trivially_destructible<T>::value>;
+        std::is_trivially_default_constructible_v<T> &&
+        std::is_trivially_copyable_v<T> &&
+        std::is_trivially_copy_assignable_v<T> &&
+        std::is_trivially_destructible_v<T>>;
 
     // Metafunction that returns true if T should be stored locally, false if it
     // should be stored remotely.

--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -320,13 +320,10 @@ namespace Usd_CrateFile {
 
 // XXX: These checks ensure VtValue can hold ValueRep in the lightest
 // possible way -- WBN not to rely on internal knowledge of that.
-static_assert(std::is_trivially_constructible<ValueRep>::value, "");
-static_assert(std::is_trivially_copyable<ValueRep>::value, "");
-// In C++17, std::is_trivially_copy_assignable<T> could be used in place of
-// std::is_trivially_assignable
-static_assert(std::is_trivially_assignable<ValueRep&, const ValueRep&>::value,
-              "");
-static_assert(std::is_trivially_destructible<ValueRep>::value, "");
+static_assert(std::is_trivially_constructible_v<ValueRep>);
+static_assert(std::is_trivially_copyable_v<ValueRep>);
+static_assert(std::is_trivially_copy_assignable_v<ValueRep>);
+static_assert(std::is_trivially_destructible_v<ValueRep>);
 
 using namespace Usd_CrateValueInliners;
 


### PR DESCRIPTION
### Description of Change(s)
#2212 and #2214 replaced `boost::has_trivial_assign<T>` with `std::is_trivially_assignable<T&, const T&>`.  C++17 has introduced `std::is_trivially_copy_assignable` which more compactly maps to the original `boost::has_trivial_assign`.

This change also replaces some usage of `{TRAIT}::value` with the equivalent `{TRAIT}_v` representation.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
