### PR TITLE
fix: use universal -j parameter for cmake build

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -350,14 +350,7 @@ def AppendCXX11ABIArg(buildFlag, context, buildArgs):
         flag=buildFlag, flags=" ".join(cxxFlags)))
 
 def FormatMultiProcs(numJobs, generator):
-    tag = "-j"
-    if generator:
-        if "Visual Studio" in generator:
-            tag = "/M:" # This will build multiple projects at once.
-        elif "Xcode" in generator:
-            tag = "-j "
-
-    return "{tag}{procs}".format(tag=tag, procs=numJobs)
+    return "-j {procs}".format(procs=numJobs)
 
 def RunCMake(context, force, extraArgs = None):
     """Invoke CMake to configure, build, and install a library whose 
@@ -454,7 +447,7 @@ def RunCMake(context, force, extraArgs = None):
                     generator=(generator or ""),
                     toolset=(toolset or ""),
                     extraArgs=(" ".join(extraArgs) if extraArgs else "")))
-        Run("cmake --build . --config {config} --target install -- {multiproc}"
+        Run("cmake --build . --config {config} --target install {multiproc}"
             .format(config=config,
                     multiproc=FormatMultiProcs(context.numJobs, generator)))
 


### PR DESCRIPTION
### Description of Change(s)
Due to cmake document, `-j` parameter is compatible for all platforms, there is no need to pass different tag to different platform build tools
https://cmake.org/cmake/help/latest/manual/cmake.1.html#build-a-project

### Fixes Issue(s)
This should fix #2486 #2722

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
