### PR TITLE
UsdLux update

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -21,6 +21,7 @@ pxr_plugin(hdEmbree
         hf
         hd
         hdx
+        usdLux
         ${TBB_tbb_LIBRARY}
         ${EMBREE_LIBRARY}
 
@@ -30,7 +31,9 @@ pxr_plugin(hdEmbree
 
     PUBLIC_CLASSES
         config
+        ies
         instancer
+        light
         mesh
         meshSamplers
         renderBuffer
@@ -39,6 +42,7 @@ pxr_plugin(hdEmbree
         renderDelegate
         renderPass
         sampler
+        pcg_basic
 
     PUBLIC_HEADERS
         context.h

--- a/pxr/imaging/plugin/hdEmbree/context.h
+++ b/pxr/imaging/plugin/hdEmbree/context.h
@@ -68,6 +68,8 @@ struct HdEmbreeInstanceContext
     RTCScene rootScene;
     /// The instance id of this instance.
     int32_t instanceId;
+    /// The light index (if this is a light)
+    int lightIndex = -1;
 };
 
 

--- a/pxr/imaging/plugin/hdEmbree/ies.cpp
+++ b/pxr/imaging/plugin/hdEmbree/ies.cpp
@@ -1,0 +1,490 @@
+/* SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#include "ies.h"
+
+#include <algorithm>
+#include <limits>
+#include <math.h>
+#include <stdio.h>
+
+bool IESFile::load(const std::string &ies) {
+    clear();
+
+    if (!parse(ies) || !process()) {
+        clear();
+        return false;
+    }
+
+    return true;
+}
+
+void IESFile::clear() {
+    _intensities.clear();
+    _v_angles.clear();
+    _h_angles.clear();
+}
+
+int IESFile::packed_size() {
+    if (_v_angles.size() && _h_angles.size() > 0) {
+        return 2 + _h_angles.size() + _v_angles.size() +
+                _h_angles.size() * _v_angles.size();
+    }
+    return 0;
+}
+
+template <class To, class From>
+std::enable_if_t<sizeof(To) == sizeof(From) &&
+                    std::is_trivially_copyable_v<From> &&
+                    std::is_trivially_copyable_v<To>,
+                    To>
+    // constexpr support needs compiler magic
+    bit_cast(const From &src) noexcept {
+    static_assert(std::is_trivially_constructible_v<To>,
+                "This implementation additionally requires "
+                "destination type to be trivially constructible");
+
+    To dst;
+    std::memcpy(&dst, &src, sizeof(To));
+    return dst;
+}
+
+void IESFile::pack(float *data) {
+    if (_v_angles.size() && _h_angles.size()) {
+        *(data++) = bit_cast<int, float>(_h_angles.size());
+        *(data++) = bit_cast<int, float>(_v_angles.size());
+
+        memcpy(data, &_h_angles[0], _h_angles.size() * sizeof(float));
+        data += _h_angles.size();
+        memcpy(data, &_v_angles[0], _v_angles.size() * sizeof(float));
+        data += _v_angles.size();
+
+        for (int h = 0; h < _intensities.size(); h++) {
+            memcpy(data, &_intensities[h][0], _v_angles.size() * sizeof(float));
+            data += _v_angles.size();
+        }
+    }
+}
+
+class IESTextParser {
+public:
+    std::vector<char> text;
+    char *data;
+    bool error;
+
+    IESTextParser(const std::string &str)
+        : text(str.begin(), str.end()), error(false) {
+        std::replace(text.begin(), text.end(), ',', ' ');
+        data = strstr(&text[0], "\nTILT=");
+    }
+
+    bool eof() { return (data == NULL) || (data[0] == '\0'); }
+
+    bool has_error() { return error; }
+
+    double get_double() {
+        if (eof()) {
+            error = true;
+            return 0.0;
+        }
+        char *old_data = data;
+        double val = strtod(data, &data);
+        if (data == old_data) {
+            data = NULL;
+            error = true;
+            return 0.0;
+        }
+        return val;
+    }
+
+    long get_long() {
+        if (eof()) {
+            error = true;
+            return 0;
+        }
+        char *old_data = data;
+        long val = strtol(data, &data, 10);
+        if (data == old_data) {
+            data = NULL;
+            error = true;
+            return 0;
+        }
+        return val;
+    }
+};
+
+bool IESFile::parse(const std::string &ies) {
+    if (ies.empty()) {
+        return false;
+    }
+
+    IESTextParser parser(ies);
+    if (parser.eof()) {
+        return false;
+    }
+
+    // Handle the tilt data block
+    if (strncmp(parser.data, "\nTILT=INCLUDE", 13) == 0) {
+        parser.data += 13;
+        parser.get_double();              //< Lamp to Luminaire geometry
+        int num_tilt = parser.get_long(); //< Amount of tilt angles and factors
+
+        // Skip over angles and factors
+        for (int i = 0; i < 2 * num_tilt; i++) {
+            parser.get_double();
+        }
+    } else {
+        // Skip to next line
+        parser.data = strstr(parser.data + 1, "\n");
+    }
+
+    if (parser.eof()) {
+        return false;
+    }
+    parser.data++;
+
+    parser.get_long();                    //< Number of lamps
+    parser.get_double();                  //< Lumens per lamp
+    double factor = parser.get_double();  //< Candela multiplier
+    int v_angles_num = parser.get_long(); //< Number of vertical angles
+    int h_angles_num = parser.get_long(); //< Number of horizontal angles 
+    _type = (IESType)parser.get_long();   //< Photometric type
+
+    // TODO(lukas): Test whether the current type B processing can also deal with
+    // type A files. In theory the only difference should be orientation which we
+    // ignore anyways, but with IES you never know...
+    //
+    if (_type != TYPE_B && _type != TYPE_C) {
+        return false;
+    }
+
+    parser.get_long();             //< Unit of the geometry data
+    parser.get_double();           //< Width
+    parser.get_double();           //< Length
+    parser.get_double();           //< Height
+    factor *= parser.get_double(); //< Ballast factor
+    factor *= parser.get_double(); //< Ballast-Lamp Photometric factor
+    parser.get_double();           //< Input Watts
+
+    _v_angles.reserve(v_angles_num);
+    for (int i = 0; i < v_angles_num; i++) {
+        _v_angles.push_back((float)parser.get_double());
+    }
+
+    _h_angles.reserve(h_angles_num);
+    for (int i = 0; i < h_angles_num; i++) {
+        _h_angles.push_back((float)parser.get_double());
+    }
+
+    _intensities.resize(h_angles_num);
+    for (int i = 0; i < h_angles_num; i++) {
+        _intensities[i].reserve(v_angles_num);
+        for (int j = 0; j < v_angles_num; j++) {
+            _intensities[i].push_back((float)(factor * parser.get_double()));
+        }
+    }
+
+    return !parser.has_error();
+}
+
+bool IESFile::process_type_b() {
+    std::vector<std::vector<float>> newintensity;
+    newintensity.resize(_v_angles.size());
+
+    for (int i = 0; i < _v_angles.size(); i++) {
+        newintensity[i].reserve(_h_angles.size());
+        for (int j = 0; j < _h_angles.size(); j++) {
+            newintensity[i].push_back(_intensities[j][i]);
+        }
+    }
+    _intensities.swap(newintensity);
+    _h_angles.swap(_v_angles);
+
+    float h_first = _h_angles[0], h_last = _h_angles[_h_angles.size() - 1];
+    if (h_last != 90.0f) {
+        return false;
+    }
+
+    if (h_first == 0.0f) {
+        // The range in the file corresponds to 90°-180°, we need to mirror that to
+        // get the full 180° range
+        std::vector<float> new_h_angles;
+        std::vector<std::vector<float>> new_intensity;
+        int hnum = _h_angles.size();
+        new_h_angles.reserve(2 * hnum - 1);
+        new_intensity.reserve(2 * hnum - 1);
+        for (int i = hnum - 1; i > 0; i--) {
+            new_h_angles.push_back(90.0f - _h_angles[i]);
+            new_intensity.push_back(_intensities[i]);
+        }
+        for (int i = 0; i < hnum; i++) {
+            new_h_angles.push_back(90.0f + _h_angles[i]);
+            new_intensity.push_back(_intensities[i]);
+        }
+        _h_angles.swap(new_h_angles);
+        _intensities.swap(new_intensity);
+    } else if (h_first == -90.0f) {
+        // We have full 180° coverage, so just shift to match the angle range
+        // convention.
+        for (int i = 0; i < _h_angles.size(); i++) {
+            _h_angles[i] += 90.0f;
+        }
+    }
+
+    // To get correct results with the cubic interpolation in the kernel, the
+    // horizontal range has to cover all 360°. Therefore, we copy the 0° entry to
+    // 360° to ensure full coverage and seamless interpolation
+    _h_angles.push_back(360.0f);
+    _intensities.push_back(_intensities[0]);
+
+    float v_first = _v_angles[0], v_last = _v_angles[_v_angles.size() - 1];
+    if (v_last != 90.0f) {
+        return false;
+    }
+
+    if (v_first == 0.0f) {
+        // The range in the file corresponds to 90°-180°, we need to mirror that to
+        // get the full 180° range
+        std::vector<float> new_v_angles;
+        int hnum = _h_angles.size();
+        int vnum = _v_angles.size();
+        new_v_angles.reserve(2 * vnum - 1);
+
+        for (int i = vnum - 1; i > 0; i--) {
+            new_v_angles.push_back(90.0f - _v_angles[i]);
+        }
+
+        for (int i = 0; i < vnum; i++) {
+            new_v_angles.push_back(90.0f + _v_angles[i]);
+        }
+
+        for (int i = 0; i < hnum; i++) {
+            std::vector<float> new_intensity;
+            new_intensity.reserve(2 * vnum - 1);
+
+            for (int j = vnum - 2; j >= 0; j--) {
+                new_intensity.push_back(_intensities[i][j]);
+            }
+
+            new_intensity.insert(new_intensity.end(), _intensities[i].begin(),
+                                _intensities[i].end());
+            _intensities[i].swap(new_intensity);
+        }
+
+        _v_angles.swap(new_v_angles);
+
+    } else if (v_first == -90.0f) {
+        // We have full 180° coverage, so just shift to match the angle range
+        // convention
+        for (int i = 0; i < _v_angles.size(); i++) {
+            _v_angles[i] += 90.0f;
+        }
+    }
+
+    return true;
+}
+
+bool IESFile::process_type_c() {
+    if (_h_angles[0] == 90.0f) {
+        // Some files are stored from 90° to 270°, so we just rotate them to the
+        // regular 0°-180° range here
+        for (int i = 0; i < _h_angles.size(); i++) {
+            _h_angles[i] -= 90.0f;
+        }
+    }
+
+    if (_h_angles[0] != 0.0f) {
+        return false;
+    }
+
+    if (_h_angles.size() == 1) {
+        _h_angles.push_back(360.0f);
+        _intensities.push_back(_intensities[0]);
+    }
+
+    if (_h_angles[_h_angles.size() - 1] == 90.0f) {
+        // Only one quadrant is defined, so we need to mirror twice (from one to
+        // two, then to four). Since the two->four mirroring step might also be
+        // required if we get an input of two quadrants, we only do the first mirror
+        // here and later do the second mirror in either case.
+        int hnum = _h_angles.size();
+        for (int i = hnum - 2; i >= 0; i--) {
+            _h_angles.push_back(180.0f - _h_angles[i]);
+            _intensities.push_back(_intensities[i]);
+        }
+    }
+
+    if (_h_angles[_h_angles.size() - 1] == 180.0f) {
+        // Mirror half to the full range
+        int hnum = _h_angles.size();
+        for (int i = hnum - 2; i >= 0; i--) {
+            _h_angles.push_back(360.0f - _h_angles[i]);
+            _intensities.push_back(_intensities[i]);
+        }
+    }
+
+    // Some files skip the 360° entry (contrary to standard) because it's supposed
+    // to be identical to the 0° entry. If the file has a discernible order in its
+    // spacing, just fix this.
+    if (_h_angles[_h_angles.size() - 1] != 360.0f) {
+        int hnum = _h_angles.size();
+        float last_step = _h_angles[hnum - 1] - _h_angles[hnum - 2];
+        float first_step = _h_angles[1] - _h_angles[0];
+        float difference = 360.0f - _h_angles[hnum - 1];
+        if (last_step == difference || first_step == difference) {
+            _h_angles.push_back(360.0f);
+            _intensities.push_back(_intensities[0]);
+        } else {
+            return false;
+        }
+    }
+
+    float v_first = _v_angles[0], v_last = _v_angles[_v_angles.size() - 1];
+    if (v_first == 90.0f) {
+        if (v_last != 180.0f) {
+            return false;
+        }
+    } else if (v_first != 0.0f) {
+        return false;
+    }
+
+    return true;
+}
+
+static float linearstep(float x, float a, float b) {
+    if (x <= a) {
+        return 0.0f;
+    }
+
+    if (x >= b) {
+        return 1.0f;
+    }
+
+    return (x - a) / (b - a);
+}
+
+static float lerp(float a, float b, float t) {
+    return (1.0f - t) * a + t * b;
+}
+
+bool IESFile::process() {
+    if (_h_angles.size() == 0 || _v_angles.size() == 0) {
+        return false;
+    }
+
+    if (_type == TYPE_B) {
+        if (!process_type_b()) {
+            return false;
+        }
+    } else {
+        assert(type == TYPE_C);
+        if (!process_type_c()) {
+            return false;
+        }
+    }
+
+    assert(_v_angles[0] == 0.0f || _v_angles[0] == 90.0f);
+    assert(_h_angles[0] == 0.0f);
+    assert(_h_angles[_h_angles.size() - 1] == 360.0f);
+
+    #if !defined(M_PI)
+    #define M_PI 3.14159265358979323846
+    #endif
+
+    // Convert from deg to rad
+    float v_angleMin = std::numeric_limits<float>::max();
+    float v_angleMax = std::numeric_limits<float>::min();
+    for (int i = 0; i < _v_angles.size(); i++) {
+        _v_angles[i] *= M_PI / 180.f;
+        v_angleMin = std::min(v_angleMin, _v_angles[i]);
+        v_angleMax = std::max(v_angleMax, _v_angles[i]);
+    }
+
+    // // does the distribution cover the whole sphere?
+    bool is_sphere = false;
+    if ((v_angleMax - v_angleMin) > (M_PI/2 + 0.1 /* fudge factor*/)) {
+        is_sphere = true;
+    }
+
+    for (int i = 0; i < _h_angles.size(); i++) {
+        _h_angles[i] *= M_PI / 180.f;
+    }
+
+    for (auto const& v_slice: _intensities) {
+        for (auto const& i: v_slice) {
+            _peakIntensity = std::max(_peakIntensity, i);
+        }
+    }
+
+    // integrate the intensity over solid angle to get power
+    for (int h = 0; h < _h_angles.size() - 1; ++h) {
+        for (int v = 0; v < _v_angles.size() - 1; ++v) {
+            // approximate dimensions of the patch
+            float dh = _h_angles[h+1] - _h_angles[h];
+            float dv = _v_angles[v+1] - _v_angles[v];
+            // bilinearly interpolate intensity at the patch center
+            float i0 = (_intensities[h][v] + _intensities[h][v+1]) / 2;
+            float i1 = (_intensities[h+1][v] + _intensities[h+1][v+1]) / 2;
+            float intensity = (i0 + i1) / 2;
+            // solid angle of the patch
+            float dS = dh * dv * sinf(_v_angles[v] + dv/2);
+            _power += dS * intensity;
+        }
+    }
+    
+    // XXX: and this factor matches Karma & RIS
+    _power /= M_PI * (is_sphere ? 4 : 2);
+
+    return true;
+}
+
+float IESFile::eval(float theta, float phi) const {
+    int hi = -1;
+    int vi = -1;
+    float dh = 0;
+    float dv = 0;
+
+    if (phi < 0) {
+        phi += 2 * M_PI;
+    } else if (phi > 2* M_PI) {
+        phi -= 2 * M_PI;
+    }
+
+    for (int i = 0; i < _h_angles.size() - 1; ++i) {
+        if (phi >= _h_angles[i] && phi < _h_angles[i+1]) {
+            hi = i;
+            dh = linearstep(phi, _h_angles[i], _h_angles[i+1]);
+            break;
+        }
+    }
+
+    if (theta < 0) {
+        vi = 0;
+        dv = 0;
+    } else if (theta >= M_PI) {
+        vi = _v_angles.size()-2;
+        dv = 1;
+    } else {
+        for (int i = 0; i < _v_angles.size() - 1; ++i) {
+            if (theta >= _v_angles[i] && theta < _v_angles[i+1]) {
+                vi = i;
+                dv = linearstep(theta, _v_angles[i], _v_angles[i+1]);
+                break;
+            }
+        }
+    }
+
+    if (hi == -1 || vi == -1) {
+        // XXX: need to indicate error somehow here
+        return 0.0f;
+    }
+
+    // XXX: This should be a cubic interpolation
+    float i0 = lerp(_intensities[hi][vi], _intensities[hi][vi+1], dv);
+    float i1 = lerp(_intensities[hi+1][vi], _intensities[hi+1][vi+1], dv);
+
+    return lerp(i0, i1, dh);
+}
+
+IESFile::~IESFile() { clear(); }

--- a/pxr/imaging/plugin/hdEmbree/ies.cpp
+++ b/pxr/imaging/plugin/hdEmbree/ies.cpp
@@ -439,7 +439,12 @@ bool IESFile::process() {
     return true;
 }
 
-float IESFile::eval(float theta, float phi) const {
+static float Clamp(float x, float mn=0.0f, float mx=1.0f) {
+    return std::max(mn, std::min(x, mx));
+}
+
+
+float IESFile::eval(float theta, float phi, float angleScale) const {
     int hi = -1;
     int vi = -1;
     float dh = 0;
@@ -459,9 +464,15 @@ float IESFile::eval(float theta, float phi) const {
         }
     }
 
+    float v = theta / M_PI;
+    const float temp1 = (1.0f - (v / angleScale));
+    const float temp2 = Clamp(temp1 * 0.5f);
+    theta = v * M_PI;
+
     if (theta < 0) {
-        vi = 0;
-        dv = 0;
+        // vi = 0;
+        // dv = 0;
+        return 0.0f;
     } else if (theta >= M_PI) {
         vi = _v_angles.size()-2;
         dv = 1;

--- a/pxr/imaging/plugin/hdEmbree/ies.h
+++ b/pxr/imaging/plugin/hdEmbree/ies.h
@@ -1,0 +1,65 @@
+/* SPDX-FileCopyrightText: 2011-2022 Blender Foundation
+ *
+ * SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __UTIL_IES_H__
+#define __UTIL_IES_H__
+
+#include <string>
+#include <vector>
+
+class IESFile {
+public:
+    IESFile() {}
+    ~IESFile();
+
+    int packed_size();
+    void pack(float *data);
+
+    bool load(const std::string &ies);
+    void clear();
+
+    // returns true if the IES files was successfully loaded and processed and is ready to evaluate
+    bool valid() const {
+        return !_intensities.empty();
+    }
+
+    // evaluate the IES file for the given spherical coordinates
+    float eval(float theta, float phi) const;
+
+    float peakIntensity() const {
+        return _peakIntensity;
+    }
+
+    float forwardIntensity() const {
+        return valid() ? _intensities[0][0] : 0.0f;
+    }
+
+    float power() const {
+        return _power;
+    }
+
+protected:
+    bool parse(const std::string &ies);
+    bool process();
+    bool process_type_b();
+    bool process_type_c();
+
+    // The brightness distribution is stored in spherical coordinates.
+    // The horizontal angles correspond to phi in the PBRT notation
+    // and always span the full range from 0° to 360°.
+    // The vertical angles correspond to theta and always start at 0°.
+    std::vector<float> _v_angles, _h_angles;
+
+    // The actual values are stored here, with every entry storing the values
+    // of one horizontal segment.
+    std::vector<std::vector<float>> _intensities;
+
+    float _peakIntensity = 0;
+    float _power = 0;
+
+    // Types of angle representation in IES files. Currently, only B and C are supported.
+    enum IESType { TYPE_A = 3, TYPE_B = 2, TYPE_C = 1 } _type;
+};
+
+#endif /* __UTIL_IES_H__ */

--- a/pxr/imaging/plugin/hdEmbree/ies.h
+++ b/pxr/imaging/plugin/hdEmbree/ies.h
@@ -25,7 +25,7 @@ public:
     }
 
     // evaluate the IES file for the given spherical coordinates
-    float eval(float theta, float phi) const;
+    float eval(float theta, float phi, float angleScale) const;
 
     float peakIntensity() const {
         return _peakIntensity;

--- a/pxr/imaging/plugin/hdEmbree/light.cpp
+++ b/pxr/imaging/plugin/hdEmbree/light.cpp
@@ -1,0 +1,223 @@
+#include "light.h"
+#include "ies.h"
+#include "renderParam.h"
+#include "renderer.h"
+
+#include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/imaging/hd/tokens.h"
+#include <pxr/imaging/hio/image.h>
+
+#include <embree3/rtcore_buffer.h>
+#include <embree3/rtcore_common.h>
+#include <embree3/rtcore_device.h>
+#include <embree3/rtcore_geometry.h>
+#include <embree3/rtcore_scene.h>
+#include <memory>
+#include <fstream>
+#include <sstream>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdEmbreeLight::HdEmbreeLight(SdfPath const &id, TfToken const &lightType)
+    : HdLight(id), _lightType(lightType) {
+    if (!id.IsEmpty()) {
+        TF_WARN("Creating light %s: %s", id.GetText(), lightType.GetText());
+    }
+}
+
+HdEmbreeLight::~HdEmbreeLight() {}
+
+static LightTexture LoadLightTexture(std::string const& path)
+{
+    if (path.empty()) {
+        return { nullptr, 0, 0 };
+    }
+
+    HioImageSharedPtr img = HioImage::OpenForReading(path);
+    if (!img) {
+        return { nullptr, 0, 0 };
+    }
+
+    int width = img->GetWidth();
+    int height = img->GetHeight();
+
+    GfVec3f* pixels = new GfVec3f[width * height * 3];
+
+    HioImage::StorageSpec storage;
+    storage.width = width;
+    storage.height = height;
+    storage.depth = 1;
+    storage.format = HioFormatFloat32Vec3;
+    storage.data = pixels;
+
+    if (img->Read(storage)) {
+        return {pixels, width, height};
+    } else {
+        TF_WARN("Could not read image %s", path.c_str());
+        return { nullptr, 0, 0 };
+    }
+}
+
+void HdEmbreeLight::Sync(HdSceneDelegate *sceneDelegate,
+                         HdRenderParam *renderParam, HdDirtyBits *dirtyBits) {
+    HdEmbreeRenderParam *embreeRenderParam =
+        static_cast<HdEmbreeRenderParam*>(renderParam);
+
+    // grabbin this bumps the scene version and causes a re-render
+    RTCScene scene = embreeRenderParam->AcquireSceneForEdit();
+    RTCDevice device = embreeRenderParam->GetEmbreeDevice();
+
+    SdfPath const &id = GetId();
+    Light light;
+
+    // Get light's transform. We'll only consider the first time sample for now
+    HdTimeSampleArray<GfMatrix4d, 1> xformSamples;
+    sceneDelegate->SampleTransform(id, &xformSamples);
+    light.xformLightToWorld = GfMatrix4f(xformSamples.values[0]);
+    light.xformWorldToLight = light.xformLightToWorld.GetInverse();
+
+    // Store luminance parameters
+    light.intensity = sceneDelegate->GetLightParamValue(id, HdLightTokens->intensity).Get<float>();
+    light.exposure = sceneDelegate->GetLightParamValue(id, HdLightTokens->exposure).Get<float>();
+    light.color = sceneDelegate->GetLightParamValue(id, HdLightTokens->color).Get<GfVec3f>();
+    light.normalize = sceneDelegate->GetLightParamValue(id, HdLightTokens->normalize).Get<bool>();
+    light.colorTemperature = sceneDelegate->GetLightParamValue(id, HdLightTokens->colorTemperature).Get<float>();
+    light.enableColorTemperature = sceneDelegate->GetLightParamValue(id, HdLightTokens->enableColorTemperature).Get<bool>();
+
+    // Get visibility
+    light.visible = sceneDelegate->GetVisible(id);
+    light.visible_camera = sceneDelegate->GetLightParamValue(id, TfToken("inputs:visibility:camera")).GetWithDefault<bool>(false);
+    // XXX: Don't think we can get this to work in Embree unless it's built with masking
+    // only solution would be to use rtcIntersect instead of rtcOccluded for shadow rays, which
+    // maybe isn't the worst for a reference renderer
+    light.visible_shadow = sceneDelegate->GetLightParamValue(id, TfToken("inputs:visibility:shadow")).GetWithDefault<bool>(false);
+
+    light.rtcMeshId = RTC_INVALID_GEOMETRY_ID;
+
+    // Switch on the light type and pull the relevant attributes from the scene delegate
+    if (_lightType == HdSprimTypeTokens->cylinderLight) {
+        light.kind = LightKind::Cylinder;
+        light.cylinder = {
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
+                .Get<float>(),
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->length)
+                .Get<float>(),
+        };
+    } else if (_lightType == HdSprimTypeTokens->diskLight) {
+        light.kind = LightKind::Disk;
+        light.disk = {
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
+                .Get<float>(),
+        };
+    } else if (_lightType == HdSprimTypeTokens->distantLight) {
+        light.kind = LightKind::Distant;
+
+        light.distant = {
+            float(GfDegreesToRadians(sceneDelegate->GetLightParamValue(id, HdLightTokens->angle)
+                .Get<float>() / 2.0f)),
+        };
+
+    } else if (_lightType == HdSprimTypeTokens->domeLight) {
+        light.kind = LightKind::Dome;
+        
+        SdfAssetPath texturePath = sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile).Get<SdfAssetPath>();
+        std::string const& resolvedPath = texturePath.GetResolvedPath();
+        light.texture = LoadLightTexture(resolvedPath);
+    } else if (_lightType == HdSprimTypeTokens->rectLight) {
+        // Get shape parameters
+        light.kind = LightKind::Rect;
+        light.rect = {
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->width)
+                .Get<float>(),
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->height)
+                .Get<float>(),
+        };
+        
+        // get texture
+        SdfAssetPath texturePath = sceneDelegate->GetLightParamValue(id, HdLightTokens->textureFile).Get<SdfAssetPath>();
+        std::string path = texturePath.GetResolvedPath();
+        if (path.empty()) {
+            path = texturePath.GetAssetPath();
+        }
+        light.texture = LoadLightTexture(path);
+    } else if (_lightType == HdSprimTypeTokens->sphereLight) {
+        light.kind = LightKind::Sphere;
+        light.sphere = {
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->radius)
+                .Get<float>(),
+        };
+    } else if (_lightType == HdSprimTypeTokens->diskLight) {
+        light.kind = LightKind::Disk;
+        light.disk = {
+            sceneDelegate->GetLightParamValue(id, HdLightTokens->radius).Get<float>()
+        };
+    }
+
+    VtValue value;
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingFocus);
+    if (value.IsHolding<float>()) {
+        light.shaping.focus = value.UncheckedGet<float>();
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingFocusTint);
+    if (value.IsHolding<GfVec3f>()) {
+        light.shaping.focusTint = value.UncheckedGet<GfVec3f>();
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingConeAngle);
+    if (value.IsHolding<float>()) {
+        light.shaping.coneAngle = value.UncheckedGet<float>();
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingConeSoftness);
+    if (value.IsHolding<float>()) {
+        light.shaping.coneSoftness = value.UncheckedGet<float>();
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingIesFile);
+    if (value.IsHolding<SdfAssetPath>()) {
+        SdfAssetPath iesAssetPath = value.UncheckedGet<SdfAssetPath>();
+        std::string iesPath = iesAssetPath.GetResolvedPath();
+        if (iesPath.empty()) {
+            iesPath = iesAssetPath.GetAssetPath();
+        }
+
+        if (!iesPath.empty()) {
+            std::ifstream in(iesPath);
+            if (!in.is_open()) {
+                printf("ERROR: could not open ies file %s\n", iesPath.c_str());
+            }
+            std::stringstream buffer;
+            buffer << in.rdbuf();
+
+            if (!light.shaping.ies.iesFile.load(buffer.str())) {
+                printf("could not load ies file\n");
+            }
+        }
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingIesNormalize);
+    if (value.IsHolding<bool>()) {
+        light.shaping.ies.normalize = value.UncheckedGet<bool>();
+    }
+
+    value = sceneDelegate->GetLightParamValue(id, HdLightTokens->shapingIesAngleScale);
+    if (value.IsHolding<float>()) {
+        light.shaping.ies.angleScale = value.UncheckedGet<float>();
+    }
+
+    HdEmbreeRenderer *renderer =
+        static_cast<HdEmbreeRenderParam *>(renderParam)->GetRenderer();
+    _lightId = renderer->SetLight(id, std::move(light), device);
+
+    *dirtyBits &= ~HdLight::AllDirty;
+}
+
+HdDirtyBits HdEmbreeLight::GetInitialDirtyBitsMask() const {
+    return HdLight::AllDirty;
+}
+
+void HdEmbreeLight::Finalize(HdRenderParam *renderParam) {
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/plugin/hdEmbree/light.h
+++ b/pxr/imaging/plugin/hdEmbree/light.h
@@ -1,0 +1,156 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_IMAGING_PLUGIN_HD_EMBREE_LIGHT_H
+#define PXR_IMAGING_PLUGIN_HD_EMBREE_LIGHT_H
+
+#include "ies.h"
+
+#include <embree3/rtcore_common.h>
+#include <embree3/rtcore_geometry.h>
+#include <pxr/imaging/hd/light.h>
+
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/matrix4f.h>
+#include <limits>
+#include <memory>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+enum class LightKind: int
+{
+    Cylinder,
+    Disk,
+    Distant,
+    Dome,
+    Rect,
+    Sphere
+};
+
+struct Cylinder
+{
+    float radius;
+    float length;
+};
+
+struct Disk
+{
+    float radius;
+};
+
+struct Distant
+{
+    float halfAngleRadians;
+};
+
+struct LightTexture
+{
+    GfVec3f* pixels = nullptr;
+    int width;
+    int height;
+};
+
+struct Rect 
+{
+    float width;
+    float height;
+};
+
+struct Sphere
+{
+    float radius;
+};
+
+struct IES
+{
+    IESFile iesFile;
+    bool normalize;
+    float angleScale;
+};
+
+struct Shaping
+{
+    GfVec3f focusTint;
+    float focus;
+    float coneAngle;
+    float coneSoftness;
+    IES ies;
+};
+
+struct Light 
+{
+    GfMatrix4f xformLightToWorld;
+    GfMatrix4f xformWorldToLight;
+    GfVec3f color;
+    LightTexture texture;
+    float intensity;
+    float exposure;
+    float colorTemperature;
+    bool enableColorTemperature;
+    LightKind kind;
+    union
+    {
+        Cylinder cylinder;
+        Disk disk;
+        Distant distant;
+        Rect rect;
+        Sphere sphere;
+    };
+    bool normalize;
+    bool visible;
+    bool visible_camera;
+    bool visible_shadow;
+    Shaping shaping;
+    unsigned rtcMeshId = RTC_INVALID_GEOMETRY_ID;
+    RTCGeometry rtcGeometry;
+};
+
+constexpr unsigned InvalidLightId = std::numeric_limits<unsigned>::max();
+
+class HdEmbreeLight final : public HdLight 
+{
+public:
+    HdEmbreeLight(SdfPath const& id, TfToken const& lightType);
+    ~HdEmbreeLight();
+
+    /// Synchronizes state from the delegate to this object.
+    void Sync(HdSceneDelegate* sceneDelegate, 
+              HdRenderParam* renderParam,
+              HdDirtyBits* dirtyBits) override;
+
+    /// Returns the minimal set of dirty bits to place in the
+    /// change tracker for use in the first sync of this prim.
+    /// Typically this would be all dirty bits.
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+    void Finalize(HdRenderParam *renderParam) override;
+
+private:
+    TfToken _lightType;
+    unsigned _lightId = InvalidLightId;
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/plugin/hdEmbree/light.h
+++ b/pxr/imaging/plugin/hdEmbree/light.h
@@ -66,8 +66,8 @@ struct Distant
 struct LightTexture
 {
     GfVec3f* pixels = nullptr;
-    int width;
-    int height;
+    int width = 0;
+    int height = 0;
 };
 
 struct Rect 
@@ -84,16 +84,16 @@ struct Sphere
 struct IES
 {
     IESFile iesFile;
-    bool normalize;
-    float angleScale;
+    bool normalize = false;
+    float angleScale = 0.0f;
 };
 
 struct Shaping
 {
     GfVec3f focusTint;
-    float focus;
-    float coneAngle;
-    float coneSoftness;
+    float focus = 0.0f;
+    float coneAngle = 180.0f;
+    float coneSoftness = 0.0f;
     IES ies;
 };
 
@@ -103,10 +103,10 @@ struct Light
     GfMatrix4f xformWorldToLight;
     GfVec3f color;
     LightTexture texture;
-    float intensity;
-    float exposure;
-    float colorTemperature;
-    bool enableColorTemperature;
+    float intensity = 1.0f;
+    float exposure = 0.0f;
+    float colorTemperature = 6500.0f;
+    bool enableColorTemperature = false;
     LightKind kind;
     union
     {
@@ -116,10 +116,10 @@ struct Light
         Rect rect;
         Sphere sphere;
     };
-    bool normalize;
-    bool visible;
-    bool visible_camera;
-    bool visible_shadow;
+    bool normalize = false;
+    bool visible = true;
+    bool visible_camera = true;
+    bool visible_shadow = true;
     Shaping shaping;
     unsigned rtcMeshId = RTC_INVALID_GEOMETRY_ID;
     RTCGeometry rtcGeometry;

--- a/pxr/imaging/plugin/hdEmbree/mesh.cpp
+++ b/pxr/imaging/plugin/hdEmbree/mesh.cpp
@@ -911,6 +911,7 @@ HdEmbreeMesh::_PopulateRtMesh(HdSceneDelegate* sceneDelegate,
             HdEmbreeInstanceContext *ctx = new HdEmbreeInstanceContext;
             ctx->rootScene = _rtcMeshScene;
             ctx->instanceId = i;
+            ctx->lightIndex = -1;
             rtcSetGeometryUserData(geom,ctx);
             _rtcInstanceGeometries[i] = geom;
         }

--- a/pxr/imaging/plugin/hdEmbree/mesh.h
+++ b/pxr/imaging/plugin/hdEmbree/mesh.h
@@ -37,8 +37,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HdEmbreePrototypeContext;
-class HdEmbreeInstanceContext;
+struct HdEmbreePrototypeContext;
+struct HdEmbreeInstanceContext;
 
 /// \class HdEmbreeMesh
 ///

--- a/pxr/imaging/plugin/hdEmbree/pcg_basic.cpp
+++ b/pxr/imaging/plugin/hdEmbree/pcg_basic.cpp
@@ -1,0 +1,116 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *       http://www.pcg-random.org
+ */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#include "pcg_basic.h"
+
+// state for global RNGs
+
+static pcg32_random_t pcg32_global = PCG32_INITIALIZER;
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate, uint64_t initseq)
+{
+    rng->state = 0U;
+    rng->inc = (initseq << 1u) | 1u;
+    pcg32_random_r(rng);
+    rng->state += initstate;
+    pcg32_random_r(rng);
+}
+
+void pcg32_srandom(uint64_t seed, uint64_t seq)
+{
+    pcg32_srandom_r(&pcg32_global, seed, seq);
+}
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random_r(pcg32_random_t* rng)
+{
+    uint64_t oldstate = rng->state;
+    rng->state = oldstate * 6364136223846793005ULL + rng->inc;
+    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+    uint32_t rot = oldstate >> 59u;
+    return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+}
+
+uint32_t pcg32_random()
+{
+    return pcg32_random_r(&pcg32_global);
+}
+
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand_r(pcg32_random_t* rng, uint32_t bound)
+{
+    // To avoid bias, we need to make the range of the RNG a multiple of
+    // bound, which we do by dropping output less than a threshold.
+    // A naive scheme to calculate the threshold would be to do
+    //
+    //     uint32_t threshold = 0x100000000ull % bound;
+    //
+    // but 64-bit div/mod is slower than 32-bit div/mod (especially on
+    // 32-bit platforms).  In essence, we do
+    //
+    //     uint32_t threshold = (0x100000000ull-bound) % bound;
+    //
+    // because this version will calculate the same modulus, but the LHS
+    // value is less than 2^32.
+
+    uint32_t threshold = -bound % bound;
+
+    // Uniformity guarantees that this loop will terminate.  In practice, it
+    // should usually terminate quickly; on average (assuming all bounds are
+    // equally likely), 82.25% of the time, we can expect it to require just
+    // one iteration.  In the worst case, someone passes a bound of 2^31 + 1
+    // (i.e., 2147483649), which invalidates almost 50% of the range.  In 
+    // practice, bounds are typically small and only a tiny amount of the range
+    // is eliminated.
+    for (;;) {
+        uint32_t r = pcg32_random_r(rng);
+        if (r >= threshold)
+            return r % bound;
+    }
+}
+
+
+uint32_t pcg32_boundedrand(uint32_t bound)
+{
+    return pcg32_boundedrand_r(&pcg32_global, bound);
+}
+

--- a/pxr/imaging/plugin/hdEmbree/pcg_basic.h
+++ b/pxr/imaging/plugin/hdEmbree/pcg_basic.h
@@ -1,0 +1,78 @@
+/*
+ * PCG Random Number Generation for C.
+ *
+ * Copyright 2014 Melissa O'Neill <oneill@pcg-random.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For additional information about the PCG random number generation scheme,
+ * including its license and other licensing options, visit
+ *
+ *     http://www.pcg-random.org
+ */
+
+/*
+ * This code is derived from the full C implementation, which is in turn
+ * derived from the canonical C++ PCG implementation. The C++ version
+ * has many additional features and is preferable if you can use C++ in
+ * your project.
+ */
+
+#ifndef PCG_BASIC_H_INCLUDED
+#define PCG_BASIC_H_INCLUDED 1
+
+#include <inttypes.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+struct pcg_state_setseq_64 {    // Internals are *Private*.
+    uint64_t state;             // RNG state.  All values are possible.
+    uint64_t inc;               // Controls which RNG sequence (stream) is
+                                // selected. Must *always* be odd.
+};
+typedef struct pcg_state_setseq_64 pcg32_random_t;
+
+// If you *must* statically initialize it, here's one.
+
+#define PCG32_INITIALIZER   { 0x853c49e6748fea9bULL, 0xda3e39cb94b95bdbULL }
+
+// pcg32_srandom(initstate, initseq)
+// pcg32_srandom_r(rng, initstate, initseq):
+//     Seed the rng.  Specified in two parts, state initializer and a
+//     sequence selection constant (a.k.a. stream id)
+
+void pcg32_srandom(uint64_t initstate, uint64_t initseq);
+void pcg32_srandom_r(pcg32_random_t* rng, uint64_t initstate,
+                     uint64_t initseq);
+
+// pcg32_random()
+// pcg32_random_r(rng)
+//     Generate a uniformly distributed 32-bit random number
+
+uint32_t pcg32_random(void);
+uint32_t pcg32_random_r(pcg32_random_t* rng);
+
+// pcg32_boundedrand(bound):
+// pcg32_boundedrand_r(rng, bound):
+//     Generate a uniformly distributed number, r, where 0 <= r < bound
+
+uint32_t pcg32_boundedrand(uint32_t bound);
+uint32_t pcg32_boundedrand_r(pcg32_random_t* rng, uint32_t bound);
+
+#if __cplusplus
+}
+#endif
+
+#endif // PCG_BASIC_H_INCLUDED

--- a/pxr/imaging/plugin/hdEmbree/renderBuffer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderBuffer.cpp
@@ -274,9 +274,11 @@ HdEmbreeRenderBuffer::Resolve()
     size_t formatSize = HdDataSizeOfFormat(_format);
     size_t sampleSize = HdDataSizeOfFormat(_GetSampleFormat(_format));
 
+    int maxSampleCount = 0;
     for (unsigned int i = 0; i < _width * _height; ++i) {
 
         int sampleCount = _sampleCount[i];
+        maxSampleCount = std::max(sampleCount, maxSampleCount);
         // Skip pixels with no samples.
         if (sampleCount == 0) {
             continue;

--- a/pxr/imaging/plugin/hdEmbree/renderBuffer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderBuffer.h
@@ -183,7 +183,7 @@ private:
     // For multisampled buffers: the input write buffer.
     std::vector<uint8_t> _sampleBuffer;
     // For multisampled buffers: the sample count buffer.
-    std::vector<uint8_t> _sampleCount;
+    std::vector<uint32_t> _sampleCount;
 
     // The number of callers mapping this buffer.
     std::atomic<int> _mappers;

--- a/pxr/imaging/plugin/hdEmbree/renderParam.h
+++ b/pxr/imaging/plugin/hdEmbree/renderParam.h
@@ -32,6 +32,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdEmbreeRenderer;
+
 ///
 /// \class HdEmbreeRenderParam
 ///
@@ -44,9 +46,10 @@ class HdEmbreeRenderParam final : public HdRenderParam
 public:
     HdEmbreeRenderParam(RTCDevice device, RTCScene scene,
                         HdRenderThread *renderThread,
+                        HdEmbreeRenderer *renderer,
                         std::atomic<int> *sceneVersion)
         : _scene(scene), _device(device)
-        , _renderThread(renderThread), _sceneVersion(sceneVersion)
+        , _renderThread(renderThread), _renderer(renderer), _sceneVersion(sceneVersion)
     {}
 
     /// Accessor for the top-level embree scene.
@@ -58,6 +61,8 @@ public:
     /// Accessor for the top-level embree device (library handle).
     RTCDevice GetEmbreeDevice() { return _device; }
 
+    HdEmbreeRenderer* GetRenderer() { return _renderer; }
+
 private:
     /// A handle to the top-level embree scene.
     RTCScene _scene;
@@ -65,6 +70,7 @@ private:
     RTCDevice _device;
     /// A handle to the global render thread.
     HdRenderThread *_renderThread;
+    HdEmbreeRenderer* _renderer;
     /// A version counter for edits to _scene.
     std::atomic<int> *_sceneVersion;
 };

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -1300,15 +1300,15 @@ float EvalIES(Light const& light, GfVec3f const& wI) {
     float phi = Phi(wE);
 
     // apply angle scale to theta, matching Karma
-    if (ies.angleScale > 0) {
-        theta = Clamp(theta / (1 - ies.angleScale), 0, M_PI);
-    } else if (ies.angleScale < 0) {
-        theta = Clamp(theta / (1 / (1 + ies.angleScale)), 0, M_PI);
-    }
+    // if (ies.angleScale > 0) {
+    //     theta = Clamp(theta / (1 - ies.angleScale), 0, M_PI);
+    // } else if (ies.angleScale < 0) {
+    //     theta = Clamp(theta / (1 / (1 + ies.angleScale)), 0, M_PI);
+    // }
 
     float norm = ies.normalize ? ies.iesFile.power() : 1.0f;
 
-    return ies.iesFile.eval(theta, phi) / norm;
+    return ies.iesFile.eval(theta, phi, ies.angleScale) / norm;
 }
 
 GfVec3f SampleLightTexture(LightTexture const& texture, float s, float t)

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -38,7 +38,7 @@
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/work/loops.h"
 
-#include "pxr/base/tf/hash.h"
+#include <boost/functional/hash.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -543,8 +543,6 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
 
         // Render by scheduling square tiles of the sample buffer in a parallel
         // for loop.
-        // Always pass the renderThread to _RenderTiles to allow the first frame
-        // to be interrupted.
         WorkParallelForN(numTilesX*numTilesY,
             std::bind(&HdEmbreeRenderer::_RenderTiles, this, renderThread,
                 std::placeholders::_1, std::placeholders::_2));
@@ -586,8 +584,7 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
 }
 
 void
-HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
-                                int progression,
+HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread, 
                                size_t tileStart, size_t tileEnd)
 {
     const unsigned int minX = _dataWindow.GetMinX();

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -21,12 +21,16 @@
 // KIND, either express or implied. See the Apache License for the specific
 // language governing permissions and limitations under the Apache License.
 //
-#include "pxr/imaging/plugin/hdEmbree/renderer.h"
+#include "renderer.h"
+#include "context.h"
+#include "light.h"
+#include "pcg_basic.h"
 
 #include "pxr/imaging/plugin/hdEmbree/renderBuffer.h"
 #include "pxr/imaging/plugin/hdEmbree/config.h"
 #include "pxr/imaging/plugin/hdEmbree/context.h"
 #include "pxr/imaging/plugin/hdEmbree/mesh.h"
+#include <pxr/usd/usdLux/blackbody.h>
 
 #include "pxr/imaging/hd/perfLog.h"
 
@@ -36,7 +40,15 @@
 
 #include "pxr/base/tf/hash.h"
 
+#include <algorithm>
 #include <chrono>
+#include <embree3/rtcore_common.h>
+#include <embree3/rtcore_geometry.h>
+#include <embree3/rtcore_ray.h>
+#include <embree3/rtcore_scene.h>
+#include <limits>
+#include <random>
+#include <stdint.h>
 #include <thread>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -57,10 +69,21 @@ HdEmbreeRenderer::HdEmbreeRenderer()
     , _ambientOcclusionSamples(0)
     , _enableSceneColors(false)
     , _completedSamples(0)
+    , _domeIndex(-1)
 {
 }
 
-HdEmbreeRenderer::~HdEmbreeRenderer() = default;
+HdEmbreeRenderer::~HdEmbreeRenderer()
+{
+    // delete any light textures that have been allocated
+    for (auto const& light: _lights)
+    {
+        if (light.kind == LightKind::Dome)
+        {
+            delete[] light.texture.pixels;
+        }
+    }
+}
 
 void
 HdEmbreeRenderer::SetScene(RTCScene scene)
@@ -121,6 +144,80 @@ HdEmbreeRenderer::SetAovBindings(
 
     // Re-validate the attachments.
     _aovBindingsNeedValidation = true;
+}
+
+unsigned HdEmbreeRenderer::SetLight(SdfPath const& lightPath, Light new_light, RTCDevice device)
+{
+
+    size_t light_index = -1;
+    auto it = _lightMap.find(lightPath);
+    if (it != _lightMap.end())
+    {
+        // if we're updating an existing light, first clean up the old old light's data
+        Light& old_light = _lights[it->second];
+        delete[] old_light.texture.pixels;
+        old_light.texture.pixels = nullptr;
+        if (old_light.rtcMeshId != RTC_INVALID_GEOMETRY_ID) {
+            rtcDetachGeometry(_scene, old_light.rtcMeshId);
+            rtcReleaseGeometry(old_light.rtcGeometry);
+            old_light.rtcMeshId = RTC_INVALID_GEOMETRY_ID;
+        }
+
+        // then assign the new light to the existing slot
+        _lights[it->second] = new_light;
+        light_index = it->second;
+    }
+    else
+    {
+        // new light isn't in the scene already, add it
+        _lights.push_back(new_light);
+        _lightMap[lightPath] = _lights.size() - 1;
+        light_index = _lights.size() - 1;
+    }
+
+    Light& light = _lights[light_index];
+
+    // Now create the light geometry, if required
+    // we do this last because we need the light index for the instance context
+    if (light.kind == LightKind::Rect && light.visible)
+    {
+        // create light mesh
+        GfVec3f v0(-light.rect.width/2, -light.rect.height/2, 0);
+        GfVec3f v1( light.rect.width/2, -light.rect.height/2, 0);
+        GfVec3f v2( light.rect.width/2,  light.rect.height/2, 0);
+        GfVec3f v3(-light.rect.width/2,  light.rect.height/2, 0);
+
+        v0 = light.xformLightToWorld.Transform(v0);
+        v1 = light.xformLightToWorld.Transform(v1);
+        v2 = light.xformLightToWorld.Transform(v2);
+        v3 = light.xformLightToWorld.Transform(v3);
+
+        light.rtcGeometry = rtcNewGeometry(device, RTC_GEOMETRY_TYPE_QUAD);
+        GfVec3f* vertices = (GfVec3f*)rtcSetNewGeometryBuffer(light.rtcGeometry, RTC_BUFFER_TYPE_VERTEX, 0, RTC_FORMAT_FLOAT3, sizeof(GfVec3f), 4);
+        vertices[0] = v0;
+        vertices[1] = v1;
+        vertices[2] = v2;
+        vertices[3] = v3;
+
+        unsigned* index = (unsigned*)rtcSetNewGeometryBuffer(light.rtcGeometry, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT4, sizeof(unsigned)*4, 1);
+        index[0] = 0; index[1] = 1; index[2] = 2; index[3] = 3;
+
+        auto* ctx = new HdEmbreeInstanceContext;
+        ctx->lightIndex = light_index;
+        rtcSetGeometryUserData(light.rtcGeometry, ctx);
+        rtcSetGeometryTimeStepCount(light.rtcGeometry, 1);
+
+        rtcCommitGeometry(light.rtcGeometry);
+        light.rtcMeshId = rtcAttachGeometry(_scene, light.rtcGeometry);
+        if (light.rtcMeshId == RTC_INVALID_GEOMETRY_ID) {
+            printf("could not create rect mesh\n");
+        }
+    } else if (light.kind == LightKind::Dome) {
+        // if it's a dome, stash its index so we can evaluate it on misses
+        _domeIndex = light_index;
+    }
+
+    return light_index;
 }
 
 bool
@@ -490,6 +587,7 @@ HdEmbreeRenderer::Render(HdRenderThread *renderThread)
 
 void
 HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
+                                int progression,
                                size_t tileStart, size_t tileEnd)
 {
     const unsigned int minX = _dataWindow.GetMinX();
@@ -512,15 +610,8 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
     const unsigned int numTilesX =
         (_dataWindow.GetWidth() + tileSize-1) / tileSize;
 
-    // Initialize the RNG for this tile (each tile creates one as
-    // a lazy way to do thread-local RNGs).
-    size_t seed = std::chrono::system_clock::now().time_since_epoch().count();
-    seed = TfHash::Combine(seed, tileStart);
-    std::default_random_engine random(seed);
-
-    // Create a uniform distribution for jitter calculations.
-    std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+    // Random number state for this thread
+    thread_local PCG pcg(std::hash<std::thread::id>()(std::this_thread::get_id()));
 
     // _RenderTiles gets a range of tiles; iterate through them.
     for (unsigned int tile = tileStart; tile < tileEnd; ++tile) {
@@ -544,11 +635,10 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
         // Loop over pixels casting rays.
         for (unsigned int y = y0; y < y1; ++y) {
             for (unsigned int x = x0; x < x1; ++x) {
-
                 // Jitter the camera ray direction.
                 GfVec2f jitter(0.0f, 0.0f);
                 if (HdEmbreeConfig::GetInstance().jitterCamera) {
-                    jitter = GfVec2f(uniform_float(), uniform_float());
+                    jitter = GfVec2f(pcg.uniform(), pcg.uniform());
                 }
 
                 // Un-transform the pixel's NDC coordinates through the
@@ -584,7 +674,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
                 dir = _inverseViewMatrix.TransformDir(dir).GetNormalized();
 
                 // Trace the ray.
-                _TraceRay(x, y, origin, dir, random);
+                _TraceRay(x, y, origin, dir, pcg);
             }
         }
     }
@@ -593,7 +683,9 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 /// Fill in an RTCRay structure from the given parameters.
 static void
 _PopulateRay(RTCRay *ray, GfVec3f const& origin, 
-             GfVec3f const& dir, float nearest)
+             GfVec3f const& dir, float nearest, 
+             float furthest = std::numeric_limits<float>::infinity(),
+             RayMask mask = RayMask::All)
 {
     ray->org_x = origin[0];
     ray->org_y = origin[1];
@@ -605,24 +697,25 @@ _PopulateRay(RTCRay *ray, GfVec3f const& origin,
     ray->dir_z = dir[2];
     ray->time = 0.0f;
 
-    ray->tfar = std::numeric_limits<float>::infinity();
-    ray->mask = -1;
+    ray->tfar = furthest;
+    ray->mask = static_cast<uint32_t>(mask);
 }
 
 /// Fill in an RTCRayHit structure from the given parameters.
 // note this containts a Ray and a RayHit
 static void
 _PopulateRayHit(RTCRayHit* rayHit, GfVec3f const& origin,
-             GfVec3f const& dir, float nearest)
+             GfVec3f const& dir, float nearest, 
+             float furthest = std::numeric_limits<float>::infinity(), 
+             RayMask mask = RayMask::All)
 {
     // Fill in defaults for the ray
-    _PopulateRay(&rayHit->ray, origin, dir, nearest);
+    _PopulateRay(&rayHit->ray, origin, dir, nearest, furthest, mask);
 
     // Fill in defaults for the hit
     rayHit->hit.primID = RTC_INVALID_GEOMETRY_ID;
     rayHit->hit.geomID = RTC_INVALID_GEOMETRY_ID;
 }
-
 
 /// Generate a random cosine-weighted direction ray (in the hemisphere
 /// around <0,0,1>).  The input is a pair of uniformly distributed random
@@ -643,15 +736,46 @@ _CosineWeightedDirection(GfVec2f const& uniform_float)
     return dir;
 }
 
+bool HdEmbreeRenderer::_RayShouldContinue(RTCRayHit const& rayHit) const {
+    if (rayHit.hit.geomID == RTC_INVALID_GEOMETRY_ID) {
+        // missed, don't continue
+        return false;
+    }
+
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // not hit an instance, but a "raw" geometry. This should be a light
+        const HdEmbreeInstanceContext *instanceContext =
+            static_cast<HdEmbreeInstanceContext*>(
+                    rtcGetGeometryUserData(rtcGetGeometry(_scene, rayHit.hit.geomID)));
+
+        if (instanceContext->lightIndex == -1) {
+            // if this isn't a light, don't know what this is
+            return false;
+        }
+
+        if ((rayHit.ray.mask & RayMask::Camera) && !_lights[instanceContext->lightIndex].visible_camera) {
+            return true;
+        } else if ((rayHit.ray.mask & RayMask::Shadow) && !_lights[instanceContext->lightIndex].visible_shadow) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // XXX: otherwise this is a regular geo. we should handle visibility here too
+    // eventually
+    return false;
+}
+
 void
 HdEmbreeRenderer::_TraceRay(unsigned int x, unsigned int y,
                             GfVec3f const &origin, GfVec3f const &dir,
-                            std::default_random_engine &random)
+                            PCG& pcg)
 {
     // Intersect the camera ray.
     RTCRayHit rayHit; // EMBREE_FIXME: use RTCRay for occlusion rays
     rayHit.ray.flags = 0;
-    _PopulateRayHit(&rayHit, origin, dir, 0.0f);
+    _PopulateRayHit(&rayHit, origin, dir, 0.0f, std::numeric_limits<float>::max(), RayMask::Camera);
     {
       RTCIntersectContext context;
       rtcInitIntersectContext(&context);
@@ -672,6 +796,15 @@ HdEmbreeRenderer::_TraceRay(unsigned int x, unsigned int y,
       rayHit.hit.Ng_z = -rayHit.hit.Ng_z;
     }
 
+    if (_RayShouldContinue(rayHit)) {
+        GfVec3f hitPos = GfVec3f(rayHit.ray.org_x + rayHit.ray.tfar * rayHit.ray.dir_x,
+                rayHit.ray.org_y + rayHit.ray.tfar * rayHit.ray.dir_y,
+                rayHit.ray.org_z + rayHit.ray.tfar * rayHit.ray.dir_z);
+
+        _TraceRay(x, y, hitPos + dir * 0.001f, dir, pcg);
+        return;
+    }
+
     // Write AOVs to attachments that aren't converged.
     for (size_t i = 0; i < _aovBindings.size(); ++i) {
         HdEmbreeRenderBuffer *renderBuffer =
@@ -681,9 +814,9 @@ HdEmbreeRenderer::_TraceRay(unsigned int x, unsigned int y,
             continue;
         }
 
-        if (_aovNames[i].name == HdAovTokens->color) {
+       if (_aovNames[i].name == HdAovTokens->color) {
             GfVec4f clearColor = _GetClearColor(_aovBindings[i].clearValue);
-            GfVec4f sample = _ComputeColor(rayHit, random, clearColor);
+            GfVec4f sample = _ComputeColor(rayHit, pcg, clearColor);
             renderBuffer->Write(GfVec3i(x,y,1), 4, sample.data());
         } else if ((_aovNames[i].name == HdAovTokens->cameraDepth ||
                     _aovNames[i].name == HdAovTokens->depth) &&
@@ -727,13 +860,18 @@ HdEmbreeRenderer::_ComputeId(RTCRayHit const& rayHit, TfToken const& idType,
         return false;
     }
 
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // not hit an instance, but a "raw" geometry. This should be a light
+        return false;
+    }
+
     // Get the instance and prototype context structures for the hit prim.
     // We don't use embree's multi-level instancing; we
     // flatten everything in hydra. So instID[0] should always be correct.
     const HdEmbreeInstanceContext *instanceContext =
         static_cast<HdEmbreeInstanceContext*>(
             rtcGetGeometryUserData(rtcGetGeometry(_scene, rayHit.hit.instID[0])));
-
+    
     const HdEmbreePrototypeContext *prototypeContext =
         static_cast<HdEmbreePrototypeContext*>(
             rtcGetGeometryUserData(rtcGetGeometry(instanceContext->rootScene,rayHit.hit.geomID)));
@@ -765,6 +903,11 @@ HdEmbreeRenderer::_ComputeDepth(RTCRayHit const& rayHit,
         return false;
     }
 
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // not hit an instance, but a "raw" geometry. This should be a light
+        return false;
+    }
+
     if (clip) {
         GfVec3f hitPos = GfVec3f(rayHit.ray.org_x + rayHit.ray.tfar * rayHit.ray.dir_x,
             rayHit.ray.org_y + rayHit.ray.tfar * rayHit.ray.dir_y,
@@ -787,6 +930,11 @@ HdEmbreeRenderer::_ComputeNormal(RTCRayHit const& rayHit,
                                  bool eye)
 {
     if (rayHit.hit.geomID == RTC_INVALID_GEOMETRY_ID) {
+        return false;
+    }
+
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // not hit an instance, but a "raw" geometry. This should be a light
         return false;
     }
 
@@ -825,6 +973,11 @@ HdEmbreeRenderer::_ComputePrimvar(RTCRayHit const& rayHit,
         return false;
     }
 
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // not hit an instance, but a "raw" geometry. This should be a light
+        return false;
+    }
+
     // We don't use embree's multi-level instancing; we
     // flatten everything in hydra. So instID[0] should always be correct.
     const HdEmbreeInstanceContext *instanceContext =
@@ -857,30 +1010,534 @@ HdEmbreeRenderer::_ComputePrimvar(RTCRayHit const& rayHit,
     return false;
 }
 
+struct ShapeSample {
+    GfVec3f pWorld;
+    GfVec3f nWorld;
+    GfVec2f uv;
+    float pdfA;
+};
+
+struct LightSample {
+    GfVec3f Li;
+    GfVec3f wI;
+    float dist;
+    float invPdfW;
+};
+
+float Lerp(float a, float b, float t) {
+    return (1-t)*a + t*b;
+}
+
+GfVec3f Lerp(GfVec3f a, GfVec3f b, float t) {
+    return (1.0f - t)*a + t*b;
+}
+
+float Sqr(float x) {
+    return x*x;
+}
+
+float PosDot(GfVec3f a, GfVec3f b) {
+    return std::max(0.0f, GfDot(a, b));
+}
+
+float Clamp(float x, float mn=0.0f, float mx=1.0f) {
+    return std::max(mn, std::min(x, mx));
+}
+
+float Linstep(float a, float b, float t) {
+    return Clamp((t - a)/(b - a));
+}
+
+
+float Smoothstep(float a, float b, float t) {
+    t = Clamp((t - a)/(b - a));
+    return t * t * (3.0f - 2.0f * t);
+}
+
+float Smootherstep(float a, float b, float t) {
+    t = Clamp((t - a)/(b - a));
+    return t * t * t * (t * (6.0f * t - 15.0f) + 10.0f);
+}
+
+// XXX: ported from PBRT
+static GfVec3f SphericalDirection(float sinTheta, float cosTheta,
+                                                float phi) {
+    return GfVec3f(GfClamp(sinTheta, -1, 1) * GfCos(phi),
+                    GfClamp(sinTheta, -1, 1) * GfSin(phi), GfClamp(cosTheta, -1, 1));
+}
+
+// XXX: ported from PBRT
+static GfVec3f SampleUniformCone(GfVec2f u, float angle) 
+{
+    float cosAngle = GfCos(angle);
+    float cosTheta = (1 - u[0]) + u[0] * cosAngle;
+    float sinTheta = GfSqrt(GfMax(0.0f, 1.0f - cosTheta*cosTheta));
+    float phi = u[1] * 2.0f * M_PI;
+    return SphericalDirection(sinTheta, cosTheta, phi);
+}
+
+// XXX: ported from PBRT
+static float UniformConePDF(float angle) {
+    return 1 / (2 * M_PI * (1 - GfCos(angle)));
+}
+
+float HdEmbreeRenderer::_Visibility(GfVec3f const& position, GfVec3f const& direction, float dist)
+{
+    RTCRay shadow;
+    shadow.flags = 0;
+    _PopulateRay(&shadow, position, direction, 0.001f, dist, RayMask::Shadow);
+    {
+        RTCIntersectContext context;
+        rtcInitIntersectContext(&context);
+        rtcOccluded1(_scene,&context,&shadow);
+    }
+    // XXX: what do we do about shadow visibility (continuation) here?
+    // probably need to use rtcIntersect instead of rtcOccluded
+
+    // occluded sets tfar < 0 if the ray hit anything
+    return shadow.tfar > 0.0f;
+}
+
+LightSample SampleDistantLight(Light const& light, GfVec3f const& position, float u1, float u2) 
+{
+    GfVec3f Le = light.color * light.intensity * powf(2.0f, light.exposure);
+    if (light.enableColorTemperature) {
+        Le = GfCompMult(Le, UsdLuxBlackbodyTemperatureAsRgb(light.colorTemperature));
+    }
+    
+    if (light.distant.halfAngleRadians > 0.0f)
+    {
+        if (light.normalize)
+        {
+            float sinTheta = sinf(light.distant.halfAngleRadians);
+            Le /= Sqr(sinTheta) * M_PI;
+        }
+
+        // There's an implicit double-negation of the wI direction here
+        GfVec3f localDir = SampleUniformCone(GfVec2f(u1, u2), light.distant.halfAngleRadians);
+        GfVec3f wI = light.xformLightToWorld.TransformDir(localDir);
+        wI.Normalize();
+
+        return LightSample {
+            Le,
+            wI,
+            std::numeric_limits<float>::max(),
+            1.0f / UniformConePDF(light.distant.halfAngleRadians)
+        };
+    }
+    else
+    {
+        // delta case, infinite pdf
+        GfVec3f wI = light.xformLightToWorld.TransformDir(GfVec3f(0.0f, 0.0f, 1.0f));
+        wI.Normalize();
+
+        return LightSample {
+            Le,
+            wI,
+            std::numeric_limits<float>::max(),
+            1.0f,
+        };
+    }
+}
+
+float AreaRect(GfMatrix4f const& xf, float width, float height) {
+    const GfVec3f U = xf.TransformDir(GfVec3f{width, 0.0f, 0.0f});
+    const GfVec3f V = xf.TransformDir(GfVec3f{0.0f, height, 0.0f});
+    return GfCross(U, V).GetLength();
+}
+
+ShapeSample SampleRect(GfMatrix4f const& xf, float width, float height, float u1, float u2) {
+    // Sample rectangle in object space
+    const GfVec3f pLight(
+      (u1 - 0.5f) * width,  
+      (u2 - 0.5f) * height,  
+      0.0f
+    );
+    const GfVec3f nLight(0.0f, 0.0f, -1.0f);
+    const GfVec2f uv(u1, u2);
+
+    // Transform to world space
+    const GfVec3f pWorld = xf.Transform(pLight);
+    const GfVec3f nWorld = xf.TransformDir(nLight).GetNormalized();
+
+    const float area = AreaRect(xf, width, height);
+
+    return ShapeSample {
+        pWorld,
+        nWorld,
+        uv,
+        1.0f / area
+    };
+}
+
+float AreaSphere(GfMatrix4f const& xf, float radius) {
+    // Area of the ellipsoid
+    const float a = xf.TransformDir(GfVec3f{radius, 0.0f, 0.0f}).GetLength();
+    const float b = xf.TransformDir(GfVec3f{0.0f, radius, 0.0f}).GetLength();
+    const float c = xf.TransformDir(GfVec3f{0.0f, 0.0f, radius}).GetLength();
+    const float ab = powf(a*b, 1.6f);
+    const float ac = powf(a*c, 1.6f);
+    const float bc = powf(b*c, 1.6f);
+    return powf((ab + ac + bc)/3, 1/1.6f) * 4 * M_PI;
+}
+
+ShapeSample SampleSphere(GfMatrix4f const& xf, float radius, float u1, float u2) {
+    // Sample sphere in light space
+    const float z = 1 - 2 * u1;
+    const float r = sqrtf(std::max(0.0f, 1 - z*z));
+    const float phi = 2 * M_PI * u2;
+    GfVec3f pLight{r * std::cos(phi), r * std::sin(phi), z};
+    const GfVec3f nLight = pLight;
+    pLight *= radius;
+    const GfVec2f uv(u2, z);
+
+    // Transform to world space
+    const GfVec3f pWorld = xf.Transform(pLight);
+    const GfVec3f nWorld = xf.TransformDir(nLight).GetNormalized();
+
+    const float area = AreaSphere(xf, radius);
+
+    return ShapeSample {
+        pWorld,
+        nWorld,
+        uv,
+        1.0f / area
+    };
+}
+
+GfVec3f SampleDiskPolar(float u1, float u2)
+{
+    const float r = sqrtf(u1);
+    const float theta = 2 * M_PI * u2;
+    return GfVec3f(r * cosf(theta), r * sinf(theta), 0.0f);
+}
+
+float AreaDisk(GfMatrix4f const& xf, float radius) {
+    // Calculate surface area of the ellipse
+    const float a = xf.TransformDir(GfVec3f{radius, 0.0f, 0.0f}).GetLength();
+    const float b = xf.TransformDir(GfVec3f{0.0f, radius, 0.0f}).GetLength();
+    return M_PI * a * b;
+}
+
+ShapeSample SampleDisk(GfMatrix4f const& xf, float radius, float u1, float u2) {
+    // Sample disk in light space
+    GfVec3f pLight = SampleDiskPolar(u1, u2);
+    const GfVec3f nLight(0.0f, 0.0f, -1.0f);
+    const GfVec2f uv(pLight[0], pLight[1]);
+    pLight *= radius;
+
+    // Transform to world space
+    const GfVec3f pWorld = xf.Transform(pLight);
+    const GfVec3f nWorld = xf.TransformDir(nLight).GetNormalized();
+
+    const float area = AreaDisk(xf, radius);
+
+    return ShapeSample {
+        pWorld,
+        nWorld,
+        uv,
+        1.0f / area
+    };
+}
+
+float AreaCylinder(GfMatrix4f const& xf, float radius, float length) {
+    const float c = xf.TransformDir(GfVec3f{length, 0.0f, 0.0f}).GetLength();
+    const float a = xf.TransformDir(GfVec3f{0.0f, radius, 0.0f}).GetLength();
+    const float b = xf.TransformDir(GfVec3f{0.0f, 0.0f, radius}).GetLength();
+    // Ramanujan's approximation to perimeter of ellipse
+    const float e = M_PI * (3*(a+b) - sqrtf((3*a + b) * (a + 3*b)));
+    return e * c;
+}
+
+ShapeSample SampleCylinder(GfMatrix4f const& xf, float radius, float length, float u1, float u2) {
+    float z = Lerp(-length/2, length/2, u1);
+    float phi = u2 * 2 * M_PI;
+    // Compute cylinder sample position _pi_ and normal _n_ from $z$ and $\phi$
+    GfVec3f pLight = GfVec3f(z, radius * cosf(phi), radius * sinf(phi));
+    // Reproject _pObj_ to cylinder surface and compute _pObjError_
+    float hitRad = sqrtf(Sqr(pLight[1]) + Sqr(pLight[2]));
+    pLight[1] *= radius / hitRad;
+    pLight[2] *= radius / hitRad;
+
+    GfVec3f nLight(0.0f, pLight[1], pLight[2]);
+    nLight.Normalize();
+
+    // Transform to world space
+    const GfVec3f pWorld = xf.Transform(pLight);
+    const GfVec3f nWorld = xf.TransformDir(nLight).GetNormalized();
+
+    const float area = AreaCylinder(xf, radius, length);
+
+    return ShapeSample {
+        pWorld,
+        nWorld,
+        GfVec2f(u2, u1),
+        1.0f / area
+    };
+}
+
+float Theta(GfVec3f const& v) {
+    return acosf(Clamp(v[2], -1.f, 1.f));
+}
+
+float Phi(GfVec3f const& v) {
+    float p = atan2f(v[1], v[0]);
+    return p < 0 ? (p + 2 * M_PI) : p;
+}
+
+float EvalIES(Light const& light, GfVec3f const& wI) {
+    IES const& ies = light.shaping.ies;
+
+    if (!ies.iesFile.valid()) {
+        // Either none specified or there was an error loading. In either case, just ignore
+        return 1.0f;
+    }
+
+    // emission direction in light space
+    GfVec3f wE = light.xformWorldToLight.TransformDir(wI).GetNormalized();
+
+    float theta = Theta(wE);
+    float phi = Phi(wE);
+
+    // apply angle scale to theta, matching Karma
+    if (ies.angleScale > 0) {
+        theta = Clamp(theta / (1 - ies.angleScale), 0, M_PI);
+    } else if (ies.angleScale < 0) {
+        theta = Clamp(theta / (1 / (1 + ies.angleScale)), 0, M_PI);
+    }
+
+    float norm = ies.normalize ? ies.iesFile.power() : 1.0f;
+
+    return ies.iesFile.eval(theta, phi) / norm;
+}
+
+GfVec3f SampleLightTexture(LightTexture const& texture, float s, float t)
+{
+    if (texture.pixels == nullptr) {
+        return GfVec3f(0.0f);
+    }
+
+    int x = float(texture.width) * s;
+    int y = float(texture.height) * t;
+
+    return texture.pixels[y*texture.width + x];
+}
+
+LightSample EvalAreaLight(Light const& light, ShapeSample const& ss, GfVec3f const& position) {
+    // Transform PDF from area measure to solid angle measure. We use the inverse PDF
+    // here to avoid division by zero when the surface point is behind the light
+    GfVec3f wI = ss.pWorld - position;
+    const float dist = wI.GetLength();
+    wI /= dist;
+    const float cosThetaON = PosDot(-wI, ss.nWorld);
+    float invPdfW = cosThetaON / Sqr(dist) / ss.pdfA;
+    GfVec4f Z = light.xformLightToWorld.GetColumn(2);
+    const float cosThetaOZ = PosDot(-wI, GfVec3f(Z[0], Z[1], -Z[2]));
+
+    // Combine the brightness parameters to get initial emission luminance (nits)
+    GfVec3f Le = cosThetaON > 0.0f ? light.color * light.intensity * powf(2.0f, light.exposure) : GfVec3f(0);
+
+    // Multiply in blackbody color, if enabled
+    if (light.enableColorTemperature) {
+        Le = GfCompMult(Le, UsdLuxBlackbodyTemperatureAsRgb(light.colorTemperature));
+    }
+
+    // Multiply by the texture, if there is one
+    if (light.texture.pixels != nullptr) {
+        Le = GfCompMult(Le, SampleLightTexture(light.texture, ss.uv[0], 1.0f - ss.uv[1]));
+    }
+
+    // If normalize is enabled, we need to divide the luminance by the surface area of the light,
+    // which for an area light is equivalent to multiplying by the area pdf, which is itself the 
+    // reciprocal of the surface area 
+    if (light.normalize) {
+        Le *= ss.pdfA;
+    }
+
+    // Apply focus shaping
+    if (light.shaping.focus > 0.0f) {
+        const float ff = powf(cosThetaOZ, light.shaping.focus);
+        const GfVec3f focusTint = Lerp(light.shaping.focusTint, GfVec3f(1), ff);
+        Le = GfCompMult(Le, focusTint);
+    }
+
+    // Apply cone shaping
+    const float thetaC = light.shaping.coneAngle * M_PI / 180.0f;
+    const float thetaS = Lerp(thetaC, 0.0f, light.shaping.coneSoftness);
+    const float thetaOZ = acosf(cosThetaOZ);
+    Le *= 1.0f - Smoothstep(thetaS, thetaC, thetaOZ);
+
+    // Applu IES
+    Le *= EvalIES(light, wI);
+
+    return LightSample {
+        Le,
+        wI,
+        dist,
+        invPdfW
+    };
+}
+
+ShapeSample IntersectAreaLight(Light const& light, RTCRayHit const& rayHit) {
+    // XXX: just rect lights at the moment, need to do the others
+    ShapeSample ss;
+
+    ss.pWorld = GfVec3f(rayHit.ray.org_x + rayHit.ray.tfar * rayHit.ray.dir_x,
+            rayHit.ray.org_y + rayHit.ray.tfar * rayHit.ray.dir_y,
+            rayHit.ray.org_z + rayHit.ray.tfar * rayHit.ray.dir_z);
+    ss.nWorld = GfVec3f(rayHit.hit.Ng_x, rayHit.hit.Ng_y, rayHit.hit.Ng_z);
+    ss.uv = GfVec2f(1.0f - rayHit.hit.u, rayHit.hit.v);
+    ss.pdfA = 1.0f / AreaRect(light.xformLightToWorld, light.rect.width, light.rect.height);
+
+    return ss;
+}
+
+LightSample SampleAreaLight(Light const& light, GfVec3f const& position, float u1, float u2) {
+    // First, sample the shape of the area light in its surface area measure
+    ShapeSample ss;
+    switch (light.kind) {
+    case LightKind::Rect:
+        ss = SampleRect(light.xformLightToWorld, light.rect.width, light.rect.height, u1, u2);
+        break;
+    case LightKind::Sphere:
+        ss = SampleSphere(light.xformLightToWorld, light.sphere.radius, u1, u2);
+        break;
+    case LightKind::Disk:
+        ss = SampleDisk(light.xformLightToWorld, light.disk.radius, u1, u2);
+        break;
+    case LightKind::Cylinder:
+        ss = SampleCylinder(light.xformLightToWorld, light.cylinder.radius, light.cylinder.length, u1, u2);
+        break;
+    case LightKind::Distant:
+    case LightKind::Dome:
+        // infinite lights handled separately
+        break;
+    }
+
+    return EvalAreaLight(light, ss, position);
+}
+
+LightSample EvalDomeLight(Light const& light, GfVec3f const& direction)
+{
+    float t = acosf(direction[1]) / M_PI;
+    float s = atan2f(direction[0], direction[2]) / (2 * M_PI);
+    s = 1.0f - fmodf(s+0.5f, 1.0f);
+
+    GfVec3f Li = light.texture.pixels != nullptr ? 
+        SampleLightTexture(light.texture, s, t) 
+        : GfVec3f(1.0f);
+
+    return LightSample {
+        Li,
+        direction,
+        std::numeric_limits<float>::max(),
+        1.0f / (4*M_PI)
+    };
+}
+
+void OrthoBasis(GfVec3f const& n, GfVec3f& b1, GfVec3f& b2)
+{
+    float sign = copysignf(1.0f, n[2]);
+    const float a = 1.0f / (sign + n[2]);
+    const float b = n[0] * n[1] * a;
+    b1 = GfVec3f(1.0f + sign * n[0] * n[0] * a, sign * b, -sign * n[0]).GetNormalized();
+    b2 = GfVec3f(b, sign + n[1] * n[1] * a, -n[1]).GetNormalized();
+}
+
+LightSample SampleDomeLight(Light const& light, GfVec3f const& W, float u1, float u2)
+{
+    GfVec3f U, V;
+    OrthoBasis(W, U, V);
+
+#if 0
+    // Cosine hemisphere sampling for simplicity
+    GfVec3f p = SampleDiskPolar(u1, u2);
+    const float z = sqrtf(std::max(0.0f, 1 - sqr(p[0]) - sqr(p[1])));
+
+    const GfVec3f wI = (W * z + p[0] * U + p[1] * V).GetNormalized();
+
+    LightSample ls = EvalDomeLight(light, wI);
+    ls.invPdfW = M_PI / z;
+
+#else
+
+    float z = u1;
+    float r = sqrtf(std::max(0.0f, 1.0f - Sqr(z)));
+    float phi = 2 * M_PI * u2;
+    
+    const GfVec3f wI = (W * z + r * cosf(phi) * U + r * sinf(phi) * V).GetNormalized();
+
+    LightSample ls = EvalDomeLight(light, wI);
+    ls.invPdfW = 2 * M_PI;
+#endif
+
+    return ls;
+}
+
 GfVec4f
 HdEmbreeRenderer::_ComputeColor(RTCRayHit const& rayHit,
-                                std::default_random_engine &random,
+                                PCG& pcg,
                                 GfVec4f const& clearColor)
 {
     if (rayHit.hit.geomID == RTC_INVALID_GEOMETRY_ID) {
-        return clearColor;
+        // if we missed all geometry in the scene, evaluate the infinite lights directly
+        if (_domeIndex >= 0)
+        {
+            LightSample ls = EvalDomeLight(
+                _lights[_domeIndex], 
+                GfVec3f(rayHit.ray.dir_x, 
+                        rayHit.ray.dir_y, 
+                        rayHit.ray.dir_z).GetNormalized()
+            );
+
+            return GfVec4f(
+                ls.Li[0],
+                ls.Li[1],
+                ls.Li[2],
+                1.0f
+            );
+        }
+        else
+        {
+            return clearColor;
+        }
     }
+
+    if (rayHit.hit.instID[0] == RTC_INVALID_GEOMETRY_ID) {
+        // if it's not an instance then it's almost certainly a light
+        const HdEmbreeInstanceContext *instanceContext =
+            static_cast<HdEmbreeInstanceContext*>(
+                    rtcGetGeometryUserData(rtcGetGeometry(_scene, rayHit.hit.geomID)));
+
+        // if we hit a light, just evaluate the light directly
+        if (instanceContext->lightIndex != -1) {
+            Light const& light = _lights[instanceContext->lightIndex];
+            ShapeSample ss = IntersectAreaLight(light, rayHit);
+            LightSample ls = EvalAreaLight(light, ss, GfVec3f(rayHit.ray.org_x, rayHit.ray.org_y, rayHit.ray.org_z));
+
+            return GfVec4f(ls.Li[0], ls.Li[1], ls.Li[2], 1);        
+        } else {
+            // should never get here. magenta warning!
+            return GfVec4f(1, 0, 1, 1);        
+        }
+
+    }
+
+    // Compute the worldspace location of the rayHit hit.
+    GfVec3f hitPos = GfVec3f(rayHit.ray.org_x + rayHit.ray.tfar * rayHit.ray.dir_x,
+            rayHit.ray.org_y + rayHit.ray.tfar * rayHit.ray.dir_y,
+            rayHit.ray.org_z + rayHit.ray.tfar * rayHit.ray.dir_z);
 
     // Get the instance and prototype context structures for the hit prim.
     // We don't use embree's multi-level instancing; we
     // flatten everything in hydra. So instID[0] should always be correct.
     const HdEmbreeInstanceContext *instanceContext =
         static_cast<HdEmbreeInstanceContext*>(
-                rtcGetGeometryUserData(rtcGetGeometry(_scene,rayHit.hit.instID[0])));
+                rtcGetGeometryUserData(rtcGetGeometry(_scene, rayHit.hit.instID[0])));
 
     const HdEmbreePrototypeContext *prototypeContext =
         static_cast<HdEmbreePrototypeContext*>(
                 rtcGetGeometryUserData(rtcGetGeometry(instanceContext->rootScene,rayHit.hit.geomID)));
-
-    // Compute the worldspace location of the rayHit hit.
-    GfVec3f hitPos = GfVec3f(rayHit.ray.org_x + rayHit.ray.tfar * rayHit.ray.dir_x,
-            rayHit.ray.org_y + rayHit.ray.tfar * rayHit.ray.dir_y,
-            rayHit.ray.org_z + rayHit.ray.tfar * rayHit.ray.dir_z);
 
     // If a normal primvar is present (e.g. from smooth shading), use that
     // for shading; otherwise use the flat face normal.
@@ -908,26 +1565,75 @@ HdEmbreeRenderer::_ComputeColor(RTCRayHit const& rayHit,
     // Make sure the normal is unit-length.
     normal.Normalize();
 
-    // Lighting model: (camera dot normal), i.e. diffuse-only point light
-    // centered on the camera.
-    GfVec3f dir = GfVec3f(rayHit.ray.dir_x, rayHit.ray.dir_y, rayHit.ray.dir_z);
-    float diffuseLight = fabs(GfDot(-dir, normal)) *
-        HdEmbreeConfig::GetInstance().cameraLightIntensity;
+    // If there are no lights, then keep the existing camera light + AO path to be
+    // able to inspect the scene
+    GfVec3f finalColor(0);
+    if (_lights.empty())
+    {
+        // Lighting model: (camera dot normal), i.e. diffuse-only point light
+        // centered on the camera.
+        GfVec3f dir = GfVec3f(rayHit.ray.dir_x, rayHit.ray.dir_y, rayHit.ray.dir_z);
+        float diffuseLight = fabs(GfDot(-dir, normal)) *
+            HdEmbreeConfig::GetInstance().cameraLightIntensity;
 
-    // Lighting gets modulated by an ambient occlusion term.
-    float aoLightIntensity =
-        _ComputeAmbientOcclusion(hitPos, normal, random);
+        // Lighting gets modulated by an ambient occlusion term.
+        float aoLightIntensity =
+            _ComputeAmbientOcclusion(hitPos, normal, pcg);
 
-    // XXX: We should support opacity here...
+        // XXX: We should support opacity here...
 
-    // Return color * diffuseLight * aoLightIntensity.
-    GfVec3f finalColor = color * diffuseLight * aoLightIntensity;
+        finalColor = color * diffuseLight * aoLightIntensity;
+    }
+    else
+    {
+        // For now just a 100% reflective diffuse BRDF
+        float brdf = 1.0f / M_PI;
 
-    // Clamp colors to [0,1].
+        // For now just iterate over all lights
+        /// XXX: simple uniform sampling may be better here
+        for (auto const& light: _lights)
+        {
+            // Skip light if it's hidden
+            if (!light.visible) 
+            {
+                continue;
+            }
+
+            // Sample the light
+            LightSample ls;
+            switch (light.kind)
+            {
+            case LightKind::Distant:
+                ls = SampleDistantLight(light, hitPos, pcg.uniform(), pcg.uniform());
+                break;
+            case LightKind::Dome:
+                ls = SampleDomeLight(light, normal, pcg.uniform(), pcg.uniform());
+                break;
+            case LightKind::Rect:
+            case LightKind::Sphere:
+            case LightKind::Disk:
+            case LightKind::Cylinder:
+                ls = SampleAreaLight(light, hitPos, pcg.uniform(), pcg.uniform());
+                break;
+            }
+
+            // Trace shadow
+            float vis = _Visibility(hitPos, ls.wI, ls.dist * 0.99f);
+
+            // Add exitant luminance
+            finalColor += ls.Li 
+                * PosDot(ls.wI, normal) 
+                * brdf 
+                * vis 
+                * ls.invPdfW;
+        }
+    }
+
+    // Clamp colors to > 0
     GfVec4f output;
-    output[0] = std::max(0.0f, std::min(1.0f, finalColor[0]));
-    output[1] = std::max(0.0f, std::min(1.0f, finalColor[1]));
-    output[2] = std::max(0.0f, std::min(1.0f, finalColor[2]));
+    output[0] = std::max(0.0f, finalColor[0]);
+    output[1] = std::max(0.0f, finalColor[1]);
+    output[2] = std::max(0.0f, finalColor[2]);
     output[3] = 1.0f;
     return output;
 }
@@ -935,12 +1641,8 @@ HdEmbreeRenderer::_ComputeColor(RTCRayHit const& rayHit,
 float
 HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
                                            GfVec3f const& normal,
-                                           std::default_random_engine &random)
+                                           PCG& pcg)
 {
-    // Create a uniform random distribution for AO calculations.
-    std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
-
     // 0 ambient occlusion samples means disable the ambient occlusion term.
     if (_ambientOcclusionSamples < 1) {
         return 1.0f;
@@ -971,12 +1673,18 @@ HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
     // equal spacing guarantees.
     std::vector<GfVec2f> samples;
     samples.resize(_ambientOcclusionSamples);
+    // for (int i = 0; i < _ambientOcclusionSamples; ++i) {
+    //     samples[i][0] = (float(i) + pcg.uniform()) / _ambientOcclusionSamples;
+    // }
+    // std::shuffle(samples.begin(), samples.end(), random);
+    // for (int i = 0; i < _ambientOcclusionSamples; ++i) {
+    //     samples[i][1] = (float(i) + pcg.uniform()) / _ambientOcclusionSamples;
+    // }
+
+    /// XXX: Do stratified here
     for (int i = 0; i < _ambientOcclusionSamples; ++i) {
-        samples[i][0] = (float(i) + uniform_float()) / _ambientOcclusionSamples;
-    }
-    std::shuffle(samples.begin(), samples.end(), random);
-    for (int i = 0; i < _ambientOcclusionSamples; ++i) {
-        samples[i][1] = (float(i) + uniform_float()) / _ambientOcclusionSamples;
+        samples[i][0] = pcg.uniform();
+        samples[i][1] = pcg.uniform();
     }
 
     // Trace ambient occlusion rays. The occlusion factor is the fraction of

--- a/pxr/imaging/plugin/hdEmbree/renderer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderer.h
@@ -166,7 +166,6 @@ private:
     // rays, and following them/calculating color with _TraceRay. This function
     // renders all tiles between tileStart and tileEnd.
     void _RenderTiles(HdRenderThread *renderThread,
-                      int progression,
                       size_t tileStart, size_t tileEnd);
 
     // Cast a ray into the scene and if it hits an object, write to the bound

--- a/pxr/usd/usdLux/distantLight.h
+++ b/pxr/usd/usdLux/distantLight.h
@@ -153,7 +153,7 @@ public:
     // --------------------------------------------------------------------- //
     // ANGLE 
     // --------------------------------------------------------------------- //
-    /// Angular size of the light in degrees.
+    /// Angular diameter of the light in degrees.
     /// As an example, the Sun is approximately 0.53 degrees as seen from Earth.
     /// Higher values broaden the light and therefore soften shadow edges.
     /// 

--- a/pxr/usd/usdLux/overview.dox
+++ b/pxr/usd/usdLux/overview.dox
@@ -101,6 +101,34 @@ constraints, such as to attach lights to moving geometry.  This is
 consistent with USD's policy of storing the computed result of rigging,
 not the rigging itself.
 
+\subsection usdLux_quantities Quantities and Units
+
+Most renderers consuming OpenUSD today are RGB renderers, rather than spectral.
+Units in RGB renderers are tricky to define as each of the red, green and blue
+channels transported by the renderer represents the convolution of a spectral
+exposure distribution, e.g. CIE Illuminant D65, with a sensor response function, e.g.
+CIE 1931 x_bar. Thus the main quantity in an RGB renderer is neither radiance nor
+luminance, but "integrated radiance" or "tristimulus weight".
+
+The emision of a default light with \c intensity 1 and \c color [1, 1, 1] is an 
+Illuminant D spectral power distribution with chromaticity matching the rendering 
+colour space white point, normalized such that a ray normally incident upon the 
+sensor with EV0 exposure settings will generate a pixel value of [1, 1, 1] in the 
+rendering colour space.
+
+Given the above definition, that means that the luminance of said default light 
+will be 1 \a nit and its emission spectral radiance distribution is easily computed by appropriate
+normalization.
+
+Note that some colour spaces, most notably ACES, define their white points by 
+chromaticity coordinates that do not exactly line up to any value of a standard illuminant. 
+In these cases, a spectral renderer should choose the closest Illuminant D spectrum
+for the lights' emission (the \a rendering \a illuminant) and perform chromatic 
+adaptation to transform the rendered image to the rendering colour space. 
+The method of "uplifting" an RGB colour to a spectral distribution is unspecified
+other than that it should round-trip under the rendering illuminant to the limits
+of numerical accuracy.
+
 \subsection usdLux_Behavior Properties & Behavior
 
 Colors specified in attributes are in energy-linear terms,
@@ -114,6 +142,14 @@ distance is a consequence of reduced visible solid angle. Environments
 that do not measure the visible solid angle are expected to provide an
 approximation, such as inverse-square falloff. Further artistic control
 over attenuation can be modelled as light filters.
+
+The behavior of all attributes is in UsdLuxLightAPI is documented on their \c Get() 
+methods. All attributes are expected to be supported by all light types, with 
+the effect of each attribute applying multiplicatively in sequence.
+
+The example hdEmbree delegate provides a reference implementation, as well as a 
+series of unit tests and reference images for renderers to check their own 
+implementation against.
 
 More complex behaviors are provided via a set of API classes.
 These behaviors are common and well-defined but may not be supported

--- a/pxr/usd/usdLux/overview.dox
+++ b/pxr/usd/usdLux/overview.dox
@@ -129,6 +129,21 @@ The method of "uplifting" an RGB colour to a spectral distribution is unspecifie
 other than that it should round-trip under the rendering illuminant to the limits
 of numerical accuracy.
 
+\subsubsection usdLux_quantities_exposure Exposure
+
+In order to generate an image, a camera effectively integrates irradiance at a patch 
+on the sensor over time to get exposure, which is converted to an electrical signal.
+The default behaviour of many renderers is to ignore this, which as we have seen means
+that 1 nit incident on the sensor results in an output signal of 1.0. 
+
+1 nit is a tiny amount of light, equivalent by definition to a single candle viewed at a distance. Thus 
+using physically plausible values for light brightnesses will result in blown out images 
+unless exposure is taken into account. A full physical camera model would be a good 
+future addition to OpenUSD, but there is already a means of communicating sensor 
+exposure via UsdGeomCamera::GetExposureAttr() and it is expected that all renderers 
+implementing UsdLux must respect the value of that attribute by scaling the rendered 
+image by \c pow(2, exposure).
+
 \subsection usdLux_Behavior Properties & Behavior
 
 Colors specified in attributes are in energy-linear terms,

--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -136,6 +136,13 @@ def main():
             'the CPU, but additionally it will prevent any tasks that require '
             'the GPU from being invoked.'))
 
+    parser.add_argument("--disableDefaultLight", action='store_true',
+        dest='defaultLightDisabled',
+        help=(
+            "Disables the default camera light that is otherwise automatically "
+            "added to the stage."
+        ))
+
     UsdAppUtils.cameraArgs.AddCmdlineArgs(parser)
     UsdAppUtils.framesArgs.AddCmdlineArgs(parser)
     UsdAppUtils.complexityArgs.AddCmdlineArgs(parser)
@@ -204,7 +211,7 @@ def main():
 
     # Initialize FrameRecorder 
     frameRecorder = UsdAppUtils.FrameRecorder(
-        rendererPluginId, args.gpuEnabled, args.rsPrimPath)
+        rendererPluginId, args.gpuEnabled, args.defaultLightDisabled, args.rsPrimPath)
     frameRecorder.SetImageWidth(args.imageWidth)
     frameRecorder.SetComplexity(args.complexity.value)
     frameRecorder.SetColorCorrectionMode(args.colorCorrectionMode)

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -53,12 +53,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 UsdAppUtilsFrameRecorder::UsdAppUtilsFrameRecorder(
     const TfToken& rendererPluginId,
     bool gpuEnabled, 
+    bool defaultLightDisabled,
     const SdfPath& renderSettingsPrimPath) :
     _imagingEngine(HdDriver(), rendererPluginId, gpuEnabled),
     _imageWidth(960u),
     _complexity(1.0f),
     _colorCorrectionMode(HdxColorCorrectionTokens->disabled),
     _purposes({UsdGeomTokens->default_, UsdGeomTokens->proxy}),
+    _defaultLightDisabled(defaultLightDisabled),
     _renderSettingsPrimPath(renderSettingsPrimPath)
 {
     // Disable presentation to avoid the need to create an OpenGL context when
@@ -410,7 +412,10 @@ UsdAppUtilsFrameRecorder::Record(
     material.SetSpecular(SPECULAR_DEFAULT);
     material.SetShininess(SHININESS_DEFAULT);
 
-    _imagingEngine.SetLightingState(lights, material, SCENE_AMBIENT);
+    if (!_defaultLightDisabled)
+    {
+        _imagingEngine.SetLightingState(lights, material, SCENE_AMBIENT);
+    }
 
     UsdImagingGLRenderParams renderParams;
     renderParams.frame = timeCode;

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -68,6 +68,7 @@ public:
     UsdAppUtilsFrameRecorder(
         const TfToken& rendererPluginId = TfToken(),
         bool gpuEnabled = true,
+        bool defaultLightDisabled = false,
         const SdfPath& renderSettingsPrimPath = SdfPath());
 
     /// Gets the ID of the Hydra renderer plugin that will be used for
@@ -155,6 +156,7 @@ private:
     TfToken _colorCorrectionMode;
     TfTokenVector _purposes;
     SdfPath _renderSettingsPrimPath;
+    bool _defaultLightDisabled;
 };
 
 

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -42,7 +42,7 @@ wrapFrameRecorder()
 
     scope s = class_<This, boost::noncopyable>("FrameRecorder")
         .def(init<>())
-        .def(init<const TfToken&, bool, const SdfPath&>(
+        .def(init<const TfToken&, bool, bool, const SdfPath&>(
             (arg("rendererPluginId") = TfToken(), 
              arg("gpuEnabled") = true,
              arg("disableDefaultLight") = false,

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -45,7 +45,9 @@ wrapFrameRecorder()
         .def(init<const TfToken&, bool, const SdfPath&>(
             (arg("rendererPluginId") = TfToken(), 
              arg("gpuEnabled") = true,
+             arg("disableDefaultLight") = false,
              arg("renderSettingsPrimPath") = SdfPath())))
+        .def(init<const TfToken&, bool, bool>())
         .def("GetCurrentRendererId", &This::GetCurrentRendererId)
         .def("SetRendererPlugin", &This::SetRendererPlugin)
         .def("SetImageWidth", &This::SetImageWidth)


### PR DESCRIPTION
### Description of Change(s)

This is a draft PR that is NOT meant to be merged, intended to provide a focal point for discussion. There are several points in the described behaviour that need agreement from the community.

This PR adds clarifying documentation of the quantities and behaviour of the parameters in UsdLux, all of which are expressed as changes to the doc comments and overview.dox in pxr/usd/usdLux.

It also adds a reference implementation to the hdEmbree example delegate, by modifying that delegate to perform direct lighting according to the specification in the (revised) UsdLux documentation. If no lights are in the stage, hdEmbree falls back to ambient occlusion, as before.

There is a separate repo, here https://github.com/anderslanglands/luxtest there does a bunch of "golden image" unit test of the behaviour and compares renderers. It's all a bit manual at the moment but it generates this result: https://anderslanglands.github.io/luxtest/luxtest.html

Questions for the USD maintainers:

1. What's the best way of incorporating the changes to UsdLux here. Since it implies a behavioral change on everyone implementing it, it feels like versioning up the schema would be the right approach? If so, what code changes are required to do that exactly?
2. Are we OK with modifying the Embree delegate in this way, or would it be preferred to split it out into a separate delegate? Or do we want to just lock the new behaviour behind a feature flag/env var? 
3. What sort of testing functionality do we want to include? It might be nice to include some part of the luxtest repo to allow people to run tests of a delegate against the reference easily. Not sure how to go about setting that up.