### PR TITLE
Autodesk: OpenVDB build error on RelWithDebugInfo

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1231,6 +1231,13 @@ def InstallOpenVDB(context, force, buildArgs):
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
 
+        # Patch files to support relwithdebinfo and minsizerel build
+        PatchFile('cmake/FindTBB.cmake',
+                  [('        IMPORTED_LOCATION_RELEASE "${Tbb_${COMPONENT}_LIBRARY_RELEASE}")',
+                    '        IMPORTED_LOCATION_RELEASE "${Tbb_${COMPONENT}_LIBRARY_RELEASE}"\n' +
+                    '        MAP_IMPORTED_CONFIG_MINSIZEREL Release\n' +
+                    '        MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release)')])
+
         RunCMake(context, force, extraArgs)
 
 OPENVDB = Dependency("OpenVDB", InstallOpenVDB, "include/openvdb/openvdb.h")


### PR DESCRIPTION
### Description of Change(s)

Fixes openvdb build error that happens with build type relwithdebuginfo

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
