### PR TITLE
Remove boost::noncopyable in CollectionCache

### DIFF
--- a/pxr/usdImaging/usdImaging/collectionCache.h
+++ b/pxr/usdImaging/usdImaging/collectionCache.h
@@ -30,7 +30,6 @@
 #include "pxr/usdImaging/usdImaging/api.h"
 #include "pxr/usd/usd/collectionAPI.h"
 
-#include <boost/noncopyable.hpp>
 #include <tbb/concurrent_unordered_map.h>
 #include <tbb/concurrent_queue.h>
 #include <mutex>
@@ -56,8 +55,12 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// As an optimization, the query that includes everything is
 /// treated as a special case and given the empty id, TfToken().
 ///
-class UsdImaging_CollectionCache : boost::noncopyable {
+class UsdImaging_CollectionCache {
 public:
+    UsdImaging_CollectionCache() = default;
+    UsdImaging_CollectionCache(const UsdImaging_CollectionCache&) = delete;
+    UsdImaging_CollectionCache& operator=(const UsdImaging_CollectionCache&) = delete;
+
     /// Query is the MembershipQuery computed from a collection's state.
     typedef UsdCollectionAPI::MembershipQuery Query;
 


### PR DESCRIPTION
### Description of Change(s)
Replace boost::noncopyable with deleted copy constructors in UsdImaging_CollectionCache

### Fixes Issue(s)
-https://github.com/PixarAnimationStudios/OpenUSD/issues/2203

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
