### PR TITLE
add option to disable default light.

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -136,6 +136,13 @@ def main():
             'the CPU, but additionally it will prevent any tasks that require '
             'the GPU from being invoked.'))
 
+    parser.add_argument("--disableDefaultLight", action='store_true',
+        dest='defaultLightDisabled',
+        help=(
+            "Disables the default camera light that is otherwise automatically "
+            "added to the stage."
+        ))
+
     UsdAppUtils.cameraArgs.AddCmdlineArgs(parser)
     UsdAppUtils.framesArgs.AddCmdlineArgs(parser)
     UsdAppUtils.complexityArgs.AddCmdlineArgs(parser)
@@ -204,7 +211,7 @@ def main():
 
     # Initialize FrameRecorder 
     frameRecorder = UsdAppUtils.FrameRecorder(
-        rendererPluginId, args.gpuEnabled, args.rsPrimPath)
+        rendererPluginId, args.gpuEnabled, args.rsPrimPath, args.defaultLightDisabled)
     frameRecorder.SetImageWidth(args.imageWidth)
     frameRecorder.SetComplexity(args.complexity.value)
     frameRecorder.SetColorCorrectionMode(args.colorCorrectionMode)

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -53,13 +53,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 UsdAppUtilsFrameRecorder::UsdAppUtilsFrameRecorder(
     const TfToken& rendererPluginId,
     bool gpuEnabled, 
-    const SdfPath& renderSettingsPrimPath) :
+    const SdfPath& renderSettingsPrimPath,
+    bool defaultLightDisabled) :
     _imagingEngine(HdDriver(), rendererPluginId, gpuEnabled),
     _imageWidth(960u),
     _complexity(1.0f),
     _colorCorrectionMode(HdxColorCorrectionTokens->disabled),
     _purposes({UsdGeomTokens->default_, UsdGeomTokens->proxy}),
-    _renderSettingsPrimPath(renderSettingsPrimPath)
+    _renderSettingsPrimPath(renderSettingsPrimPath),
+    _defaultLightDisabled(defaultLightDisabled)
 {
     // Disable presentation to avoid the need to create an OpenGL context when
     // using other graphics APIs such as Metal and Vulkan.
@@ -400,7 +402,10 @@ UsdAppUtilsFrameRecorder::Record(
     material.SetSpecular(SPECULAR_DEFAULT);
     material.SetShininess(SHININESS_DEFAULT);
 
-    _imagingEngine.SetLightingState(lights, material, SCENE_AMBIENT);
+    if (!_defaultLightDisabled)
+    {
+        _imagingEngine.SetLightingState(lights, material, SCENE_AMBIENT);
+    }
 
     UsdImagingGLRenderParams renderParams;
     renderParams.frame = timeCode;

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -68,7 +68,8 @@ public:
     UsdAppUtilsFrameRecorder(
         const TfToken& rendererPluginId = TfToken(),
         bool gpuEnabled = true,
-        const SdfPath& renderSettingsPrimPath = SdfPath());
+        const SdfPath& renderSettingsPrimPath = SdfPath(),
+        bool defaultLightDisabled = false);
 
     /// Gets the ID of the Hydra renderer plugin that will be used for
     /// recording.
@@ -155,6 +156,7 @@ private:
     TfToken _colorCorrectionMode;
     TfTokenVector _purposes;
     SdfPath _renderSettingsPrimPath;
+    bool _defaultLightDisabled;
 };
 
 

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -42,10 +42,11 @@ wrapFrameRecorder()
 
     scope s = class_<This, boost::noncopyable>("FrameRecorder")
         .def(init<>())
-        .def(init<const TfToken&, bool, const SdfPath&>(
+        .def(init<const TfToken&, bool, const SdfPath&, bool>(
             (arg("rendererPluginId") = TfToken(), 
              arg("gpuEnabled") = true,
-             arg("renderSettingsPrimPath") = SdfPath())))
+             arg("renderSettingsPrimPath") = SdfPath(),
+             arg("disableDefaultLight") = false)))
         .def("GetCurrentRendererId", &This::GetCurrentRendererId)
         .def("SetRendererPlugin", &This::SetRendererPlugin)
         .def("SetImageWidth", &This::SetImageWidth)


### PR DESCRIPTION
### Description of Change(s)
adds a command-line option, --disableDefaultight to usdrecord that causes UsdAppUtilsFrameRecorder to not add the default camera light to the imaging engine.

This is a resubmission of https://github.com/PixarAnimationStudios/OpenUSD/pull/2674 which is closed due to being based on release. This PR has been rebased on dev.

This issue was previously filed internally as  #USD-8688

### Fixes Issue(s)
usdrecord is a useful tool for generating images from usd layers. The addition of the default light, however, makes it not very useful for anything where lighting is important.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
