### PR TITLE
Replace boost hash in hdEmbree

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -34,7 +34,7 @@
 #include "pxr/base/gf/vec2f.h"
 #include "pxr/base/work/loops.h"
 
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <chrono>
 #include <thread>
@@ -515,7 +515,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
     // Initialize the RNG for this tile (each tile creates one as
     // a lazy way to do thread-local RNGs).
     size_t seed = std::chrono::system_clock::now().time_since_epoch().count();
-    boost::hash_combine(seed, tileStart);
+    seed = TfHash::Combine(seed, tileStart);
     std::default_random_engine random(seed);
 
     // Create a uniform distribution for jitter calculations.


### PR DESCRIPTION
### Description of Change(s)
Replace boost hash with TfHash in hdEmbree

### Fixes Issue(s)
-https://github.com/PixarAnimationStudios/OpenUSD/issues/2172 (will be 3 PRs for imaging)

### Related PRs
https://github.com/PixarAnimationStudios/OpenUSD/pull/2764
https://github.com/PixarAnimationStudios/OpenUSD/pull/2765

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
