### PR TITLE
Replace boost hash with TfHash in imaging

### DIFF
--- a/pxr/imaging/garch/glPlatformContextGLX.cpp
+++ b/pxr/imaging/garch/glPlatformContextGLX.cpp
@@ -24,7 +24,7 @@
 /// \file glPlatformContext.cpp
 
 #include "pxr/imaging/garch/glPlatformContext.h"
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -61,11 +61,11 @@ GarchGLXContextState::operator==(const GarchGLXContextState& rhs) const
 size_t
 GarchGLXContextState::GetHash() const
 {
-    size_t result = 0;
-    boost::hash_combine(result, display);
-    boost::hash_combine(result, drawable);
-    boost::hash_combine(result, context);
-    return result;
+    return TfHash::Combine(        
+        display,
+        drawable,
+        context
+    );
 }
 
 bool

--- a/pxr/imaging/garch/glPlatformContextWindows.cpp
+++ b/pxr/imaging/garch/glPlatformContextWindows.cpp
@@ -22,8 +22,8 @@
 // language governing permissions and limitations under the Apache License.
 //
 #include "pxr/imaging/garch/glPlatformContextWindows.h"
+#include "pxr/base/tf/hash.h"
 
-#include <boost/functional/hash.hpp>
 #include <Windows.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -63,10 +63,10 @@ GarchWGLContextState::operator==(const GarchWGLContextState& rhs) const
 size_t
 GarchWGLContextState::GetHash() const
 {
-    size_t result = 0;
-    boost::hash_combine(result, _detail->hdc);
-    boost::hash_combine(result, _detail->hglrc);
-    return result;
+    return TfHash::Combine(
+        _detail->hdc,
+        _detail->hglrc
+    );
 }
 
 bool

--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -51,7 +51,7 @@
 #include "pxr/imaging/hgiGL/graphicsCmds.h"
 #include "pxr/imaging/glf/diagnostic.h"
 
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iostream>
 
@@ -1016,17 +1016,20 @@ size_t
 HdxPickResult::_GetHash(int index) const
 {
     size_t hash = 0;
-    boost::hash_combine(hash, _GetPrimId(index));
-    boost::hash_combine(hash, _GetInstanceId(index));
+    hash = TfHash::Combine(
+        hash,
+        _GetPrimId(index),
+        _GetInstanceId(index)
+    );
     if (_pickTarget == HdxPickTokens->pickFaces) {
-        boost::hash_combine(hash, _GetElementId(index));
+        hash = TfHash::Combine(hash, _GetElementId(index));
     }
     if (_pickTarget == HdxPickTokens->pickEdges) {
-        boost::hash_combine(hash, _GetEdgeId(index));
+        hash = TfHash::Combine(hash, _GetEdgeId(index));
     }
     if (_pickTarget == HdxPickTokens->pickPoints ||
         _pickTarget == HdxPickTokens->pickPointsAndInstances) {
-        boost::hash_combine(hash, _GetPointId(index));
+        hash = TfHash::Combine(hash, _GetPointId(index));
     }
     return hash;
 }
@@ -1234,20 +1237,23 @@ HdxPickHit::GetHash() const
 {
     size_t hash = 0;
 
-    boost::hash_combine(hash, delegateId.GetHash());
-    boost::hash_combine(hash, objectId.GetHash());
-    boost::hash_combine(hash, instancerId);
-    boost::hash_combine(hash, instanceIndex);
-    boost::hash_combine(hash, elementIndex);
-    boost::hash_combine(hash, edgeIndex);
-    boost::hash_combine(hash, pointIndex);
-    boost::hash_combine(hash, worldSpaceHitPoint[0]);
-    boost::hash_combine(hash, worldSpaceHitPoint[1]);
-    boost::hash_combine(hash, worldSpaceHitPoint[2]);
-    boost::hash_combine(hash, worldSpaceHitNormal[0]);
-    boost::hash_combine(hash, worldSpaceHitNormal[1]);
-    boost::hash_combine(hash, worldSpaceHitNormal[2]);
-    boost::hash_combine(hash, normalizedDepth);
+    hash = TfHash::Combine(
+        hash,
+        delegateId.GetHash(),
+        objectId.GetHash(),
+        instancerId,
+        instanceIndex,
+        elementIndex,
+        edgeIndex,
+        pointIndex,
+        worldSpaceHitPoint[0],
+        worldSpaceHitPoint[1],
+        worldSpaceHitPoint[2],
+        worldSpaceHitNormal[0],
+        worldSpaceHitNormal[1],
+        worldSpaceHitNormal[2],
+        normalizedDepth
+    );
     
     return hash;
 }

--- a/pxr/imaging/hdx/unitTestUtils.cpp
+++ b/pxr/imaging/hdx/unitTestUtils.cpp
@@ -29,7 +29,8 @@
 #include "pxr/imaging/hd/tokens.h"
 #include "pxr/imaging/hdx/selectionTracker.h"
 
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
+
 #include <iostream>
 #include <unordered_map>
 #include <set>
@@ -51,10 +52,13 @@ _GetPartialHitHash(HdxPickHit const& hit)
 {
     size_t hash = 0;
 
-    boost::hash_combine(hash, hit.delegateId.GetHash());
-    boost::hash_combine(hash, hit.objectId.GetHash());
-    boost::hash_combine(hash, hit.instancerId.GetHash());
-    boost::hash_combine(hash, hit.instanceIndex);
+    hash = TfHash::Combine(
+        hash,
+        hit.delegateId.GetHash(),
+        hit.objectId.GetHash(),
+        hit.instancerId.GetHash(),
+        hit.instanceIndex
+    );
 
     return hash;
 }

--- a/pxr/imaging/hio/glslfx.cpp
+++ b/pxr/imaging/hio/glslfx.cpp
@@ -40,8 +40,7 @@
 #include "pxr/base/tf/stl.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/pathUtils.h"
-
-#include <boost/functional/hash.hpp>
+#include "pxr/base/tf/hash.h"
 
 #include <iostream>
 #include <istream>
@@ -320,7 +319,7 @@ HioGlslfx::_ProcessInput(std::istream * input,
         ++context.lineNo;
 
         // update hash
-        boost::hash_combine(_hash, context.currentLine);
+        _hash = TfHash::Combine(_hash, context.currentLine);
 
         if (context.lineNo > 1 && context.version < 0) {
             TF_RUNTIME_ERROR("Syntax Error on line 1 of %s. First line in file "


### PR DESCRIPTION
### Description of Change(s)
Replaces boost hash with TfHash in imaging. PR 3/3, this groups the smaller set of changes.

### Fixes Issue(s)
-https://github.com/PixarAnimationStudios/OpenUSD/issues/2172 (will be 3 PRs for imaging)

### Related PRs
https://github.com/PixarAnimationStudios/OpenUSD/pull/2763
https://github.com/PixarAnimationStudios/OpenUSD/pull/2764


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
