### PR TITLE
Apple: Mesh shaders 

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -102,6 +102,7 @@ extern HD_API TfEnvSetting<bool> HD_USE_DEPRECATED_INSTANCER_PRIMVAR_NAMES;
     (primID)                                    \
     (primitiveParam)                            \
     (tessFactors)                               \
+    (meshletRemap)                              \
     (quadInfo)                                  \
     (renderTags)                                \
     (rightHanded)                               \
@@ -249,6 +250,8 @@ extern HD_API TfEnvSetting<bool> HD_USE_DEPRECATED_INSTANCER_PRIMVAR_NAMES;
     (tessEvalShader)                            \
     (postTessControlShader)                     \
     (postTessVertexShader)                      \
+    (meshObjectShader)                          \
+    (meshletShader)                             \
     (tessLevel)                                 \
     (viewport)                                  \
     (vertexShader)                              \

--- a/pxr/imaging/hdSt/codeGen.h
+++ b/pxr/imaging/hdSt/codeGen.h
@@ -127,6 +127,16 @@ public:
         return _ptvsSource;
     }
 
+    /// Return the generated mesh object shader source
+    const std::string &GetMeshObjectShaderSource() const {
+        return _mosSource;
+    }
+
+    /// Return the generated meshlet shader source
+    const std::string &GetMeshletShaderSource() const {
+        return _msSource;
+    }
+
     /// Return the pointer of metadata to be populated by resource binder.
     HdSt_ResourceBinder::MetaData *GetMetaData() { return &_metaData; }
 
@@ -168,9 +178,10 @@ private:
     std::stringstream _genDecl;
     std::stringstream _genAccessors;
     std::stringstream _genVS, _genTCS, _genTES;
-    std::stringstream _genPTCS, _genPTVS;
+    std::stringstream _genPTCS, _genPTVS, _genMOS, _genMS;
     std::stringstream _genGS, _genFS, _genCS;
     std::stringstream _procVS, _procTCS, _procTES, _procGS;
+    std::stringstream _procMSDecl, _procMSIn, _procMSOut;
     std::stringstream _procPTVSOut;
     std::stringstream _osd;
 
@@ -183,6 +194,8 @@ private:
     ElementVector _resFS;
     ElementVector _resPTCS;
     ElementVector _resPTVS;
+    ElementVector _resMOS;
+    ElementVector _resMS;
     ElementVector _resCS;
 
     ElementVector _resInterstage;
@@ -203,6 +216,8 @@ private:
     std::string _csSource;
     std::string _ptcsSource;
     std::string _ptvsSource;
+    std::string _mosSource;
+    std::string _msSource;
 
     bool _hasVS;
     bool _hasTCS;
@@ -212,6 +227,8 @@ private:
     bool _hasCS;
     bool _hasPTCS;
     bool _hasPTVS;
+    bool _hasMOS;
+    bool _hasMS;
 
     bool _hasClipPlanes;
 };

--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -167,7 +167,7 @@ HdStCommandBuffer::ExecuteDraw(
     // Reset per-commandBuffer performance counters, updated by batch execution
     HD_PERF_COUNTER_SET(HdPerfTokens->drawCalls, 0);
     HD_PERF_COUNTER_SET(HdTokens->itemsDrawn, 0);
-
+    
     //
     // draw batches
     //
@@ -425,22 +425,22 @@ HdStCommandBuffer::_FrustumCullCPU(GfMatrix4d const &cullMatrix)
 {
     HD_TRACE_FUNCTION();
 
-    const bool mtCullingDisabled = 
-        TfDebug::IsEnabled(HDST_DISABLE_MULTITHREADED_CULLING) || 
+    const bool mtCullingDisabled =
+        TfDebug::IsEnabled(HDST_DISABLE_MULTITHREADED_CULLING) ||
         _drawItems->size() < 10000;
 
     struct _Worker {
         static
         void cull(std::vector<HdStDrawItemInstance> * drawItemInstances,
                   GfMatrix4d const &cullMatrix,
-                  size_t begin, size_t end) 
+                  size_t begin, size_t end)
         {
             for(size_t i = begin; i < end; i++) {
                 HdStDrawItemInstance& itemInstance = (*drawItemInstances)[i];
                 HdStDrawItem const* item = itemInstance.GetDrawItem();
-                bool visible = item->GetVisible() && 
+                bool visible = item->GetVisible() &&
                     item->IntersectsViewVolume(cullMatrix);
-                if ((itemInstance.IsVisible() != visible) || 
+                if ((itemInstance.IsVisible() != visible) ||
                     (visible && item->HasInstancer())) {
                     itemInstance.SetVisible(visible);
                 }
@@ -449,15 +449,15 @@ HdStCommandBuffer::_FrustumCullCPU(GfMatrix4d const &cullMatrix)
     };
 
     if (!mtCullingDisabled) {
-        WorkParallelForN(_drawItemInstances.size(), 
-                         std::bind(&_Worker::cull, &_drawItemInstances, 
+        WorkParallelForN(_drawItemInstances.size(),
+                         std::bind(&_Worker::cull, &_drawItemInstances,
                                    std::cref(cullMatrix),
                                    std::placeholders::_1,
                                    std::placeholders::_2));
     } else {
-        _Worker::cull(&_drawItemInstances, 
-                      cullMatrix, 
-                      0, 
+        _Worker::cull(&_drawItemInstances,
+                      cullMatrix,
+                      0,
                       _drawItemInstances.size());
     }
 

--- a/pxr/imaging/hdSt/geometricShader.cpp
+++ b/pxr/imaging/hdSt/geometricShader.cpp
@@ -47,6 +47,7 @@ HdSt_GeometricShader::HdSt_GeometricShader(std::string const &glslfxString,
                                        bool hasMirroredTransform,
                                        bool doubleSided,
                                        bool useMetalTessellation,
+                                       bool useMeshShaders,
                                        HdPolygonMode polygonMode,
                                        bool cullingPass,
                                        FvarPatchType fvarPatchType,
@@ -59,6 +60,7 @@ HdSt_GeometricShader::HdSt_GeometricShader(std::string const &glslfxString,
     , _hasMirroredTransform(hasMirroredTransform)
     , _doubleSided(doubleSided)
     , _useMetalTessellation(useMetalTessellation)
+    , _useMeshShaders(useMeshShaders)
     , _polygonMode(polygonMode)
     , _lineWidth(lineWidth)
     , _frustumCullingPass(cullingPass)
@@ -123,6 +125,9 @@ HdSt_GeometricShader::ResolveCullMode(
         case HdCullStyleFront:
             if (_hasMirroredTransform) {
                 resolvedCullMode = HgiCullModeBack;
+                if (_useMeshShaders) {
+                    resolvedCullMode = HgiCullModeNone;
+                }
             } else {
                 resolvedCullMode = HgiCullModeFront;
             }
@@ -131,6 +136,9 @@ HdSt_GeometricShader::ResolveCullMode(
             if (!_doubleSided) {
                 if (_hasMirroredTransform) {
                     resolvedCullMode = HgiCullModeBack;
+                    if (_useMeshShaders) {
+                        resolvedCullMode = HgiCullModeNone;
+                    }
                 } else {
                     resolvedCullMode = HgiCullModeFront;
                 }
@@ -141,6 +149,9 @@ HdSt_GeometricShader::ResolveCullMode(
                 resolvedCullMode = HgiCullModeFront;
             } else {
                 resolvedCullMode = HgiCullModeBack;
+                if (_useMeshShaders) {
+                    resolvedCullMode = HgiCullModeNone;
+                }
             }
             break;
         case HdCullStyleBackUnlessDoubleSided:
@@ -149,6 +160,9 @@ HdSt_GeometricShader::ResolveCullMode(
                     resolvedCullMode = HgiCullModeFront;
                 } else {
                     resolvedCullMode = HgiCullModeBack;
+                    if (_useMeshShaders) {
+                        resolvedCullMode = HgiCullModeNone;
+                    }
                 }
             }
             break;
@@ -370,6 +384,7 @@ HdSt_GeometricShader::GetHgiPrimitiveType() const
                 shaderKey.HasMirroredTransform(),
                 shaderKey.IsDoubleSided(),
                 shaderKey.UseMetalTessellation(),
+                shaderKey.UseMeshShaders(),
                 shaderKey.GetPolygonMode(),
                 shaderKey.IsFrustumCullingPass(),
                 shaderKey.GetFvarPatchType(),

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -129,7 +129,7 @@ public:
                primType == PrimitiveType::PRIM_BASIS_CURVES_CUBIC_PATCHES ||
                primType == PrimitiveType::PRIM_BASIS_CURVES_LINEAR_PATCHES;
     }
-
+    
     static inline bool IsPrimTypeCompute(PrimitiveType primType) {
         return primType == PrimitiveType::PRIM_COMPUTE;
     }
@@ -153,6 +153,7 @@ public:
                        bool hasMirroredTransform,
                        bool doubleSided,
                        bool useMetalTessellation,
+                       bool useMeshShaders,
                        HdPolygonMode polygonMode,
                        bool cullingPass,
                        FvarPatchType fvarPatchType,
@@ -188,6 +189,11 @@ public:
 
     bool GetUseMetalTessellation() const {
         return _useMetalTessellation;
+    }
+    
+    bool GetUseMeshShaders() const {
+        return _useMeshShaders &&
+            IsPrimTypeTriangles(_primType);
     }
 
     float GetLineWidth() const {
@@ -274,6 +280,7 @@ private:
     bool _hasMirroredTransform;
     bool _doubleSided;
     bool _useMetalTessellation;
+    bool _useMeshShaders;
     HdPolygonMode _polygonMode;
     float _lineWidth;
 

--- a/pxr/imaging/hdSt/glslProgram.cpp
+++ b/pxr/imaging/hdSt/glslProgram.cpp
@@ -145,6 +145,10 @@ _GetShaderType(HgiShaderStage stage)
             return "POST_TESS_CONTROL_SHADER";
         case HgiShaderStagePostTessellationVertex:
             return "POST_TESS_VERTEX_SHADER";
+        case HgiShaderStageMeshObject:
+            return "MESH_OBJECT_SHADER";
+        case HgiShaderStageMeshlet:
+            return "MESHLET_SHADER";
         default:
             return nullptr;
     }

--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -2609,7 +2609,14 @@ HdStMesh::_UpdateDrawItemGeometricShader(HdSceneDelegate *sceneDelegate,
     bool const hasMetalTessellation =
         resourceRegistry->GetHgi()->GetCapabilities()->
             IsSet(HgiDeviceCapabilitiesBitsMetalTessellation);
-
+    
+    bool usePtex =_MaterialHasPtex(
+           sceneDelegate->GetRenderIndex(), GetMaterialId());
+    
+    bool hasMeshShaders =
+        resourceRegistry->GetHgi()->GetCapabilities()->
+            IsSet(HgiDeviceCapabilitiesBitsMeshShading);
+    
     // create a shaderKey and set to the geometric shader.
     HdSt_MeshShaderKey shaderKey(primType,
                                  shadingTerminal,
@@ -2622,6 +2629,7 @@ HdStMesh::_UpdateDrawItemGeometricShader(HdSceneDelegate *sceneDelegate,
                                  _doubleSided || desc.doubleSided,
                                  hasBuiltinBarycentrics,
                                  hasMetalTessellation,
+                                 hasMeshShaders && !usePtex,
                                  hasCustomDisplacement,
                                  hasPerFaceInterpolation,
                                  hasTopologicalVisibility,

--- a/pxr/imaging/hdSt/meshShaderKey.cpp
+++ b/pxr/imaging/hdSt/meshShaderKey.cpp
@@ -38,6 +38,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((normalsScene,                "MeshNormal.Scene"))
     ((normalsScenePatches,         "MeshNormal.Scene.Patches"))
     ((normalsSmooth,               "MeshNormal.Smooth"))
+    ((normalsSmoothUnpackSSBO,     "MeshNormal.Smooth.UnpackSmoothSSBO"))
+    ((normalsSmoothUnpackVBO,      "MeshNormal.Smooth.UnpackSmoothVBO"))
     ((normalsFlat,                 "MeshNormal.Flat"))
     ((normalsPass,                 "MeshNormal.Pass"))
     ((normalsScreenSpaceFS,        "MeshNormal.Fragment.ScreenSpace"))
@@ -122,6 +124,12 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((mainBSplineQuadPTVS,         "Mesh.PostTessVertex.BSplineQuad"))
     ((mainBoxSplineTrianglePTCS,   "Mesh.PostTessControl.BoxSplineTriangle"))
     ((mainBoxSplineTrianglePTVS,   "Mesh.PostTessVertex.BoxSplineTriangle"))
+    ((mainVaryingInterpPTVS,       "Mesh.PostTessVertex.VaryingInterpolation"))
+    ((mainMOS,                     "Mesh.MeshObject.Main"))
+    ((mainTriangleMS,              "Mesh.Meshlet.Triangle"))
+    ((noCullmainTriangleMS,        "Mesh.Meshlet.TriangleNoCull"))
+    ((cullBackfaceMS,              "Mesh.Meshlet.Triangle.CullBackface"))
+    ((noCullBackfaceMS,            "Mesh.Meshlet.Triangle.NoCullBackface"))
     ((mainTriangleTessGS,          "Mesh.Geometry.TriangleTess"))
     ((mainTriangleGS,              "Mesh.Geometry.Triangle"))
     ((mainTriQuadGS,               "Mesh.Geometry.TriQuad"))
@@ -167,6 +175,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     bool doubleSided,
     bool hasBuiltinBarycentrics,
     bool hasMetalTessellation,
+    bool hasMeshShaders,
     bool hasCustomDisplacement,
     bool hasPerFaceInterpolation,
     bool hasTopologicalVisibility,
@@ -181,10 +190,12 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     , hasMirroredTransform(hasMirroredTransform)
     , doubleSided(doubleSided)
     , useMetalTessellation(false)
+    , useMeshShaders(hasMeshShaders)
     , polygonMode(HdPolygonModeFill)
     , lineWidth(lineWidth)
     , fvarPatchType(fvarPatchType)
     , glslfx(_tokens->baseGLSLFX)
+
 {
     if (geomStyle == HdMeshGeomStyleEdgeOnly ||
         geomStyle == HdMeshGeomStyleHullEdgeOnly) {
@@ -254,14 +265,21 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
         (normalsSource == NormalSourceScene && !vsSceneNormals);
     bool const ptvsGeometricNormals =
         (normalsSource == NormalSourceFlatGeometric);
-
+    
+    if (ptvsGeometricNormals) {
+        useMeshShaders = false;
+    }
     // vertex shader
     uint8_t vsIndex = 0;
     VS[vsIndex++] = _tokens->instancing;
-
-    VS[vsIndex++] = (normalsSource == NormalSourceSmooth) ?
-        _tokens->normalsSmooth :
-        (vsSceneNormals ? _tokens->normalsScene : _tokens->normalsPass);
+    if (normalsSource == NormalSourceSmooth) {
+        VS[vsIndex++] = _tokens->normalsSmoothUnpackVBO;
+        VS[vsIndex++] = _tokens->normalsSmooth;
+    } else if (vsSceneNormals) {
+        VS[vsIndex++] = _tokens->normalsScene;
+    } else {
+        VS[vsIndex++] = _tokens->normalsPass;
+    }
 
     if (isPrimTypePoints) {
         // Add mixins that allow for picking and sel highlighting of points.
@@ -277,20 +295,88 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     VS[vsIndex] = TfToken();
 
     // Determine if PTVS should be used for Metal.
-    bool const usePTVSTechniques =
+    bool usePTVSTechniques =
             isPrimTypePatches ||
             hasCustomDisplacement ||
             ptvsSceneNormals ||
             ptvsGeometricNormals ||
             !hasBuiltinBarycentrics;
+    
+    if (useMeshShaders && !isPrimTypePatches) {
+        usePTVSTechniques = false;
+    }
 
     // Determine if using actually using Metal PTVS.
     useMetalTessellation =
         hasMetalTessellation && !isPrimTypePoints && usePTVSTechniques;
 
+    bool useMeshShading = UseMeshShaders();
+
     // PTVS shaders can provide barycentric coords w/o GS.
     bool const hasFragmentShaderBarycentrics =
-        hasBuiltinBarycentrics || useMetalTessellation;
+        hasBuiltinBarycentrics || useMetalTessellation || useMeshShading;
+
+    uint8_t mosIndex = 0;
+    uint8_t msIndex = 0;
+    
+    bool const faceCullFrontFacing =
+        !useHardwareFaceCulling &&
+            (cullStyle == HdCullStyleFront ||
+             (cullStyle == HdCullStyleFrontUnlessDoubleSided && !doubleSided));
+    bool const faceCullBackFacingMS =
+            (cullStyle == HdCullStyleBack ||
+             (cullStyle == HdCullStyleBackUnlessDoubleSided && !doubleSided));
+    bool const faceCullBackFacing =
+        !useHardwareFaceCulling && faceCullBackFacingMS;
+    
+    if (useMeshShading) {
+        MS[msIndex++] = _tokens->instancing;
+        if (ptvsGeometricNormals) {
+            MS[msIndex++] = _tokens->normalsGeometryFlat;
+        } else {
+            MS[msIndex++] = _tokens->normalsGeometryNoFlat;
+        }
+
+        // Now handle the vs style normals
+        if (normalsSource == NormalSourceFlat) {
+            MS[msIndex++] = _tokens->normalsFlat;
+        }
+        else if (normalsSource == NormalSourceSmooth) {
+            MS[msIndex++] = _tokens->normalsSmoothUnpackSSBO;
+            MS[msIndex++] = _tokens->normalsSmooth;
+        } else if (vsSceneNormals) {
+            MS[msIndex++] = _tokens->normalsScene;
+        } else if (gsSceneNormals && isPrimTypePatches) {
+            MS[msIndex++] = _tokens->normalsScenePatches;
+        } else {
+            MS[msIndex++] = _tokens->normalsPass;
+        }
+        
+        if (hasCustomDisplacement) {
+            MS[msIndex++] = _tokens->customDisplacementGS;
+        } else {
+            MS[msIndex++] = _tokens->noCustomDisplacementGS;
+        }
+        
+        if (faceCullBackFacingMS) {
+            MS[msIndex++] = _tokens->noCullBackfaceMS;
+        } else {
+            MS[msIndex++] = _tokens->cullBackfaceMS;
+        }
+        
+        MOS[mosIndex++] = _tokens->mainMOS;
+        if (isPrimTypeQuads || isPrimTypeTriQuads) {
+            TF_CODING_ERROR("Quad prims not supported yet");
+        } else if (isPrimTypeTris) {
+            if (faceCullBackFacingMS) {
+                MS[msIndex++] = _tokens->mainTriangleMS;
+            } else {
+                MS[msIndex++] = _tokens->noCullmainTriangleMS;
+            }
+        } else {
+            TF_CODING_ERROR("Unsupported meshlet primitive type");
+        }
+    }
 
     // post tess vertex shader vertex steps
     uint8_t ptvsIndex = 0;
@@ -312,6 +398,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
             PTVS[ptvsIndex++] = _tokens->normalsFlat;
         }
         else if (normalsSource == NormalSourceSmooth) {
+            PTVS[ptvsIndex++] = _tokens->normalsSmoothUnpackVBO;
             PTVS[ptvsIndex++] = _tokens->normalsSmooth;
         } else if (vsSceneNormals) {
             PTVS[ptvsIndex++] = _tokens->normalsScene;
@@ -419,7 +506,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
 
     // Optimization : See if we can skip the geometry shader.
     bool const canSkipGS =
-            ptvsStageEnabled ||
+            ptvsStageEnabled || UseMeshShaders() ||
             // Whether we can skip executing the displacement shading terminal
             (!hasCustomDisplacement
             && (normalsSource != NormalSourceLimit)
@@ -450,7 +537,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     // fragment shader
     uint8_t fsIndex = 0;
     FS[fsIndex++] = _tokens->instancing;
-
+    
     FS[fsIndex++] =
         (normalsSource == NormalSourceFlatScreenSpace)
             ? _tokens->normalsScreenSpaceFS
@@ -463,20 +550,21 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     FS[fsIndex++] = doubleSided ?
         _tokens->normalsDoubleSidedFS : _tokens->normalsSingleSidedFS;
 
-    bool const faceCullFrontFacing =
-        !useHardwareFaceCulling &&
-            (cullStyle == HdCullStyleFront ||
-             (cullStyle == HdCullStyleFrontUnlessDoubleSided && !doubleSided));
-    bool const faceCullBackFacing =
-        !useHardwareFaceCulling &&
-            (cullStyle == HdCullStyleBack ||
-             (cullStyle == HdCullStyleBackUnlessDoubleSided && !doubleSided));
-    FS[fsIndex++] =
-        faceCullFrontFacing
-            ? _tokens->faceCullFrontFacingFS
-            : faceCullBackFacing
-                ? _tokens->faceCullBackFacingFS
-                : _tokens->faceCullNoneFS; // DontCare, Nothing, HW
+    if (!useMeshShading) {
+        FS[fsIndex++] =
+            faceCullFrontFacing
+                ? _tokens->faceCullFrontFacingFS
+                : faceCullBackFacing
+                    ? _tokens->faceCullBackFacingFS
+                    : _tokens->faceCullNoneFS; // DontCare, Nothing, HW
+    } else {
+        FS[fsIndex++] =
+            faceCullFrontFacing
+                ? _tokens->faceCullFrontFacingFS
+                    : _tokens->faceCullNoneFS; // DontCare, Nothing, HW
+    }
+    
+        
 
     // Wire (edge) related mixins
     if (renderWireframe || renderEdges) {
@@ -484,7 +572,7 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
             FS[fsIndex++] = _tokens->edgeCoordTessCoordTriangleFS;
         } else if ((isPrimTypeQuads||isPrimTypeTriQuads) && ptvsStageEnabled) {
             FS[fsIndex++] = _tokens->edgeCoordTessCoordFS;
-        } else {
+            } else {
             FS[fsIndex++] = _tokens->edgeCoordBarycentricCoordFS;
         }
 

--- a/pxr/imaging/hdSt/meshShaderKey.h
+++ b/pxr/imaging/hdSt/meshShaderKey.h
@@ -57,6 +57,7 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
                        bool doubleSided,
                        bool hasBuiltinBarycentrics,
                        bool hasMetalTessellation,
+                       bool hasMeshShaders,
                        bool hasCustomDisplacement,
                        bool hasPerFaceInterpolation,
                        bool hasTopologicalVisibility,
@@ -87,6 +88,10 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
     bool UseMetalTessellation() const override {
         return useMetalTessellation;
     }
+    bool UseMeshShaders() const override {
+        return useMeshShaders &&
+            HdSt_GeometricShader::IsPrimTypeTriangles(primType);
+    }
 
     HdPolygonMode GetPolygonMode() const override { return polygonMode; }
     float GetLineWidth() const override { return lineWidth; }
@@ -99,10 +104,12 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
 
     HdSt_GeometricShader::PrimitiveType primType;
     HdCullStyle cullStyle;
+    bool hasCustomDisplacement;
     bool useHardwareFaceCulling;
     bool hasMirroredTransform;
     bool doubleSided;
     bool useMetalTessellation;
+    bool useMeshShaders;
     HdPolygonMode polygonMode;
     float lineWidth;
     HdSt_GeometricShader::FvarPatchType fvarPatchType;
@@ -113,15 +120,19 @@ struct HdSt_MeshShaderKey : public HdSt_ShaderKey
     TfToken const *GetTES() const override { return TES; }
     TfToken const *GetPTCS()  const override { return PTCS; }
     TfToken const *GetPTVS()  const override { return PTVS; }
+    TfToken const *GetMOS()  const override { return MOS; }
+    TfToken const *GetMS()  const override { return MS; }
     TfToken const *GetGS()  const override { return GS; }
     TfToken const *GetFS()  const override { return FS; }
 
     TfToken glslfx;
-    TfToken VS[7];
+    TfToken VS[8];
     TfToken TCS[3];
     TfToken TES[4];
     TfToken PTCS[5];
-    TfToken PTVS[12];
+    TfToken PTVS[13];
+    TfToken MOS[3];
+    TfToken MS[10];
     TfToken GS[10];
     TfToken FS[22];
 };

--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -71,6 +71,7 @@ TF_DEFINE_PRIVATE_TOKENS(
 
     (dispatchBuffer)
     (drawCullInput)
+    (drawBuffer)
 
     (drawIndirect)
     (drawIndirectCull)
@@ -133,6 +134,9 @@ HdSt_PipelineDrawBatch::_Init(HdStDrawItemInstance * drawItemInstance)
     _useDrawIndexed = static_cast<bool>(drawItem->GetTopologyRange());
     _useInstancing  = static_cast<bool>(drawItem->GetInstanceIndexRange());
     _useGpuCulling  = _allowGpuFrustumCulling && IsEnabledGPUFrustumCulling();
+    _allowIndirectCommandEncoding =
+        _allowIndirectCommandEncoding &&
+        !drawItem->GetGeometricShader()->GetUseMeshShaders();
 
     // note: _useInstancing condition is not necessary. it can be removed
     //       if we decide always to use instance culling.
@@ -147,6 +151,7 @@ HdSt_PipelineDrawBatch::_Init(HdStDrawItemInstance * drawItemInstance)
     TF_DEBUG(HDST_DRAW_BATCH).Msg(
         "   Resetting dispatch buffer.\n");
     _dispatchBuffer.reset();
+    _meshletDispatchBuffer.reset();
 }
 
 void
@@ -312,6 +317,20 @@ struct _DrawIndexedCommand
     _DrawingCoord drawingCoord;
 };
 
+struct _DrawIndexedMeshCommand
+{
+    struct {
+        uint32_t count;
+        uint32_t instanceCount;
+        uint32_t baseIndex;
+        uint32_t baseVertex;
+        uint32_t baseInstance;
+        uint32_t meshletCoord;
+        uint32_t numMeshlets;
+    } common;
+    _DrawingCoord drawingCoord;
+};
+
 // DrawIndexed + Instance culling : 19 integers (+ numInstanceLevels)
 struct _DrawIndexedInstanceCullCommand
 {
@@ -429,7 +448,8 @@ _DrawCommandTraits
 _GetDrawCommandTraits(int const instancerNumLevels,
                       bool const useDrawIndexed,
                       bool const useInstanceCulling,
-                      size_t const uint32Alignment)
+                      size_t const uint32Alignment,
+                      bool useMeshShaders = false)
 {
     _DrawCommandTraits traits;
     if (!useDrawIndexed) {
@@ -453,11 +473,18 @@ _GetDrawCommandTraits(int const instancerNumLevels,
             _SetInstanceCullTraits<CmdType>(&traits);
             _SetDrawingCoordTraits<CmdType>(&traits);
         } else {
+            if(useMeshShaders) {
+                using CmdType = _DrawIndexedMeshCommand;
+                _SetDrawCommandTraits<CmdType>(&traits, instancerNumLevels,
+                                               uint32Alignment);
+                _SetDrawingCoordTraits<CmdType>(&traits);
+            } else {
             using CmdType = _DrawIndexedCommand;
             _SetDrawCommandTraits<CmdType>(&traits, instancerNumLevels,
                                            uint32Alignment);
             _SetDrawingCoordTraits<CmdType>(&traits);
         }
+    }
     }
     return traits;
 }
@@ -601,7 +628,202 @@ _AllocateTessFactorsBuffer(
         HgiBufferUsageUniform);
 }
 
+HdStBufferResourceSharedPtr
+_AllocateMeshletDispatchBuffer(
+    HdStResourceRegistrySharedPtr const & resourceRegistry,
+    std::vector<uint32_t> meshletDrawCommands)
+{
+    HdStBufferResourceSharedPtr buf = resourceRegistry->RegisterBufferResource(
+        HdTokens->meshletRemap,
+        HdTupleType{HdTypeInt32, meshletDrawCommands.size()},
+        HgiBufferUsageStorage);
+    // Use blit op to copy over the data.
+    Hgi* hgi = resourceRegistry->GetHgi();
+    HgiBlitCmdsUniquePtr blitCmds = hgi->CreateBlitCmds();
+    HgiBufferCpuToGpuOp blitOp;
+    blitOp.byteSize = meshletDrawCommands.size() * sizeof(uint32_t);
+    blitOp.cpuSourceBuffer = meshletDrawCommands.data();
+    blitOp.sourceByteOffset = 0;
+    blitOp.gpuDestinationBuffer = buf->GetHandle();
+    blitOp.destinationByteOffset = 0;
+    blitCmds->CopyBufferCpuToGpu(blitOp);
+    hgi->SubmitCmds(blitCmds.get());
+
+    return buf;;
+}
+
 } // annonymous namespace
+
+constexpr uint32_t max_primitives = 512;
+constexpr uint32_t max_vertices = 256;
+
+struct VertexInfo {
+    uint32_t vertexId;
+    uint32_t indexId; // this is a promise that of the primitive associated, this is the index row associated
+    uint32_t GetDisplacementIndex() {
+        return indexId % 3;
+    }
+    uint32_t GetPrimitiveID() {
+        return indexId / 3;
+    }
+};
+
+struct Meshlet {
+    uint32_t vertexCount;
+    uint32_t primitiveCount;
+    std::vector<VertexInfo> vertexInfo;
+    std::vector<uint32_t> remappedIndices;
+    std::vector<uint32_t> remappedPrimIDs;
+};
+
+//process mesh at a time
+std::vector<Meshlet> processIndices(uint32_t* indices, int indexCount, uint32_t meshStartLocation = 0, uint32_t meshEndLocation = 0) {
+    int numPrimsProcessed = 0;
+    int numVerticesProcessed = 0;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> m;
+    std::vector<Meshlet> meshlets;
+    std::unordered_map<uint32_t, uint32_t> globalToLocalVertex;
+    bool maxVertsReached = false;
+    bool maxPrimsReached = false;
+    Meshlet meshlet;
+    int startPrimitive = meshStartLocation / 3;
+    int endPrimitive = meshStartLocation / 3;
+    uint primId = 0;
+    for(uint32_t i = meshStartLocation; i < meshEndLocation + 1; i += 3) {
+        if (maxVertsReached || maxPrimsReached || i >= meshEndLocation) {
+            endPrimitive = numPrimsProcessed + startPrimitive;
+            int count = 0;
+            meshlet.vertexInfo.resize(m.size());
+            for(auto it = m.begin(); it != m.end(); ++it) {
+                VertexInfo vertexInfo;
+                vertexInfo.vertexId = it->first;
+                vertexInfo.indexId = it->second[0];
+                meshlet.vertexInfo[count] = vertexInfo;
+                globalToLocalVertex[it->first] = count;
+                count++;
+            }
+            
+            for(uint32_t n = startPrimitive; n < (endPrimitive); n++) {
+                uint ind0 = globalToLocalVertex[indices[n*3]];
+                uint ind1 = globalToLocalVertex[indices[n*3+1]];
+                uint ind2 = globalToLocalVertex[indices[n*3+2]];
+                uint packed = ind0;
+                packed |= ind1 << 8;
+                packed |= ind2 << 16;
+                meshlet.remappedIndices.push_back(packed);
+                meshlet.remappedPrimIDs.push_back(primId);
+                primId++;
+            }
+            meshlet.vertexCount = meshlet.vertexInfo.size();
+            meshlet.primitiveCount = numPrimsProcessed;
+
+            maxVertsReached = false;
+            maxPrimsReached = false;
+            numPrimsProcessed = 0;
+            numVerticesProcessed = 0;
+            m = std::unordered_map<uint32_t, std::vector<uint32_t>>();
+            globalToLocalVertex = std::unordered_map<uint32_t, uint32_t>();
+            meshlets.push_back(meshlet);
+            if(i >= meshEndLocation) {
+                continue;
+            }
+            meshlet = Meshlet();
+            startPrimitive = endPrimitive;
+        }
+        
+        //TODO see if we can be smarter
+        auto it1 = m.find(i);
+        auto it2 = m.find(i+1);
+        auto it3 = m.find(i+2);
+        if((m.size() + 4) > max_vertices) {
+            int space = max_vertices - m.size();
+            int wantedSpace = 0;
+            wantedSpace += it1 == m.end();
+            wantedSpace += it2 == m.end();
+            wantedSpace += it3 == m.end();
+            if (space < wantedSpace) {
+                maxVertsReached = true;
+                i = i-3;
+                continue;
+            }
+        }
+        
+        if (it1 == m.end()) {
+            m[indices[i]] = {i};
+            numVerticesProcessed++;
+        } else {
+            it1->second.push_back(i);
+        }
+        if (it2 == m.end()) {
+            m[indices[i+1]] = {i+1};
+            numVerticesProcessed++;
+        } else {
+            it2->second.push_back(i+1);
+        }
+        if (it3 == m.end()) {
+            m[indices[i+2]] = {i+2};
+            numVerticesProcessed++;
+        } else {
+            it3->second.push_back(i+2);
+        }
+        numPrimsProcessed++;
+        if(numPrimsProcessed >= (max_primitives)) {
+            maxPrimsReached = true;
+            continue;
+        }
+    }
+    return meshlets;
+}
+
+struct MeshletCoord
+{
+    uint32_t meshlet_coord;
+    uint32_t numMeshlets;
+};
+//has the coords for the meshlet at the start of this buffer
+void flattenMeshlets(std::vector<uint32_t> &flattenInto, std::vector<MeshletCoord> &drawingCoords, const std::vector<std::vector<Meshlet>> &meshlets) {
+    uint32_t currentOffset = 0;
+    uint32_t lastOffset = 0;
+    for(int i = 0; i < meshlets.size(); i++) {
+        int localOffset = 0;
+        const std::vector<Meshlet> &meshletsInMesh = meshlets[i];
+        for(int l = 0; l < meshletsInMesh.size(); l++) {
+            flattenInto.push_back(meshletsInMesh.size());
+            currentOffset++;
+            localOffset++;
+        }
+        for(int j = 0; j < meshletsInMesh.size(); j++) {
+            const Meshlet &m = meshletsInMesh[j];
+            flattenInto.push_back(m.vertexCount);
+            flattenInto.push_back(m.primitiveCount);
+            currentOffset += 2;
+            localOffset += 2;
+            for (uint32_t k = 0; k < m.vertexInfo.size(); k++) {
+                auto vertexInfo = m.vertexInfo[k];
+                flattenInto.push_back(vertexInfo.vertexId);
+                flattenInto.push_back(vertexInfo.indexId);
+                currentOffset += 2;
+                localOffset += 2;
+            }
+            
+            for (int k = 0; k < m.remappedIndices.size(); k++) {
+                flattenInto.push_back(m.remappedIndices[k]);
+                flattenInto.push_back(m.remappedPrimIDs[k]);
+
+                currentOffset += 2;
+                localOffset += 2;
+            }
+            if (j < (meshletsInMesh.size()-1)) {
+                flattenInto[lastOffset+(j+1)] = localOffset;
+            }
+        }
+        MeshletCoord mlCoord;
+        mlCoord.meshlet_coord = lastOffset;
+        lastOffset = currentOffset;
+        mlCoord.numMeshlets = meshlets[i].size();
+        drawingCoords.push_back(mlCoord);
+    }
+}
 
 void
 HdSt_PipelineDrawBatch::_CompileBatch(
@@ -620,6 +842,8 @@ HdSt_PipelineDrawBatch::_CompileBatch(
     bool const useMetalTessellation =
         _drawItemInstances[0]->GetDrawItem()->
                 GetGeometricShader()->GetUseMetalTessellation();
+    bool isMeshShader = _drawItemInstances[0]->GetDrawItem()->
+        GetGeometricShader()->GetUseMeshShaders();
 
     // Align drawing commands to 32 bytes for Metal.
     size_t const uint32Alignment = useMetalTessellation ? 8 : 0;
@@ -629,17 +853,63 @@ HdSt_PipelineDrawBatch::_CompileBatch(
         _GetDrawCommandTraits(instancerNumLevels,
                               _useDrawIndexed,
                               _useInstanceCulling,
-                              uint32Alignment);
+                              uint32Alignment,
+                              isMeshShader);
 
     TF_DEBUG(HDST_DRAW).Msg("\nCompile Dispatch Buffer\n");
     TF_DEBUG(HDST_DRAW).Msg(" - numUInt32: %zd\n", traits.numUInt32);
     TF_DEBUG(HDST_DRAW).Msg(" - useDrawIndexed: %d\n", _useDrawIndexed);
     TF_DEBUG(HDST_DRAW).Msg(" - useInstanceCulling: %d\n", _useInstanceCulling);
     TF_DEBUG(HDST_DRAW).Msg(" - num draw items: %zu\n", numDrawItemInstances);
-
     _drawCommandBuffer.resize(numDrawItemInstances * traits.numUInt32);
+    //estimate this required overallication
+    //_meshletDrawBuffer.resize(numDrawItemInstances * 2 * 258);
     std::vector<uint32_t>::iterator cmdIt = _drawCommandBuffer.begin();
-
+    
+    HdStBufferResourceSharedPtr indexBuffer;
+        
+    uint32_t* cpuBuffer;
+    std::vector<std::vector<Meshlet>> meshlets;
+    std::vector<MeshletCoord> meshletDrawCoord;
+    if (isMeshShader) {
+        auto indexBar =
+        std::static_pointer_cast<HdStBufferArrayRange>(
+            _drawItemInstances.front()->GetDrawItem()->GetTopologyRange());
+        indexBuffer = indexBar->GetResource(HdTokens->indices);
+        cpuBuffer = ((uint32_t*)indexBuffer->GetHandle()->GetCPUStagingAddress());
+        for (size_t item = 0; item < numDrawItemInstances; ++item) {
+            HdStDrawItemInstance const *drawItemInstance = _drawItemInstances[item];
+            HdStDrawItem const *drawItem = drawItemInstance->GetDrawItem();
+            
+            
+            _DrawItemState const dc(drawItem);
+            
+            // drawing coordinates.
+            uint32_t const vertexDC        = _GetElementOffset(dc.vertexBar);
+            uint32_t const primitiveDC     = _GetElementOffset(dc.indexBar);
+            
+            // 3 for triangles, 4 for quads, 6 for triquads, n for patches
+            uint32_t const numIndicesPerPrimitive =
+            drawItem->GetGeometricShader()->GetPrimitiveIndexSize();
+            
+            uint32_t const baseVertex = vertexDC;
+            uint32_t const vertexCount = _GetElementCount(dc.vertexBar);
+            
+            // if delegate fails to get vertex primvars, it could be empty.
+            // skip the drawitem to prevent drawing uninitialized vertices.
+            uint32_t const numElements =
+            vertexCount != 0 ? _GetElementCount(dc.indexBar) : 0;
+            
+            uint32_t const baseIndex = primitiveDC * numIndicesPerPrimitive;
+            uint32_t const indexCount = numElements * numIndicesPerPrimitive;
+            
+            auto meshlet = processIndices(cpuBuffer, indexCount, baseIndex, baseIndex + indexCount);
+            meshlets.push_back(meshlet);
+        }
+        flattenMeshlets(_meshletDrawBuffer, meshletDrawCoord, meshlets);
+    }
+    
+    
     // Count the number of visible items. We may actually draw fewer
     // items than this when GPU frustum culling is active.
     _numVisibleItems = 0;
@@ -657,7 +927,10 @@ HdSt_PipelineDrawBatch::_CompileBatch(
                             drawItem->GetElementOffsetsHash());
 
         _DrawItemState const dc(drawItem);
-
+        MeshletCoord coord;
+        if (isMeshShader && !meshletDrawCoord.empty()) {
+            coord = meshletDrawCoord[item];
+        }
         // drawing coordinates.
         uint32_t const modelDC         = 0; // reserved for future extension
         uint32_t const constantDC      = _GetElementOffset(dc.constantBar);
@@ -755,11 +1028,17 @@ HdSt_PipelineDrawBatch::_CompileBatch(
                     *cmdIt++ = baseIndex;
                     *cmdIt++ = baseVertex;
                     *cmdIt++ = baseInstance;
-
+                    if (isMeshShader) {
+                        *cmdIt++ = coord.meshlet_coord;
+                        *cmdIt++ = coord.numMeshlets;
+                        *cmdIt++ = 0;
+                        *cmdIt++ = 0;
+                    } else {
                     *cmdIt++ = 1;             /* cullCount (always 1) */
                     *cmdIt++ = instanceCount; /* cullInstanceCount */
                     *cmdIt++ = 0;             /* cullBaseVertex (not used)*/
                     *cmdIt++ = baseInstance;  /* cullBaseInstance */
+                }
                 }
             } else {
                 // _DrawIndexedCommand
@@ -775,6 +1054,10 @@ HdSt_PipelineDrawBatch::_CompileBatch(
                     *cmdIt++ = baseIndex;
                     *cmdIt++ = baseVertex;
                     *cmdIt++ = baseInstance;
+                    if(isMeshShader) {
+                        *cmdIt++ = coord.meshlet_coord;
+                        *cmdIt++ = coord.numMeshlets;
+                    }
                 }
             }
         }
@@ -844,7 +1127,9 @@ HdSt_PipelineDrawBatch::_CompileBatch(
         resourceRegistry->RegisterDispatchBuffer(_tokens->drawIndirect,
                                                  numDrawItemInstances,
                                                  traits.numUInt32);
-
+    if (isMeshShader) {
+        _meshletDispatchBuffer = _AllocateMeshletDispatchBuffer(resourceRegistry, _meshletDrawBuffer);
+    }
     // allocate tessFactors buffer for Metal tessellation
     if (useMetalTessellation &&
         _drawItemInstances[0]->GetDrawItem()->
@@ -972,11 +1257,13 @@ HdSt_PipelineDrawBatch::PrepareDraw(
     // On the first time through, after batches have just been compiled,
     // the flag will be false because the resource registry will have already
     // uploaded the buffer.
+    
     bool const updateBufferData = _drawCommandBufferDirty;
     if (updateBufferData) {
         _dispatchBuffer->CopyData(_drawCommandBuffer);
         _drawCommandBufferDirty = false;
     }
+    
 
     if (_useGpuCulling) {
         // Ignore passed in gfxCmds for now since GPU frustum culling
@@ -1042,6 +1329,7 @@ struct _BindingState : public _DrawItemState
     void GetBindingsForDrawing(
                 HgiResourceBindingsDesc * bindingsDesc,
                 HdStBufferResourceSharedPtr const & tessFactorsBuffer,
+                HdStBufferResourceSharedPtr const & meshletRemapBuffer,
                 bool bindTessFactors) const;
 
     HdStDispatchBufferSharedPtr dispatchBuffer;
@@ -1075,6 +1363,7 @@ void
 _BindingState::GetBindingsForDrawing(
     HgiResourceBindingsDesc * bindingsDesc,
     HdStBufferResourceSharedPtr const & tessFactorsBuffer,
+    HdStBufferResourceSharedPtr const & meshletRemapBuffer,
     bool bindTessFactors) const
 {
     GetBindingsForViewTransformation(bindingsDesc);
@@ -1088,6 +1377,14 @@ _BindingState::GetBindingsForDrawing(
     binder.GetBufferArrayBindingDesc(bindingsDesc, elementBar);
     binder.GetBufferArrayBindingDesc(bindingsDesc, fvarBar);
     binder.GetBufferArrayBindingDesc(bindingsDesc, varyingBar);
+    
+    if (geometricShader->GetUseMeshShaders()) {
+        binder.GetBufferArrayBindingDesc(bindingsDesc, vertexBar);
+        binder.GetBufferBindingDesc(bindingsDesc,
+                                    HdTokens->meshletRemap,
+                                    meshletRemapBuffer,
+                                    meshletRemapBuffer->GetOffset());
+    }
 
     if (tessFactorsBuffer) {
         binder.GetBufferBindingDesc(bindingsDesc,
@@ -1265,7 +1562,6 @@ _GetDrawPipeline(
     // pipeline state are the same.
     HgiShaderProgramHandle const & programHandle =
                                         state.glslProgram->GetProgram();
-
     static const uint64_t salt = ArchHash64(__FUNCTION__, sizeof(__FUNCTION__));
     uint64_t hash = salt;
     hash = TfHash::Combine(hash, programHandle.Get());
@@ -1278,10 +1574,27 @@ _GetDrawPipeline(
     if (pipelineInstance.IsFirstInstance()) {
         HgiGraphicsPipelineDesc pipeDesc;
 
-        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,
+        renderPassState->InitGraphicsPipelineDesc(&pipeDesc,      
                                                   state.geometricShader);
-
         pipeDesc.shaderProgram = state.glslProgram->GetProgram();
+        pipeDesc.meshState.useMeshShader = state.geometricShader->GetUseMeshShaders();
+        if (pipeDesc.meshState.useMeshShader) {
+            for (const auto& fun : programHandle->GetDescriptor().shaderFunctions) {
+                if (fun->GetDescriptor().shaderStage == HgiShaderStageMeshlet) {
+                    pipeDesc.meshState.maxTotalThreadsPerMeshThreadgroup =
+                        fun->GetDescriptor().meshDescriptor.
+                            maxTotalThreadsPerMeshletThreadgroup;
+                }
+                if (fun->GetDescriptor().shaderStage == HgiShaderStageMeshObject) {
+                    pipeDesc.meshState.maxTotalThreadsPerObjectThreadgroup =
+                        fun->GetDescriptor().meshDescriptor.
+                            maxTotalThreadsPerObjectThreadgroup;
+                    pipeDesc.meshState.maxTotalThreadGroupsPerObject =
+                        fun->GetDescriptor().meshDescriptor.
+                            maxTotalThreadgroupsPerMeshObject;
+                }
+            }
+        }
         pipeDesc.vertexBuffers = _GetVertexBuffersForDrawing(state);
 
         Hgi* hgi = resourceRegistry->GetHgi();
@@ -1404,12 +1717,24 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
         gfxCmds->BindPipeline(psoHandle);
 
         HgiResourceBindingsDesc bindingsDesc;
+        bool const useMeshShaders =
+                _drawItemInstances[0]->GetDrawItem()->
+                        GetGeometricShader()->GetUseMeshShaders();
+        if (useMeshShaders) {
+            state.binder.GetBufferBindingDesc(
+                &bindingsDesc,
+                _tokens->drawBuffer,
+                _dispatchBuffer->GetEntireResource(),
+                _dispatchBuffer->GetEntireResource()->GetOffset());
+             
+        }
         state.GetBindingsForDrawing(&bindingsDesc,
-                _tessFactorsBuffer, /*bindTessFactors=*/true);
-
+                _tessFactorsBuffer,
+                _meshletDispatchBuffer, /*bindTessFactors=*/true);
+        
         HgiResourceBindingsHandle resourceBindings =
                 hgi->CreateResourceBindings(bindingsDesc);
-        gfxCmds->BindResources(resourceBindings);
+        gfxCmds->BindResources(resourceBindings, useMeshShaders);
 
         HgiVertexBufferBindingVector bindings;
         _GetVertexBufferBindingsForDrawing(&bindings, state);
@@ -1422,9 +1747,9 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
             capabilities->IsSet(HgiDeviceCapabilitiesBitsMultiDrawIndirect);
 
         if (drawIndirect) {
-            _ExecuteDrawIndirect(gfxCmds, state.indexBar);
+            _ExecuteDrawIndirect(gfxCmds, state.indexBar, psoHandle, renderPassState);
         } else {
-            _ExecuteDrawImmediate(gfxCmds, state.indexBar);
+            _ExecuteDrawImmediate(gfxCmds, state.indexBar, psoHandle);
         }
 
         hgi->DestroyResourceBindings(&resourceBindings);
@@ -1437,13 +1762,19 @@ HdSt_PipelineDrawBatch::ExecuteDraw(
 void
 HdSt_PipelineDrawBatch::_ExecuteDrawIndirect(
     HgiGraphicsCmds * gfxCmds,
-    HdStBufferArrayRangeSharedPtr const & indexBar)
+    HdStBufferArrayRangeSharedPtr const & indexBar,
+    HgiGraphicsPipelineHandle psoHandle,
+    HdStRenderPassStateSharedPtr const & renderPassState)
 {
     TRACE_FUNCTION();
 
     HdStBufferResourceSharedPtr paramBuffer = _dispatchBuffer->
         GetBufferArrayRange()->GetResource(HdTokens->drawDispatch);
     if (!TF_VERIFY(paramBuffer)) return;
+
+    bool const useMeshShaders =
+            _drawItemInstances[0]->GetDrawItem()->
+                    GetGeometricShader()->GetUseMeshShaders();
 
     if (!_useDrawIndexed) {
         gfxCmds->DrawIndirect(
@@ -1455,7 +1786,25 @@ HdSt_PipelineDrawBatch::_ExecuteDrawIndirect(
         HdStBufferResourceSharedPtr indexBuffer =
             indexBar->GetResource(HdTokens->indices);
         if (!TF_VERIFY(indexBuffer)) return;
+        if (useMeshShaders) {
+            struct Uniforms {
+                uint32_t drawIndexCount;
+                uint32_t drawCommandNumUints;
+                uint32_t drawCoordOffset;
+            };
 
+            // set instanced cull parameters
+            Uniforms cullParams;
+            cullParams.drawCommandNumUints = _dispatchBuffer->GetCommandNumUints();
+            cullParams.drawCoordOffset = uint32_t(_drawCoordOffset);
+
+            gfxCmds->SetConstantValues(
+                    psoHandle, 0, 27,
+                    sizeof(Uniforms), &cullParams);
+            gfxCmds->DrawIndexedMeshIndirect(
+                    indexBuffer->GetHandle(),
+                    _dispatchBuffer->GetCount());
+        } else {
         gfxCmds->DrawIndexedIndirect(
             indexBuffer->GetHandle(),
             paramBuffer->GetHandle(),
@@ -1465,12 +1814,14 @@ HdSt_PipelineDrawBatch::_ExecuteDrawIndirect(
             _drawCommandBuffer,
             _patchBaseVertexByteOffset);
     }
+    }
 }
 
 void
 HdSt_PipelineDrawBatch::_ExecuteDrawImmediate(
     HgiGraphicsCmds * gfxCmds,
-    HdStBufferArrayRangeSharedPtr const & indexBar)
+    HdStBufferArrayRangeSharedPtr const & indexBar,
+    HgiGraphicsPipelineHandle psoHandle)
 {
     TRACE_FUNCTION();
 
@@ -1499,6 +1850,9 @@ HdSt_PipelineDrawBatch::_ExecuteDrawImmediate(
         bool const useMetalTessellation =
             _drawItemInstances[0]->GetDrawItem()->
                     GetGeometricShader()->GetUseMetalTessellation();
+        bool const useMeshShaders =
+        _drawItemInstances[0]->GetDrawItem()->
+                GetGeometricShader()->GetUseMeshShaders();
 
         for (uint32_t i = 0; i < drawCount; ++i) {
             _DrawIndexedCommand const * cmd =
@@ -1509,6 +1863,10 @@ HdSt_PipelineDrawBatch::_ExecuteDrawImmediate(
                 static_cast<uint32_t>(cmd->common.baseIndex * sizeof(uint32_t));
 
             if (cmd->common.count && cmd->common.instanceCount) {
+                if (useMeshShaders) {
+                    //We don't support direct drawing with mesh shaders.
+                    return;
+                } else {
                 if (useMetalTessellation) {
                     gfxCmds->DrawIndexed(
                         indexBuffer->GetHandle(),
@@ -1528,6 +1886,7 @@ HdSt_PipelineDrawBatch::_ExecuteDrawImmediate(
                 }
             }
         }
+    }
     }
 }
 
@@ -1597,7 +1956,8 @@ HdSt_PipelineDrawBatch::_PrepareIndirectCommandBuffer(
 
     HgiResourceBindingsDesc bindingsDesc;
     state.GetBindingsForDrawing(&bindingsDesc,
-            _tessFactorsBuffer, /*bindTessFactors=*/true);
+            _tessFactorsBuffer,
+            _meshletDispatchBuffer, /*bindTessFactors=*/true);
 
     HgiResourceBindingsHandle resourceBindings =
             hgi->CreateResourceBindings(bindingsDesc);
@@ -1703,7 +2063,6 @@ HdSt_PipelineDrawBatch::_ExecuteFrustumCull(
                 _tokens->drawIndirectResult,
                 _resultBuffer,
                 _resultBuffer->GetOffset());
-                
     }
 
     // bind destination buffer
@@ -1809,7 +2168,8 @@ HdSt_PipelineDrawBatch::_ExecutePTCS(
 
     HgiResourceBindingsDesc bindingsDesc;
     state.GetBindingsForDrawing(&bindingsDesc,
-            _tessFactorsBuffer, /*bindTessFactors=*/false);
+            _tessFactorsBuffer,
+            _meshletDispatchBuffer, /*bindTessFactors=*/false);
 
     HgiResourceBindingsHandle resourceBindings =
             hgi->CreateResourceBindings(bindingsDesc);
@@ -1820,9 +2180,9 @@ HdSt_PipelineDrawBatch::_ExecutePTCS(
     ptcsGfxCmds->BindVertexBuffers(bindings);
 
     if (drawIndirect) {
-        _ExecuteDrawIndirect(ptcsGfxCmds, state.indexBar);
+        _ExecuteDrawIndirect(ptcsGfxCmds, state.indexBar, psoTessHandle, renderPassState);
     } else {
-        _ExecuteDrawImmediate(ptcsGfxCmds, state.indexBar);
+        _ExecuteDrawImmediate(ptcsGfxCmds, state.indexBar, psoTessHandle);
     }
 
     hgi->DestroyResourceBindings(&resourceBindings);
@@ -1951,10 +2311,8 @@ HdSt_PipelineDrawBatch::_CreateCullingProgram(
             HdSt_GeometricShader::Create(shaderKey, resourceRegistry);
         _cullingProgram.SetDrawingCoordBufferBinding(drawingCoordBufferBinding);
         _cullingProgram.SetGeometricShader(cullShader);
-
         _cullingProgram.CompileShader(_drawItemInstances.front()->GetDrawItem(),
                                       resourceRegistry);
-
         _dirtyCullingProgram = false;
     }
 }

--- a/pxr/imaging/hdSt/pipelineDrawBatch.h
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.h
@@ -145,11 +145,14 @@ private:
 
     void _ExecuteDrawIndirect(
                 HgiGraphicsCmds * gfxCmds,
-                HdStBufferArrayRangeSharedPtr const & indexBar);
+                HdStBufferArrayRangeSharedPtr const & indexBar,
+                HgiGraphicsPipelineHandle psoHandle,
+                HdStRenderPassStateSharedPtr const & renderPassState);
 
     void _ExecuteDrawImmediate(
                 HgiGraphicsCmds * gfxCmds,
-                HdStBufferArrayRangeSharedPtr const & indexBar);
+                HdStBufferArrayRangeSharedPtr const & indexBar,
+                HgiGraphicsPipelineHandle psoHandle);
 
     void _ExecuteFrustumCull(
                 bool updateDispatchBuffer,
@@ -172,8 +175,10 @@ private:
     HdStDispatchBufferSharedPtr _dispatchBufferCullInput;
 
     HdStBufferResourceSharedPtr _tessFactorsBuffer;
+    HdStBufferResourceSharedPtr _meshletDispatchBuffer;
 
     std::vector<uint32_t> _drawCommandBuffer;
+    std::vector<uint32_t> _meshletDrawBuffer;
     bool _drawCommandBufferDirty;
 
     size_t _bufferArraysHash;
@@ -194,7 +199,7 @@ private:
     bool _useGpuCulling;
     bool _useInstanceCulling;
     bool const _allowGpuFrustumCulling;
-    bool const _allowIndirectCommandEncoding;
+    bool _allowIndirectCommandEncoding;
 
     size_t _instanceCountOffset;
     size_t _cullInstanceCountOffset;

--- a/pxr/imaging/hdSt/resourceBinder.h
+++ b/pxr/imaging/hdSt/resourceBinder.h
@@ -330,6 +330,7 @@ public:
         BindingDeclaration instanceIndexBaseBinding;
         BindingDeclaration primitiveParamBinding;
         BindingDeclaration tessFactorsBinding;
+        BindingDeclaration meshletRemapBinding;
         BindingDeclaration edgeIndexBinding;
         BindingDeclaration coarseFaceIndexBinding;
         BindingDeclaration indexBufferBinding;

--- a/pxr/imaging/hdSt/shaderKey.cpp
+++ b/pxr/imaging/hdSt/shaderKey.cpp
@@ -44,6 +44,8 @@ HdSt_ShaderKey::ComputeHash() const
     TfToken const *VS = GetVS();
     TfToken const *TCS = GetTCS();
     TfToken const *TES = GetTES();
+    TfToken const *MOS = GetMOS();
+    TfToken const *MS = GetMS();
     TfToken const *PTCS = GetPTCS();
     TfToken const *PTVS = GetPTVS();
     TfToken const *GS = GetGS();
@@ -151,6 +153,8 @@ HdSt_ShaderKey::GetGlslfxString() const
     ss << _JoinTokens("tessEvalShader",    GetTES(), &firstStage);
     ss << _JoinTokens("postTessControlShader",  GetPTCS(), &firstStage);
     ss << _JoinTokens("postTessVertexShader",   GetPTVS(), &firstStage);
+    ss << _JoinTokens("meshObjectShader",  GetMOS(), &firstStage);
+    ss << _JoinTokens("meshletShader",   GetMS(), &firstStage);
     ss << _JoinTokens("geometryShader",    GetGS(),  &firstStage);
     ss << _JoinTokens("fragmentShader",    GetFS(),  &firstStage);
     ss << "}}}\n";
@@ -195,6 +199,20 @@ HdSt_ShaderKey::GetPTVS() const
 
 /*virtual*/
 TfToken const*
+HdSt_ShaderKey::GetMOS() const
+{
+    return nullptr;
+}
+
+/*virtual*/
+TfToken const*
+HdSt_ShaderKey::GetMS() const
+{
+    return nullptr;
+}
+
+/*virtual*/
+TfToken const*
 HdSt_ShaderKey::GetGS() const
 {
     return nullptr;
@@ -206,7 +224,7 @@ HdSt_ShaderKey::GetFS() const
 {
     return nullptr;
 }
-
+    
 /*virtual*/
 TfToken const*
 HdSt_ShaderKey::GetCS() const

--- a/pxr/imaging/hdSt/shaderKey.h
+++ b/pxr/imaging/hdSt/shaderKey.h
@@ -76,6 +76,10 @@ struct HdSt_ShaderKey {
     HDST_API
     virtual TfToken const *GetPTVS() const;
     HDST_API
+    virtual TfToken const *GetMOS() const;
+    HDST_API
+    virtual TfToken const *GetMS() const;
+    HDST_API
     virtual TfToken const *GetGS() const;
     HDST_API
     virtual TfToken const *GetFS() const;
@@ -104,6 +108,8 @@ struct HdSt_ShaderKey {
     virtual bool IsDoubleSided() const;
     HDST_API
     virtual bool UseMetalTessellation() const;
+    HDST_API
+    virtual bool UseMeshShaders() const {return false;};
     HDST_API
     virtual HdPolygonMode GetPolygonMode() const;
     HDST_API

--- a/pxr/imaging/hdSt/shaders/instancing.glslfx
+++ b/pxr/imaging/hdSt/shaders/instancing.glslfx
@@ -35,17 +35,17 @@ MAT4 GetRotationMatrix(vec4 q)
 {
     MAT4 r;
     r[0].xyzw = vec4(1 - 2 * (q.y * q.y + q.z * q.z),
-                         2 * (q.x * q.y + q.z * q.w),
-                         2 * (q.x * q.z - q.y * q.w),
+                     2 * (q.x * q.y + q.z * q.w),
+                     2 * (q.x * q.z - q.y * q.w),
                      0);
     r[1].xyzw = vec4(    2 * (q.x * q.y - q.z * q.w),
-                     1 - 2 * (q.x * q.x + q.z * q.z),
+                         1 - 2 * (q.x * q.x + q.z * q.z),
                          2 * (q.y * q.z + q.x * q.w),
-                     0);
+                         0);
     r[2].xyzw = vec4(    2 * (q.x * q.z + q.y * q.w),
                          2 * (q.y * q.z - q.x * q.w),
-                     1 - 2 * (q.x * q.x + q.y * q.y),
-                     0);
+                         1 - 2 * (q.x * q.x + q.y * q.y),
+                         0);
     r[3] = vec4(0, 0, 0, 1);
     return r;
 }
@@ -187,12 +187,20 @@ MAT4 GetInstanceTransformInverse()
 
 MAT4 ApplyInstanceTransform(MAT4 m)
 {
-    return GetInstanceTransform() * m;
+#if defined(HD_INSTANCER_NUM_LEVELS) || defined(HD_HAS_instancerTransform)
+return GetInstanceTransform() * m;
+#else
+return m;
+#endif
 }
 
 MAT4 ApplyInstanceTransformInverse(MAT4 m)
 {
-    return m * GetInstanceTransformInverse();
+#if defined(HD_INSTANCER_NUM_LEVELS) || defined(HD_HAS_instancerTransform)
+return m * GetInstanceTransformInverse();
+#else
+return m;
+#endif
 }
 
 bool IsFlipped()

--- a/pxr/imaging/hdSt/shaders/mesh.glslfx
+++ b/pxr/imaging/hdSt/shaders/mesh.glslfx
@@ -146,7 +146,6 @@ void main(void)
 
 --- --------------------------------------------------------------------------
 -- layout Mesh.PostTessVertex.Quad
-
 [
     ["out block", "VertexData", "outData",
         ["vec4", "Peye"],
@@ -307,6 +306,487 @@ void main(void)
 
     ProcessPrimvarsOut(basis, 0, 1, 2, 4);
 }
+
+--- --------------------------------------------------------------------------
+-- layout Mesh.MeshObject.Main
+[
+["uniform block", "Uniforms", "meshObjectParams",
+["uint", "drawIndexCount"],
+["uint", "drawCommandNumUints"],
+["uint", "drawCoordOffset"]
+]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Mesh.MeshObject.Main
+
+int GetDrawingField(uint off, uint drawCommandIndex)
+{
+    uint offset = drawCommandIndex * drawCommandNumUints;
+    offset += off;
+    return int(drawBuffer[offset]);
+}
+
+static constant constexpr uchar indexCountOffset = 0;
+static constant constexpr uchar instanceCountOffset = 1;
+static constant constexpr uchar baseIndexOffset = 2;
+static constant constexpr uchar baseVertexOffset = 3;
+static constant constexpr uchar baseInstanceOffset = 4;
+static constant constexpr uchar meshletCoordOffset = 5;
+static constant constexpr uchar numMeshletsOffset = 6;
+
+static constant constexpr uchar gl_InstanceID = 0;
+static constant constexpr uchar gl_BaseInstance = 0;
+
+void main(void)
+{
+    if (hd_LocalIndexID == 0) {
+        payload.indexCount = GetDrawingField(indexCountOffset, hd_LocalInvocationID.x);
+        payload.baseIndex = GetDrawingField(baseIndexOffset, hd_LocalInvocationID.x);
+        payload.baseVertex = GetDrawingField(baseVertexOffset, hd_LocalInvocationID.x);
+        payload.meshletCoord = GetDrawingField(meshletCoordOffset, hd_LocalInvocationID.x);
+        payload.numberMeshlets = GetDrawingField(numMeshletsOffset, hd_LocalInvocationID.x);
+        payload.baseInstance = hd_LocalInvocationID.x;
+        payload.drawCommandIndexPayload = hd_LocalInvocationID.x;
+        payload.drawCommandNumUintLocal = drawCommandNumUints;
+
+        //IDEAS go in scan order
+        uint instanceCount = GetDrawingField(instanceCountOffset, hd_LocalInvocationID.x);
+        meshGridProperties->set_threadgroups_per_grid(uint3(instanceCount, payload.numberMeshlets, 1));
+    }
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Mesh.Meshlet.Triangle.CullBackface
+
+bool pixelBboxCull(vec2 pixelMin, vec2 pixelMax)
+{
+  // Apply some safety around the bbox to take into account fixed point rasterization.
+  // This logic will only work without MSAA active.
+  const float epsilon = (1.0 / 256.0);
+  pixelMin -= epsilon;
+  pixelMax += epsilon;
+  // bbox culling
+  pixelMin = round(pixelMin);
+  pixelMax = round(pixelMax);
+  return ( ( pixelMin.x == pixelMax.x) || ( pixelMin.y == pixelMax.y));
+}
+
+bool testTriangle(vec2 a, vec2 b, vec2 c, float winding)
+{
+  // back face culling
+
+  vec2 ab = b.xy - a.xy;
+  vec2 ac = c.xy - a.xy;
+  float cross_product = ab.x * ac.y - ab.y * ac.x;
+
+  //possibly needs reversal
+  if (cross_product * winding < 0.0f) {return false;}
+  #ifdef TINY_TRIANGLE_CULL
+  vec2 pixelMin = min(a,min(b,c));
+  vec2 pixelMax = max(a,max(b,c));
+
+  if (pixelBboxCull(pixelMin, pixelMax)) return false;
+  #endif
+  return true;
+}
+
+--- --------------------------------------------------------------------------
+-- glsl Mesh.Meshlet.Triangle.NoCullBackface
+
+bool pixelBboxCull(vec2 pixelMin, vec2 pixelMax)
+{
+  // Apply some safety around the bbox to take into account fixed point rasterization.
+  // This logic will only work without MSAA active.
+  const float epsilon = (1.0 / 256.0);
+  pixelMin -= epsilon;
+  pixelMax += epsilon;
+  // bbox culling
+  pixelMin = round(pixelMin);
+  pixelMax = round(pixelMax);
+  return ( ( pixelMin.x == pixelMax.x) || ( pixelMin.y == pixelMax.y));
+}
+
+bool testTriangle(vec2 a, vec2 b, vec2 c, float winding)
+{
+  #ifdef TINY_TRIANGLE_CULL
+  vec2 pixelMin = min(a,min(b,c));
+  vec2 pixelMax = max(a,max(b,c));
+
+  if (pixelBboxCull(pixelMin, pixelMax)) return false;
+  #endif
+  return true;
+}
+
+
+--- --------------------------------------------------------------------------
+-- layout Mesh.Meshlet.Triangle
+[
+["out block", "VertexData", "outData",
+["vec4", "Peye"],
+["vec3", "Neye"]
+],
+["uniform block", "Uniforms", "meshletParams",
+["uint", "drawIndexCount"],
+["uint", "drawCommandNumUints"],
+["uint", "drawCoordOffset"]
+]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Mesh.Meshlet.Triangle
+
+vec4 GetPatchCoord(int index)
+{
+    vec2 uv[3];
+    uv[0] = vec2(0, 0); // (0, 0, 1);
+    uv[1] = vec2(1, 0); // (1, 0, 0);
+    uv[2] = vec2(0, 1); // (0, 1, 0);
+
+    ivec3 patchParam = GetPatchParam();
+    return InterpolatePatchCoordTriangle(uv[index], patchParam);
+}
+
+vec2 getScreenPos(vec4 hPos)
+{
+    hPos /= hPos.w;
+    return vec2((hPos.xy * 0.5f + 0.5) *
+        (renderPassState.viewport.zw - renderPassState.viewport.xy));
+}
+
+bool testTriangle(const vec2 a, const vec2 b, const vec2 c, const float winding, const uchar3 cullBits)
+{
+    if ((cullBits.x & cullBits.y & cullBits.z) == 0) {
+        return testTriangle(a,b,c,winding);
+    }
+    return false;
+}
+
+uchar getCullBits(vec4 hPos)
+{
+    uchar cullBits = 0;
+    cullBits |= hPos.x < -hPos.w ?  1 : 0;
+    cullBits |= hPos.x >  hPos.w ?  2 : 0;
+    cullBits |= hPos.y < -hPos.w ?  4 : 0;
+    cullBits |= hPos.y >  hPos.w ?  8 : 0;
+    cullBits |= hPos.z <  0.0f      ? 16 : 0;
+    cullBits |= hPos.z >  hPos.w ? 32 : 0;
+    cullBits |= hPos.w <= 0.0f      ? 64 : 0;
+    return cullBits;
+}
+
+
+// Fwd declare methods defined in pointId.glslfx, that are used below.
+FORWARD_DECL(int GetPointId());
+FORWARD_DECL(float GetPointRasterSize(int));
+FORWARD_DECL(void ProcessPointId(int));
+uint32_t hd_VertexID;
+uint32_t primitive_id;
+uint32_t gl_InstanceID;
+uint32_t gl_BaseInstance;
+uint32_t baseVertex;
+uint32_t baseIndex;
+
+
+hd_drawingCoord dcMemb;
+void main(void) {
+    if(hd_LocalIndexID == 191){
+        atomic_store_explicit(&accumulator,0,memory_order_relaxed);
+    }
+    const device uint *meshletStart = meshletRemap + payload.meshletCoord;
+    const uint thisMeshCoordOff = *(meshletStart + hd_LocalInvocationID.y);
+    const device uint *thisMeshCoord = (meshletStart + thisMeshCoordOff);
+
+    const uint meshletVertexCount = *(thisMeshCoord);
+    const uint meshletPrimitiveCount = *(thisMeshCoord + 1);
+
+    const device uint *meshletVerticesStart = (thisMeshCoord + 2);
+
+    const uint numUintsPerVertex = 2;
+    const device uint *meshletIndicesStart =
+        (thisMeshCoord + 2 + (meshletVertexCount * numUintsPerVertex));
+    const uint endIndex  = meshletPrimitiveCount * 3;
+    if(endIndex < 1) {
+        return;
+    }
+
+    if (hd_LocalIndexID < endIndex)
+    {
+        baseVertex = payload.baseVertex;
+        baseIndex = payload.baseIndex;
+        gl_BaseInstance = payload.baseInstance;
+        gl_InstanceID = hd_LocalInvocationID.x + payload.baseInstance + 1;
+        hd_VertexID = hd_LocalIndexID;
+    }
+
+    if( hd_LocalIndexID < meshletVertexCount )
+    {
+        primitive_id = ((hd_LocalInvocationID.y * MAX_PRIMITIVES) + hd_LocalIndexID)/3;
+        const uint index = *(meshletVerticesStart + hd_LocalIndexID * numUintsPerVertex + 1);
+
+        VertexOut vertexOut;
+        const uint vertIndirection =
+            *(meshletVerticesStart + hd_LocalIndexID * numUintsPerVertex);
+        dcMemb = GetDrawingCoordFull();
+        ProcessPrimvarsIn(vertIndirection);
+        float4 point = float4(HdGet_points(vertIndirection), 1.0f);
+
+        vec3 Neye0 = GetNormal(vec3(0),vertIndirection);
+        const MAT4 transform = ApplyInstanceTransform(HdGet_transform());
+        vertexOut.Peye = vec4(GetWorldToViewMatrix() * transform * point);
+        vertexOut.Peye = DisplacementTerminal(
+            hd_LocalIndexID%3, vertexOut.Peye, Neye0, GetPatchCoord(hd_LocalIndexID%3));
+
+        vertexOut.Neye = Neye0; // normalized
+
+        vertexOut.position = vec4(GetProjectionMatrix() * vertexOut.Peye);
+        vec3 posCached;
+        posCached.xy = getScreenPos(vertexOut.position);
+        uchar cullBits = getCullBits(vertexOut.position);
+        posCached.z = reinterpret_cast<thread float &>(cullBits);
+        posCache[hd_LocalIndexID] = posCached;
+        vertexOut.drawIndexVS = payload.drawCommandIndexPayload;
+        ProcessPrimvarsOut(vertexOut);
+        mesh.set_vertex(hd_LocalIndexID, vertexOut);
+        //ApplyClipPlanes(vertexOut.Peye);
+    }
+
+    const uint base2 = hd_LocalIndexID * 4;
+    const device uint *indicesOff = meshletIndicesStart + base2;
+    const uint currPrim = hd_LocalIndexID * 2;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if((currPrim ) < (meshletPrimitiveCount)) {
+        uchar3 indA = as_type<uchar3>(*(indicesOff));
+
+        vec3 p0A = posCache[indA.x];
+        vec3 p1A = posCache[indA.y];
+        vec3 p2A = posCache[indA.z];
+
+        //Not use vec3
+        uchar3 cullBitsA;
+        cullBitsA.x = *((reinterpret_cast<thread uint *>(&p0A))+2);
+        cullBitsA.y = *((reinterpret_cast<thread uint *>(&p1A))+2);
+        cullBitsA.z = *((reinterpret_cast<thread uint *>(&p2A))+2);
+
+        bool culledA = !testTriangle(p0A.xy, p1A.xy, p2A.xy, 1.0, cullBitsA);
+
+        uchar3 indB = as_type<uchar3>(*(indicesOff + 2));
+        vec3 p0B = posCache[indB.x];
+        vec3 p1B = posCache[indB.y];
+        vec3 p2B = posCache[indB.z];
+
+        uchar3 cullBitsB;
+        cullBitsB.x = *((reinterpret_cast<thread uint *>(&p0B))+2);
+        cullBitsB.y = *((reinterpret_cast<thread uint *>(&p1B))+2);
+        cullBitsB.z = *((reinterpret_cast<thread uint *>(&p2B))+2);
+
+        uchar primsHere = uchar(min(meshletPrimitiveCount - currPrim, uint(2)));
+        bool culledB
+            = !testTriangle(p0B.xy, p1B.xy, p2B.xy, 1.0, cullBitsB) && primsHere > 1;
+
+        //now we know if a triangle got culled or not, we can focus on figuring out
+        //how to compact and write it out
+        //we compute a local (in clique) scan offset
+        ushort total = ushort(!culledB) + ushort(!culledA);
+        ushort localIndex = simd_prefix_exclusive_sum(total);
+        //here we also compute how many primitives in the clique pass
+        ushort passingPrims = simd_sum(total);
+
+        int localOffset = 0;
+        //one thread per wave/clique will need to increment the atomic
+        //this will give back the local offset. When we do the atomic, we reserve
+        //n element in the array, where N is the number of surviving triangles, we
+        //get back the numbre before the atomic, meaning localOffset + n is reserved for this
+        //clique and we can safely write to it
+        if(hd_ThreadLocalIndexID == 0)
+        {
+           localOffset =
+               atomic_fetch_add_explicit(&accumulator,passingPrims,memory_order_relaxed);
+        }
+        //lets give the value of the local offset to all the threads in the clique
+        localOffset = simd_broadcast(localOffset,0);
+        uint writePrim = (localIndex + localOffset);
+        uint writeIndex = writePrim * 3;
+        if(!culledA)
+        {
+            PrimOut primOutA;
+            primOutA.primitive_id_ms = *(indicesOff + 1);
+            mesh.set_primitive(writePrim, primOutA);
+
+            // Set the output indices.
+            mesh.set_index(writeIndex , indA.x);
+            mesh.set_index(writeIndex + 1, indA.y);
+            mesh.set_index(writeIndex + 2, indA.z);
+            writePrim++;
+            writeIndex +=3;
+        }
+        if(!culledB)
+        {
+            PrimOut primOutB;
+            primOutB.primitive_id_ms = *(indicesOff + 3);
+            mesh.set_primitive(writePrim, primOutB);
+
+            // Set the output indices.
+            mesh.set_index(writeIndex, indB.x);
+            mesh.set_index(writeIndex + 1, indB.y);
+            mesh.set_index(writeIndex + 2, indB.z);
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if(hd_LocalIndexID == 1){
+        int accumulatorValue = (int)atomic_load_explicit(&accumulator,memory_order_relaxed);
+        mesh.set_primitive_count(accumulatorValue);
+        //mesh.set_primitive_count(meshletPrimitiveCount);
+    }
+}
+
+--- --------------------------------------------------------------------------
+-- layout Mesh.Meshlet.TriangleNoCull
+[
+["out block", "VertexData", "outData",
+["vec4", "Peye"],
+["vec3", "Neye"]
+],
+["uniform block", "Uniforms", "meshletParams",
+["uint", "drawIndexCount"],
+["uint", "drawCommandNumUints"],
+["uint", "drawCoordOffset"]
+]
+]
+
+--- --------------------------------------------------------------------------
+-- glsl Mesh.Meshlet.TriangleNoCull
+
+vec4 GetPatchCoord(int index)
+{
+    vec2 uv[3];
+    uv[0] = vec2(0, 0); // (0, 0, 1);
+    uv[1] = vec2(1, 0); // (1, 0, 0);
+    uv[2] = vec2(0, 1); // (0, 1, 0);
+
+    ivec3 patchParam = GetPatchParam();
+    return InterpolatePatchCoordTriangle(uv[index], patchParam);
+}
+
+
+// Fwd declare methods defined in pointId.glslfx, that are used below.
+FORWARD_DECL(int GetPointId());
+FORWARD_DECL(float GetPointRasterSize(int));
+FORWARD_DECL(void ProcessPointId(int));
+uint32_t hd_VertexID;
+uint32_t primitive_id;
+uint32_t gl_InstanceID;
+uint32_t gl_BaseInstance;
+uint32_t baseVertex;
+uint32_t baseIndex;
+
+
+hd_drawingCoord dcMemb;
+void main(void) {
+    const device uint *meshletStart = meshletRemap + payload.meshletCoord;
+    const uint thisMeshCoordOff = *(meshletStart + hd_LocalInvocationID.y);
+    const device uint *thisMeshCoord = (meshletStart + thisMeshCoordOff);
+
+    const uint meshletVertexCount = *(thisMeshCoord);
+    const uint meshletPrimitiveCount = *(thisMeshCoord + 1);
+
+    //TODO don't need to store this here
+    const device uint *meshletVerticesStart = (thisMeshCoord + 2);
+
+    const uint numUintsPerVertex = 2;
+    const device uint *meshletIndicesStart = (thisMeshCoord + 2 + (meshletVertexCount * numUintsPerVertex));
+
+    //can be simplified to always use payload.baseVertex
+    const uint endIndex  = meshletPrimitiveCount * 3;
+    if(endIndex < 1) {
+        return;
+    }
+
+    if (hd_LocalIndexID < endIndex)
+    {
+        //TODO can we simply try to not use registers for this
+        //TODO probably not needed
+        baseVertex = payload.baseVertex;
+        //TODO probably not needed
+        baseIndex = payload.baseIndex;
+        gl_BaseInstance = payload.baseInstance;
+        gl_InstanceID = hd_LocalInvocationID.x + payload.baseInstance + 1;
+        hd_VertexID = hd_LocalIndexID;
+    }
+
+    if( hd_LocalIndexID < meshletVertexCount )
+    {
+        primitive_id = ((hd_LocalInvocationID.y * 512) + hd_LocalIndexID)/3;
+        const uint index = *(meshletVerticesStart + hd_LocalIndexID * numUintsPerVertex + 1);
+        //todo resolve the index
+        //TODO investigate this
+        //this is problematic because of threads
+
+        VertexOut vertexOut;
+        const uint vertIndirection = *(meshletVerticesStart + hd_LocalIndexID * numUintsPerVertex);
+        dcMemb = GetDrawingCoordFull();
+        ProcessPrimvarsIn(vertIndirection);
+        float4 point = float4(HdGet_points(vertIndirection), 1.0f);
+
+        vec3 Neye0 = GetNormal(vec3(0),vertIndirection);
+        const MAT4 transform = ApplyInstanceTransform(HdGet_transform());
+        vertexOut.Peye = vec4(GetWorldToViewMatrix() * transform * point);
+        vertexOut.Peye = DisplacementTerminal(hd_LocalIndexID%3, vertexOut.Peye, Neye0, GetPatchCoord(hd_LocalIndexID%3));
+
+        vertexOut.Neye = Neye0; // normalized
+
+        vertexOut.position = vec4(GetProjectionMatrix() * vertexOut.Peye);
+        vertexOut.drawIndexVS = payload.drawCommandIndexPayload;
+        ProcessPrimvarsOut(vertexOut);
+        mesh.set_vertex(hd_LocalIndexID, vertexOut);
+        //ApplyClipPlanes(vertexOut.Peye);
+    }
+    const uint base = hd_LocalIndexID * 6;
+    const uint base2 = hd_LocalIndexID * 4;
+    //TODO try to place this work at the end of the group
+    //So that if vertices are way fewer, have the work on the less used threads
+    const device uint *indicesOff = meshletIndicesStart + base2;
+    const uint currPrim = hd_LocalIndexID * 2;
+    if((currPrim ) < (meshletPrimitiveCount)) {
+        {
+            mesh.set_primitive_count(meshletPrimitiveCount);
+            //TODO actually set the primitive ID here
+            PrimOut primOut;
+            //TODO export a smarter primitive ID
+            primOut.primitive_id_ms = *(indicesOff + 1);
+            mesh.set_primitive(currPrim, primOut);
+
+            uint unpackedInds = *(indicesOff);
+            uint ind0 = unpackedInds & 0xFF;
+            uint ind1 = unpackedInds >> 8 & 0x000000FF;
+            uint ind2 = unpackedInds >> 16 & 0x000000FF;
+            // Set the output indices.
+            //TODO cache base index calc
+            mesh.set_index(base, ind0);
+            mesh.set_index(base+1, ind1);
+            mesh.set_index(base+2, ind2);
+        }
+        {
+            //TODO actually set the primitive ID here
+            PrimOut primOut2;
+            primOut2.primitive_id_ms = *(indicesOff + 3);
+            //TODO export a smarter primitive ID
+            mesh.set_primitive(currPrim + 1, primOut2);
+
+            uint unpackedInds = *(indicesOff + 2);
+            uint ind0 = unpackedInds & 0x000000FF;
+            uint ind1 = unpackedInds >> 8 & 0x000000FF;
+            uint ind2 = unpackedInds >> 16 & 0x000000FF;
+            // Set the output indices.
+            //TODO cache base index calc
+            mesh.set_index(base+3, ind0);
+            mesh.set_index(base+4, ind1);
+            mesh.set_index(base+5, ind2);
+        }
+    }
+
+}
+
 
 --- --------------------------------------------------------------------------
 -- layout Mesh.TessControl.BSplineQuad
@@ -989,39 +1469,39 @@ void main(void)
 --- --------------------------------------------------------------------------
 -- glsl Mesh.TessEval.VaryingInterpolation
 
-float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3, 
+float InterpolatePrimvar(float inPv0, float inPv1, float inPv2, float inPv3,
                          vec4 basis, vec2 uv)
-{   
-    return basis[0] * inPv0 + 
-           basis[1] * inPv1 + 
-           basis[2] * inPv2 + 
+{
+    return basis[0] * inPv0 +
+           basis[1] * inPv1 +
+           basis[2] * inPv2 +
            basis[3] * inPv3;
 }
 
-vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3, 
+vec2 InterpolatePrimvar(vec2 inPv0, vec2 inPv1, vec2 inPv2, vec2 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return basis[0] * inPv0 + 
-           basis[1] * inPv1 + 
-           basis[2] * inPv2 + 
+{
+    return basis[0] * inPv0 +
+           basis[1] * inPv1 +
+           basis[2] * inPv2 +
            basis[3] * inPv3;
 }
 
-vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3, 
+vec3 InterpolatePrimvar(vec3 inPv0, vec3 inPv1, vec3 inPv2, vec3 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return basis[0] * inPv0 + 
-           basis[1] * inPv1 + 
-           basis[2] * inPv2 + 
+{
+    return basis[0] * inPv0 +
+           basis[1] * inPv1 +
+           basis[2] * inPv2 +
            basis[3] * inPv3;
 }
 
-vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3, 
+vec4 InterpolatePrimvar(vec4 inPv0, vec4 inPv1, vec4 inPv2, vec4 inPv3,
                         vec4 basis, vec2 uv)
-{   
-    return basis[0] * inPv0 + 
-           basis[1] * inPv1 + 
-           basis[2] * inPv2 + 
+{
+    return basis[0] * inPv0 +
+           basis[1] * inPv1 +
+           basis[2] * inPv2 +
            basis[3] * inPv3;
 }
 
@@ -1354,7 +1834,7 @@ vec2 GetPatchCoordLocalST()
 vec4 GetInterpolatedPatchCoord()
 {
     return InterpolatePatchCoordTriangle(
-                        GetPatchCoordLocalST(), GetPatchParam());
+                         GetPatchCoordLocalST(), GetPatchParam());
 }
 
 --- --------------------------------------------------------------------------
@@ -1437,11 +1917,24 @@ vec4 GetInterpolatedPatchCoord()
     ["in block", "VertexData", "inData",
         ["vec4", "Peye"],
         ["vec3", "Neye"]
-    ]
+    ],
+["uniform block", "Uniforms", "fragmentParams",
+["uint", "drawIndexCount"],
+["uint", "drawCommandNumUints"],
+["uint", "drawCoordOffset"]
+]
 ]
 
 --- --------------------------------------------------------------------------
 -- glsl Mesh.Fragment
+
+//TODO Thor make sure only for specific ones
+hd_drawingCoord dcMemb;
+
+static constant constexpr uint gl_BaseInstance = 0;
+static constant constexpr uint gl_InstanceID = 1;
+
+uint primitive_id_ms;
 
 #ifndef HD_HAS_ptexFaceOffset
 #define HD_HAS_ptexFaceOffset
@@ -1476,6 +1969,7 @@ vec3 ComputeScreenSpaceNeye()
 
 void main(void)
 {
+    dcMemb = GetDrawingCoordFull();
     bool isFlipped = IsFlipped();
 
     DiscardBasedOnShading(gl_FrontFacing, isFlipped);
@@ -1504,14 +1998,12 @@ void main(void)
 
     vec4 patchCoord = GetPatchCoord();
     color = ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord);
-
     color = ApplyEdgeColor(color, patchCoord);
 
-#ifdef HD_MATERIAL_TAG_MASKED   
+#ifdef HD_MATERIAL_TAG_MASKED
     if (ShouldDiscardByAlpha(color)) {
         discard;
     }
 #endif
-
     RenderOutput(vec4(Peye, 1), Neye, color, patchCoord);
 }

--- a/pxr/imaging/hdSt/shaders/meshNormal.glslfx
+++ b/pxr/imaging/hdSt/shaders/meshNormal.glslfx
@@ -72,6 +72,23 @@ vec3 GetNormal(vec3 Neye, int index, vec2 localST)
 }
 
 --- --------------------------------------------------------------------------
+-- glsl MeshNormal.Smooth.UnpackSmoothVBO
+
+vec3 GetUnpackedSmoothNormal(int index) {
+    return vec3(HdGet_packedSmoothNormals(index).xyz);
+}
+
+--- --------------------------------------------------------------------------
+-- glsl MeshNormal.Smooth.UnpackSmoothSSBO
+
+vec3 GetUnpackedSmoothNormal(int index) {
+    uint packed = uint(HdGet_packedSmoothNormals(index));
+    vec3 unpacked = unpack_unorm10a2_to_float(packed).xyz;
+    unpacked = mix(unpacked, -(1.0f - unpacked), float3(unpacked >= 0.5f)) * 2.03f;
+    return unpacked;
+}
+
+--- --------------------------------------------------------------------------
 -- glsl MeshNormal.Smooth
 
 vec3 GetNormal(vec3 Neye, int index)
@@ -80,7 +97,7 @@ vec3 GetNormal(vec3 Neye, int index)
 #if defined(HD_HAS_smoothNormals)
     normal = vec3(HdGet_smoothNormals(index).xyz);
 #elif defined(HD_HAS_packedSmoothNormals)
-    normal = vec3(HdGet_packedSmoothNormals(index).xyz);
+    normal = GetUnpackedSmoothNormal(index);
 #endif
 
     MAT4 transformInv = ApplyInstanceTransformInverse(HdGet_transformInverse());

--- a/pxr/imaging/hdSt/shaders/renderPassShader.glslfx
+++ b/pxr/imaging/hdSt/shaders/renderPassShader.glslfx
@@ -44,6 +44,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader": {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -398,7 +398,7 @@ HdSt_TextureTestDriver::Draw(HgiTextureHandle const &colorDst,
 
     HgiGraphicsCmdsUniquePtr gfxCmds = _hgi->CreateGraphicsCmds(gfxDesc);
     gfxCmds->PushDebugGroup("Debug HdSt_TextureTestDriver");
-    gfxCmds->BindResources(_resourceBindings);
+    gfxCmds->BindResources(_resourceBindings, false);
     gfxCmds->BindPipeline(_pipeline);
     gfxCmds->BindVertexBuffers({{_vertexBuffer, 0, 0}});
     gfxCmds->SetViewport(viewport);

--- a/pxr/imaging/hdx/boundingBoxTask.cpp
+++ b/pxr/imaging/hdx/boundingBoxTask.cpp
@@ -141,6 +141,7 @@ HdxBoundingBoxTask::_CreateShaderResources()
     dashStartParam.nameInShader = "dashStart";
     dashStartParam.type = "vec2";
     dashStartParam.interpolation = HgiInterpolationFlat;
+    dashStartParam.isPointerToValue = false;
     HgiShaderFunctionAddStageOutput(
         &vertDesc, dashStartParam);
     addConstantParams(&vertDesc);

--- a/pxr/imaging/hdx/shaders/renderPassColorAndSelectionShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorAndSelectionShader.glslfx
@@ -48,6 +48,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassColorShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorShader.glslfx
@@ -46,6 +46,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassColorWithOccludedSelectionShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassColorWithOccludedSelectionShader.glslfx
@@ -48,6 +48,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassIdShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassIdShader.glslfx
@@ -45,6 +45,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassOitOpaqueShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitOpaqueShader.glslfx
@@ -46,6 +46,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassOitShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitShader.glslfx
@@ -46,6 +46,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassOitVolumeShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassOitVolumeShader.glslfx
@@ -46,6 +46,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
@@ -45,6 +45,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hdx/shaders/renderPassShadowShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassShadowShader.glslfx
@@ -45,6 +45,9 @@
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]
             },
+            "meshletShader" : {
+                "source": [ "RenderPass.Camera"]
+            },
             "tessControlShader" : {
                 "source": [ "RenderPass.Camera" ]
             },

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -97,6 +97,7 @@ enum HgiDeviceCapabilitiesBits : HgiBits
     HgiDeviceCapabilitiesBitsBasePrimitiveOffset     = 1 << 15,
     HgiDeviceCapabilitiesBitsPrimitiveIdEmulation    = 1 << 16,
     HgiDeviceCapabilitiesBitsIndirectCommandBuffers  = 1 << 17,
+    HgiDeviceCapabilitiesBitsMeshShading             = 1 << 18,
 };
 
 using HgiDeviceCapabilities = HgiBits;
@@ -365,7 +366,9 @@ enum HgiShaderStageBits : HgiBits
     HgiShaderStageGeometry               = 1 << 5,
     HgiShaderStagePostTessellationControl = 1 << 6,
     HgiShaderStagePostTessellationVertex = 1 << 7,
-    HgiShaderStageCustomBitsBegin        = 1 << 8,
+    HgiShaderStageMeshObject             = 1 << 8,
+    HgiShaderStageMeshlet                = 1 << 9,
+    HgiShaderStageCustomBitsBegin        = 1 << 10,
 };
 using HgiShaderStage = HgiBits;
 

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -78,7 +78,8 @@ public:
     /// Usually you call this right after BindPipeline() and the resources bound
     /// must be compatible with the bound pipeline.
     HGI_API
-    virtual void BindResources(HgiResourceBindingsHandle resources) = 0;
+    virtual void BindResources(HgiResourceBindingsHandle resources,
+       bool useMeshShaders = false) = 0;
 
     /// Set Push / Function constants.
     /// `pipeline` is the pipeline that you are binding before the draw call. It
@@ -158,6 +159,11 @@ public:
         uint32_t baseVertex,
         uint32_t instanceCount,
         uint32_t baseInstance) = 0;
+
+    HGI_API
+    virtual void DrawIndexedMeshIndirect(
+            HgiBufferHandle const& indexBuffer,
+            uint32_t indexCount) = 0;
 
     /// Records a indexed multi-draw command that reads the draw parameters
     /// from a provided drawParameterBuffer, and indices from indexBuffer.

--- a/pxr/imaging/hgi/graphicsPipeline.h
+++ b/pxr/imaging/hgi/graphicsPipeline.h
@@ -385,6 +385,15 @@ struct HgiTessellationState
     HgiTessellationLevel tessellationLevel;
 };
 
+struct HgiMeshState
+{
+    bool useMeshShader = false;
+    uint32_t maxTotalThreadsPerObjectThreadgroup;
+    uint32_t maxTotalThreadsPerMeshThreadgroup;
+    uint32_t maxTotalThreadGroupsPerObject;
+    uint32_t maxTotalThreadGroupsPerMesh;
+};
+
 /// \struct HgiGraphicsPipelineDesc
 ///
 /// Describes the properties needed to create a GPU pipeline.
@@ -433,6 +442,7 @@ struct HgiGraphicsPipelineDesc
     bool resolveAttachments;
     HgiGraphicsShaderConstantsDesc shaderConstantsDesc;
     HgiTessellationState tessellationState;
+    HgiMeshState meshState;
 };
 
 HGI_API

--- a/pxr/imaging/hgi/resourceBindings.cpp
+++ b/pxr/imaging/hgi/resourceBindings.cpp
@@ -40,7 +40,8 @@ HgiResourceBindings::GetDescriptor() const
 
 HgiBufferBindDesc::HgiBufferBindDesc()
     : bindingIndex(0)
-    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex)
+    , stageUsage(HgiShaderStageVertex | HgiShaderStagePostTessellationVertex |
+                 HgiShaderStageMeshObject | HgiShaderStageMeshlet)
     , writable(false)
 {
 }
@@ -68,7 +69,7 @@ bool operator!=(
 HgiTextureBindDesc::HgiTextureBindDesc()
     : resourceType(HgiBindResourceTypeCombinedSamplerImage)
     , bindingIndex(0)
-    , stageUsage(HgiShaderStageFragment)
+    , stageUsage(HgiShaderStageFragment | HgiShaderStagePostTessellationVertex | HgiShaderStageMeshlet)
     , writable(false)
 {
 }

--- a/pxr/imaging/hgi/shaderFunctionDesc.cpp
+++ b/pxr/imaging/hgi/shaderFunctionDesc.cpp
@@ -394,6 +394,8 @@ HgiShaderFunctionAddConstantParam(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
     
     desc->constantParams.push_back(std::move(paramDesc));
 }
@@ -409,6 +411,8 @@ HgiShaderFunctionAddStageInput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.role = role;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageInputs.push_back(std::move(paramDesc));
 }
@@ -421,17 +425,40 @@ HgiShaderFunctionAddStageInput(
     functionDesc->stageInputs.push_back(paramDesc);
 }
 
+/// Adds a field to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
+    const uint32_t arraySize) {
+    HgiShaderFunctionParamDesc paramDesc;
+    paramDesc.nameInShader = nameInShader;
+    paramDesc.type = type;
+    paramDesc.arraySize = std::to_string(arraySize);
+    if (arraySize < 1) {
+        paramDesc.arraySize = "";
+    }
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
+    desc->payloadMembers.push_back(std::move(paramDesc));
+}
+
 void
 HgiShaderFunctionAddGlobalVariable(
    HgiShaderFunctionDesc *desc,
    const std::string &nameInShader,
    const std::string &type,
-   const std::string &arraySize)
+   const std::string &arraySize,
+   const bool isThreadGroupParam)
 {
     HgiShaderFunctionParamDesc paramDesc;
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.arraySize = arraySize;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = isThreadGroupParam;
     desc->stageGlobalMembers.push_back(std::move(paramDesc));
 }
 
@@ -448,6 +475,8 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.type = type;
     paramDesc.role = role;
     paramDesc.arraySize = arraySize;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }
@@ -463,6 +492,8 @@ HgiShaderFunctionAddStageOutput(
     paramDesc.nameInShader = nameInShader;
     paramDesc.type = type;
     paramDesc.location = location;
+    paramDesc.isPointerToValue = false;
+    paramDesc.isThreadGroupParam = false;
 
     desc->stageOutputs.push_back(std::move(paramDesc));
 }

--- a/pxr/imaging/hgi/shaderFunctionDesc.h
+++ b/pxr/imaging/hgi/shaderFunctionDesc.h
@@ -174,6 +174,8 @@ struct HgiShaderFunctionParamDesc
     HgiStorageType storage;
     std::string role;
     std::string arraySize;
+    bool isThreadGroupParam = false;
+    bool isPointerToValue = false;
 };
 
 using HgiShaderFunctionParamDescVector =
@@ -324,7 +326,50 @@ bool operator!=(
         const HgiShaderFunctionTessellationDesc& lhs,
         const HgiShaderFunctionTessellationDesc& rhs);
 
-/// \struct HgiShaderFunctionGeometryDesc
+/// \struct HgiShaderFunctionMeshDesc
+///
+/// Describes a mesh shader's function description
+///
+/// <ul>
+/// <li>meshTopology:
+///   The type of topology</li>
+/// <li>maxMeshletVertexCount
+///   Max number of vertices per meshlet in shader</li>
+/// <li>maxPrimitiveCount
+///   Max number of primitives in shader</li>
+/// <li>maxTotalThreadsPerObjectThreadgroup
+///   Max number of threads per object threadgroup</li>
+/// <li>maxTotalThreadsPerMeshletThreadgroup:
+///   Maximum total threads per meshlet threadgroup</li>
+/// <li>maxTotalThreadgroupsPerMeshObject:
+///   Maximum total threadgroups per mesh object shader</li>
+/// <li>maxTotalThreadgroupsPerMeshlet:
+///   Max total threadgroups per meshlet shader</li>
+/// </ul>
+///
+struct HgiShaderFunctionMeshDesc
+{
+    enum class MeshTopology { Point, Line, Triangle, None };
+    MeshTopology meshTopology = MeshTopology::None;
+    uint32_t maxMeshletVertexCount;
+    uint32_t maxPrimitiveCount;
+    uint32_t maxTotalThreadsPerObjectThreadgroup;
+    uint32_t maxTotalThreadsPerMeshletThreadgroup;
+    uint32_t maxTotalThreadgroupsPerMeshObject;
+    uint32_t maxTotalThreadgroupsPerMeshlet;
+    bool meshUser = false;
+};
+
+HGI_API
+bool operator==(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
+HGI_API
+bool operator!=(
+        const HgiShaderFunctionMeshDesc& lhs,
+        const HgiShaderFunctionMeshDesc& rhs);
+
 ///
 /// Describes a geometry function's description
 ///
@@ -448,10 +493,13 @@ struct HgiShaderFunctionDesc
     std::vector<HgiShaderFunctionParamDesc> constantParams;
     std::vector<HgiShaderFunctionParamDesc> stageGlobalMembers;
     std::vector<HgiShaderFunctionParamDesc> stageInputs;
+    std::vector<HgiShaderFunctionParamDesc> stagePayload;
     std::vector<HgiShaderFunctionParamDesc> stageOutputs;
+    std::vector<HgiShaderFunctionParamDesc> payloadMembers;
     std::vector<HgiShaderFunctionParamBlockDesc> stageInputBlocks;
     std::vector<HgiShaderFunctionParamBlockDesc> stageOutputBlocks;
     HgiShaderFunctionComputeDesc computeDescriptor;
+    HgiShaderFunctionMeshDesc meshDescriptor;
     HgiShaderFunctionTessellationDesc tessellationDescriptor;
     HgiShaderFunctionGeometryDesc geometryDescriptor;
     HgiShaderFunctionFragmentDesc fragmentDescriptor;
@@ -515,6 +563,15 @@ HgiShaderFunctionAddBuffer(
     HgiBindingType binding,
     const uint32_t arraySize = 0);
 
+/// Adds a member to descriptor to given shader function payload's descriptor.
+HGI_API
+void
+HgiShaderFunctionAddPayloadMember(
+    HgiShaderFunctionDesc *desc,
+    const std::string &nameInShader,
+    const std::string &type,
+    const uint32_t arraySize = 0);
+
 /// Adds buffer descriptor to given shader function descriptor.
 HGI_API
 void
@@ -560,7 +617,8 @@ HgiShaderFunctionAddGlobalVariable(
    HgiShaderFunctionDesc *desc,
    const std::string &nameInShader,
    const std::string &type,
-   const std::string &arraySize);
+   const std::string &arraySize,
+   const bool isThreadGroupParam = false);
 
 /// Adds stage output function param descriptor to given shader function
 /// descriptor.

--- a/pxr/imaging/hgi/shaderGenerator.h
+++ b/pxr/imaging/hgi/shaderGenerator.h
@@ -57,7 +57,7 @@ public:
     // Return generated shader source.
     HGI_API
     const char *GetGeneratedShaderCode() const;
-
+    const HgiShaderFunctionDesc &_descriptor;
 protected:
     HGI_API
     explicit HgiShaderGenerator(const HgiShaderFunctionDesc &descriptor);
@@ -73,9 +73,8 @@ protected:
 
     HGI_API
     HgiShaderStage _GetShaderStage() const;
-
+    
 private:
-    const HgiShaderFunctionDesc &_descriptor;
 
     // This is used if the descriptor does not specify a string
     // to be used as the destination for generated output.

--- a/pxr/imaging/hgi/tokens.h
+++ b/pxr/imaging/hgi/tokens.h
@@ -59,7 +59,13 @@ TF_DECLARE_PUBLIC_TOKENS(HgiTokens, HGI_API, HGI_TOKENS);
     (hdPositionInPatch) \
     (hdPatchID) \
     (hdGlobalInvocationID) \
-    (hdBaryCoordNoPerspNV)
+    (hdLocalInvocationID) \
+    (hdThreadID) \
+    (hdLocalIndexID) \
+    (hdThreadLocalIndexID) \
+    (hdPayload) \
+    (hdBaryCoordNoPerspNV) \
+    (emptyAttribute)
 
 TF_DECLARE_PUBLIC_TOKENS(
     HgiShaderKeywordTokens, HGI_API, HGI_SHADER_KEYWORD_TOKENS);

--- a/pxr/imaging/hgiGL/graphicsCmds.cpp
+++ b/pxr/imaging/hgiGL/graphicsCmds.cpp
@@ -102,7 +102,7 @@ HgiGLGraphicsCmds::BindPipeline(HgiGraphicsPipelineHandle pipeline)
 }
 
 void
-HgiGLGraphicsCmds::BindResources(HgiResourceBindingsHandle res)
+HgiGLGraphicsCmds::BindResources(HgiResourceBindingsHandle res, bool useMeshShaders)
 {
     _ops.push_back( HgiGLOps::BindResources(res) );
 }

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -69,8 +69,8 @@ public:
     HGIGL_API
     void BindPipeline(HgiGraphicsPipelineHandle pipeline) override;
 
-    HGIGL_API
-    void BindResources(HgiResourceBindingsHandle resources) override;
+    HGI_API
+    void BindResources(HgiResourceBindingsHandle resources, bool useMeshShaders = false) override;
 
     HGIGL_API
     void SetConstantValues(
@@ -106,6 +106,11 @@ public:
         uint32_t baseVertex,
         uint32_t instanceCount,
         uint32_t baseInstance) override;
+
+    HGIGL_API
+    void DrawIndexedMeshIndirect(
+            HgiBufferHandle const& indexBuffer,
+            uint32_t indexCount) override {}
 
     HGIGL_API
     void DrawIndexedIndirect(

--- a/pxr/imaging/hgiMetal/capabilities.mm
+++ b/pxr/imaging/hgiMetal/capabilities.mm
@@ -46,7 +46,24 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
     bool unifiedMemory = false;
     bool barycentrics = false;
     bool hasAppleSilicon = false;
+    bool hasMeshShaders = false;
     bool icbSupported = false;
+    try {
+        if (@available(macOS 14.0, *)) {
+            auto arch = [device architecture];
+            NSArray *archSpl =
+            [[arch name] componentsSeparatedByString:@"_"];
+            NSString *gpu = archSpl[1];
+            NSString *archNumS = [gpu substringWithRange:NSMakeRange(1, 3)];
+            NSInteger archNum = [archNumS integerValue];
+            //TODO Thor verify
+            if (archNum > 13) {
+                hasMeshShaders = true;
+            }
+        }
+    } catch (NSException *ex) {
+        hasMeshShaders = false;
+    }
     if (@available(macOS 100.100, ios 12.0, *)) {
         unifiedMemory = true;
     } else if (@available(macOS 10.15, ios 13.0, *)) {
@@ -55,6 +72,7 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
 #else
         unifiedMemory = [device isLowPower];
 #endif
+        
         // On macOS 10.15 and 11.0 the AMD drivers reported the wrong value for
         // supportsShaderBarycentricCoordinates so check both flags.
         // Also, Intel GPU drivers do not correctly support barycentrics.
@@ -97,6 +115,8 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
     _SetFlag(HgiDeviceCapabilitiesBitsMultiDrawIndirect, true);
     
     _SetFlag(HgiDeviceCapabilitiesBitsIndirectCommandBuffers, icbSupported);
+
+    _SetFlag(HgiDeviceCapabilitiesBitsMeshShading, hasMeshShaders);
 
     // This is done to decide whether to use a workaround for post tess
     // patch primitive ID lookup. The bug causes the firstPatch offset

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -59,7 +59,7 @@ public:
     void BindPipeline(HgiGraphicsPipelineHandle pipeline) override;
 
     HGIMETAL_API
-    void BindResources(HgiResourceBindingsHandle resources) override;
+    void BindResources(HgiResourceBindingsHandle resources, bool useMeshShaders) override;
 
     HGIMETAL_API
     void SetConstantValues(
@@ -95,6 +95,11 @@ public:
         uint32_t baseVertex,
         uint32_t instanceCount,
         uint32_t baseInstance) override;
+
+    HGIMETAL_API
+    void DrawIndexedMeshIndirect(
+            HgiBufferHandle const& indexBuffer,
+            uint32_t indexCount) override;
 
     HGIMETAL_API
     void DrawIndexedIndirect(
@@ -154,6 +159,7 @@ private:
         MTLViewport viewport;
         MTLScissorRect scissorRect;
         
+        bool useMeshShaders = false;
         HgiMetalResourceBindings* resourceBindings;
         HgiMetalGraphicsPipeline* graphicsPipeline;
         id<MTLBuffer> argumentBuffer;

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -64,10 +64,9 @@ _SetVertexBindings(id<MTLRenderCommandEncoder> encoder,
         if (binding.buffer) {
             HgiMetalBuffer* mtlBuffer =
                 static_cast<HgiMetalBuffer*>(binding.buffer.Get());
-
-            [encoder setVertexBuffer:mtlBuffer->GetBufferId()
-                              offset:binding.byteOffset
-                             atIndex:binding.index];
+                [encoder setVertexBuffer:mtlBuffer->GetBufferId()
+                                  offset:binding.byteOffset
+                                 atIndex:binding.index];
         }
     }
 }
@@ -312,10 +311,12 @@ HgiMetalGraphicsCmds::_SetCachedEncoderState(id<MTLRenderCommandEncoder> encoder
     if (_CachedEncState.resourceBindings) {
         _CachedEncState.resourceBindings->BindResources(_hgi,
                                                         encoder,
-                                                        _CachedEncState.argumentBuffer);
+                                                        _CachedEncState.argumentBuffer,
+                                                        _CachedEncState.useMeshShaders);
     }
-
-    _SetVertexBindings(encoder, _CachedEncState.vertexBindings);
+    if (!_CachedEncState.useMeshShaders) {
+        _SetVertexBindings(encoder, _CachedEncState.vertexBindings);
+    }
 }
 
 void
@@ -483,8 +484,9 @@ HgiMetalGraphicsCmds::BindPipeline(HgiGraphicsPipelineHandle pipeline)
 }
 
 void
-HgiMetalGraphicsCmds::BindResources(HgiResourceBindingsHandle r)
+HgiMetalGraphicsCmds::BindResources(HgiResourceBindingsHandle r, bool useMeshShaders)
 {
+    _CachedEncState.useMeshShaders = useMeshShaders;
     _CreateArgumentBuffer();
 
     _CachedEncState.resourceBindings =
@@ -495,7 +497,8 @@ HgiMetalGraphicsCmds::BindResources(HgiResourceBindingsHandle r)
         for (auto& encoder : _encoders) {
             _CachedEncState.resourceBindings->BindResources(_hgi,
                                                             encoder,
-                                                            _argumentBuffer);
+                                                            _argumentBuffer,
+                                                            useMeshShaders);
         }
     }
 }
@@ -518,6 +521,9 @@ void
 HgiMetalGraphicsCmds::BindVertexBuffers(
     HgiVertexBufferBindingVector const &bindings)
 {
+    if (_CachedEncState.useMeshShaders) {
+        return;
+    }
     _stepFunctions.Bind(bindings);
 
     _CachedEncState.vertexBindings.insert(
@@ -657,7 +663,8 @@ HgiMetalGraphicsCmds::DrawIndexed(
     id<MTLRenderCommandEncoder> encoder = GetEncoder();
         
     _stepFunctions.SetVertexBufferOffsets(encoder, baseInstance);
-
+    
+    
     if (_primitiveType == HgiPrimitiveTypePatchList) {
         const NSUInteger controlPointCount = _primitiveIndexSize;
 
@@ -685,6 +692,26 @@ HgiMetalGraphicsCmds::DrawIndexed(
                           baseInstance:baseInstance];
     }
 
+    _hasWork = true;
+}
+
+void
+HgiMetalGraphicsCmds::DrawIndexedMeshIndirect(
+    HgiBufferHandle const& indexBuffer,
+    uint32_t drawCount)
+{
+    _SyncArgumentBuffer();
+
+    HgiMetalBuffer* indexBuf = static_cast<HgiMetalBuffer*>(indexBuffer.Get());
+
+    MTLPrimitiveType mtlType =
+        HgiMetalConversions::GetPrimitiveType(_primitiveType);
+
+    id<MTLRenderCommandEncoder> encoder = GetEncoder();
+        
+    _CachedEncState.useMeshShaders = true;
+    //TODO use better decision for thread count
+    [encoder drawMeshThreadgroups:MTLSizeMake(drawCount, 1, 1) threadsPerObjectThreadgroup:MTLSizeMake(1, 1, 1) threadsPerMeshThreadgroup:MTLSizeMake(256, 1, 1)];
     _hasWork = true;
 }
 

--- a/pxr/imaging/hgiMetal/graphicsPipeline.h
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.h
@@ -59,6 +59,7 @@ private:
     void _CreateVertexDescriptor();
     void _CreateDepthStencilState(HgiMetal *hgi);
     void _CreateRenderPipelineState(HgiMetal *hgi);
+    void _CreateMeshRenderPipelineState(HgiMetal *hgi);
 
     MTLVertexDescriptor *_vertexDescriptor;
     id<MTLDepthStencilState> _depthStencilState;

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -725,7 +725,7 @@ HgiMetalIndirectCommandEncoder::ExecuteDraw(
         static_cast<HgiMetalResourceBindings*>(metalCommands->resourceBindings.Get());
     resourceBindings->BindResources(_hgi,
                                     encoder,
-                                    mainArgumentBuffer);
+                                    mainArgumentBuffer, false);
     
     // Ensure the the main argument buffer is updated on managed hardware.
     if (mainArgumentBuffer.storageMode != MTLStorageModeShared &&

--- a/pxr/imaging/hgiMetal/resourceBindings.h
+++ b/pxr/imaging/hgiMetal/resourceBindings.h
@@ -80,7 +80,8 @@ public:
     HGIMETAL_API
     void BindResources(HgiMetal *hgi,
                        id<MTLRenderCommandEncoder> renderEncoder,
-                       id<MTLBuffer> argBuffer);
+                       id<MTLBuffer> argBuffer,
+                       bool useMeshShaders);
 
     HGIMETAL_API
     void BindResources(HgiMetal *hgi,

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -49,9 +49,12 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
 
         MTLCompileOptions *options = [[MTLCompileOptions alloc] init];
         options.fastMathEnabled = YES;
-
-        if (@available(macOS 10.15, ios 13.0, *)) {
-            options.languageVersion = MTLLanguageVersion2_2;
+        
+        if (@available(macOS 14.0, *)){
+            options.languageVersion = MTLLanguageVersion3_0;
+        }
+        else if (@available(macOS 10.15, ios 13.0, *)) {
+            options.languageVersion = MTLLanguageVersion2_1;
         } else {
             options.languageVersion = MTLLanguageVersion2_1;
         }
@@ -65,6 +68,10 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             [hgi->GetPrimaryDevice() newLibraryWithSource:@(shaderCode)
                                                         options:options
                                                         error:&error];
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
+        }
 
         [options release];
         options = nil;
@@ -86,6 +93,12 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             case HgiShaderStagePostTessellationVertex:
                 entryPoint = @"vertexEntryPoint";
                 break;
+            case HgiShaderStageMeshObject:
+                entryPoint = @"meshObjectEntryPoint";
+                break;
+            case HgiShaderStageMeshlet:
+                entryPoint = @"meshletEntryPoint";
+                break;
             case HgiShaderStageTessellationControl:
             case HgiShaderStageTessellationEval:
             case HgiShaderStageGeometry:
@@ -101,6 +114,11 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         }
         else {
             HGIMETAL_DEBUG_LABEL(_shaderId, _descriptor.debugName.c_str());
+        }
+        
+        if (error) {
+            NSString *err = [error localizedDescription];
+            _errors = [err UTF8String];
         }
         
         [library release];

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -25,11 +25,15 @@
 #include "pxr/imaging/hgiMetal/shaderGenerator.h"
 #include "pxr/imaging/hgiMetal/resourceBindings.h"
 #include "pxr/imaging/hgi/tokens.h"
+#include "pxr/base/tf/envSetting.h"
 
 #include <sstream>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_ENV_SETTING(HGIMETAL_ENABLE_TINY_TRIANGLE_CULLING, false,
+                      "Enable indirect command buffers");
 
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
@@ -73,10 +77,15 @@ public:
         HgiShaderStage stage);
     HgiMetalShaderSectionPtrVector AccumulateBufferBindings(
         const HgiShaderFunctionBufferDescVector &buffers,
-        HgiMetalShaderGenerator *generator);
+        HgiMetalShaderGenerator *generator,
+        bool canUseConstantSpace);
     HgiMetalShaderSectionPtrVector AccumulateTextureBindings(
         const HgiShaderFunctionTextureDescVector &textures,
         HgiMetalShaderGenerator *generator);
+    HgiMetalShaderSectionPtrVector AccumulatePayload(
+        const HgiShaderFunctionParamDescVector &params,
+        HgiMetalShaderGenerator *generator,
+        HgiShaderStage stage);
 
     const HgiMetalShaderSectionPtrVector& GetConstantParams() const;
     const HgiMetalShaderSectionPtrVector& GetInputs() const;
@@ -84,6 +93,7 @@ public:
     const HgiMetalShaderSectionPtrVector& GetBufferBindings() const;
     const HgiMetalShaderSectionPtrVector& GetSamplerBindings() const;
     const HgiMetalShaderSectionPtrVector& GetTextureBindings() const;
+    const HgiMetalShaderSectionPtrVector& GetPayload() const;
 
     const std::string inputsGenericWrapper;
     const std::string inputsGenericParameters;
@@ -98,6 +108,7 @@ private:
     const HgiMetalInterstageBlockShaderSectionPtrVector _outputBlocks;
     const HgiMetalShaderSectionPtrVector _inputs;
     const HgiMetalShaderSectionPtrVector _outputs;
+    const HgiMetalShaderSectionPtrVector _payload;
     const HgiMetalShaderSectionPtrVector _bufferBindings;
     HgiMetalShaderSectionPtrVector _samplerBindings;
     HgiMetalShaderSectionPtrVector _textureBindings;
@@ -112,19 +123,23 @@ T* _BuildStructInstance(
     const bool isPointer,
     const HgiMetalShaderSectionPtrVector &members,
     HgiMetalShaderGenerator *generator,
-    const std::string templateWrapper = std::string())
+    const std::string templateWrapper = std::string(),
+    const bool writeArrayInDeclaration = true)
 {
     //If it doesn't have any members, don't declare an empty struct instance
     if(typeName.empty() || members.empty()) {
         return nullptr;
     }
-
     HgiMetalStructTypeDeclarationShaderSection * const section =
         generator->CreateShaderSection<
             HgiMetalStructTypeDeclarationShaderSection>(
                 typeName,
                 members,
-                templateWrapper);
+                templateWrapper,
+                std::string(),
+                true,
+                writeArrayInDeclaration
+                );
 
     const HgiShaderSectionAttributeVector attributes = {
         HgiShaderSectionAttribute{attribute, ""}};
@@ -144,11 +159,16 @@ _GetBuiltinKeyword(HgiShaderFunctionParamDesc const &param,
     //possible metal attributes on shader inputs.
     // Map from descriptor to Metal
     const static std::unordered_map<std::string, std::string> roleIndexM {
+       {HgiShaderKeywordTokens->emptyAttribute, " "},
        {HgiShaderKeywordTokens->hdVertexID, "vertex_id"},
        {HgiShaderKeywordTokens->hdInstanceID, "instance_id"},
        {HgiShaderKeywordTokens->hdBaseVertex, "base_vertex"},
        {HgiShaderKeywordTokens->hdBaseInstance, "base_instance"},
        {HgiShaderKeywordTokens->hdGlobalInvocationID, "thread_position_in_grid"},
+       {HgiShaderKeywordTokens->hdLocalInvocationID, "threadgroup_position_in_grid"},
+       {HgiShaderKeywordTokens->hdThreadID, "thread_position_in_threadgroup"},
+       {HgiShaderKeywordTokens->hdLocalIndexID, "thread_index_in_threadgroup"},
+       {HgiShaderKeywordTokens->hdThreadLocalIndexID, "thread_index_in_simdgroup"},
        {HgiShaderKeywordTokens->hdPatchID, "patch_id"},
        {HgiShaderKeywordTokens->hdPositionInPatch, "position_in_patch"},
        {HgiShaderKeywordTokens->hdPrimitiveID, "primitive_id"},
@@ -218,7 +238,7 @@ public:
     std::string GetBindingsSamplerTypeName() const;
     std::string GetBindingsTextureTypeName() const;
     HgiMetalParameterInputShaderSection* GetParameters();
-    HgiMetalParameterInputShaderSection* GetInputs();
+    HgiMetalShaderSection* GetInputs();
     HgiMetalStageOutputShaderSection* GetOutputs();
     HgiMetalArgumentBufferInputShaderSection* GetBufferBindings();
     HgiMetalArgumentBufferInputShaderSection* GetTextureBindings();
@@ -231,6 +251,7 @@ private:
         const HgiMetalShaderSectionPtrVector &stageBufferBindings,
         const HgiMetalShaderSectionPtrVector &stageSamplerBindings,
         const HgiMetalShaderSectionPtrVector &stageTextureBindings,
+        const HgiMetalShaderSectionPtrVector &payload,
         HgiMetalShaderGenerator *generator);
 
     HgiMetalShaderStageEntryPoint & operator=(
@@ -240,8 +261,9 @@ private:
 
     //Owned by and stored in shadersections
     HgiMetalParameterInputShaderSection* _parameters;
-    HgiMetalParameterInputShaderSection* _inputs;
+    HgiMetalShaderSection* _inputs;
     HgiMetalStageOutputShaderSection* _outputs;
+    HgiMetalPayloadShaderSection* _payload;
     HgiMetalArgumentBufferInputShaderSection* _bufferBindings;
     HgiMetalArgumentBufferInputShaderSection* _samplerBindings;
     HgiMetalArgumentBufferInputShaderSection* _textureBindings;
@@ -352,10 +374,28 @@ _GetPackedTypeDefinitions()
 }
 
 std::string
-_ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
+_ComputeHeader(id<MTLDevice> device, const HgiShaderFunctionDesc &descriptor)
 {
+    HgiShaderStage stage = descriptor.shaderStage;
     std::stringstream header;
-
+    
+    if (stage == HgiShaderStageMeshObject || stage == HgiShaderStageMeshlet) {
+        header << "#ifndef MESH_SHADING_CONFIG_H\n"
+               << "#define MESH_SHADING_CONFIG_H\n";
+        if (stage == HgiShaderStageMeshObject) {
+            header << "#define MAX_OBJECT_THREADS         ("
+                   << descriptor.meshDescriptor.maxTotalThreadsPerObjectThreadgroup << ")\n";
+        }
+        if (stage == HgiShaderStageMeshlet) {
+            header << "#define MAX_MESHLET_THREADS         ("
+                   << descriptor.meshDescriptor.maxTotalThreadsPerMeshletThreadgroup << ")\n";
+        }
+        header << "#define MAX_VERTICES                (" << descriptor.meshDescriptor.maxMeshletVertexCount << ")\n"
+               << "#define MAX_PRIMITIVES            (" << descriptor.meshDescriptor.maxPrimitiveCount << ")\n"
+               << "#endif // MESH_SHADING_CONFIG_H\n";
+    }
+    header << "#define TINY_TRIANGLE_CULL\n";
+    
     // Metal feature set defines
     // Define all macOS 10.13 feature set enums onwards
     if (@available(macos 10.13, ios 100.100, *)) {
@@ -560,11 +600,13 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
     return header.str();
 }
 
-std::string const&
-_GetHeader(id<MTLDevice> device, HgiShaderStage stage)
+std::string
+_GetHeader(id<MTLDevice> device, const HgiShaderFunctionDesc &descriptor)
 {
     // This assumes that there is only ever one MTLDevice.
-    static std::string header = _ComputeHeader(device, stage);
+  
+    std::string header;
+        header = _ComputeHeader(device, descriptor);
     return header;
 }
 
@@ -600,6 +642,11 @@ ShaderStageData::ShaderStageData(
             generator,
             descriptor.shaderStage,
             false))
+    , _payload(
+       AccumulatePayload(
+           descriptor.payloadMembers,
+           generator,
+           descriptor.shaderStage))
     , _inputBlocks(
         AccumulateParamBlocks(
             descriptor.stageInputBlocks,
@@ -633,7 +680,9 @@ ShaderStageData::ShaderStageData(
     , _bufferBindings(
         AccumulateBufferBindings(
             descriptor.buffers,
-            generator))
+            generator,
+            !(descriptor.shaderStage == HgiShaderStageMeshObject ||
+                 descriptor.shaderStage == HgiShaderStageMeshlet)))
 {
     // Also populates _samplerBindings
     _textureBindings = AccumulateTextureBindings(
@@ -700,6 +749,7 @@ ShaderStageData::AccumulateParams(
                     HgiMetalMemberShaderSection>(
                         p.nameInShader,
                         p.type,
+                        false,
                         attributes,
                         p.arraySize);
             stageShaderSections.push_back(section);
@@ -724,6 +774,7 @@ ShaderStageData::AccumulateParams(
                     HgiMetalMemberShaderSection>(
                         p.nameInShader,
                         p.type,
+                        false,
                         attributes,
                         p.arraySize);
             stageShaderSections.push_back(section);
@@ -755,6 +806,7 @@ ShaderStageData::AccumulateParamBlocks(
                         HgiMetalMemberShaderSection>(
                             m.name,
                             m.type,
+                            false,
                             attributes,
                             std::string(),
                             p.instanceName);
@@ -779,9 +831,28 @@ ShaderStageData::AccumulateParamBlocks(
 }
 
 HgiMetalShaderSectionPtrVector
+ShaderStageData::AccumulatePayload(
+    const HgiShaderFunctionParamDescVector &params,
+    HgiMetalShaderGenerator *generator,
+    HgiShaderStage stage)
+{
+    const HgiShaderSectionAttributeVector attributes;
+    HgiMetalShaderSectionPtrVector members;
+    for (const HgiShaderFunctionParamDesc &p : params) {
+        HgiMetalShaderSection *section =
+        generator->CreateShaderSection<HgiMetalRawShaderSection>(
+            p.nameInShader, p.type, attributes,
+            p.arraySize, std::string());
+        members.push_back(section);
+    }
+    return members;
+}
+
+HgiMetalShaderSectionPtrVector
 ShaderStageData::AccumulateBufferBindings(
     const HgiShaderFunctionBufferDescVector &buffers,
-    HgiMetalShaderGenerator *generator)
+    HgiMetalShaderGenerator *generator,
+    bool canUseConstantSpace)
 {
     HgiMetalShaderSectionPtrVector stageShaderSections;
     uint32_t maxBindIndex = 0;
@@ -812,7 +883,8 @@ ShaderStageData::AccumulateBufferBindings(
                         p->type,
                         p->binding,
                         p->writable,
-                        attributes);
+                        attributes,
+                        canUseConstantSpace);
         }
         else {
             // Unused padding entry
@@ -908,6 +980,12 @@ ShaderStageData::GetTextureBindings() const
     return _textureBindings;
 }
 
+const HgiMetalShaderSectionPtrVector&
+ShaderStageData::GetPayload() const
+{
+    return _payload;
+}
+
 std::string _BuildOutputTypeName(const HgiMetalShaderStageEntryPoint &ep)
 {
     const std::string &shortHandPrefix = ep.GetOutputShortHandPrefix();
@@ -946,6 +1024,7 @@ HgiMetalShaderStageEntryPoint::HgiMetalShaderStageEntryPoint(
         stageData.GetBufferBindings(),
         stageData.GetSamplerBindings(),
         stageData.GetTextureBindings(),
+        stageData.GetPayload(),
         generator);
 }
 
@@ -962,7 +1041,8 @@ HgiMetalShaderStageEntryPoint::HgiMetalShaderStageEntryPoint(
     _scopePostfix(scopePostfix),
     _entryPointStageName(entryPointStageName),
     _outputTypeName(outputTypeName),
-    _entryPointFunctionName(entryPointFunctionName)
+    _entryPointFunctionName(entryPointFunctionName),
+    _entryPointAttributes(entryPointAttributes)
 {
     _Init(
         stageData.GetConstantParams(),
@@ -971,6 +1051,7 @@ HgiMetalShaderStageEntryPoint::HgiMetalShaderStageEntryPoint(
         stageData.GetBufferBindings(),
         stageData.GetSamplerBindings(),
         stageData.GetTextureBindings(),
+        stageData.GetPayload(),
         generator);
 }
 
@@ -1096,7 +1177,7 @@ HgiMetalShaderStageEntryPoint::GetParameters()
     return _parameters;
 }
 
-HgiMetalParameterInputShaderSection*
+HgiMetalShaderSection*
 HgiMetalShaderStageEntryPoint::GetInputs()
 {
     return _inputs;
@@ -1116,6 +1197,7 @@ HgiMetalShaderStageEntryPoint::_Init(
     const HgiMetalShaderSectionPtrVector &stageBufferBindings,
     const HgiMetalShaderSectionPtrVector &stageSamplerBindings,
     const HgiMetalShaderSectionPtrVector &stageTextureBindings,
+    const HgiMetalShaderSectionPtrVector &payload,
     HgiMetalShaderGenerator *generator)
 {
     static const std::string constIndex =
@@ -1136,7 +1218,12 @@ HgiMetalShaderStageEntryPoint::_Init(
         /* isPointer = */ true,
         /* members = */ stageConstantBuffers,
         generator);
-
+    //Removes stage_in for mesh shaders
+    if (generator->_descriptor.shaderStage != HgiShaderStageMeshObject
+        && generator->_descriptor.shaderStage != HgiShaderStageMeshlet) {
+        bool isMeshFragment = generator->_descriptor.meshDescriptor.meshTopology
+            != HgiShaderFunctionMeshDesc::MeshTopology::None;
+        if (!isMeshFragment) {
     _inputs =
         _BuildStructInstance<HgiMetalParameterInputShaderSection>(
         GetInputsTypeName(),
@@ -1146,8 +1233,50 @@ HgiMetalShaderStageEntryPoint::_Init(
         /* isPointer = */ false,
         /* members = */ stageInputs,
         generator,
-        _inputsGenericWrapper);
+        _inputsGenericWrapper,
+        generator->_descriptor.shaderStage != HgiShaderStagePostTessellationVertex
+            && generator->_descriptor.shaderStage != HgiShaderStagePostTessellationVertex);
+        } else {
+            _inputs =
+            _BuildStructInstance<HgiMetalParameterMeshInputShaderSection>(
+                      GetInputsTypeName(),
+                      GetInputsInstanceName(),
+                      /* attribute = */ "stage_in",
+                      /* addressSpace = */ std::string(),
+                      /* isPointer = */ false,
+                      /* members = */ stageInputs,
+                      generator,
+                      _inputsGenericWrapper);
+        }
+    } else {
+        _inputs =
+            _BuildStructInstance<HgiMetalParameterInputShaderSection>(
+            GetInputsTypeName(),
+            GetInputsInstanceName(),
+            /* attribute = */ "",
+            /* addressSpace = */ std::string(),
+            /* isPointer = */ false,
+            /* members = */ {},
+            generator,
+            _inputsGenericWrapper);
+    }
+    
+    if (generator->_descriptor.shaderStage == HgiShaderStageMeshObject) {
+        _outputs = nullptr;
+    } else if (generator->_descriptor.shaderStage == HgiShaderStageMeshlet) {
 
+        HgiMetalStructTypeDeclarationShaderSection * const structTypeSection =
+        generator->CreateShaderSection<
+        HgiMetalStructTypeDeclarationShaderSection>(
+                    "VertexOut",
+                    stageOutputs,
+                    "",
+                    "",
+                    false);
+        generator->CreateShaderSection<
+            HgiMetalStageOutputMeshShaderSection>(structTypeSection);
+    }
+    else {
     _outputs =
         _BuildStructInstance<HgiMetalStageOutputShaderSection>(
         GetOutputTypeName(),
@@ -1157,6 +1286,25 @@ HgiMetalShaderStageEntryPoint::_Init(
         /* isPointer = */ false,
         /* members = */ stageOutputs,
         generator);
+    }
+    if (!payload.empty()){
+        HgiMetalStructTypeDeclarationShaderSection * const section =
+        generator->CreateShaderSection<
+        HgiMetalStructTypeDeclarationShaderSection>(
+                    "Payload",
+                    payload);
+        
+        const HgiShaderSectionAttributeVector attributes = {
+            HgiShaderSectionAttribute{"payload", ""}};
+        
+        _payload = generator->CreateShaderSection<HgiMetalPayloadShaderSection>(
+                    "payload",
+                    attributes,
+                    "object_data",
+                    false,
+                    generator->_descriptor.shaderStage == HgiShaderStageMeshlet,
+                    section);
+    }
     
     _bufferBindings =
         _BuildStructInstance<HgiMetalArgumentBufferInputShaderSection>(
@@ -1216,7 +1364,8 @@ void HgiMetalShaderGenerator::_BuildKeywordInputShaderSections(
             CreateShaderSection<HgiMetalKeywordInputShaderSection>(
                 keywordName,
                 p.type,
-                attributes);
+                attributes,
+                p.isPointerToValue);
         }
     }
 }
@@ -1234,11 +1383,33 @@ _BuildTessAttribute(
         case HgiShaderFunctionTessellationDesc::PatchType::Quads:
             ss << "quad, ";
             break;
-        default:
-            TF_CODING_ERROR("Unknown patch type");
+            default:
+                TF_CODING_ERROR("Unknown patch type");
             break;
     }
     ss << tessDesc.numVertsPerPatchIn << ")]]";
+}
+
+void
+_BuildMeshObjectAttribute(
+        std::stringstream &ss,
+        const HgiShaderFunctionMeshDesc &meshDesc)
+{
+    ss << "[[object,";
+    ss << "max_total_threads_per_threadgroup(";
+    ss << meshDesc.maxTotalThreadsPerObjectThreadgroup << "),";
+    ss << "max_total_threadgroups_per_mesh_grid(";
+    ss << meshDesc.maxTotalThreadgroupsPerMeshObject << ")]]";
+}
+
+void
+_BuildMeshletAttribute(
+        std::stringstream &ss,
+        const HgiShaderFunctionMeshDesc &meshDesc)
+{
+    ss << "[[mesh,";
+    ss << "max_total_threads_per_threadgroup(";
+    ss << meshDesc.maxTotalThreadsPerMeshletThreadgroup << ")]]";
 }
 
 void
@@ -1345,6 +1516,36 @@ HgiMetalShaderGenerator::_BuildShaderStageEntryPoints(
                             "tcInput",
                             functionAttributesSS.str());
         }
+        case HgiShaderStageMeshObject: {
+            _BuildMeshObjectAttribute(functionAttributesSS,
+                                descriptor.meshDescriptor);
+
+            return std::make_unique
+                    <HgiMetalShaderStageEntryPoint>(
+                            stageData,
+                            this,
+                            "mo",
+                            "Mesh",
+                            "",
+                            "void", //no stage definer for MOS
+                            "meshObjectEntryPoint",
+                            functionAttributesSS.str());
+        }
+        case HgiShaderStageMeshlet: {
+            _BuildMeshletAttribute(functionAttributesSS,
+                                descriptor.meshDescriptor);
+
+            return std::make_unique
+                    <HgiMetalShaderStageEntryPoint>(
+                            stageData,
+                            this,
+                            "ms",
+                            "Mesh",
+                            "",
+                            "meshlet", //no stage definer for MS
+                            "meshletEntryPoint",
+                            functionAttributesSS.str());
+        }
         default: {
             TF_CODING_ERROR("Unknown shader stage");
             return nullptr;
@@ -1364,11 +1565,12 @@ HgiMetalShaderGenerator::HgiMetalShaderGenerator(
             HgiMetalMemberShaderSection>(
                 member.nameInShader,
                 member.type,
+                member.isThreadGroupParam,
                 attrs,
                 member.arraySize);
     }
     std::stringstream macroSection;
-    macroSection << _GetHeader(device, descriptor.shaderStage);
+    macroSection << _GetHeader(device, descriptor);
     if (_IsTessFunction(descriptor)) {
         macroSection << "#define VERTEX_CONTROL_POINTS_PER_PATCH "
         << descriptor.tessellationDescriptor.numVertsPerPatchIn
@@ -1378,6 +1580,9 @@ HgiMetalShaderGenerator::HgiMetalShaderGenerator(
     CreateShaderSection<HgiMetalMacroShaderSection>(
         macroSection.str(),
         "Headers");
+    if (_descriptor.shaderStage == HgiShaderStageMeshlet) {
+        CreateShaderSection<HgiMetalMeshShaderSection>("mesh", "MeshType");
+    }
 
 }
 
@@ -1387,26 +1592,37 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
 {
     HgiMetalShaderSectionUniquePtrVector * const shaderSections =
         GetShaderSections();
-
+    
     ss << "\n// //////// Global Macros ////////\n";
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         section->VisitGlobalMacros(ss);
     }
-
+    
     ss << _GetShaderCodeDeclarations();
-
+    
     ss << "\n// //////// Global Member Declarations ////////\n";
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         section->VisitGlobalMemberDeclarations(ss);
     }
+    
+    // MESH declaration
+    if (_descriptor.shaderStage == HgiShaderStageMeshlet) {
+        
+        ss << "\n// //////// Mesh Declaration ////////\n";
 
+        ss << "using MeshType = metal::mesh<VertexOut, PrimOut,\n";
+        ss << _descriptor.meshDescriptor.maxMeshletVertexCount << ", ";
+        ss << _descriptor.meshDescriptor.maxPrimitiveCount;
+        ss << ", metal::topology::triangle>;\n";
+    }
+    
     //generate scope area in metal.
     //We create a class that wraps the main shader function, and to simulate
     //global space in metal which it has not by default, we put all
     //glslfx global members into a Scope struct, and host the global members
     //as members of that instance
     ss << "struct " << _generatorShaderSections->GetScopeTypeName() << " { \n";
-
+    
     // Metal extends the global scope into a "scope" embedder,
     // which simulates a global scope for some member variables
     ss << "\n// //////// Scope Structs ////////\n";
@@ -1421,7 +1637,7 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         section->VisitScopeFunctionDefinitions(ss);
     }
-
+    
     //constructor
     ss << _generatorShaderSections->GetScopeTypeName() << "(\n";
     bool firstParam = true;
@@ -1463,13 +1679,15 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
     
     ss << _GetShaderCode();
     ss << "};\n\n";
-
+    
     //write out the entry point signature
     HgiMetalStageOutputShaderSection* const outputs =
         _generatorShaderSections->GetOutputs();
     std::stringstream returnSS;
-    if (outputs &&
-        (_GetShaderStage() != HgiShaderStagePostTessellationControl)) {
+    
+    if (outputs && _GetShaderStage() != HgiShaderStageMeshObject
+        && _GetShaderStage() != HgiShaderStageMeshlet
+        && _GetShaderStage() != HgiShaderStagePostTessellationControl) {
         const HgiMetalStructTypeDeclarationShaderSection* const decl =
             outputs->GetStructTypeDeclaration();
         decl->WriteIdentifier(returnSS);
@@ -1478,9 +1696,9 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
         //handle compute
         returnSS << "void";
     }
-
+    
     ss << _generatorShaderSections->GetEntryPointAttributes();
-
+    
     ss << _generatorShaderSections->GetEntryPointStageName();
     ss << " " << returnSS.str() << " "
        << _generatorShaderSections->GetEntryPointFunctionName() << "(\n";
@@ -1502,9 +1720,12 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
         }
     }
     ss <<"){\n";
+    
+    for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
+        section->VisitPreScopeConstructorInstantiation(ss);
+    }
     ss << _generatorShaderSections->GetScopeTypeName() << " "
        << _generatorShaderSections->GetScopeInstanceName();
-    
     if (hasContructorParams) {
         ss << "(\n";
         firstParam = true;
@@ -1527,6 +1748,10 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
 
     // Execute all code that hooks into the entry point function
     ss << "\n// //////// Entry Point Function Executions ////////\n";
+    if (_descriptor.meshDescriptor.meshUser) {
+        ss << _generatorShaderSections->GetScopeInstanceName();
+        ss << ".primitive_id_ms = vsOutput.primOut.primitive_id_ms;\n";
+    }
     for (const HgiMetalShaderSectionUniquePtr &section : *shaderSections) {
         if (section->VisitEntryPointFunctionExecutions(
                 ss, _generatorShaderSections->GetScopeInstanceName())) {
@@ -1535,12 +1760,12 @@ void HgiMetalShaderGenerator::_Execute(std::ostream &ss)
     }
     //return the instance of the shader entrypoint output type
     if (outputs &&
-        (_GetShaderStage() != HgiShaderStagePostTessellationControl)) {
+        (_GetShaderStage() != HgiShaderStagePostTessellationControl) && (_GetShaderStage() != HgiShaderStageMeshObject)
+       && (_GetShaderStage() != HgiShaderStageMeshlet)) {
         const std::string outputInstanceName =
                 _generatorShaderSections->GetOutputInstanceName();
         ss << "return " << outputInstanceName << ";\n";
-    }
-    else {
+    } else {
         ss << _generatorShaderSections->GetScopeInstanceName() << ".main();\n";
     }
     ss << "}\n";

--- a/pxr/imaging/hgiMetal/shaderProgram.h
+++ b/pxr/imaging/hgiMetal/shaderProgram.h
@@ -86,6 +86,16 @@ public:
         return _postTessControlFunction;
     }
 
+    HGIMETAL_API
+            id<MTLFunction> GetMeshObjectFunction() const {
+        return _meshObjectFunction;
+    }
+
+    HGIMETAL_API
+            id<MTLFunction> GetMeshletFunction() const {
+        return _meshletFunction;
+    }
+
 protected:
     friend class HgiMetal;
 
@@ -105,6 +115,8 @@ private:
     id<MTLFunction> _computeFunction;
     id<MTLFunction> _postTessVertexFunction;
     id<MTLFunction> _postTessControlFunction;
+    id<MTLFunction> _meshObjectFunction;
+    id<MTLFunction> _meshletFunction;
 };
 
 

--- a/pxr/imaging/hgiMetal/shaderProgram.mm
+++ b/pxr/imaging/hgiMetal/shaderProgram.mm
@@ -34,6 +34,8 @@ HgiMetalShaderProgram::HgiMetalShaderProgram(HgiShaderProgramDesc const& desc)
     , _computeFunction(nil)
     , _postTessVertexFunction(nil)
     , _postTessControlFunction(nil)
+    , _meshObjectFunction(nil)
+    , _meshletFunction(nil)
 {
     HgiShaderFunctionHandleVector const &shaderFuncs = desc.shaderFunctions;
     for (auto const& func : shaderFuncs) {
@@ -54,6 +56,12 @@ HgiMetalShaderProgram::HgiMetalShaderProgram(HgiShaderProgramDesc const& desc)
                 break;
             case HgiShaderStagePostTessellationControl:
                 _postTessControlFunction = metalFunction->GetShaderId();
+                break;
+            case HgiShaderStageMeshObject:
+                _meshObjectFunction = metalFunction->GetShaderId();
+                break;
+            case HgiShaderStageMeshlet:
+                _meshletFunction = metalFunction->GetShaderId();
                 break;
         }
     }

--- a/pxr/imaging/hgiMetal/shaderSection.h
+++ b/pxr/imaging/hgiMetal/shaderSection.h
@@ -61,6 +61,8 @@ public:
     HGIMETAL_API
     virtual bool VisitScopeConstructorInitialization(std::ostream &ss);
     HGIMETAL_API
+    virtual bool VisitPreScopeConstructorInstantiation(std::ostream &ss);
+    HGIMETAL_API
     virtual bool VisitScopeConstructorInstantiation(std::ostream &ss);
     HGIMETAL_API
     virtual bool VisitEntryPointParameterDeclarations(std::ostream &ss);
@@ -74,6 +76,15 @@ public:
     HGIMETAL_API
     void WriteAttributesWithIndex(std::ostream& ss) const;
 
+    HGIMETAL_API
+    void WriteAttributesOnlyWithoutIndex(std::ostream& ss) const;
+    
+    HgiMetalShaderSection(
+        const std::string &identifier,
+        const HgiShaderSectionAttributeVector& attributes = {},
+        const std::string &defaultValue = std::string(),
+        const std::string &arraySize = std::string(),
+        const std::string &blockInstanceIdentifier = std::string());
     using HgiShaderSection::HgiShaderSection;
 };
 
@@ -121,6 +132,7 @@ public:
     HgiMetalMemberShaderSection(
         const std::string &identifier,
         const std::string &type,
+        const bool isThreadGroupGlobal = false,
         const HgiShaderSectionAttributeVector &attributes = {},
         const std::string arraySize = std::string(),
         const std::string &blockInstanceIdentifier = std::string());
@@ -133,6 +145,76 @@ public:
 
     HGIMETAL_API
     bool VisitScopeMemberDeclarations(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitPreScopeConstructorInstantiation(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorInstantiation(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorDeclarations(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorInitialization(std::ostream &ss) override;
+
+private:
+    const std::string _type;
+    const bool _isThreadGroupGlobal;
+};
+
+/// \class MetalRawShaderSection
+///
+/// Defines a member that will be defined within the scope
+///
+class HgiMetalRawShaderSection final : public HgiMetalShaderSection
+{
+public:
+    HGIMETAL_API
+    HgiMetalRawShaderSection(
+        const std::string &identifier,
+        const std::string &type,
+        const HgiShaderSectionAttributeVector &attributes = {},
+        const std::string arraySize = std::string(),
+        const std::string &blockInstanceIdentifier = std::string());
+
+    HGIMETAL_API
+    ~HgiMetalRawShaderSection() override;
+
+    HGIMETAL_API
+    void WriteType(std::ostream &ss) const override;
+
+private:
+    const std::string _type;
+};
+
+/// \class MetalMeshShaderSection
+///
+/// Defines a member that will be defined within the scope
+///
+class HgiMetalMeshShaderSection final : public HgiMetalShaderSection
+{
+public:
+    HGIMETAL_API
+    HgiMetalMeshShaderSection(
+        const std::string &identifier,
+        const std::string &type);
+
+    HGIMETAL_API
+    ~HgiMetalMeshShaderSection() override;
+
+    HGIMETAL_API
+    void WriteType(std::ostream &ss) const override;
+    HGIMETAL_API
+    bool VisitScopeConstructorDeclarations(std::ostream &ss) override;
+    HGIMETAL_API
+    bool VisitScopeConstructorInitialization(std::ostream &ss) override;
+    HGIMETAL_API
+    bool VisitScopeConstructorInstantiation(std::ostream &ss) override;
+    HGIMETAL_API
+    bool VisitScopeMemberDeclarations(std::ostream &ss) override;
+    HGIMETAL_API
+    bool VisitEntryPointParameterDeclarations(std::ostream &ss) override;
 
 private:
     const std::string _type;
@@ -251,7 +333,8 @@ public:
         const std::string &type,
         const HgiBindingType binding,
         const bool writable,
-        const HgiShaderSectionAttributeVector &attributes);
+        const HgiShaderSectionAttributeVector &attributes,
+        const bool canUseConstantSpace);
 
     // For a dummy padded binding point
     HGIMETAL_API
@@ -283,6 +366,7 @@ private:
     const HgiBindingType _binding;
     const bool _writable;
     const bool _unused;
+    const bool _canUseConstantSpace;
     const std::string _samplerSharedIdentifier;
     const std::string _parentScopeIdentifier;
 };
@@ -301,7 +385,9 @@ public:
         const HgiMetalShaderSectionPtrVector &members,
         const std::string &templateWrapper = std::string(),
         const std::string &templateWrapperParameters
-                            = std::string());
+                            = std::string(),
+        const bool useAttributes = true,
+        const bool useArrayInDeclaration = true);
 
     HGIMETAL_API
     void WriteType(std::ostream &ss) const override;
@@ -325,6 +411,8 @@ private:
     const HgiMetalShaderSectionPtrVector _members;
     const std::string _templateWrapper;
     const std::string _templateWrapperParameters;
+    const bool _useAttributes;
+    const bool _useArrayInDeclaration;
 };
 
 /// \class HgiMetalStructInstanceShaderSection
@@ -387,6 +475,41 @@ private:
     const bool _isPointer;
 };
 
+/// \class HgiMetalParameterInputShaderSection
+///
+/// An input struct to a shader stage
+///
+class HgiMetalParameterMeshInputShaderSection final
+        : public HgiMetalStructInstanceShaderSection
+{
+public:
+    HGIMETAL_API
+    explicit HgiMetalParameterMeshInputShaderSection(
+        const std::string &identifier,
+        const HgiShaderSectionAttributeVector &attributes,
+        const std::string &addressSpace,
+        const bool isPointer,
+        HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration);
+
+    HGIMETAL_API
+    bool VisitEntryPointParameterDeclarations(std::ostream &ss) override;
+
+    HGIMETAL_API
+    bool VisitEntryPointFunctionExecutions(
+        std::ostream& ss,
+        const std::string &scopeInstanceName) override;
+
+    HGIMETAL_API
+    bool VisitGlobalMemberDeclarations(std::ostream &ss) override;
+
+    HGIMETAL_API
+    void WriteParameter(std::ostream& ss) const override;
+
+private:
+    const std::string _addressSpace;
+    const bool _isPointer;
+};
+
 /// \class HgiMetalArgumentBufferInputShaderSection
 ///
 /// An argument buffer for all bindless buffer bindings to a shader stage
@@ -417,6 +540,45 @@ private:
     const bool _isPointer;
 };
 
+class HgiMetalPayloadShaderSection final
+    : public HgiMetalStructInstanceShaderSection
+{
+public:
+    HGIMETAL_API
+    explicit HgiMetalPayloadShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string &addressSpace,
+    const bool isPointer,
+    const bool isConstParameter,
+    HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration);
+
+    HGIMETAL_API
+    bool VisitEntryPointParameterDeclarations(std::ostream &ss) override;
+
+    HGIMETAL_API
+    bool VisitGlobalMemberDeclarations(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeMemberDeclarations(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorDeclarations(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorInitialization(std::ostream &ss) override;
+    
+    HGIMETAL_API
+    bool VisitScopeConstructorInstantiation(std::ostream &ss) override;
+
+    HGIMETAL_API
+    void WriteParameter(std::ostream& ss) const override;
+
+    private:
+    const std::string _addressSpace;
+    const bool _isConstParameter;
+};
+
 /// \class HgiMetalKeywordInputShaderSection
 ///
 /// Defines and writes out special shader keyword inputs
@@ -429,7 +591,8 @@ public:
     explicit HgiMetalKeywordInputShaderSection(
         const std::string &identifier,
         const std::string &type,
-        const HgiShaderSectionAttributeVector &attributes);
+        const HgiShaderSectionAttributeVector &attributes,
+        const bool isPointerToValue = false);
 
     HGIMETAL_API
     void WriteType(std::ostream& ss) const override;
@@ -447,16 +610,17 @@ private:
     HgiMetalKeywordInputShaderSection() = delete;
     HgiMetalKeywordInputShaderSection & operator=(
         const HgiMetalKeywordInputShaderSection&) = delete;
-    HgiMetalKeywordInputShaderSection(const HgiMetalBufferShaderSection&) = delete;
+    HgiMetalKeywordInputShaderSection(const HgiMetalKeywordInputShaderSection&) = delete;
 
     const std::string _type;
+    const bool _isPointerToValue;
 };
 
 /// \class HgiMetalStageOutputShaderSection
 ///
 /// Defines and writes out shader stage outputs
 ///
-class HgiMetalStageOutputShaderSection final
+class HgiMetalStageOutputShaderSection
     : public HgiMetalStructInstanceShaderSection
 {
 public:
@@ -480,6 +644,23 @@ public:
 
     HGIMETAL_API
     bool VisitGlobalMemberDeclarations(std::ostream &ss) override;
+};
+
+/// \class HgiMetalStageOutputShaderSection
+///
+/// Defines and writes out shader stage outputs
+///
+class HgiMetalStageOutputMeshShaderSection : public HgiMetalShaderSection
+{
+public:
+    HGIMETAL_API
+    explicit HgiMetalStageOutputMeshShaderSection(
+        HgiMetalStructTypeDeclarationShaderSection * const structTypeDeclaration);
+
+    HGIMETAL_API
+    bool VisitGlobalMemberDeclarations(std::ostream &ss) override;
+private:
+    const HgiMetalStructTypeDeclarationShaderSection *_structTypeDeclaration;
 };
 
 /// \class HgiMetalInterstageBlockShaderSection

--- a/pxr/imaging/hgiMetal/shaderSection.mm
+++ b/pxr/imaging/hgiMetal/shaderSection.mm
@@ -28,6 +28,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 HgiMetalShaderSection::~HgiMetalShaderSection() = default;
 
+HgiMetalShaderSection::HgiMetalShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector& attributes,
+    const std::string &defaultValue,
+    const std::string &arraySize,
+    const std::string &blockInstanceIdentifier)
+  : HgiShaderSection(identifier
+  , attributes
+  , defaultValue
+  , arraySize
+  , blockInstanceIdentifier)
+{
+}
+
 bool
 HgiMetalShaderSection::VisitScopeStructs(std::ostream &ss)
 {
@@ -54,6 +68,12 @@ HgiMetalShaderSection::VisitScopeConstructorDeclarations(std::ostream &ss)
 
 bool
 HgiMetalShaderSection::VisitScopeConstructorInitialization(std::ostream &ss)
+{
+    return false;
+}
+
+bool
+HgiMetalShaderSection::VisitPreScopeConstructorInstantiation(std::ostream &ss)
 {
     return false;
 }
@@ -101,9 +121,40 @@ HgiMetalShaderSection::WriteAttributesWithIndex(std::ostream& ss) const
     }
 }
 
+void
+HgiMetalShaderSection::WriteAttributesOnlyWithoutIndex(std::ostream& ss) const
+{
+    const HgiShaderSectionAttributeVector &att = GetAttributes();
+    HgiShaderSectionAttributeVector attributes;
+    for (size_t i = 0; i < att.size(); i++) {
+        const HgiShaderSectionAttribute &a = att[i];
+        if (a.identifier.find("user") == std::string::npos) {
+            attributes.push_back(a);
+        }
+    }
+    if (attributes.size() > 0) {
+        ss << "[[";
+    }
+    for (size_t i = 0; i < attributes.size(); i++) {
+        if (i > 0) {
+            ss << ", ";
+        }
+        
+        const HgiShaderSectionAttribute &a = attributes[i];
+        ss << a.identifier;
+        if (!a.index.empty()) {
+            ss << "(" << a.index << ")";
+        }
+    }
+    if (attributes.size() > 0) {
+        ss << "]]";
+    }
+}
+
 HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
     const std::string &identifier,
     const std::string &type,
+    const bool isThreadGroupGlobal,
     const HgiShaderSectionAttributeVector &attributes,
     const std::string arraySize,
     const std::string &blockInstanceIdentifier)
@@ -111,6 +162,7 @@ HgiMetalMemberShaderSection::HgiMetalMemberShaderSection(
                           std::string(), arraySize,
                           blockInstanceIdentifier)
   , _type{type}
+  , _isThreadGroupGlobal{isThreadGroupGlobal}
 {
 }
 
@@ -126,9 +178,165 @@ bool
 HgiMetalMemberShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
 {
     if (!HasBlockInstanceIdentifier()) {
-        WriteDeclaration(ss);
+        if (_isThreadGroupGlobal) {
+            ss << "threadgroup ";
+        }
+        WriteType(ss);
+        ss << " ";
+        if (_isThreadGroupGlobal) {
+            ss << "(&";
+        }
+        WriteIdentifier(ss);
+        if (_isThreadGroupGlobal) {
+            ss << ")";
+        }
+        WriteArraySize(ss);
+        ss << ";";
         ss << std::endl;
     }
+    return true;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitPreScopeConstructorInstantiation(std::ostream &ss)
+{
+    if (_isThreadGroupGlobal) {
+        ss << "threadgroup ";
+        WriteDeclaration(ss);
+        ss << std::endl;
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorInstantiation(std::ostream &ss)
+{
+    
+    if (_isThreadGroupGlobal) {
+        ss << "";
+        WriteIdentifier(ss);
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    if (_isThreadGroupGlobal) {
+        ss << "threadgroup ";
+        WriteType(ss);
+        ss << " (&_";
+        WriteIdentifier(ss);
+        ss << ")";
+        WriteArraySize(ss);
+        return true;
+    }
+    return false;
+}
+
+bool
+HgiMetalMemberShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    if(_isThreadGroupGlobal) {
+        WriteIdentifier(ss);
+        ss << "(_";
+        WriteIdentifier(ss);
+        ss << ")";
+        return true;
+    }
+    return false;
+}
+
+HgiMetalRawShaderSection::HgiMetalRawShaderSection(
+    const std::string &identifier,
+    const std::string &type,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string arraySize,
+    const std::string &blockInstanceIdentifier)
+  : HgiMetalShaderSection(identifier, attributes,
+                          std::string(), arraySize,
+                          blockInstanceIdentifier)
+  , _type{type}
+{
+}
+
+HgiMetalRawShaderSection::~HgiMetalRawShaderSection() = default;
+
+void
+HgiMetalRawShaderSection::WriteType(std::ostream &ss) const
+{
+    ss << _type;
+}
+
+HgiMetalMeshShaderSection::HgiMetalMeshShaderSection(
+    const std::string &identifier,
+    const std::string &type)
+  : HgiMetalShaderSection(identifier, {},
+                          std::string(), std::string(),
+                          std::string())
+  , _type{type}
+{
+}
+
+HgiMetalMeshShaderSection::~HgiMetalMeshShaderSection() = default;
+
+void
+HgiMetalMeshShaderSection::WriteType(std::ostream &ss) const
+{
+    ss << _type;
+}
+
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    ss << "thread ";
+    WriteType(ss);
+    ss << " &_";
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    ss << "(_";
+    WriteIdentifier(ss);
+    ss << ")";
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeConstructorInstantiation(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
+{
+    ss << "thread ";
+    WriteType(ss);
+    ss << " &";
+    WriteIdentifier(ss);
+    ss << ";\n";
+    return true;
+}
+
+bool
+HgiMetalMeshShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    WriteParameter(ss);
     return true;
 }
 
@@ -637,7 +845,8 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
     const std::string &type,
     const HgiBindingType binding,
     const bool writable,
-    const HgiShaderSectionAttributeVector &attributes)
+    const HgiShaderSectionAttributeVector &attributes,
+    const bool canUseConstantSpace)
   : HgiMetalShaderSection(
       samplerSharedIdentifier,
       attributes,
@@ -646,6 +855,7 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
   , _binding(binding)
   , _writable(writable)
   , _unused(false)
+  , _canUseConstantSpace(canUseConstantSpace)
   , _samplerSharedIdentifier(samplerSharedIdentifier)
   , _parentScopeIdentifier(parentScopeIdentifier)
 {
@@ -662,6 +872,7 @@ HgiMetalBufferShaderSection::HgiMetalBufferShaderSection(
   , _binding(HgiBindingTypePointer)
   , _writable(false)
   , _unused(true)
+  , _canUseConstantSpace(false)
 {
 }
 
@@ -674,7 +885,8 @@ HgiMetalBufferShaderSection::WriteType(std::ostream& ss) const
 void
 HgiMetalBufferShaderSection::WriteParameter(std::ostream& ss) const
 {
-    if (!_writable) {
+    //TODO resolve -> meshlet shader buffers can't be declared in constant space
+    if (!_writable && _canUseConstantSpace) {
         ss << "constant ";
     } else {
         ss << "device ";
@@ -701,7 +913,7 @@ HgiMetalBufferShaderSection::VisitScopeMemberDeclarations(std::ostream &ss)
 {
     if (_unused) return false;
 
-    if (!_writable) {
+    if (!_writable && _canUseConstantSpace) {
         ss << "constant ";
     } else {
         ss << "device ";
@@ -730,8 +942,8 @@ HgiMetalBufferShaderSection::VisitScopeConstructorDeclarations(
     std::ostream &ss)
 {
     if (_unused) return false;
-
-    if (!_writable) {
+    
+    if (!_writable && _canUseConstantSpace) {
         ss << "const ";
         ss << "constant ";
     } else {
@@ -788,11 +1000,15 @@ HgiMetalStructTypeDeclarationShaderSection::HgiMetalStructTypeDeclarationShaderS
     const std::string &identifier,
     const HgiMetalShaderSectionPtrVector &members,
     const std::string &templateWrapper,
-    const std::string &templateWrapperParameters)
+    const std::string &templateWrapperParameters,
+    const bool useAttributes,
+    const bool useArrayInDeclaration)
   : HgiMetalShaderSection(identifier)
   , _members(members)
   , _templateWrapper(templateWrapper)
   , _templateWrapperParameters(templateWrapperParameters)
+  , _useAttributes(useAttributes)
+  , _useArrayInDeclaration(useArrayInDeclaration)
 {
 }
 
@@ -833,9 +1049,13 @@ HgiMetalStructTypeDeclarationShaderSection::WriteDeclaration(
     for (HgiMetalShaderSection* member : _members) {
         member->WriteParameter(ss);
         if (!member->HasBlockInstanceIdentifier()) {
-            member->WriteAttributesWithIndex(ss);
+            if (_useAttributes) {
+                member->WriteAttributesWithIndex(ss);
+            } else {
+                member->WriteAttributesOnlyWithoutIndex(ss);
+            }
         }
-        if (!PTCSOrPTVS) {
+        if (_useArrayInDeclaration) {
             member->WriteArraySize(ss);
         }
         ss << ";\n";
@@ -986,6 +1206,115 @@ HgiMetalParameterInputShaderSection::VisitGlobalMemberDeclarations(
     return true;
 }
 
+HgiMetalParameterMeshInputShaderSection::HgiMetalParameterMeshInputShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string &addressSpace,
+    const bool isPointer,
+    HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration)
+  : HgiMetalStructInstanceShaderSection(
+      identifier,
+      attributes,
+      structTypeDeclaration)
+  , _addressSpace(addressSpace)
+  , _isPointer(isPointer)
+{
+}
+
+void
+HgiMetalParameterMeshInputShaderSection::WriteParameter(std::ostream& ss) const
+{
+    GetStructTypeDeclaration()->WriteTemplateWrapper(ss);
+    ss << " ";
+    if(_isPointer) {
+        ss << "*";
+    }
+    WriteIdentifier(ss);
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    if(!_addressSpace.empty()) {
+        ss << _addressSpace << " ";
+    }
+    
+    WriteParameter(ss);
+    WriteAttributesWithIndex(ss);
+    return true;
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitEntryPointFunctionExecutions(
+    std::ostream& ss,
+    const std::string &scopeInstanceName)
+{
+    const auto &structDeclMembers = GetStructTypeDeclaration()->GetMembers();
+    for (size_t i = 0; i < structDeclMembers.size(); ++i) {
+        if (i > 0) {
+            ss << "\n";
+        }
+        HgiShaderSection *member = structDeclMembers[i];
+        const std::string &arraySize = member->GetArraySize();
+        if (!arraySize.empty()) {
+            ss << "for (int arrInd = 0; arrInd < ";
+            ss << arraySize;
+            ss << "; arrInd++) {\n";
+            ss << scopeInstanceName << ".";
+            member->WriteIdentifier(ss);
+            ss << "[arrInd] = ";
+            WriteIdentifier(ss);
+            ss << "[arrInd]"
+               << (_isPointer ? "->" : ".");
+            member->WriteIdentifier(ss);
+            ss << ";\n}";
+        } else {
+            ss << scopeInstanceName << ".";
+            if (member->HasBlockInstanceIdentifier()) {
+                member->WriteBlockInstanceIdentifier(ss);
+                ss << ".";
+            }
+            member->WriteIdentifier(ss);
+            ss << " = ";
+            WriteIdentifier(ss);
+            ss << (_isPointer ? "->" : ".");
+            ss << "vertexOut.";
+            member->WriteIdentifier(ss);
+            ss << ";";
+        }
+    }
+    return true;
+}
+
+bool
+HgiMetalParameterMeshInputShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    ss << "struct PrimOut {\n";
+    ss << "uint primitive_id_ms;\n";
+    ss << "};\n";
+    ss << "struct VertexOut {\n";
+    
+    for (auto &member : GetStructTypeDeclaration()->GetMembers()) {
+        //member->WriteParameter(ss);
+        member->WriteType(ss);
+        ss << " ";
+        member->WriteIdentifier(ss);
+        ss << ";\n";
+    }
+    ss << "};\n";
+    
+    ss << "struct ";
+    GetStructTypeDeclaration()->WriteIdentifier(ss);
+    ss << "{\n";
+    ss << "VertexOut vertexOut;\n";
+    ss << "PrimOut primOut;\n";
+    ss << "};\n";
+    return true;
+}
+
+
 HgiMetalArgumentBufferInputShaderSection::HgiMetalArgumentBufferInputShaderSection(
     const std::string &identifier,
     const HgiShaderSectionAttributeVector &attributes,
@@ -1034,15 +1363,114 @@ HgiMetalArgumentBufferInputShaderSection::VisitGlobalMemberDeclarations(
     return true;
 }
 
+HgiMetalPayloadShaderSection::HgiMetalPayloadShaderSection(
+    const std::string &identifier,
+    const HgiShaderSectionAttributeVector &attributes,
+    const std::string &addressSpace,
+    const bool isPointer,
+    const bool isConstParameter,
+    HgiMetalStructTypeDeclarationShaderSection *structTypeDeclaration)
+  : HgiMetalStructInstanceShaderSection(
+      identifier,
+      attributes,
+      structTypeDeclaration)
+  , _addressSpace(addressSpace)
+  , _isConstParameter(isConstParameter)
+{
+}
+
+void
+HgiMetalPayloadShaderSection::WriteParameter(std::ostream& ss) const
+{
+    WriteType(ss);
+    ss << " &";
+    WriteIdentifier(ss);
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitEntryPointParameterDeclarations(
+    std::ostream &ss)
+{
+    if(!_addressSpace.empty()) {
+        if (_isConstParameter) {
+            ss << "const ";
+        }
+        ss << _addressSpace << " ";
+    }
+    
+    WriteParameter(ss);
+    WriteAttributesWithIndex(ss);
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    GetStructTypeDeclaration()->WriteDeclaration(ss);
+    ss << "\n";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeMemberDeclarations(
+    std::ostream &ss)
+{
+    if (_isConstParameter) {
+        ss << "const ";
+    }
+    ss << "object_data ";
+    WriteType(ss);
+    ss << "& ";
+    WriteIdentifier(ss);
+    ss << ";\n";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorDeclarations(
+    std::ostream &ss)
+{
+    if (_isConstParameter) {
+        ss << "const ";
+    }
+    ss << "object_data ";
+        WriteType(ss);
+        ss << "& _";
+    WriteIdentifier(ss);
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorInitialization(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    ss << "(_";
+    WriteIdentifier(ss);
+    ss << ")";
+    return true;
+}
+
+bool
+HgiMetalPayloadShaderSection::VisitScopeConstructorInstantiation(
+    std::ostream &ss)
+{
+    WriteIdentifier(ss);
+    return true;
+}
+
 HgiMetalKeywordInputShaderSection::HgiMetalKeywordInputShaderSection(
     const std::string &identifier,
     const std::string &type,
-    const HgiShaderSectionAttributeVector &attributes)
+    const HgiShaderSectionAttributeVector &attributes,
+    const bool isPointerToValue)
   : HgiMetalShaderSection(
       identifier,
       attributes,
       "")
   , _type(type)
+  , _isPointerToValue(isPointerToValue)
 {
 }
 
@@ -1055,9 +1483,14 @@ HgiMetalKeywordInputShaderSection::WriteType(std::ostream& ss) const
 bool
 HgiMetalKeywordInputShaderSection::VisitScopeMemberDeclarations(
     std::ostream &ss)
-{
+{   if (_isPointerToValue) {
+        ss << "thread ";
+    }
     WriteType(ss);
     ss << " ";
+    if (_isPointerToValue) {
+        ss << "* ";
+    }
     WriteIdentifier(ss);
     ss << ";\n";
     return true;
@@ -1083,6 +1516,9 @@ HgiMetalKeywordInputShaderSection::VisitEntryPointFunctionExecutions(
     ss << scopeInstanceName << ".";
     WriteIdentifier(ss);
     ss << " = ";
+    if (_isPointerToValue) {
+        ss << "&";
+    }
     WriteIdentifier(ss);
     ss << ";";
     return true;
@@ -1164,6 +1600,25 @@ HgiMetalStageOutputShaderSection::VisitGlobalMemberDeclarations(
     std::ostream &ss)
 {
     GetStructTypeDeclaration()->WriteDeclaration(ss);
+    ss << "\n";
+    return true;
+}
+
+HgiMetalStageOutputMeshShaderSection::HgiMetalStageOutputMeshShaderSection(
+    HgiMetalStructTypeDeclarationShaderSection * const structTypeDeclaration)
+  : HgiMetalShaderSection("")
+, _structTypeDeclaration(structTypeDeclaration)
+{
+}
+
+bool
+HgiMetalStageOutputMeshShaderSection::VisitGlobalMemberDeclarations(
+    std::ostream &ss)
+{
+    ss << "struct PrimOut {\n";
+    ss << "uint primitive_id_ms;\n";
+    ss << "};\n";
+    _structTypeDeclaration->WriteDeclaration(ss);
     ss << "\n";
     return true;
 }

--- a/pxr/imaging/hio/glslfx.h
+++ b/pxr/imaging/hio/glslfx.h
@@ -56,6 +56,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (tessEvalShader)            \
     (postTessControlShader)     \
     (postTessVertexShader)      \
+    (meshObjectShader)          \
+    (meshletShader)             \
     (vertexShader)              \
     (vertexShaderInjection)     \
                                 \


### PR DESCRIPTION
This PR is intended as an all in one for using mesh shaders, updated from prior PRs

### Description of Change(s)
- Adds support for mesh shaders
- Triangle frustum culling, mesh shader backface culling
- Adds mesh shader stage
- Create a new pipeline for mesh shaders
- Manages drawing coordinates for interstage data
- Shader generation for payloads
- Draw batch setup and generation

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
