### PR TITLE
Replace `BOOST_PP_IIF` with `_TF_PP_IFF` in python bindings

### DIFF
--- a/pxr/base/tf/pyStaticTokens.h
+++ b/pxr/base/tf/pyStaticTokens.h
@@ -102,7 +102,7 @@ private:
     _TF_PY_TOKENS_WRAP_ATTR_MEMBER(r, key, _TF_PY_TOKEN_GET_ELEM(elem))
 
 #define _TF_PY_TOKEN_GET_ELEM(elem)                                         \
-    BOOST_PP_IIF(TF_PP_IS_TUPLE(elem),                                      \
+    _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                        \
         TF_PP_TUPLE_ELEM(0, elem), elem)
 
 // Private macros to wrap a sequence.


### PR DESCRIPTION
### Description of Change(s)

#2682 removed the usage of `BOOST_PP_IIF` from the main code base (sans the unused `preprocessorUtils.{h,cpp}`.  This completes its removal by removing it from the python bindings.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
