### PR TITLE
Support `TfHashAppend` leveraging of `std::hash` for unspecialized types

### DIFF
--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -31,6 +31,7 @@
 
 #include <set>
 #include <string>
+#include <variant>
 #include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -302,6 +303,17 @@ Test_TfHash()
 
     // Validate support for std::unique_ptr
     printf("hash(unique_ptr): %zu\n", h(std::make_unique<int>(7)));
+
+    // Validate support for std::optional
+    printf("hash(optional): %zu\n", h(std::make_optional<std::string>("xyz")));
+    TF_AXIOM(h(std::optional<std::string>("xyz")) ==
+             h(std::optional<std::string>("xyz")));
+
+    // Validate support for std::variant
+    printf("hash(variant): %zu\n",
+           h(std::variant<std::string, int, double>("abc")));
+    TF_AXIOM(h(std::variant<std::string, int, double>("abc")) ==
+             h(std::variant<std::string, int, double>("abc")));
 
     TfHasher tfh;
 


### PR DESCRIPTION
### Description of Change(s)

A C++17 friendly implementation of leveraging `std::hash` in `TfHashAppend` had been left commented out. During the removal of `boost::hash`, specializations were added (#2298, #2304) for some types that explicitly forwarded the result of `std::hash` as their `TfHashAppend` implementation.

Now that OpenUSD requires C++17, `TfHashAppend` can hash any type that supports `std::hash` and those specializations can be removed.  To avoid `stdext::hash_value` from being prioritized over `std::hash` on some platforms, the lookup order is reordered so that `std::hash` is second and `hash_value` is last.

This also removes SFINAE for the `std::vector` specialization in favor of a `static_assert` guard against using `AppendContiguous` on `std::vector<bool>`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
