### PR TITLE
Replace `boost::hash` with `TfHash` in `usd/sdf` python bindings

### DIFF
--- a/pxr/usd/sdf/wrapTypes.cpp
+++ b/pxr/usd/sdf/wrapTypes.cpp
@@ -289,7 +289,7 @@ _SdfValueBlockRepr(const SdfValueBlock &self)
 static int
 _SdfValueBlockHash(const SdfValueBlock &self)
 {
-    return boost::hash<SdfValueBlock>()(self);  
+    return TfHash{}(self);
 }
 
 SdfValueTypeName


### PR DESCRIPTION
### Description of Change(s)

#2180 replaced `boost::hash` and `boost::hash_combine` with `TfHash`, but excluded updating the python bindings.  This completes the removal of `boost::hash` from the entire `sdf` library.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
