### PR TITLE
Remove unused `BoostHasher` from `base/tf` test case

### DIFF
--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -29,10 +29,6 @@
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/weakPtr.h"
 
-// We're getting rid of our dependency on boost::hash -- this code is left
-// commented for testing purposes, for now (6/2020).
-//#include <boost/functional/hash.hpp>
-
 #include <set>
 #include <string>
 #include <vector>
@@ -155,23 +151,6 @@ _TestStatsTwo(Hasher const &h, char const *label)
     sw.Stop();
     printf("took %f seconds\n", sw.GetSeconds());
 }
-
-/*  See comment at top of file.
-
-struct BoostHasher
-{
-    size_t operator()(uint64_t x) const {
-        return boost::hash<uint64_t>()(x);
-    }
-    
-    size_t operator()(Two t) const {
-        size_t seed = 0;
-        boost::hash_combine(seed, t.x);
-        boost::hash_combine(seed, t.y);
-        return seed;
-    }
-};
-*/
 
 struct TfHasher
 {
@@ -325,12 +304,9 @@ Test_TfHash()
     printf("hash(unique_ptr): %zu\n", h(std::make_unique<int>(7)));
 
     TfHasher tfh;
-    //BoostHasher bh;
 
     _TestStatsOne(tfh, "TfHash");
     _TestStatsTwo(tfh, "TfHash");
-    //_TestStatsOne(bh, "Boost hash");
-    //_TestStatsTwo(bh, "Boost hash");
 
     bool status = true;
     return status;


### PR DESCRIPTION
### Description of Change(s)

`BoostHasher` is commented out and unused in `pxr/base/tf/testenv/hash.cpp`.  With #2785 removing the last boost dependency in `pxr`, this unused code can be safely removed.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
