### PR TITLE
Add an iterator to tf to decode UTF-8 strings

### DIFF
--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -83,6 +83,7 @@ pxr_library(tf
         type
         typeFunctions
         typeNotice
+        unicodeUtils
         warning
         weakBase
         weakPtr
@@ -383,6 +384,7 @@ pxr_build_test(testTf
         testenv/type.cpp
         testenv/typeMultipleInheritance.cpp
         testenv/typeInfoMap.cpp
+        testenv/unicodeUtils.cpp
         testenv/weakPtr.cpp
 )
 
@@ -645,6 +647,9 @@ pxr_register_test(TfTypeInfoMap
 )
 pxr_register_test(TfType_MultipleInheritance
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfType_MultipleInheritance"
+)
+pxr_register_test(TfUnicodeUtils
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfUnicodeUtils"
 )
 pxr_register_test(TfWeakPtr
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testTf TfWeakPtr"

--- a/pxr/base/tf/testenv/unicodeUtils.cpp
+++ b/pxr/base/tf/testenv/unicodeUtils.cpp
@@ -1,0 +1,110 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include "pxr/pxr.h"
+#include "pxr/base/tf/diagnosticLite.h"
+#include "pxr/base/tf/regTest.h"
+#include "pxr/base/tf/unicodeUtils.h"
+
+#include <string_view>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static bool
+TestUtf8CodePointView()
+{
+
+    {
+        TF_AXIOM(TfUnicodeUtils::Utf8CodePointView{}.empty());
+    }
+
+    // Exercise the iterator converting from UTF-8 char to code point
+    {
+        const std::string_view s1{"ⅈ75_hgòð㤻"};
+        TfUnicodeUtils::Utf8CodePointView u1{s1};
+        auto i1 = std::cbegin(u1);
+        TF_AXIOM(i1.GetBase() == s1.begin());
+        TF_AXIOM(*i1 == 8520);
+        std::advance(i1, 9);
+        TF_AXIOM(i1 == std::cend(u1));
+
+        for (const uint32_t codePoint : u1) {
+            TF_AXIOM(codePoint != TfUnicodeUtils::INVALID_CODE_POINT);
+        }
+    }
+
+    {
+        const std::string_view s2{"㤼01৪∫"};
+        TfUnicodeUtils::Utf8CodePointView u2{s2};
+        auto i2 = std::cbegin(u2);
+        TF_AXIOM(i2.GetBase() == s2.begin());
+        TF_AXIOM(*i2 == 14652);
+        std::advance(i2, 5);
+        TF_AXIOM(i2 == std::cend(u2));
+
+        for (const uint32_t codePoint : u2) {
+            TF_AXIOM(codePoint != TfUnicodeUtils::INVALID_CODE_POINT);
+        }
+    }
+
+    {
+        const std::string_view s3{"㤻üaf-∫⁇…🔗"};
+        TfUnicodeUtils::Utf8CodePointView u3{s3};
+        auto i3a = std::cbegin(u3);
+        auto i3b = std::cbegin(u3);
+
+        // The C++20 ranges version of find_if can be used with sentinels in
+        // C++20
+        for (; i3b != std::cend(u3); ++i3b) {
+            if (*(i3b.GetBase()) == '-') {
+                break;
+            }
+        }
+        TF_AXIOM(i3b != std::cend(u3));
+
+        // i3a should contain all characters before the "-"
+        TF_AXIOM(*i3a == 14651);
+        std::advance(i3a, 4);
+        TF_AXIOM(i3a == i3b);
+        TF_AXIOM(i3a.GetBase() == i3b.GetBase());
+
+        // i3b should include the "-" character
+        TF_AXIOM(*i3b == 45);
+        std::advance(i3b, 5);
+        TF_AXIOM(i3b == std::cend(u3));
+
+        for (const uint32_t codePoint : u3) {
+            TF_AXIOM(codePoint != TfUnicodeUtils::INVALID_CODE_POINT);
+        }
+
+    }
+    return true;
+}
+
+static bool
+Test_TfUnicodeUtils()
+{
+    return TestUtf8CodePointView();
+}
+
+TF_ADD_REGTEST(TfUnicodeUtils);

--- a/pxr/base/tf/unicodeUtils.cpp
+++ b/pxr/base/tf/unicodeUtils.cpp
@@ -1,0 +1,191 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/unicodeUtils.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace TfUnicodeUtils {
+
+uint32_t Utf8CodePointIterator::_GetCodePoint() const
+{
+    // determine what encoding length the character is
+    _EncodingLength encodingLength = this->_GetEncodingLength();
+    if (encodingLength > std::distance(_it, _end)) {
+        // error condition, would read bytes past the end of the range
+        return INVALID_CODE_POINT;
+    }
+    if (encodingLength == 1)
+    {
+        return static_cast<uint32_t>(static_cast<unsigned char>(*_it));
+    }
+    auto begin = _it;
+    if (encodingLength == 2)
+    {
+        unsigned char byte1 = static_cast<unsigned char>(*begin);
+        unsigned char byte2 = static_cast<unsigned char>(*(++begin));
+
+        // ensure the ranges we expect, or it's not a valid character
+        if (byte1 < static_cast<unsigned char>('\xc2') ||
+            byte1 > static_cast<unsigned char>('\xdf'))
+        {
+            return INVALID_CODE_POINT;
+        }
+        if (byte2 < static_cast<unsigned char>('\x80') ||
+            byte2 > static_cast<unsigned char>('\xbf'))
+        {
+            return INVALID_CODE_POINT;
+        }
+
+        // the code point is constructed from the last 5 bits of byte1
+        // and the last 6 bits of byte2
+        return ((byte1 & 0x1f) << 6) + (byte2 & 0x3f);
+    }
+    else if (encodingLength == 3)
+    {
+        unsigned char byte1 = static_cast<unsigned char>(*begin);
+        unsigned char byte2 = static_cast<unsigned char>(*(++begin));
+        unsigned char byte3 = static_cast<unsigned char>(*(++begin));
+
+        // ensure the ranges we expect, or it's not a valid character
+        if (byte1 == static_cast<unsigned char>('\xe0'))
+        {
+            // byte2 must be in range A0..BF
+            // byte3 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\xa0') ||
+                byte2 > static_cast<unsigned char>('\xbf') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else if ((byte1 >= static_cast<unsigned char>('\xe1') &&
+                  byte1 <= static_cast<unsigned char>('\xec')) ||
+                  byte1 == static_cast<unsigned char>('\xee') ||
+                  byte1 == static_cast<unsigned char>('\xef'))
+        {
+            // byte2 must be in range 80..BF
+            // byte3 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\x80') ||
+                byte2 > static_cast<unsigned char>('\xbf') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else if (byte1 == static_cast<unsigned char>('\xed'))
+        {
+            // byte2 must be in range 80..9F
+            // byte3 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\x80') ||
+                byte2 > static_cast<unsigned char>('\x9f') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else
+        {
+            // byte 1 invalid
+            return INVALID_CODE_POINT;
+        }
+
+        // code point is constructed from the last 4 bits of byte1
+        // and the last 6 bits of bytes 2 and 3
+        return ((byte1 & 0xf) << 12) + ((byte2 & 0x3f) << 6) +
+                (byte3 & 0x3f);
+    }
+    else if (encodingLength == 4)
+    {
+        unsigned char byte1 = static_cast<unsigned char>(*begin);
+        unsigned char byte2 = static_cast<unsigned char>(*(++begin));
+        unsigned char byte3 = static_cast<unsigned char>(*(++begin));
+        unsigned char byte4 = static_cast<unsigned char>(*(++begin));
+
+        if (byte1 == static_cast<unsigned char>('\xf0'))
+        {
+            // byte2 must be in range 90..BF
+            // byte3 must be in range 80..BF
+            // byte4 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\x90') ||
+                byte2 > static_cast<unsigned char>('\xbf') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf') ||
+                byte4 < static_cast<unsigned char>('\x80') ||
+                byte4 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else if (byte1 >= static_cast<unsigned char>('\xf1') &&
+                 byte1 <= static_cast<unsigned char>('\xf3'))
+        {
+            // byte2 must be in range 80..BF
+            // byte3 must be in range 80..BF
+            // byte4 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\x80') ||
+                byte2 > static_cast<unsigned char>('\xbf') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf') ||
+                byte4 < static_cast<unsigned char>('\x80') ||
+                byte4 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else if (byte1 == static_cast<unsigned char>('\xf4'))
+        {
+            // byte2 must be in range 80..8F
+            // byte3 must be in range 80..BF
+            // byte4 must be in range 80..BF
+            if (byte2 < static_cast<unsigned char>('\x80') ||
+                byte2 > static_cast<unsigned char>('\x8f') ||
+                byte3 < static_cast<unsigned char>('\x80') ||
+                byte3 > static_cast<unsigned char>('\xbf') ||
+                byte4 < static_cast<unsigned char>('\x80') ||
+                byte4 > static_cast<unsigned char>('\xbf'))
+            {
+                return INVALID_CODE_POINT;
+            }
+        }
+        else
+        {
+            // byte 1 is invalid
+            return INVALID_CODE_POINT;
+        }
+
+        // code point is constructed from the last 3 bits of byte 1
+        // and the last 6 bits of bytes 2, 3, and 4
+        return ((byte1 & 0x7) << 18) + ((byte2 & 0x3f) << 12) +
+               ((byte3 & 0x3f) << 6) + (byte4 & 0x3f);
+    }
+    return INVALID_CODE_POINT;
+}
+} // end TfUnicodeUtils
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeUtils.h
+++ b/pxr/base/tf/unicodeUtils.h
@@ -1,0 +1,315 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_BASE_TF_UNICODE_UTILS_H
+#define PXR_BASE_TF_UNICODE_UTILS_H
+
+/// \file tf/unicodeUtils.h
+/// \ingroup group_tf_String
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/api.h"
+#include "pxr/base/tf/diagnostic.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \namespace TfUnicodeUtils
+/// \ingroup group_tf_String
+///
+/// Contains utility methods for processing classes of Unicode characters
+/// according to the Unicode standard.
+namespace TfUnicodeUtils {
+
+constexpr uint32_t INVALID_CODE_POINT = 0xFFFD;
+
+class Utf8CodePointIterator;
+
+/// Wrapper for a UTF-8 encoded `std::string_view` that can be iterated over
+/// as code points instead of bytes.
+///
+/// Because of the variable length encoding, the `Utf8StringView` iterator is
+/// a ForwardIterator and is read only.
+///
+/// \code{.cpp}
+/// std::string value{"∫dx"};
+/// TfUnicodeUtils::Utf8CodePointView view{value};
+/// for (const uint32_t codePoint : view) {
+///     if (codePoint == TfUnicodeUtils::INVALID_CODE_POINT) {
+///         TF_WARN("String cannot be decoded.");
+///     }
+/// }
+/// (The Utf8CodePointView's sentinel end() will make it compatible with
+///  the STL ranges library).
+/// \endcode
+class Utf8CodePointView final {
+public:
+    using const_iterator = Utf8CodePointIterator;
+
+    /// Model iteration ending when the underlying string_view's end iterator
+    /// has been exceeded. This guards against strings whose variable length
+    /// encoding pushes the iterator past the end of the underlying
+    /// string_view.
+    class PastTheEndSentinel final {};
+
+    Utf8CodePointView() = default;
+    explicit Utf8CodePointView(const std::string_view& view) : _view(view) {}
+
+    const_iterator begin() const;
+
+    /// The sentinel will compare as equal with any iterator at or past the end
+    /// of the underlying string_view
+    PastTheEndSentinel end() const
+    {
+        return PastTheEndSentinel{};
+    }
+
+    const_iterator cbegin() const;
+
+    /// The out of range sentinel will compare as equal with any iterator
+    /// at or past the end of the underlying string_view's
+    PastTheEndSentinel cend() const
+    {
+        return end();
+    }
+
+    /// Returns true if the underlying view is empty
+    bool empty() const
+    {
+        return _view.empty();
+    }
+
+private:
+    std::string_view _view;
+};
+
+/// Defines an iterator over a UTF-8 encoded string that extracts unicode
+/// code point values.
+///
+/// UTF-8 is a variable length encoding, meaning that one Unicode
+/// character can be encoded in UTF-8 as 1, 2, 3, or 4 bytes.  This
+/// iterator takes care of iterating the necessary characters in a string
+/// and extracing the Unicode code point of each UTF-8 encoded character
+/// in the sequence.
+class Utf8CodePointIterator final {
+public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = uint32_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = uint32_t;
+
+    /// Retrieves the next UTF-8 character in the sequence as its Unicode
+    /// code point value. Returns INVALID_CODE_POINT when the byte sequence
+    /// pointed to by the iterator cannot be decoded.
+    ///
+    /// If during read of the UTF-8 character sequence the underlying
+    /// string iterator would go beyond \a end defined at construction
+    /// time, a std::out_of_range exception will be thrown.
+    uint32_t operator* () const
+    {
+        // If the current UTF-8 character is invalid, instead of
+        // throwing an exception, _GetCodePoint signals this is
+        // bad by setting the code point to 0xFFFD (this mostly happens
+        // when a high / low private surrogate is used)
+        // TODO: note that this isn't precisely conformant, as we
+        // likely consumed an entire sequence when a subset would have
+        // been invalid e.g. the byte sequence C2 41 would be detected
+        // as a 2-byte  sequence, but it is invalid because of the
+        // second byte signature by the standard, this should process
+        // the C2 as invalid but consume 41 as a valid 1-byte UTF-8
+        // character
+        return _GetCodePoint();
+    }
+
+    /// Retrieves the wrapped string iterator.
+    std::string_view::const_iterator GetBase() const
+    {
+        return this->_it;
+    }
+
+    /// Determines if two iterators are equal.
+    /// This intentionally does not consider the end iterator to allow for
+    /// comparison of iterators between substring views.
+    bool operator== (const Utf8CodePointIterator& rhs) const
+    {
+        return (this->_it == rhs._it);
+    }
+
+    /// Determines if two iterators are unequal.
+    /// This intentionally does not consider the end iterator to allow for
+    /// comparison of iterators between substring views.
+    bool operator!= (const Utf8CodePointIterator& rhs) const
+    {
+        return (this->_it != rhs._it);
+    }
+
+    /// Advances the iterator logically one UTF-8 character sequence in
+    /// the string. The underlying string iterator will be advanced
+    /// according to the variable length encoding of the next UTF-8
+    /// character. Invalid leading bytes will increment until the end
+    /// of the range is reached.
+    Utf8CodePointIterator& operator++ ()
+    {
+        // note that in cases where the encoding is invalid, we move to the
+        // next byte this is necessary because otherwise the iterator would
+        // never advanced and the end condition of == iterator::end() would
+        // never be satisfied
+        _EncodingLength encodingLength = _GetEncodingLength();
+        std::advance(_it, (encodingLength != 0) ? encodingLength : 1);
+        if (_IsPastTheEnd()) {
+            _it = _end;
+        }
+        return *this;
+    }
+
+    /// Advances the iterator logically one UTF-8 character sequence in the
+    /// string. The underlying string iterator will be advanced according
+    /// to the variable length encoding of the next UTF-8 character.
+    Utf8CodePointIterator operator++ (int)
+    {
+        // note that in cases where the encoding is invalid, we move to the
+        // next byte this is necessary because otherwise the iterator would
+        // never advanced and the end condition of == iterator::end() would
+        // never be satisfied
+        auto temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    /// Checks if the `lhs` iterator is at or past the end for the
+    /// underlying string_view
+    friend bool operator==(const Utf8CodePointIterator& lhs,
+                           Utf8CodePointView::PastTheEndSentinel)
+    {
+        return lhs._IsPastTheEnd();
+    }
+
+    friend bool operator==(Utf8CodePointView::PastTheEndSentinel lhs,
+                           const Utf8CodePointIterator& rhs)
+    {
+        return rhs == lhs;
+    }
+
+    friend bool operator!=(const Utf8CodePointIterator& lhs,
+                           Utf8CodePointView::PastTheEndSentinel rhs)
+    {
+        return !(lhs == rhs);
+    }
+    friend bool operator!=(Utf8CodePointView::PastTheEndSentinel lhs,
+                           Utf8CodePointIterator rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+private:
+    // Constructs an iterator that can read UTF-8 character sequences from
+    // the given starting string_view iterator \a it. \a end is used as a
+    // guard against reading byte sequences past the end of the source string.
+    Utf8CodePointIterator(
+        const std::string_view::const_iterator& it,
+        const std::string_view::const_iterator& end) : _it(it), _end(end) {
+            TF_DEV_AXIOM(_it <= _end);
+        }
+
+    using _EncodingLength = unsigned char;
+
+    // Retrieves the variable encoding length of the UTF-8 character
+    // currently pointed to by the iterator. This can be 1, 2, 3, or 4
+    // depending on the encoding of the UTF-8 character. If the encoding
+    // cannot be determined, this method will return 0.
+    _EncodingLength _GetEncodingLength() const
+    {
+        // already at the end, no valid character sequence
+        if (_IsPastTheEnd())
+        {
+            return 0;
+        }
+        // determine what encoding length the character is
+        // 1-byte characters have a leading 0 sequence
+        // 2-byte characters have a leading 110 sequence
+        // 3-byte characters have a leading 1110 sequence
+        // 4-byte characters have a leading 11110 sequence
+        unsigned char x = static_cast<unsigned char>(*_it);
+        if (x < 0x80)
+        {
+            return 1;
+        }
+        else if ((x >> 5) == 0x6)
+        {
+            return 2;
+        }
+        else if ((x >> 4) == 0xe)
+        {
+            return 3;
+        }
+        else if ((x >> 3) == 0x1e)
+        {
+            return 4;
+        }
+        else
+        {
+            // can't determine encoding, this is an error
+            return 0;
+        }
+    }
+
+    // Retrieves the Unicode code point of the next character in the UTF-8
+    // encoded sequence (defined by \a begin) and returns the value in
+    // \a codePoint. This method will return \a true if the encoded
+    // sequence is valid. If the encoding is invalid, this method will
+    // return \a false and \a codePoint will be set to 0.
+    TF_API uint32_t _GetCodePoint() const;
+
+    // Returns true if the iterator at or past the end and can no longer be
+    // dereferenced.
+    bool _IsPastTheEnd() const
+    {
+        return _it >= _end;
+    }
+
+    std::string_view::const_iterator _it;
+    std::string_view::const_iterator _end;
+
+    friend class Utf8CodePointView;
+};
+
+Utf8CodePointView::const_iterator Utf8CodePointView::begin() const
+{
+    return Utf8CodePointView::const_iterator{
+        std::cbegin(_view), std::cend(_view)};
+}
+
+Utf8CodePointView::const_iterator Utf8CodePointView::cbegin() const
+{
+    return begin();
+}
+
+} // namespace TfUnicodeUtils
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_BASE_TF_UNICODE_UTILS_H_


### PR DESCRIPTION
### Description of Change(s)
#2687 will be introducing support for identifying code points in the `Xid` unicode class.  This foundational change adds `Utf8CodePointIterator` and `Utf8CodePointView` to convert UTF-8 encoded strings to code points.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
