### PR TITLE
Autodesk: Redirecting shader parameters

### DIFF
--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -256,6 +256,10 @@ static void _EmitAccessor(std::stringstream &str,
                           TfToken const &type,
                           HdStBinding const &binding,
                           const char *index=NULL);
+
+static void _EmitScalarAccessor(std::stringstream &str,
+                                TfToken const &name,
+                                TfToken const &type);
 /*
   1. If the member is a scalar consuming N basic machine units,
   the base alignment is N.
@@ -3151,6 +3155,8 @@ static void _EmitStageAccessor(std::stringstream &str,
     // default to localIndex=0
     str << _GetUnpackedType(type, false) << " HdGet_" << name << "()"
         << " { return HdGet_" << name << "(0); }\n";
+
+    _EmitScalarAccessor(str, name, type);
 }
 
 static void _EmitStructAccessor(std::stringstream &str,
@@ -3206,6 +3212,7 @@ static void _EmitStructAccessor(std::stringstream &str,
         str << _GetUnpackedType(type, false) << " HdGet_" << accessorName << "()"
             << " { return HdGet_" << accessorName << "(0); }\n";
     }
+    _EmitScalarAccessor(str, accessorName, type);
 }
 
 static void _EmitBufferAccessor(std::stringstream &str,
@@ -6428,11 +6435,6 @@ HdSt_CodeGen::_GenerateShaderParameters(bool bindlessTextureEnabled)
                 << "\n}\n"
                 << "#define HD_HAS_" << it->second.name << " 1\n";
             
-            if (it->second.name == it->second.inPrimvars[0]) {
-                accessors
-                    << "#endif\n";
-            }
-
             // Emit scalar accessors to support shading languages like MSL which
             // do not support swizzle operators on scalar values.
             if (_GetNumComponents(it->second.dataType) <= 4) {
@@ -6442,6 +6444,11 @@ HdSt_CodeGen::_GenerateShaderParameters(bool bindlessTextureEnabled)
                     << " { return HdGet_" << it->second.name << "()"
                     << _GetFlatTypeSwizzleString(it->second.dataType)
                     << "; }\n";
+            }
+
+            if (it->second.name == it->second.inPrimvars[0]) {
+                accessors
+                    << "#endif\n";
             }
 
         } else if (bindingType == HdStBinding::TRANSFORM_2D) {


### PR DESCRIPTION
### Description of Change(s)

Revert change [68dec0df](https://github.com/PixarAnimationStudios/OpenUSD/commit/68dec0dff7791b74fbbc679bed3350e897c4bcb8) and use the correct way to resolve the issue for redirecting shader parameters.

The change [68dec0df](https://github.com/PixarAnimationStudios/OpenUSD/commit/68dec0dff7791b74fbbc679bed3350e897c4bcb8) is because if a shader parameter has the same name as the primvar, it will redirect to the primvar. If the primvar doesn't emit scalar accessor, the shader parameter must define the scalar accessor for Mac platform. This change has a problem when the primvar has already emitted the scalar accessor. For example, if EmitAccessor is called, it will then call EmitScalarAccessor. In this case, there will be both the scalar accessor for primvar and the scalar accessor for shader parameter. As the name for the primvar and the shader parameter is the same, the two scalar accessor function will be duplicated. The correct solution is that every primvar that has the potential scalar access must provide the scalar accessor. In this change, we add EmitScalarAccessor to EmitStageAccessor and EmitStructAccessor. We may also need to add to _EmitComputeAccessor and _EmitBufferAccessor, but we can wait until we meet with the problem.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
