### PR TITLE
Autodesk: WaitUntilCompleted on Metal

### DIFF
--- a/pxr/imaging/hgiMetal/computeCmds.h
+++ b/pxr/imaging/hgiMetal/computeCmds.h
@@ -101,7 +101,6 @@ private:
     id<MTLBuffer> _argumentBuffer;
     id<MTLComputeCommandEncoder> _encoder;
     bool _secondaryCommandBuffer;
-    bool _hasWork;
     HgiComputeDispatch _dispatchMethod;
 };
 

--- a/pxr/imaging/hgiMetal/computeCmds.mm
+++ b/pxr/imaging/hgiMetal/computeCmds.mm
@@ -44,7 +44,6 @@ HgiMetalComputeCmds::HgiMetalComputeCmds(
     , _argumentBuffer(nil)
     , _encoder(nil)
     , _secondaryCommandBuffer(false)
-    , _hasWork(false)
     , _dispatchMethod(desc.dispatchMethod)
 {
     _CreateEncoder();
@@ -152,7 +151,8 @@ HgiMetalComputeCmds::Dispatch(int dimX, int dimY)
         threadsPerThreadgroup:MTLSizeMake(MIN(thread_width, dimX),
                                           MIN(thread_height, dimY), 1)];
 
-    _hasWork = true;
+    if(!_secondaryCommandBuffer)
+        _hgi->SetHasWork();
     _argumentBuffer = nil;
 }
 
@@ -191,11 +191,9 @@ HgiMetalComputeCmds::GetDispatchMethod() const
 bool
 HgiMetalComputeCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
 {
-    bool submittedWork = false;
     if (_encoder) {
         [_encoder endEncoding];
         _encoder = nil;
-        submittedWork = true;
 
         HgiMetal::CommitCommandBufferWaitType waitType;
         switch(wait) {
@@ -221,7 +219,7 @@ HgiMetalComputeCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
     _commandBuffer = nil;
     _argumentBuffer = nil;
 
-    return submittedWork;
+    return true;
 }
 
 HGIMETAL_API

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -170,7 +170,6 @@ private:
     uint32_t _primitiveIndexSize;
     uint32_t _drawBufferBindingIndex;
     NSString* _debugLabel;
-    bool _hasWork;
     bool _viewportSet;
     bool _scissorRectSet;
     bool _enableParallelEncoder;

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -85,7 +85,6 @@ HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
     , _primitiveIndexSize(0)
     , _drawBufferBindingIndex(0)
     , _debugLabel(nil)
-    , _hasWork(false)
     , _viewportSet(false)
     , _scissorRectSet(false)
     , _enableParallelEncoder(false)
@@ -566,7 +565,7 @@ HgiMetalGraphicsCmds::Draw(
         }
     }
 
-    _hasWork = true;
+    _hgi->SetHasWork();
 }
 
 void
@@ -636,6 +635,7 @@ HgiMetalGraphicsCmds::DrawIndirect(
             });
         }
     });
+    _hgi->SetHasWork();
 }
 
 void
@@ -685,7 +685,7 @@ HgiMetalGraphicsCmds::DrawIndexed(
                           baseInstance:baseInstance];
     }
 
-    _hasWork = true;
+    _hgi->SetHasWork();
 }
 
 void
@@ -778,6 +778,7 @@ HgiMetalGraphicsCmds::DrawIndexedIndirect(
             });
         }
     });
+    _hgi->SetHasWork();
 }
 
 void
@@ -875,7 +876,7 @@ HgiMetalGraphicsCmds::_Submit(Hgi* hgi, HgiSubmitWaitType wait)
     _encoders.clear();
     _CachedEncState.ResetCachedEncoderState();
     
-    return _hasWork;
+    return true;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -204,6 +204,8 @@ public:
     HGIMETAL_API
     id<MTLBuffer> GetArgBuffer();
 
+    inline void SetHasWork() { _workToFlush = true; }
+
 protected:
     HGIMETAL_API
     bool _SubmitCmds(HgiCmds* cmds, HgiSubmitWaitType wait) override;

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -515,7 +515,7 @@ HgiMetal::_SubmitCmds(HgiCmds* cmds, HgiSubmitWaitType wait)
     TRACE_FUNCTION();
 
     if (cmds) {
-        _workToFlush = Hgi::_SubmitCmds(cmds, wait);
+        Hgi::_SubmitCmds(cmds, wait);
         if (cmds == _currentCmds) {
             _currentCmds = nullptr;
         }


### PR DESCRIPTION
### Description of Change(s)

Correct the behavior when we want to submit a command. This will also make WaitTypeWaitUntilCompleted work properly.

The issue was introduced in change [28116f1](https://github.com/PixarAnimationStudios/OpenUSD/commit/28116f1390ee756cfcd25f4e26cd4e2707cb77f2). Before the change, the command buffer is committed in HgiMetal::_SubmitCmds(), and before the buffer commit, HgiMetal::_workToFlush was set to indicate if there is dispatching work in compute encoder or drawing work in graphics encoder. So when command buffer is committed, if _workToFlush is true, it will commit the commands to GPU. But in change [28116f1](https://github.com/PixarAnimationStudios/OpenUSD/commit/28116f1390ee756cfcd25f4e26cd4e2707cb77f2), because they want to introduce the secondary command buffer, the commit of the command buffer is moved to HgiCmds::_Submit (in _hgi->CommitPrimaryCommandBuffer(waitType)), which is before the set of _workToFlush. So even if the encoder contains dispatching work or drawing work, the command buffer will not be committed to GPU. This has two drawbacks. For HgiSubmitWaitTypeNoWait waitType, we push the work to GPU too late. This didn't make the most use of GPU. For HgiSubmitWaitTypeWaitUntilCompleted waitType, it doesn't wait at all.

As you can see, the problem is that _workToFlush is set after the commit of command buffer. So in this change, I add an API HgiMetal::HasWork(). It will set _workToFlush to true. When graphics encoder encodes the draw command or the compute encoder encodes the dispatch command, it can call the HasWork API to indicate there is already work command. So when command buffer is committed, _workToFlush is correctly set.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
