### PR TITLE
cmake: fix for absolute path to libm.so in pxrConfig.cmake

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -159,8 +159,11 @@ add_definitions(${TBB_DEFINITIONS})
 if(WIN32)
     # Math functions are linked automatically by including math.h on Windows.
     set(M_LIB "")
+    set(M_LIB_DIR "")
 else()
-    find_library(M_LIB m)
+    find_library(M_LIB_ABS_PATH m REQUIRED)
+    set(M_LIB "m")
+    get_filename_component(M_LIB_DIR "${M_LIB_ABS_PATH}" DIRECTORY)
 endif()
 
 if (NOT PXR_MALLOC_LIBRARY)

--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -60,6 +60,10 @@ pxr_library(arch
         overview.dox
 )
 
+if(M_LIB_DIR)
+    target_link_directories(arch PRIVATE ${M_LIB_DIR})
+endif()
+
 pxr_build_test_shared_lib(testArchAbiPlugin
     CPPFILES
         testenv/testArchAbiPlugin.cpp


### PR DESCRIPTION
### Description of Change(s)

The absolute path makes `pxrConfig.cmake` non-portable between different distros of Linux (or any other situation where the location of `libm.so` differs).

I'm pushing two PRs with two different approaches to fixing this

- the "simple" fix ([PR2796](https://github.com/PixarAnimationStudios/OpenUSD/pull/2796))
  - instead of linking to the absolute path of `libm.so` (found via `find_library`), we simply link to the lib `m`, and assume that the standard cmake variables / methods for finding libs will be sufficient
- the "safe" fix (this one)
  - we still use `find_library` to find the location of `libm.so`, but we don't link directly to the absolute path this finds; instead, we link to just `m`, but we make sure the directory we find it in is searched by the linker for any targets using it, via `target_link_directories`

Of the two approaches, I prefer the **simple one** ([PR2796](https://github.com/PixarAnimationStudios/OpenUSD/pull/2796)), because they will only differ in behavior if:

- someone is linking against a `libm.so` not installed in a standard system library directory (ie, not via the distro's standard package manager)
- AND this non-standard `libm.so`is in a location that WON'T be found at link time via CMake or the compiler's standard mechanisms for altering linking commands (ie, due to modifcations to the `CMAKE_SHARED_LINKER_FLAGS` cmake variable or the `LDFLAGS` env variable)
- AND this location WILL be found via `find_library`

I think that particular combination of circustances is rare enough that it's unlikely a current member of the USD community will see a difference.  Given that, I'd prefer to keep the codebase simpler.  (ie, the "safe" approach would require remembering to call `target_link_directories(new_lib PRIVATE ${M_LIB_DIR})` on any new_lib which has a dependency on `libm.so`...)



### Fixes Issue(s)
- #2798

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
