### PR TITLE
Document dangling layers through new test

### DIFF
--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -976,6 +976,10 @@ if (BUILD_SHARED_LIBS)
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverChanged"
         EXPECTED_RETURN_CODE 0
     )
+    pxr_register_test(testUsdResolverChanged_danglingLayer
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolverChanged --demonstrate-dangling-layers"
+        EXPECTED_RETURN_CODE 0
+    )
 endif()
 
 pxr_register_test(testUsdStageNoPython

--- a/pxr/usd/usd/testenv/testUsdResolverChanged.cpp
+++ b/pxr/usd/usd/testenv/testUsdResolverChanged.cpp
@@ -111,10 +111,99 @@ private:
     }
 };
 
+// It is possible for handles to layers to exist outside of the registry.
+// This demonstrates how to construct that situation and some of the
+// implications. Layers existing outside of the registry is not ideal.
+// This test simply demonstrates and exercises the current behavior.
+void DemonstrateDanglingLayers()
+{
+    // Configure the resolver to open Buzz as ts1
+    const _TestResolverContext context1{"toy_story"};
+    _ResolverInterface->SetAssetPathsForConfig(
+        "toy_story", {
+        { "Buzz", "ts1/Buzz.usda" }
+    });
+    SdfLayerRefPtr buzz1;
+    {
+        ArResolverContextBinder binder{context1};
+        buzz1 = SdfLayer::FindOrOpen("Buzz");
+        TF_AXIOM(buzz1);
+        TF_AXIOM(TfStringEndsWith(buzz1->GetRealPath(), "ts1/Buzz.usda"));
+    }
+
+    // Configure the resolver to open Buzz as ts2
+    _ResolverInterface->SetAssetPathsForConfig(
+        "toy_story", {
+        { "Buzz", "ts2/Buzz.usda" }
+    });
+    const _TestResolverContext context2{"toy_story"};
+    ArGetResolver().RefreshContext(context2);
+    SdfLayerRefPtr buzz2;
+    {
+        ArResolverContextBinder binder{context2};
+        buzz2 = SdfLayer::FindOrOpen("Buzz");
+        TF_AXIOM(buzz2);
+        TF_AXIOM(TfStringEndsWith(buzz2->GetRealPath(), "ts2/Buzz.usda"));
+    }
+
+    // Return to the original context and update asset info
+    ArGetResolver().RefreshContext(context1);
+    {
+        ArResolverContextBinder binder{context1};
+        buzz1->UpdateAssetInfo();
+    }
+
+    // Both buzz1 and buzz2 have the same real path
+    TF_AXIOM(TfStringEndsWith(buzz1->GetRealPath(), "ts2/Buzz.usda"));
+    TF_AXIOM(TfStringEndsWith(buzz2->GetRealPath(), "ts2/Buzz.usda"));
+    TF_AXIOM(buzz1->GetRealPath() == buzz2->GetRealPath());
+    // However, they are different handles.
+    TF_AXIOM(buzz1 != buzz2);
+
+    // In both contexts, `SdfLayer::Find` returns buzz2
+    {
+        ArResolverContextBinder binder{context1};
+        TF_AXIOM(buzz1 != SdfLayer::Find("Buzz"));
+        TF_AXIOM(buzz2 == SdfLayer::Find("Buzz"));
+    }
+
+    {
+        ArResolverContextBinder binder{context2};
+        TF_AXIOM(buzz1 != SdfLayer::Find("Buzz"));
+        TF_AXIOM(buzz2 == SdfLayer::Find("Buzz"));
+    }
+
+    buzz2 = nullptr;
+
+    // buzz1 still exists but cannot be found in the registry.
+    {
+        ArResolverContextBinder binder{context1};
+        TF_AXIOM(buzz1);
+        TF_AXIOM(buzz1->GetIdentifier() == "Buzz");
+        TF_AXIOM(SdfLayer::Find("Buzz") == nullptr);
+    }
+
+    {
+        ArResolverContextBinder binder{context2};
+        TF_AXIOM(buzz1);
+        TF_AXIOM(buzz1->GetIdentifier() == "Buzz");
+        TF_AXIOM(SdfLayer::Find("Buzz") == nullptr);
+    }
+}
+
 int
 main(int argc, char** argv)
 {
     SetupPlugins();
+
+    if (argc >= 2) {
+        if (strcmp(argv[1], "--demonstrate-dangling-layers") == 0) {
+            DemonstrateDanglingLayers();
+            return 0;
+        }
+        // There should be no arguments otherwise.
+        return 1;
+    }
 
     // The "shots" in this test use asset paths with two different forms
     // to exercise UsdStage's change processing:


### PR DESCRIPTION
### Description of Change(s)

Resolver context changes combined with layer updating can result in layer handles that exist outside of the registry. This PR documents how to construct such a case and some of the resulting behavior.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
