### PR TITLE
Replace `boost::optional` with `std::optional` in `usd/usd`

### DIFF
--- a/pxr/usd/usd/clip.cpp
+++ b/pxr/usd/usd/clip.cpp
@@ -42,8 +42,7 @@
 #include "pxr/base/gf/interval.h"
 #include "pxr/base/tf/stringUtils.h"
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -305,7 +304,7 @@ Usd_Clip::_GetBracketingTimeSamplesForPathFromClipLayer(
         return true;
     }
 
-    boost::optional<ExternalTime> translatedLower, translatedUpper;
+    std::optional<ExternalTime> translatedLower, translatedUpper;
     auto _CanTranslate = [&time, &upperInClip, &lowerInClip, this, 
                           &translatedLower, &translatedUpper](
         const TimeMappings& mappings, size_t i1, size_t i2,
@@ -331,19 +330,19 @@ Usd_Clip::_GetBracketingTimeSamplesForPathFromClipLayer(
 
         if (lower <= timeInClip && timeInClip <= upper) {
             if (map1.internalTime != map2.internalTime) {
-                translated.reset(
-                    this->_TranslateTimeToExternal(timeInClip, i1, i2));
+                translated =
+                    this->_TranslateTimeToExternal(timeInClip, i1, i2);
             } else {
                 const bool lowerUpperMatch = (lowerInClip == upperInClip);
                 if (lowerUpperMatch && time == map1.externalTime) {
-                    translated.reset(map1.externalTime);
+                    translated = map1.externalTime;
                 } else if (lowerUpperMatch && time == map2.externalTime) {
-                    translated.reset(map2.externalTime);
+                    translated = map2.externalTime;
                 } else {
                     if (translatingLower) {
-                        translated.reset(map1.externalTime);
+                        translated = map1.externalTime;
                     } else {
-                        translated.reset(map2.externalTime);
+                        translated = map2.externalTime;
                     }
                 }
             }
@@ -378,17 +377,17 @@ Usd_Clip::_GetBracketingTimeSamplesForPathFromClipLayer(
         // The 'timingOutsideClip' test case in testUsdModelClips exercises
         // this behavior.
         if (lowerInClip < times->front().internalTime) {
-            translatedLower.reset(times->front().externalTime);
+            translatedLower = times->front().externalTime;
         }
         else if (lowerInClip > times->back().internalTime) {
-            translatedLower.reset(times->back().externalTime);
+            translatedLower = times->back().externalTime;
         }
 
         if (upperInClip < times->front().internalTime) {
-            translatedUpper.reset(times->front().externalTime);
+            translatedUpper = times->front().externalTime;
         }
         else if (upperInClip > times->back().internalTime) {
-            translatedUpper.reset(times->back().externalTime);
+            translatedUpper = times->back().externalTime;
         }
     }
             

--- a/pxr/usd/usd/clipSet.cpp
+++ b/pxr/usd/usd/clipSet.cpp
@@ -307,7 +307,8 @@ Usd_ClipSet::New(
     //      message..
     if (!_ValidateClipFields(
             *clipDef.clipAssetPaths, *clipDef.clipPrimPath, 
-            *clipDef.clipActive, clipDef.clipTimes.get_ptr(), 
+            *clipDef.clipActive,
+            clipDef.clipTimes ? &(clipDef.clipTimes.value()) : nullptr,
             status)) {
         return nullptr;
     }

--- a/pxr/usd/usd/clipSetDefinition.cpp
+++ b/pxr/usd/usd/clipSetDefinition.cpp
@@ -149,9 +149,9 @@ _DeriveClipInfo(const std::string& templateAssetPath,
                 const double activeOffset,
                 const double startTimeCode,
                 const double endTimeCode,
-                boost::optional<VtVec2dArray>* clipTimes,
-                boost::optional<VtVec2dArray>* clipActive,
-                boost::optional<VtArray<SdfAssetPath>>* clipAssetPaths,
+                std::optional<VtVec2dArray>* clipTimes,
+                std::optional<VtVec2dArray>* clipActive,
+                std::optional<VtArray<SdfAssetPath>>* clipAssetPaths,
                 const SdfPath& usdPrimPath,
                 const PcpLayerStackPtr& sourceLayerStack,
                 const size_t indexOfSourceLayer)
@@ -329,7 +329,7 @@ struct _ClipSet {
 
 template <class T>
 static bool
-_SetInfo(const VtDictionary& dict, const TfToken& key, boost::optional<T>* out)
+_SetInfo(const VtDictionary& dict, const TfToken& key, std::optional<T>* out)
 {
     const VtValue* v = TfMapLookupPtr(dict, key.GetString());
     if (v && v->IsHolding<T>()) {

--- a/pxr/usd/usd/clipSetDefinition.h
+++ b/pxr/usd/usd/clipSetDefinition.h
@@ -33,8 +33,7 @@
 #include "pxr/base/tf/declarePtrs.h"
 #include "pxr/base/tf/hash.h"
 
-#include <boost/optional.hpp>
-
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -110,12 +109,12 @@ public:
         h.Append(definition.GetHash());
     }
 
-    boost::optional<VtArray<SdfAssetPath> > clipAssetPaths;
-    boost::optional<SdfAssetPath> clipManifestAssetPath;
-    boost::optional<std::string> clipPrimPath;
-    boost::optional<VtVec2dArray> clipActive;
-    boost::optional<VtVec2dArray> clipTimes;
-    boost::optional<bool> interpolateMissingClipValues;
+    std::optional<VtArray<SdfAssetPath>> clipAssetPaths;
+    std::optional<SdfAssetPath> clipManifestAssetPath;
+    std::optional<std::string> clipPrimPath;
+    std::optional<VtVec2dArray> clipActive;
+    std::optional<VtVec2dArray> clipTimes;
+    std::optional<bool> interpolateMissingClipValues;
 
     PcpLayerStackPtr sourceLayerStack;
     SdfPath sourcePrimPath;

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -96,8 +96,6 @@
 #include "pxr/base/work/utils.h"
 #include "pxr/base/work/withScopedParallelism.h"
 
-#include <boost/optional.hpp>
-
 #include <tbb/spin_rw_mutex.h>
 #include <tbb/spin_mutex.h>
 
@@ -105,6 +103,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1036,7 +1035,7 @@ _OpenLayer(
     const std::string &filePath,
     const ArResolverContext &resolverContext = ArResolverContext())
 {
-    boost::optional<ArResolverContextBinder> binder;
+    std::optional<ArResolverContextBinder> binder;
     if (!resolverContext.IsEmpty())
         binder.emplace(resolverContext);
 
@@ -1178,8 +1177,8 @@ public:
 
 private:
     SdfLayerHandle _rootLayer;
-    boost::optional<SdfLayerHandle> _sessionLayer;
-    boost::optional<ArResolverContext> _pathResolverContext;
+    std::optional<SdfLayerHandle> _sessionLayer;
+    std::optional<ArResolverContext> _pathResolverContext;
     UsdStage::InitialLoadSet _initialLoadSet;
 };
 
@@ -3251,11 +3250,11 @@ UsdStage::_ComposeSubtreesInParallel(
                 }
             }
             catch (...) {
-                _dispatcher = boost::none;
+                _dispatcher = std::nullopt;
                 throw;
             }
             
-            _dispatcher = boost::none;
+            _dispatcher = std::nullopt;
         });
 }
 
@@ -3408,7 +3407,7 @@ UsdStage::_DestroyPrimsInParallel(const vector<SdfPath>& paths)
                 });
             }
         }
-        _dispatcher = boost::none;
+        _dispatcher = std::nullopt;
     });
 }
 
@@ -8416,12 +8415,13 @@ struct UsdStage::_ResolveInfoResolver
     {
         const SdfLayerOffset layerToStageOffset =
             _GetLayerToStageOffset(node, layer);
-        boost::optional<double> localTime;
+        std::optional<double> localTime;
         if (time) {
             localTime = layerToStageOffset.GetInverse() * (*time);
         }
 
-        if (_HasTimeSamples(layer, specPath, localTime.get_ptr(), 
+        if (_HasTimeSamples(layer, specPath,
+                            localTime ? std::addressof(*localTime) : nullptr,
                             &_extraInfo->lowerSample, 
                             &_extraInfo->upperSample)) {
             _resolveInfo->_source = UsdResolveInfoSourceTimeSamples;

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -51,8 +51,6 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/work/dispatcher.h"
 
-#include <boost/optional.hpp>
-
 #include <tbb/concurrent_vector.h>
 #include <tbb/concurrent_unordered_set.h>
 #include <tbb/concurrent_hash_map.h>
@@ -61,6 +59,7 @@
 #include <functional>
 #include <string>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 
@@ -2321,7 +2320,7 @@ private:
     class _PendingChanges;
     _PendingChanges* _pendingChanges;
 
-    boost::optional<WorkDispatcher> _dispatcher;
+    std::optional<WorkDispatcher> _dispatcher;
 
     // To provide useful aggregation of malloc stats, we bill everything
     // for this stage - from all access points - to this tag.


### PR DESCRIPTION
### Description of Change(s)

Replaces usage of `boost::optional` throughout `pxr/usd/usd`. This leaves some usage to be addressed by #2715 due to interlibrary dependencies.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
