### PR TITLE
Remove leftover minus sign

### DIFF
--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -165,7 +165,7 @@ _ValidateResourceIdentifierScheme(const std::string& caseFoldedScheme) {
         }
         else {
             return std::make_pair(
--               false, TfStringPrintf("Character '%c' not allowed in scheme. "
+                false, TfStringPrintf("Character '%c' not allowed in scheme. "
                                       "Must be ASCII 'a-z', '-', '+', or '.'",
                                       *it));
         }


### PR DESCRIPTION
Remove an unneeded minus sign at the start of the line, probably a leftover from a diff.

### Description of Change(s)

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [ ] I have submitted a signed Contributor License Agreement
