### PR TITLE
Support transparent hashing of `std::optional` for `TfHash`

### DIFF
--- a/pxr/base/tf/hash.h
+++ b/pxr/base/tf/hash.h
@@ -33,6 +33,7 @@
 
 #include <cstring>
 #include <string>
+#include <optional>
 #include <map>
 #include <memory>
 #include <set>
@@ -107,6 +108,20 @@ inline void
 TfHashAppend(HashState &h, std::vector<bool> const &vec)
 {
     h.Append(std::hash<std::vector<bool>>{}(vec));
+}
+
+// Support std::optional.
+// Transparently hashes if valued
+// (ie. TfHash{}(possibleValue) == TfHash{}(possibleValue.value()))
+template <class HashState, class T>
+inline void
+TfHashAppend(HashState &h, std::optional<T> const &possibleValue)
+{
+    if (possibleValue.has_value()) {
+        h.Append(possibleValue.value());
+    } else {
+        h.Append(std::type_index(typeid(T)));
+    }
 }
 
 // Support std::set.

--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -310,6 +310,15 @@ Test_TfHash()
     TF_AXIOM(h(std::optional<std::string>("xyz")) ==
              h(std::optional<std::string>("xyz")));
 
+    // Validate transparent hashing of std::optional
+    TF_AXIOM(h(std::optional<std::string>("xyz")) ==
+             h(std::string("xyz")));
+
+    // Validate support for empty optional
+    printf("hash(optional): %zu\n", h(std::make_optional<std::string>()));
+    TF_AXIOM(h(std::make_optional<std::string>()) ==
+             h(std::make_optional<std::string>()));
+
     // Validate support for std::variant
     printf("hash(variant): %zu\n",
            h(std::variant<std::string, int, double>("abc")));


### PR DESCRIPTION
### Description of Change(s)

#2781 adds support for `TfHash` to fallback to `std::hash` when a `TfHashAppend` implementation isn't available. This provided support for `std::optional`.  However, `std::hash` will forward a valued `std::optional<T>` to `std::hash<T>{}(optional.value())` instead of `TfHash`.  This provides a specialization that forwards a valued `std::optional` to `TfHash` (following the lookup ordering of `TfHashAppend`, `std::hash`, and unqualified `hash_value`).

Transparent hashing of a valued `std::optional` matches the specification of `std::hash`.

An unvalued `std::optional` will derive its hash from its contents' `typeid`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
