### PR TITLE
Guard against unnecessary array detaches in attribute creation

### DIFF
--- a/pxr/usd/usd/schemaRegistry.cpp
+++ b/pxr/usd/usd/schemaRegistry.cpp
@@ -1330,7 +1330,7 @@ BuildPrimDefinition(_SchemaDefInitHelper *defInitHelper)
 
     // Get the list of names of any override properties this schema may have as
     // we want to skip these at first when initializing the prim definition.
-    VtTokenArray overridePropertyNames = _GetOverridePropertyNames(
+    const VtTokenArray overridePropertyNames = _GetOverridePropertyNames(
         schematicsLayer, schematicsPrimPath);
 
     // Multiple apply schemas are actually templates for creating an instance of
@@ -1535,7 +1535,7 @@ _PopulateConcretePrimDefinitions() const
         const SdfPath schematicsPrimPath = 
             SdfPath::AbsoluteRootPath().AppendChild(schemaInfo->identifier);
 
-        VtTokenArray overridePropertyNames = _GetOverridePropertyNames(
+        const VtTokenArray overridePropertyNames = _GetOverridePropertyNames(
             schematicsLayer, schematicsPrimPath);
 
         // Create and initialize a new prim definition for the concrete schema.


### PR DESCRIPTION
### Description of Change(s)
Consider the following snippet--

```
# testDetach.py
from pxr import Usd
from pxr import UsdGeom

stage = Usd.Stage.CreateInMemory()
points = UsdGeom.Points.Define(stage, "/points")
points.CreatePointsAttr()
```

Running 
```
VT_LOG_STACK_ON_ARRAY_DETACH_COPY=1 python3 testDetach.py
```
produces 16 `VtArray` detaches due to non-const access of override property names in `schemaRegistry.cpp`.  While not verified, we suspect that there are two detaches per schema in its type hierarchy (`Points` has 7 ancestors plus itself => 8 total schema types).

This guards against detaches by both making the `VtTokenArray`s `const`.  Rerunning `testDetach.py` with this change and `VT_LOG_STACK_ON_ARRAY_DETACH_COPY=1` shows zero detaches.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
