### PR TITLE
Replace boost with std library in UsdAbc

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicFileFormat.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicFileFormat.cpp
@@ -36,7 +36,6 @@
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/staticData.h"
 
-#include <boost/assign.hpp>
 #include <ostream>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -36,8 +36,6 @@
 #include "pxr/base/tf/staticData.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/ostreamMethods.h"
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/utility/enable_if.hpp>
 #include <Alembic/Abc/ArchiveInfo.h>
 #include <Alembic/Abc/IArchive.h>
 #include <Alembic/Abc/IObject.h>
@@ -54,6 +52,7 @@
 #include <Alembic/AbcGeom/IXform.h>
 #include <Alembic/AbcGeom/SchemaInfoDeclarations.h>
 #include <Alembic/AbcGeom/Visibility.h>
+#include <optional>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -658,7 +657,7 @@ public:
                                 const ISampleSelector&)> Converter;
 
     /// An optional ordering of name children or properties.
-    typedef boost::optional<TfTokenVector> Ordering;
+    typedef std::optional<TfTokenVector> Ordering;
 
     /// Sample times.
     typedef UsdAbc_AlembicDataReader::TimeSamples TimeSamples;
@@ -820,11 +819,14 @@ private:
                    const UsdAbc_AlembicDataAny& value) const;
 
     // Custom auto-lock that safely ignores a NULL pointer.
-    class _Lock : boost::noncopyable {
+    class _Lock {
     public:
         _Lock(std::recursive_mutex* mutex) : _mutex(mutex) {
             if (_mutex) _mutex->lock();
         }
+        _Lock (const _Lock&) = delete;
+        _Lock& operator= (const _Lock&) = delete;
+
         ~_Lock() { if (_mutex) _mutex->unlock(); }
 
     private:
@@ -2630,7 +2632,7 @@ struct _CopyXform {
     }
 
 private:
-    mutable boost::optional<MetaData> _metadata;
+    mutable std::optional<MetaData> _metadata;
 };
 
 /// Base class to copy attributes of an almebic camera to a USD camera
@@ -3800,7 +3802,7 @@ _ReadPrim(
 
         // Discard name children ordering since we don't have any name
         // children (except via the prototype reference).
-        instance->primOrdering = boost::none;
+        instance->primOrdering = std::nullopt;
     }
 
     // Get the prim cache.  If instance is true then prim is the prototype,
@@ -3851,7 +3853,7 @@ _ReadPrim(
         if (instance && instance->promoted) {
             // prim is the prototype.
             prim.properties.clear();
-            prim.propertyOrdering = boost::none;
+            prim.propertyOrdering = std::nullopt;
             prim.metadata.clear();
             prim.propertiesCache.clear();
         }

--- a/pxr/usd/plugin/usdAbc/alembicReader.h
+++ b/pxr/usd/plugin/usdAbc/alembicReader.h
@@ -30,7 +30,6 @@
 #include "pxr/usd/sdf/abstractData.h"
 #include "pxr/usd/sdf/fileFormat.h"
 #include "pxr/base/tf/token.h"
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <stdint.h>
 #include <string>
@@ -46,11 +45,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// An alembic reader suitable for an SdfAbstractData.
 ///
-class UsdAbc_AlembicDataReader : boost::noncopyable {
+class UsdAbc_AlembicDataReader {
 public:
     typedef int64_t Index;
 
     UsdAbc_AlembicDataReader();
+    UsdAbc_AlembicDataReader (const UsdAbc_AlembicDataReader&) = delete;
+    UsdAbc_AlembicDataReader& operator= (const UsdAbc_AlembicDataReader&) = delete;
     ~UsdAbc_AlembicDataReader();
 
     /// Open a file.  Returns \c true on success;  errors are reported by

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -37,14 +37,8 @@
 #include "pxr/base/tf/staticTokens.h"
 #include <Alembic/Abc/ICompoundProperty.h>
 #include <Alembic/Abc/ISampleSelector.h>
-#include <boost/call_traits.hpp>
-#include <boost/operators.hpp>
-#include <boost/optional.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-#include <boost/variant.hpp>
 
+#include <type_traits>
 #include <functional>
 #include <algorithm>
 #include <iosfwd>
@@ -52,6 +46,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <variant>
 
 
 namespace Alembic {
@@ -126,6 +121,13 @@ TF_DECLARE_PUBLIC_TOKENS(UsdAbcPropertyNames, USD_ABC_PROPERTY_NAMES);
     /* end */
 TF_DECLARE_PUBLIC_TOKENS(UsdAbcCustomMetadata, USD_ABC_CUSTOM_METADATA);
 
+// Convert non-trivial types like `std::string` to `const std::string&` while
+// preserving the type for `int`, `bool`, `char`, etc.
+template <typename T>
+using UsdAbc_SetParameter = std::conditional<
+    std::is_arithmetic_v<T>, std::add_const_t<T>,
+    std::add_lvalue_reference_t<std::add_const_t<T>>>;
+
 //
 // Alembic property value types.
 //
@@ -133,7 +135,7 @@ TF_DECLARE_PUBLIC_TOKENS(UsdAbcCustomMetadata, USD_ABC_CUSTOM_METADATA);
 /// A type to represent an Alembic value type.  An Alembic DataType has
 /// a POD and extent but not scalar vs array;  this type includes that
 /// extra bit.  It also supports compound types as their schema titles.
-struct UsdAbc_AlembicType : boost::totally_ordered<UsdAbc_AlembicType> {
+struct UsdAbc_AlembicType {
     PlainOldDataType pod;     // POD type in scalar and array.
     uint8_t extent;           // Extent of POD (e.g. 3 for a 3-tuple).
     bool_t array;             // true for array, false otherwise.
@@ -161,6 +163,26 @@ struct UsdAbc_AlembicType : boost::totally_ordered<UsdAbc_AlembicType> {
         array(header.getPropertyType() == kArrayProperty)
     {
         // Do nothing
+    }
+
+    friend bool operator !=(UsdAbc_AlembicType const &lhs,
+                            UsdAbc_AlembicType const &rhs) {
+        return !(lhs == rhs);
+    }
+
+    friend bool operator>(const UsdAbc_AlembicType& lhs, const UsdAbc_AlembicType& rhs)
+    {
+        return rhs < lhs;
+    }
+
+    friend bool operator<=(const UsdAbc_AlembicType& lhs, const UsdAbc_AlembicType& rhs)
+    {
+        return !(rhs < lhs);
+    }
+
+    friend bool operator>=(const UsdAbc_AlembicType& lhs, const UsdAbc_AlembicType& rhs)
+    {
+        return !(lhs < rhs);
     }
 
     bool IsEmpty() const
@@ -212,22 +234,22 @@ public:
     /// Assigns \p rhs to the value passed in the c'tor.
     bool Set(const VtValue& rhs) const
     {
-        return boost::apply_visitor(_Set(rhs), _valuePtr);
+        return std::visit(_Set(rhs), _valuePtr);
     }
 
     /// Assigns \p rhs to the value passed in the c'tor.
     template <class T>
     bool Set(T rhs) const
     {
-        typedef typename boost::remove_reference<
-                    typename boost::remove_const<T>::type>::type Type;
-        return boost::apply_visitor(_SetTyped<Type>(rhs), _valuePtr);
+        typedef std::remove_reference_t<
+                    std::remove_const_t<T>> Type;
+        return std::visit(_SetTyped<Type>(rhs), _valuePtr);
     }
 
     /// Returns \c true iff constructed with a NULL pointer.
     bool IsEmpty() const
     {
-        return _valuePtr.which() == 0;
+        return _valuePtr.index() == 0;
     }
 
     /// Explicit bool conversion operator. Converts to true iff this object was 
@@ -242,7 +264,7 @@ private:
     class _Empty {};
 
     // Visitor for assignment.
-    struct _Set : public boost::static_visitor<bool> {
+    struct _Set {
         _Set(const VtValue& rhs) : value(rhs) { }
 
         bool operator()(_Empty) const
@@ -268,8 +290,8 @@ private:
 
     // Visitor for assignment.
     template <class T>
-    struct _SetTyped : public boost::static_visitor<bool> {
-        _SetTyped(typename boost::call_traits<T>::param_type rhs) : value(rhs){}
+    struct _SetTyped {
+        _SetTyped(typename UsdAbc_SetParameter<T>::type rhs) : value(rhs){}
 
         bool operator()(_Empty) const
         {
@@ -289,11 +311,11 @@ private:
             return dst->StoreValue(value);
         }
 
-        typename boost::call_traits<T>::param_type value;
+        typename UsdAbc_SetParameter<T>::type value;
     };
 
 private:
-    boost::variant<_Empty, VtValue*, SdfAbstractDataValue*> _valuePtr;
+    std::variant<_Empty, VtValue*, SdfAbstractDataValue*> _valuePtr;
 };
 
 //

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -47,7 +47,6 @@
 #include <Alembic/AbcGeom/OXform.h>
 #include <Alembic/AbcGeom/Visibility.h>
 #include <Alembic/AbcCoreOgawa/All.h>
-#include <boost/functional/hash.hpp>
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -683,7 +682,7 @@ public:
     }
 
     /// Returns the Usd data.
-    const SdfAbstractData& GetData() const { return *boost::get_pointer(_data);}
+    const SdfAbstractData& GetData() const { return *get_pointer(_data);}
 
     /// Sets or resets the flag named \p flagName.
     void SetFlag(const TfToken& flagName, bool set);
@@ -1492,9 +1491,8 @@ _Copy(
     DST* dst,
     R (DST::*method)(T))
 {
-    typedef typename boost::remove_const<
-                typename boost::remove_reference<T>::type
-            >::type SampleValueType;
+    typedef std::remove_const_t<
+                std::remove_reference_t<T>> SampleValueType;
 
     const SdfValueTypeName& usdType = samples.GetTypeName();
     const _WriterSchema::Converter& converter = schema.GetConverter(usdType);
@@ -1522,9 +1520,8 @@ _Copy(
     DST* dst,
     R (DST::*method)(T))
 {
-    typedef typename boost::remove_const<
-                typename boost::remove_reference<T>::type
-            >::type SampleValueType;
+    typedef std::remove_const_t<
+                std::remove_reference_t<T>> SampleValueType;
 
     const SdfValueTypeName& usdType = samples.GetTypeName();
 

--- a/pxr/usd/plugin/usdAbc/alembicWriter.h
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/declarePtrs.h"
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <set>
 #include <string>
@@ -45,9 +44,11 @@ TF_DECLARE_WEAK_AND_REF_PTRS(SdfAbstractData);
 ///
 /// An alembic writer suitable for an SdfAbstractData.
 ///
-class UsdAbc_AlembicDataWriter : boost::noncopyable {
+class UsdAbc_AlembicDataWriter {
 public:
     UsdAbc_AlembicDataWriter();
+    UsdAbc_AlembicDataWriter (const UsdAbc_AlembicDataWriter&) = delete;
+    UsdAbc_AlembicDataWriter& operator= (const UsdAbc_AlembicDataWriter&) = delete;
     ~UsdAbc_AlembicDataWriter();
 
     bool Open(const std::string& filePath, const std::string& comment);


### PR DESCRIPTION
### Description of Change(s)
Replaces all boost usage except for python bindings in UsdAbc.

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/2211

- [x] I have submitted a signed Contributor License Agreement
- [x]  I have verified that all unit tests pass with the proposed changes
