### PR TITLE
cmake: fix absolute path to GL libraries in pxrConfig.cmake

### DIFF
--- a/pxr/imaging/garch/CMakeLists.txt
+++ b/pxr/imaging/garch/CMakeLists.txt
@@ -27,7 +27,7 @@ pxr_library(garch
         arch
         tf
         ${X11_LIBRARIES}
-        ${OPENGL_gl_LIBRARY}
+        OpenGL::GL
         ${GARCH_PLATFORM_LIBRARIES}
 
     INCLUDE_DIRS


### PR DESCRIPTION
### Description of Change(s)

The absolute path to GL makes pxrConfig.cmake non-portable.

### Fixes Issue(s)
- can't use pxrConfig.cmake on computers where location of GL library differs.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
