### PR TITLE
Replace `BOOST_PP_SEQ_FOR_EACH_I` with `constexpr` expressions in `vt`

### DIFF
--- a/pxr/base/vt/visitValue.h
+++ b/pxr/base/vt/visitValue.h
@@ -109,12 +109,12 @@ auto VtVisitValue(VtValue const &value, Visitor &&visitor)
     switch (value.GetKnownValueTypeIndex()) {
 
 // Cases for known types.
-#define VT_CASE_FOR_TYPE_INDEX(r, unused, i, elem)                             \
-        case i:                                                                \
+#define VT_CASE_FOR_TYPE_INDEX(r, unused, elem)                                \
+        case VtGetKnownValueTypeIndex<VT_TYPE(elem)>():                        \
             return Vt_ValueVisitDetail::Visit<VT_TYPE(elem)>(                  \
                 value, std::forward<Visitor>(visitor), 0);                     \
             break;
-BOOST_PP_SEQ_FOR_EACH_I(VT_CASE_FOR_TYPE_INDEX, ~, VT_VALUE_TYPES)
+BOOST_PP_SEQ_FOR_EACH(VT_CASE_FOR_TYPE_INDEX, ~, VT_VALUE_TYPES)
 #undef VT_CASE_FOR_TYPE_INDEX
     
         default:


### PR DESCRIPTION
### Description of Change(s)

`BOOST_PP_SEQ_FOR_EACH_I` is used currently to generate compile time indices for all vt value types.  This PR generates a `TfMetaList` from the `VT_VALUE_TYPE` sequence which is leveraged by a recursive `constexpr` implementation of `GetIndex`.

Both changes still require `BOOST_PP_SEQ_FOR_EACH`, but a forthcoming change will provide a boost free implementation of sequence iteration.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
