### PR TITLE
Fix 'usdcat --flattenLayerStack' output

### DIFF
--- a/pxr/usd/bin/usdcat/CMakeLists.txt
+++ b/pxr/usd/bin/usdcat/CMakeLists.txt
@@ -50,6 +50,11 @@ pxr_register_test(testUsdCatMissingOrInvalidFiles2
     EXPECTED_RETURN_CODE 1 
 )
 
+pxr_register_test(testUsdCatMissingOrInvalidFiles3
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --flattenLayerStack foo.usda"
+    EXPECTED_RETURN_CODE 1
+)
+
 pxr_install_test_dir(
     SRC testenv/testUsdCatMask
     DEST testUsdCatMask
@@ -83,6 +88,17 @@ pxr_install_test_dir(
 
 pxr_register_test(testUsdCatLayerMetadata
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --layerMetadata input.usda -o output.usda"
+    DIFF_COMPARE output.usda
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_install_test_dir(
+    SRC testenv/testFlattenLayerStack
+    DEST testUsdCatFlattenLayerStack
+)
+
+pxr_register_test(testUsdCatFlattenLayerStack
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdcat --flattenLayerStack input.usda --out output.usda"
     DIFF_COMPARE output.usda
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/baseline/output.usda
+++ b/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/baseline/output.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+
+def Xform "Prim" (
+    references = @reference.usda@</Prim>
+)
+{
+    int primvars:should_be_here = 0
+}
+

--- a/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/input.usda
+++ b/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/input.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    subLayers = [
+        @./sublayer.usda@
+    ]
+)
+
+over "Prim" (
+    references = @reference.usda@</Prim>
+)
+{
+}

--- a/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/sublayer.usda
+++ b/pxr/usd/bin/usdcat/testenv/testFlattenLayerStack/sublayer.usda
@@ -1,0 +1,5 @@
+#usda 1.0
+
+def Xform "Prim" {
+    int primvars:should_be_here = 0
+}

--- a/pxr/usd/bin/usdcat/usdcat.cpp
+++ b/pxr/usd/bin/usdcat/usdcat.cpp
@@ -216,7 +216,9 @@ static int UsdCat(const Args &args) {
             }
         } else if (args.flattenLayerStack) {
             stage = UsdStage::Open(input, UsdStage::LoadNone);
-            layer = UsdUtilsFlattenLayerStack(stage);
+            if (stage) {
+                layer = UsdUtilsFlattenLayerStack(stage);
+            }
         } else if (args.layerMetadata) {
             auto srcLayer = SdfLayer::OpenAsAnonymous(
                 input, /* metadataOnly = */ true);
@@ -263,12 +265,12 @@ static int UsdCat(const Args &args) {
 
         // Write to either stdout or the specified output file
         if (!args.output.empty()) {
-            if (stage) {
+            if (layer) {
+                layer->Export(args.output, std::string(), formatArgs);
+            }
+            else {
                 stage->Export(
                     args.output, !args.skipSourceFileComment, formatArgs);
-            }
-            else if (layer) {
-                layer->Export(args.output, std::string(), formatArgs);
             }
 
             if (!errMark.IsClean()) {
@@ -288,10 +290,11 @@ static int UsdCat(const Args &args) {
         }
         else {
             std::string usdString;
-            if (stage) {
-                stage->ExportToString(&usdString);
-            } else {
+            if (layer) {
                 layer->ExportToString(&usdString);
+            }
+            else {
+                stage->ExportToString(&usdString);
             }
 
             if (errMark.IsClean()) {


### PR DESCRIPTION

### Description of Change(s)

This PR addresses 2 issues: `usdcat --flattenLayerStack ...` outputting the wrong data, and a crash when calling the command on a non-existant file.

The first issue was due to the logic guiding what to export. If the `stage` was initialized, it would export it. Otherwise, it would export the `layer`. This doesn't work because, in the presence of the `--flattenLayerStack` flag, both the `stage` and the `layer` are initialized, but the **`layer`** should be exported. Instead, it was outputting the flattened, unloaded stage. To fix this, I simply flipped the order of the conditional blocks so that the `stage` is only exported in the absence of the `layer`. Since the only conditional branches that can result in both the `stage` and `layer` being initialized are bound to the `--flattenLayerStack` flag, we can verify that this change does not impact the behavior of any of the other cases.

The second issue is the result of an unsafe assumption that the input file is valid. Since the `--flattenLayerStack` command generates the layer from the input stage, we need to be sure that the stage successfully opened before creating the layer. `UsdUtilsFlattenLayerStack`expects a valid stage as input, so giving it a `TfNullPtr` results in a crash. I addressed this by requiring that the stage exist before running `UsdUtilsFlattenLayerStack`.

I also added a couple of new test cases that should help prevent similar issues from happening in the future.

### Fixes Issue(s)
- N/A

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
