### PR TITLE
Text file format parser prep

### DIFF
--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -116,6 +116,7 @@ pxr_library(sdf
         pathParser
         subLayerListEditor
         textParserContext
+        textParserHelpers
         valueTypeRegistry
         variableExpressionImpl
         variableExpressionParser

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -113,6 +113,7 @@ pxr_library(sdf
         listOpListEditor
         parserHelpers
         parserValueContext
+        pathParser
         subLayerListEditor
         textParserContext
         valueTypeRegistry

--- a/pxr/usd/sdf/pathParser.cpp
+++ b/pxr/usd/sdf/pathParser.cpp
@@ -1,0 +1,211 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+
+#include "pxr/pxr.h"
+#include "pxr/usd/sdf/pathParser.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+using namespace tao::TAO_PEGTL_NAMESPACE;
+
+namespace Sdf_PathParser {
+
+template <>
+struct Action<ReflexiveRelative> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() = SdfPath::ReflexiveRelativePath();
+    }
+};
+
+template <>
+struct Action<AbsoluteRoot> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() = SdfPath::AbsoluteRootPath();
+    }
+};
+
+template <>
+struct Action<DotDot> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        if (pp.paths.back().IsEmpty()) {
+            pp.paths.back() = SdfPath::ReflexiveRelativePath();
+        }
+        pp.paths.back() = pp.paths.back().GetParentPath();
+    }
+};
+
+template <>
+struct Action<PrimName> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        if (pp.paths.back().IsEmpty()) {
+            pp.paths.back() = SdfPath::ReflexiveRelativePath();
+        }
+        pp.paths.back() = pp.paths.back().AppendChild(GetToken(in));
+    }
+};
+
+template <>
+struct Action<VariantSetName> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.varSetName = in.string();
+    }
+};
+
+template <>
+struct Action<VariantName> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.varName = in.string();
+    }
+};
+
+template <>
+struct Action<VariantSelection> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() =
+            pp.paths.back().AppendVariantSelection(pp.varSetName, pp.varName);
+        pp.varSetName.clear();
+        pp.varName.clear();
+    }
+};
+
+template <>
+struct Action<PropertyName> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        if (pp.paths.back().IsEmpty()) {
+            pp.paths.back() = SdfPath::ReflexiveRelativePath();
+        }
+        pp.paths.back() = pp.paths.back().AppendProperty(GetToken(in));
+    }
+};
+
+template <>
+struct Action<RelationalAttributeName> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() =
+            pp.paths.back().AppendRelationalAttribute(GetToken(in));
+    }
+};
+
+template <>
+struct Action<TargetPathOpen> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.emplace_back();
+    }
+};
+
+template <>
+struct Action<TargetPath> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.targetType = PPContext::IsTargetPath;
+    }
+};
+
+template <>
+struct Action<MapperPath> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.targetType = PPContext::IsMapperPath;
+    }
+};
+
+template <>
+struct Action<MapperArg> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() = pp.paths.back().AppendMapperArg(GetToken(in));
+    }
+};
+
+template <>
+struct Action<TargetPathClose> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        SdfPath targetPath = std::move(pp.paths.back());
+        pp.paths.pop_back();
+        if (pp.targetType == PPContext::IsTargetPath) {
+            pp.paths.back() =
+                pp.paths.back().AppendTarget(std::move(targetPath));
+        }
+        else {
+            pp.paths.back() =
+                pp.paths.back().AppendMapper(std::move(targetPath));
+        }
+    }
+};
+
+template <>
+struct Action<Expression> {
+    template <class Input>
+    static void apply(Input const &in, PPContext &pp) {
+        pp.paths.back() = pp.paths.back().AppendExpression();
+    }
+};
+
+}
+
+bool
+Sdf_ParsePath(std::string const &pathStr, SdfPath *path, std::string *errMsg)
+{
+    Sdf_PathParser::PPContext context;
+    try {
+        if (!parse<must<Sdf_PathParser::Path, eolf>, Sdf_PathParser::Action>(
+                string_input<> { pathStr, "" }, context)) {
+            if (errMsg) {
+                *errMsg = TfStringPrintf(
+                    "Ill-formed SdfPath with no exception parsing <%s>",
+                    pathStr.c_str());
+            }
+            if (path) {
+                *path = SdfPath();
+            }
+            return false;
+        }
+    }
+    catch (parse_error const &err) {
+        if (errMsg) {
+            *errMsg = TfStringPrintf(
+                "Ill-formed SdfPath <%s>: %s", pathStr.c_str(), err.what());
+        }
+        if (path) {
+            *path = SdfPath();
+        }
+        return false;
+    }
+    if (path) {
+        *path = std::move(context.paths.back());
+    }
+    return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/sdf/pathParser.h
+++ b/pxr/usd/sdf/pathParser.h
@@ -1,0 +1,180 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_SDF_PATH_PARSER_H
+#define PXR_USD_SDF_PATH_PARSER_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/usd/sdf/path.h"
+
+#include "pxr/base/tf/pxrPEGTL/pegtl.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+bool
+Sdf_ParsePath(std::string const &pathStr, SdfPath *path, std::string *errMsg);
+
+namespace Sdf_PathParser {
+
+namespace PEGTL_NS = tao::TAO_PEGTL_NAMESPACE;
+
+////////////////////////////////////////////////////////////////////////
+// SdfPath grammar:
+
+struct Slash : PEGTL_NS::one<'/'> {};
+struct Dot : PEGTL_NS::one<'.'> {};
+struct DotDot : PEGTL_NS::two<'.'> {};
+
+struct AbsoluteRoot : Slash {};
+struct ReflexiveRelative : Dot {};
+
+struct DotDots : PEGTL_NS::list<DotDot, Slash> {};
+
+struct PrimName : PEGTL_NS::identifier {};
+
+// XXX This replicates old behavior where '-' chars are allowed in variant set
+// names in SdfPaths, but variant sets in layers cannot have '-' in their names.
+// For now we preserve the behavior. Internal bug USD-8321 tracks removing
+// support for '-' characters in variant set names in SdfPath.
+struct VariantSetName :
+    PEGTL_NS::seq<PEGTL_NS::identifier_first,
+    PEGTL_NS::star<PEGTL_NS::sor<
+    PEGTL_NS::identifier_other, PEGTL_NS::one<'-'>>>> {};
+
+struct VariantName :
+    PEGTL_NS::seq<PEGTL_NS::opt<
+    PEGTL_NS::one<'.'>>, PEGTL_NS::star<
+    PEGTL_NS::sor<PEGTL_NS::identifier_other,
+    PEGTL_NS::one<'|', '-'>>>> {};
+
+struct VarSelOpen : PEGTL_NS::pad<PEGTL_NS::one<'{'>, PEGTL_NS::blank> {};
+struct VarSelClose : PEGTL_NS::pad<PEGTL_NS::one<'}'>, PEGTL_NS::blank> {};
+
+struct VariantSelection : PEGTL_NS::if_must<
+    VarSelOpen,
+    VariantSetName, PEGTL_NS::pad<PEGTL_NS::one<'='>, 
+    PEGTL_NS::blank>, PEGTL_NS::opt<VariantName>,
+    VarSelClose>
+{};
+
+struct VariantSelections : PEGTL_NS::plus<VariantSelection> {};
+
+template <class Rule, class Sep>
+struct LookaheadList : PEGTL_NS::seq<Rule, PEGTL_NS::star<
+    PEGTL_NS::at<Sep, Rule>, Sep, Rule>> {};
+
+struct PrimElts : PEGTL_NS::seq<
+    LookaheadList<PrimName, PEGTL_NS::sor<Slash, VariantSelections>>,
+    PEGTL_NS::opt<VariantSelections>> {};
+
+struct PropertyName : PEGTL_NS::list<PEGTL_NS::identifier, PEGTL_NS::one<':'>> {};
+
+struct MapperPath;
+struct TargetPath;
+
+struct TargetPathOpen : PEGTL_NS::one<'['> {};
+struct TargetPathClose : PEGTL_NS::one<']'> {};
+
+template <class TargPath>
+struct BracketPath : PEGTL_NS::if_must<TargetPathOpen, TargPath, TargetPathClose> {};
+
+struct RelationalAttributeName : PropertyName {};
+
+struct MapperKW : TAO_PEGTL_KEYWORD("mapper") {};
+
+struct MapperArg : PEGTL_NS::identifier {};
+
+struct MapperPathSeq : PEGTL_NS::if_must<
+    PEGTL_NS::seq<Dot, MapperKW>, BracketPath<MapperPath>,
+    PEGTL_NS::opt<Dot, MapperArg>> {};
+
+struct Expression : TAO_PEGTL_KEYWORD("expression") {};
+
+struct RelAttrSeq : PEGTL_NS::if_must<
+    PEGTL_NS::one<'.'>, RelationalAttributeName,
+    PEGTL_NS::opt<PEGTL_NS::sor<BracketPath<TargetPath>,
+            MapperPathSeq,
+            PEGTL_NS::if_must<Dot, Expression>>>> {};
+
+struct TargetPathSeq : PEGTL_NS::seq<BracketPath<TargetPath>, 
+    PEGTL_NS::opt<RelAttrSeq>> {};
+
+struct PropElts :
+    PEGTL_NS::seq<PEGTL_NS::one<'.'>, PropertyName,
+        PEGTL_NS::opt<PEGTL_NS::sor<TargetPathSeq, MapperPathSeq,
+        PEGTL_NS::if_must<Dot, Expression>>>
+    >
+{};
+
+struct PathElts : PEGTL_NS::if_then_else<PrimElts, PEGTL_NS::opt<PropElts>, PropElts> {};
+
+struct PrimFirstPathElts : PEGTL_NS::seq<PrimElts, PEGTL_NS::opt<PropElts>> {};
+
+struct Path : PEGTL_NS::sor<
+    PEGTL_NS::seq<AbsoluteRoot, PEGTL_NS::opt<PrimFirstPathElts>>,
+    PEGTL_NS::seq<DotDots, PEGTL_NS::opt<PEGTL_NS::seq<Slash, PathElts>>>,
+    PathElts,
+    ReflexiveRelative
+    > {};
+
+struct TargetPath : Path {};
+struct MapperPath : Path {};
+
+////////////////////////////////////////////////////////////////////////
+// Actions.
+
+struct PPContext {
+    std::vector<SdfPath> paths { 1 };
+    enum { IsTargetPath, IsMapperPath } targetType;
+    std::string varSetName;
+    std::string varName;
+};
+
+template <class Input>
+TfToken GetToken(Input const &in) {
+    constexpr int BufSz = 32;
+    char buf[BufSz];
+    size_t strSize = std::distance(in.begin(), in.end());
+    TfToken tok;
+    if (strSize < BufSz) {
+        // copy & null-terminate.
+        std::copy(in.begin(), in.end(), buf);
+        buf[strSize] = '\0';
+        tok = TfToken(buf);
+    }
+    else {
+        // fall back to string path.
+        tok = TfToken(in.string());
+    }
+    return tok;
+}
+
+template <class Rule>
+struct Action : PEGTL_NS::nothing<Rule> {};
+
+} // Sdf_PathParser
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_SDF_PATH_PARSER_H

--- a/pxr/usd/sdf/textParserHelpers.cpp
+++ b/pxr/usd/sdf/textParserHelpers.cpp
@@ -1,0 +1,1003 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/usd/sdf/textParserHelpers.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace Sdf_TextFileFormatParser {
+
+#define ERROR_AND_RETURN_IF_NOT_ALLOWED(context, allowed)        \
+    {                                                            \
+        const SdfAllowed allow = allowed;                        \
+        if (!allow) {                                            \
+            Sdf_TextFileFormatParser_Err(context, "%s",          \
+            allow.GetWhyNot().c_str());                          \
+            return;                                              \
+        }                                                        \
+    }
+
+bool
+_SetupValue(const std::string& typeName, Sdf_TextParserContext *context)
+{
+    return context->values.SetupFactory(typeName);
+}
+
+void
+_MatchMagicIdentifier(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+{
+    const std::string cookie = TfStringTrimRight(arg1.Get<std::string>());
+    const std::string expected = "#" + context->magicIdentifierToken + " ";
+    if (TfStringStartsWith(cookie, expected)) {
+        if (!context->versionString.empty() &&
+            !TfStringEndsWith(cookie, context->versionString)) {
+            TF_WARN("File '%s' is not the latest %s version (found '%s', "
+                "expected '%s'). The file may parse correctly and yield "
+                "incorrect results.",
+                context->fileContext.c_str(),
+                context->magicIdentifierToken.c_str(),
+                cookie.substr(expected.length()).c_str(),
+                context->versionString.c_str());
+        }
+    }
+    else {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, "Magic Cookie '%s'. Expected prefix of '%s'",
+            TfStringTrim(cookie).c_str(),
+            expected.c_str());
+    }
+}
+
+SdfPermission
+_GetPermissionFromString(const std::string & str,
+                         Sdf_TextParserContext *context)
+{
+    if (str == "public") {
+        return SdfPermissionPublic;
+    } else if (str == "private") {
+        return SdfPermissionPrivate;
+    } else {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "'%s' is not a valid permission constant", str.c_str());
+        return SdfPermissionPublic;
+    }
+}
+
+TfEnum
+_GetDisplayUnitFromString(const std::string & name,
+                          Sdf_TextParserContext *context)
+{
+    const TfEnum &unit = SdfGetUnitFromName(name);
+    if (unit == TfEnum()) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context,
+            "'%s' is not a valid display unit", name.c_str());
+    }
+    return unit;
+}
+
+void
+_ValueAppendAtomic(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+{
+    context->values.AppendValue(arg1);
+}
+
+void
+_ValueSetAtomic(Sdf_TextParserContext *context)
+{
+    if (!context->values.IsRecordingString()) {
+        if (context->values.valueIsShaped) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context,
+                "Type name has [] for non-shaped value!\n");
+            return;
+        }
+    }
+
+    std::string errStr;
+    context->currentValue = context->values.ProduceValue(&errStr);
+    if (context->currentValue.IsEmpty()) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context,
+            "Error parsing simple value: %s", errStr.c_str());
+        return;
+    }
+}
+
+void
+_PrimSetInheritListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+{
+    if (context->inheritParsingTargetPaths.empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting inherit paths to None (or empty list) is only allowed "
+            "when setting explicit inherit paths, not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(path, context->inheritParsingTargetPaths) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidInheritPath(*path));
+    }
+
+    _SetListOpItems(SdfFieldKeys->InheritPaths, opType, 
+                    context->inheritParsingTargetPaths, context);
+}
+
+void
+_InheritAppendPath(Sdf_TextParserContext *context)
+{
+    // Expand paths relative to the containing prim.
+    //
+    // This strips any variant selections from the containing prim
+    // path before expanding the relative path, which is what we
+    // want.  Inherit paths are not allowed to be variants.
+    SdfPath absPath = 
+        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+
+    context->inheritParsingTargetPaths.push_back(absPath);
+}
+
+void
+_PrimSetSpecializesListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+{
+    if (context->specializesParsingTargetPaths.empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting specializes paths to None (or empty list) is only allowed "
+            "when setting explicit specializes paths, not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(path, context->specializesParsingTargetPaths) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidSpecializesPath(*path));
+    }
+
+    _SetListOpItems(SdfFieldKeys->Specializes, opType, 
+                    context->specializesParsingTargetPaths, context);
+}
+
+void
+_SpecializesAppendPath(Sdf_TextParserContext *context)
+{
+    // Expand paths relative to the containing prim.
+    //
+    // This strips any variant selections from the containing prim
+    // path before expanding the relative path, which is what we
+    // want.  Specializes paths are not allowed to be variants.
+    SdfPath absPath = 
+        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+
+    context->specializesParsingTargetPaths.push_back(absPath);
+}
+
+void
+_PrimSetReferenceListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+{
+    if (context->referenceParsingRefs.empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting references to None (or an empty list) is only allowed "
+            "when setting explicit references, not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(ref, context->referenceParsingRefs) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidReference(*ref));
+    }
+
+    _SetListOpItems(SdfFieldKeys->References, opType, 
+                    context->referenceParsingRefs, context);
+}
+
+void
+_PrimSetPayloadListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+{
+    if (context->payloadParsingRefs.empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting payload to None (or an empty list) is only allowed "
+            "when setting explicit payloads, not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(ref, context->payloadParsingRefs) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidPayload(*ref));
+    }
+
+    _SetListOpItems(SdfFieldKeys->Payload, opType, 
+                    context->payloadParsingRefs, context);
+}
+
+void
+_PrimSetVariantSetNamesListItems(SdfListOpType opType, 
+                                 Sdf_TextParserContext *context)
+{
+    std::vector<std::string> names;
+    names.reserve(context->nameVector.size());
+    TF_FOR_ALL(name, context->nameVector) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidVariantIdentifier(*name));
+        names.push_back(name->GetText());
+    }
+
+    _SetListOpItems(SdfFieldKeys->VariantSetNames, opType, names, context);
+
+    // If the op type is added or explicit, create the variant sets
+    if (opType == SdfListOpTypeAdded || opType == SdfListOpTypeExplicit) {
+        TF_FOR_ALL(i, context->nameVector) {
+            _CreateSpec(
+                context->path.AppendVariantSelection(*i,""),
+                SdfSpecTypeVariantSet, context);
+        }
+
+        _SetField(
+            context->path, SdfChildrenKeys->VariantSetChildren, 
+            context->nameVector, context);
+    }
+
+}
+
+void
+_RelationshipInitTarget(const SdfPath& targetPath,
+                        Sdf_TextParserContext *context)
+{
+    SdfPath path = context->path.AppendTarget(targetPath);
+
+    if (!_HasSpec(path, context)) {
+        // Create relationship target spec by setting the appropriate 
+        // object type flag.
+        _CreateSpec(path, SdfSpecTypeRelationshipTarget, context);
+
+        // Add the target path to the owning relationship's list of target 
+        // children.
+        context->relParsingNewTargetChildren.push_back(targetPath);
+    }
+}
+
+void
+_RelationshipSetTargetsList(SdfListOpType opType, 
+                            Sdf_TextParserContext *context)
+{
+    if (!context->relParsingTargetPaths) {
+        // No target paths were encountered.
+        return;
+    }
+
+    if (context->relParsingTargetPaths->empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting relationship targets to None (or empty list) is only "
+            "allowed when setting explicit targets, not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(path, *context->relParsingTargetPaths) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidRelationshipTargetPath(*path));
+    }
+
+    if (opType == SdfListOpTypeAdded || 
+        opType == SdfListOpTypeExplicit) {
+
+        // Initialize relationship target specs for each target path that
+        // is added in this layer.
+        TF_FOR_ALL(pathIter, *context->relParsingTargetPaths) {
+            _RelationshipInitTarget(*pathIter, context);
+        }
+    }
+
+    _SetListOpItems(SdfFieldKeys->TargetPaths, opType, 
+                    *context->relParsingTargetPaths, context);
+}
+
+void
+_PrimSetVariantSelection(Sdf_TextParserContext *context)
+{
+    SdfVariantSelectionMap refVars;
+
+    // The previous parser implementation allowed multiple variant selection
+    // dictionaries in prim metadata to be merged, so we do the same here.
+    VtValue oldVars;
+    if (_HasField(
+            context->path, SdfFieldKeys->VariantSelection, &oldVars, context)) {
+        refVars = oldVars.Get<SdfVariantSelectionMap>();
+    }
+
+    TF_FOR_ALL(it, context->currentDictionaries[0]) {
+        if (!it->second.IsHolding<std::string>()) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context, "variant name must be a string");
+            return;
+        } else {
+            const std::string variantName = it->second.Get<std::string>();
+            ERROR_AND_RETURN_IF_NOT_ALLOWED(
+                context, 
+                SdfSchema::IsValidVariantSelection(variantName));
+
+            refVars[it->first] = variantName;
+        }
+    }
+
+    _SetField(context->path, SdfFieldKeys->VariantSelection, refVars, context);
+    context->currentDictionaries[0].clear();
+}
+
+void
+_RelocatesAdd(const Sdf_ParserHelpers::Value& arg1, const Sdf_ParserHelpers::Value& arg2, 
+              Sdf_TextParserContext *context)
+{
+    const std::string& srcStr    = arg1.Get<std::string>();
+    const std::string& targetStr = arg2.Get<std::string>();
+
+    SdfPath srcPath(srcStr);
+    SdfPath targetPath(targetStr);
+
+    if (!SdfSchema::IsValidRelocatesPath(srcPath)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid relocates path",
+            srcStr.c_str());
+        return;
+    }
+    if (!SdfSchema::IsValidRelocatesPath(targetPath)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid relocates path",
+            targetStr.c_str());
+        return;
+    }
+
+    // The relocates map is expected to only hold absolute paths. The
+    // SdRelocatesMapProxy ensures that all paths are made absolute when
+    // editing, but since we're bypassing that proxy and setting the map
+    // directly into the underlying SdfData, we need to explicitly absolutize
+    // paths here.
+    const SdfPath srcAbsPath = srcPath.MakeAbsolutePath(context->path);
+    const SdfPath targetAbsPath = targetPath.MakeAbsolutePath(context->path);
+
+    context->relocatesParsingMap.insert(std::make_pair(srcAbsPath, 
+                                                        targetAbsPath));
+    context->layerHints.mightHaveRelocates = true;
+}
+
+void
+_AttributeSetConnectionTargetsList(SdfListOpType opType, 
+                                   Sdf_TextParserContext *context)
+{
+    if (context->connParsingTargetPaths.empty() &&
+        opType != SdfListOpTypeExplicit) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Setting connection paths to None (or an empty list) "
+            "is only allowed when setting explicit connection paths, "
+            "not for list editing");
+        return;
+    }
+
+    TF_FOR_ALL(path, context->connParsingTargetPaths) {
+        ERROR_AND_RETURN_IF_NOT_ALLOWED(
+            context, 
+            SdfSchema::IsValidAttributeConnectionPath(*path));
+    }
+
+    if (opType == SdfListOpTypeAdded || 
+        opType == SdfListOpTypeExplicit) {
+
+        TF_FOR_ALL(pathIter, context->connParsingTargetPaths) {
+            SdfPath path = context->path.AppendTarget(*pathIter);
+            if (!_HasSpec(path, context)) {
+                _CreateSpec(path, SdfSpecTypeConnection, context);
+            }
+        }
+
+        _SetField(
+            context->path, SdfChildrenKeys->ConnectionChildren,
+            context->connParsingTargetPaths, context);
+    }
+
+    _SetListOpItems(SdfFieldKeys->ConnectionPaths, opType, 
+                    context->connParsingTargetPaths, context);
+}
+
+void
+_AttributeAppendConnectionPath(Sdf_TextParserContext *context)
+{
+    // Expand paths relative to the containing prim.
+    //
+    // This strips any variant selections from the containing prim
+    // path before expanding the relative path, which is what we
+    // want.  Connection paths never point into the variant namespace.
+    SdfPath absPath = 
+        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+
+    // XXX Workaround for bug 68132:
+    // Prior to the fix to bug 67916, FilterGenVariantBase was authoring
+    // invalid connection paths containing variant selections (which
+    // Sd was failing to report as erroneous).  As a result, there's
+    // a fair number of assets out there with these broken forms of
+    // connection paths.  As a migration measure, we discard those
+    // variant selections here.
+    if (absPath.ContainsPrimVariantSelection()) {
+        TF_WARN("Connection path <%s> (in file @%s@, line %i) has a variant "
+                "selection, but variant selections are not meaningful in "
+                "connection paths.  Stripping the variant selection and "
+                "using <%s> instead.  Resaving the file will fix this issue.",
+                absPath.GetText(),
+                context->fileContext.c_str(),
+                context->sdfLineNo,
+                absPath.StripAllVariantSelections().GetText());
+        absPath = absPath.StripAllVariantSelections();
+    }
+
+    context->connParsingTargetPaths.push_back(absPath);
+}
+
+void
+_PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1, Sdf_TextParserContext *context)  
+{
+    TfToken name(arg1.Get<std::string>());
+    if (!SdfPath::IsValidNamespacedIdentifier(name)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid attribute name", 
+            name.GetText());
+    }
+
+    context->path = context->path.AppendProperty(name);
+
+    // If we haven't seen this attribute before, then set the object type
+    // and add it to the parent's list of properties. Otherwise both have
+    // already been done, so we don't need to do anything.
+    if (!_HasSpec(context->path, context)) {
+        context->propertiesStack.back().push_back(name);
+        _CreateSpec(context->path, SdfSpecTypeAttribute, context);
+        _SetField(context->path, SdfFieldKeys->Custom, false, context);
+    }
+
+    if(context->custom)
+        _SetField(context->path, SdfFieldKeys->Custom, true, context);
+
+    // If the type was previously set, check that it matches. Otherwise set it.
+    const TfToken newType(context->values.valueTypeName);
+
+    VtValue oldTypeValue;
+    if (_HasField(
+            context->path, SdfFieldKeys->TypeName, &oldTypeValue, context)) {
+        const TfToken& oldType = oldTypeValue.Get<TfToken>();
+
+        if (newType != oldType) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context,
+                "attribute '%s' already has type '%s', cannot change to '%s'",
+                context->path.GetName().c_str(),
+                oldType.GetText(),
+                newType.GetText());
+        }
+    }
+    else {
+        _SetField(context->path, SdfFieldKeys->TypeName, newType, context);
+    }
+
+    // If the variability was previously set, check that it matches. Otherwise
+    // set it.  If the 'variability' VtValue is empty, that indicates varying
+    // variability.
+    SdfVariability variability = context->variability.IsEmpty() ? 
+        SdfVariabilityVarying : context->variability.Get<SdfVariability>();
+    VtValue oldVariability;
+    if (_HasField(
+            context->path, SdfFieldKeys->Variability, &oldVariability, 
+            context)) {
+        if (variability != oldVariability.Get<SdfVariability>()) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                "attribute '%s' already has variability '%s', "
+                "cannot change to '%s'",
+                context->path.GetName().c_str(),
+                TfEnum::GetName(oldVariability.Get<SdfVariability>()).c_str(),
+                TfEnum::GetName(variability).c_str() );
+        }
+    } else {
+        _SetField(
+            context->path, SdfFieldKeys->Variability, variability, context);
+    }
+}
+
+void
+_DictionaryBegin(Sdf_TextParserContext *context)
+{
+    context->currentDictionaries.push_back(VtDictionary());
+
+    // Whenever we parse a value for an unregistered generic metadata field, 
+    // the parser value context records the string representation only, because
+    // we don't have enough type information to generate a C++ value. However,
+    // dictionaries are a special case because we have all the type information
+    // we need to generate C++ values. So, override the previous setting.
+    if (context->values.IsRecordingString()) {
+        context->values.StopRecordingString();
+    }
+}
+
+void
+_DictionaryEnd(Sdf_TextParserContext *context)
+{
+    context->currentDictionaries.pop_back();
+}
+
+void
+_DictionaryInsertValue(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+{
+    size_t n = context->currentDictionaries.size();
+    context->currentDictionaries[n-2][arg1.Get<std::string>()] = 
+        context->currentValue;
+}
+
+void
+_DictionaryInsertDictionary(const Sdf_ParserHelpers::Value& arg1,
+                            Sdf_TextParserContext *context)
+{
+    size_t n = context->currentDictionaries.size();
+    // Insert the parsed dictionary into the parent dictionary.
+    context->currentDictionaries[n-2][arg1.Get<std::string>()].Swap(
+        context->currentDictionaries[n-1]);
+    // Clear out the last dictionary (there can be more dictionaries on the
+    // same nesting level).
+    context->currentDictionaries[n-1].clear();
+}
+
+void
+_DictionaryInitScalarFactory(const Sdf_ParserHelpers::Value& arg1,
+                             Sdf_TextParserContext *context)
+{
+    const std::string& typeName = arg1.Get<std::string>();
+    if (!_SetupValue(typeName, context)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Unrecognized value typename '%s' for dictionary", 
+            typeName.c_str());
+    }
+}
+
+void
+_DictionaryInitShapedFactory(const Sdf_ParserHelpers::Value& arg1,
+                             Sdf_TextParserContext *context)
+{
+    const std::string typeName = arg1.Get<std::string>() + "[]";
+    if (!_SetupValue(typeName, context)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Unrecognized value typename '%s' for dictionary", 
+            typeName.c_str());
+    }
+}
+
+void
+_ValueSetTuple(Sdf_TextParserContext *context)
+{
+    if (!context->values.IsRecordingString()) {
+        if (context->values.valueIsShaped) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                "Type name has [] for non-shaped value.\n");
+            return;
+        }
+    }
+
+    std::string errStr;
+    context->currentValue = context->values.ProduceValue(&errStr);
+    if (context->currentValue == VtValue()) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Error parsing tuple value: %s", errStr.c_str());
+        return;
+    }
+}
+
+void
+_ValueSetList(Sdf_TextParserContext *context)
+{
+    if (!context->values.IsRecordingString()) {
+        if (!context->values.valueIsShaped) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                "Type name missing [] for shaped value.");
+            return;
+        }
+    }
+
+    std::string errStr;
+    context->currentValue = context->values.ProduceValue(&errStr);
+    if (context->currentValue == VtValue()) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Error parsing shaped value: %s", errStr.c_str());
+        return;
+    }
+}
+
+void
+_ValueSetShaped(Sdf_TextParserContext *context)
+{
+    if (!context->values.IsRecordingString()) {
+        if (!context->values.valueIsShaped) {
+            SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                "Type name missing [] for shaped value.");
+            return;
+        }
+    }
+
+    std::string errStr;
+    context->currentValue = context->values.ProduceValue(&errStr);
+    if (context->currentValue == VtValue()) {
+        // The factory method ProduceValue() uses for shaped types
+        // only returns empty VtArrays, not empty VtValues, so this
+        // is impossible to hit currently.
+        // CODE_COVERAGE_OFF
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Error parsing shaped value: %s", errStr.c_str());
+        // CODE_COVERAGE_OFF_GCOV_BUG
+        // The following line actually shows as executed (a ridiculous 
+        // number of times) even though the line above shwos as 
+        // not executed
+        return;
+        // CODE_COVERAGE_ON_GCOV_BUG
+        // CODE_COVERAGE_ON
+    }
+}
+
+void
+_ValueSetCurrentToSdfPath(const Sdf_ParserHelpers::Value& arg1,
+                                     Sdf_TextParserContext *context)
+{
+    // make current Value an SdfPath of the given argument...
+    std::string s = arg1.Get<std::string>();
+    // If path is empty, use default c'tor to construct empty path.
+    // XXX: 08/04/08 Would be nice if SdfPath would allow 
+    // SdfPath("") without throwing a warning.
+    context->currentValue = s.empty() ? SdfPath() : SdfPath(s);
+}
+
+void
+_PrimInitRelationship(const Sdf_ParserHelpers::Value& arg1,
+                      Sdf_TextParserContext *context)
+{
+    TfToken name( arg1.Get<std::string>() );
+    if (!SdfPath::IsValidNamespacedIdentifier(name)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "'%s' is not a valid relationship name", name.GetText());
+        return;
+    }
+
+    context->path = context->path.AppendProperty(name);
+
+    if (!_HasSpec(context->path, context)) {
+        context->propertiesStack.back().push_back(name);
+        _CreateSpec(context->path, SdfSpecTypeRelationship, context);
+    }
+
+    _SetField(
+        context->path, SdfFieldKeys->Variability, 
+        context->variability, context);
+
+    if (context->custom) {
+        _SetField(context->path, SdfFieldKeys->Custom, context->custom, context);
+    }
+
+    context->relParsingAllowTargetData = false;
+    context->relParsingTargetPaths.reset();
+    context->relParsingNewTargetChildren.clear();
+}
+
+void
+_PrimEndRelationship(Sdf_TextParserContext *context)
+{
+    if (!context->relParsingNewTargetChildren.empty()) {
+        std::vector<SdfPath> children = 
+            context->data->GetAs<std::vector<SdfPath> >(
+                context->path, SdfChildrenKeys->RelationshipTargetChildren);
+
+        children.insert(children.end(), 
+                        context->relParsingNewTargetChildren.begin(),
+                        context->relParsingNewTargetChildren.end());
+
+        _SetField(
+            context->path, SdfChildrenKeys->RelationshipTargetChildren, 
+            children, context);
+    }
+
+    context->path = context->path.GetParentPath();
+}
+
+void
+_RelationshipAppendTargetPath(const Sdf_ParserHelpers::Value& arg1,
+                              Sdf_TextParserContext *context)
+{
+    // Add a new target to the current relationship
+    const std::string& pathStr = arg1.Get<std::string>();
+    SdfPath path(pathStr);
+
+    if (!path.IsAbsolutePath()) {
+        // Expand paths relative to the containing prim.
+        //
+        // This strips any variant selections from the containing prim
+        // path before expanding the relative path, which is what we
+        // want.  Target paths never point into the variant namespace.
+        path = path.MakeAbsolutePath(context->path.GetPrimPath());
+    }
+
+    if (!context->relParsingTargetPaths) {
+        // This is the first target we've seen for this relationship.
+        // Start tracking them in a vector.
+        context->relParsingTargetPaths = SdfPathVector();
+    }
+    context->relParsingTargetPaths->push_back(path);
+}
+
+void
+_PathSetPrim(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+{
+    const std::string& pathStr = arg1.Get<std::string>();
+    context->savedPath = SdfPath(pathStr);
+    if (!context->savedPath.IsPrimPath()) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "'%s' is not a valid prim path", pathStr.c_str());
+    }
+}
+
+void
+_PathSetPrimOrPropertyScenePath(const Sdf_ParserHelpers::Value& arg1,
+                                Sdf_TextParserContext *context)
+{
+    const std::string& pathStr = arg1.Get<std::string>();
+    context->savedPath = SdfPath(pathStr);
+    // Valid paths are prim or property paths that do not contain variant
+    // selections.
+    SdfPath const &path = context->savedPath;
+    bool pathValid = (path.IsPrimPath() || path.IsPropertyPath()) &&
+        !path.ContainsPrimVariantSelection();
+    if (!pathValid) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "'%s' is not a valid prim or property scene path",
+            pathStr.c_str());
+    }
+}
+
+void
+_SetGenericMetadataListOpItems(const TfType& fieldType, 
+                               Sdf_TextParserContext *context)
+{
+    // Chain together attempts to set list op items using 'or' to bail
+    // out as soon as we successfully write out the list op we're holding.
+    _SetItemsIfListOp<SdfIntListOp>(fieldType, context)    ||
+    _SetItemsIfListOp<SdfInt64ListOp>(fieldType, context)  ||
+    _SetItemsIfListOp<SdfUIntListOp>(fieldType, context)   ||
+    _SetItemsIfListOp<SdfUInt64ListOp>(fieldType, context) ||
+    _SetItemsIfListOp<SdfStringListOp>(fieldType, context) ||
+    _SetItemsIfListOp<SdfTokenListOp>(fieldType, context);
+}
+
+bool
+_IsGenericMetadataListOpType(const TfType& type,
+                             TfType* itemArrayType)
+{
+    static std::pair<TfType, TfType> listOpAndArrayTypes[] = {
+        _GetListOpAndArrayTfTypes<SdfIntListOp>(),
+        _GetListOpAndArrayTfTypes<SdfInt64ListOp>(),
+        _GetListOpAndArrayTfTypes<SdfUIntListOp>(),
+        _GetListOpAndArrayTfTypes<SdfUInt64ListOp>(),
+        _GetListOpAndArrayTfTypes<SdfStringListOp>(),
+        _GetListOpAndArrayTfTypes<SdfTokenListOp>(),
+    };
+
+    auto iter = std::find_if(std::begin(listOpAndArrayTypes),
+                             std::end(listOpAndArrayTypes),
+                             [&type](auto const &p) {
+                                 return p.first == type;
+                             });
+
+    if (iter == std::end(listOpAndArrayTypes)) {
+        return false;
+    }
+
+    if (itemArrayType) {
+        *itemArrayType = iter->second;
+    }
+    
+    return true;
+}
+
+void
+_GenericMetadataStart(const Sdf_ParserHelpers::Value &name, SdfSpecType specType,
+                      Sdf_TextParserContext *context)
+{
+    context->genericMetadataKey = TfToken(name.Get<std::string>());
+    context->listOpType = SdfListOpTypeExplicit;
+
+    const SdfSchema& schema = SdfSchema::GetInstance();
+    const SdfSchema::SpecDefinition &specDef = 
+        *schema.GetSpecDefinition(specType);
+    if (specDef.IsMetadataField(context->genericMetadataKey)) {
+        // Prepare to parse a known field
+        const SdfSchema::FieldDefinition &fieldDef = 
+            *schema.GetFieldDefinition(context->genericMetadataKey);
+        const TfType fieldType = fieldDef.GetFallbackValue().GetType();
+
+        // For list op-valued metadata fields, set up the parser as if
+        // we were parsing an array of the list op's underlying type.
+        // In _GenericMetadataEnd, we'll produce this list and set it
+        // into the appropriate place in the list op.
+        TfType itemArrayType;
+        if (_IsGenericMetadataListOpType(fieldType, &itemArrayType)) {
+            _SetupValue(schema.FindType(itemArrayType).
+                            GetAsToken().GetString(), context);
+        }
+        else {
+            _SetupValue(schema.FindType(fieldDef.GetFallbackValue()).
+		            GetAsToken().GetString(), context);
+        }
+    } else {
+        // Prepare to parse only the string representation of this metadata
+        // value, since it's an unregistered field.
+        context->values.StartRecordingString();
+    }
+}
+
+void
+_GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
+{
+    const SdfSchema& schema = SdfSchema::GetInstance();
+    const SdfSchema::SpecDefinition &specDef = 
+        *schema.GetSpecDefinition(specType);
+    if (specDef.IsMetadataField(context->genericMetadataKey)) {
+        // Validate known fields before storing them
+        const SdfSchema::FieldDefinition &fieldDef = 
+            *schema.GetFieldDefinition(context->genericMetadataKey);
+        const TfType fieldType = fieldDef.GetFallbackValue().GetType();
+
+        if (_IsGenericMetadataListOpType(fieldType)) {
+            if (!fieldDef.IsValidListValue(context->currentValue)) {
+                SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                    "invalid value for field \"%s\"", 
+                    context->genericMetadataKey.GetText());
+            }
+            else {
+                _SetGenericMetadataListOpItems(fieldType, context);
+            }
+        }
+        else {
+            if (!fieldDef.IsValidValue(context->currentValue) ||
+                context->currentValue.IsEmpty()) {
+                SDF_TEXTFILEFORMATPARSER_ERR(context, 
+                    "invalid value for field \"%s\"", 
+                    context->genericMetadataKey.GetText());
+            }
+            else {
+                _SetField(
+                    context->path, context->genericMetadataKey, 
+                    context->currentValue, context);
+            }
+        }
+    } else if (specDef.IsValidField(context->genericMetadataKey)) {
+        // Prevent the user from overwriting fields that aren't metadata
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "\"%s\" is registered as a non-metadata field", 
+            context->genericMetadataKey.GetText());
+    } else {
+        // Stuff unknown fields into a SdfUnregisteredValue so they can pass
+        // through loading and saving unmodified
+        VtValue value;
+        if (context->currentValue.IsHolding<VtDictionary>()) {
+            // If we parsed a dictionary, store it's actual value. Dictionaries
+            // can be parsed fully because they contain type information.
+            value = 
+                SdfUnregisteredValue(context->currentValue.Get<VtDictionary>());
+        } else {
+            // Otherwise, we parsed a simple value or a shaped list of simple
+            // values. We want to store the parsed string, but we need to
+            // determine whether to unpack it into an SdfUnregisteredListOp
+            // or to just store the string directly.
+            auto getOldValue = [context]() {
+                VtValue v;
+                if (_HasField(context->path, context->genericMetadataKey,
+                              &v, context)
+                    && TF_VERIFY(v.IsHolding<SdfUnregisteredValue>())) {
+                    v = v.UncheckedGet<SdfUnregisteredValue>().GetValue();
+                }
+                else {
+                    v = VtValue();
+                }
+                return v;
+            };
+
+            auto getRecordedStringAsUnregisteredValue = [context]() {
+                std::string s = context->values.GetRecordedString();
+                if (s == "None") { 
+                    return std::vector<SdfUnregisteredValue>(); 
+                }
+
+                // Put the entire string representation of this list into
+                // a single SdfUnregisteredValue, but strip off the enclosing
+                // brackets so that we don't write out two sets of brackets
+                // when serializing out the list op.
+                if (!s.empty() && s.front() == '[') { s.erase(0, 1); }
+                if (!s.empty() && s.back() == ']') { s.pop_back(); }
+                return std::vector<SdfUnregisteredValue>(
+                    { SdfUnregisteredValue(s) });
+            };
+
+            VtValue oldValue = getOldValue();
+            if (context->listOpType == SdfListOpTypeExplicit) {
+                // In this case, we can't determine whether the we've parsed
+                // an explicit list op statement or a simple value.
+                // We just store the recorded string directly, as that's the
+                // simplest thing to do.
+                value = 
+                    SdfUnregisteredValue(context->values.GetRecordedString());
+            }
+            else if (oldValue.IsEmpty()
+                     || oldValue.IsHolding<SdfUnregisteredValueListOp>()) {
+                // In this case, we've parsed a list op statement so unpack
+                // it into a list op unless we've already parsed something
+                // for this field that *isn't* a list op.
+                SdfUnregisteredValueListOp listOp = 
+                    oldValue.GetWithDefault<SdfUnregisteredValueListOp>();
+                listOp.SetItems(getRecordedStringAsUnregisteredValue(), 
+                                context->listOpType);
+                value = SdfUnregisteredValue(listOp);
+            }
+            else {
+                // If we've parsed a list op statement but have a non-list op
+                // stored in this field, leave that value in place and ignore
+                // the new value. We should only encounter this case if someone
+                // hand-edited the layer in an unexpected or invalid way, so
+                // just keeping the first value we find should be OK.
+            }
+        }
+
+        if (!value.IsEmpty()) {
+            _SetField(context->path, context->genericMetadataKey, 
+                      value, context);
+        }
+    }
+
+    context->values.Clear();
+    context->currentValue = VtValue();
+}
+
+void _RaiseError(Sdf_TextParserContext *context, const char *msg)
+{
+    int errLineNumber = context->sdfLineNo;
+
+    std::string s = TfStringPrintf(
+        "%s in <%s> on line %i",
+        msg,
+        context->path.GetText(),
+        errLineNumber);
+
+    // Append file context, if known.
+    if (!context->fileContext.empty()) {
+        s += " in file " + context->fileContext;
+    }
+    s += "\n";
+
+    // Return the line number in the error info.
+    TfDiagnosticInfo info(errLineNumber);
+
+    TF_ERROR(info, TF_DIAGNOSTIC_RUNTIME_ERROR_TYPE, s);
+
+    context->seenError = true;
+}
+
+} // end namespace Sdf_TextFileFormatParser
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/sdf/textParserHelpers.h
+++ b/pxr/usd/sdf/textParserHelpers.h
@@ -1,0 +1,307 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#ifndef PXR_USD_SDF_TEXT_PARSER_HELPERS_H
+#define PXR_USD_SDF_TEXT_PARSER_HELPERS_H
+
+#include "pxr/base/tf/enum.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/base/tf/type.h"
+#include "pxr/base/vt/value.h"
+#include "pxr/usd/sdf/listOp.h"
+#include "pxr/usd/sdf/parserHelpers.h"
+#include "pxr/usd/sdf/path.h"
+#include "pxr/usd/sdf/schema.h"
+#include "pxr/usd/sdf/types.h"
+#include "pxr/usd/sdf/textParserContext.h"
+
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace Sdf_TextFileFormatParser {
+
+#define SDF_TEXTFILEFORMATPARSER_ERR(context, ...) \
+    _RaiseError(context, TfStringPrintf(__VA_ARGS__).c_str())
+
+//--------------------------------------------------------------------
+// Helpers
+//--------------------------------------------------------------------
+
+bool _SetupValue(const std::string& typeName, Sdf_TextParserContext* context);
+void _MatchMagicIdentifier(const Sdf_ParserHelpers::Value& arg1, 
+    Sdf_TextParserContext *context);
+SdfPermission _GetPermissionFromString(const std::string & str,
+    Sdf_TextParserContext *context);
+TfEnum _GetDisplayUnitFromString(const std::string & name,
+    Sdf_TextParserContext *context);
+void _ValueAppendAtomic(const Sdf_ParserHelpers::Value& arg1, 
+    Sdf_TextParserContext *context);
+void _ValueSetAtomic(Sdf_TextParserContext *context);
+void _PrimSetInheritListItems(SdfListOpType opType, Sdf_TextParserContext *context);
+void _InheritAppendPath(Sdf_TextParserContext *context);
+void _PrimSetSpecializesListItems(SdfListOpType opType,
+    Sdf_TextParserContext *context);
+void _SpecializesAppendPath(Sdf_TextParserContext *context);
+void _PrimSetReferenceListItems(SdfListOpType opType,
+    Sdf_TextParserContext *context);
+void _PrimSetPayloadListItems(SdfListOpType opType, Sdf_TextParserContext *context);
+void _PrimSetVariantSetNamesListItems(SdfListOpType opType,
+    Sdf_TextParserContext *context);
+void _RelationshipInitTarget(const SdfPath& targetPath,
+    Sdf_TextParserContext *context);
+void _RelationshipSetTargetsList(SdfListOpType opType, 
+    Sdf_TextParserContext *context);
+void _PrimSetVariantSelection(Sdf_TextParserContext *context);
+void _RelocatesAdd(const Sdf_ParserHelpers::Value& arg1,
+    const Sdf_ParserHelpers::Value& arg2, Sdf_TextParserContext *context);
+void _AttributeSetConnectionTargetsList(SdfListOpType opType, 
+    Sdf_TextParserContext *context);
+void _AttributeAppendConnectionPath(Sdf_TextParserContext *context);
+void _PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1,
+    Sdf_TextParserContext *context);
+void _DictionaryBegin(Sdf_TextParserContext *context);
+void _DictionaryEnd(Sdf_TextParserContext *context);
+void _DictionaryInsertValue(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _DictionaryInsertDictionary(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _DictionaryInitScalarFactory(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _DictionaryInitShapedFactory(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _ValueSetTuple(Sdf_TextParserContext *context);
+void _ValueSetList(Sdf_TextParserContext *context);
+void _ValueSetShaped(Sdf_TextParserContext *context);
+void _ValueSetCurrentToSdfPath(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _PrimInitRelationship(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _PrimEndRelationship(Sdf_TextParserContext *context);
+void _RelationshipAppendTargetPath(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _PathSetPrim(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context);
+void _PathSetPrimOrPropertyScenePath(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext *context);
+void _SetGenericMetadataListOpItems(const TfType& fieldType, 
+    Sdf_TextParserContext *context);
+bool _IsGenericMetadataListOpType(const TfType& type,
+    TfType* itemArrayType = nullptr);
+void _GenericMetadataStart(const Sdf_ParserHelpers::Value &name, SdfSpecType specType,
+    Sdf_TextParserContext *context);
+void _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context);
+void _RaiseError(Sdf_TextParserContext *context, const char *msg);
+
+template <class T>
+bool
+_GeneralHasDuplicates(const std::vector<T> &v)
+{
+    // Copy and sort to look for dupes.
+    std::vector<T> copy(v);
+    std::sort(copy.begin(), copy.end());
+    return std::adjacent_find(copy.begin(), copy.end()) != copy.end();
+}
+
+template <class T>
+inline bool
+_HasDuplicates(const std::vector<T> &v)
+{
+    // Many of the vectors we see here are either just a few elements long
+    // (references, payloads) or are already sorted and unique (topology
+    // indexes, etc).
+    if (v.size() <= 1) {
+        return false;
+    }
+
+    // Many are of small size, just check all pairs.
+    if (v.size() <= 10) {
+       using iter = typename std::vector<T>::const_iterator;
+       iter iend = std::prev(v.end()), jend = v.end();
+       for (iter i = v.begin(); i != iend; ++i) {
+           for (iter j = std::next(i); j != jend; ++j) {
+               if (*i == *j) {
+                   return true;
+               }
+           }
+       }
+       return false;
+    }
+
+    // Check for strictly sorted order.
+    if (std::adjacent_find(v.begin(), v.end(),
+                           [](T const &l, T const &r) {
+                               return l >= r;
+                           }) == v.end()) {
+        return false;
+    }
+    // Otherwise do a more expensive copy & sort to check for dupes.
+    return _GeneralHasDuplicates(v);
+}
+
+template <class T> 
+const std::vector<T>& _ToItemVector(const std::vector<T>& v)
+{
+    return v;
+}
+template <class T>
+std::vector<T> _ToItemVector(const VtArray<T>& v)
+{
+    return std::vector<T>(v.begin(), v.end());
+}
+
+// Set a single ListOp vector in the list op for the current
+// path and specified key.
+template <class T>
+void
+_SetListOpItems(const TfToken &key, SdfListOpType type,
+                const T &itemList, Sdf_TextParserContext *context)
+{
+    typedef SdfListOp<typename T::value_type> ListOpType;
+    typedef typename ListOpType::ItemVector ItemVector;
+
+    const ItemVector& items = _ToItemVector(itemList);
+
+    if (_HasDuplicates(items)) {
+        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+            "Duplicate items exist for field '%s' at '%s'",
+            key.GetText(), context->path.GetText());
+    }
+
+    ListOpType op = context->data->GetAs<ListOpType>(context->path, key);
+    op.SetItems(items, type);
+
+    context->data->Set(context->path, key, VtValue::Take(op));
+}
+
+// Append a single item to the vector for the current path and specified key.
+template <class T>
+void
+_AppendVectorItem(const TfToken& key, const T& item,
+                  Sdf_TextParserContext *context)
+{
+    std::vector<T> vec =
+        context->data->GetAs<std::vector<T> >(context->path, key);
+    vec.push_back(item);
+
+    context->data->Set(context->path, key, VtValue(vec));
+}
+
+inline void
+_SetDefault(const SdfPath& path, VtValue val,
+            Sdf_TextParserContext *context)
+{
+    // If is holding SdfPathExpression (or array of same), make absolute with
+    // path.GetPrimPath() as anchor.
+    if (val.IsHolding<SdfPathExpression>()) {
+        val.UncheckedMutate<SdfPathExpression>([&](SdfPathExpression &pe) {
+            pe = pe.MakeAbsolute(path.GetPrimPath());
+        });
+    }
+    else if (val.IsHolding<VtArray<SdfPathExpression>>()) {
+        val.UncheckedMutate<VtArray<SdfPathExpression>>(
+            [&](VtArray<SdfPathExpression> &peArr) {
+                for (SdfPathExpression &pe: peArr) {
+                    pe = pe.MakeAbsolute(path.GetPrimPath());
+                }
+            });
+    }
+    /*
+    else if (val.IsHolding<SdfPath>()) {
+        SdfPath valPath;
+        val.UncheckedSwap(valPath);
+        expr.MakeAbsolutePath(path.GetPrimPath());
+        val.UncheckedSwap(valPath);
+    }
+    */
+    context->data->Set(path, SdfFieldKeys->Default, val);
+}        
+
+template <class T>
+inline void
+_SetField(const SdfPath& path, const TfToken& key, const T& item,
+          Sdf_TextParserContext *context)
+{
+    context->data->Set(path, key, VtValue(item));
+}
+
+inline bool
+_HasField(const SdfPath& path, const TfToken& key, VtValue* value, 
+          Sdf_TextParserContext *context)
+{
+    return context->data->Has(path, key, value);
+}
+
+inline bool
+_HasSpec(const SdfPath& path, Sdf_TextParserContext *context)
+{
+    return context->data->HasSpec(path);
+}
+
+inline void
+_CreateSpec(const SdfPath& path, SdfSpecType specType, 
+            Sdf_TextParserContext *context)
+{
+    context->data->CreateSpec(path, specType);
+}
+
+template <class ListOpType>
+bool
+_SetItemsIfListOp(const TfType& type, Sdf_TextParserContext *context)
+{
+    if (!type.IsA<ListOpType>()) {
+        return false;
+    }
+
+    typedef VtArray<typename ListOpType::value_type> ArrayType;
+
+    if (!TF_VERIFY(context->currentValue.IsHolding<ArrayType>() ||
+                   context->currentValue.IsEmpty())) {
+        return true;
+    }
+
+    ArrayType vtArray;
+    if (context->currentValue.IsHolding<ArrayType>()) {
+        vtArray = context->currentValue.UncheckedGet<ArrayType>();
+    }
+
+    _SetListOpItems(
+        context->genericMetadataKey, context->listOpType, vtArray, context);
+    return true;
+}
+
+template <class ListOpType>
+std::pair<TfType, TfType>
+_GetListOpAndArrayTfTypes() {
+    return {
+        TfType::Find<ListOpType>(),
+        TfType::Find<VtArray<typename ListOpType::value_type>>()
+    };
+}
+
+} // end namespace Sdf_TextFileFormatParser
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif


### PR DESCRIPTION
### Description of Change(s)

In preparation for a new PEGTL Text File Format parser that uses the same helper functions as the existing ones
embedded in the current yacc parser, these helper methods are extracted into a new file and properly namespaced.

The existing yacc parser was not modified and will continue to function as normal, using the helper functions already embedded in the .yy file.

The purpose of this change is to make it easier to see where (if at all) these helper methods change when used by a new PEGTL based text file format parser.

All templated functions remain in the header.  Any functions marked with `inline static` had the `static` qualifier removed, otherwise they remain in the header.  Any functions not marked `inline` had the `static` qualifier removed, forward declared in the header and implemented in the cpp.

Partially addresses #USD-8970.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
