### PR TITLE
Autodesk: Provided initialization hgi backend selection for render plugin.

### DIFF
--- a/extras/imaging/examples/hdTiny/rendererPlugin.cpp
+++ b/extras/imaging/examples/hdTiny/rendererPlugin.cpp
@@ -54,7 +54,7 @@ HdTinyRendererPlugin::DeleteRenderDelegate(HdRenderDelegate *renderDelegate)
 }
 
 bool 
-HdTinyRendererPlugin::IsSupported(bool /* gpuEnabled */) const
+HdTinyRendererPlugin::IsSupported(bool /* gpuEnabled */, TfToken /*hgiToken*/) const
 {
     // Nothing more to check for now, we assume if the plugin loads correctly
     // it is supported.

--- a/extras/imaging/examples/hdTiny/rendererPlugin.h
+++ b/extras/imaging/examples/hdTiny/rendererPlugin.h
@@ -60,7 +60,7 @@ public:
         HdRenderDelegate *renderDelegate) override;
 
     /// Checks to see if the plugin is supported on the running system.
-    virtual bool IsSupported(bool gpuEnabled = true) const override;
+    virtual bool IsSupported(bool gpuEnabled = true, TfToken hgiToken = TfToken("")) const override;
 
 private:
     // This class does not support copying.

--- a/pxr/imaging/hd/rendererPlugin.cpp
+++ b/pxr/imaging/hd/rendererPlugin.cpp
@@ -60,7 +60,14 @@ HdRendererPlugin::~HdRendererPlugin() = default;
 HdPluginRenderDelegateUniqueHandle
 HdRendererPlugin::CreateDelegate(HdRenderSettingsMap const& settingsMap)
 {
-    if (!IsSupported()) {
+    TfToken backendToken;
+
+    auto iter = settingsMap.find(TfToken("HgiBackend"));
+    if (iter != settingsMap.end()) {
+        backendToken = iter->second.Get<TfToken>();
+    }
+
+    if (!IsSupported(true, backendToken)) {
         return nullptr;
     }
 

--- a/pxr/imaging/hd/rendererPlugin.h
+++ b/pxr/imaging/hd/rendererPlugin.h
@@ -103,7 +103,7 @@ public:
     /// parameter indicates if the GPU is available for use by the plugin in
     /// case this information is necessary to make this determination.
     ///
-    virtual bool IsSupported(bool gpuEnabled = true) const = 0;
+    virtual bool IsSupported(bool gpuEnabled = true, TfToken token = TfToken("")) const = 0;
 
 protected:
     HdRendererPlugin() = default;

--- a/pxr/imaging/hdSt/renderDelegate.cpp
+++ b/pxr/imaging/hdSt/renderDelegate.cpp
@@ -546,9 +546,9 @@ HdStRenderDelegate::CommitResources(HdChangeTracker *tracker)
 }
 
 bool
-HdStRenderDelegate::IsSupported()
+HdStRenderDelegate::IsSupported(const TfToken& hgiToken)
 {
-    return Hgi::IsSupported();
+    return Hgi::IsSupported(hgiToken);
 }
 
 TfTokenVector

--- a/pxr/imaging/hdSt/renderDelegate.h
+++ b/pxr/imaging/hdSt/renderDelegate.h
@@ -143,7 +143,7 @@ public:
     // Returns whether or not HdStRenderDelegate can run on the current
     // hardware.
     HDST_API
-    static bool IsSupported();
+    static bool IsSupported(const TfToken& token = TfToken(""));
 
     // Returns a raw pointer to the draw items cache owned (solely) by the
     // render delegate.

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -141,6 +141,17 @@ public:
     HGI_API
     static HgiUniquePtr CreatePlatformDefaultHgi();
 
+    /// Helper function to return a Hgi object of choice supported by current platform.
+    /// For example on Linux this may allow HgiGL only while on macOS HgiMetal.
+    /// If the HGI device specified is not available on the current platform the default 
+    /// HGI type (HgiGL on windows and linux, HgiMetal on mac) will be created.
+    /// Caller, usually the application, owns the lifetime of the Hgi object and
+    /// the object is destroyed when the caller drops the unique ptr.
+    /// Thread safety: Not thread safe.
+    /// Supported TfToken values are HgiGL, HgiMetal, HgiVulkan
+    HGI_API
+    static HgiUniquePtr CreateHgiOfChoice(const TfToken& type);
+
     /// Determine if Hgi instance can run on current hardware.
     /// Thread safety: This call is thread safe.
     HGI_API
@@ -150,7 +161,7 @@ public:
     /// the object's IsBackendSupported() function.
     /// Thread safety: Not thread safe.
     HGI_API
-    static bool IsSupported();
+    static bool IsSupported(const TfToken& token = TfToken(""));
 
     /// Returns a GraphicsCmds object (for temporary use) that is ready to
     /// record draw commands. GraphicsCmds is a lightweight object that

--- a/pxr/imaging/hgiInterop/hgiInterop.cpp
+++ b/pxr/imaging/hgiInterop/hgiInterop.cpp
@@ -29,11 +29,14 @@
 #if defined(PXR_METAL_SUPPORT_ENABLED)
     #include "pxr/imaging/hgiMetal/hgi.h"
     #include "pxr/imaging/hgiInterop/metal.h"
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
-    #include "pxr/imaging/hgiVulkan/hgi.h"
-    #include "pxr/imaging/hgiInterop/vulkan.h"
 #else
-    #include "pxr/imaging/hgiInterop/opengl.h"
+// Include Vulkan headers if vulkan build option option enabled.
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
+    #include "pxr/imaging/hgiVulkan/hgi.h"
+#include "vulkan.h"
+#endif
+// Always include opengl (even if vulkan build option enabled)
+#include "pxr/imaging/hgiInterop/opengl.h"
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -63,7 +66,9 @@ void HgiInterop::TransferToApp(
     } else {
         TF_CODING_ERROR("Unsupported Hgi backend: %s", srcApi.GetText());
     }
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
+#else
+
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
     if (srcApi==HgiTokens->Vulkan && dstApi==HgiTokens->OpenGL) {
         // Transfer Vulkan textures to OpenGL application
         if (!_vulkanToOpenGL) {
@@ -71,10 +76,10 @@ void HgiInterop::TransferToApp(
         }
         _vulkanToOpenGL->CompositeToInterop(
             srcColor, srcDepth, dstFramebuffer, dstRegion);
-    } else {
-        TF_CODING_ERROR("Unsupported Hgi backend: %s", srcApi.GetText());
+
     }
-#else
+    else
+#endif
     if (srcApi==HgiTokens->OpenGL && dstApi==HgiTokens->OpenGL) {
         // Transfer OpenGL textures to OpenGL application
         if (!_openGLToOpenGL) {

--- a/pxr/imaging/hgiInterop/hgiInterop.h
+++ b/pxr/imaging/hgiInterop/hgiInterop.h
@@ -102,9 +102,10 @@ private:
 
 #if defined(PXR_METAL_SUPPORT_ENABLED)
     std::unique_ptr<HgiInteropMetal> _metalToOpenGL;
-#elif defined(PXR_VULKAN_SUPPORT_ENABLED)
-    std::unique_ptr<HgiInteropVulkan> _vulkanToOpenGL;
 #else
+#if defined(PXR_VULKAN_SUPPORT_ENABLED)
+    std::unique_ptr<HgiInteropVulkan> _vulkanToOpenGL;
+#endif
     std::unique_ptr<HgiInteropOpenGL> _openGLToOpenGL;
 #endif
 };

--- a/pxr/imaging/plugin/hdEmbree/rendererPlugin.cpp
+++ b/pxr/imaging/plugin/hdEmbree/rendererPlugin.cpp
@@ -54,7 +54,7 @@ HdEmbreeRendererPlugin::DeleteRenderDelegate(HdRenderDelegate *renderDelegate)
 }
 
 bool 
-HdEmbreeRendererPlugin::IsSupported(bool /* gpuEnabled */) const
+HdEmbreeRendererPlugin::IsSupported(bool /* gpuEnabled */, TfToken /* hgiToken */) const
 {
     // Nothing more to check for now, we assume if the plugin loads correctly
     // it is supported.

--- a/pxr/imaging/plugin/hdEmbree/rendererPlugin.h
+++ b/pxr/imaging/plugin/hdEmbree/rendererPlugin.h
@@ -66,7 +66,7 @@ public:
 
     /// Checks to see if the embree plugin is supported on the running system
     ///
-    bool IsSupported(bool gpuEnabled = true) const override;
+    bool IsSupported(bool gpuEnabled = true, TfToken hgiToken = TfToken("")) const override;
 
 private:
     // This class does not support copying.

--- a/pxr/imaging/plugin/hdStorm/rendererPlugin.cpp
+++ b/pxr/imaging/plugin/hdStorm/rendererPlugin.cpp
@@ -55,9 +55,9 @@ HdStormRendererPlugin::DeleteRenderDelegate(HdRenderDelegate *renderDelegate)
 }
 
 bool
-HdStormRendererPlugin::IsSupported(bool gpuEnabled) const
+HdStormRendererPlugin::IsSupported(bool gpuEnabled, TfToken hgiToken) const
 {
-    return gpuEnabled ? HdStRenderDelegate::IsSupported() : false;
+    return gpuEnabled ? HdStRenderDelegate::IsSupported(hgiToken) : false;
 }
 
 


### PR DESCRIPTION
### Description of Change(s)

This PR provides the ability to select Vulkan/OpenGL as a Hgi backend from the render delegate and plugin's perspective.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
