### PR TITLE
Unicode character classes doxygen

### DIFF
--- a/pxr/base/tf/unicode/unicodeCharacterClasses.template.cpp
+++ b/pxr/base/tf/unicode/unicodeCharacterClasses.template.cpp
@@ -29,7 +29,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the character class data
 /// contained within the XID_Start set of Unicode character classes.
 ///
@@ -42,7 +42,7 @@ public:
     std::vector<std::pair<uint32_t, uint32_t>> ranges;
 };
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the character class data
 /// contained within the XID_Continue set of Unicode character classes.
 ///

--- a/pxr/base/tf/unicodeCharacterClasses.cpp
+++ b/pxr/base/tf/unicodeCharacterClasses.cpp
@@ -29,7 +29,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the character class data
 /// contained within the XID_Start set of Unicode character classes.
 ///
@@ -42,7 +42,7 @@ public:
     std::vector<std::pair<uint32_t, uint32_t>> ranges;
 };
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the character class data
 /// contained within the XID_Continue set of Unicode character classes.
 ///

--- a/pxr/base/tf/unicodeCharacterClasses.h
+++ b/pxr/base/tf/unicodeCharacterClasses.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // but we need the flags to be contiguous
 constexpr uint32_t TF_MAX_CODE_POINT = 1114112;
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the whether a Unicode code
 /// point is contained with the XID_Start set of Unicode character
 /// classes.
@@ -47,10 +47,10 @@ public:
 
     TfUnicodeXidStartFlagData();
 
-    /// @brief Determines whether the given code point is contained within
+    /// \brief Determines whether the given code point is contained within
     /// the XID_Start character class.
-    /// @param codePoint The Unicode code point to determine inclusion for.
-    /// @return true if the given codePoint is in the XID_Start character
+    /// \param codePoint The Unicode code point to determine inclusion for.
+    /// \return true if the given codePoint is in the XID_Start character
     /// class, false otherwise.
     bool IsXidStartCodePoint(uint32_t codePoint) const;
 
@@ -59,7 +59,7 @@ private:
     std::bitset<TF_MAX_CODE_POINT> _flags;
 };
 
-/// @brief 
+/// \brief 
 /// Provides static initialization of the whether a Unicode code
 /// point is contained with the XID_Continue set of Unicode character
 /// classes.
@@ -70,10 +70,10 @@ public:
 
     TfUnicodeXidContinueFlagData();
 
-    /// @brief Determines whether the given code point is contained within
+    /// \brief Determines whether the given code point is contained within
     /// the XID_Continue character class.
-    /// @param codePoint The Unicode code point to determine inclusion for.
-    /// @return true if the given codePoint is in the XID_Continue 
+    /// \param codePoint The Unicode code point to determine inclusion for.
+    /// \return true if the given codePoint is in the XID_Continue 
     /// character class false otherwise.
     bool IsXidContinueCodePoint(uint32_t codePoint) const;
 
@@ -82,13 +82,13 @@ private:
     std::bitset<TF_MAX_CODE_POINT> _flags;
 };
 
-/// @brief Retreives character class data for XID_Start.
-/// @return An object which can be used to interrogate whether a code point
+/// \brief Retreives character class data for XID_Start.
+/// \return An object which can be used to interrogate whether a code point
 /// is contained within the XID_Start character class.
 const TfUnicodeXidStartFlagData& TfUnicodeGetXidStartFlagData();
 
-/// @brief Retreives character class data for XID_Continue.
-/// @return An object which can be used to interrogate whether a code point
+/// \brief Retreives character class data for XID_Continue.
+/// \return An object which can be used to interrogate whether a code point
 /// is contained within the XID_Continue character class.
 const TfUnicodeXidContinueFlagData& TfUnicodeGetXidContinueFlagData();
 


### PR DESCRIPTION
### Description of Change(s)

Fixes issue with doxygen commenting conventions within unicode character classes, changing from use of `@` to `\`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
