### PR TITLE
Convert xid ranges classes into compile time lookup tables

### DIFF
--- a/pxr/base/tf/unicode/tfGenCharacterClasses.py
+++ b/pxr/base/tf/unicode/tfGenCharacterClasses.py
@@ -68,25 +68,25 @@ def _write_cpp_file(source_template_path : str, destination_directory : str):
     generated_cpp_file_name = os.path.join(destination_directory,
                                            CPP_FILE_NAME)
     with open(generated_cpp_file_name, 'w') as generated_cpp_file:
-        # we need to replace two markers, {xid_start_ranges}
-        # and {xid_continue_ranges} with the content we derived
-        # from DerivedCoreProperties.txt
-        xid_start_range_expression = "ranges = {\n"
-        for x in xid_start_range_pairs:
-            range_expression = "{" + str(x[0]) + ", " + str(x[1]) + "}"
-            xid_start_range_expression += f"        {range_expression},\n"
-        xid_start_range_expression += "    };"
+        # we need to replace markers {xid_start_ranges} and
+        # {xid_continue_ranges} (along with their sizes) with the content we
+        # derived from DerivedCoreProperties.txt
+        xid_start_range_expression = "\n".join(
+            "        {{{}, {}}},".format(str(x[0]), str(x[1]))
+            for x in xid_start_range_pairs)
 
-        xid_continue_range_expression = "ranges = {\n"
-        for x in xid_continue_range_pairs:
-            range_expression = "{" + str(x[0]) + ", " + str(x[1]) + "}"
-            xid_continue_range_expression += f"        {range_expression},\n"
-        xid_continue_range_expression += "    };"
+        xid_continue_range_expression = "\n".join(
+            "        {{{}, {}}},".format(str(x[0]), str(x[1]))
+            for x in xid_continue_range_pairs)
 
         destination_template_content = source_template_content.replace(
             r"{xid_start_ranges}", xid_start_range_expression)
         destination_template_content = destination_template_content.replace(
             r"{xid_continue_ranges}", xid_continue_range_expression)
+        destination_template_content = destination_template_content.replace(
+            r"{xid_start_ranges_size}", str(len(xid_start_range_pairs)))
+        destination_template_content = destination_template_content.replace(
+            r"{xid_continue_ranges_size}", str(len(xid_continue_range_pairs)))
 
         generated_cpp_file.write(destination_template_content)
 

--- a/pxr/base/tf/unicode/unicodeCharacterClasses.template.cpp
+++ b/pxr/base/tf/unicode/unicodeCharacterClasses.template.cpp
@@ -25,73 +25,38 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/unicodeCharacterClasses.h"
 
-#include <vector>
+#include <array>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/// @brief 
-/// Provides static initialization of the character class data
-/// contained within the XID_Start set of Unicode character classes.
-///
-struct Tf_UnicodeXidStartRangeData
-{
-public:
+static constexpr
+std::array<std::pair<uint32_t, uint32_t>, {xid_start_ranges_size}>
+_xidStartRanges = {{
+{xid_start_ranges}
+}};
 
-    Tf_UnicodeXidStartRangeData();
-
-    std::vector<std::pair<uint32_t, uint32_t>> ranges;
-};
-
-/// @brief 
-/// Provides static initialization of the character class data
-/// contained within the XID_Continue set of Unicode character classes.
-///
-struct Tf_UnicodeXidContinueRangeData
-{
-public:
-
-    Tf_UnicodeXidContinueRangeData();
-
-    std::vector<std::pair<uint32_t, uint32_t>> ranges;
-};
-
-// holds the compacted ranges of XID_Start and XID_Continue
-// character classes
-static TfStaticData<Tf_UnicodeXidStartRangeData> _xidStartRangeData;
-static TfStaticData<Tf_UnicodeXidContinueRangeData> _xidContinueRangeData;
-
-Tf_UnicodeXidStartRangeData::Tf_UnicodeXidStartRangeData()
-{
-    {xid_start_ranges}
-}
-
-Tf_UnicodeXidContinueRangeData::Tf_UnicodeXidContinueRangeData()
-{
-    {xid_continue_ranges}
-}
+static constexpr
+std::array<std::pair<uint32_t, uint32_t>, {xid_continue_ranges_size}>
+_xidContinueRanges = {{
+{xid_continue_ranges}
+}};
 
 TfUnicodeXidStartFlagData::TfUnicodeXidStartFlagData()
 {
     // set all of the bits corresponding to the code points in the range
-    for (const auto& pair : _xidStartRangeData->ranges)
+    for (const auto& pair : _xidStartRanges)
     {
         for (uint32_t i = pair.first; i <= pair.second; i++)
         {
             this->_flags[static_cast<size_t>(i)] = true;
         }
     }
-}
-
-bool
-TfUnicodeXidStartFlagData::IsXidStartCodePoint(uint32_t codePoint) const
-{
-    return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
 }
 
 TfUnicodeXidContinueFlagData::TfUnicodeXidContinueFlagData()
 {
     // set all of the bits corresponding to the code points in the range
-    for (const auto& pair : _xidContinueRangeData->ranges)
+    for (const auto& pair : _xidContinueRanges)
     {
         for (uint32_t i = pair.first; i <= pair.second; i++)
         {
@@ -100,25 +65,19 @@ TfUnicodeXidContinueFlagData::TfUnicodeXidContinueFlagData()
     }
 }
 
-bool
-TfUnicodeXidContinueFlagData::IsXidContinueCodePoint(uint32_t codePoint) const
-{
-    return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
-}
-
-static TfStaticData<TfUnicodeXidStartFlagData> xidStartFlagData;
-static TfStaticData<TfUnicodeXidContinueFlagData> xidContinueFlagData;
+static TfStaticData<TfUnicodeXidStartFlagData> _xidStartFlagData;
+static TfStaticData<TfUnicodeXidContinueFlagData> _xidContinueFlagData;
 
 const TfUnicodeXidStartFlagData&
 TfUnicodeGetXidStartFlagData()
 {
-    return *xidStartFlagData;
+    return *_xidStartFlagData;
 }
 
 const TfUnicodeXidContinueFlagData&
 TfUnicodeGetXidContinueFlagData()
 {
-    return *xidContinueFlagData;
+    return *_xidContinueFlagData;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeCharacterClasses.cpp
+++ b/pxr/base/tf/unicodeCharacterClasses.cpp
@@ -25,44 +25,13 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/unicodeCharacterClasses.h"
 
-#include <vector>
+#include <array>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/// @brief 
-/// Provides static initialization of the character class data
-/// contained within the XID_Start set of Unicode character classes.
-///
-struct Tf_UnicodeXidStartRangeData
-{
-public:
-
-    Tf_UnicodeXidStartRangeData();
-
-    std::vector<std::pair<uint32_t, uint32_t>> ranges;
-};
-
-/// @brief 
-/// Provides static initialization of the character class data
-/// contained within the XID_Continue set of Unicode character classes.
-///
-struct Tf_UnicodeXidContinueRangeData
-{
-public:
-
-    Tf_UnicodeXidContinueRangeData();
-
-    std::vector<std::pair<uint32_t, uint32_t>> ranges;
-};
-
-// holds the compacted ranges of XID_Start and XID_Continue
-// character classes
-static TfStaticData<Tf_UnicodeXidStartRangeData> _xidStartRangeData;
-static TfStaticData<Tf_UnicodeXidContinueRangeData> _xidContinueRangeData;
-
-Tf_UnicodeXidStartRangeData::Tf_UnicodeXidStartRangeData()
-{
-    ranges = {
+static constexpr
+std::array<std::pair<uint32_t, uint32_t>, 743>
+_xidStartRanges = {{
         {65, 90},
         {97, 122},
         {170, 170},
@@ -806,12 +775,11 @@ Tf_UnicodeXidStartRangeData::Tf_UnicodeXidStartRangeData()
         {194560, 195101},
         {196608, 201546},
         {201552, 205743},
-    };
-}
+}};
 
-Tf_UnicodeXidContinueRangeData::Tf_UnicodeXidContinueRangeData()
-{
-    ranges = {
+static constexpr
+std::array<std::pair<uint32_t, uint32_t>, 1348>
+_xidContinueRanges = {{
         {48, 57},
         {65, 90},
         {95, 95},
@@ -2160,31 +2128,24 @@ Tf_UnicodeXidContinueRangeData::Tf_UnicodeXidContinueRangeData()
         {196608, 201546},
         {201552, 205743},
         {917760, 917999},
-    };
-}
+}};
 
 TfUnicodeXidStartFlagData::TfUnicodeXidStartFlagData()
 {
     // set all of the bits corresponding to the code points in the range
-    for (const auto& pair : _xidStartRangeData->ranges)
+    for (const auto& pair : _xidStartRanges)
     {
         for (uint32_t i = pair.first; i <= pair.second; i++)
         {
             this->_flags[static_cast<size_t>(i)] = true;
         }
     }
-}
-
-bool
-TfUnicodeXidStartFlagData::IsXidStartCodePoint(uint32_t codePoint) const
-{
-    return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
 }
 
 TfUnicodeXidContinueFlagData::TfUnicodeXidContinueFlagData()
 {
     // set all of the bits corresponding to the code points in the range
-    for (const auto& pair : _xidContinueRangeData->ranges)
+    for (const auto& pair : _xidContinueRanges)
     {
         for (uint32_t i = pair.first; i <= pair.second; i++)
         {
@@ -2193,25 +2154,19 @@ TfUnicodeXidContinueFlagData::TfUnicodeXidContinueFlagData()
     }
 }
 
-bool
-TfUnicodeXidContinueFlagData::IsXidContinueCodePoint(uint32_t codePoint) const
-{
-    return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
-}
-
-static TfStaticData<TfUnicodeXidStartFlagData> xidStartFlagData;
-static TfStaticData<TfUnicodeXidContinueFlagData> xidContinueFlagData;
+static TfStaticData<TfUnicodeXidStartFlagData> _xidStartFlagData;
+static TfStaticData<TfUnicodeXidContinueFlagData> _xidContinueFlagData;
 
 const TfUnicodeXidStartFlagData&
 TfUnicodeGetXidStartFlagData()
 {
-    return *xidStartFlagData;
+    return *_xidStartFlagData;
 }
 
 const TfUnicodeXidContinueFlagData&
 TfUnicodeGetXidContinueFlagData()
 {
-    return *xidContinueFlagData;
+    return *_xidContinueFlagData;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeCharacterClasses.h
+++ b/pxr/base/tf/unicodeCharacterClasses.h
@@ -52,7 +52,9 @@ public:
     /// @param codePoint The Unicode code point to determine inclusion for.
     /// @return true if the given codePoint is in the XID_Start character
     /// class, false otherwise.
-    bool IsXidStartCodePoint(uint32_t codePoint) const;
+    inline bool IsXidStartCodePoint(uint32_t codePoint) const {
+        return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
+    }
 
 private:
 
@@ -75,7 +77,9 @@ public:
     /// @param codePoint The Unicode code point to determine inclusion for.
     /// @return true if the given codePoint is in the XID_Continue 
     /// character class false otherwise.
-    bool IsXidContinueCodePoint(uint32_t codePoint) const;
+    inline bool IsXidContinueCodePoint(uint32_t codePoint) const {
+        return (codePoint < TF_MAX_CODE_POINT) ? _flags[codePoint] : false;
+    }
 
 private:
     


### PR DESCRIPTION
### Description of Change(s)

This change converts the original `TfStaticData` based Unicode XidStart / XidContinue ranges into compile time lookup tables through the use of `constexpr` in order to minimize the initialization overhead of creating these ranges (and associated flag data) on startup.
 
### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
