### PR TITLE
Add class to facilitate serialization and validation of code points

### DIFF
--- a/pxr/base/tf/unicodeUtils.cpp
+++ b/pxr/base/tf/unicodeUtils.cpp
@@ -27,13 +27,50 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+std::ostream&
+operator<<(std::ostream& stream, const TfUtf8CodePoint codePoint)
+{
+    const auto value = codePoint.AsUInt32();
+    if (value < 0x80)
+    {
+        // 1-byte UTF-8 encoding
+        stream << static_cast<char>(value);
+    }
+    else if (value < 0x800)
+    {
+        // 2-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 6) | 0xc0)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x10000)
+    {
+        // 3-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 12) | 0xe0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x110000)
+    {
+        // 4-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 18) | 0xf0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 12) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else
+    {
+        stream << TfUtf8InvalidCodePoint;
+    }
+    return stream;
+}
+
 uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
 {
     // determine what encoding length the character is
     _EncodingLength encodingLength = this->_GetEncodingLength();
     if (encodingLength > std::distance(_it, _end)) {
         // error condition, would read bytes past the end of the range
-        return INVALID_CODE_POINT;
+        return TfUtf8InvalidCodePoint.AsUInt32();
     }
     if (encodingLength == 1)
     {
@@ -49,12 +86,12 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         if (byte1 < static_cast<unsigned char>('\xc2') ||
             byte1 > static_cast<unsigned char>('\xdf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
         if (byte2 < static_cast<unsigned char>('\x80') ||
             byte2 > static_cast<unsigned char>('\xbf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // the code point is constructed from the last 5 bits of byte1
@@ -77,7 +114,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if ((byte1 >= static_cast<unsigned char>('\xe1') &&
@@ -92,7 +129,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xed'))
@@ -104,13 +141,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 4 bits of byte1
@@ -137,7 +174,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 >= static_cast<unsigned char>('\xf1') &&
@@ -153,7 +190,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xf4'))
@@ -168,13 +205,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 is invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 3 bits of byte 1
@@ -182,7 +219,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         return ((byte1 & 0x7) << 18) + ((byte2 & 0x3f) << 12) +
                ((byte3 & 0x3f) << 6) + (byte4 & 0x3f);
     }
-    return INVALID_CODE_POINT;
+    return TfUtf8InvalidCodePoint.AsUInt32();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

Depends on (#2855)

#2788 was added to decode UTF-8 strings into code points.  This change repurposes the encoding logic from #2120 into a wrapper around a `uint32_t`.  This wrapper validates on construction and only stores valid UTF-8 code points (ie. surrogates are excluded). Invalid code points are replaced (silently) with the `ReplacementValue`. A stream operator for serialization is provided.

The `TF_INVALID_CODE_POINT` `uint32_t` has been replaced with a `TfUtf8InvalidCodePoint` `constexpr` instance.

To aid testing, `EndAsIterator()` has been added to the `TfUtf8CodePointView` class which returns an iterator of the same type as `begin()`.  While the language (via range based for loops) supports sentinel `end()` types as of C++17, many STL algorithms don't until C++20. While `EndAsIterator()` this creates redundant copies of the `string_view`'s `end()` value, in non-performance critical code, it may be preferable to enable usage of the STL.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
