### PR TITLE
Handle error cases when no resolvers are available

### DIFF
--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -39,6 +39,7 @@
 #include "pxr/base/plug/registry.h"
 #include "pxr/base/js/utils.h"
 #include "pxr/base/js/value.h"
+#include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/errorMark.h"
 #include "pxr/base/tf/pathUtils.h"
@@ -350,7 +351,11 @@ _GetAvailablePrimaryResolvers(
             break;
         }
     }
-    TF_VERIFY(availablePrimaryResolvers.back().type == defaultResolverType);
+    if (availablePrimaryResolvers.size() > 0) {
+        TF_VERIFY(availablePrimaryResolvers.back().type == defaultResolverType);
+    } else {
+        TF_CODING_ERROR("No primary resolvers could be found.");
+    }
 
     return availablePrimaryResolvers;
 }
@@ -1297,10 +1302,16 @@ private:
         if (uriResolver) {
             return *uriResolver;
         }
+
+        if (!_resolver)
+        {
+            TF_FATAL_CODING_ERROR("Resolver is uninitialized.");
+        }
         
         if (info) {
             *info = &_resolver->info;
         }
+
         return *(_resolver->Get());
     }
 

--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -1305,7 +1305,7 @@ private:
 
         if (!_resolver)
         {
-            TF_FATAL_CODING_ERROR("Resolver is uninitialized.");
+            TF_WARN("Resolver is uninitialized.");
         }
         
         if (info) {


### PR DESCRIPTION
### Description of Change(s)

We were hitting a couple segfaults in a couple spots where resolver initialization was failing (due to other reasons). But this would help provide slightly better diagnostics when we encounter those situations instead.



<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
