### PR TITLE
Allow multiple USD in the same process on MacOS (#93)

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -214,3 +214,18 @@ if (${PXR_BUILD_PYTHON_DOCUMENTATION})
         set(PXR_BUILD_PYTHON_DOCUMENTATION "OFF" CACHE BOOL "" FORCE)
     endif()
 endif()
+
+# Adobe fix
+# On MacOS there are issues with multiple versions of usd in the same
+# process related to globally registering constructors and destructors
+# in the macho header. This is a value which is injected into the version
+# field of the Arch_ConstructorEntry which means the two different usd
+# instances can distinguish entries from different builds.
+# If linking multiple versions of usd you
+# need to make sure each version uses a unique value for each build.
+set(PXR_MACHO_CTR_VERSION "0u"
+    CACHE
+    STRING
+    "Value to make contructor/destructor unique per usd build on Macos"
+)
+# End Adobe fix

--- a/pxr/base/arch/CMakeLists.txt
+++ b/pxr/base/arch/CMakeLists.txt
@@ -60,6 +60,8 @@ pxr_library(arch
         overview.dox
 )
 
+target_compile_definitions(arch PUBLIC PXR_MACHO_CTR_VERSION=${PXR_MACHO_CTR_VERSION})
+
 pxr_build_test_shared_lib(testArchAbiPlugin
     CPPFILES
         testenv/testArchAbiPlugin.cpp

--- a/pxr/base/arch/attributes.cpp
+++ b/pxr/base/arch/attributes.cpp
@@ -208,7 +208,7 @@ AddImage(const struct mach_header* mh, intptr_t slide)
 
     // Execute in priority order.
     for (size_t i = 0, n = entries.size(); i != n; ++i) {
-        if (entries[i].function && entries[i].version == 0u) {
+        if (entries[i].function && entries[i].version == PXR_MACHO_CTR_VERSION) {
             entries[i].function();
         }
     }
@@ -223,7 +223,7 @@ RemoveImage(const struct mach_header* mh, intptr_t slide)
 
     // Execute in reverse priority order.
     for (size_t i = entries.size(); i-- != 0; ) {
-        if (entries[i].function && entries[i].version == 0u) {
+        if (entries[i].function && entries[i].version == PXR_MACHO_CTR_VERSION) {
             entries[i].function();
         }
     }

--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -33,6 +33,10 @@
 #include "pxr/pxr.h"
 #include "pxr/base/arch/export.h"
 
+#ifndef PXR_MACHO_CTR_VERSION
+#define PXR_MACHO_CTR_VERSION 0u
+#endif // PXR_MACHO_CTR_VERSION
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 #if defined(doxygen)
@@ -248,7 +252,7 @@ struct Arch_ConstructorEntry {
     static const Arch_ConstructorEntry _ARCH_CAT_NOEXPAND(arch_ctor_, _name)   \
         __attribute__((used, section("__DATA,pxrctor"))) = {                   \
         reinterpret_cast<Arch_ConstructorEntry::Type>(&_name),                 \
-        0u,                                                                    \
+        PXR_MACHO_CTR_VERSION,                                                 \
         _priority                                                              \
     };                                                                         \
     static void _name(__VA_ARGS__)
@@ -259,7 +263,7 @@ struct Arch_ConstructorEntry {
     static const Arch_ConstructorEntry _ARCH_CAT_NOEXPAND(arch_dtor_, _name)   \
         __attribute__((used, section("__DATA,pxrdtor"))) = {                   \
         reinterpret_cast<Arch_ConstructorEntry::Type>(&_name),                 \
-        0u,                                                                    \
+        PXR_MACHO_CTR_VERSION,                                                 \
         _priority                                                              \
     };                                                                         \
     static void _name(__VA_ARGS__)


### PR DESCRIPTION
### Description of Change(s)
This PR allows loading multiple usd libraries into the same process on macos (assuming they are uniquely namespaced and plugins are loaded from different locations etc).

It's implemented by driving the ArchConstructorEntry's version field through a preprocessor define so that the logic for calling them can distinguish entries from the two different builds and only call the appropriate ones.

This is arguably a hack abusing the field for something it should not be used for but if we change the layout of the struct it will break cases where we don't have control of the other usd instance than the one we are building ourselves since the struct is at play in both usd builds.

Note, I don't necessarily want this PR merged in this form, I just want to point out an issue through a workaround we had to apply to solve an issue.

### Fixes Issue(s)
- Adds the ability to load multiple usd libraries into the same process on macos.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
