### PR TITLE
Cleanup arkit checks

### DIFF
--- a/pxr/usd/bin/usdchecker/usdchecker.py
+++ b/pxr/usd/bin/usdchecker/usdchecker.py
@@ -81,7 +81,7 @@ def main():
                         'aggregate stages.')
     parser.add_argument('--arkit', dest='arkit', action='store_true', 
                         help='Check if the given USD stage is compatible with '
-                        'ARKit\'s initial implementation of usdz. These assets '
+                        'RealityKit\'s implementation of USDZ as of 2023. These assets '
                         'operate under greater constraints that usdz files for '
                         'more general in-house uses, and this option attempts '
                         'to ensure that these constraints are met.')

--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -742,7 +742,7 @@ class ARKitShaderChecker(BaseRuleChecker):
     @staticmethod
     def GetDescription():
         return "Shader nodes must have \"id\" as the implementationSource, "  \
-               "with id values that begin with \"Usd*\". Also, shader inputs "\
+               "with id values that begin with \"Usd*|ND_*\". Also, shader inputs "\
                "with connections must each have a single, valid connection "  \
                "source."
 
@@ -773,7 +773,8 @@ class ARKitShaderChecker(BaseRuleChecker):
            not (shaderId in [NodeTypes.UsdPreviewSurface, 
                              NodeTypes.UsdUVTexture, 
                              NodeTypes.UsdTransform2d] or
-                shaderId.startswith(NodeTypes.UsdPrimvarReader)) :
+                shaderId.startswith(NodeTypes.UsdPrimvarReader) or
+                shaderId.startswith("ND_")) :
             self._AddFailedCheck("Shader <%s> has unsupported info:id '%s'." 
                     % (prim.GetPath(), shaderId))
 

--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -720,7 +720,9 @@ class ARKitPrimTypeChecker(BaseRuleChecker):
                             'Mesh', 'Sphere', 'Cube', 'Cylinder', 'Cone',
                             'Capsule', 'GeomSubset', 'Points', 
                             'SkelRoot', 'Skeleton', 'SkelAnimation', 
-                            'BlendShape', 'SpatialAudio')
+                            'BlendShape', 'SpatialAudio', 'PhysicsScene',
+                            'Preliminary_ReferenceImage', 'Preliminary_Text',
+                            'Preliminary_Trigger')
 
     @staticmethod
     def GetDescription():
@@ -735,8 +737,10 @@ class ARKitPrimTypeChecker(BaseRuleChecker):
 
     def CheckPrim(self, prim):
         self._Msg("Checking prim <%s>." % prim.GetPath())
-        if prim.GetTypeName() not in \
-            ARKitPrimTypeChecker._allowedPrimTypeNames:
+        if (
+            (prim.GetTypeName() not in ARKitPrimTypeChecker._allowedPrimTypeNames) and
+            (not prim.GetTypeName().startswith("RealityKit"))
+        ):
             self._AddFailedCheck("Prim <%s> has unsupported type '%s'." % 
                                     (prim.GetPath(), prim.GetTypeName()))
 


### PR DESCRIPTION
### Description of Change(s)

This updates the ARKit checker based on what is supported as of WWDC 2023 as per this document:
https://developer.apple.com/documentation/realitykit/validating-usd-files

Though as per that doc, there may be some inter-platform variance that cannot be accounted for in the checker. I've aimed for most permissive in those cases.

Changes include:
1. Allowing MaterialX shaders within the USD file, denoted by an `ND_*` prefix.
2. Support new Prim types, including physics schema, RealityKit components and Preliminary schemas
3. Removed the ARKitRootLayerChecker and left a deprecation warning for the flag that invoked it
4. Modified the help docs for usdchecker to specify the year of RealityKit that it is based around. This should help in future iterations to provide more clarity to users as both USD and RealityKit grow.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
