### PR TITLE
Replace `boost::optional` with `std::optional` in `SdfLayer` and `Sdf_TextParserContext`

### DIFF
--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -307,7 +307,7 @@ SdfLayer::_WaitForInitializationAndCheckIfSuccessful()
     // The callers of this method are responsible for checking the result
     // and dropping any references they hold.  As a convenience to them,
     // we return the value here.
-    return _initializationWasSuccessful.get();
+    return _initializationWasSuccessful.value();
 }
 
 static bool
@@ -2954,7 +2954,7 @@ SdfLayer::_ShouldNotify() const
 {
     // Only notify if this layer has been successfully initialized.
     // (If initialization is not yet complete, do not notify.)
-    return _initializationWasSuccessful.get_value_or(false);
+    return _initializationWasSuccessful.value_or(false);
 }
 
 void

--- a/pxr/usd/sdf/layer.h
+++ b/pxr/usd/sdf/layer.h
@@ -45,8 +45,6 @@
 #include "pxr/base/vt/value.h"
 #include "pxr/base/work/dispatcher.h"
 
-#include <boost/optional.hpp>
-
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -1956,7 +1954,7 @@ private:
 
     // This is an optional<bool> that is only set once initialization
     // is complete, before _initializationComplete is set.
-    boost::optional<bool> _initializationWasSuccessful;
+    std::optional<bool> _initializationWasSuccessful;
 
     // remembers the last 'IsDirty' state.
     mutable bool _lastDirtyState;

--- a/pxr/usd/sdf/textParserContext.h
+++ b/pxr/usd/sdf/textParserContext.h
@@ -39,8 +39,6 @@
 
 #include "pxr/base/tf/token.h"
 
-#include <boost/optional.hpp>
-
 #include <string>
 #include <vector>
 
@@ -85,7 +83,7 @@ public:
     bool relParsingAllowTargetData;
     // relationship target paths that will be saved in a list op
     // (use a boost::optional to track whether we have seen an opinion at all.)
-    boost::optional<SdfPathVector> relParsingTargetPaths;
+    std::optional<SdfPathVector> relParsingTargetPaths;
     // relationship target paths that will be appended to the relationship's
     // list of target children.
     SdfPathVector relParsingNewTargetChildren;


### PR DESCRIPTION
### Description of Change(s)

Most of the usage of `boost::optional` is addressed by #2702 and #2715. This PR removes the remaining usage in `SdfLayer` and `Sdf_TextParserContext`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
