### PR TITLE
Replace `boost::ref` with `std::ref`

### DIFF
--- a/pxr/usd/pcp/wrapCache.cpp
+++ b/pxr/usd/pcp/wrapCache.cpp
@@ -78,12 +78,12 @@ _ComputePrimIndex( PcpCache& cache, const SdfPath & path )
     // Wrap the prim index to python as an internal reference on cache.
     // The return_internal_reference<> says that the result is owned
     // by the first argument, the PcpCache, and shouldn't be destroyed
-    // by Python.  The boost::ref() around the arguments ensure that
+    // by Python.  The std::ref() around the arguments ensure that
     // boost python will not make temporary copies of them.
     object pyWrapPrimIndex =
         make_function(_WrapPrimIndex, return_internal_reference<>());
-    object pyPrimIndex(pyWrapPrimIndex(boost::ref(cache),
-                                       boost::ref(primIndex)));
+    object pyPrimIndex(pyWrapPrimIndex(std::ref(cache),
+                                       std::ref(primIndex)));
 
     // Return the prim index and errors to python.
     return boost::python::make_tuple(pyPrimIndex, errors);
@@ -96,12 +96,12 @@ _FindPrimIndex( PcpCache& cache, const SdfPath & path )
         // Wrap the prim index to python as an internal reference on cache.
         // The return_internal_reference<> says that the result is owned
         // by the first argument, the PcpCache, and shouldn't be destroyed
-        // by Python.  The boost::ref() around the arguments ensure that
+        // by Python.  The std::ref() around the arguments ensure that
         // boost python will not make temporary copies of them.
         object pyWrapPrimIndex =
             make_function(_WrapPrimIndex, return_internal_reference<>());
-        object pyPrimIndex(pyWrapPrimIndex(boost::ref(cache),
-                                           boost::ref(*primIndex)));
+        object pyPrimIndex(pyWrapPrimIndex(std::ref(cache),
+                                           std::ref(*primIndex)));
         return pyPrimIndex;
     }
     return boost::python::object();
@@ -131,12 +131,12 @@ _FindPropertyIndex( PcpCache& cache, const SdfPath & path )
         // Wrap the index to python as an internal reference on cache.
         // The return_internal_reference<> says that the result is owned
         // by the first argument, the PcpCache, and shouldn't be destroyed
-        // by Python.  The boost::ref() around the arguments ensure that
+        // by Python.  The std::ref() around the arguments ensure that
         // boost python will not make temporary copies of them.
         object pyWrapPropertyIndex =
             make_function(_WrapPropertyIndex, return_internal_reference<>());
-        object pyPropertyIndex(pyWrapPropertyIndex(boost::ref(cache),
-                                           boost::ref(*propIndex)));
+        object pyPropertyIndex(pyWrapPropertyIndex(std::ref(cache),
+                                           std::ref(*propIndex)));
         return pyPropertyIndex;
     }
     return boost::python::object();


### PR DESCRIPTION
### Description of Change(s)

`std::ref` was introduced in C++11 and can be used in place of `boost::ref`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
