### PR TITLE
Validate code point ordering for non-ASCII range

### DIFF
--- a/pxr/base/tf/unicodeUtils.cpp
+++ b/pxr/base/tf/unicodeUtils.cpp
@@ -27,13 +27,50 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+std::ostream&
+operator<<(std::ostream& stream, const TfUtf8CodePoint codePoint)
+{
+    const auto value = codePoint.AsUInt32();
+    if (value < 0x80)
+    {
+        // 1-byte UTF-8 encoding
+        stream << static_cast<char>(value);
+    }
+    else if (value < 0x800)
+    {
+        // 2-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 6) | 0xc0)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x10000)
+    {
+        // 3-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 12) | 0xe0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x110000)
+    {
+        // 4-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 18) | 0xf0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 12) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else
+    {
+        stream << TfUtf8InvalidCodePoint;
+    }
+    return stream;
+}
+
 uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
 {
     // determine what encoding length the character is
     _EncodingLength encodingLength = this->_GetEncodingLength();
     if (encodingLength > std::distance(_it, _end)) {
         // error condition, would read bytes past the end of the range
-        return INVALID_CODE_POINT;
+        return TfUtf8InvalidCodePoint.AsUInt32();
     }
     if (encodingLength == 1)
     {
@@ -49,12 +86,12 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         if (byte1 < static_cast<unsigned char>('\xc2') ||
             byte1 > static_cast<unsigned char>('\xdf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
         if (byte2 < static_cast<unsigned char>('\x80') ||
             byte2 > static_cast<unsigned char>('\xbf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // the code point is constructed from the last 5 bits of byte1
@@ -77,7 +114,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if ((byte1 >= static_cast<unsigned char>('\xe1') &&
@@ -92,7 +129,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xed'))
@@ -104,13 +141,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 4 bits of byte1
@@ -137,7 +174,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 >= static_cast<unsigned char>('\xf1') &&
@@ -153,7 +190,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xf4'))
@@ -168,13 +205,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 is invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 3 bits of byte 1
@@ -182,7 +219,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         return ((byte1 & 0x7) << 18) + ((byte2 & 0x3f) << 12) +
                ((byte3 & 0x3f) << 6) + (byte4 & 0x3f);
     }
-    return INVALID_CODE_POINT;
+    return TfUtf8InvalidCodePoint.AsUInt32();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeUtils.h
+++ b/pxr/base/tf/unicodeUtils.h
@@ -32,10 +32,59 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/unicodeCharacterClasses.h"
 
+#include <ostream>
 #include <string>
 #include <string_view>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+/// Wrapper for a code point value that can be encoded as UTF-8
+class TfUtf8CodePoint {
+public:
+    /// Code points that cannot be decoded or outside of the valid range are
+    /// may be replaced with this value.
+    static constexpr uint32_t ReplacementValue = 0xFFFD;
+
+    /// Values higher than this will be replaced with the replacement
+    /// code point.
+    static constexpr uint32_t MaximumValue = 0x10FFFF;
+
+    /// Values in this range (inclusive) cannot be constructed and will be
+    /// replaced by the replacement code point.
+    static constexpr std::pair<uint32_t, uint32_t>
+    SurrogateRange = {0xD800, 0xDFFF};
+
+    /// Construct a code point initialized to the replacement value
+    constexpr TfUtf8CodePoint() = default;
+
+    /// Construct a UTF-8 valued code point, constrained by the maximum value
+    /// and surrogate range.
+    constexpr explicit TfUtf8CodePoint(uint32_t value) :
+        _value(((value <= MaximumValue) &&
+                ((value < SurrogateRange.first) ||
+                 (value > SurrogateRange.second))) ?
+               value : ReplacementValue) {}
+
+    constexpr uint32_t AsUInt32() const { return _value; }
+
+    friend constexpr bool operator==(const TfUtf8CodePoint left,
+                                     const TfUtf8CodePoint right) {
+        return left._value == right._value;
+    }
+    friend constexpr bool operator!=(const TfUtf8CodePoint left,
+                                     const TfUtf8CodePoint right) {
+        return left._value != right._value;
+    }
+
+private:
+    uint32_t _value{ReplacementValue};
+};
+
+TF_API std::ostream& operator<<(std::ostream&, const TfUtf8CodePoint);
+
+/// The replacement code point can be used to signal that a code point could
+/// not be decoded and needed to be replaced.
+constexpr TfUtf8CodePoint TfUtf8InvalidCodePoint = TfUtf8CodePoint{0xFFFD};
 
 class TfUtf8CodePointIterator;
 
@@ -49,7 +98,7 @@ class TfUtf8CodePointIterator;
 /// std::string value{"∫dx"};
 /// TfUtf8CodePointView view{value};
 /// for (const uint32_t codePoint : view) {
-///     if (codePoint == TfTfUtf8CodePointIterator::INVALID_CODE_POINT) {
+///     if (codePoint == TfUtf8InvalidCodePoint.AsUInt32()) {
 ///         TF_WARN("String cannot be decoded.");
 ///     }
 /// }
@@ -125,11 +174,9 @@ public:
     using pointer = void;
     using reference = uint32_t;
 
-    static constexpr uint32_t INVALID_CODE_POINT = 0xFFFD;
-
     /// Retrieves the next UTF-8 character in the sequence as its Unicode
-    /// code point value. Returns INVALID_CODE_POINT when the byte sequence
-    /// pointed to by the iterator cannot be decoded.
+    /// code point value. Returns TfUtf8InvalidCodePoint.AsUInt32() when the
+    /// byte sequence pointed to by the iterator cannot be decoded.
     ///
     /// If during read of the UTF-8 character sequence the underlying
     /// string iterator would go beyond \a end defined at construction


### PR DESCRIPTION
### Description of Change(s)

(Depends on #2858)

#2673 updated `TfStringUtils` to order non-ASCII characters by bytes. This was to produce code point ordering for non-ASCII characters.  With the serialization of code points provided by #2858, we can now validate this property with unit testing.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
