### PR TITLE
Boost: Use CXX17

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -283,8 +283,8 @@ def Run(cmd, logCommandOutput = True):
         if verbosity < 3:
             with open("log.txt", "r") as logfile:
                 Print(logfile.read())
-        raise RuntimeError("Failed to run '{cmd}'\nSee {log} for more details."
-                           .format(cmd=cmd, log=os.path.abspath("log.txt")))
+        raise RuntimeError("Failed to run '{cmd}' in {path} .\nSee {log} for more details."
+                           .format(cmd=cmd, path=os.getcwd(),log=os.path.abspath("log.txt")))
 
 @contextlib.contextmanager
 def CurrentWorkingDirectory(dir):
@@ -780,7 +780,7 @@ def InstallBoost_Helper(context, force, buildArgs):
                         primaryArch, secondaryArch)
 
             if macOSArch:
-                bootstrapCmd += " cxxflags=\"{0}\" " \
+                bootstrapCmd += " cxxflags=\"{0} -std=c++17 -stdlib=libc++\" " \
                                 " cflags=\"{0}\" " \
                                 " linkflags=\"{0}\"".format(macOSArch)
             bootstrapCmd += " --with-toolset=clang"
@@ -889,7 +889,7 @@ def InstallBoost_Helper(context, force, buildArgs):
             b2_settings.append("toolset=clang")
 
             if macOSArch:
-                b2_settings.append("cxxflags=\"{0}\"".format(macOSArch))
+                b2_settings.append("cxxflags=\"{0} -std=c++17 -stdlib=libc++\"".format(macOSArch))
                 b2_settings.append("cflags=\"{0}\"".format(macOSArch))
                 b2_settings.append("linkflags=\"{0}\"".format(macOSArch))
 
@@ -903,8 +903,8 @@ def InstallBoost_Helper(context, force, buildArgs):
         AppendCXX11ABIArg("cxxflags", context, b2_settings)
 
         b2 = "b2" if Windows() else "./b2"
-        Run('{b2} {options} install'
-            .format(b2=b2, options=" ".join(b2_settings)))
+        b2_command = '{b2} {options} install'.format(b2=b2, options=" ".join(b2_settings))
+        Run(b2_command)
 
 def InstallBoost(context, force, buildArgs):
     # Boost's build system will install the version.hpp header before


### PR DESCRIPTION
### Description of Change(s)
Splitting this out from https://github.com/PixarAnimationStudios/OpenUSD/pull/2742
Boost doesn't build on newer macOS toolchains because it make use of previous deprecated and now removed std lib functions.

In theory, all platforms should use CXX17 but Boost does some more platform aware logic for other toolchains that mitigate it to some degree. At least on macOS, its best to force Boost to use CXX17


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
