### PR TITLE
Replace `boost::optional` with `std::optional` in `SdfAllowed`

### DIFF
--- a/pxr/usd/sdf/allowed.h
+++ b/pxr/usd/sdf/allowed.h
@@ -30,9 +30,9 @@
 #include "pxr/usd/sdf/api.h"
 #include "pxr/base/tf/diagnostic.h"
 
+#include <optional>
 #include <string>
 #include <utility>
-#include <boost/optional.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -45,7 +45,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 class SdfAllowed {
 private:
-    typedef boost::optional<std::string> _State;
+    typedef std::optional<std::string> _State;
 
 public:
     typedef std::pair<bool, std::string> Pair;
@@ -60,12 +60,13 @@ public:
     SdfAllowed(const std::string& whyNot) : _state(whyNot) { }
     /// Construct in \p condition with annotation \p whyNot if \c false.
     SdfAllowed(bool condition, const char* whyNot) :
-        _state(!condition, std::string(whyNot)) { }
+        SdfAllowed(condition, std::string(whyNot)) { }
     /// Construct in \p condition with annotation \p whyNot if \c false.
     SdfAllowed(bool condition, const std::string& whyNot) :
-        _state(!condition, whyNot) { }
+        _state(condition ? std::nullopt :
+               std::make_optional(whyNot)) { }
     /// Construct from bool,string pair \p x.
-    SdfAllowed(const Pair& x) : _state(!x.first, x.second) { }
+    SdfAllowed(const Pair& x) : SdfAllowed(x.first, x.second) { }
     ~SdfAllowed() { }
 
 #if !defined(doxygen)


### PR DESCRIPTION
### Description of Change(s)

#2864 was meant to replace the remaining usage of `boost::optional` in `sdf`, but missed `SdfAllowed`. This completes that work.

There is still a spurious include in the parser that can be addressed once the UTF-8 work (#2848) is integrated.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
