### PR TITLE
Fix for skipARKitRootLayerCheck warning

### DIFF
--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -906,7 +906,7 @@ class ComplianceChecker(object):
                       ARKitMaterialBindingChecker,
                       ARKitFileExtensionChecker, 
                       ARKitPackageEncapsulationChecker]
-        if not skipARKitRootLayerCheck:
+        if skipARKitRootLayerCheck:
             warnings.warn("skipARKitRootLayerCheck is no longer supported. It will be removed in a future version",
                           PendingDeprecationWarning)
         return arkitRules


### PR DESCRIPTION
### Description of Change(s)
I forgot to remove the `not` in the check when providing the deprecation warning.
https://github.com/PixarAnimationStudios/OpenUSD/pull/2863/

This fixes it so it only warns when the flag is actually supplied as True, since the default is False and would have always triggered. 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
