### PR TITLE
UsdOutput::IsOutput should check attr validity

### DIFF
--- a/pxr/usd/usdShade/output.cpp
+++ b/pxr/usd/usdShade/output.cpp
@@ -181,7 +181,8 @@ UsdShadeOutput::ClearSdrMetadataByKey(const TfToken &key) const
 bool 
 UsdShadeOutput::IsOutput(const UsdAttribute &attr)
 {
-    return TfStringStartsWith(attr.GetName().GetString(), 
+    return attr && attr.IsDefined() &&
+        TfStringStartsWith(attr.GetName().GetString(),
                               UsdShadeTokens->outputs);
 }
 


### PR DESCRIPTION
### Description of Change(s)

UsdShadeOutput::IsOutput should be checking for attr validity like UsdShadeInput::IsInput does.
Thanks to Maddy Adams for catching this and suggesting the fix.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/2876

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
