### PR TITLE
If should only have one f

### DIFF
--- a/pxr/base/gf/camera.h
+++ b/pxr/base/gf/camera.h
@@ -228,10 +228,10 @@ public:
     /// Returns the focus distance in world units.
     GF_API float GetFocusDistance() const;
 
-    /// Equality operator. true iff all parts match.
+    /// Equality operator. true if all parts match.
     GF_API bool operator==(const GfCamera& other) const;
 
-    // Inequality operator. true iff not equality.
+    // Inequality operator. true if not equality.
     GF_API bool operator!=(const GfCamera& other) const;
 
 private:

--- a/pxr/base/gf/frustum.h
+++ b/pxr/base/gf/frustum.h
@@ -199,7 +199,7 @@ class GfFrustum {
         );
     }
 
-    // Equality operator. true iff all parts match.
+    // Equality operator. true if all parts match.
     bool operator ==(const GfFrustum& f) const {
         if (_position       != f._position)        return false;
         if (_rotation       != f._rotation)        return false;
@@ -211,7 +211,7 @@ class GfFrustum {
         return true;
     }
 
-    // Inequality operator. true iff not equality.
+    // Inequality operator. true if not equality.
     bool operator !=(const GfFrustum& f) const {
         return !(*this == f);
     }

--- a/pxr/base/gf/interval.h
+++ b/pxr/base/gf/interval.h
@@ -160,7 +160,7 @@ public:
         return IsMaxFinite() && IsMinFinite();
     }
 
-    /// Return true iff the interval is empty.
+    /// Return true if the interval is empty.
     bool IsEmpty() const {
         return (_min.value > _max.value) ||
             ((_min.value == _max.value)
@@ -176,7 +176,7 @@ public:
     // For 2x compatibility
     double Size() const { return GetSize(); }
 
-    /// Return true iff the value d is contained in the interval.
+    /// Return true if the value d is contained in the interval.
     /// An empty interval contains no values.
     bool Contains(double d) const {
         return ((d > _min.value) || (d == _min.value && _min.closed))
@@ -186,14 +186,14 @@ public:
     // For 2x compatibility
     bool In(double d) const { return Contains(d); }
 
-    /// Return true iff the interval i is entirely contained in the interval.
+    /// Return true if the interval i is entirely contained in the interval.
     /// An empty interval contains no intervals, not even other
     /// empty intervals.
     bool Contains(const GfInterval &i) const {
         return (*this & i) == i;
     }
 
-    /// Return true iff the given interval i intersects this interval.
+    /// Return true if the given interval i intersects this interval.
     bool Intersects(const GfInterval &i) const {
         return !(*this & i).IsEmpty();
     }

--- a/pxr/base/js/rapidjson/error/error.h
+++ b/pxr/base/js/rapidjson/error/error.h
@@ -117,7 +117,7 @@ public:
     //! Get the error offset, if \ref IsError(), 0 otherwise.
     size_t Offset() const { return offset_; }
 
-    //! Explicit conversion to \c bool, returns \c true, iff !\ref IsError().
+    //! Explicit conversion to \c bool, returns \c true, if !\ref IsError().
     operator BooleanType() const { return !IsError() ? &ParseResult::IsError : NULL; }
     //! Whether the result is an error.
     bool IsError() const { return code_ != kParseErrorNone; }

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -151,7 +151,7 @@ public:
     // Replace the list of matches.
     void SetMatchList(const std::string& matchList);
 
-    // Return \c true iff \p s matches the most recently set match list.
+    // Return \c true if \p s matches the most recently set match list.
     bool Match(const char* s) const;
 
 private:

--- a/pxr/base/tf/pyUtils.h
+++ b/pxr/base/tf/pyUtils.h
@@ -128,10 +128,10 @@ inline void TfPyThrowTypeError(std::string const &msg)
     TfPyThrowTypeError(msg.c_str());
 }
 
-/// Return true iff \a obj is None.
+/// Return true if \a obj is None.
 TF_API bool TfPyIsNone(boost::python::object const &obj);
 
-/// Return true iff \a obj is None.
+/// Return true if \a obj is None.
 TF_API bool TfPyIsNone(boost::python::handle<> const &obj);
 
 // Helper for \c TfPyObject().

--- a/pxr/base/tf/token.h
+++ b/pxr/base/tf/token.h
@@ -301,10 +301,10 @@ public:
     /// Allow \c TfToken to be auto-converted to \c string
     operator std::string const& () const { return GetString(); }
     
-    /// Returns \c true iff this token contains the empty string \c ""
+    /// Returns \c true if this token contains the empty string \c ""
     bool IsEmpty() const { return _rep.GetLiteral() == 0; }
 
-    /// Returns \c true iff this is an immortal token.  Note that a return of \c
+    /// Returns \c true if this is an immortal token.  Note that a return of \c
     /// false could be instantly stale if another thread races to immortalize
     /// this token.  A return of \c true is always valid since tokens cannot
     /// lose immortality.

--- a/pxr/base/tf/weakPtr.h
+++ b/pxr/base/tf/weakPtr.h
@@ -277,7 +277,7 @@ TfRefPtr<T>
 TfCreateRefPtrFromProtectedWeakPtr(TfWeakPtr<T> const &p) {
     typedef typename TfRefPtr<T>::_Counter Counter;
     if (T *rawPtr = get_pointer(p)) {
-        // Atomically increment the ref-count iff it's nonzero.
+        // Atomically increment the ref-count if it's nonzero.
         if (Counter::AddRefIfNonzero(rawPtr)) {
             // There was at least 1 other ref at the time we acquired our ref,
             // so this object is safe from destruction.  Transfer ownership of

--- a/pxr/base/vt/value.h
+++ b/pxr/base/vt/value.h
@@ -1082,7 +1082,7 @@ public:
         return _info.GetLiteral() && _TypeIs<T>();
     }
 
-    /// Returns true iff this is holding an array type (see VtIsArray<>).
+    /// Returns true if this is holding an array type (see VtIsArray<>).
     VT_API bool IsArrayValued() const;
 
     /// Return the number of elements in the held value if IsArrayValued(),
@@ -1295,7 +1295,7 @@ public:
         return _CanCast(GetTypeid(), type);
     }
 
-    /// Returns true iff this value is empty.
+    /// Returns true if this value is empty.
     bool IsEmpty() const { return _info.GetLiteral() == 0; }
 
     /// Return true if the held object provides a hash implementation.

--- a/pxr/usd/ndr/declare.h
+++ b/pxr/usd/ndr/declare.h
@@ -112,7 +112,7 @@ public:
     /// Return the minor version number or zero for an invalid version.
     NDR_API
     int GetMinor() const { return _minor; }
-    /// Return true iff this version is marked as default.
+    /// Return true if this version is marked as default.
     NDR_API
     bool IsDefault() const { return _isDefault; }
 
@@ -132,35 +132,35 @@ public:
                 static_cast<std::size_t>(_minor);
     }
 
-    /// Return true iff the version is valid.
+    /// Return true if the version is valid.
     NDR_API
     explicit operator bool() const
     {
         return !!*this;
     }
 
-    /// Return true iff the version is invalid.
+    /// Return true if the version is invalid.
     NDR_API
     bool operator!() const
     {
         return _major == 0 && _minor == 0;
     }
 
-    /// Return true iff versions are equal.
+    /// Return true if versions are equal.
     NDR_API
     friend bool operator==(const NdrVersion& lhs, const NdrVersion& rhs)
     {
         return lhs._major == rhs._major && lhs._minor == rhs._minor;
     }
 
-    /// Return true iff versions are not equal.
+    /// Return true if versions are not equal.
     NDR_API
     friend bool operator!=(const NdrVersion& lhs, const NdrVersion& rhs)
     {
         return !(lhs == rhs);
     }
 
-    /// Return true iff the left side is less than the right side.
+    /// Return true if the left side is less than the right side.
     NDR_API
     friend bool operator<(const NdrVersion& lhs, const NdrVersion& rhs)
     {
@@ -168,7 +168,7 @@ public:
                (lhs._major == rhs._major && lhs._minor < rhs._minor);
     }
 
-    /// Return true iff the left side is less than or equal to the right side.
+    /// Return true if the left side is less than or equal to the right side.
     NDR_API
     friend bool operator<=(const NdrVersion& lhs, const NdrVersion& rhs)
     {
@@ -176,14 +176,14 @@ public:
                (lhs._major == rhs._major && lhs._minor <= rhs._minor);
     }
 
-    /// Return true iff the left side is greater than the right side.
+    /// Return true if the left side is greater than the right side.
     NDR_API
     friend bool operator>(const NdrVersion& lhs, const NdrVersion& rhs)
     {
         return !(lhs <= rhs);
     }
 
-    /// Return true iff the left side is greater than or equal to the right side.
+    /// Return true if the left side is greater than or equal to the right side.
     NDR_API
     friend bool operator>=(const NdrVersion& lhs, const NdrVersion& rhs)
     {

--- a/pxr/usd/pcp/cache.h
+++ b/pxr/usd/pcp/cache.h
@@ -398,7 +398,7 @@ public:
     /// this will compose relationship targets from local nodes only.  If
     /// \p stopProperty is not \c NULL then this will stop composing
     /// relationship targets at \p stopProperty, including \p stopProperty
-    /// iff \p includeStopProperty is \c true.  If not \c NULL, \p deletedPaths
+    /// if \p includeStopProperty is \c true.  If not \c NULL, \p deletedPaths
     /// will be populated with target paths whose deletion contributed to
     /// the computed result.  \p allErrors will contain any errors encountered
     /// while performing this operation.
@@ -417,7 +417,7 @@ public:
     /// this will compose attribute connections from local nodes only.  If
     /// \p stopProperty is not \c NULL then this will stop composing
     /// attribute connections at \p stopProperty, including \p stopProperty
-    /// iff \p includeStopProperty is \c true.  If not \c NULL, \p deletedPaths
+    /// if \p includeStopProperty is \c true.  If not \c NULL, \p deletedPaths
     /// will be populated with connection paths whose deletion contributed to
     /// the computed result.  \p allErrors will contain any errors encountered
     /// while performing this operation.

--- a/pxr/usd/pcp/changes.h
+++ b/pxr/usd/pcp/changes.h
@@ -281,7 +281,7 @@ public:
     PCP_API
     void Swap(PcpChanges& other);
 
-    /// Returns \c true iff there are no changes.
+    /// Returns \c true if there are no changes.
     PCP_API
     bool IsEmpty() const;
 

--- a/pxr/usd/pcp/targetIndex.h
+++ b/pxr/usd/pcp/targetIndex.h
@@ -75,7 +75,7 @@ PcpBuildTargetIndex(
 /// If \p localOnly is \c true then this will compose relationship
 /// targets from local nodes only. If \p stopProperty is not \c
 /// NULL then this will stop composing relationship targets at \p
-/// stopProperty, including \p stopProperty iff \p includeStopProperty
+/// stopProperty, including \p stopProperty if \p includeStopProperty
 /// is \c true.
 ///
 /// \p cacheForValidation is a PcpCache that will be used to compute

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -720,7 +720,7 @@ public:
     /// \name Reader caching
     /// @{
 
-    /// Returns \c true iff a flag is in the set.
+    /// Returns \c true if a flag is in the set.
     bool IsFlagSet(const TfToken& flagName) const;
 
     /// Creates and returns the prim cache for path \p path.

--- a/pxr/usd/plugin/usdAbc/alembicReader.h
+++ b/pxr/usd/plugin/usdAbc/alembicReader.h
@@ -120,7 +120,7 @@ public:
         /// Swaps the contents of this with \p other.
         void Swap(TimeSamples& other);
 
-        /// Returns \c true iff there are no samples.
+        /// Returns \c true if there are no samples.
         bool IsEmpty() const;
 
         /// Returns the number of samples.

--- a/pxr/usd/plugin/usdAbc/alembicTest.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicTest.cpp
@@ -85,7 +85,7 @@ public:
     }
 
 protected:
-    /// Iff this returns \c true, \p id is passed to the wrapped visitor.
+    /// If this returns \c true, \p id is passed to the wrapped visitor.
     /// The default returns \c true.
     virtual bool _Pass(const SdfAbstractData& data,
                        const SdfPath& id) {

--- a/pxr/usd/plugin/usdAbc/alembicUtil.h
+++ b/pxr/usd/plugin/usdAbc/alembicUtil.h
@@ -246,13 +246,13 @@ public:
         return std::visit(_SetTyped<Type>(rhs), _valuePtr);
     }
 
-    /// Returns \c true iff constructed with a NULL pointer.
+    /// Returns \c true if constructed with a NULL pointer.
     bool IsEmpty() const
     {
         return _valuePtr.index() == 0;
     }
 
-    /// Explicit bool conversion operator. Converts to true iff this object was 
+    /// Explicit bool conversion operator. Converts to true if this object was 
     /// constructed with a non-NULL pointer.
     explicit operator bool() const
     {
@@ -430,7 +430,7 @@ public:
         return _value.IsError(message);
     }
 
-    /// Explicit bool conversion operator. Converts to \c true iff the data is 
+    /// Explicit bool conversion operator. Converts to \c true if the data is 
     /// valid.
     explicit operator bool() const
     {

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -133,13 +133,13 @@ public:
     /// Returns a path.
     SdfPath GetPath() const;
 
-    /// Returns \c true iff there are no samples.
+    /// Returns \c true if there are no samples.
     bool IsEmpty() const;
 
     /// Returns the number of samples.
     size_t GetNumSamples() const;
 
-    /// Returns \c true iff the property is time sampled, \c false if
+    /// Returns \c true if the property is time sampled, \c false if
     /// the value was taken from the default or if there were no opinions.
     bool IsTimeSampled() const;
 
@@ -561,10 +561,10 @@ public:
         return AddType(TfToken());
     }
 
-    /// Returns \c true iff the samples are valid.
+    /// Returns \c true if the samples are valid.
     bool IsValid(const UsdSamples&) const;
 
-    /// Returns \c true iff the samples are a shaped type.
+    /// Returns \c true if the samples are a shaped type.
     bool IsShaped(const UsdSamples&) const;
 
     /// Returns the Alembic DataType suitable for the values in \p samples.
@@ -687,7 +687,7 @@ public:
     /// Sets or resets the flag named \p flagName.
     void SetFlag(const TfToken& flagName, bool set);
 
-    /// Returns \c true iff a flag is in the set.
+    /// Returns \c true if a flag is in the set.
     bool IsFlagSet(const TfToken& flagName) const;
 
     /// Adds/returns a time sampling.

--- a/pxr/usd/sdf/listEditorProxy.h
+++ b/pxr/usd/sdf/listEditorProxy.h
@@ -393,7 +393,7 @@ public:
     }
 
     /// Explicit bool conversion operator. A ListEditorProxy object 
-    /// converts to \c true iff the list editor is valid, converts to \c false 
+    /// converts to \c true if the list editor is valid, converts to \c false
     /// otherwise.
     explicit operator bool() const
     {

--- a/pxr/usd/sdf/namespaceEdit.h
+++ b/pxr/usd/sdf/namespaceEdit.h
@@ -238,10 +238,10 @@ public:
         return _edits;
     }
 
-    /// Functor that returns \c true iff an object exists at the given path.
+    /// Functor that returns \c true if an object exists at the given path.
     typedef std::function<bool(const SdfPath&)> HasObjectAtPath;
 
-    /// Functor that returns \c true iff the namespace edit will succeed.
+    /// Functor that returns \c true if the namespace edit will succeed.
     /// If not it returns \c false and sets the string argument.
     typedef std::function<bool(const SdfNamespaceEdit&,std::string*)> CanEdit;
 
@@ -259,9 +259,9 @@ public:
     ///
     /// This function needs help to determine if edits are allowed.  The
     /// callbacks provide that help.  \p hasObjectAtPath returns \c true
-    /// iff there's an object at the given path.  This path will be in the
+    /// if there's an object at the given path.  This path will be in the
     /// original namespace not any intermediate or final namespace.
-    /// \p canEdit returns \c true iff the object at the current path can
+    /// \p canEdit returns \c true if the object at the current path can
     /// be namespace edited to the new path, ignoring whether an object
     /// already exists at the new path.  Both paths are in the original
     /// namespace.  If it returns \c false it should set the string to the

--- a/pxr/usd/sdf/site.h
+++ b/pxr/usd/sdf/site.h
@@ -79,7 +79,7 @@ public:
         return !(*this < other);
     }
 
-    /// Explicit bool conversion operator. A site object converts to \c true iff 
+    /// Explicit bool conversion operator. A site object converts to \c true if
     /// both the layer and path fields are filled with valid values, \c false
     /// otherwise.
     /// This does NOT imply that there are opinions in the layer at that path.

--- a/pxr/usd/sdf/valueTypeName.h
+++ b/pxr/usd/sdf/valueTypeName.h
@@ -131,12 +131,12 @@ public:
     SDF_API
     SdfValueTypeName GetArrayType() const;
 
-    /// Returns \c true iff this type is a scalar.  The invalid type is
+    /// Returns \c true if this type is a scalar.  The invalid type is
     /// considered neither scalar nor array.
     SDF_API
     bool IsScalar() const;
 
-    /// Returns \c true iff this type is an array.  The invalid type is
+    /// Returns \c true if this type is an array.  The invalid type is
     /// considered neither scalar nor array.
     SDF_API
     bool IsArray() const;

--- a/pxr/usd/usd/clip.h
+++ b/pxr/usd/usd/clip.h
@@ -184,7 +184,7 @@ public:
     /// been opened already.
     SdfLayerHandle GetLayer() const;
 
-    /// Return the layer associated with this clip iff it has already been
+    /// Return the layer associated with this clip if it has already been
     /// opened successfully.
     ///
     /// USD tries to be as lazy as possible about opening clip layers to

--- a/pxr/usd/usd/doxygen/commonIdioms.dox
+++ b/pxr/usd/usd/doxygen/commonIdioms.dox
@@ -65,7 +65,7 @@ In general, you should use CreateXXXAttr() when authoring scene description,
 and GetXXXAttr() when reading/importing scene description.  CreateXXXAttr() 
 also allows you to specify a default value to assign to the attribute, which
 you can specify to author sparsely, which means that we will refrain from
-authoring the provided value iff:
+authoring the provided value if:
 \li there is currently no authored value for the attribute on the composed
 prim
 \li the attribute has a fallback value on the composed prim, and the fallback

--- a/pxr/usd/usd/resolver.h
+++ b/pxr/usd/usd/resolver.h
@@ -80,7 +80,7 @@ public:
     /// Advances the resolver to the next weaker Layer in the layer
     /// stack, if the current LayerStack has no more layers, the resolver will
     /// be advanced to the next weaker PcpNode. If no layers are available, the
-    /// resolver will be marked as invalid.  Returns \c true iff the resolver
+    /// resolver will be marked as invalid.  Returns \c true if the resolver
     /// advanced to another node or became invalid.
     ///
     /// If the resolver is already invalid, the behavior of this function is 

--- a/pxr/usd/usd/testenv/testUsdResolveTarget.cpp
+++ b/pxr/usd/usd/testenv/testUsdResolveTarget.cpp
@@ -218,7 +218,7 @@ _VerifyQuery(
         TfStringify(expectedTimeSampleTimes).c_str());
 
     // Since this test currently doesn't involve clips, we expect 
-    // ValueMightBeTimeVarying to be true iff we expect more than one time 
+    // ValueMightBeTimeVarying to be true if we expect more than one time
     // sample.
     if (expectedTimeSampleValues.size() > 1) {
         TF_VERIFY(attrQuery.ValueMightBeTimeVarying());

--- a/pxr/usd/usd/testenv/testUsdResolveTargetPy.py
+++ b/pxr/usd/usd/testenv/testUsdResolveTargetPy.py
@@ -52,7 +52,7 @@ class TestUsdResolveTargetPy(unittest.TestCase):
         self.assertEqual(attrQuery.GetTimeSamples(), expectedTimeSampleTimes)
 
         # Since this test currently doesn't involve clips, we expect 
-        # ValueMightBeTimeVarying to be true iff we expect more than one time 
+        # ValueMightBeTimeVarying to be true if we expect more than one time
         # sample.
         if len(expectedTimeSampleTimes) > 1:
             self.assertTrue(attrQuery.ValueMightBeTimeVarying())

--- a/pxr/usd/usd/testenv/testUsdSchemaVersioning.py
+++ b/pxr/usd/usd/testenv/testUsdSchemaVersioning.py
@@ -974,21 +974,21 @@ class TestUsdSchemaRegistry(unittest.TestCase):
         # values given the instances for the given schema it is expected to have
         def _VerifyHasAPIInstances(prim, schemaInfo, expectedHasInstanceNames):
             # Verify the return value for all calls to HasAPI without a 
-            # specified instance name. We expect these to return true iff we
+            # specified instance name. We expect these to return true if we
             # expect the prim to have any instances of the schema.
             if expectedHasInstanceNames:
                 self._VerifyHasAPI(prim, schemaInfo)
             else:
                 self._VerifyNotHasAPI(prim, schemaInfo)
             
-            # Verify all calls to HasAPI "foo" return true iff we expect the
+            # Verify all calls to HasAPI "foo" return true if we expect the
             # prim to have a "foo" instance of the schema.
             if "foo" in expectedHasInstanceNames:
                 self._VerifyHasAPIInstance(prim, schemaInfo, "foo")
             else:
                 self._VerifyNotHasAPIInstance(prim, schemaInfo, "foo")
 
-            # Verify all calls to HasAPI "bar" return true iff we expect the
+            # Verify all calls to HasAPI "bar" return true if we expect the
             # prim to have a "bar" instance of the schema.
             if "bar" in expectedHasInstanceNames:
                 self._VerifyHasAPIInstance(prim, schemaInfo, "bar")
@@ -1002,7 +1002,7 @@ class TestUsdSchemaRegistry(unittest.TestCase):
                 prim, schemaInfo, versionPolicy, expectedHasInstanceNames):
             # Verify the return value for all calls to HasAPIInFamily
             # without a specified instance name. We expect these to return true
-            # iff we expect the prim to have any instances of the schema.
+            # if we expect the prim to have any instances of the schema.
             if expectedHasInstanceNames:
                 self._VerifyHasAPIInFamily(
                     prim, schemaInfo, versionPolicy)
@@ -1010,7 +1010,7 @@ class TestUsdSchemaRegistry(unittest.TestCase):
                 self._VerifyNotHasAPIInFamily(
                     prim, schemaInfo, versionPolicy)
             
-            # Verify all calls to HasAPIInFamily "foo" return true iff
+            # Verify all calls to HasAPIInFamily "foo" return true if
             # we expect the# prim to have a "foo" instance of the schema.
             if "foo" in expectedHasInstanceNames:
                 self._VerifyHasAPIInFamilyInstance(
@@ -1019,7 +1019,7 @@ class TestUsdSchemaRegistry(unittest.TestCase):
                 self._VerifyNotHasAPIInFamilyInstance(
                     prim, schemaInfo, versionPolicy, "foo")
 
-            # Verify all calls to HasAPIInFamily "bar" return true iff
+            # Verify all calls to HasAPIInFamily "bar" return true if
             # we expect the prim to have a "bar" instance of the schema.
             if "bar" in expectedHasInstanceNames:
                 self._VerifyHasAPIInFamilyInstance(

--- a/pxr/usd/usdGeom/constraintTarget.h
+++ b/pxr/usd/usdGeom/constraintTarget.h
@@ -117,7 +117,7 @@ public:
     
     /// \anchor UsdGeomConstraintTarget_explicit_bool
     /// Explicit bool conversion operator. A ConstraintTarget object converts
-    /// to \c true iff it is valid for querying and authoring values and 
+    /// to \c true if it is valid for querying and authoring values and
     /// metadata (which is identically equivalent to IsDefined()). It converts
     /// to \c false otherwise.
     explicit operator bool() const {

--- a/pxr/usd/usdGeom/xformOp.h
+++ b/pxr/usd/usdGeom/xformOp.h
@@ -338,7 +338,7 @@ public:
 public:
     /// \anchor UsdGeomXformOp_explicit_bool
     /// Explicit bool conversion operator. An XformOp object converts to 
-    /// \c true iff it is valid for querying and authoring values and metadata, 
+    /// \c true if it is valid for querying and authoring values and metadata,
     /// (which is identically equivalent to IsDefined()), and converts to 
     /// \c false otherwise.
     explicit operator bool() const {

--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -1394,13 +1394,13 @@ _Context::AddVariants(const mx::ConstElementPtr& mtlx)
                 variant[_Name(mtlxValue)] = mtlxValue;
             }
 
-            // Keep the variant iff there was something in it.
+            // Keep the variant if there was something in it.
             if (!variant.empty()) {
                 variantSet[_Name(mtlxVariant)] = std::move(variant);
             }
         }
 
-        // Keep the variant set iff there was something in it.
+        // Keep the variant set if there was something in it.
         if (!variantSet.empty()) {
             auto& variantSetName = _Name(mtlxVariantSet);
             _variantSets[variantSetName] = std::move(variantSet);

--- a/pxr/usd/usdMtlx/utils.h
+++ b/pxr/usd/usdMtlx/utils.h
@@ -95,7 +95,7 @@ UsdMtlxGetDocumentFromString(const std::string &mtlxXml);
 // Return the version of the mtlx element.  If the version cannot be
 // found then return an invalid default version.  If implicitDefault
 // isn't null then we do to two things:  we set implicitDefault to
-// false iff the isdefaultversion attribute exists and isn't empty,
+// false if the isdefaultversion attribute exists and isn't empty,
 // otherwise we set it to true;  and we return the version as a
 // default if isdefaultversion exists and is set to "true".
 USDMTLX_API
@@ -137,7 +137,7 @@ struct UsdMtlxUsdTypeInfo {
     /// then zero.  For "dynamic arrays" this will be zero.
     int arraySize;
 
-    /// \c true iff the value type name is an exact match to the
+    /// \c true if the value type name is an exact match to the
     /// MaterialX type.
     bool valueTypeNameIsExact;
 };

--- a/pxr/usd/usdSkel/utils.cpp
+++ b/pxr/usd/usdSkel/utils.cpp
@@ -1123,7 +1123,7 @@ _ResizeInfluences(VtArray<T>* array, int srcNumInfluencesPerComponent,
         array->resize(numComponents*newNumInfluencesPerComponent);
     } else {
         // Expand influences in-place.
-        // This is possible IFF all elements are copied in *reverse order*
+        // This is possible IF all elements are copied in *reverse order*
         array->resize(numComponents*newNumInfluencesPerComponent);
 
         auto* data = array->data();

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewPrimTreeExpansion/testUsdviewPrimTreeExpansion.py
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewPrimTreeExpansion/testUsdviewPrimTreeExpansion.py
@@ -168,7 +168,7 @@ def _testAllExpanded(appController):
     
     # If we have a selected prim, and the stage mutates such that that prim 
     # no longer exists on the stage, it should be safely pruned from the 
-    # selection, which should revert to the pseudoroot iff there are no other
+    # selection, which should revert to the pseudoroot if there are no other
     # remaining selected prims
     _expandPrims(appController, ["/spheres", "/A", "/A/B", "/A/B/C"])
     _selectAndSetActive(appController, True, ["/A/B/C"])

--- a/pxr/usdImaging/usdImaging/cylinderAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/cylinderAdapter.cpp
@@ -151,7 +151,7 @@ UsdImagingCylinderAdapter::TrackVariability(UsdPrim const& prim,
     // attribute is _not_ varying.  Since we have multiple attributes (and the
     // base adapter invocation) that might result in the bit being set, we need
     // to be careful not to reset it.  Translation: only check _IsVarying for a
-    // given cause IFF the bit wasn't already set by a previous invocation.
+    // given cause IF the bit wasn't already set by a previous invocation.
     if ((*timeVaryingBits & HdChangeTracker::DirtyPoints) == 0) {
         _IsVarying(prim, UsdGeomTokens->height,
                    HdChangeTracker::DirtyPoints,

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1719,7 +1719,7 @@ class AppController(QtCore.QObject):
 
         # Usage of OCIO is driven by the OCIO env var.
         # * Disable OCIO color management option if env var isn't set.
-        # * Populate the OCIO menu items iff PyOpenColorIO module and
+        # * Populate the OCIO menu items if PyOpenColorIO module and
         #   a valid config file was found.
         if not os.environ.get('OCIO'):
             self._disableOCIOAction()

--- a/pxr/usdImaging/usdviewq/settings.py
+++ b/pxr/usdImaging/usdviewq/settings.py
@@ -376,7 +376,7 @@ class ConfigManager:
         ----------
         newName : str
             The name of the config we will be saving to (it may or may not
-            exist in the _configDirPath). Iff same as defaultConfig, we save on
+            exist in the _configDirPath). If same as defaultConfig, we save on
             application close.
         """
         if newName:

--- a/third_party/renderman-25/plugin/hdPrman/renderParam.cpp
+++ b/third_party/renderman-25/plugin/hdPrman/renderParam.cpp
@@ -3075,7 +3075,7 @@ HdPrman_RenderParam::UpdateQuickIntegrator(
 // delegate construction. See HdPrmanExperimentalRenderSpecTokens->camera
 // and _tokens->renderCameraPath (latter is used by Solaris).
 //
-// When the said camera is sync'd, we commit its shutter interval IFF it is
+// When the said camera is sync'd, we commit its shutter interval IF it is
 // the one to use for rendering. See HdPrman_Camera::Sync.
 //
 // This "shutter interval discovery" issue may not be relevant when using the


### PR DESCRIPTION
### Description of Change(s)
I noticed that a lot of older USD files seemed to have had a find/replace accident where `if` was replaced with `iff`.
This is a rather boring PR that just finds all uses of `iff`, and drops the second `f`.

Edit: some folks mentioned that it might have meant [If and only if](https://en.wikipedia.org/wiki/If_and_only_if) which was not an abbreviation that I was aware of. Feel free to disregard if that's the case, but I might suggest adding a disclaimer in the docs somewhere to point to that?

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
