### PR TITLE
PEGTL Text File Format Parser

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -51,6 +51,8 @@ option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)
+option(PXR_ENABLE_LEGACY_TEXT_FILE_FORMAT_PARSER
+    "Enables the legacy yacc parser and disables the new pegtl parser" OFF)
 
 # Determine GFX api
 # Metal only valid on Apple platforms
@@ -214,4 +216,11 @@ if (${PXR_BUILD_PYTHON_DOCUMENTATION})
             "PXR_ENABLE_PYTHON_SUPPORT=OFF")
         set(PXR_BUILD_PYTHON_DOCUMENTATION "OFF" CACHE BOOL "" FORCE)
     endif()
+endif()
+
+# enable the yacc legacy parser if the option is on
+if(${PXR_ENABLE_LEGACY_TEXT_FILE_FORMAT_PARSER})
+    message(STATUS
+        "Using legacy yacc text file format parser")
+    add_definitions(-DPXR_SDF_TEXT_FILE_FORMAT_LEGACY_PARSER)
 endif()

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -69,6 +69,7 @@ pxr_library(sdf
         spec
         specType
         textFileFormat
+        textFileFormatParser
         timeCode
         tokens
         types
@@ -350,6 +351,14 @@ pxr_build_test(testSdfPredicateExpression_Cpp
         testenv/testSdfPredicateExpression.cpp
 )
 
+pxr_build_test(testSdfTextFileFormatParsing
+    LIBRARIES
+        sdf
+        tf
+    CPPFILES
+        testenv/testSdfTextFileFormatParsing.cpp
+)
+
 pxr_install_test_dir(
     SRC testenv/testSdfBatchNamespaceEdit.testenv
     DEST testSdfBatchNamespaceEdit/testSdfBatchNamespaceEdit.testenv
@@ -509,6 +518,10 @@ pxr_register_test(testSdfPathThreading
 
 pxr_register_test(testSdfPredicateExpression_Cpp
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPredicateExpression_Cpp"
+)
+
+pxr_register_test(testSdfTextFileFormatParsing
+   COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTextFileFormatParsing"
 )
 
 pxr_register_test(testSdfPayload

--- a/pxr/usd/sdf/debugCodes.h
+++ b/pxr/usd/sdf/debugCodes.h
@@ -38,6 +38,15 @@ TF_DEBUG_CODES(
     SDF_VARIABLE_EXPRESSION_PARSING
 );
 
+////////////////////////////////////////////////////////////////////////
+// Debugging Symbols for Grammar
+// These symbols can be turned off at compile time by setting the first
+// argument value to `false`.
+TF_CONDITIONALLY_COMPILE_TIME_ENABLED_DEBUG_CODES(
+    true,
+    SDF_TEXT_FILE_FORMAT_RULES
+);
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // PXR_USD_SDF_DEBUG_CODES_H

--- a/pxr/usd/sdf/testenv/testSdfTextFileFormatParsing.cpp
+++ b/pxr/usd/sdf/testenv/testSdfTextFileFormatParsing.cpp
@@ -1,0 +1,1525 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/diagnostic.h"
+#include "pxr/usd/sdf/textFileFormatParser.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace PEGTL_NS = Sdf_TextFileFormatParser::PEGTL_NS;
+
+template <typename T>
+bool DoParse(const std::string& expression)
+{
+    try
+    {
+        Sdf_TextParserContext context;
+        context.magicIdentifierToken = "sdf";
+        context.versionString = "1.4.32";
+
+        std::cout << "Parsing " << expression << "\n";
+        if(!PEGTL_NS::parse<T, Sdf_TextFileFormatParser::TextParserAction>(
+            PEGTL_NS::string_input<> { expression ,""}, context))
+        {
+            return false;
+        }
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+        return false;
+    }
+
+    return true;    
+}
+
+bool
+TestDigits()
+{
+    std::vector<std::string> validExpressions = {
+        "0",
+        "12345",
+        "98765",
+        "02345",
+        "-0",
+        "-12345",
+        "-98765",
+        "-02345",
+        "0.425436",
+        ".625462",
+        "-0.43626",
+        ".9097456",
+        "0e2359670",
+        "12345e2359670",
+        "98765e2359670",
+        "02345e2359670",
+        "-0e2359670",
+        "-12345e2359670",
+        "-98765e2359670",
+        "-02345e2359670",
+        "0.425436e2359670",
+        ".625462e2359670",
+        "-0.43626e2359670",
+        ".9097456e2359670",
+        "12345E2359670",
+        "98765E2359670",
+        "02345E2359670",
+        "-0E2359670",
+        "-12345E2359670",
+        "-98765E2359670",
+        "-02345E2359670",
+        "0.425436E2359670",
+        ".625462E2359670",
+        "-0.43626E2359670",
+        ".9097456E2359670",
+        "12345e-2359670",
+        "98765e-2359670",
+        "02345e-2359670",
+        "-0e-2359670",
+        "-12345e-2359670",
+        "-98765e-2359670",
+        "-02345e-2359670",
+        "0.425436e-2359670",
+        ".625462e-2359670",
+        "-0.43626e-2359670",
+        ".9097456e-2359670",
+        "12345E-2359670",
+        "98765E-2359670",
+        "02345E-2359670",
+        "-0E-2359670",
+        "-12345E-2359670",
+        "-98765E-2359670",
+        "-02345E-2359670",
+        "0.425436E-2359670",
+        ".625462E-2359670",
+        "-0.43626E-2359670",
+        ".9097456E-2359670",
+        "-0e+2359670",
+        "-12345e+2359670",
+        "-98765e+2359670",
+        "-02345e+2359670",
+        "0.425436e+2359670",
+        ".625462e+2359670",
+        "-0.43626e+2359670",
+        ".9097456e+2359670",
+        "12345E+2359670",
+        "98765E+2359670",
+        "02345E+2359670",
+        "-0E+2359670",
+        "-12345E+2359670",
+        "-98765E+2359670",
+        "-02345E+2359670",
+        "0.425436E+2359670",
+        ".625462E+2359670",
+        "-0.43626E+2359670",
+        ".9097456E+2359670",
+        "inf",
+        "-inf",
+        "nan"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "-",
+        "-nan",
+        "0.",
+        "0e",
+        "e",
+        "E",
+        "E324",
+        "-.E324",
+        "-.",
+        "0345346a",
+        "63.42534t",
+        "-23452.e",
+        "8476.343e",
+        "4264einf",
+        "45346e-inf",
+        "3456-",
+        ".inf",
+        ".nan",
+        "-.inf",
+        "-.nan"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(), 
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::Number, PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::Number, PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestIdentifiers()
+{
+    std::vector<std::string> validIdentifiers = {
+        "foo",
+        "foo_bar",
+        "_foo",
+        "_12432foo",
+        "foo1257__",
+        "foo_1235_bar__",
+        "foo::bar",
+        "foo::bar::baz",
+        "FOO",
+        "FOO::BAR",
+        "foo__::__bar::_4BAZ99_"
+    };
+
+    std::vector<std::string> invalidIdentifiers = {
+        "1foo",
+        "connect",
+        "rel",
+        "0foo",
+        "-inf",
+        "None",
+        "foo:bar",
+        "foo:bar:baz",
+        "foo_bar:baz",
+        "FOO::bAr84_:baz",
+        "foo::relocates",
+        "foo/234"
+    };
+
+    TF_AXIOM(std::all_of(validIdentifiers.begin(), 
+        validIdentifiers.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::Identifier, PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidIdentifiers.begin(),
+        invalidIdentifiers.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::Identifier, PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validNamespacedNames = {
+        "foo:bar",
+        "foo:bar:baz",
+        "foo_bar:baz",
+        "FOO:bAr84_:baz",
+        "foo",
+        "_foo",
+        "foo_12345_bar__",
+        "relocates",
+        "def",
+        "over",
+        "rootPrims:specializes:over"
+    };
+
+    std::vector<std::string> invalidNamespacedNames = {
+        "foo::bar",
+        "foo::bar::baz",
+        "0foo",
+        "f71.3124o7125o",
+        "foo/234",
+        "/"
+    };
+
+    TF_AXIOM(std::all_of(validNamespacedNames.begin(),
+        validNamespacedNames.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::NamespacedName, PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidNamespacedNames.begin(),
+        invalidNamespacedNames.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+            Sdf_TextFileFormatParser::NamespacedName, PEGTL_NS::eof>>(expression);
+        }));
+
+    // valid dictionary value types include all identifiers
+    // plus identifiers with [] possibly padded with spaces / tabs
+    // we algorithmically build this test from the existing identifiers
+    size_t i = 1;
+    std::vector<std::string> validTypeNames = validIdentifiers;
+    for (const std::string& str : validIdentifiers)
+    {
+        std::string typeName = str;
+        if ((i%2) == 0)
+        {
+            // pad tabs on front
+            for (size_t numTabs = 0; numTabs < i; numTabs++)
+            {
+                typeName += "\t";
+            }
+
+            typeName += "[]";
+        }
+        else
+        {
+            // pad spaces on front
+            for (size_t numSpaces = 0; numSpaces < i; numSpaces++)
+            {
+                typeName += " ";
+            }
+
+            typeName += "[]";
+        }
+
+        validTypeNames.push_back(typeName);
+        i++;
+    }
+
+    // all invalid identifiers are invalid type names
+    std::vector<std::string> invalidTypeNames = invalidIdentifiers;
+    invalidTypeNames.push_back("foo \n []");
+    invalidTypeNames.push_back("foo [3]");
+
+    TF_AXIOM(std::all_of(validTypeNames.begin(),
+        validTypeNames.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::DictionaryValueType,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidTypeNames.begin(),
+        invalidTypeNames.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::DictionaryValueType,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true; 
+}
+
+bool
+TestStrings()
+{
+    // analyze will fail with custom actions like those we need for strings
+    // so we skip the analyze part
+    std::vector<std::string> validSingleLineStrings = {
+        "'a simple string'",
+        "'a simple string with a couple of utf-8 characters ß篲ü濯'",
+        "'a string with an escaped \\''",
+        "'a string with an escaped character \\b\\b'",
+        "'ß___\\y\\x'",
+        "'a string with embedded double quote\"'"
+    };
+
+    std::vector<std::string> invalidSingleLineStrings = {
+        "'''",
+        "'a string with an embedded CR \r'",
+        "'a string with no end quote",
+        "'a string with an embedded LF \n'",
+        "'a string with an attempt at escaping \''",
+        "'a string with a properly escaped \\' but ending wrong''",
+    };
+
+    TF_AXIOM(std::all_of(validSingleLineStrings.begin(),
+        validSingleLineStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::SinglelineSingleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidSingleLineStrings.begin(),
+        invalidSingleLineStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::SinglelineSingleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validMultiLineStrings = {
+        "'''a simple multi-line string\n'''",
+        "'''a \n many \n lined \r\n multi-line \n string\n'''",
+        "'''a multiline string \n\n\n\r\n with an escaped \\'\\' set\n'''",        
+        "'''\n\n A string \n containing \n utf-8 characters\n ß篲ü濯 \n '''"
+    };
+
+    std::vector<std::string> invalidMultiLineStrings = {
+        "'''\nan \nunterminated multi-\r\nline string",
+        "'''An incorrectly \n terminated multi-line string''",
+        "'''\n\n A string \n containing \n utf-8 characters\n ß篲ü濯 \n ''\\''",
+        "'A regular single quote string'"
+    };
+
+    TF_AXIOM(std::all_of(validMultiLineStrings.begin(),
+        validMultiLineStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::MultilineSingleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidMultiLineStrings.begin(),
+        invalidMultiLineStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::MultilineSingleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validSingleLineDoubleQuoteStrings = {
+        "\"a simple string\"",
+        "\"a simple string with a couple of utf-8 characters ß篲ü濯\"",
+        "\"a string with an escaped \\\"\"",
+        "\"a string with an escaped character \\b\\b\"",
+        "\"ß___\\y\\x\"",
+        "\"a string with embedded single quote '\""
+    };
+
+    std::vector<std::string> invalidSingleLineDoubleQuoteStrings = {
+        "\"\"\"",
+        "\"a string with an embedded CR \r\"",
+        "\"a string with no end quote",
+        "\"a string with an embedded LF \n\"",
+        "\"a string with an attempt at escaping \\ \"\"",
+        "\"a string with a properly escaped \\\" but ending wrong\"\"",
+    };
+
+    TF_AXIOM(std::all_of(validSingleLineDoubleQuoteStrings.begin(),
+        validSingleLineDoubleQuoteStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::SinglelineDoubleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidSingleLineDoubleQuoteStrings.begin(),
+        invalidSingleLineDoubleQuoteStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::SinglelineDoubleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validMultiLineDoubleQuoteStrings = {
+        "\"\"\"a simple multi-line string\n\"\"\"",
+        "\"\"\"a \n many \n lined \r\n multi-line \n string\n\"\"\"",
+        "\"\"\"a multiline string \n\n\n\r\n with"
+        " an escaped \\\"\\\" set\n\"\"\"",
+        "\"\"\"\n\n A string \n containing \n "
+        "utf-8 characters\n ß篲ü濯 \n \"\"\""
+    };
+
+    std::vector<std::string> invalidMultiLineDoubleQuoteStrings = {
+        "\"\"\"\nan \nunterminated multi-\r\nline string",
+        "\"\"\"An incorrectly \n terminated multi-line string\"\"",
+        "\"\"\"\n\n A string \n containing \n "
+        "utf-8 characters\n ß篲ü濯 \n ''\\'\"\"",
+        "\"A regular single quote string\""
+    };
+
+    TF_AXIOM(std::all_of(validMultiLineDoubleQuoteStrings.begin(),
+        validMultiLineDoubleQuoteStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::MultilineDoubleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidMultiLineDoubleQuoteStrings.begin(),
+        invalidMultiLineDoubleQuoteStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::MultilineDoubleQuoteString,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validMixedStrings = {
+        "''",
+        "\"\"",
+        "''''''",
+        "\"\"\"\"\"\"",
+        "\"a simple string\"",
+        "'''a multiline string \n\n\n\r\n with an escaped \\'\\' set\n'''",
+        "'''\n\n\n\n\n\\'\\'\n\n\n'''",
+        "\"\"\"''\\\"\\\"\'\n\n\n\n\n\n\n\"\"\""
+    };
+
+    std::vector<std::string> invalidMixedStrings = {
+        "'",
+        "\"",
+        "'''''",
+        "\"\"\"\"\"",
+        "\"a string with a properly escaped \\\" but ending wrong\"\"",
+        "\"\"\"\n\n A string \n containing \n "
+        "utf-8 characters\n ß篲ü濯 \n ''\\'\"\"",
+        "'''\n\n A string \n containing \n utf-8 characters\n ß篲ü濯 \n ''\\''",
+        "'''\n\n\n\n\n\n''\n\n\n\n\n'''"
+    };
+
+    TF_AXIOM(std::all_of(validMixedStrings.begin(),
+        validMixedStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::String,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidMixedStrings.begin(),
+        invalidMixedStrings.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::String,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestAssetRefs()
+{
+    std::vector<std::string> validExpressions = {
+        "@@",
+        "@c:\\foo\\bar_baz\\foo@",
+        "@foo__34-123\\ß篲ü濯@",
+        "@@@C:foobar_bazfoo@@@",
+        "@@@c:\\foo\\bar_baz\\foo@@@",
+        "@@@foo__34-123\\ß篲ü濯@@@",
+        "@@@c:\\foo\\@@@\\@@_@_\\@@@@@@"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "@c:\\foo\\@bar_baz\\foo@",
+        "@@@c:\\foo@@@\\@@_@_\\@@@@@@"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::AssetRef,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::AssetRef,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPathRefs()
+{
+    std::vector<std::string> validExpressions = {
+        "</Foo/Bar.baz>",
+        "<Foo>",
+        "<Foo/Bar>",
+        "<Foo.bar>",
+        "<Foo/Bar.bar>",
+        "<.bar>",
+        "</Some/Kinda/Long/Path/Just/To/Make/Sure>",
+        "<Some/Kinda/Long/Path/Just/To/Make/Sure.property>",
+        "<../Some/Kinda/Long/Path/Just/To/Make/Sure>",
+        "<../../Some/Kinda/Long/Path/Just/To/Make/Sure.property>",
+        "</Foo/Bar.baz[targ].boom>",
+        "<Foo.bar[targ].boom>",
+        "<.bar[targ].boom>",
+        "<Foo.bar[targ.attr].boom>",
+        "</A/B/C.rel3[/Blah].attr3>",
+        "<A/B.rel2[/A/B/C.rel3[/Blah].attr3].attr2>",
+        "</A.rel1[/A/B.rel2[/A/B/C.rel3[/Blah].attr3].attr2].attr1>"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "</Foo/Bar.baz",
+        "<DD/DDD.&ddf$>",
+        "<DD[]/DDD>",
+        "<DD[]/DDD.bar>",
+        "<foo.prop/bar>",
+        "</foo.prop/bar.blah>",
+        "</foo.prop/bar.blah>",
+        "</foo//bar>",
+        "</foo/.bar>",
+        "</foo..bar>",
+        "</foo.bar.baz>",
+        "</.foo>",
+        "</foo.bar",
+        "</Foo/Bar/>",
+        "</Foo.bar[targ]/Bar>",
+        "</Foo.bar[targ].foo.foo>",
+        "<123>",
+        "<123test>",
+        "</Foo:Bar>",
+        "</Foo.bar.mapper[/Targ.attr].arg:name:space>",
+        "</root_utf8_umlaute_ß_3>"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PathRef,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PathRef,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestTupleValues()
+{
+    std::vector<std::string> validExpressions = {
+        "(-inf)",
+        "(-inf,)",
+        "(  -923452345.2,            .234125e+56243   ,)",
+        "(foo, bar, baz)",
+        "(   foo   , bar, baz)",
+        "(\n \"this is a string value\", -67.45e2311, \n\n 'another string',)",
+        "(\"\"\"a multiline \n \n string as a tuple value\n\"\"\")",
+        "(@this is an asset references in a tuple@, foo, nan)",
+        "(45.75, @@@an escaped asset reference @ in \\@@@ a tuple@@@)",
+        "(foo,   bar,    baz,)",
+        "(-0.56e-456,   foo,            0, 0.56, bar)",
+        "(\n-inf)",
+        "(\r\n-inf,)",
+        "(\r  -923452345.2,            .234125e+56243   ,)",
+        "(foo, bar, baz\n)",
+        "(\nfoo,  \n bar,  \n  baz,)",
+        "(-0.56e-456,   foo,            0, 0.56, bar\r\n)",
+        "(\n  foo, \n  bar  ,\n  (\n    baz,\n\n    567.3e-45\n)\n\n\n)"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "(",
+        ")",
+        "()",
+        "(foo, bar, ())",
+        "\n(foo, bar, baz)",
+        "(varying)",
+        "(foo, uniform)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::TupleValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::TupleValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestListValues()
+{
+    std::vector<std::string> validExpressions = {
+        "[-inf]",
+        "[-inf,]",
+        "[  -923452345.2,            .234125e+56243   ,]",
+        "[foo, bar, baz]",
+        "[   foo   , bar, baz]",
+        "[\n \"this is a string value\", -67.45e2311, \n\n 'another string',]",
+        "[\"\"\"a multiline \n \n string as a list value\n\"\"\"]",
+        "[@this is an asset references in a list@, foo, nan]",
+        "[45.75, @@@an escaped asset reference @ in \\@@@ a list@@@]",
+        "[foo,   bar,    baz,]",
+        "[-0.56e-456,   foo,            0, 0.56, bar]",
+        "[\n-inf]",
+        "[\r\n-inf,]",
+        "[\r  -923452345.2,            .234125e+56243   ,]",
+        "[foo, bar, baz\n]",
+        "[\nfoo,  \n bar,  \n  baz,]",
+        "[-0.56e-456,   foo,            0, 0.56, bar\r\n]",
+        "[\n  foo, \n  bar  ,\n  (\n    baz,\n\n    567.3e-45\n)\n\n\n]",
+        "[\n  foo, \n  bar  ,\n  [\n    baz,\n\n    567.3e-45\n]\n\n\n]",
+        "[\n  foo, \n  bar  ,\n  (\n    baz,\n\n"
+        "    567.3e-45\n)  , [(4.5, -2)]    , \n\n\n]"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "[",
+        "]",
+        "[]",
+        "[foo, bar, []]",
+        "[foo, bar, ()]",
+        "\n[foo, bar, baz]",
+        "[varying]",
+        "[foo, uniform]",
+        "[foo, bar, \n  (7, config)]"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::ListValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::ListValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestDictionaryValues()
+{
+    std::vector<std::string> validExpressions = {
+        "{}",
+        "{\n\n\n\n}",
+        "{\r\n\r\n\n\r}",
+        "{  \n   \n  \n  }",
+        "{\n\nfoo \"bar_key\"=[foo, bar, baz]\n}",
+        "{\n\nfoo \"bar_key\"     =       [foo, bar, baz];\n}",
+        "{\n\ndictionary \"bar_key\"     =       "
+        "{float foo = bar; int bar=baz; newType baz=foo;};\n}",
+        "{\n\ndictionary \"bar_key\"     =       "
+        "{float foo = bar\nint bar=baz\nnewType baz=foo;};\n}",
+        "{foo_   uniform  =  \"myValue\"}",
+        "{foo_   _bar_234  =  \"\"\"my\n\nValue\"\"\"}",
+        "{\n    dictionary foo={double key=-23.6e7}    ;"
+        "\n\n foo_type baz_key   =  \"bazValue\"\n\n string add = "
+        "(\"keyword_test\");\n\n}"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "{",
+        "{foo=bar add=baz}",
+        "{float foo=bar double add=baz}",
+        "{dictionary foo=bar add=baz}",
+        "{foo=2;bar=\"string\";baz=;}",
+        "{foo=2;bar=\"string\";baz=foo;;;}",
+        "no_open_brace = \"foo\";}",
+        "{\n\ndictionary foo \"bar_key\"     =       [foo, bar, baz];\n}",
+        "{\n\ndictionary \"bar_key\"     =       [foo, bar, baz];\n}",
+        "{\n    dictionary foo={double key=-23.6e7}    ;"
+        "\n\n foo_type baz_key   =  \"bazValue\"\n\n; add = "
+        "(\"keyword_test\");\n\n}"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::DictionaryValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::DictionaryValue,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestMetadata()
+{
+    std::vector<std::string> validExpressions = {
+        "()",
+        "(    \t   \t\t\t     )",
+        "(\r\n\n\n\r)",
+        "(  \r    \n\n\n\n\n  \n\n   \n\n )",
+        "(\"a comment\" ; \"another comment\"; \n \n \n )",
+        "(\n\tfoo =    baz\n\ndoc     =  \"my doc\"   ;  "
+        "\n\t\treorder foo   =  None\ndelete bar::baz    ="
+        "    [\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n)",
+        "(doc=\"\"\"all list\n ops\n\"\"\";delete foo =[\"not an empty list\"]"
+        " ;\nadd bar::baz= [@@@asset\\ref\\@@@@@@ , [ 123e45]];prepend "
+        "foo_bar=[\"string1\",'string2'];\nappend foo2bar5=[(34, 45, 56)]"
+        "\n\nreorder foo2::bar5=[-.9876];\n)",
+        "(\n\npermission=foo;)",
+        "(permission=foo::bar)",
+        "(symmetryFunction=)",
+        "(doc=\"test of symmetryFunction\"\nsymmetryFunction=foo::bar;)"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "(",
+        ")",
+        "(\r\n\n  \n doc=\"several metadata items not properly "
+        "separated\"\nfoo=bar baz=foo)",
+        "(doc=\"no close parenthesis\";",
+    };
+
+    std::vector<std::string> invalidRelationshipOnlyExpressions = {
+        "(\t   doc=\"test of displayUnit\"\n    displayUnit = foo)",
+        "(displayUnit         =\t\t  foo::bar::baz)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimRelationshipMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimRelationshipMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidRelationshipOnlyExpressions.begin(),
+        invalidRelationshipOnlyExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimRelationshipMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    // all of the above metadata should also be valid prim attribute metadata
+    // but prim attributes also have displayUnit, so we check both the original
+    // set and a few new ones
+    std::vector<std::string> validAdditionalExpressions = {
+        "(\t   doc=\"test of displayUnit\"\n    displayUnit = foo)",
+        "(displayUnit         =\t\t  foo::bar::baz)"
+    };
+
+    std::vector<std::string> invalidAdditionalExpressions = {
+        "(displayUnit=)",
+        "(doc='An invalid display unit definition'\n    "
+        "displayUnit=foo:bar:baz)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttributeMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttributeMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::all_of(validAdditionalExpressions.begin(),
+        validAdditionalExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttributeMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidAdditionalExpressions.begin(),
+        invalidAdditionalExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttributeMetadataList,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPrimRelationship()
+{
+    std::vector<std::string> validExpressions = {
+        "add rel add:delete",
+        "delete custom rel foo_bar_23 = None",
+        "prepend custom varying rel FOO_=[]",
+        "append varying rel F00OO = <Foo.bar[targ.attr].boom>",
+        "reorder rel foo =[<Foo.bar[targ.attr].boom>,  \n<.bar>]",
+        "add   \t\t   \t  rel  \t\t  add:delete",
+        "prepend\t\t\tvarying            rel my:relationship=[<Foo.bar"
+        "[targ.attr].boom>,\n\n<Foo.bar[targ.attr].boom>,"
+        "\r\n<Foo.bar[targ.attr].boom>,\n]",
+        "rel F00OO = [  <Foo.bar[targ.attr].boom>   ]",
+        "custom varying rel add:delete.timeSamples     \t  = {\n\n 24.567e23 "
+        "  : @foo\\asset\\ref@  ,\t\n foo: \"string value\",bar    :(\""
+        "tuple_value\", -65.8),\n45.65    :\t None\n}",
+        "varying \t\t rel foo.\tdefault\t\t = <.bar>",
+        "rel myRel = <.bar> (doc=\"\"\"all list\n ops\n\"\"\";delete foo ="
+        "[\"not an empty list\"] ;\nadd bar::baz= [@@@asset\\ref\\@@@@@@ , "
+        "[ 123e45]];prepend foo_bar=[\"string1\",'string2'];\nappend foo2bar5="
+        "[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)",
+        "custom rel withoutAssignment   (\n\tfoo =    baz\n\ndoc     =  \"my "
+        "doc\"   ;  \n\t\treorder foo   =  None\ndelete bar::baz    =    "
+        "[\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n)"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "add",
+        "rel",
+        "custom varying rel foo.",
+        "custom rel varying foo",
+        "varying rel badMetadata=<.bar>(displayUnit=mm)",
+        "custom varying rel add:delete.timeSamples     \t  = {\n\n 24.567e23"
+        "   : @foo\\asset\\ref@  ,\t\n foo: \"string value\",(\"tuple_value\""
+        ", -65.8),\n45.65    :\t None\n}",
+        "prepend\t\t\tvarying            rel my:relationship=[<Foo.bar"
+        "[targ.attr].boom>\n\n<Foo.bar[targ.attr].boom>,\r\n<Foo.bar"
+        "[targ.attr].boom>,\n]",
+        "custom rel withoutAssignment\n\n(\n\tfoo =    baz\n\ndoc     "
+        "=  \"my doc\"   ;  \n\t\treorder foo   =  None\ndelete bar::baz    "
+        "=    [\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimRelationship,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimRelationship,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPrimAttribute()
+{
+    std::vector<std::string> validExpressions = {
+        "custom float[] add:delete:rootPrims",
+        "float3 foo",
+        "uniform half bar_\t\t=  \"not a valid value but validated later\"",
+        "double3   [] foo.connect      =     None",
+        "add int2 foo:bar.connect=[]",
+        "delete myType _F00_.connect\t=[\n\n\n\n]",
+        "prepend foo[] __:connect:_.connect=<Foo.bar[targ.attr].boom>",
+        "append string bar__\t.\t  connect    \t\t =[<Foo.bar[targ.attr].boom>]",
+        "reorder foo::bar[] _baz00.connect=[<Foo.bar[targ.attr].boom>,"
+        "\n<Foo.bar[targ.attr].boom>,]",
+        "custom_type my:custom:type:instance:_:add.\t\ttimeSamples = "
+        "{\n\n 24.567e23   : @foo\\asset\\ref@  ,\t\n foo: \"string value\","
+        "bar    :(\"tuple_value\", -65.8),\n45.65    :\t None\n}",
+        "uniform int3 foo          =     (7, 6,\n 2)(displayUnit=mm)",
+        "config int3 foo\t= (\n7,2,\n\n5)(doc=\"\"\"all list\n ops\n\"\"\";"
+        "delete foo =[\"not an empty list\"] ;\nadd bar::baz= [@@@asset\\ref\\@@@@@@ , "
+        "[ 123e45]];prepend foo_bar=[\"string1\",'string2'];\nappend foo2bar5="
+        "[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)"
+    };
+    
+    std::vector<std::string> invalidExpressions = {
+        "noTypeAttribute",
+        "custom\nfloat[] add:delete:rootPrims",
+        "double3   [].connect",
+        "config int3 foo\t= (\n7,2,\n\n5)\n(doc=\"\"\"all list\n ops\n\"\"\";"
+        "delete foo =[\"not an empty list\"] \n;\nadd bar::baz= [@@@asset\\ref"
+        "\\@@@@@@ , [ 123e45]];prepend foo_bar=[\"string1\",'string2'];\n"
+        "append foo2bar5=[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876]\n;\n)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttribute,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimAttribute,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPrimProperty()
+{
+    // a prim property is either a relationship or attribute
+    // so we take all the valid relationships and attributes
+    // we had in the individual tests, combine them and make
+    // sure the rule parses (or doesn't for the invalid ones)
+    std::vector<std::string> validExpressions = {
+        "add rel add:delete",
+        "delete custom rel foo_bar_23 = None",
+        "prepend custom varying rel FOO_=[]",
+        "append varying rel F00OO = <Foo.bar[targ.attr].boom>",
+        "reorder rel foo =[<Foo.bar[targ.attr].boom>,\n<.bar>]",
+        "add   \t\t   \t  rel  \t\t  add:delete",
+        "prepend\t\t\tvarying            rel my:relationship=[<Foo.bar[targ.attr]."
+        "boom>,\n\n<Foo.bar[targ.attr].boom>,\r\n<Foo.bar[targ.attr].boom>,\n]",
+        "rel F00OO = [  <Foo.bar[targ.attr].boom>   ]",
+        "custom varying rel add:delete.timeSamples     \t  = {\n\n 24.567e23   : "
+        "@foo\\asset\\ref@  ,\t\n foo: \"string value\",bar    :(\"tuple_"
+        "value\", -65.8),\n45.65    :\t None\n}",
+        "varying \t\t rel foo.\tdefault\t\t = <.bar>",
+        "rel myRel = <.bar> (doc=\"\"\"all list\n ops\n\"\"\";delete foo "
+        "=[\"not an empty list\"] ;\nadd bar::baz= [@@@asset\\ref\\@@@@@@ , "
+        "[ 123e45]];prepend foo_bar=[\"string1\",'string2'];\nappend "
+        "foo2bar5=[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)",
+        "custom rel withoutAssignment(\n\tfoo =    baz\n\ndoc     =  \"my "
+        "doc\"   ;  \n\t\treorder foo   =  None\ndelete bar::baz    =    "
+        "[\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n)",
+        "custom float[] add:delete:rootPrims",
+        "float3 foo",
+        "uniform half bar_\t\t=  \"not a valid value but validated later\"",
+        "double3   [] foo.connect      =     None",
+        "add int2 foo:bar.connect=[]",
+        "delete myType _F00_.connect\t=[\n\n\n\n]",
+        "prepend foo[] __:connect:_.connect=<Foo.bar[targ.attr].boom>",
+        "append string bar__\t.\t  connect    \t\t ="
+        "[<Foo.bar[targ.attr].boom>]",
+        "reorder foo::bar[] _baz00.connect=[<Foo.bar[targ.attr].boom>,"
+        "\n<Foo.bar[targ.attr].boom>,]",
+        "custom_type my:custom:type:instance:_:add.\t\ttimeSamples = "
+        "{\n\n 24.567e23   : @foo\\asset\\ref@  ,\t\n foo: \"string value\","
+        "bar    :(\"tuple_value\", -65.8),\n45.65    :\t None\n}",
+        "uniform int3 foo          =     (7, 6,\n 2)(displayUnit=mm)",
+        "config int3 foo\t= (\n7,2,\n\n5)(doc=\"\"\"all list\n ops\n\"\"\";"
+        "delete foo =[\"not an empty list\"] ;\nadd bar::baz= [@@@asset\\ref\\"
+        "@@@@@@ , [ 123e45]];prepend foo_bar=[\"string1\",'string2'];\nappend "
+        "foo2bar5=[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "add",
+        "rel",
+        "custom varying rel foo.",
+        "custom rel varying foo",
+        "custom varying rel add:delete.timeSamples     \t  = "
+        "{\n\n 24.567e23   : @foo\\asset\\ref@  ,\t\n foo: \""
+        "string value\",(\"tuple_value\", -65.8),\n45.65    :\t None\n}",
+        "prepend\t\t\tvarying            rel my:relationship="
+        "[<Foo.bar[targ.attr].boom>\n\n<Foo.bar[targ.attr].boom>,"
+        "\r\n<Foo.bar[targ.attr].boom>,\n]",
+        "noTypeAttribute",
+        "custom\nfloat[] add:delete:rootPrims",
+        "double3   [].connect",
+        "config int3 foo\t= (\n7,2,\n\n5)\n(doc=\"\"\"all list\n "
+        "ops\n\"\"\";delete foo =[\"not an empty list\"] \n;\nadd bar::"
+        "baz= [@@@asset\\ref\\@@@@@@ , [ 123e45]];prepend foo_bar=[\""
+        "string1\",'string2'];\nappend foo2bar5=[(34, 45, 56)]\n\n"
+        "reorder foo2::bar5=[-.9876]\n;\n)",
+        "custom rel withoutAssignment\n\n(\n\tfoo =    baz\n\ndoc     "
+        "=  \"my doc\"   ;  \n\t\treorder foo   =  None\ndelete bar::"
+        "baz    =    [\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n)"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimProperty,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimProperty,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPrimMetadata()
+{
+    std::vector<std::string> validExpressions = {
+        "\n\n\n",
+        "\n()",
+        "(\n\n\n)",
+        "()",
+        "(\"one piece of prim metadata\"    ;\n\n)",
+        "('foo'; foo=\"\"\"bar\n\n\"\"\"   ; foo   =\t\t34.64\n\nadd __  =  "
+        "None;delete foo\t=[-89.723   , \"foo_string\"]    ;prepend foo_bar="
+        "[bar\t, baz::foo]\nappend _056245 =    \t[@c:\\asset\\ref\\path@  "
+        ",];\n\n\n\n\nreorder _my__f00  = None;)",
+        "(    doc=\"\"\"my_Documentation \n\n string\n\"\"\")",
+        "(kind\t   =  '____'  ;   \n\n)",
+        "(kind = \"class\"\npermission=__foo)",
+        "\n\n  (\t\tpayload\t\t = \tNone\n\npayload  =[]; payload=[  \n  \n  "
+        "\n];payload=[\n\n@./asset1@  , @@@escaped_asset\\@@@_1@@@   ,\n\n])",
+        "(payload=[@my_layer_ref@</my/path/ref>  (offset =  45\n  scale = 2.6)"
+        "  ,  <just/a/path/ref>])",
+        "(add payload=\t\t[@my_layer_ref@</my/path/ref>  (offset =  45\n  "
+        "scale = 2.6)  ,  <just/a/path/ref>] ;\n\n  delete payload=\t\t"
+        "[@my_layer_ref@</my/path/ref>  (offset =  45\n  scale = 2.6)  ,  "
+        "<just/a/path/ref>])",
+        "(  prepend payload=\t\t[@my_layer_ref@</my/path/ref>  (offset =  "
+        "45\n  scale = 2.6)  ,  <just/a/path/ref>] ;\n\n  append payload="
+        "\t\t[@my_layer_ref@</my/path/ref>  (offset =  45\n  scale = 2.6)  "
+        ",  <just/a/path/ref>])",
+        "(reorder payload=\t\t[<just/a/path/ref>   \t,\n@my_layer_ref@"
+        "</my/path/ref>  (offset =  45\n  scale = 2.6)  ,  ])",
+        "(references =  [] ;  \n  references = None)",
+        "(references=[@@@my_lay@@er_ref@@@</my/path/ref>  (offset =  "
+        "45\n  scale = 2.6)])",
+        "(references=[@@@my_lay@@er_ref@@@</my/path/ref>  ()])",
+        "(references=[@@@my_lay@@er_ref@@@</my/path/ref>  (  \n\n)])",
+        "(references=[@@@my_lay@@er_ref@@@</my/path/ref>  (  customData "
+        "= { float \"my_key\" = 457.0e23})])",
+        "(kind = \"custom_kind_01\"\nsymmetryFunction=\nsymmetryFunction="
+        "my_symmetry_function;prefixSubstitutions = {};suffixSubstitutions = "
+        "{'key1':'my_value', 'key2':'68.32'})",
+        "(explicit=foo_valu3\n'some string metadata')",
+        "(inherits =  []\n\n inherits=[];inherits=[\n\n\n  ]\ninherits=[ "
+        "</my/prim_path/path>    ,\n <my/other/prim/path>]  \n)",
+        "(add inherits = [<this/new/prim/path> ];delete inherits=[]\n\nappend "
+        "inherits=   [</prim/path/p1.property>, </prim/path/p2>   ];  prepend "
+        "inherits = [</this/other/prim/path>  ]; reorder inherits = [</prim/"
+        "path/p2>, </this/other/prim/path> ])",
+        "(specializes = \t[]\nspecializes=[    \n\n\t\t  ]; specializes=None"
+        "\n\nspecializes = [</prim/path/p1.property>, </prim/path/p2>   ,])",
+        "(add specializes = []; \n\n delete specializes = None\n\nprepend "
+        "specializes = [\n];append specializes = [</prim/path/p1.property>, "
+        "\n</prim/path/p2>]\n\n\n  reorder specializes = [</another/prim/"
+        "path.with_property>])",
+        "(  relocates = {}; relocates = {\n\n   }  ;relocates={\n\n</prim/"
+        "path/p1.property>  :   </another/prim/path.with_property>, \n\n</"
+        "another/prim/path.with_property> : <prim/path/p1.property>})",
+        "(  variants = {\n\n  float3[] add = (8.3, 0.5,\n  6.7)\n\nstring "
+        "shadingVariant = \"red\";})",
+        "(\n\tvariants = {\n\t\tstring shadingVariant = \"green\"\n\t}\n\t"
+        "prepend variantSets = \"shadingVariant\"\n)",
+        "(variantSets=[\"shadingVariant1\",\"shadingVariant2\",\"shadingVariant3"
+        "\",\"shadingVariant4\",\"shadingVariant5\"])",
+        "(\tvariantSets = [\"shadingVariant1\"  , \"shadingVariant2\",\n"
+        "\"shadingVariant3\", 'shadingVariant4', \"\"\"shadingVariant5\"\"\"\n\n])",
+        "(add variantSets=[\n\"shadingVariant\"]\ndelete variantSets="
+        "[\"shadingVariant\"]; prepend variantSets=\"___\"\n append variantSets="
+        "[\"56\", \"anotherVariant\"]; reorder variantSets    =\t[\n\n"
+        "\"anotherVariant\",\n\n\"variant2\",\n])"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "(",
+        "(kind=   =  '____'  ;   \n\n)",
+        "(kind-class)",
+        "(payload=[@my_layer_ref@</my/path/ref>  (offset =  45\n  scale = 2.6)"
+        "  ;  <just/a/path/ref>])",
+        "(references=[@@@my_lay@@er_ref@@@</my/path/ref>  (  customData = "
+        "{ \"my_key\" = 457.0e23})])",
+        "(kind = \"custom_kind_01\"\nsymmetryFunction=\nsymmetryFunction="
+        "my_symmetry_function;displayUnit=mm\n\n\n;permission=\tfoo)",
+        "(kind = \"custom_kind_01\"\nsymmetryFunction=\nsymmetryFunction="
+        "my_symmetry_function;prefixSubstitutions = {};suffixSubstitutions "
+        "= {'key1'='my_value', 'key2'='68.32'})",
+        "(variantSets=[])",
+        "(variantSets=[56])",
+        "(variantSets=[\"variant1\", 56])",
+        "(\tvariantSets = [\"shadingVariant1\"  , \"shadingVariant2\"\n\""
+        "shadingVariant3\", 'shadingVariant4', \"\"\"shadingVariant5\"\"\"\n\n])"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimMetadata,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimMetadata,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestVariantSetStatement()
+{
+    std::vector<std::string> validVariantStatements = {
+        "\"blue\" {}",
+        "\"blue\" {\n\t}",
+        "\"blue\" {\n\t}\n"
+    };
+
+    std::vector<std::string> invalidVariantStatements = {
+        "\"blue {}",
+        "\"blue\" {"
+    };
+
+    TF_AXIOM(std::all_of(validVariantStatements.begin(),
+        validVariantStatements.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::VariantStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidVariantStatements.begin(),
+        invalidVariantStatements.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::VariantStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validExpressions = {
+        "variantSet \"shadingVariant\" = { \"blue\" {}}",
+        "variantSet 'shadingVaraint' = {'blue'{}'green'{}}",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n}",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t}\n}",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tvariantSet \"subShadingVariant\" =\n\t\t"
+        "{\n\t\t\t\"scarlet\" {\n\t\t\t}\n\t\t}\t\n}\n}",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tover \"world\"\n\t\t{}\n\t\n}\n}",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tover \"world\"\n\t\t{\n\t\t\tcolor3f[] "
+        "primvars:displayColor = [(1, 0, 0)]\n\t\t}\n\t\n}\n}"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "variantSet",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tvariantSet \"subShadingVariant\" =\n\t\t"
+        "{\n\t\t\t\"scarlet\" {\n\t\t\t}\n\t\t}\t\n}\n}\n",
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::VariantSetStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::VariantSetStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestPrim()
+{
+    std::vector<std::string> validExpressions = {
+        "custom float[] add:delete:rootPrims\n",
+        "float3 foo;",
+        "uniform half bar_\t\t=  \"not a valid value but validated later\"\n",
+        "double3   [] foo.connect      =     None;",
+        "add int2 foo:bar.connect=[]\n",
+        "delete myType _F00_.connect\t=[\n\n\n\n];",
+        "prepend foo[] __:connect:_.connect=<Foo.bar[targ.attr].boom>\n",
+        "append string bar__\t.\t  connect    \t\t =[<Foo.bar"
+        "[targ.attr].boom>];",
+        "reorder foo::bar[] _baz00.connect=[<Foo.bar[targ.attr].boom>,\n"
+        "<Foo.bar[targ.attr].boom>,]\n",
+        "custom_type my:custom:type:instance:_:add.\t\ttimeSamples = {\n\n "
+        "24.567e23   : @foo\\asset\\ref@  ,\t\n foo: \"string value\",bar    "
+        ":(\"tuple_value\", -65.8),\n45.65    :\t None\n};",
+        "uniform int3 foo          =     (7, 6,\n 2)(displayUnit=mm)\n",
+        "config int3 foo\t= (\n7,2,\n\n5)(doc=\"\"\"all list\n ops\n\"\"\";"
+        "delete foo =[\"not an empty list\"] \t;\nadd bar::baz= [@@@asset\\ref"
+        "\\@@@@@@ , [ 123e45]];prepend foo_bar=[\"string1\",'string2'];\n"
+        "append foo2bar5=[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)\n",
+        "add rel add:delete\n",
+        "delete custom rel foo_bar_23 = None;",
+        "prepend custom varying rel FOO_=[]\n",
+        "append varying rel F00OO = <Foo.bar[targ.attr].boom>;",
+        "reorder rel foo =[<Foo.bar[targ.attr].boom>,\n<.bar>]\n",
+        "add   \t\t   \t  rel  \t\t  add:delete;",
+        "prepend\t\t\tvarying            rel my:relationship=[<Foo.bar"
+        "[targ.attr].boom>,\n\n<Foo.bar[targ.attr].boom>,\r\n<Foo.bar"
+        "[targ.attr].boom>,\n]\n",
+        "rel F00OO = [  <Foo.bar[targ.attr].boom>   ];",
+        "custom varying rel add:delete.timeSamples     \t  = {\n\n "
+        "24.567e23   : @foo\\asset\\ref@  ,\t\n foo: \"string value\","
+        "bar    :(\"tuple_value\", -65.8),\n45.65    :\t None\n}\n",
+        "varying \t\t rel foo.\tdefault\t\t = <.bar>;",
+        "rel myRel = <.bar> (doc=\"\"\"all list\n ops\n\"\"\";delete foo ="
+        "[\"not an empty list\"] ;\nadd bar::baz= [@@@asset\\ref\\@@@@@@ , "
+        "[ 123e45]];prepend foo_bar=[\"string1\",'string2'];\nappend foo2bar5="
+        "[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876];\n)\n",
+        "custom rel withoutAssignment(\n\tfoo =    baz\n\ndoc     =  \"my doc\""
+        "   ;  \n\t\treorder foo   =  None\ndelete bar::baz    =    [\"myString\""
+        ", (23.4, -inf, @assetRef\\path@)]\n\n);",
+        "variantSet \"shadingVariant\" = { \"blue\" {}}\n",
+        "variantSet 'shadingVaraint' = {'blue'{}'green'{}}\n",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n}\n",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t}\n}\n",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tvariantSet \"subShadingVariant\" =\n\t\t"
+        "{\n\t\t\t\"scarlet\" {\n\t\t\t}\n\t\t}\t\n}\n}\n",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tover \"world\"\n\t\t{}\n\t\n}\n}\n",
+        "variantSet \"shadingVariant\" = {\n\t\"blue\" {\n\t}\n\n\t\"green\" "
+        "{\n\t}\n\n\t\"red\" {\n\t\tover \"world\"\n\t\t{\n\t\t\tcolor3f[] "
+        "primvars:displayColor = [(1, 0, 0)]\n\t\t}\n\t\n}\n}\n",
+        "reorder nameChildren = [\"foo\", \"bar\"];",
+        "reorder nameChildren = ['foo', 'bar',\n 'baz']\n",
+        "reorder properties = ['prop1', \"_prop2\"];"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "custom float[] add:delete:rootPrims",
+        "float3 foo",
+        "variantSet \"shadingVariant\" = { \"blue\" {}};",
+        "config int3 foo\t= (\n7,2,\n\n5)\n(doc=\"\"\"all list\n ops\n\"\"\";"
+        "delete foo =[\"not an empty list\"] \n;\nadd bar::baz= [@@@asset\\ref"
+        "\\@@@@@@ , [ 123e45]];prepend foo_bar=[\"string1\",'string2'];\n"
+        "append foo2bar5=[(34, 45, 56)]\n\nreorder foo2::bar5=[-.9876]\n;\n);",
+        "custom rel withoutAssignment\n\n(\n\tfoo =    baz\n\ndoc     =  "
+        "\"my doc\"   ;  \n\t\treorder foo   =  None\ndelete bar::baz    "
+        "=    [\"myString\", (23.4, -inf, @assetRef\\path@)]\n\n);"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimContentsListItem,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimContentsListItem,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    std::vector<std::string> validPrimStatements = {
+        "def \"foo\" {}",
+        "def F00 \"foo\" {}",
+        "class \"foo\" {}",
+        "class _ \"foo\" {}",
+        "over \"foo\" {}",
+        "over __ \"B_A_5\" {}",
+        "reorder rootPrims = ['foo', '_', \"\"\"B_A_5\"\"\"]",
+        "def Xform \"hello\"\n{\n\tdef Sphere \"world\"\n\t{\n\t}\n}"
+    };
+
+    std::vector<std::string> invalidPrimStatements = {
+        "def",
+        "def foo {}",
+        "def Xform \"hello\"\n{\n\tdef Sphere \"world\"\n\t{\n\t}}"
+    };
+
+    TF_AXIOM(std::all_of(validPrimStatements.begin(),
+        validPrimStatements.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidPrimStatements.begin(),
+        invalidPrimStatements.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::PrimStatement,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestLayerMetadata()
+{
+    std::vector<std::string> validExpressions = {
+        "\n",
+        "\n\n\n",
+        "()",
+        "\n(\n)\n",
+        "(\"layerMetadata\"; foo = (3, 2, 1); doc=\"\"\"some documentation "
+        "for\n layer \n metadata\n\"\"\"\n)",
+        "(add foo = None\ndelete foo = [3, \"5 in a string\", bar,];prepend "
+        "_=[(1, 2, \"3\")]\nappend F00 = None;\n\n\nreorder "
+        "foo =\t[bar, baz, foo::bar])",
+        "(subLayers = [])",
+        "(subLayers = [];subLayers=[\n\n\n])",
+        "(subLayers = [];subLayers=[\n\n\n]\nsubLayers\t=\t"
+        "[\n\n@an/asset/ref@])",
+        "(subLayers = [];subLayers=[\n\n\n]\nsubLayers\t=\t"
+        "[\n\n@an/asset/ref@];subLayers=[@another/asset/ref@"
+        "(offset = 6;\n scale=4.5e0)])"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "(",
+        "\n\n(\n\n",
+        "subLayers=[@@@an/asset/path@@@(offset=\"myOffset\")]",
+        "(add foo = None\ndelete foo = [3, \"5 in a string\", bar,];"
+        "prepend _=[(1, 2, \"3\")\nappend = None;\n\n\nreorder "
+        "foo =\t[bar, baz, foo::bar])",
+        "(subLayers = [];subLayers=[\n\n\n]\nsubLayers\t=\t[\n\n@an/"
+        "asset/ref@];subLayers=[@another/asset/ref@[offset = 6,\n scale=4.5e0]])"
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::LayerMetadata,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::LayerMetadata,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+bool
+TestLayer()
+{
+    std::vector<std::string> validExpressions = {
+        "#sdf 1.4.32",
+        "#sdf 1.4.32\n\ndef Xform \"hello\"\n{\n\tdef Sphere \"world\"\n"
+        "\t{\n\t}\n}",
+        "#sdf 1.4.32\n\nover \"refSphere\" (\n\tprepend references = @./"
+        "HelloWorld.usda@\n)\n{\n}",
+        "#sdf 1.4.32\n(\n    doc = \"\"\"Generated from Composed Stage "
+        "of root layer RefExample.usda\n\"\"\"\n)\n\ndef Xform \"refSphere"
+        "\"\n{\n    double3 xformOp:translate = (4, 5, 6) \n    uniform "
+        "token[] xformOpOrder = []\n\n    def Sphere \"world\"\n    {\n    "
+        "    float3[] extent = [(-2, -2, -2), (2, 2, 2)]\n        color3f[] "
+        "primvars:displayColor = [(0, 0, 1)] \n        double radius = 2\n   "
+        " }\n}\n\ndef Xform \"refSphere2\"\n{\n   double3 xformOp:translate ="
+        " (4, 5, 6)\n    uniform token[] xformOpOrder = [\"xformOp:translate\""
+        "]\n\n    def Sphere \"world\"\n    {\n       float3[] extent = [(-2, "
+        "-2, -2), (2, 2, 2)]\n        color3f[] primvars:displayColor = [(1, "
+        "0, 0)]\n        double radius = 2\n    }\n}",
+        "#sdf 1.4.32\n(\n    doc = \"\"\"Generated from Composed Stage "
+        "of root layer RefExample.usda\n\"\"\"\n)\n\ndef Xform \"refSphere"
+        "\"\n{\n    double3 xformOp:translate = (4, 5, 6) \n    uniform "
+        "token[] xformOpOrder = [\"xformOp:translate\"]\n}\n\ndef Xform "
+        "\"refSphere2\"\n{\n   double3 xformOp:translate = (4, 5, 6)\n    "
+        "uniform token[] xformOpOrder = [\"xformOp:translate\"]\n\n}"
+    };
+
+    std::vector<std::string> invalidExpressions = {
+        "def Xform \"hello\"\n{\n\tdef Sphere \"world\"\n\t{\n\t}\n}",
+        "usda 1.0\n\ndef Xform \"hello\"\n{\n\tdef Sphere "
+        "\"world\"\n\t{\n\t}\n}",
+    };
+
+    TF_AXIOM(std::all_of(validExpressions.begin(),
+        validExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::Layer,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    TF_AXIOM(std::none_of(invalidExpressions.begin(),
+        invalidExpressions.end(), [](const std::string& expression)
+        {
+            return DoParse<PEGTL_NS::must<
+                Sdf_TextFileFormatParser::Layer,
+                PEGTL_NS::eof>>(expression);
+        }));
+
+    return true;
+}
+
+int
+main()
+{
+    bool valid = TestDigits() &&
+        TestIdentifiers() &&
+        TestStrings() &&
+        TestAssetRefs() &&
+        TestPathRefs() &&
+        TestTupleValues() &&
+        TestListValues() &&
+        TestDictionaryValues() &&
+        TestMetadata() &&
+        TestPrimRelationship() &&
+        TestPrimAttribute() &&
+        TestPrimProperty() &&
+        TestPrimMetadata() &&
+        TestVariantSetStatement() &&
+        TestPrim() &&
+        TestLayerMetadata() &&
+        TestLayer();
+
+    return valid ? 0 : -1;
+}

--- a/pxr/usd/sdf/textFileFormat.cpp
+++ b/pxr/usd/sdf/textFileFormat.cpp
@@ -56,6 +56,8 @@ TF_DEFINE_ENV_SETTING(
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
+#ifdef PXR_SDF_TEXT_FILE_FORMAT_LEGACY_PARSER
+
 // Our interface to the YACC layer parser for parsing to SdfData.
 extern bool Sdf_ParseLayer(
     const string& context, 
@@ -72,6 +74,37 @@ extern bool Sdf_ParseLayerFromString(
     const string& version,
     PXR_NS::SdfDataRefPtr data,
     PXR_NS::SdfLayerHints *hints);
+
+#else
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Our interface to the PEGTL layer parser for parsing to SdfData.
+namespace Sdf_TextFileFormatParser {
+
+extern bool Sdf_ParseLayer(
+    const string& context, 
+    const std::shared_ptr<PXR_NS::ArAsset>& asset,
+    const string& token,
+    const string& version,
+    bool metadataOnly,
+    PXR_NS::SdfDataRefPtr data,
+    PXR_NS::SdfLayerHints *hints);
+
+extern bool Sdf_ParseLayerFromString(
+    const std::string & layerString,
+    const string& token,
+    const string& version,
+    PXR_NS::SdfDataRefPtr data,
+    PXR_NS::SdfLayerHints *hints);
+
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+using namespace PXR_NS::Sdf_TextFileFormatParser;
+
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/usd/sdf/textFileFormatParser.cpp
+++ b/pxr/usd/sdf/textFileFormatParser.cpp
@@ -1,0 +1,3786 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+
+#include "pxr/pxr.h"
+#include "pxr/base/trace/trace.h"
+#include "pxr/usd/ar/asset.h"
+#include "pxr/usd/sdf/textParserContext.h"
+#include "pxr/usd/sdf/textParserHelpers.h"
+#include "pxr/usd/sdf/textFileFormatParser.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace Sdf_TextFileFormatParser {
+
+////////////////////////////////////////////////////////////////////////
+// TextFileFormat customized errors
+template<> constexpr auto errorMessage<Digit> = "expected number";
+template<> constexpr auto errorMessage<SingleQuote> = "expected '";
+template<> constexpr auto errorMessage<DoubleQuote> = "expected \"";
+template<> constexpr auto errorMessage<At> = "expected @";
+template<> constexpr auto errorMessage<LeftCurlyBrace> = "expected {";
+template<> constexpr auto errorMessage<RightCurlyBrace> = "expected }";
+template<> constexpr auto errorMessage<LeftAngleBracket> = "expected <";
+template<> constexpr auto errorMessage<RightAngleBracket> = "expected >";
+template<> constexpr auto errorMessage<LeftBrace> = "expected [";
+template<> constexpr auto errorMessage<RightBrace> = "expected ]";
+template<> constexpr auto errorMessage<LeftParen> = "expected (";
+template<> constexpr auto errorMessage<RightParen> = "expected )";
+template<> constexpr auto errorMessage<ListValueClose> = "expected ]";
+template<> constexpr auto errorMessage<TupleValueClose> = "expected )";
+template<> constexpr auto errorMessage<DictionaryValueClose> = "expected }";
+template<> constexpr auto errorMessage<TokenSpace> = "expected space";
+template<> constexpr auto errorMessage<Sdf_PathParser::Path> = "expected Path";
+template<> constexpr auto errorMessage<PathRef> = "expected Path reference";
+template<> constexpr auto errorMessage<Utf8SingleQuoteCharacter> =
+    "expected sequence of non-CRLF UTF-8 encoded characters followed by '";
+template<> constexpr auto errorMessage<Utf8SingleQuoteMultilineCharacter> =
+    "expected sequence of UTF-8 encoded characters followed by '";
+template<> constexpr auto errorMessage<Utf8DoubleQuoteCharacter> =
+    "expected sequence of non-CRLF UTF-8 encoded characters followed by \"";
+template<> constexpr auto errorMessage<Utf8DoubleQuoteMultilineCharacter> =
+    "expected sequence of UTF-8 encoded characters followed by \"";
+template<> constexpr auto errorMessage<Utf8AssetPathCharacter> =
+    "expected sequence of non-CRLF UTF-8 encoded characters followed by @";
+template<> constexpr auto errorMessage<Utf8AssetPathEscapedCharacter> =
+    "expected sequence of non-CRLF UTF-8 encoded characters followed by @@@";
+template<> constexpr auto errorMessage<ListValueInterior> =
+    "expected one or more simple, tuple, or list values separated by ,";
+template<> constexpr auto errorMessage<TupleValueInterior> =
+    "expected on or more simple or tuple values separated by ,";
+template<> constexpr auto errorMessage<DictionaryKey> =
+    "expected string or identifier";
+template<> constexpr auto errorMessage<Assignment> = "expected =";
+template<> constexpr auto errorMessage<DictionaryValue> =
+    "expected dictionary value";
+template<> constexpr auto errorMessage<TypedValue> =
+    "expected simple, tuple, list, or path ref value";
+template<> constexpr auto errorMessage<TimeSamplesEnd> = "expected }";
+template<> constexpr auto errorMessage<TimeSample> = 
+    "expected number or identifier followed by"
+    " : followed by None or typed value";
+template<> constexpr auto errorMessage<DocString> =
+    "expected string value";
+template<> constexpr auto errorMessage<PermissionIdentifier> =
+    "expected identifier";
+template<> constexpr auto errorMessage<NameListEnd> = "expected ]";
+template<> constexpr auto errorMessage<PrimMetadataListOpList> =
+    "expected None or list value";
+template<> constexpr auto errorMessage<PrimAttributeMetadataListOpList> =
+    "expected None or list value";
+template<> constexpr auto errorMessage<PrimAttributeMetadataValue> =
+    "expected None, simple, tuple, list, dictionary, or path ref value";
+template<> constexpr auto 
+errorMessage<PrimAttributeMetadataDisplayUnitIdentifier> =
+    "expected identifier";
+template<> constexpr auto errorMessage<PrimAttributeMetadataListInterior> =
+    "expected sequence of metadata items separated by ,";
+template<> constexpr auto errorMessage<ReferenceList> =
+    "expected None, single layer / path ref, or list of layer / path refs";
+template<> constexpr auto errorMessage<PrimAttributeValue> =
+    "expected None, simple, tuple, list, or path ref value";
+template<> constexpr auto errorMessage<PrimAttributeFullType> =
+    "expected attribute type";
+template<> constexpr auto errorMessage<PrimAttributeFallbackNamespacedName> =
+    "expected namespaced identifier";
+template<> constexpr auto errorMessage<PrimAttributeConnectName> =
+    "expected namespaced name followed by . followed by connect";
+template<> constexpr auto errorMessage<PrimAttributeConnectList> =
+    "expected list of path refs separated by ,";
+template<> constexpr auto errorMessage<PrimAttributeConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributeAddConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributeDeleteConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributeAppendConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributePrependConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributeReorderConnectValue> =
+    "expected None, path ref, or list of path refs";
+template<> constexpr auto errorMessage<PrimAttributeTimeSamplesValue> =
+    "expected list of time samples separated by ,";
+template<> constexpr auto errorMessage<PrimRelationshipMetadataListOpList> =
+    "expected None or list value";
+template<> constexpr auto errorMessage<PrimRelationshipMetadataValue> =
+    "expected None, simple, tuple, list, dictionary, or path ref value";
+template<> constexpr auto errorMessage<PrimRelationshipMetadataListInterior> =
+    "expected sequence of metadata items separated by ,";
+template<> constexpr auto errorMessage<PrimRelationshipTarget> =
+    "expected path reference";
+template<> constexpr auto errorMessage<PrimRelationshipTargetNone> =
+    "expected None or []";
+template<> constexpr auto errorMessage<PrimRelationshipTargetList> =
+    "expected list of path refs separated by ,";
+template<> constexpr auto errorMessage<LayerRefOffsetValue> =
+    "expected number";
+template<> constexpr auto errorMessage<LayerRefScaleValue> =
+    "expected number";
+template<> constexpr auto errorMessage<LayerMetadataList> =
+    "expected sequence of metadata items separated by ,";
+template<> constexpr auto errorMessage<SublayerList> =
+    "expected empty list or sequence of sublayer statements separated by ,";
+template<> constexpr auto errorMessage<LayerOffsetList> =
+    "expected sequence of layer offset statements separated by ,";
+template<> constexpr auto errorMessage<LayerMetadataValue> =
+    "expected None, simple, tuple, list, dictionary, or path ref value";
+template<> constexpr auto errorMessage<LayerMetadataListOpList> =
+    "expected None or list value";
+template<> constexpr auto errorMessage<PrimReorderNameList> =
+    "expected string or list";
+template<> constexpr auto errorMessage<PrimTypeName> =
+    "expected identifier";
+template<> constexpr auto errorMessage<PrimStatementInterior> =
+    "expected identifier followed by prim interior";
+template<> constexpr auto errorMessage<NameList> =
+    "expected string or list";
+template<> constexpr auto errorMessage<PrimVariantSetName> =
+    "expected string";
+template<> constexpr auto errorMessage<VariantList> =
+    "expected list of variants";
+template<> constexpr auto errorMessage<KindValue> =
+    "expected string";
+template<> constexpr auto errorMessage<PayloadListInterior> =
+    "expected sequence of layer or path references separated by ,";
+template<> constexpr auto errorMessage<PayloadList> =
+    "expected None, empty list, or list of layer or path references";
+template<> constexpr auto errorMessage<InheritListInterior> =
+    "expected sequence of layer or path references separated by ,";
+template<> constexpr auto errorMessage<InheritList> =
+    "expected None, empty list, or list of path references";
+    template<> constexpr auto errorMessage<SpecializesListInterior> =
+    "expected sequence of layer or path references separated by ,";
+template<> constexpr auto errorMessage<SpecializesList> =
+    "expected None, empty list, or list of path references";
+template<> constexpr auto errorMessage<ReferenceListInterior> =
+    "expected sequence of layer or path references separated by ,";
+template<> constexpr auto errorMessage<NamespaceSeparator> =
+    "expected :";
+template<> constexpr auto errorMessage<RelocatesMap> =
+    "expected dictionary or list of relocates statements";
+template<> constexpr auto errorMessage<StringDictionary> =
+    "expected dictionary of strings";
+
+template<> constexpr bool emitRule<EolWhitespace> = false;
+
+////////////////////////////////////////////////////////////////////////
+// TextFileFormat actions
+
+////////////////////////////////////////////////////////////////////////
+// Shared actions
+
+template <>
+struct TextParserAction<MetadataListOpList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // when a MetadataListOpList is consumed, it can
+        // either be a None value or a ListValue
+        // if it was a ListValue, the specialized action
+        // for ListValue picked it up, so we only need
+        // to handle None here
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<NameListItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string value = _GetEvaluatedStringFromString(
+            in.string(), context);
+        context.nameVector.push_back(TfToken(value));
+    }  
+};
+
+template <>
+struct TextParserAction<TimeSamplesBegin>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.timeSamples = SdfTimeSampleMap();
+    }
+};
+
+template <>
+struct TextParserAction<TimeSampleExtendedNumber>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        Sdf_ParserHelpers::Value value = _GetValueFromString(
+            in.string(), in.position().line, context);
+        context.timeSampleTime = value.Get<double>();
+    }
+};
+
+template <>
+struct TextParserAction<TimeSampleExtendedNumberValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.timeSamples[context.timeSampleTime] = context.currentValue;
+    }
+};
+
+template <>
+struct TextParserAction<TimeSampleExtendedNumberNone>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.timeSamples[context.timeSampleTime] = VtValue(SdfValueBlock());
+    }
+};
+
+template <>
+struct TextParserAction<DocString>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->Documentation, 
+            _GetEvaluatedStringFromString(in.string(), context), context);
+    }
+};
+
+template <>
+struct TextParserAction<PermissionIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        SdfPermission permission;
+        if (!_GetPermissionFromString(in.string(), permission))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "'%s' is not a valid permission constant",
+                in.string().c_str());
+        }
+
+        _SetField(context.path, SdfFieldKeys->Permission,
+            permission, context);
+    }
+};
+
+template <>
+struct TextParserAction<SymmetryFunctionIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->SymmetryFunction,
+            TfToken(_GetEvaluatedStringFromString(in.string(), context)),
+            context);
+    }
+};
+
+template <>
+struct TextParserAction<SymmetryFunctionEmpty>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->SymmetryFunction,
+            TfToken(), context);
+    }
+};
+
+template <>
+struct TextParserAction<StringValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string evaluatedString = _GetEvaluatedStringFromString(
+            in.string(), context);
+        _ValueAppendAtomic(evaluatedString, context);
+    }
+};
+
+template <>
+struct TextParserAction<IdentifierValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // the ParserValueContext needs identifiers to be stored
+        // as TfToken instead of std::string to be able to distinguish
+        // between them
+        _ValueAppendAtomic(TfToken(in.string()), context);
+    }
+};
+
+template <>
+struct TextParserAction<NumberValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // super special case for negative 0
+        // we have to store this as a double to preserve
+        // the sign.  There is no negative zero integral
+        // value, and we don't know at this point
+        // what the final stored type will be.
+        Sdf_ParserHelpers::Value value = _GetValueFromString(
+            in.string(), in.position().line, context);
+        _ValueAppendAtomic(value, context);
+    }
+};
+
+template <>
+struct TextParserAction<AssetRefValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // the ParserValueContext needs asset paths to be stored
+        // as SdfAssetPath instead of std::string to be able to
+        // distinguish between them
+        std::string evaluatedAssetPath = _GetAssetRefFromString(in.string());
+        _ValueAppendAtomic(SdfAssetPath(evaluatedAssetPath), context);
+    }
+};
+
+template <>
+struct TextParserAction<TupleValueOpen>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.values.BeginTuple();
+    }
+};
+
+template <>
+struct TextParserAction<TupleValueClose>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.values.EndTuple();
+    }
+};
+
+template <>
+struct TextParserAction<ListValueOpen>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.values.BeginList();
+    }
+};
+
+template <>
+struct TextParserAction<ListValueClose>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.values.EndList();
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryValueOpen>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _DictionaryBegin(context);
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryValueClose>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _DictionaryEnd(context);
+    }
+};
+
+template <>
+struct TextParserAction<TypedValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // we have to evaluate values at a higher level
+        // for the final value set
+        std::string errorMessage;
+        std::string value = TfStringTrimLeft(in.string());
+        if (TfStringStartsWith(value, "("))
+        {
+            // this is a list value and we are completely
+            // finished reducing it
+            if (!_ValueSetTuple(context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+        else if (TfStringStartsWith(value, "["))
+        {
+            // this is either a list or an empty array type
+            // array type matches '[' and ']' with an
+            // arbitrary number of spaces / tabs in between
+            constexpr std::string_view arrayType {"[]"};
+            std::string collapsedArrayType = TfStringReplace(value, " ", "");
+            collapsedArrayType = TfStringReplace(value, "\t", "");
+            if (collapsedArrayType != arrayType)
+            {
+                // it's a list
+                if (!_ValueSetList(context, errorMessage))
+                {
+                    Sdf_TextFileFormatParser_Err(
+                        context,
+                        in.input(),
+                        in.position(),
+                        "%s",
+                        errorMessage.c_str());
+                }
+            }
+            else
+            {
+                // it's an array type
+                // Set the recorded string on the ParserValueContext. Normally
+                // 'values' is able to keep track of the parsed string, but in this
+                // case it doesn't get the BeginList() and EndList() calls so the
+                // recorded string would have been "". We want "[]" instead.
+                if (context.values.IsRecordingString()) {
+                    context.values.SetRecordedString("[]");
+                }
+
+                if(!_ValueSetShaped(context, errorMessage))
+                {
+                    Sdf_TextFileFormatParser_Err(
+                        context,
+                        in.input(),
+                        in.position(),
+                        "%s",
+                        errorMessage.c_str());
+                }
+            }
+        }
+        else if (TfStringStartsWith(value, "<"))
+        {
+            std::string pathRef = TfStringTrimRight(value);
+            std::string evaluatedPath = Sdf_EvalQuotedString(
+                pathRef.c_str(), pathRef.length(), 1);
+            _ValueSetCurrentToSdfPath(evaluatedPath, context);
+        }
+        else
+        {
+            // this is the atomic value and we are completely
+            // finished reducing it
+            if (!_ValueSetAtomic(context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryElementDictionaryValueAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // the input string contains the full assignment, but we
+        // only want what is before the '=' - we had to match the
+        // value first which is why this is a combined rule apply
+        // TODO: what if the key itself has a = in it?
+        std::vector<std::string> assignmentPieces = 
+            TfStringSplit(in.string(), "=");
+        if (assignmentPieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid assignment statement '%s'",
+                in.string());
+        }
+        std::string dictionaryKey = TfStringTrim(assignmentPieces[0]);
+        if (TfStringStartsWith(dictionaryKey, "\""))
+        {
+            dictionaryKey = 
+                _GetEvaluatedStringFromString(dictionaryKey, context);
+        }
+
+        _DictionaryInsertDictionary(dictionaryKey, context);
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryElementTypedValueAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // the input string contains the full assignment, but we
+        // only want what is before the '=' - we had to match the
+        // value first which is why this is a combined rule apply
+        // what if the key itself has a = in it?
+        std::vector<std::string> assignmentPieces =
+            TfStringSplit(in.string(), "=");
+        if (assignmentPieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid assignment statement '%s'",
+                in.string().c_str());
+        }
+
+        // if the key was a string, we want what is inside
+        std::string dictionaryKey = TfStringTrim(assignmentPieces[0]);
+        if (TfStringStartsWith(dictionaryKey, "\""))
+        {
+            dictionaryKey = _GetEvaluatedStringFromString(dictionaryKey, context);
+        }
+        _DictionaryInsertValue(dictionaryKey, context);
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryValueScalarType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_DictionaryInitScalarFactory(in.string(), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<DictionaryValueShapedType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this matches the entire sequence of type + []
+        // with possible spaces padding the array type
+        // we only want the identifier part, so we strip off
+        // everything before the first brace and trim
+        std::vector<std::string> typePieces = TfStringSplit(in.string(), "[");
+        if (typePieces.size() < 2)
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid shaped type identifier '%s'",
+                in.string());
+        }
+
+        std::string errorMessage;
+        if (!_DictionaryInitShapedFactory(
+            TfStringTrim(typePieces[0]), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<StringDictionaryElementKey>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_DictionaryInitScalarFactory(
+            Sdf_ParserHelpers::Value(std::string("string")),
+            context,
+            errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<StringDictionaryElementValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _ValueAppendAtomic(
+            _GetEvaluatedStringFromString(in.string(), context), context);
+        std::string errorMessage;
+        if (!_ValueSetAtomic(context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<StringDictionaryElement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // the input string contains the full key : value, but we
+        // only want what is before the ':' - we had to match the
+        // value first which is why this is a combined rule apply
+        // what if the key itself has a : in it?
+        std::vector<std::string> assignmentPieces =
+            TfStringSplit(in.string(), ":");
+        if (assignmentPieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid dictionary element '%s'",
+                in.string().c_str());
+        }
+        std::string dictionaryKey = TfStringTrim(assignmentPieces[0]);
+        _DictionaryInsertValue(dictionaryKey, context);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+// Layer actions
+
+template <>
+struct TextParserAction<LayerHeader>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        const std::string cookie = TfStringTrimRight(in.string());
+        const std::string expected = "#" +  context.magicIdentifierToken + " ";
+        if (TfStringStartsWith(cookie, expected))
+        {
+            if (!context.versionString.empty() && 
+                !TfStringEndsWith(cookie, context.versionString))
+            {
+                TF_WARN("File '%s' is not the latest %s version (found '%s', "
+                    "expected '%s'). The file may parse correctly and yield "
+                    "incorrect results.",
+                    context.fileContext.c_str(),
+                    context.magicIdentifierToken.c_str(),
+                    cookie.substr(expected.length()).c_str(),
+                    context.versionString.c_str());
+            }
+        }
+        else
+        {
+            // throw error
+            std::string errorMessage = TfStringPrintf(
+                "Magic Cookie '%s'.  Expected prefix of '%s'",
+                TfStringTrim(cookie).c_str(),
+                expected.c_str());
+
+            throw PEGTL_NS::parse_error(errorMessage, in);
+        }
+
+        context.nameChildrenStack.push_back(std::vector<TfToken>());
+        context.data->CreateSpec(
+            SdfPath::AbsoluteRootPath(), SdfSpecTypePseudoRoot);
+    }
+};
+
+template <>
+struct TextParserAction<LayerContent>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // store the names of the root prims
+        context.data->Set(SdfPath::AbsoluteRootPath(), 
+            SdfChildrenKeys->PrimChildren,
+            VtValue(context.nameChildrenStack.back()));
+
+        context.nameChildrenStack.pop_back();
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataString>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->Comment,
+            _GetEvaluatedStringFromString(in.string(), context), context);
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataKey>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // a MetadataValue can be either a dictionary, typed value
+        // or None, but we only need to take specific actions when
+        // it's a dictionary or None
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if(TfStringStartsWith(value, "{"))
+        {
+            // it's a dictionary, we need to ensure the current
+            // value that gets set in the context is the dictionary
+            // we've been parsing
+            context.currentValue.Swap(context.currentDictionaries[0]);
+            context.currentDictionaries[0].clear();
+        }
+
+        std::string errorMessage;
+        if (!_GenericMetadataEnd(SdfSpecTypePseudoRoot, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpAddIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+        context.listOpType = SdfListOpTypeAdded;
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpDeleteIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+        context.listOpType = SdfListOpTypeDeleted;
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpAppendIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+        context.listOpType = SdfListOpTypeAppended;
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpPrependIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+        context.listOpType = SdfListOpTypePrepended;
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpReorderIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePseudoRoot, context);
+        context.listOpType = SdfListOpTypeOrdered;
+    }
+};
+
+template <>
+struct TextParserAction<LayerMetadataListOpList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_GenericMetadataEnd(SdfSpecTypePseudoRoot, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SublayerList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(SdfPath::AbsoluteRootPath(), SdfFieldKeys->SubLayers,
+            context.subLayerPaths, context);
+        _SetField(SdfPath::AbsoluteRootPath(), SdfFieldKeys->SubLayerOffsets,
+            context.subLayerOffsets, context);
+        
+        context.subLayerPaths.clear();
+        context.subLayerOffsets.clear();
+    }
+};
+
+template <>
+struct TextParserAction<SublayerStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.subLayerPaths.push_back(context.layerRefPath);
+        context.subLayerOffsets.push_back(context.layerRefOffset);
+    }
+};
+
+template <>
+struct TextParserAction<LayerRef>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string evaluatedAssetPath = _GetAssetRefFromString(in.string());
+        context.layerRefPath = evaluatedAssetPath;
+        context.layerRefOffset = SdfLayerOffset();
+    }
+};
+
+template <>
+struct TextParserAction<LayerRefOffsetValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        Sdf_ParserHelpers::Value value =
+            _GetValueFromString(in.string(), in.position().line, context);
+        context.layerRefOffset.SetOffset(value.Get<double>());
+    }
+};
+
+template <>
+struct TextParserAction<LayerRefScaleValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        Sdf_ParserHelpers::Value value =
+            _GetValueFromString(in.string(), in.position().line, context);
+        context.layerRefOffset.SetScale(value.Get<double>());
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+// Prim actions
+
+template <>
+struct TextParserAction<PrimMetadataListOpAddIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+        context.listOpType = SdfListOpTypeAdded;
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataListOpDeleteIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+        context.listOpType = SdfListOpTypeDeleted;
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataListOpAppendIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+        context.listOpType = SdfListOpTypeAppended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataListOpPrependIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+        context.listOpType = SdfListOpTypePrepended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataListOpReorderIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+        context.listOpType = SdfListOpTypeOrdered;
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataListOpList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // when a MetadataListOpList is consumed, it can
+        // either be a None value or a ListValue
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        std::string errorMessage;
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if (TfStringStartsWith(value, "["))
+        {
+            if (!_ValueSetList(context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+
+        if (!_GenericMetadataEnd(SdfSpecTypePrim, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<KindValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, 
+            SdfFieldKeys->Kind,
+           TfToken(_GetEvaluatedStringFromString(in.string(), context)), 
+           context);
+    }
+};
+
+template <>
+struct TextParserAction<PrefixSubstitutionsMetadata>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->PrefixSubstitutions,
+            context.currentDictionaries[0], context);
+        
+        context.currentDictionaries[0].clear();
+    }
+};
+
+template <>
+struct TextParserAction<SuffixSubstitutionsMetadata>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->SuffixSubstitutions,
+            context.currentDictionaries[0], context);
+        
+        context.currentDictionaries[0].clear();
+    }
+};
+
+template <>
+struct TextParserAction<PayloadMetadataKeyword>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.layerRefPath = std::string();
+        context.savedPath = SdfPath();
+        context.payloadParsingRefs.clear();
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOpAdd>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOpDelete>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOpAppend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOpPrepend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadListOpReorder>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetPayloadListItems(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadLayerRefItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (context.layerRefPath.empty())
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "Payload asset path must not be empty.  If this "
+                "is intended to be an internal payload, remove the "
+                "'@' delimeters.");
+        }
+
+        SdfPayload payload(context.layerRefPath, context.savedPath,
+            context.layerRefOffset);
+
+        context.payloadParsingRefs.push_back(payload);
+    }  
+};
+
+template <>
+struct TextParserAction<OptionalPayloadPrimPath>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (in.string().length() == 0)
+        {
+            // this matched the optional rule
+            context.savedPath = SdfPath();
+        }
+        else
+        {
+            // this matched an actual prim path
+            std::string path = Sdf_EvalQuotedString(
+                in.string().c_str(), in.string().length(), 1);
+            if (path.length() == 0)
+            {
+                context.savedPath = SdfPath();
+            }
+            else
+            {
+                std::string errorMessage;
+                if (!_PathSetPrim(path, context, errorMessage))
+                {
+                    Sdf_TextFileFormatParser_Err(
+                        context,
+                        in.input(),
+                        in.position(),
+                        "%s",
+                        errorMessage.c_str());
+                }
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadPathRef>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.layerRefPath.clear();
+        context.layerRefOffset = SdfLayerOffset();
+
+        std::string pathRef = Sdf_EvalQuotedString(
+            in.string().c_str(), in.string().length(), 1);
+        if (pathRef.length() == 0)
+        {
+            context.savedPath = SdfPath::EmptyPath();
+        }
+        else
+        {
+            std::string errorMessage;
+            if (!_PathSetPrim(pathRef, context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PayloadPathRefItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        SdfPayload payload(std::string(), context.savedPath,
+            context.layerRefOffset);
+        context.payloadParsingRefs.push_back(payload);
+    }
+};
+
+template <>
+struct TextParserAction<InheritsMetadataKeyword>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.inheritParsingTargetPaths.clear();
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOpAdd>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOpDelete>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOpAppend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOpPrepend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritsListOpReorder>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetInheritListItems(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<InheritListItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_PathSetPrim(
+            Sdf_EvalQuotedString(in.string().c_str(), in.string().length(), 1),
+            context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _InheritAppendPath(context);
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesMetadataKeyword>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.specializesParsingTargetPaths.clear();
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOpAdd>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOpDelete>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOpAppend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOpPrepend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListOpReorder>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetSpecializesListItems(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<SpecializesListItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_PathSetPrim(
+            Sdf_EvalQuotedString(in.string().c_str(), in.string().length(), 1),
+            context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _SpecializesAppendPath(context);
+    }
+};
+
+template<>
+struct TextParserAction<RelocatesMetadata>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->Relocates,
+            context.relocatesParsingMap, context);
+
+        context.relocatesParsingMap.clear();
+    }
+};
+
+template <>
+struct TextParserAction<RelocatesStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this statement is accepted in its entirety, but we need
+        // access to both path refs here to add the relocates operation
+        // the incoming string has both separated by a ':' character
+        std::vector<std::string> pathRefs = TfStringSplit(in.string(), ":");
+        if (pathRefs.size() < 2)
+        {
+            // there has to be at least two path refs!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid relocates statement '%s'",
+                in.string().c_str());
+        }
+        std::string relocatesSource = 
+            _GetEvaluatedStringFromString(TfStringTrim(pathRefs[0]), context);
+        std::string relocatesTarget = 
+            _GetEvaluatedStringFromString(TfStringTrim(pathRefs[1]), context);
+        std::string errorMessage;
+        if (!_RelocatesAdd(relocatesSource, relocatesTarget, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOpAdd>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOpDelete>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOpAppend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOpPrepend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOpReorder>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetsListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetVariantSetNamesListItems(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<VariantsMetadata>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_PrimSetVariantSelection(context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesMetadataKeyword>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.layerRefPath = std::string();
+        context.savedPath = SdfPath();
+        context.referenceParsingRefs.clear();
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOpAdd>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOpDelete>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOpAppend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOpPrepend>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencesListOpReorder>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimSetReferenceListItems(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferenceLayerRefItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (context.layerRefPath.empty())
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(), 
+                "Reference asset path must not be empty.  If this "
+                "is intended to be an internal reference, remove the "
+                "'@' delimeters.");
+        }
+
+        SdfReference ref(context.layerRefPath, context.savedPath,
+            context.layerRefOffset);
+
+        ref.SwapCustomData(context.currentDictionaries[0]);
+        context.referenceParsingRefs.push_back(ref);
+    }  
+};
+
+template <>
+struct TextParserAction<OptionalReferencePrimPath>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (in.string().length() == 0)
+        {
+            // this matched the optional rule
+            context.savedPath = SdfPath();
+        }
+        else
+        {
+            // this matched an actual prim path
+            std::string path = Sdf_EvalQuotedString(
+                in.string().c_str(), in.string().length(), 1);
+            if (path.length() == 0)
+            {
+                context.savedPath = SdfPath();
+            }
+            else
+            {
+                std::string errorMessage;
+                if (!_PathSetPrim(path, context, errorMessage))
+                {
+                    Sdf_TextFileFormatParser_Err(
+                        context,
+                        in.input(),
+                        in.position(),
+                        "%s",
+                        errorMessage.c_str());
+                }
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencePathRef>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.layerRefPath.clear();
+        context.layerRefOffset = SdfLayerOffset();
+
+        std::string pathRef = Sdf_EvalQuotedString(
+            in.string().c_str(), in.string().length(), 1);
+        if (pathRef.length() == 0)
+        {
+            context.savedPath = SdfPath::EmptyPath();
+        }
+        else
+        {
+            std::string errorMessage;
+            if (!_PathSetPrim(pathRef, context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+    }
+};
+
+template <>
+struct TextParserAction<ReferencePathRefItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        SdfReference ref(std::string(), 
+            context.savedPath,
+            context.layerRefOffset);
+        ref.SwapCustomData(context.currentDictionaries[0]);
+        context.referenceParsingRefs.push_back(ref);
+    }
+};
+
+template <>
+struct TextParserAction<PrimDefSpecifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.specifier = SdfSpecifierDef;
+        context.typeName = TfToken();
+    }
+};
+
+template <>
+struct TextParserAction<PrimClassSpecifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.specifier = SdfSpecifierClass;
+        context.typeName = TfToken();
+    }
+};
+
+template <>
+struct TextParserAction<PrimOverSpecifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.specifier = SdfSpecifierOver;
+        context.typeName = TfToken();
+    }
+};
+
+template <>
+struct TextParserAction<PrimTypeName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this matched the entirety of the prim type name
+        // which could have spaces padding the separator
+        // (in this case '.'), so we need to tokenize and trim
+        // to form an unpadded type name
+        std::vector<std::string> typeNameParts =
+            TfStringTokenize(in.string(), ".");
+        std::string typeName = typeNameParts[0];
+        if (typeNameParts.size() > 1)
+        {
+            for (size_t i = 1; i < typeNameParts.size(); i++)
+            {
+                typeName = typeName + "." + TfStringTrim(typeNameParts[i]);
+            }
+        }
+
+        context.typeName = TfToken(typeName);
+    }
+};
+
+template <>
+struct TextParserAction<PrimReorderNameList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path,
+            SdfFieldKeys->PrimOrder,
+            context.nameVector,
+            context);
+
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<PrimIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        TfToken name(_GetEvaluatedStringFromString(in.string(), context));
+        if (!SdfPath::IsValidIdentifier(name))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "'%s' is not a valid prim name",
+                name.GetText());
+        }
+
+        context.path = context.path.AppendChild(name);
+        if (_HasSpec(context.path, context))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "Duplicate prim '%s'",
+                context.path.GetText());
+        }
+        else
+        {
+            // record the existence of this prim
+            _CreateSpec(context.path, SdfSpecTypePrim, context);
+
+            // add this prim to its parent's name children
+            context.nameChildrenStack.back().push_back(name);
+        }
+
+        // create our name children vector and properties vector
+        context.nameChildrenStack.push_back(std::vector<TfToken>());
+        context.propertiesStack.push_back(std::vector<TfToken>());
+
+        _SetField(context.path,
+            SdfFieldKeys->Specifier,
+            context.specifier,
+            context);
+
+        if (!context.typeName.IsEmpty())
+        {
+            _SetField(context.path, SdfFieldKeys->TypeName,
+                context.typeName, context);
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimStatementInterior>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // store the names of our children
+        if (!context.nameChildrenStack.back().empty())
+        {
+            _SetField(context.path, SdfChildrenKeys->PrimChildren,
+                context.nameChildrenStack.back(), context);
+        }
+
+        // store the names of our properties, if there are any
+        if (!context.propertiesStack.back().empty())
+        {
+            _SetField(context.path, SdfChildrenKeys->PropertyChildren,
+                context.propertiesStack.back(), context);
+        }
+
+        context.nameChildrenStack.pop_back();
+        context.propertiesStack.pop_back();
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimChildOrderStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->PrimOrder,
+            context.nameVector, context);
+        
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<PrimPropertyOrderStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->PropertyOrder,
+            context.nameVector, context);
+        
+        context.nameVector.clear();
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataString>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->Comment,
+            _GetEvaluatedStringFromString(in.string(), context), context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataKey>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypePrim, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimMetadataValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // a MetadataValue can be either a dictionary, typed value
+        // or None, but we only need to take specific actions when
+        // it's a dictionary or None
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if(TfStringStartsWith(value, "{"))
+        {
+            // it's a dictionary, we need to ensure the current
+            // value that gets set in the context is the dictionary
+            // we've been parsing
+            context.currentValue.Swap(context.currentDictionaries[0]);
+            context.currentDictionaries[0].clear();
+        }
+
+        std::string errorMessage;
+        if (!_GenericMetadataEnd(SdfSpecTypePrim, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimVariantSetName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string name = _GetEvaluatedStringFromString(in.string(), context);
+        const SdfAllowed allow = SdfSchema::IsValidVariantIdentifier(name);
+        if (!allow)
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                allow.GetWhyNot().c_str());
+        }
+
+        context.currentVariantSetNames.push_back(name);
+        context.currentVariantNames.push_back(std::vector<std::string>());
+        context.path = context.path.AppendVariantSelection(name, "");
+    }
+};
+
+template <>
+struct TextParserAction<VariantSetStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        SdfPath variantSetPath = context.path;
+        context.path = context.path.GetParentPath();
+
+        // create this VariantSetSpec if it does not already exist
+        if (!_HasSpec(variantSetPath, context))
+        {
+            _CreateSpec(variantSetPath, SdfSpecTypeVariantSet, context);
+
+            // add the name of this variant set to the VariantSets field
+            _AppendVectorItem(SdfChildrenKeys->VariantSetChildren,
+                TfToken(context.currentVariantSetNames.back()),
+                context);
+        }
+
+        // author the variant set's variants
+        _SetField(variantSetPath, SdfChildrenKeys->VariantChildren,
+            TfToTokenVector(context.currentVariantNames.back()), context);
+
+        context.currentVariantSetNames.pop_back();
+        context.currentVariantNames.pop_back();
+    }
+};
+
+template <>
+struct TextParserAction<PrimVariantName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        const std::string variantName =
+            _GetEvaluatedStringFromString(in.string(), context);
+        const SdfAllowed allow =
+            SdfSchema::IsValidVariantIdentifier(variantName);
+        if (!allow)
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                allow.GetWhyNot().c_str());
+        }
+
+        context.currentVariantNames.back().push_back(variantName);
+
+        // a variant is basically like a new pseudo-root, so we need to push
+        // a new item onto our name children stack to store prims defined
+        // within this variant
+        context.nameChildrenStack.push_back(std::vector<TfToken>());
+        context.propertiesStack.push_back(std::vector<TfToken>());
+
+        std::string variantSetName = context.currentVariantSetNames.back();
+        context.path = context.path.GetParentPath()
+            .AppendVariantSelection(variantSetName, variantName);
+
+        _CreateSpec(context.path, SdfSpecTypeVariant, context);
+    }
+};
+
+template <>
+struct TextParserAction<VariantStatement>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // store the names of the prims and properties defined in this variant
+        if (!context.nameChildrenStack.back().empty())
+        {
+            _SetField(context.path, SdfChildrenKeys->PrimChildren,
+                context.nameChildrenStack.back(), context);
+        }
+
+        if (!context.propertiesStack.back().empty())
+        {
+            _SetField(context.path, SdfChildrenKeys->PropertyChildren,
+                context.propertiesStack.back(), context);
+        }
+
+        context.nameChildrenStack.pop_back();
+        context.propertiesStack.pop_back();
+
+        std::string variantSet = context.path.GetVariantSelection().first;
+        context.path =
+            context.path.GetParentPath().AppendVariantSelection(variantSet, "");
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+// Prim Relationship actions
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataString>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->Comment,
+            _GetEvaluatedStringFromString(in.string(), context), context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataKey>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // a MetadataValue can be either a dictionary, typed value
+        // or None, but we only need to take specific actions when
+        // it's a dictionary or None
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if(TfStringStartsWith(value, "{"))
+        {
+            // it's a dictionary, we need to ensure the current
+            // value that gets set in the context is the dictionary
+            // we've been parsing
+            context.currentValue.Swap(context.currentDictionaries[0]);
+            context.currentDictionaries[0].clear();
+        }
+
+        std::string errorMessage;
+        if (!_GenericMetadataEnd(
+            SdfSpecTypeRelationship, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpAddIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+        context.listOpType = SdfListOpTypeAdded;
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpDeleteIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+        context.listOpType = SdfListOpTypeDeleted;
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpAppendIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+        context.listOpType = SdfListOpTypeAppended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpPrependIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+        context.listOpType = SdfListOpTypePrepended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpReorderIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeRelationship, context);
+        context.listOpType = SdfListOpTypeOrdered;
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipMetadataListOpList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // when a MetadataListOpList is consumed, it can
+        // either be a None value or a ListValue
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        std::string errorMessage;
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if (TfStringStartsWith(value, "["))
+        {
+            if (!_ValueSetList(context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+        
+        if (!_GenericMetadataEnd(
+            SdfSpecTypeRelationship, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string namespacedName = _UnpadNamespacedName(in.string());
+        std::string errorMessage;
+        if (!_PrimInitRelationship(namespacedName, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTimesamplesName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this production matches the entire NamespacedName.timeSamples
+        // so we need to parse out just the NamespacedName portion
+        std::vector<std::string> timeSamplesNamePieces =
+            TfStringSplit(in.string(), ".");
+        if (timeSamplesNamePieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid time samples relationship name '%s'",
+                in.string().c_str());
+        }
+
+        std::string errorMessage;
+        if (!_PrimInitRelationship(
+            _UnpadNamespacedName(TfStringTrim(
+                timeSamplesNamePieces[0])), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipDefaultName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this production matches the entire NamespacedName.default
+        // so we need to parse out just the NamespacedName portion
+        std::vector<std::string> defaultNamePieces =
+            TfStringSplit(in.string(), ".");
+        if (defaultNamePieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid default relationship name '%s'",
+                in.string().c_str());
+        }
+
+        std::string errorMessage;
+        if (!_PrimInitRelationship(
+            _UnpadNamespacedName(TfStringTrim(
+                defaultNamePieces[0])), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipDefaultRef>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // if path is empty, use dfeault c'tor to construct empty path
+        // XXX: 08/04/08 would be nice if SdfPath would allow
+        // SdfPath("") without throwing a warning
+        std::string pathString = _GetEvaluatedStringFromString(in.string(), context);
+        SdfPath path = pathString.empty() ? SdfPath() : SdfPath(pathString);
+        _SetDefault(context.path, VtValue(path), context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipDefault>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTimeSamplesValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->TimeSamples,
+            context.timeSamples, context);
+        
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTypeUniform>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = false;
+        context.variability = VtValue(SdfVariabilityUniform);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTypeCustomUniform>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = true;
+        context.variability = VtValue(SdfVariabilityUniform);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTypeCustomVarying>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = true;
+        context.variability = VtValue(SdfVariabilityVarying);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTypeVarying>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = false;
+        context.variability = VtValue(SdfVariabilityVarying);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTarget>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string targetPath = 
+            Sdf_EvalQuotedString(in.string().c_str(), in.string().length(), 1);
+        _RelationshipAppendTargetPath(targetPath, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipTargetNone>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.relParsingTargetPaths = SdfPathVector();
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _RelationshipInitTarget(
+            context.relParsingTargetPaths->back(), context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipAddListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage);
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipDeleteListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipPrependListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipAppendListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipReorderListOp>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimRelationshipStandard>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_RelationshipSetTargetsList(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+
+        _PrimEndRelationship(context);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+// Prim Attribute actions
+
+template <>
+struct TextParserAction<PrimAttributeMetadataString>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path,
+            SdfFieldKeys->Comment,
+            _GetEvaluatedStringFromString(in.string(), context),
+            context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataKey>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // a MetadataValue can be either a dictionary, typed value
+        // or None, but we only need to take specific actions when
+        // it's a dictionary or None
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if(TfStringStartsWith(value, "{"))
+        {
+            // it's a dictionary, we need to ensure the current
+            // value that gets set in the context is the dictionary
+            // we've been parsing
+            context.currentValue.Swap(context.currentDictionaries[0]);
+            context.currentDictionaries[0].clear();
+        }
+
+        std::string errorMessage;
+        if (!_GenericMetadataEnd(SdfSpecTypeAttribute, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpAddIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+        context.listOpType = SdfListOpTypeAdded;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpDeleteIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+        context.listOpType = SdfListOpTypeDeleted;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpAppendIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+        context.listOpType = SdfListOpTypeAppended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpPrependIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+        context.listOpType = SdfListOpTypePrepended;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpReorderIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _GenericMetadataStart(in.string(), SdfSpecTypeAttribute, context);
+        context.listOpType = SdfListOpTypeOrdered;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataListOpList>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // when a MetadataListOpList is consumed, it can
+        // either be a None value or a ListValue
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        std::string errorMessage;
+        if (value == none)
+        {
+            // if the value is None, set the string
+            // being recorded to None
+            context.currentValue = VtValue();
+            if (context.values.IsRecordingString())
+            {
+                context.values.SetRecordedString(std::string(none));
+            }
+        }
+        else if (TfStringStartsWith(value, "["))
+        {
+            if (!_ValueSetList(context, errorMessage))
+            {
+                Sdf_TextFileFormatParser_Err(
+                    context,
+                    in.input(),
+                    in.position(),
+                    "%s",
+                    errorMessage.c_str());
+            }
+        }
+
+        if (!_GenericMetadataEnd(SdfSpecTypeAttribute, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeMetadataDisplayUnitIdentifier>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        TfEnum displayUnit;
+        if (!_GetDisplayUnitFromString(in.string(), displayUnit))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "'%s' is not a valid display unit",
+                in.string());
+        }
+
+        _SetField(context.path, SdfFieldKeys->DisplayUnit,
+            displayUnit, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeStandardType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetupValue(in.string(), context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeArrayType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this rule matched the sequence identifier[] with possible
+        // whitespace between the end of the identifier and the start of
+        // the array type signal and between the braces
+        // we need to trim out all of the space
+        std::string arrayType = TfStringTrim(in.string());
+        arrayType = TfStringReplace(arrayType, " ", "");
+        arrayType = TfStringReplace(arrayType, "\t", "");
+        _SetupValue(arrayType, context);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeVariability>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this handles matches for both KeywordUniform and KeywordConfig
+        // which ultimately have the same variability
+        // convert legacy "config" variability to SdfVariabilityUniform
+        // this value was never officially used in USD but we handle
+        // this just in case the value was written outiform = "uniform";
+        context.variability = VtValue(SdfVariabilityUniform);
+        context.assoc = VtValue();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeQualifiedType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = false;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeType>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.variability = VtValue();
+        context.custom = false;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeFallback>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeFallbackNamespacedName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.custom = true;
+        std::string errorMessage;
+        if (!_PrimInitAttribute(
+            _UnpadNamespacedName(in.string()), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeFallbackTypeName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (!context.values.valueTypeIsValid)
+        {
+            context.values.StartRecordingString();
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeAssignmentOptional>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (!context.values.valueTypeIsValid)
+        {
+            context.values.StopRecordingString();
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeDefaultNamespacedName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if(!_PrimInitAttribute(
+            _UnpadNamespacedName(in.string()), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeDefaultTypeName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        if (!context.values.valueTypeIsValid)
+        {
+            context.values.StartRecordingString();
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeDefault>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeTimeSamplesName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this production matches the entire NamespacedName.timeSamples
+        // so we need to parse out just the NamespacedName portion
+        std::vector<std::string> timeSamplesNamePieces =
+            TfStringSplit(in.string(), ".");
+        if (timeSamplesNamePieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid time samples attribute name '%s'",
+                in.string().c_str());
+        }
+
+        std::string errorMessage;
+        if (!_PrimInitAttribute(
+            _UnpadNamespacedName(TfStringTrim(
+                timeSamplesNamePieces[0])), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeTimeSamplesValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        _SetField(context.path, SdfFieldKeys->TimeSamples,
+            context.timeSamples, context);
+        
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        constexpr std::string_view none {"None"};
+        std::string value = TfStringTrim(in.string());
+        if (value == none)
+        {
+            _SetDefault(context.path, VtValue(SdfValueBlock()), context);
+        }
+        else
+        {
+            _SetDefault(context.path, context.currentValue, context);
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeConnectName>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        // this production matches the entire NamespacedName.connect
+        // so we need to parse out just the NamespacedName portion
+        std::vector<std::string> connectNamePieces =
+            TfStringSplit(in.string(), ".");
+        if (connectNamePieces.size() < 2)
+        {
+            // there has to be at least two pieces!
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "invalid connect attribute name '%s'",
+                in.string().c_str());
+        }
+
+        std::string errorMessage;
+        if (!_PrimInitAttribute(
+            _UnpadNamespacedName(TfStringTrim(
+                connectNamePieces[0])), context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = true;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeConnectItem>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string path = Sdf_EvalQuotedString(
+            in.string().c_str(), in.string().length(), 1);
+        std::string errorMessage;
+        if (!_PathSetPrimOrPropertyScenePath(path, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        _AttributeAppendConnectionPath(context, in.position().line);
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypeExplicit, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeAddConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypeAdded, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeDeleteConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypeDeleted, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeAppendConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypeAppended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributePrependConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypePrepended, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeReorderConnectValue>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        std::string errorMessage;
+        if (!_AttributeSetConnectionTargetsList(
+            SdfListOpTypeOrdered, context, errorMessage))
+        {
+            Sdf_TextFileFormatParser_Err(
+                context,
+                in.input(),
+                in.position(),
+                "%s",
+                errorMessage.c_str());
+        }
+        context.path = context.path.GetParentPath();
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeAddConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = true;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeDeleteConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = false;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeAppendConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = true;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributePrependConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = true;
+    }
+};
+
+template <>
+struct TextParserAction<PrimAttributeReorderConnectAssignment>
+{
+    template <class Input>
+    static void apply(const Input& in, Sdf_TextParserContext& context)
+    {
+        context.connParsingTargetPaths.clear();
+        context.connParsingAllowConnectionData = false;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////
+// Parsing entry-point methods
+
+/// Parse a text layer into an SdfData
+bool 
+Sdf_ParseLayer(
+    const std::string& fileContext, 
+    const std::shared_ptr<ArAsset>& asset,
+    const std::string& magicId,
+    const std::string& versionString,
+    bool metadataOnly,
+    SdfDataRefPtr data,
+    SdfLayerHints *hints)
+{
+    TfAutoMallocTag2 tag("Sdf", "Sdf_ParseLayer");
+
+    TRACE_FUNCTION();
+
+    // Configure for input file.
+    Sdf_TextParserContext context;
+
+    context.data = data;
+    context.fileContext = fileContext;
+    context.magicIdentifierToken = magicId;
+    context.versionString = versionString;
+    context.metadataOnly = metadataOnly;
+
+    // read the entire file into memory
+    size_t size = asset->GetSize();
+    std::string buffer(size, ' ');
+    if (asset->Read(&buffer[0], size, 0) != size)
+    {
+        TF_RUNTIME_ERROR("Failed to read asset contents @%s@: "
+            "an error occurred while reading",
+            fileContext.c_str());
+    }
+
+    PEGTL_NS::string_input<> content { std::move(buffer), fileContext};
+    context.values.errorReporter =
+        std::bind(_ReportParseError<PEGTL_NS::string_input<>>,
+        std::ref(context), std::cref(content), std::placeholders::_1);
+    bool status = false;
+    try
+    {
+        if (!metadataOnly)
+        {
+            status = PEGTL_NS::parse<
+                PEGTL_NS::must<Layer, PEGTL_NS::internal::eof>,
+                TextParserAction,
+                TextParserControl>(content, context);
+            *hints = context.layerHints;
+        }
+        else
+        {
+            // note the absence of the eof here - there will be more
+            // content in the layer and we don't know what that content is,
+            // so we stop at reduction of LayerMetadataOnly
+            status = PEGTL_NS::parse<
+                PEGTL_NS::must<LayerMetadataOnly>,
+                TextParserAction,
+                TextParserControl>(content, context);
+            *hints = context.layerHints;
+        }
+    }
+    catch (boost::bad_get const &)
+    {
+        TF_CODING_ERROR("Bad boost:get<T>() in layer parser.");
+        Sdf_TextFileFormatParser_Err(
+            context,
+            content,
+            content.position(),
+            "Internal layer parser error.");
+    }
+    catch (const PEGTL_NS::parse_error& e)
+    {
+        Sdf_TextFileFormatParser_Err(
+            context,
+            content,
+            e.positions.size() == 0 ? content.position() : e.positions[0],
+            e.what());
+    }
+
+    return status;
+}
+
+/// Parse a layer text string into an SdfData
+bool
+Sdf_ParseLayerFromString(
+    const std::string & layerString, 
+    const std::string & magicId,
+    const std::string & versionString,
+    SdfDataRefPtr data,
+    SdfLayerHints *hints)
+{
+    TfAutoMallocTag2 tag("Sdf", "Sdf_ParseLayerFromString");
+
+    TRACE_FUNCTION();
+
+    // Configure for input string.
+    Sdf_TextParserContext context;
+
+    context.data = data;
+    context.magicIdentifierToken = magicId;
+    context.versionString = versionString;
+
+    PEGTL_NS::string_input<> content { std::move(layerString), ""};
+    context.values.errorReporter =
+        std::bind(_ReportParseError<PEGTL_NS::string_input<>>,
+        std::ref(context), std::cref(content), std::placeholders::_1);
+    bool status;
+    try
+    {
+        status = PEGTL_NS::parse<
+            PEGTL_NS::must<Layer, PEGTL_NS::internal::eof>,
+            TextParserAction,
+            TextParserControl>(content, context);
+    }
+    catch (boost::bad_get const &)
+    {
+        TF_CODING_ERROR("Bad boost:get<T>() in layer parser.");
+        Sdf_TextFileFormatParser_Err(
+            context,
+            content,
+            content.position(),
+            "Internal layer parser error.");
+    }
+    catch (const PEGTL_NS::parse_error& e)
+    {
+        Sdf_TextFileFormatParser_Err(
+            context,
+            content,
+            e.positions.size() == 0 ? content.position() : e.positions[0],
+            e.what());
+    }
+
+    return status;
+}
+
+}  // end namespace Sdf_TextFileFormatParser
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/sdf/textFileFormatParser.h
+++ b/pxr/usd/sdf/textFileFormatParser.h
@@ -1,0 +1,2396 @@
+//
+// Copyright 2023 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "Apache License")
+// with the following modification; you may not use this file except in
+// compliance with the Apache License and the following modification to it:
+// Section 6. Trademarks. is deleted and replaced with:
+//
+// 6. Trademarks. This License does not grant permission to use the trade
+//    names, trademarks, service marks, or product names of the Licensor
+//    and its affiliates, except as required to comply with Section 4(c) of
+//    the License and to reproduce the content of the NOTICE file.
+//
+// You may obtain a copy of the Apache License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the Apache License with the above modification is
+// distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the Apache License for the specific
+// language governing permissions and limitations under the Apache License.
+//
+#ifndef PXR_USD_SDF_TEXT_FILE_FORMAT_PARSER_H
+#define PXR_USD_SDF_TEXT_FILE_FORMAT_PARSER_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/debug.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/base/vt/value.h"
+#include "pxr/usd/sdf/data.h"
+#include "pxr/usd/sdf/debugCodes.h"
+#include "pxr/usd/sdf/listOp.h"
+#include "pxr/usd/sdf/parserHelpers.h"
+#include "pxr/usd/sdf/path.h"
+
+// transitively including pxr/base/tf/pxrPEGTL/pegtl.h
+#include "pxr/usd/sdf/pathParser.h"
+#include "pxr/usd/sdf/parserHelpers.h"
+#include "pxr/usd/sdf/parserValueContext.h"
+#include "pxr/usd/sdf/schema.h"
+#include "pxr/usd/sdf/textParserContext.h"
+#include "pxr/usd/sdf/textParserHelpers.h"
+
+#include <vector>
+#include <string>
+#include <utility>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+////////////////////////////////////////////////////////////////////////
+// TextFileFormat grammar:
+// We adopt the convention in the following PEGTL rules where they take
+// care of "internal padding" (i.e. whitespace within the grammar rule 
+// itself) but not "external padding" (i.e. they will not consume
+// whitespace prior to the first token, nor whitespace following the
+// last token in the rule).
+//
+// The exception to this rule is the class of "separators" which do
+// try to consume leading and trailing whitespace where appropriate
+
+namespace Sdf_TextFileFormatParser {
+
+namespace PEGTL_NS = tao::TAO_PEGTL_NAMESPACE;
+
+// special characters
+// note - Dot comes from pathParser.h
+struct SingleQuote : PEGTL_NS::one<'\''> {};
+struct DoubleQuote : PEGTL_NS::one<'"'> {};
+struct LeftParen : PEGTL_NS::one<'('> {};
+struct RightParen : PEGTL_NS::one<')'> {};
+struct LeftBrace : PEGTL_NS::one<'['> {};
+struct RightBrace : PEGTL_NS::one<']'> {};
+struct LeftCurlyBrace : PEGTL_NS::one<'{'> {};
+struct RightCurlyBrace : PEGTL_NS::one<'}'> {};
+struct LeftAngleBracket : PEGTL_NS::one<'<'> {};
+struct RightAngleBracket : PEGTL_NS::one<'>'> {};
+struct At : PEGTL_NS::one<'@'> {};
+struct Equals : PEGTL_NS::one<'='> {};
+struct Minus : PEGTL_NS::one<'-'> {};
+struct Exponent : PEGTL_NS::one<'e', 'E'> {};
+struct Space : PEGTL_NS::one<' ', '\t'> {};
+
+// character classes
+struct Digit : PEGTL_NS::digit {};
+
+// keywords
+struct StrAdd : TAO_PEGTL_STRING("add") {};
+struct StrAppend : TAO_PEGTL_STRING("append") {};
+struct StrClass : TAO_PEGTL_STRING("class") {};
+struct StrConfig : TAO_PEGTL_STRING("config") {};
+struct StrConnect : TAO_PEGTL_STRING("connect") {};
+struct StrCustom : TAO_PEGTL_STRING("custom") {};
+struct StrCustomData : TAO_PEGTL_STRING("customData") {};
+struct StrDefault : TAO_PEGTL_STRING("default") {};
+struct StrDef : TAO_PEGTL_STRING("def") {};
+struct StrDelete : TAO_PEGTL_STRING("delete") {};
+struct StrDictionary : TAO_PEGTL_STRING("dictionary") {};
+struct StrDisplayUnit : TAO_PEGTL_STRING("displayUnit") {};
+struct StrDoc : TAO_PEGTL_STRING("doc") {};
+struct StrInherits : TAO_PEGTL_STRING("inherits") {};
+struct StrKind : TAO_PEGTL_STRING("kind") {};
+struct StrNameChildren : TAO_PEGTL_STRING("nameChildren") {};
+struct StrNone : TAO_PEGTL_STRING("None") {};
+struct StrOffset: TAO_PEGTL_STRING("offset") {};
+struct StrOver : TAO_PEGTL_STRING("over") {};
+struct StrPayload : TAO_PEGTL_STRING("payload") {};
+struct StrPermission : TAO_PEGTL_STRING("permission") {};
+struct StrPrefixSubstitutions : TAO_PEGTL_STRING("prefixSubstitutions") {};
+struct StrPrepend : TAO_PEGTL_STRING("prepend") {};
+struct StrProperties : TAO_PEGTL_STRING("properties") {};
+struct StrReferences : TAO_PEGTL_STRING("references") {};
+struct StrRelocates : TAO_PEGTL_STRING("relocates") {};
+struct StrRel : TAO_PEGTL_STRING("rel") {};
+struct StrReorder : TAO_PEGTL_STRING("reorder") {};
+struct StrRootPrims : TAO_PEGTL_STRING("rootPrims") {};
+struct StrScale : TAO_PEGTL_STRING("scale") {};
+struct StrSubLayers : TAO_PEGTL_STRING("subLayers") {};
+struct StrSuffixSubstitutions : TAO_PEGTL_STRING("suffixSubstitutions") {};
+struct StrSpecializes : TAO_PEGTL_STRING("specializes") {};
+struct StrSymmetryArguments : TAO_PEGTL_STRING("symmetryArguments") {};
+struct StrSymmetryFunction : TAO_PEGTL_STRING("symmetryFunction") {};
+struct StrTimeSamples : TAO_PEGTL_STRING("timeSamples") {};
+struct StrUniform : TAO_PEGTL_STRING("uniform") {};
+struct StrVariantSet : TAO_PEGTL_STRING("variantSet") {};
+struct StrVariantSets : TAO_PEGTL_STRING("variantSets") {};
+struct StrVariants : TAO_PEGTL_STRING("variants") {};
+struct StrVarying : TAO_PEGTL_STRING("varying") {};
+
+struct StrKeywords : PEGTL_NS::sor<StrAdd, StrAppend, StrClass, StrConfig,
+  StrConnect, StrCustom, StrCustomData, StrDefault, StrDef, StrDelete,
+  StrDictionary, StrDisplayUnit, StrDoc, StrInherits, StrKind, StrNameChildren,
+  StrNone, StrOffset, StrOver, StrPayload, StrPermission,
+  StrPrefixSubstitutions, StrPrepend, StrProperties, StrReferences,
+  StrRelocates, StrRel, StrReorder, StrRootPrims, StrScale, StrSubLayers,
+  StrSuffixSubstitutions, StrSpecializes, StrSymmetryArguments, 
+  StrSymmetryFunction, StrTimeSamples, StrUniform, StrVariantSets,
+  StrVariantSet, StrVariants, StrVarying> {};
+
+struct StrInf : TAO_PEGTL_STRING("inf") {};
+struct StrNan : TAO_PEGTL_STRING("nan") {};
+
+struct StrMathKeywords : PEGTL_NS::sor<StrInf, StrNan> {};
+
+template <typename R>
+struct Keyword : PEGTL_NS::seq<
+    R, PEGTL_NS::not_at<PEGTL_NS::identifier_other>> {};
+
+struct KeywordAdd : Keyword<StrAdd> {};
+struct KeywordAppend : Keyword<StrAppend> {};
+struct KeywordClass : Keyword<StrClass> {};
+struct KeywordConfig : Keyword<StrConfig> {};
+struct KeywordConnect : Keyword<StrConnect> {};
+struct KeywordCustom : Keyword<StrCustom> {};
+struct KeywordCustomData : Keyword<StrCustomData> {};
+struct KeywordDefault : Keyword<StrDefault> {};
+struct KeywordDef : Keyword<StrDef> {};
+struct KeywordDelete : Keyword<StrDelete> {};
+struct KeywordDictionary : Keyword<StrDictionary> {};
+struct KeywordDisplayUnit : Keyword<StrDisplayUnit> {};
+struct KeywordDoc : Keyword<StrDoc> {};
+struct KeywordInherits : Keyword<StrInherits> {};
+struct KeywordKind : Keyword<StrKind> {};
+struct KeywordNameChildren : Keyword<StrNameChildren> {};
+struct KeywordNone : Keyword<StrNone> {};
+struct KeywordOffset : Keyword<StrOffset> {};
+struct KeywordOver : Keyword<StrOver> {};
+struct KeywordPayload : Keyword<StrPayload> {};
+struct KeywordPermission : Keyword<StrPermission> {};
+struct KeywordPrefixSubstitutions : Keyword<StrPrefixSubstitutions> {};
+struct KeywordPrepend : Keyword<StrPrepend> {};
+struct KeywordProperties : Keyword<StrProperties> {};
+struct KeywordReferences : Keyword<StrReferences> {};
+struct KeywordRelocates : Keyword<StrRelocates> {};
+struct KeywordRel : Keyword<StrRel> {};
+struct KeywordReorder : Keyword<StrReorder> {};
+struct KeywordRootPrims : Keyword<StrRootPrims> {};
+struct KeywordScale : Keyword<StrScale> {};
+struct KeywordSubLayers : Keyword<StrSubLayers> {};
+struct KeywordSuffixSubstitutions : Keyword<StrSuffixSubstitutions> {};
+struct KeywordSpecializes : Keyword<StrSpecializes> {};
+struct KeywordSymmetryArguments : Keyword<StrSymmetryArguments> {};
+struct KeywordSymmetryFunction : Keyword<StrSymmetryFunction> {};
+struct KeywordTimeSamples : Keyword<StrTimeSamples> {};
+struct KeywordUniform : Keyword<StrUniform> {};
+struct KeywordVariantSet : Keyword<StrVariantSet> {};
+struct KeywordVariantSets : Keyword<StrVariantSets> {};
+struct KeywordVariants : Keyword<StrVariants> {};
+struct KeywordVarying : Keyword<StrVarying> {};
+
+struct Keywords : Keyword<StrKeywords> {};
+
+struct MathKeywordInf : Keyword<StrInf> {};
+struct MathKeywordNan : Keyword<StrNan> {};
+
+struct MathKeywords : Keyword<StrMathKeywords> {};
+
+struct Utf8CharacterNoEolf
+{
+    using rule_t = Utf8CharacterNoEolf;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        if (!in.empty())
+        {
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                // any UTF8-character that isn't a CR / LF
+                if ((static_cast<uint32_t>(utf8_char.data) == 0x000Au) ||
+                    (static_cast<uint32_t>(utf8_char.data) == 0x000Du))
+                {
+                    return false;
+                }
+
+                in.bump(utf8_char.size);
+                return true;
+            }
+        }
+
+        return false;
+    }
+};
+
+struct PythonStyleComment : PEGTL_NS::disable<
+    PEGTL_NS::one<'#'>, PEGTL_NS::star<PEGTL_NS::not_at<PEGTL_NS::eolf>,
+    Utf8CharacterNoEolf>> {};
+struct CppStyleSingleLineComment : PEGTL_NS::disable<
+    PEGTL_NS::two<'/'>, PEGTL_NS::star<PEGTL_NS::not_at<PEGTL_NS::eolf>,
+    Utf8CharacterNoEolf>> {};
+struct CppStyleMultiLineComment : PEGTL_NS::disable<
+    PEGTL_NS::seq<PEGTL_NS::one<'/'>, PEGTL_NS::one<'*'>,
+    PEGTL_NS::until<PEGTL_NS::seq<PEGTL_NS::one<'*'>,
+    PEGTL_NS::one<'/'>>>>> {};
+struct Comment : PEGTL_NS::sor<
+    PythonStyleComment,
+    CppStyleSingleLineComment,
+    CppStyleMultiLineComment> {};
+
+// whitespace rules
+// TokenSpace represents whitespace between tokens,
+// which can include space, tab, and c++ multiline style comments
+// but MUST include a single space / tab character, that is:
+// def/*comment*/foo is illegal but
+// def /*comment*/foo or
+// def/*comment*/ foo are both legal
+struct TokenSpace : PEGTL_NS::sor<
+    PEGTL_NS::seq<PEGTL_NS::plus<Space>,
+        PEGTL_NS::opt<PEGTL_NS::list_tail<CppStyleMultiLineComment, Space>>>,
+        PEGTL_NS::seq<PEGTL_NS::list<CppStyleMultiLineComment, Space>,
+            PEGTL_NS::plus<Space>>> {};
+
+struct EolWhitespace : PEGTL_NS::star<PEGTL_NS::sor<Space, Comment>> {};
+struct Crlf : PEGTL_NS::sor<
+    PEGTL_NS::seq<PEGTL_NS::one<'\r'>, PEGTL_NS::one<'\n'>>,
+    PEGTL_NS::one<'\r', '\n'>> {};
+struct NewLine : PEGTL_NS::seq<
+    EolWhitespace, 
+    Crlf> {};
+struct NewLines : PEGTL_NS::plus<NewLine> {};
+
+// array type
+struct ArrayType : PEGTL_NS::if_must<
+    LeftBrace,
+    PEGTL_NS::opt<TokenSpace>,
+    RightBrace> {};
+
+// separators
+struct ListSeparator : PEGTL_NS::seq<PEGTL_NS::one<','>,
+    PEGTL_NS::opt<NewLines>> {};
+struct ListEnd : PEGTL_NS::sor<
+    ListSeparator,
+    PEGTL_NS::opt<NewLines>> {};
+struct StatementSeparator : PEGTL_NS::sor<
+    PEGTL_NS::seq<PEGTL_NS::one<';'>, PEGTL_NS::opt<NewLines>>,
+    NewLines> {};
+struct StatementEnd : PEGTL_NS::sor<
+    StatementSeparator,
+    PEGTL_NS::opt<NewLines>> {};
+struct NamespaceSeparator : PEGTL_NS::one<':'> {};
+struct CXXNamespaceSeparator : PEGTL_NS::seq<NamespaceSeparator,
+    NamespaceSeparator> {};
+struct Assignment : PEGTL_NS::seq<PEGTL_NS::opt<TokenSpace>,
+    Equals, PEGTL_NS::opt<TokenSpace>> {};
+
+// numbers
+struct ExponentPart : PEGTL_NS::opt_must<
+    Exponent,
+    PEGTL_NS::opt<PEGTL_NS::one<'+', '-'>>,
+    PEGTL_NS::plus<Digit>> {};
+struct NumberStandard : PEGTL_NS::seq<
+    PEGTL_NS::opt<Minus>, PEGTL_NS::plus<Digit>,
+    PEGTL_NS::opt_must<Sdf_PathParser::Dot, PEGTL_NS::plus<Digit>>,
+    ExponentPart> {};
+struct NumberLeadingDot : PEGTL_NS::seq<
+    PEGTL_NS::opt<Minus>,
+    PEGTL_NS::if_must<Sdf_PathParser::Dot,
+    PEGTL_NS::plus<Digit>>,
+    ExponentPart> {};
+struct Number : PEGTL_NS::sor<
+    MathKeywordInf, 
+    PEGTL_NS::seq<Minus, MathKeywordInf>,
+    MathKeywordNan,
+    NumberStandard,
+    NumberLeadingDot> {};
+
+// string supporting methods
+struct Utf8SingleQuoteCharacter
+{
+    using rule_t = Utf8SingleQuoteCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        if (!in.empty())
+        {
+            // peek at the next character in the input
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                // a quote can be consumed if it's preceeded by a '\'
+                if (static_cast<uint32_t>(utf8_char.data) == 0x005Cu)
+                {
+                    // consume and check the next character
+                    // unfortunately there isn't a replace, so
+                    // we've consumed this character even if it
+                    // ultimately wasn't a valid match
+                    // this is ok, because without the closed quote
+                    // it can't be any other valid production
+                    in.bump(utf8_char.size);
+                    auto utf8_char2 = PEGTL_NS::internal::peek_utf8::peek(in);
+                    if (utf8_char2.size != 0)
+                    {
+                        // if it's a CR or LF, it's an error,
+                        // everything else is ok
+                        if ((static_cast<uint32_t>(utf8_char2.data) != 0x000Au) && 
+                            (static_cast<uint32_t>(utf8_char2.data) != 0x000Du))
+                        {
+                            in.bump(utf8_char2.size);
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                // if it's a CR, LF, or ', don't consume
+                if ((static_cast<uint32_t>(utf8_char.data) != 0x000Au) && 
+                    (static_cast<uint32_t>(utf8_char.data) != 0x000Du) &&
+                    (static_cast<uint32_t>(utf8_char.data) != 0x0027u))
+                {
+                    in.bump(utf8_char.size);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+};
+
+struct Utf8DoubleQuoteCharacter
+{
+    using rule_t = Utf8DoubleQuoteCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        if (!in.empty())
+        {
+            // peek at the next character in the input
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                // a double quote can be consumed if it's preceeded by a '\'
+                if (static_cast<uint32_t>(utf8_char.data) == 0x005Cu)
+                {
+                    // consume and check the next character
+                    // unfortunately there isn't a replace, so
+                    // we've consumed this character even if it
+                    // ultimately wasn't a valid match
+                    // this is ok, because without the closed quote
+                    // it can't be any other valid production
+                    in.bump(utf8_char.size);
+                    auto utf8_char2 = PEGTL_NS::internal::peek_utf8::peek(in);
+                    if (utf8_char2.size != 0)
+                    {
+                        // if it's a CR or LF, it's an error,
+                        // everything else is ok
+                        if ((static_cast<uint32_t>(utf8_char2.data) != 0x000Au) &&
+                            (static_cast<uint32_t>(utf8_char2.data) != 0x000Du))
+                        {
+                            in.bump(utf8_char2.size);
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                // if it's a CR, LF, or ", don't consume
+                if ((static_cast<uint32_t>(utf8_char.data) != 0x000Au) && 
+                    (static_cast<uint32_t>(utf8_char.data) != 0x000Du) &&
+                    (static_cast<uint32_t>(utf8_char.data) != 0x0022u))
+                {
+                    in.bump(utf8_char.size);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+};
+
+struct Utf8SingleQuoteMultilineCharacter
+{
+    using rule_t = Utf8SingleQuoteMultilineCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        if (!in.empty())
+        {
+            // peek at the next character in the input
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                // a quote can be consumed if it's preceeded by a '\'
+                if (static_cast<uint32_t>(utf8_char.data) == 0x005Cu)
+                {
+                    // consume and check the next character
+                    // unfortunately there isn't a replace, so
+                    // we've consumed this character even if it
+                    // ultimately wasn't a valid match
+                    // this is ok, because without the closed quote
+                    // it can't be any other valid production
+                    in.bump(utf8_char.size);
+                    auto utf8_char2 = PEGTL_NS::internal::peek_utf8::peek(in);
+                    if (utf8_char2.size != 0)
+                    {
+                        in.bump(utf8_char2.size);
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                // if it's an unescaped ', don't consume
+                if (static_cast<uint32_t>(utf8_char.data) != 0x0027u)
+                {
+                    in.bump(utf8_char.size);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+};
+
+struct Utf8DoubleQuoteMultilineCharacter
+{
+    using rule_t = Utf8DoubleQuoteMultilineCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        if (!in.empty())
+        {
+            // peek at the next character in the input
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                // a double quote can be consumed if it's preceeded by a '\'
+                if (static_cast<uint32_t>(utf8_char.data) == 0x005Cu)
+                {
+                    // consume and check the next character
+                    // unfortunately there isn't a replace, so
+                    // we've consumed this character even if it
+                    // ultimately wasn't a valid match
+                    // this is ok, because without the closed quote
+                    // it can't be any other valid production
+                    in.bump(utf8_char.size);
+                    auto utf8_char2 = PEGTL_NS::internal::peek_utf8::peek(in);
+                    if (utf8_char2.size != 0)
+                    {
+                        in.bump(utf8_char2.size);
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                // unescaped quotes are allowed in the string,
+                // but only if they are a single double quote or a set of two
+                // double quotes (3 would close the string)
+                if (static_cast<uint32_t>(utf8_char.data) == 0x0022u)
+                {
+                    auto nextChar = in.peek_uint8(1);
+                    auto nextNextChar = in.peek_uint8(2);
+                    if (static_cast<uint32_t>(nextChar) == 0x0022u &&
+                        static_cast<uint32_t>(nextNextChar) == 0x0022u)
+                    {
+                        // this would mark the end of the multi-line string
+                        return false;
+                    }
+                    else
+                    {
+                        // find to consume the quote
+                        in.bump(utf8_char.size);
+                        return true;
+                    }    
+                }
+                else
+                {
+                    // valid
+                    in.bump(utf8_char.size);
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+};
+
+// strings
+struct EmptyMultilineSingleQuoteString : PEGTL_NS::seq<
+    SingleQuote, SingleQuote, SingleQuote,
+    SingleQuote, SingleQuote, SingleQuote> {};
+struct EmptyMultilineDoubleQuoteString : PEGTL_NS::seq<
+    DoubleQuote, DoubleQuote, DoubleQuote,
+    DoubleQuote, DoubleQuote, DoubleQuote> {};
+struct MultilineSingleQuoteString : PEGTL_NS::if_must<
+    PEGTL_NS::seq<SingleQuote, SingleQuote, SingleQuote>,
+    PEGTL_NS::plus<Utf8SingleQuoteMultilineCharacter>,
+    PEGTL_NS::seq<SingleQuote, SingleQuote, SingleQuote>> {};
+struct MultilineDoubleQuoteString : PEGTL_NS::if_must<
+    PEGTL_NS::seq<DoubleQuote, DoubleQuote, DoubleQuote>,
+    PEGTL_NS::plus<Utf8DoubleQuoteMultilineCharacter>,
+    PEGTL_NS::seq<DoubleQuote, DoubleQuote, DoubleQuote>> {};
+struct EmptySingleQuoteString : PEGTL_NS::seq<SingleQuote, SingleQuote> {};
+struct EmptyDoubleQuoteString : PEGTL_NS::seq<DoubleQuote, DoubleQuote> {};
+struct SinglelineSingleQuoteString : PEGTL_NS::if_must<
+    SingleQuote, PEGTL_NS::plus<Utf8SingleQuoteCharacter>, SingleQuote> {};
+struct SinglelineDoubleQuoteString : PEGTL_NS::if_must<
+    DoubleQuote, PEGTL_NS::plus<Utf8DoubleQuoteCharacter>, DoubleQuote> {};
+struct SingleQuoteString : PEGTL_NS::sor<
+    EmptyMultilineSingleQuoteString,
+    MultilineSingleQuoteString,
+    EmptySingleQuoteString,
+    SinglelineSingleQuoteString> {};
+struct DoubleQuoteString : PEGTL_NS::sor<
+    EmptyMultilineDoubleQuoteString,
+    MultilineDoubleQuoteString,
+    EmptyDoubleQuoteString,
+    SinglelineDoubleQuoteString> {};
+struct String : PEGTL_NS::sor<
+    SingleQuoteString,
+    DoubleQuoteString> {};
+
+// asset references
+struct Utf8AssetPathCharacter
+{
+    using rule_t = Utf8AssetPathCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        while(!in.empty())
+        {
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                if ((static_cast<uint32_t>(utf8_char.data) == 0x000Au) ||
+                    (static_cast<uint32_t>(utf8_char.data) == 0x000Du))
+                {
+                    // end of sequence
+                    return false;
+                }
+                else if ((static_cast<uint32_t>(utf8_char.data) == 0x0040u))
+                {
+                    // this is the '@' signaling the end of the sequence
+                    // we consumed what we can, don't consume this character
+                    return true;
+                }
+                else
+                {
+                    // consume and keep going
+                    in.bump(utf8_char.size);
+                }
+            }
+            else
+            {
+                return false;
+            }
+
+        }
+
+        return false;
+    }
+};
+
+struct Utf8AssetPathEscapedCharacter
+{
+    using rule_t = Utf8AssetPathEscapedCharacter;
+    using analyze_t = PEGTL_NS::analysis::generic<
+        PEGTL_NS::analysis::rule_type::any >;
+
+    template <typename ParseInput>
+    static bool match(ParseInput& in)
+    {
+        while(!in.empty())
+        {
+            auto utf8_char = PEGTL_NS::internal::peek_utf8::peek(in);
+            if (utf8_char.size != 0)
+            {
+                if ((static_cast<uint32_t>(utf8_char.data) == 0x000Au) ||
+                    (static_cast<uint32_t>(utf8_char.data) == 0x000Du))
+                {
+                    // end of sequence
+                    return false;
+                }
+                else if(static_cast<uint32_t>(utf8_char.data) == 0x0040u)
+                {
+                    // if we are not currently processing an escape, this
+                    // could either be a consumeable character or the end
+                    // of the stream - we need to look ahead to the next
+                    // input (without consuming this one yet) to see if
+                    // we need to potentially process the end sequence
+                    auto nextChar = in.peek_uint8(1);
+                    if (static_cast<uint32_t>(nextChar) == 0x0040u)
+                    {
+                        // the next one was a '@' as well, look for the last
+                        nextChar = in.peek_uint8(2);
+                        if (static_cast<uint32_t>(nextChar) == 0x0040u)
+                        {
+                            // that's it, we are done, signal success
+                            // and don't consume any of the '@' chars
+                            return true;
+                        }
+                        else
+                        {
+                            // we got 2 '@', but not a third
+                            // so we consider that part of our
+                            // asset string and eat the sequence
+                            in.bump(2);
+                        }
+                    }
+                    else
+                    {
+                        // the next byte wasn't another '@', so
+                        // eat the first '@' and move on
+                        in.bump(utf8_char.size);
+                    }
+                }
+                else if (static_cast<uint32_t>(utf8_char.data) == 0x005Cu)
+                {
+                    // this is an escape sequence
+                    // if we aren't escaping a '@@@' sequence, just consume
+                    // and move on
+                    auto nextChar = in.peek_uint8(1);
+                    if (static_cast<uint32_t>(nextChar) != 0x0040u)
+                    {
+                        // consume the '\'
+                        in.bump(utf8_char.size);
+                    }
+                    else
+                    {
+                        // it's a '@', keep going to see if we can
+                        // eat the whole sequence
+                        nextChar = in.peek_uint8(2);
+                        if (static_cast<uint32_t>(nextChar) == 0x0040u)
+                        {
+                            nextChar = in.peek_uint8(3);
+                            if (static_cast<uint32_t>(nextChar) == 0x0040u)
+                            {
+                                // that's the end of the escaped '@@@'
+                                // eat the whole sequence (4 bytes)
+                                in.bump(4);
+                            }
+                            else
+                            {
+                                // we had a \@@ sequence, but not a fully
+                                // escaped one - nevertheless we can eat
+                                // the whole thing
+                                in.bump(3);
+                            }
+                        }
+                        else
+                        {
+                            // the next char was not a '@', meaning
+                            // we had a `\@' sequence, which is fine
+                            // we can eat both of those for efficiency
+                            in.bump(2);
+                        }
+                    }
+                }
+                else
+                {
+                    // consume and keep going
+                    in.bump(utf8_char.size);
+                }
+            }
+            else
+            {
+                return false;
+            }
+
+        }
+
+        return false;
+    }
+};
+
+struct AssetRef : PEGTL_NS::sor<
+    PEGTL_NS::if_must<
+        PEGTL_NS::seq<At, At, At>, 
+        Utf8AssetPathEscapedCharacter, 
+        PEGTL_NS::seq<At, At, At>>,
+    PEGTL_NS::if_must<
+        At,
+        Utf8AssetPathCharacter,
+        At>> {};
+
+// path reference
+struct PathRef : PEGTL_NS::if_must<
+    LeftAngleBracket,
+    PEGTL_NS::sor<
+        RightAngleBracket,
+        PEGTL_NS::seq<
+            Sdf_PathParser::Path,
+            RightAngleBracket>>> {};
+
+// grammar rule that currently matches ASCII identifiers
+// but that can be more easily changed in the future for UTF-8
+struct BaseIdentifier : PEGTL_NS::identifier {};
+struct KeywordlessIdentifier : PEGTL_NS::seq<
+    PEGTL_NS::not_at<Keywords>,
+    BaseIdentifier> {};
+struct CXXNamespacedIdentifier : PEGTL_NS::seq<
+    KeywordlessIdentifier,
+    PEGTL_NS::plus<CXXNamespaceSeparator, KeywordlessIdentifier>> {};
+struct NamespacedIdentifier : PEGTL_NS::seq<
+    BaseIdentifier,
+    PEGTL_NS::plus<NamespaceSeparator, BaseIdentifier>> {};
+struct Identifier : PEGTL_NS::sor<
+    CXXNamespacedIdentifier,
+    KeywordlessIdentifier> {};
+struct NamespacedName : PEGTL_NS::sor<
+    NamespacedIdentifier, 
+    BaseIdentifier,
+    Keywords> {};
+
+// atomic values
+struct NumberValue : Number {};
+struct IdentifierValue : Identifier {};
+struct StringValue : String {};
+struct AssetRefValue : AssetRef {};
+struct AtomicValue : PEGTL_NS::sor<
+    NumberValue,
+    IdentifierValue,
+    StringValue,
+    AssetRefValue> {};
+
+struct TupleValue;
+struct ListValue;
+struct EmptyListValue;
+struct PathRefValue : PathRef {};
+struct TypedValue : PEGTL_NS::sor<
+    AtomicValue,
+    TupleValue,
+    EmptyListValue,
+    ListValue,
+    PathRefValue> {};
+
+// tuple values
+struct TupleValueOpen : LeftParen {};
+struct TupleValueClose : RightParen {};
+struct TupleValueItem : PEGTL_NS::sor<
+    AtomicValue,
+    TupleValue> {};
+struct TupleValueItems : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>, 
+        TupleValueItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct TupleValueInterior : PEGTL_NS::seq<
+    PEGTL_NS::opt<NewLines>,
+    TupleValueItems,
+    PEGTL_NS::opt<TokenSpace>,
+    ListEnd> {};
+struct TupleValue : PEGTL_NS::if_must<
+    TupleValueOpen,
+    TupleValueInterior,
+    PEGTL_NS::opt<TokenSpace>,
+    TupleValueClose> {};
+
+// list values
+struct ListValueOpen : LeftBrace {};
+struct ListValueClose : RightBrace {};
+struct ListValueItem : PEGTL_NS::sor<
+    AtomicValue,
+    ListValue,
+    TupleValue> {};
+struct ListValueItems : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        ListValueItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct ListValueInterior : PEGTL_NS::seq<
+    PEGTL_NS::opt<NewLines>,
+    ListValueItems,
+    PEGTL_NS::opt<TokenSpace>,
+    ListEnd> {};
+struct ListValue : PEGTL_NS::if_must<
+    ListValueOpen,
+    ListValueInterior,
+    PEGTL_NS::opt<TokenSpace>,
+    ListValueClose> {};
+
+// empty list value uses LeftBrace / RightBrace
+// rather than ListValueOpen / ListValueClose
+// because it doesn't want to execute the
+// action semantics on reduction
+struct EmptyListValue : PEGTL_NS::seq<
+    LeftBrace,
+    PEGTL_NS::opt<TokenSpace>,
+    RightBrace> {};
+
+// dictionary values
+struct DictionaryValue;
+struct DictionaryValueOpen : LeftCurlyBrace {};
+struct DictionaryValueClose : RightCurlyBrace {};
+struct DictionaryKey : PEGTL_NS::sor<
+    String,
+    Identifier,
+    Keywords> {};
+struct DictionaryValueScalarType : Identifier {};
+struct DictionaryValueShapedType : PEGTL_NS::seq<
+    Identifier,
+    PEGTL_NS::opt<TokenSpace>,
+    ArrayType> {};
+struct DictionaryValueType : PEGTL_NS::sor<
+    DictionaryValueShapedType,
+    DictionaryValueScalarType> {};
+struct DictionaryElementTypedValueAssignment : PEGTL_NS::must<
+    DictionaryKey,
+    Assignment,
+    TypedValue> {};
+struct DictionaryElementDictionaryValueAssignment : PEGTL_NS::must<
+    DictionaryKey,
+    Assignment,
+    DictionaryValue> {};
+struct DictionaryElementTypedValue : PEGTL_NS::seq<
+    DictionaryValueType,
+    TokenSpace,
+    DictionaryElementTypedValueAssignment> {};
+struct DictionaryElementDictionaryValue : PEGTL_NS::if_must<
+    KeywordDictionary,
+    TokenSpace,
+    DictionaryElementDictionaryValueAssignment> {};
+struct DictionaryValueElement : PEGTL_NS::sor<
+    DictionaryElementDictionaryValue,
+    DictionaryElementTypedValue> {}; 
+struct DictionaryValueItems : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        DictionaryValueElement,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct DictionaryValueInterior : PEGTL_NS::seq<
+    DictionaryValueItems,
+    StatementEnd> {};
+struct DictionaryValue : PEGTL_NS::if_must<
+    DictionaryValueOpen,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::opt<DictionaryValueInterior>,
+    PEGTL_NS::opt<TokenSpace>,
+    DictionaryValueClose> {};
+
+// metadata
+struct MetadataValue : PEGTL_NS::sor<
+    KeywordNone,
+    DictionaryValue,
+    TypedValue> {};
+
+// time samples
+struct ExtendedNumber : PEGTL_NS::sor<
+    Number,
+    Identifier> {};
+struct TimeSampleExtendedNumber : ExtendedNumber {};
+struct TimeSampleExtendedNumberSequence : PEGTL_NS::seq<
+    TimeSampleExtendedNumber,
+    PEGTL_NS::opt<TokenSpace>, 
+    NamespaceSeparator> {};
+struct TimeSampleExtendedNumberNone : KeywordNone {};
+struct TimeSampleExtendedNumberValue : PEGTL_NS::seq<TypedValue> {};
+struct TimeSample: PEGTL_NS::seq<
+    TimeSampleExtendedNumberSequence,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::sor<
+        TimeSampleExtendedNumberNone,
+        TimeSampleExtendedNumberValue>> {};
+struct TimeSamplesListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        TimeSample,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct TimeSamplesList : PEGTL_NS::seq<TimeSamplesListInterior, ListEnd> {};
+struct TimeSamplesBegin : LeftCurlyBrace {};
+struct TimeSamplesEnd : RightCurlyBrace {};
+struct TimeSamplesValue : PEGTL_NS::if_must<
+    TimeSamplesBegin,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::opt<TimeSamplesList>,
+    PEGTL_NS::opt<TokenSpace>,
+    TimeSamplesEnd> {};
+
+// list ops
+struct MetadataListOpList : PEGTL_NS::sor<
+    KeywordNone,
+    ListValue> {};
+
+// generic metadata shared between attributes and relationships
+struct MetadataKey : PEGTL_NS::sor<
+    KeywordCustomData,
+    KeywordSymmetryArguments,
+    Identifier> {};
+struct MetadataKeyMetadata : PEGTL_NS::seq<
+    MetadataKey,
+    Assignment,
+    MetadataValue> {};
+struct DocString : String {};
+struct DocMetadata : PEGTL_NS::if_must<
+    KeywordDoc,
+    Assignment,
+    DocString> {};
+struct PermissionIdentifier : Identifier {};
+struct PermissionMetadata : PEGTL_NS::if_must<
+    KeywordPermission,
+    Assignment,
+    PermissionIdentifier> {};
+struct SymmetryFunctionIdentifier : Identifier {};
+struct SymmetryFunctionEmpty : PEGTL_NS::seq<
+    KeywordSymmetryFunction,
+    Assignment> {};
+struct SymmetryFunctionMetadata : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        KeywordSymmetryFunction, 
+        Assignment,
+        SymmetryFunctionIdentifier>,
+    SymmetryFunctionEmpty> {};
+struct NameListItem : String {};
+struct NameListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        NameListItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct NameListBegin : LeftBrace {};
+struct NameListEnd : RightBrace {};
+struct NameList : PEGTL_NS::sor<
+    NameListItem,
+    PEGTL_NS::if_must<
+        NameListBegin,
+        PEGTL_NS::opt<NewLines>,
+        NameListInterior,
+        ListEnd,
+        PEGTL_NS::opt<TokenSpace>,
+        NameListEnd>> {};
+
+// prim attributes
+struct PrimAttributeMetadataListOpAddIdentifier : Identifier {};
+struct PrimAttributeMetadataListOpDeleteIdentifier : Identifier {};
+struct PrimAttributeMetadataListOpAppendIdentifier : Identifier {};
+struct PrimAttributeMetadataListOpPrependIdentifier : Identifier {};
+struct PrimAttributeMetadataListOpReorderIdentifier : Identifier {};
+struct PrimAttributeMetadataListOpList : MetadataListOpList {};
+struct PrimAttributeMetadataListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PrimAttributeMetadataListOpAddIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataListOpList>> {};
+struct PrimAttributeMetadataListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PrimAttributeMetadataListOpDeleteIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataListOpList>> {};
+struct PrimAttributeMetadataListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PrimAttributeMetadataListOpAppendIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataListOpList>> {};
+struct PrimAttributeMetadataListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PrimAttributeMetadataListOpPrependIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataListOpList>> {};
+struct PrimAttributeMetadataListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PrimAttributeMetadataListOpReorderIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataListOpList>> {};
+struct PrimAttributeListOpMetadata : PEGTL_NS::sor<
+    PrimAttributeMetadataListOpAdd,
+    PrimAttributeMetadataListOpDelete,
+    PrimAttributeMetadataListOpAppend,
+    PrimAttributeMetadataListOpPrepend,
+    PrimAttributeMetadataListOpReorder> {};
+struct PrimAttributeMetadataKey : Identifier {};
+struct PrimAttributeMetadataValue : MetadataValue {};
+struct PrimAttributeMetadataKeyMetadata : PEGTL_NS::seq<
+    PrimAttributeMetadataKey,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeMetadataValue>> {};
+struct PrimAttributeMetadataString : String {};
+struct PrimAttributeMetadataDisplayUnitIdentifier : Identifier {};
+struct PrimAttributeDisplayUnitMetadata : PEGTL_NS::if_must<
+    KeywordDisplayUnit,
+    Assignment,
+    PrimAttributeMetadataDisplayUnitIdentifier> {};
+struct PrimAttributeMetadataItem : PEGTL_NS::sor<
+    PrimAttributeMetadataString,
+    PrimAttributeMetadataKeyMetadata,
+    PrimAttributeListOpMetadata,
+    DocMetadata,
+    PermissionMetadata,
+    SymmetryFunctionMetadata,
+    PrimAttributeDisplayUnitMetadata> {};
+struct PrimAttributeMetadataListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimAttributeMetadataItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct PrimAttributeMetadataList : PEGTL_NS::if_must<
+    LeftParen,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::sor<
+        RightParen,
+        PEGTL_NS::seq<
+            PrimAttributeMetadataListInterior,
+            StatementEnd,
+            PEGTL_NS::opt<TokenSpace>,
+            RightParen>>> {};
+struct PrimAttributeVariability : PEGTL_NS::sor<
+    KeywordUniform,
+    KeywordConfig> {};
+struct PrimAttributeStandardType : Identifier {};
+struct PrimAttributeArrayType : PEGTL_NS::seq<
+    Identifier,
+    PEGTL_NS::opt<TokenSpace>,
+    ArrayType> {};
+struct PrimAttributeType : PEGTL_NS::sor<
+    PrimAttributeArrayType,
+    PrimAttributeStandardType> {};
+struct PrimAttributeQualifiedTypeName : PrimAttributeType {};
+struct PrimAttributeQualifiedType : PEGTL_NS::seq<
+    PrimAttributeVariability,
+    TokenSpace,
+    PrimAttributeQualifiedTypeName> {};
+struct PrimAttributeFullType : PEGTL_NS::sor<
+    PrimAttributeQualifiedType,
+    PrimAttributeType> {};
+struct PrimAttributeValue : PEGTL_NS::sor<
+    KeywordNone,
+    TypedValue> {};
+struct PrimAttributeAssignment : PEGTL_NS::if_must<
+    Assignment,
+    PrimAttributeValue> {};
+struct PrimAttributeDefaultNamespacedName : NamespacedName {};
+struct PrimAttributeAssignmentOptional : PEGTL_NS::opt<PrimAttributeAssignment> {};
+struct PrimAttributeDefaultTypeName : PEGTL_NS::seq<
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeDefaultNamespacedName> {};
+struct PrimAttributeDefault : PEGTL_NS::seq<
+    PrimAttributeDefaultTypeName,
+    PrimAttributeAssignmentOptional,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PrimAttributeMetadataList>> {};
+struct PrimAttributeFallbackNamespacedName : NamespacedName {};
+struct PrimAttributeFallbackTypeName : PEGTL_NS::seq<
+    KeywordCustom,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeFallbackNamespacedName> {};
+struct PrimAttributeFallback : PEGTL_NS::seq<
+    PrimAttributeFallbackTypeName,
+    PrimAttributeAssignmentOptional,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PrimAttributeMetadataList>> {};
+struct PrimAttributeConnectName : PEGTL_NS::seq<
+    NamespacedName,
+    PEGTL_NS::opt<TokenSpace>,
+    Sdf_PathParser::Dot,
+    PEGTL_NS::opt<TokenSpace>,
+    KeywordConnect> {};
+struct PrimAttributeConnectItem : PathRef {};
+struct PrimAttributeConnectList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimAttributeConnectItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct PrimAttributeConnectRhs : PEGTL_NS::sor<
+    KeywordNone,
+    PrimAttributeConnectItem,
+    PEGTL_NS::if_must<
+    LeftBrace,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<NewLines>, 
+    PEGTL_NS::sor<
+        RightBrace, 
+        PEGTL_NS::seq<
+            PrimAttributeConnectList,
+            ListEnd,
+            PEGTL_NS::opt<TokenSpace>,
+            RightBrace>>>> {};
+struct PrimAttributeConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributeAddConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributeDeleteConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributeAppendConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributePrependConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributeReorderConnectValue : PrimAttributeConnectRhs {};
+struct PrimAttributeAddConnectAssignment : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributeDeleteConnectAssignment : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributeAppendConnectAssignment : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributePrependConnectAssignment : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributeReorderConnectAssignment : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributeAddConnectStatement : PEGTL_NS::seq<
+    PrimAttributeAddConnectAssignment,
+    PEGTL_NS::must<PrimAttributeAddConnectValue>> {};
+struct PrimAttributeDeleteConnectStatement : PEGTL_NS::seq<
+    PrimAttributeDeleteConnectAssignment,
+    PEGTL_NS::must<PrimAttributeDeleteConnectValue>> {};
+struct PrimAttributeAppendConnectStatement : PEGTL_NS::seq<
+    PrimAttributeAppendConnectAssignment,
+    PEGTL_NS::must<PrimAttributeAppendConnectValue>> {};
+struct PrimAttributePrependConnectStatement : PEGTL_NS::seq<
+    PrimAttributePrependConnectAssignment,
+    PEGTL_NS::must<PrimAttributePrependConnectValue>> {};
+struct PrimAttributeReorderConnectStatement : PEGTL_NS::seq<
+    PrimAttributeReorderConnectAssignment,
+    PEGTL_NS::must<PrimAttributeReorderConnectValue>> {};
+struct PrimAttributeListOpConnectStatement : PEGTL_NS::sor<
+    PrimAttributeAddConnectStatement,
+    PrimAttributeDeleteConnectStatement,
+    PrimAttributeAppendConnectStatement,
+    PrimAttributePrependConnectStatement,
+    PrimAttributeReorderConnectStatement> {};
+struct PrimAttributeConnectAssignment : PEGTL_NS::seq<
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeConnectName,
+    Assignment> {};
+struct PrimAttributeConnectStatement : PEGTL_NS::seq<
+    PrimAttributeConnectAssignment,
+    PEGTL_NS::must<PrimAttributeConnectValue>> {};
+struct PrimAttributeTimeSamplesValue : TimeSamplesValue {};
+struct PrimAttributeTimeSamplesName : PEGTL_NS::seq<
+    NamespacedName,
+    PEGTL_NS::opt<TokenSpace>,
+    Sdf_PathParser::Dot,
+    PEGTL_NS::opt<TokenSpace>,
+    KeywordTimeSamples> {};
+struct PrimAttributeTimeSamples : PEGTL_NS::seq<
+    PrimAttributeFullType,
+    TokenSpace,
+    PrimAttributeTimeSamplesName,
+    PEGTL_NS::must<
+        Assignment,
+        PrimAttributeTimeSamplesValue>> {};
+struct PrimAttributeConnect : PEGTL_NS::sor<
+    PrimAttributeConnectStatement,
+    PrimAttributeListOpConnectStatement> {};
+struct PrimAttribute : PEGTL_NS::sor<
+    PrimAttributeFallback,
+    PrimAttributeConnect,
+    PrimAttributeTimeSamples,
+    PrimAttributeDefault> {};
+
+// prim relationships
+struct PrimRelationshipMetadataListOpAddIdentifier : Identifier {};
+struct PrimRelationshipMetadataListOpDeleteIdentifier : Identifier {};
+struct PrimRelationshipMetadataListOpAppendIdentifier : Identifier {};
+struct PrimRelationshipMetadataListOpPrependIdentifier : Identifier {};
+struct PrimRelationshipMetadataListOpReorderIdentifier : Identifier {};
+struct PrimRelationshipMetadataListOpList : MetadataListOpList {};
+struct PrimRelationshipMetadataListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PrimRelationshipMetadataListOpAddIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataListOpList>> {};
+struct PrimRelationshipMetadataListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PrimRelationshipMetadataListOpDeleteIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataListOpList>> {};
+struct PrimRelationshipMetadataListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PrimRelationshipMetadataListOpAppendIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataListOpList>> {};
+struct PrimRelationshipMetadataListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PrimRelationshipMetadataListOpPrependIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataListOpList>> {};
+struct PrimRelationshipMetadataListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PrimRelationshipMetadataListOpReorderIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataListOpList>> {};
+struct PrimRelationshipListOpMetadata : PEGTL_NS::sor<
+    PrimRelationshipMetadataListOpAdd,
+    PrimRelationshipMetadataListOpDelete,
+    PrimRelationshipMetadataListOpAppend,
+    PrimRelationshipMetadataListOpPrepend,
+    PrimRelationshipMetadataListOpReorder> {};
+struct PrimRelationshipMetadataKey : Identifier {};
+struct PrimRelationshipMetadataValue : MetadataValue {};
+struct PrimRelationshipMetadataKeyMetadata : PEGTL_NS::seq<
+    PrimRelationshipMetadataKey,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipMetadataValue>> {};
+struct PrimRelationshipMetadataString : String {};
+struct PrimRelationshipMetadataItem : PEGTL_NS::sor<
+    PrimRelationshipMetadataString,
+    PrimRelationshipMetadataKeyMetadata,
+    PrimRelationshipListOpMetadata,
+    DocMetadata,
+    PermissionMetadata,
+    SymmetryFunctionMetadata> {};
+struct PrimRelationshipMetadataListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimRelationshipMetadataItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct PrimRelationshipMetadataList : PEGTL_NS::if_must<
+    LeftParen,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::sor<
+        RightParen, 
+        PEGTL_NS::seq<
+            PrimRelationshipMetadataListInterior,
+            StatementEnd,
+            PEGTL_NS::opt<TokenSpace>,
+            RightParen>>> {};
+struct PrimRelationshipName : NamespacedName {};
+struct PrimRelationshipTimesamplesName : PEGTL_NS::seq<
+    NamespacedName,
+    PEGTL_NS::opt<TokenSpace>,
+    Sdf_PathParser::Dot,
+    PEGTL_NS::opt<TokenSpace>,
+    KeywordTimeSamples> {};
+struct PrimRelationshipDefaultName : PEGTL_NS::seq<
+    NamespacedName,
+    PEGTL_NS::opt<TokenSpace>,
+    Sdf_PathParser::Dot,
+    PEGTL_NS::opt<TokenSpace>,
+    KeywordDefault> {};
+struct PrimRelationshipTypeUniform : KeywordRel {};
+struct PrimRelationshipTypeCustomUniform : PEGTL_NS::seq<
+    KeywordCustom,
+    TokenSpace,
+    KeywordRel> {};
+struct PrimRelationshipTypeCustomVarying : PEGTL_NS::seq<
+    KeywordCustom,
+    TokenSpace,
+    KeywordVarying,
+    TokenSpace,
+    KeywordRel> {};
+struct PrimRelationshipTypeVarying : PEGTL_NS::seq<
+    KeywordVarying,
+    TokenSpace,
+    KeywordRel> {};
+struct PrimRelationshipType: PEGTL_NS::sor<
+    PrimRelationshipTypeUniform,
+    PrimRelationshipTypeCustomUniform,
+    PrimRelationshipTypeCustomVarying,
+    PrimRelationshipTypeVarying> {};
+struct PrimRelationshipTimeSamplesValue : TimeSamplesValue {};
+struct PrimRelationshipTimeSamples : PEGTL_NS::seq<
+    PrimRelationshipType,
+    TokenSpace,
+    PrimRelationshipTimesamplesName,
+    PEGTL_NS::must<
+        Assignment,
+        PrimRelationshipTimeSamplesValue>> {};
+struct PrimRelationshipDefault : PEGTL_NS::seq<
+    PrimRelationshipType,
+    TokenSpace,
+    PrimRelationshipDefaultName,
+    PEGTL_NS::must<
+        Assignment,
+        PathRef>> {};
+struct PrimRelationshipTarget : PathRef {};
+struct PrimRelationshipDefaultRef : PathRef {};
+struct PrimRelationshipTargetList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimRelationshipTarget,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct PrimRelationshipTargetNone : PEGTL_NS::sor<
+    KeywordNone, 
+    PEGTL_NS::seq<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>> {}; 
+struct PrimRelationshipAssignment : PEGTL_NS::if_must<
+    Assignment,
+    PEGTL_NS::sor<
+        PrimRelationshipTarget,
+        PrimRelationshipTargetNone,
+        PEGTL_NS::seq<
+            LeftBrace,
+            PEGTL_NS::opt<NewLines>,
+            PEGTL_NS::opt<PEGTL_NS::seq<
+                PrimRelationshipTargetList, 
+                ListEnd>>, 
+            PEGTL_NS::opt<TokenSpace>,
+            RightBrace>>> {};
+struct PrimRelationshipStandardTypeName : PEGTL_NS::seq<
+    PrimRelationshipType,
+    TokenSpace,
+    PrimRelationshipName> {};
+struct PrimRelationshipListOpContent : PEGTL_NS::seq<
+    PrimRelationshipType,
+    TokenSpace,
+    PrimRelationshipName,
+    PEGTL_NS::opt<PrimRelationshipAssignment>> {};
+struct PrimRelationshipAddListOp : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PrimRelationshipListOpContent> {};
+struct PrimRelationshipDeleteListOp : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PrimRelationshipListOpContent> {};
+struct PrimRelationshipPrependListOp : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PrimRelationshipListOpContent> {};
+struct PrimRelationshipAppendListOp : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PrimRelationshipListOpContent> {};
+struct PrimRelationshipReorderListOp : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PrimRelationshipListOpContent> {};
+struct PrimRelationshipListOp : PEGTL_NS::sor<
+    PrimRelationshipAddListOp,
+    PrimRelationshipDeleteListOp,
+    PrimRelationshipPrependListOp,
+    PrimRelationshipAppendListOp,
+    PrimRelationshipReorderListOp> {};
+struct PrimRelationshipStandard : PEGTL_NS::seq<
+    PrimRelationshipStandardTypeName,
+    PEGTL_NS::opt<PrimRelationshipAssignment>,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PrimRelationshipMetadataList>> {};
+struct PrimRelationshipList : PEGTL_NS::seq<
+    PrimRelationshipType,
+    TokenSpace,
+    PrimRelationshipName,
+    PEGTL_NS::opt<TokenSpace>,
+    LeftBrace,
+    PEGTL_NS::opt<TokenSpace>,
+    PrimRelationshipTarget,
+    PEGTL_NS::opt<TokenSpace>,
+    RightBrace> {};
+struct PrimRelationshipTypeStatements : PEGTL_NS::sor<
+    PrimRelationshipStandard,
+    PrimRelationshipList> {};
+struct PrimRelationship : PEGTL_NS::sor<
+    PrimRelationshipListOp,
+    PrimRelationshipTimeSamples,
+    PrimRelationshipDefault,
+    PrimRelationshipTypeStatements> {};
+
+// layer reference and offset
+struct LayerRef : AssetRef {};
+struct LayerRefOffsetValue : Number {};
+struct LayerRefScaleValue : Number {};
+struct LayerOffsetStatement : PEGTL_NS::sor<
+    PEGTL_NS::if_must<KeywordOffset, Assignment, LayerRefOffsetValue>,
+    PEGTL_NS::if_must<KeywordScale, Assignment, LayerRefScaleValue>> {};
+
+// string dictionary
+struct StringDictionaryElementKey : String {};
+struct StringDictionaryElementValue : String {};
+struct StringDictionaryElement : PEGTL_NS::seq<
+    StringDictionaryElementKey,
+    PEGTL_NS::opt<TokenSpace>,
+    NamespaceSeparator,
+    PEGTL_NS::opt<TokenSpace>,
+    StringDictionaryElementValue> {};
+struct StringDictionaryList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        StringDictionaryElement,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct StringDictionary : PEGTL_NS::seq<
+    DictionaryValueOpen,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::opt<StringDictionaryList>,
+    PEGTL_NS::opt<TokenSpace>,
+    DictionaryValueClose> {};
+
+// prim metadata
+struct KindValue : String {};
+struct KindMetadata : PEGTL_NS::seq<
+    KeywordKind,
+    PEGTL_NS::must<
+        Assignment,
+        KindValue>> {};
+struct PayloadParameter : LayerOffsetStatement {};
+struct PayloadParametersInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PayloadParameter,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct PayloadParameters : PEGTL_NS::seq<LeftParen,
+    PEGTL_NS::sor<
+        PEGTL_NS::seq<
+            PEGTL_NS::opt<NewLines>,
+            PEGTL_NS::opt<TokenSpace>,
+            PayloadParametersInterior,
+            PEGTL_NS::opt<TokenSpace>,
+            StatementEnd>,
+        PEGTL_NS::opt<NewLines>>,
+    PEGTL_NS::opt<TokenSpace>, RightParen> {};
+struct PayloadPrimPath : PathRef {};
+struct OptionalPayloadPrimPath : PEGTL_NS::opt<PayloadPrimPath> {};
+struct PayloadPathRef : PathRef {};
+struct PayloadPathRefItem : PEGTL_NS::seq<
+    PayloadPathRef,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PayloadParameters>> {};
+struct PayloadLayerRefItem : PEGTL_NS::seq<
+    LayerRef,
+    PEGTL_NS::opt<TokenSpace>,
+    OptionalPayloadPrimPath,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PayloadParameters>> {};
+struct PayloadListItem : PEGTL_NS::sor<
+    PayloadLayerRefItem,
+    PayloadPathRefItem> {};
+struct PayloadListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PayloadListItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct PayloadList : PEGTL_NS::sor<
+    KeywordNone,
+    PayloadListItem,
+    PEGTL_NS::seq<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>,
+    PEGTL_NS::if_must<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PayloadListInterior,
+        ListEnd,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>> {}; 
+struct PayloadMetadataKeyword : KeywordPayload {};
+struct PayloadListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadListOp : PEGTL_NS::seq<
+    PayloadMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        PayloadList>> {};
+struct PayloadMetadata : PEGTL_NS::sor<
+    PayloadListOpAdd,
+    PayloadListOpDelete,
+    PayloadListOpAppend,
+    PayloadListOpPrepend,
+    PayloadListOpReorder,
+    PayloadListOp> {};
+struct InheritListItem : PathRef {};
+struct InheritListInterior: PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        InheritListItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct InheritList : PEGTL_NS::sor<
+    KeywordNone, 
+    InheritListItem,
+    PEGTL_NS::seq<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>,
+    PEGTL_NS::if_must<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        InheritListInterior,
+        ListEnd,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>> {}; 
+struct InheritsMetadataKeyword : KeywordInherits {};
+struct InheritsListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsListOp : PEGTL_NS::seq<
+    InheritsMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        InheritList>> {};
+struct InheritsMetadata : PEGTL_NS::sor<
+    InheritsListOpAdd,
+    InheritsListOpDelete,
+    InheritsListOpAppend,
+    InheritsListOpPrepend,
+    InheritsListOpReorder,
+    InheritsListOp> {};
+struct SpecializesListItem : PathRef {};
+struct SpecializesListInterior: PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        SpecializesListItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct SpecializesList : PEGTL_NS::sor<
+    KeywordNone,
+    SpecializesListItem,
+    PEGTL_NS::seq<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>,
+    PEGTL_NS::if_must<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        SpecializesListInterior,
+        ListEnd,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>> {};
+struct SpecializesMetadataKeyword : KeywordSpecializes {};
+struct SpecializesListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesListOp : PEGTL_NS::seq<
+    SpecializesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        SpecializesList>> {};
+struct SpecializesMetadata : PEGTL_NS::sor<
+    SpecializesListOpAdd,
+    SpecializesListOpDelete,
+    SpecializesListOpAppend,
+    SpecializesListOpPrepend,
+    SpecializesListOpReorder,
+    SpecializesListOp> {};
+struct ReferenceParameter : PEGTL_NS::sor<
+    PEGTL_NS::seq<KeywordCustomData, Assignment, DictionaryValue>,
+    LayerOffsetStatement> {};
+struct ReferenceParametersInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        ReferenceParameter,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct ReferenceParameters : PEGTL_NS::seq<LeftParen,
+    PEGTL_NS::sor<
+        PEGTL_NS::seq<
+            PEGTL_NS::opt<NewLines>,
+            PEGTL_NS::opt<TokenSpace>,
+            ReferenceParametersInterior,
+            PEGTL_NS::opt<TokenSpace>, StatementEnd>,
+        PEGTL_NS::opt<NewLines>>,
+    PEGTL_NS::opt<TokenSpace>, RightParen> {};
+struct ReferencePrimPath : PathRef {};
+struct OptionalReferencePrimPath : PEGTL_NS::opt<ReferencePrimPath> {};
+struct ReferencePathRef : PathRef {};
+struct ReferencePathRefItem : PEGTL_NS::seq<
+    ReferencePathRef,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<ReferenceParameters>> {};
+struct ReferenceLayerRefItem : PEGTL_NS::seq<
+    LayerRef,
+    PEGTL_NS::opt<TokenSpace>,
+    OptionalReferencePrimPath,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<ReferenceParameters>> {};
+struct ReferenceListItem : PEGTL_NS::sor<
+    ReferenceLayerRefItem,
+    ReferencePathRefItem> {};
+struct ReferenceListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        ReferenceListItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct ReferenceList : PEGTL_NS::sor<
+    KeywordNone,
+    ReferenceListItem,
+    PEGTL_NS::seq<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>,
+    PEGTL_NS::if_must<
+        LeftBrace,
+        PEGTL_NS::opt<NewLines>,
+        ReferenceListInterior,
+        ListEnd,
+        PEGTL_NS::opt<TokenSpace>,
+        RightBrace>> {};
+struct ReferencesMetadataKeyword : KeywordReferences {};
+struct ReferencesListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesListOp : PEGTL_NS::seq<
+    ReferencesMetadataKeyword,
+    PEGTL_NS::must<
+        Assignment,
+        ReferenceList>> {};
+struct ReferencesMetadata : PEGTL_NS::sor<
+    ReferencesListOpAdd,
+    ReferencesListOpDelete,
+    ReferencesListOpAppend,
+    ReferencesListOpPrepend,
+    ReferencesListOpReorder,
+    ReferencesListOp> {};
+struct RelocatesStatement : PEGTL_NS::seq<
+    PathRef,
+    PEGTL_NS::must<
+        PEGTL_NS::opt<TokenSpace>,
+        NamespaceSeparator,
+        PEGTL_NS::opt<TokenSpace>,
+        PathRef>> {};
+struct RelocatesStatementList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        RelocatesStatement,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct RelocatesMap : PEGTL_NS::seq<
+    LeftCurlyBrace,
+    PEGTL_NS::opt<NewLines>,
+    PEGTL_NS::sor<
+        PEGTL_NS::seq<
+            PEGTL_NS::opt<RelocatesStatementList>,
+            PEGTL_NS::opt<TokenSpace>,
+            ListEnd>,
+        PEGTL_NS::opt<NewLines>>,
+    PEGTL_NS::opt<TokenSpace>,
+    RightCurlyBrace> {};
+struct RelocatesMetadata : PEGTL_NS::seq<
+    KeywordRelocates,
+    PEGTL_NS::must<
+        Assignment,
+        RelocatesMap>> {};
+struct VariantsMetadata : PEGTL_NS::seq<
+    KeywordVariants,
+    PEGTL_NS::must<
+        Assignment,
+        DictionaryValue>> {};
+struct VariantSetsListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsListOp : PEGTL_NS::seq<
+    KeywordVariantSets,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct VariantSetsMetadata : PEGTL_NS::sor<
+    VariantSetsListOpAdd,
+    VariantSetsListOpDelete,
+    VariantSetsListOpAppend,
+    VariantSetsListOpPrepend,
+    VariantSetsListOpReorder,
+    VariantSetsListOp> {};
+struct PrefixSubstitutionsMetadata : PEGTL_NS::seq<
+    KeywordPrefixSubstitutions,
+    PEGTL_NS::must<
+        Assignment,
+        StringDictionary>> {};
+struct SuffixSubstitutionsMetadata : PEGTL_NS::seq<
+    KeywordSuffixSubstitutions,
+    PEGTL_NS::must<
+        Assignment,
+        StringDictionary>> {};
+struct PrimMetadataString : String {};
+struct PrimMetadataKey : Identifier {};
+struct PrimMetadataValue : MetadataValue {};
+struct PrimMetadataListOpAddIdentifier : Identifier {};
+struct PrimMetadataListOpDeleteIdentifier : Identifier {};
+struct PrimMetadataListOpAppendIdentifier : Identifier {};
+struct PrimMetadataListOpPrependIdentifier : Identifier {};
+struct PrimMetadataListOpReorderIdentifier : Identifier {};
+struct PrimMetadataListOpList : MetadataListOpList {};
+struct PrimMetadataListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    PrimMetadataListOpAddIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataListOpList>> {};
+struct PrimMetadataListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    PrimMetadataListOpDeleteIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataListOpList>> {};
+struct PrimMetadataListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    PrimMetadataListOpAppendIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataListOpList>> {};
+struct PrimMetadataListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    PrimMetadataListOpPrependIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataListOpList>> {};
+struct PrimMetadataListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    PrimMetadataListOpReorderIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataListOpList>> {};
+struct PrimMetadataListOpMetadata : PEGTL_NS::sor<
+    PrimMetadataListOpAdd,
+    PrimMetadataListOpDelete,
+    PrimMetadataListOpAppend,
+    PrimMetadataListOpPrepend,
+    PrimMetadataListOpReorder> {};
+struct PrimMetadataKeyMetadata : PEGTL_NS::seq<
+    PrimMetadataKey,
+    PEGTL_NS::must<
+        Assignment,
+        PrimMetadataValue>> {};
+struct PrimMetadataItem : PEGTL_NS::sor<
+    PrimMetadataString,
+    PrimMetadataKeyMetadata,
+    PrimMetadataListOpMetadata,
+    DocMetadata,
+    KindMetadata,
+    PermissionMetadata,
+    PayloadMetadata,
+    InheritsMetadata,
+    SpecializesMetadata,
+    ReferencesMetadata,
+    RelocatesMetadata,
+    VariantsMetadata,
+    VariantSetsMetadata,
+    SymmetryFunctionMetadata,
+    PrefixSubstitutionsMetadata,
+    SuffixSubstitutionsMetadata> {};
+struct PrimMetadataList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimMetadataItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct PrimMetadataInterior : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        PrimMetadataList,
+        StatementEnd>,
+    PEGTL_NS::opt<NewLines>> {}; 
+struct PrimMetadata : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        LeftParen,
+        PrimMetadataInterior,
+        PEGTL_NS::opt<TokenSpace>,
+        RightParen,
+        PEGTL_NS::opt<NewLines>>,
+    PEGTL_NS::opt<NewLines>> {};
+
+// prims
+// (VariantName and VariantSetName conflict with rule structures
+// in the included path parser so we use PrimVariantName and 
+// PrimVariantSetName instead)
+struct PrimStatement;
+struct PrimContentsList;
+struct PrimIdentifier : String {};
+struct PrimProperty : PEGTL_NS::sor<
+    PrimAttribute,
+    PrimRelationship> {};
+struct PrimVariantName : String {};
+struct VariantStatement : PEGTL_NS::seq<
+    PrimVariantName,
+    PEGTL_NS::must<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimMetadata,
+        PEGTL_NS::opt<TokenSpace>,
+        LeftCurlyBrace,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        PEGTL_NS::opt<PrimContentsList>,
+        PEGTL_NS::opt<TokenSpace>,
+        RightCurlyBrace,
+        PEGTL_NS::opt<NewLines>>> {};
+struct VariantList : PEGTL_NS::plus<PEGTL_NS::seq<
+    PEGTL_NS::opt<TokenSpace>,
+    VariantStatement,
+    PEGTL_NS::opt<TokenSpace>>> {};
+struct PrimVariantSetName : String {};
+struct VariantSetStatement : PEGTL_NS::seq<
+    KeywordVariantSet,
+    PEGTL_NS::must<
+        TokenSpace,
+        PrimVariantSetName,
+        Assignment,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        LeftCurlyBrace,
+        PEGTL_NS::opt<NewLines>,
+        VariantList,
+        PEGTL_NS::opt<TokenSpace>,
+        RightCurlyBrace>> {};
+struct PrimChildOrderStatement : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    KeywordNameChildren,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct PrimPropertyOrderStatement : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    KeywordProperties,
+    PEGTL_NS::must<
+        Assignment,
+        NameList>> {};
+struct PrimContentsListItem : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PrimChildOrderStatement,
+        PEGTL_NS::opt<TokenSpace>,
+        StatementSeparator>,
+    PEGTL_NS::seq<
+        PrimPropertyOrderStatement,
+        PEGTL_NS::opt<TokenSpace>,
+        StatementSeparator>,
+    PEGTL_NS::seq<
+        PrimStatement,
+        PEGTL_NS::opt<TokenSpace>,
+        NewLines>,
+    PEGTL_NS::seq<
+        VariantSetStatement,
+        PEGTL_NS::opt<TokenSpace>,
+        NewLines>,
+    PEGTL_NS::seq<
+        PrimProperty,
+        PEGTL_NS::opt<TokenSpace>,
+        StatementSeparator>> {};
+struct PrimContentsList : PEGTL_NS::plus<
+    PEGTL_NS::opt<TokenSpace>,
+    PrimContentsListItem> {};
+struct PrimContentsListOp : PEGTL_NS::sor<
+    PEGTL_NS::seq<PEGTL_NS::opt<NewLines>, PrimContentsList>,
+    PEGTL_NS::opt<NewLines>> {};
+struct PrimStatementInterior : PEGTL_NS::seq<
+    PrimIdentifier,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<PrimMetadata>,
+    PEGTL_NS::opt<TokenSpace>,
+    LeftCurlyBrace,
+    PEGTL_NS::must<
+        PEGTL_NS::opt<TokenSpace>,
+        PrimContentsListOp,
+        PEGTL_NS::opt<TokenSpace>,
+        RightCurlyBrace>> {};
+struct PrimTypeName : PEGTL_NS::list<Identifier, PEGTL_NS::seq<
+    PEGTL_NS::opt<TokenSpace>,
+    Sdf_PathParser::Dot,
+    PEGTL_NS::opt<TokenSpace>>> {};
+struct PrimDefSpecifier : KeywordDef {};
+struct PrimClassSpecifier : KeywordClass {};
+struct PrimOverSpecifier : KeywordOver {};
+struct PrimReorderNameList : NameList {};
+struct PrimDefinition : PEGTL_NS::seq<
+    PrimDefSpecifier,
+    PEGTL_NS::must<
+        TokenSpace,
+        PEGTL_NS::sor<
+            PrimStatementInterior, 
+            PEGTL_NS::seq<
+                PrimTypeName,
+                TokenSpace,
+                PrimStatementInterior>>>> {};
+struct PrimClass : PEGTL_NS::seq<
+    PrimClassSpecifier,
+    PEGTL_NS::must<
+        TokenSpace,
+        PEGTL_NS::sor<
+            PrimStatementInterior, 
+            PEGTL_NS::seq<
+                PrimTypeName,
+                TokenSpace,
+                PrimStatementInterior>>>> {};
+struct PrimOver : PEGTL_NS::seq<
+    PrimOverSpecifier,
+    PEGTL_NS::must<
+        TokenSpace,
+        PEGTL_NS::sor<
+            PrimStatementInterior,
+            PEGTL_NS::seq<
+                PrimTypeName,
+                TokenSpace,
+                PrimStatementInterior>>>> {};
+struct PrimReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    KeywordRootPrims,
+    PEGTL_NS::must<
+        Assignment,
+        PrimReorderNameList>> {};
+struct PrimStatement : PEGTL_NS::sor<
+    PrimDefinition, 
+    PrimClass,
+    PrimOver,
+    PrimReorder> {};
+
+// layer metadata
+struct LayerMetadataListOpAddIdentifier : Identifier {};
+struct LayerMetadataListOpDeleteIdentifier : Identifier {};
+struct LayerMetadataListOpAppendIdentifier : Identifier {};
+struct LayerMetadataListOpPrependIdentifier : Identifier {};
+struct LayerMetadataListOpReorderIdentifier : Identifier {};
+struct LayerMetadataListOpList : MetadataListOpList {};
+struct LayerMetadataKey : Identifier {};
+struct LayerMetadataValue : MetadataValue {};
+struct LayerMetadataListOpAdd : PEGTL_NS::seq<
+    KeywordAdd,
+    TokenSpace,
+    LayerMetadataListOpAddIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataListOpList>> {};
+struct LayerMetadataListOpDelete : PEGTL_NS::seq<
+    KeywordDelete,
+    TokenSpace,
+    LayerMetadataListOpDeleteIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataListOpList>> {};
+struct LayerMetadataListOpAppend : PEGTL_NS::seq<
+    KeywordAppend,
+    TokenSpace,
+    LayerMetadataListOpAppendIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataListOpList>> {};
+struct LayerMetadataListOpPrepend : PEGTL_NS::seq<
+    KeywordPrepend,
+    TokenSpace,
+    LayerMetadataListOpPrependIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataListOpList>> {};
+struct LayerMetadataListOpReorder : PEGTL_NS::seq<
+    KeywordReorder,
+    TokenSpace,
+    LayerMetadataListOpReorderIdentifier,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataListOpList>> {};
+struct LayerMetadataListOpMetadata : PEGTL_NS::sor<
+    LayerMetadataListOpAdd,
+    LayerMetadataListOpDelete,
+    LayerMetadataListOpAppend,
+    LayerMetadataListOpPrepend,
+    LayerMetadataListOpReorder> {};
+struct LayerMetadataKeyMetadata : PEGTL_NS::seq<
+    LayerMetadataKey,
+    PEGTL_NS::must<
+        Assignment,
+        LayerMetadataValue>> {};
+struct LayerOffsetList : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        LayerOffsetStatement,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct LayerOffset : PEGTL_NS::if_must<
+    LeftParen,
+    LayerOffsetList,
+    PEGTL_NS::opt<TokenSpace>,
+    StatementEnd,
+    RightParen> {};
+struct SublayerStatement : PEGTL_NS::seq<
+    LayerRef,
+    PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::opt<LayerOffset>> {};
+struct SublayerListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        SublayerStatement,
+        PEGTL_NS::opt<TokenSpace>>,
+    ListSeparator> {};
+struct SublayerList : PEGTL_NS::seq<LeftBrace, PEGTL_NS::opt<TokenSpace>,
+    PEGTL_NS::sor<
+        PEGTL_NS::seq<PEGTL_NS::opt<NewLines>, SublayerListInterior, ListEnd>,
+        PEGTL_NS::opt<NewLines>>,
+    PEGTL_NS::opt<TokenSpace>, RightBrace> {}; 
+struct SublayersMetadata : PEGTL_NS::seq<
+    KeywordSubLayers,
+    PEGTL_NS::must<
+        Assignment,
+        SublayerList>> {};
+struct LayerMetadataString : String {};
+struct LayerMetadataItem : PEGTL_NS::sor<
+    LayerMetadataString,
+    LayerMetadataKeyMetadata,
+    LayerMetadataListOpMetadata,
+    DocMetadata,
+    SublayersMetadata> {};
+struct LayerMetadataListInterior : PEGTL_NS::list<PEGTL_NS::seq<
+        PEGTL_NS::opt<TokenSpace>,
+        LayerMetadataItem,
+        PEGTL_NS::opt<TokenSpace>>,
+    StatementSeparator> {};
+struct LayerMetadataList : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        LayerMetadataListInterior,
+        PEGTL_NS::opt<TokenSpace>,
+        StatementEnd>,
+    PEGTL_NS::opt<NewLines>> {};
+struct LayerMetadata : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<TokenSpace>,
+        PEGTL_NS::if_must<
+            LeftParen,
+            LayerMetadataList,
+            PEGTL_NS::opt<TokenSpace>,
+            RightParen,
+            PEGTL_NS::opt<NewLines>>>,
+    PEGTL_NS::opt<NewLines>> {};
+
+// layers
+struct PrimList : PEGTL_NS::list<PEGTL_NS::seq<
+    PEGTL_NS::opt<TokenSpace>,
+    PrimStatement,
+    PEGTL_NS::opt<TokenSpace>>,
+    NewLines> {};
+struct LayerContent : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::opt<LayerMetadata>,
+        PEGTL_NS::opt<TokenSpace>,
+        PrimList,
+        PEGTL_NS::opt<NewLines>,
+        PEGTL_NS::opt<EolWhitespace>>,
+    PEGTL_NS::opt<LayerMetadata>> {};
+struct LayerHeader : PEGTL_NS::sor<
+    PEGTL_NS::seq<
+        PEGTL_NS::one<'#'>,
+        PEGTL_NS::until<NewLine>>, 
+    PEGTL_NS::seq<
+        PEGTL_NS::one<'#'>,
+        PEGTL_NS::until<PEGTL_NS::eof>>> {};
+struct Layer : PEGTL_NS::sor<
+    PEGTL_NS::seq<LayerHeader, LayerContent>,
+    LayerHeader> {};
+struct LayerMetadataOnly : PEGTL_NS::sor<
+    PEGTL_NS::seq<LayerHeader, PEGTL_NS::opt<LayerMetadata>>,
+    LayerHeader> {};
+
+////////////////////////////////////////////////////////////////////////
+// TextFileFormat actions
+
+template <class Rule>
+inline std::string _GetUnnamespacedType()
+{
+    std::string rule = PEGTL_NS::internal::demangle<Rule>();
+    if (TfStringEndsWith(rule, ">"))
+    {
+        // filters out PEGTL specific rules like seq, star, etc.
+        return "";
+    }
+
+    // otherwise we have the full struct type here, we only want
+    // the unnamespaced parts
+    size_t namespaceIndex = rule.rfind("::");
+    if (namespaceIndex != std::string::npos)
+    {
+        // we want the substring after that
+        return rule.substr(namespaceIndex + 2) + "\n";
+    }
+
+    // unable to match ::
+    return "";
+}
+
+template <class Rule>
+struct TextParserAction : PEGTL_NS::nothing<Rule> {};
+
+////////////////////////////////////////////////////////////////////////
+// TextFileFormat custom control
+
+template <typename Controller, template<typename...> class Base = PEGTL_NS::normal>
+struct TextParserDefaultErrorControl
+{
+    template <typename Rule>
+    struct control : Base<Rule>
+    {
+        template <typename Input, typename... States>
+        static void success(const Input& in, States&&... st) noexcept
+        {
+            if constexpr(Controller::template emit<Rule>)
+            {
+                TF_DEBUG(SDF_TEXT_FILE_FORMAT_RULES).Msg(_GetUnnamespacedType<Rule>());
+            }
+
+            Base<Rule>::success(in, st...);
+        }
+
+        template <typename Input, typename... States>
+        [[noreturn]]
+        static void raise(const Input& in, [[maybe_unused]] States&&... st)
+        {
+            if constexpr(Controller::template message<Rule> != nullptr)
+            {
+                // use custom error message for rule
+                constexpr const char* errorMessage = 
+                    Controller::template message<Rule>;
+                throw PEGTL_NS::parse_error(errorMessage, in);
+            }
+            else
+            {
+                // emit default parse error for the rule
+                Base<Rule>::raise(in, st...);
+            }
+        }
+    };
+};
+
+// default error message is nullptr, which redirects parse error
+// message to default control class raise method
+template <typename> inline constexpr const char* errorMessage = nullptr;
+
+// default emit rule is true, this enables debugging for which
+// rules successfully matched - some rules may turn this off
+// to avoid over emission of e.g. whitespace matching
+template <typename> inline constexpr bool emitRule = true;
+
+// TextParserDefaultControl doesn't take the error_message as a template
+// parameter directly, so it's wrapped here
+struct TextParserControlValues
+{
+    template<typename Rule>
+    static constexpr auto message = errorMessage<Rule>;
+
+    template<typename Rule>
+    static constexpr auto emit = emitRule<Rule>;
+};
+
+template <typename Rule>
+using TextParserControl = 
+    TextParserDefaultErrorControl<TextParserControlValues>::control<Rule>;
+
+} // end namespace Sdf_TextFileFormatParser
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_SDF_TEXT_FILE_FORMAT_PARSER_H

--- a/pxr/usd/sdf/textParserContext.h
+++ b/pxr/usd/sdf/textParserContext.h
@@ -55,6 +55,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 class Sdf_TextParserContext {
 public:
     // Constructor.
+    SDF_API
     Sdf_TextParserContext();
     
     std::string magicIdentifierToken;

--- a/pxr/usd/sdf/textParserHelpers.cpp
+++ b/pxr/usd/sdf/textParserHelpers.cpp
@@ -28,122 +28,96 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace Sdf_TextFileFormatParser {
 
-#define ERROR_AND_RETURN_IF_NOT_ALLOWED(context, allowed)        \
-    {                                                            \
-        const SdfAllowed allow = allowed;                        \
-        if (!allow) {                                            \
-            SDF_TEXTFILEFORMATPARSER_ERR(context, "%s",          \
-            allow.GetWhyNot().c_str());                          \
-            return;                                              \
-        }                                                        \
-    }
+bool
+_SetupValue(const std::string& typeName, Sdf_TextParserContext& context)
+{
+    return context.values.SetupFactory(typeName);
+}
 
 bool
-_SetupValue(const std::string& typeName, Sdf_TextParserContext *context)
+_GetPermissionFromString(const std::string& str, 
+                         SdfPermission& permission)
 {
-    return context->values.SetupFactory(typeName);
+    if (str == "public")
+    {
+        permission = SdfPermissionPublic;
+        return true;
+    }
+    else if(str == "private")
+    {
+        permission = SdfPermissionPrivate;
+        return true;
+    }
+
+    return false;
 }
 
-void
-_MatchMagicIdentifier(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
-{
-    const std::string cookie = TfStringTrimRight(arg1.Get<std::string>());
-    const std::string expected = "#" + context->magicIdentifierToken + " ";
-    if (TfStringStartsWith(cookie, expected)) {
-        if (!context->versionString.empty() &&
-            !TfStringEndsWith(cookie, context->versionString)) {
-            TF_WARN("File '%s' is not the latest %s version (found '%s', "
-                "expected '%s'). The file may parse correctly and yield "
-                "incorrect results.",
-                context->fileContext.c_str(),
-                context->magicIdentifierToken.c_str(),
-                cookie.substr(expected.length()).c_str(),
-                context->versionString.c_str());
-        }
-    }
-    else {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, "Magic Cookie '%s'. Expected prefix of '%s'",
-            TfStringTrim(cookie).c_str(),
-            expected.c_str());
-    }
-}
-
-SdfPermission
-_GetPermissionFromString(const std::string & str,
-                         Sdf_TextParserContext *context)
-{
-    if (str == "public") {
-        return SdfPermissionPublic;
-    } else if (str == "private") {
-        return SdfPermissionPrivate;
-    } else {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "'%s' is not a valid permission constant", str.c_str());
-        return SdfPermissionPublic;
-    }
-}
-
-TfEnum
+bool
 _GetDisplayUnitFromString(const std::string & name,
-                          Sdf_TextParserContext *context)
+                          TfEnum& value)
 {
     const TfEnum &unit = SdfGetUnitFromName(name);
     if (unit == TfEnum()) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context,
-            "'%s' is not a valid display unit", name.c_str());
+        return false;
     }
-    return unit;
+    value = unit;
+    return true;
 }
 
 void
-_ValueAppendAtomic(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+_ValueAppendAtomic(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context)
 {
-    context->values.AppendValue(arg1);
+    context.values.AppendValue(arg1);
 }
 
-void
-_ValueSetAtomic(Sdf_TextParserContext *context)
+bool
+_ValueSetAtomic(Sdf_TextParserContext& context, std::string& errorMessage)
 {
-    if (!context->values.IsRecordingString()) {
-        if (context->values.valueIsShaped) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context,
-                "Type name has [] for non-shaped value!\n");
-            return;
+    if (!context.values.IsRecordingString()) {
+        if (context.values.valueIsShaped) {
+            errorMessage = "Type name has [] for non-shaped value!\n";
+            return false;
         }
     }
 
     std::string errStr;
-    context->currentValue = context->values.ProduceValue(&errStr);
-    if (context->currentValue.IsEmpty()) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context,
-            "Error parsing simple value: %s", errStr.c_str());
-        return;
+    context.currentValue = context.values.ProduceValue(&errStr);
+    if (context.currentValue.IsEmpty()) {
+        errorMessage = "Error parsing simple value: " + errStr;
+        return false;
     }
+
+    return true;
 }
 
-void
-_PrimSetInheritListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+bool
+_PrimSetInheritListItems(SdfListOpType opType, Sdf_TextParserContext& context,
+    std::string& errorMessage) 
 {
-    if (context->inheritParsingTargetPaths.empty() &&
+    if (context.inheritParsingTargetPaths.empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+        errorMessage =
             "Setting inherit paths to None (or empty list) is only allowed "
-            "when setting explicit inherit paths, not for list editing");
-        return;
+            "when setting explicit inherit paths, not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(path, context->inheritParsingTargetPaths) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidInheritPath(*path));
+    TF_FOR_ALL(path, context.inheritParsingTargetPaths) {
+        const SdfAllowed allow = SdfSchema::IsValidInheritPath(*path);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
-    _SetListOpItems(SdfFieldKeys->InheritPaths, opType, 
-                    context->inheritParsingTargetPaths, context);
+    return _SetListOpItems(SdfFieldKeys->InheritPaths, opType, 
+            context.inheritParsingTargetPaths, context, errorMessage);
 }
 
 void
-_InheritAppendPath(Sdf_TextParserContext *context)
+_InheritAppendPath(Sdf_TextParserContext& context)
 {
     // Expand paths relative to the containing prim.
     //
@@ -151,34 +125,38 @@ _InheritAppendPath(Sdf_TextParserContext *context)
     // path before expanding the relative path, which is what we
     // want.  Inherit paths are not allowed to be variants.
     SdfPath absPath = 
-        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+        context.savedPath.MakeAbsolutePath(context.path.GetPrimPath());
 
-    context->inheritParsingTargetPaths.push_back(absPath);
+    context.inheritParsingTargetPaths.push_back(absPath);
 }
 
-void
-_PrimSetSpecializesListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+bool
+_PrimSetSpecializesListItems(SdfListOpType opType,
+    Sdf_TextParserContext& context, std::string& errorMessage) 
 {
-    if (context->specializesParsingTargetPaths.empty() &&
+    if (context.specializesParsingTargetPaths.empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+        errorMessage = 
             "Setting specializes paths to None (or empty list) is only allowed "
-            "when setting explicit specializes paths, not for list editing");
-        return;
+            "when setting explicit specializes paths, not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(path, context->specializesParsingTargetPaths) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidSpecializesPath(*path));
+    TF_FOR_ALL(path, context.specializesParsingTargetPaths) {
+        const SdfAllowed allow = SdfSchema::IsValidSpecializesPath(*path);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
-    _SetListOpItems(SdfFieldKeys->Specializes, opType, 
-                    context->specializesParsingTargetPaths, context);
+    return _SetListOpItems(SdfFieldKeys->Specializes, opType, 
+            context.specializesParsingTargetPaths, context, errorMessage);
 }
 
 void
-_SpecializesAppendPath(Sdf_TextParserContext *context)
+_SpecializesAppendPath(Sdf_TextParserContext& context)
 {
     // Expand paths relative to the containing prim.
     //
@@ -186,88 +164,105 @@ _SpecializesAppendPath(Sdf_TextParserContext *context)
     // path before expanding the relative path, which is what we
     // want.  Specializes paths are not allowed to be variants.
     SdfPath absPath = 
-        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+        context.savedPath.MakeAbsolutePath(context.path.GetPrimPath());
 
-    context->specializesParsingTargetPaths.push_back(absPath);
+    context.specializesParsingTargetPaths.push_back(absPath);
 }
 
-void
-_PrimSetReferenceListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+bool
+_PrimSetReferenceListItems(SdfListOpType opType, Sdf_TextParserContext& context,
+    std::string& errorMessage) 
 {
-    if (context->referenceParsingRefs.empty() &&
+    if (context.referenceParsingRefs.empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+        errorMessage = 
             "Setting references to None (or an empty list) is only allowed "
-            "when setting explicit references, not for list editing");
-        return;
+            "when setting explicit references, not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(ref, context->referenceParsingRefs) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidReference(*ref));
+    TF_FOR_ALL(ref, context.referenceParsingRefs) {
+        const SdfAllowed allow = SdfSchema::IsValidReference(*ref);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
-    _SetListOpItems(SdfFieldKeys->References, opType, 
-                    context->referenceParsingRefs, context);
+    return _SetListOpItems(SdfFieldKeys->References, opType, 
+        context.referenceParsingRefs, context, errorMessage);
 }
 
-void
-_PrimSetPayloadListItems(SdfListOpType opType, Sdf_TextParserContext *context) 
+bool
+_PrimSetPayloadListItems(SdfListOpType opType, Sdf_TextParserContext& context,
+    std::string& errorMessage) 
 {
-    if (context->payloadParsingRefs.empty() &&
+    if (context.payloadParsingRefs.empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+        errorMessage = 
             "Setting payload to None (or an empty list) is only allowed "
-            "when setting explicit payloads, not for list editing");
-        return;
+            "when setting explicit payloads, not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(ref, context->payloadParsingRefs) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidPayload(*ref));
+    TF_FOR_ALL(ref, context.payloadParsingRefs) {
+        const SdfAllowed allow = SdfSchema::IsValidPayload(*ref);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
-    _SetListOpItems(SdfFieldKeys->Payload, opType, 
-                    context->payloadParsingRefs, context);
+    return _SetListOpItems(SdfFieldKeys->Payload, opType, 
+        context.payloadParsingRefs, context, errorMessage);
 }
 
-void
+bool
 _PrimSetVariantSetNamesListItems(SdfListOpType opType, 
-                                 Sdf_TextParserContext *context)
+                                 Sdf_TextParserContext& context,
+                                 std::string& errorMessage)
 {
     std::vector<std::string> names;
-    names.reserve(context->nameVector.size());
-    TF_FOR_ALL(name, context->nameVector) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidVariantIdentifier(*name));
+    names.reserve(context.nameVector.size());
+    TF_FOR_ALL(name, context.nameVector) {
+        const SdfAllowed allow = SdfSchema::IsValidVariantIdentifier(*name);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
         names.push_back(name->GetText());
     }
 
-    _SetListOpItems(SdfFieldKeys->VariantSetNames, opType, names, context);
+    if(!_SetListOpItems(SdfFieldKeys->VariantSetNames, opType,
+        names, context, errorMessage))
+    {
+        return false;
+    }
 
     // If the op type is added or explicit, create the variant sets
     if (opType == SdfListOpTypeAdded || opType == SdfListOpTypeExplicit) {
-        TF_FOR_ALL(i, context->nameVector) {
+        TF_FOR_ALL(i, context.nameVector) {
             _CreateSpec(
-                context->path.AppendVariantSelection(*i,""),
+                context.path.AppendVariantSelection(*i,""),
                 SdfSpecTypeVariantSet, context);
         }
 
         _SetField(
-            context->path, SdfChildrenKeys->VariantSetChildren, 
-            context->nameVector, context);
+            context.path, SdfChildrenKeys->VariantSetChildren, 
+            context.nameVector, context);
     }
 
+    return true;
 }
 
 void
 _RelationshipInitTarget(const SdfPath& targetPath,
-                        Sdf_TextParserContext *context)
+                        Sdf_TextParserContext& context)
 {
-    SdfPath path = context->path.AppendTarget(targetPath);
+    SdfPath path = context.path.AppendTarget(targetPath);
 
     if (!_HasSpec(path, context)) {
         // Create relationship target spec by setting the appropriate 
@@ -276,31 +271,35 @@ _RelationshipInitTarget(const SdfPath& targetPath,
 
         // Add the target path to the owning relationship's list of target 
         // children.
-        context->relParsingNewTargetChildren.push_back(targetPath);
+        context.relParsingNewTargetChildren.push_back(targetPath);
     }
 }
 
-void
+bool
 _RelationshipSetTargetsList(SdfListOpType opType, 
-                            Sdf_TextParserContext *context)
+                            Sdf_TextParserContext& context,
+                            std::string& errorMessage)
 {
-    if (!context->relParsingTargetPaths) {
+    if (!context.relParsingTargetPaths) {
         // No target paths were encountered.
-        return;
+        return true;
     }
 
-    if (context->relParsingTargetPaths->empty() &&
+    if (context.relParsingTargetPaths->empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
+        errorMessage = 
             "Setting relationship targets to None (or empty list) is only "
-            "allowed when setting explicit targets, not for list editing");
-        return;
+            "allowed when setting explicit targets, not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(path, *context->relParsingTargetPaths) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidRelationshipTargetPath(*path));
+    TF_FOR_ALL(path, *context.relParsingTargetPaths) {
+        const SdfAllowed allow = SdfSchema::IsValidRelationshipTargetPath(*path);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
     if (opType == SdfListOpTypeAdded || 
@@ -308,17 +307,17 @@ _RelationshipSetTargetsList(SdfListOpType opType,
 
         // Initialize relationship target specs for each target path that
         // is added in this layer.
-        TF_FOR_ALL(pathIter, *context->relParsingTargetPaths) {
+        TF_FOR_ALL(pathIter, *context.relParsingTargetPaths) {
             _RelationshipInitTarget(*pathIter, context);
         }
     }
 
-    _SetListOpItems(SdfFieldKeys->TargetPaths, opType, 
-                    *context->relParsingTargetPaths, context);
+    return _SetListOpItems(SdfFieldKeys->TargetPaths, opType, 
+        *context.relParsingTargetPaths, context, errorMessage);
 }
 
-void
-_PrimSetVariantSelection(Sdf_TextParserContext *context)
+bool
+_PrimSetVariantSelection(Sdf_TextParserContext& context, std::string& errorMessage)
 {
     SdfVariantSelectionMap refVars;
 
@@ -326,31 +325,37 @@ _PrimSetVariantSelection(Sdf_TextParserContext *context)
     // dictionaries in prim metadata to be merged, so we do the same here.
     VtValue oldVars;
     if (_HasField(
-            context->path, SdfFieldKeys->VariantSelection, &oldVars, context)) {
+            context.path, SdfFieldKeys->VariantSelection, &oldVars, context)) {
         refVars = oldVars.Get<SdfVariantSelectionMap>();
     }
 
-    TF_FOR_ALL(it, context->currentDictionaries[0]) {
+    TF_FOR_ALL(it, context.currentDictionaries[0]) {
         if (!it->second.IsHolding<std::string>()) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context, "variant name must be a string");
-            return;
+            errorMessage = "variant name must be a string";
+            return false;
         } else {
             const std::string variantName = it->second.Get<std::string>();
-            ERROR_AND_RETURN_IF_NOT_ALLOWED(
-                context, 
-                SdfSchema::IsValidVariantSelection(variantName));
+            const SdfAllowed allow = SdfSchema::IsValidVariantSelection(variantName);
+            if (!allow)
+            {
+                errorMessage = allow.GetWhyNot();
+                return false;
+            }
 
             refVars[it->first] = variantName;
         }
     }
 
-    _SetField(context->path, SdfFieldKeys->VariantSelection, refVars, context);
-    context->currentDictionaries[0].clear();
+    _SetField(context.path, SdfFieldKeys->VariantSelection, refVars, context);
+    context.currentDictionaries[0].clear();
+
+    return true;
 }
 
-void
-_RelocatesAdd(const Sdf_ParserHelpers::Value& arg1, const Sdf_ParserHelpers::Value& arg2, 
-              Sdf_TextParserContext *context)
+bool
+_RelocatesAdd(const Sdf_ParserHelpers::Value& arg1, 
+    const Sdf_ParserHelpers::Value& arg2, Sdf_TextParserContext& context,
+    std::string& errorMessage)
 {
     const std::string& srcStr    = arg1.Get<std::string>();
     const std::string& targetStr = arg2.Get<std::string>();
@@ -359,14 +364,12 @@ _RelocatesAdd(const Sdf_ParserHelpers::Value& arg1, const Sdf_ParserHelpers::Val
     SdfPath targetPath(targetStr);
 
     if (!SdfSchema::IsValidRelocatesPath(srcPath)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid relocates path",
-            srcStr.c_str());
-        return;
+        errorMessage = srcStr + " is not a valid relocates path";
+        return false;
     }
     if (!SdfSchema::IsValidRelocatesPath(targetPath)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid relocates path",
-            targetStr.c_str());
-        return;
+        errorMessage = targetStr + " is not a valid relocates path";
+        return false;
     }
 
     // The relocates map is expected to only hold absolute paths. The
@@ -374,54 +377,61 @@ _RelocatesAdd(const Sdf_ParserHelpers::Value& arg1, const Sdf_ParserHelpers::Val
     // editing, but since we're bypassing that proxy and setting the map
     // directly into the underlying SdfData, we need to explicitly absolutize
     // paths here.
-    const SdfPath srcAbsPath = srcPath.MakeAbsolutePath(context->path);
-    const SdfPath targetAbsPath = targetPath.MakeAbsolutePath(context->path);
+    const SdfPath srcAbsPath = srcPath.MakeAbsolutePath(context.path);
+    const SdfPath targetAbsPath = targetPath.MakeAbsolutePath(context.path);
 
-    context->relocatesParsingMap.insert(std::make_pair(srcAbsPath, 
-                                                        targetAbsPath));
-    context->layerHints.mightHaveRelocates = true;
+    context.relocatesParsingMap.insert(std::make_pair(srcAbsPath, 
+                                                      targetAbsPath));
+    context.layerHints.mightHaveRelocates = true;
+
+    return true;
 }
 
-void
+bool
 _AttributeSetConnectionTargetsList(SdfListOpType opType, 
-                                   Sdf_TextParserContext *context)
+                                   Sdf_TextParserContext& context,
+                                   std::string& errorMessage)
 {
-    if (context->connParsingTargetPaths.empty() &&
+    if (context.connParsingTargetPaths.empty() &&
         opType != SdfListOpTypeExplicit) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Setting connection paths to None (or an empty list) "
+        errorMessage = "Setting connection paths to None (or an empty list) "
             "is only allowed when setting explicit connection paths, "
-            "not for list editing");
-        return;
+            "not for list editing";
+        return false;
     }
 
-    TF_FOR_ALL(path, context->connParsingTargetPaths) {
-        ERROR_AND_RETURN_IF_NOT_ALLOWED(
-            context, 
-            SdfSchema::IsValidAttributeConnectionPath(*path));
+    TF_FOR_ALL(path, context.connParsingTargetPaths) {
+        const SdfAllowed allow = 
+            SdfSchema::IsValidAttributeConnectionPath(*path);
+        if (!allow)
+        {
+            errorMessage = allow.GetWhyNot();
+            return false;
+        }
     }
 
     if (opType == SdfListOpTypeAdded || 
         opType == SdfListOpTypeExplicit) {
 
-        TF_FOR_ALL(pathIter, context->connParsingTargetPaths) {
-            SdfPath path = context->path.AppendTarget(*pathIter);
+        TF_FOR_ALL(pathIter, context.connParsingTargetPaths) {
+            SdfPath path = context.path.AppendTarget(*pathIter);
             if (!_HasSpec(path, context)) {
                 _CreateSpec(path, SdfSpecTypeConnection, context);
             }
         }
 
         _SetField(
-            context->path, SdfChildrenKeys->ConnectionChildren,
-            context->connParsingTargetPaths, context);
+            context.path, SdfChildrenKeys->ConnectionChildren,
+            context.connParsingTargetPaths, context);
     }
 
-    _SetListOpItems(SdfFieldKeys->ConnectionPaths, opType, 
-                    context->connParsingTargetPaths, context);
+    return _SetListOpItems(SdfFieldKeys->ConnectionPaths, opType, 
+        context.connParsingTargetPaths, context, errorMessage);
 }
 
 void
-_AttributeAppendConnectionPath(Sdf_TextParserContext *context)
+_AttributeAppendConnectionPath(Sdf_TextParserContext& context,
+size_t lineNumber)
 {
     // Expand paths relative to the containing prim.
     //
@@ -429,7 +439,7 @@ _AttributeAppendConnectionPath(Sdf_TextParserContext *context)
     // path before expanding the relative path, which is what we
     // want.  Connection paths never point into the variant namespace.
     SdfPath absPath = 
-        context->savedPath.MakeAbsolutePath(context->path.GetPrimPath());
+        context.savedPath.MakeAbsolutePath(context.path.GetPrimPath());
 
     // XXX Workaround for bug 68132:
     // Prior to the fix to bug 67916, FilterGenVariantBase was authoring
@@ -439,288 +449,301 @@ _AttributeAppendConnectionPath(Sdf_TextParserContext *context)
     // connection paths.  As a migration measure, we discard those
     // variant selections here.
     if (absPath.ContainsPrimVariantSelection()) {
-        TF_WARN("Connection path <%s> (in file @%s@, line %i) has a variant "
+        TF_WARN("Connection path <%s> (in file @%s@, line %zu) has a variant "
                 "selection, but variant selections are not meaningful in "
                 "connection paths.  Stripping the variant selection and "
                 "using <%s> instead.  Resaving the file will fix this issue.",
                 absPath.GetText(),
-                context->fileContext.c_str(),
-                context->sdfLineNo,
+                context.fileContext.c_str(),
+                lineNumber,
                 absPath.StripAllVariantSelections().GetText());
         absPath = absPath.StripAllVariantSelections();
     }
 
-    context->connParsingTargetPaths.push_back(absPath);
+    context.connParsingTargetPaths.push_back(absPath);
 }
 
-void
-_PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1, Sdf_TextParserContext *context)  
+bool
+_PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1,
+    Sdf_TextParserContext& context, std::string& errorMessage)  
 {
     TfToken name(arg1.Get<std::string>());
     if (!SdfPath::IsValidNamespacedIdentifier(name)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, "'%s' is not a valid attribute name", 
-            name.GetText());
+        errorMessage = "'" + name.GetString() + 
+            "' is not a valid attribute name";
+        return false;
     }
 
-    context->path = context->path.AppendProperty(name);
+    context.path = context.path.AppendProperty(name);
 
     // If we haven't seen this attribute before, then set the object type
     // and add it to the parent's list of properties. Otherwise both have
     // already been done, so we don't need to do anything.
-    if (!_HasSpec(context->path, context)) {
-        context->propertiesStack.back().push_back(name);
-        _CreateSpec(context->path, SdfSpecTypeAttribute, context);
-        _SetField(context->path, SdfFieldKeys->Custom, false, context);
+    if (!_HasSpec(context.path, context)) {
+        context.propertiesStack.back().push_back(name);
+        _CreateSpec(context.path, SdfSpecTypeAttribute, context);
+        _SetField(context.path, SdfFieldKeys->Custom, false, context);
     }
 
-    if(context->custom)
-        _SetField(context->path, SdfFieldKeys->Custom, true, context);
+    if(context.custom)
+        _SetField(context.path, SdfFieldKeys->Custom, true, context);
 
     // If the type was previously set, check that it matches. Otherwise set it.
-    const TfToken newType(context->values.valueTypeName);
+    const TfToken newType(context.values.valueTypeName);
 
     VtValue oldTypeValue;
     if (_HasField(
-            context->path, SdfFieldKeys->TypeName, &oldTypeValue, context)) {
+            context.path, SdfFieldKeys->TypeName, &oldTypeValue, context)) {
         const TfToken& oldType = oldTypeValue.Get<TfToken>();
 
         if (newType != oldType) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context,
-                "attribute '%s' already has type '%s', cannot change to '%s'",
-                context->path.GetName().c_str(),
-                oldType.GetText(),
-                newType.GetText());
+            errorMessage = "attribute '" + context.path.GetName() + 
+                "' already has type '" + oldType.GetString() + 
+                "', cannot change to '" + newType.GetString() + "'";
+
+            return false;
         }
     }
     else {
-        _SetField(context->path, SdfFieldKeys->TypeName, newType, context);
+        _SetField(context.path, SdfFieldKeys->TypeName, newType, context);
     }
 
     // If the variability was previously set, check that it matches. Otherwise
     // set it.  If the 'variability' VtValue is empty, that indicates varying
     // variability.
-    SdfVariability variability = context->variability.IsEmpty() ? 
-        SdfVariabilityVarying : context->variability.Get<SdfVariability>();
+    SdfVariability variability = context.variability.IsEmpty() ? 
+        SdfVariabilityVarying : context.variability.Get<SdfVariability>();
     VtValue oldVariability;
     if (_HasField(
-            context->path, SdfFieldKeys->Variability, &oldVariability, 
+            context.path, SdfFieldKeys->Variability, &oldVariability, 
             context)) {
         if (variability != oldVariability.Get<SdfVariability>()) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                "attribute '%s' already has variability '%s', "
-                "cannot change to '%s'",
-                context->path.GetName().c_str(),
-                TfEnum::GetName(oldVariability.Get<SdfVariability>()).c_str(),
-                TfEnum::GetName(variability).c_str() );
+            errorMessage = "attribute '" + context.path.GetName() +
+                "' already has variability '" +
+                TfEnum::GetName(oldVariability.Get<SdfVariability>()) +
+                "', cannot change to '" +
+                TfEnum::GetName(variability) + "'";
+            return false;
         }
     } else {
         _SetField(
-            context->path, SdfFieldKeys->Variability, variability, context);
+            context.path, SdfFieldKeys->Variability, variability, context);
     }
+
+    return true;
 }
 
 void
-_DictionaryBegin(Sdf_TextParserContext *context)
+_DictionaryBegin(Sdf_TextParserContext& context)
 {
-    context->currentDictionaries.push_back(VtDictionary());
+    context.currentDictionaries.push_back(VtDictionary());
 
     // Whenever we parse a value for an unregistered generic metadata field, 
     // the parser value context records the string representation only, because
     // we don't have enough type information to generate a C++ value. However,
     // dictionaries are a special case because we have all the type information
     // we need to generate C++ values. So, override the previous setting.
-    if (context->values.IsRecordingString()) {
-        context->values.StopRecordingString();
+    if (context.values.IsRecordingString()) {
+        context.values.StopRecordingString();
     }
 }
 
 void
-_DictionaryEnd(Sdf_TextParserContext *context)
+_DictionaryEnd(Sdf_TextParserContext& context)
 {
-    context->currentDictionaries.pop_back();
+    context.currentDictionaries.pop_back();
 }
 
 void
-_DictionaryInsertValue(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+_DictionaryInsertValue(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context)
 {
-    size_t n = context->currentDictionaries.size();
-    context->currentDictionaries[n-2][arg1.Get<std::string>()] = 
-        context->currentValue;
+    size_t n = context.currentDictionaries.size();
+    context.currentDictionaries[n-2][arg1.Get<std::string>()] = 
+        context.currentValue;
 }
 
 void
 _DictionaryInsertDictionary(const Sdf_ParserHelpers::Value& arg1,
-                            Sdf_TextParserContext *context)
+                            Sdf_TextParserContext& context)
 {
-    size_t n = context->currentDictionaries.size();
+    size_t n = context.currentDictionaries.size();
     // Insert the parsed dictionary into the parent dictionary.
-    context->currentDictionaries[n-2][arg1.Get<std::string>()].Swap(
-        context->currentDictionaries[n-1]);
+    context.currentDictionaries[n-2][arg1.Get<std::string>()].Swap(
+        context.currentDictionaries[n-1]);
     // Clear out the last dictionary (there can be more dictionaries on the
     // same nesting level).
-    context->currentDictionaries[n-1].clear();
+    context.currentDictionaries[n-1].clear();
 }
 
-void
+bool
 _DictionaryInitScalarFactory(const Sdf_ParserHelpers::Value& arg1,
-                             Sdf_TextParserContext *context)
+                             Sdf_TextParserContext& context,
+                             std::string& errorMessage)
 {
     const std::string& typeName = arg1.Get<std::string>();
     if (!_SetupValue(typeName, context)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Unrecognized value typename '%s' for dictionary", 
-            typeName.c_str());
+        errorMessage = "Unrecognized value typename '" + typeName +
+            "' for dictionary";
+        return false;
     }
+
+    return true;
 }
 
-void
+bool
 _DictionaryInitShapedFactory(const Sdf_ParserHelpers::Value& arg1,
-                             Sdf_TextParserContext *context)
+                             Sdf_TextParserContext& context,
+                             std::string& errorMessage)
 {
     const std::string typeName = arg1.Get<std::string>() + "[]";
     if (!_SetupValue(typeName, context)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Unrecognized value typename '%s' for dictionary", 
-            typeName.c_str());
+        errorMessage = "Unrecognized value typename '" + typeName +
+            "' for dictionary";
+        return false;
     }
+
+    return true;
 }
 
-void
-_ValueSetTuple(Sdf_TextParserContext *context)
+bool
+_ValueSetTuple(Sdf_TextParserContext& context, std::string& errorMessage)
 {
-    if (!context->values.IsRecordingString()) {
-        if (context->values.valueIsShaped) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                "Type name has [] for non-shaped value.\n");
-            return;
+    if (!context.values.IsRecordingString()) {
+        if (context.values.valueIsShaped) {
+            errorMessage = "Type name has [] for non-shaped value.\n";
+            return false;
         }
     }
 
     std::string errStr;
-    context->currentValue = context->values.ProduceValue(&errStr);
-    if (context->currentValue == VtValue()) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Error parsing tuple value: %s", errStr.c_str());
-        return;
+    context.currentValue = context.values.ProduceValue(&errStr);
+    if (context.currentValue == VtValue()) {
+        errorMessage = "Error parsing tuple value: " + errStr;
+        return false;
     }
+
+    return true;
 }
 
-void
-_ValueSetList(Sdf_TextParserContext *context)
+bool
+_ValueSetList(Sdf_TextParserContext& context, std::string& errorMessage)
 {
-    if (!context->values.IsRecordingString()) {
-        if (!context->values.valueIsShaped) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                "Type name missing [] for shaped value.");
-            return;
+    if (!context.values.IsRecordingString()) {
+        if (!context.values.valueIsShaped) {
+            errorMessage = "Type name missing [] for shaped value.";
+            return false;
         }
     }
 
     std::string errStr;
-    context->currentValue = context->values.ProduceValue(&errStr);
-    if (context->currentValue == VtValue()) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Error parsing shaped value: %s", errStr.c_str());
-        return;
+    context.currentValue = context.values.ProduceValue(&errStr);
+    if (context.currentValue == VtValue()) {
+        errorMessage = "Error parsing shaped value: " + errStr;
+        return false;
     }
+
+    return true;
 }
 
-void
-_ValueSetShaped(Sdf_TextParserContext *context)
+bool
+_ValueSetShaped(Sdf_TextParserContext& context, std::string& errorMessage)
 {
-    if (!context->values.IsRecordingString()) {
-        if (!context->values.valueIsShaped) {
-            SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                "Type name missing [] for shaped value.");
-            return;
+    if (!context.values.IsRecordingString()) {
+        if (!context.values.valueIsShaped) {
+            errorMessage = "Type name missing [] for shaped value.";
+            return false;
         }
     }
 
     std::string errStr;
-    context->currentValue = context->values.ProduceValue(&errStr);
-    if (context->currentValue == VtValue()) {
+    context.currentValue = context.values.ProduceValue(&errStr);
+    if (context.currentValue == VtValue()) {
         // The factory method ProduceValue() uses for shaped types
         // only returns empty VtArrays, not empty VtValues, so this
         // is impossible to hit currently.
         // CODE_COVERAGE_OFF
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Error parsing shaped value: %s", errStr.c_str());
+        errorMessage = "Error parsing shaped value: " + errStr;
         // CODE_COVERAGE_OFF_GCOV_BUG
         // The following line actually shows as executed (a ridiculous 
         // number of times) even though the line above shwos as 
         // not executed
-        return;
+        return false;
         // CODE_COVERAGE_ON_GCOV_BUG
         // CODE_COVERAGE_ON
     }
+
+    return true;
 }
 
 void
 _ValueSetCurrentToSdfPath(const Sdf_ParserHelpers::Value& arg1,
-                                     Sdf_TextParserContext *context)
+                                     Sdf_TextParserContext& context)
 {
     // make current Value an SdfPath of the given argument...
     std::string s = arg1.Get<std::string>();
     // If path is empty, use default c'tor to construct empty path.
     // XXX: 08/04/08 Would be nice if SdfPath would allow 
     // SdfPath("") without throwing a warning.
-    context->currentValue = s.empty() ? SdfPath() : SdfPath(s);
+    context.currentValue = s.empty() ? SdfPath() : SdfPath(s);
 }
 
-void
+bool
 _PrimInitRelationship(const Sdf_ParserHelpers::Value& arg1,
-                      Sdf_TextParserContext *context)
+                      Sdf_TextParserContext& context,
+                      std::string& errorMessage)
 {
     TfToken name( arg1.Get<std::string>() );
     if (!SdfPath::IsValidNamespacedIdentifier(name)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "'%s' is not a valid relationship name", name.GetText());
-        return;
+        errorMessage = std::string(name.GetText()) +
+            " is not a valid relationship name";
+        return false;
     }
 
-    context->path = context->path.AppendProperty(name);
+    context.path = context.path.AppendProperty(name);
 
-    if (!_HasSpec(context->path, context)) {
-        context->propertiesStack.back().push_back(name);
-        _CreateSpec(context->path, SdfSpecTypeRelationship, context);
+    if (!_HasSpec(context.path, context)) {
+        context.propertiesStack.back().push_back(name);
+        _CreateSpec(context.path, SdfSpecTypeRelationship, context);
     }
 
     _SetField(
-        context->path, SdfFieldKeys->Variability, 
-        context->variability, context);
+        context.path, SdfFieldKeys->Variability, 
+        context.variability, context);
 
-    if (context->custom) {
-        _SetField(context->path, SdfFieldKeys->Custom, context->custom, context);
+    if (context.custom) {
+        _SetField(context.path, SdfFieldKeys->Custom, context.custom, context);
     }
 
-    context->relParsingAllowTargetData = false;
-    context->relParsingTargetPaths.reset();
-    context->relParsingNewTargetChildren.clear();
+    context.relParsingTargetPaths.reset();
+    context.relParsingNewTargetChildren.clear();
+
+    return true;
 }
 
 void
-_PrimEndRelationship(Sdf_TextParserContext *context)
+_PrimEndRelationship(Sdf_TextParserContext& context)
 {
-    if (!context->relParsingNewTargetChildren.empty()) {
+    if (!context.relParsingNewTargetChildren.empty()) {
         std::vector<SdfPath> children = 
-            context->data->GetAs<std::vector<SdfPath> >(
-                context->path, SdfChildrenKeys->RelationshipTargetChildren);
+            context.data->GetAs<std::vector<SdfPath> >(
+                context.path, SdfChildrenKeys->RelationshipTargetChildren);
 
         children.insert(children.end(), 
-                        context->relParsingNewTargetChildren.begin(),
-                        context->relParsingNewTargetChildren.end());
+                        context.relParsingNewTargetChildren.begin(),
+                        context.relParsingNewTargetChildren.end());
 
         _SetField(
-            context->path, SdfChildrenKeys->RelationshipTargetChildren, 
+            context.path, SdfChildrenKeys->RelationshipTargetChildren, 
             children, context);
     }
 
-    context->path = context->path.GetParentPath();
+    context.path = context.path.GetParentPath();
 }
 
 void
 _RelationshipAppendTargetPath(const Sdf_ParserHelpers::Value& arg1,
-                              Sdf_TextParserContext *context)
+                              Sdf_TextParserContext& context)
 {
     // Add a new target to the current relationship
     const std::string& pathStr = arg1.Get<std::string>();
@@ -732,58 +755,64 @@ _RelationshipAppendTargetPath(const Sdf_ParserHelpers::Value& arg1,
         // This strips any variant selections from the containing prim
         // path before expanding the relative path, which is what we
         // want.  Target paths never point into the variant namespace.
-        path = path.MakeAbsolutePath(context->path.GetPrimPath());
+        path = path.MakeAbsolutePath(context.path.GetPrimPath());
     }
 
-    if (!context->relParsingTargetPaths) {
+    if (!context.relParsingTargetPaths) {
         // This is the first target we've seen for this relationship.
         // Start tracking them in a vector.
-        context->relParsingTargetPaths = SdfPathVector();
+        context.relParsingTargetPaths = SdfPathVector();
     }
-    context->relParsingTargetPaths->push_back(path);
+    context.relParsingTargetPaths->push_back(path);
 }
 
-void
-_PathSetPrim(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context)
+bool
+_PathSetPrim(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context, std::string& errorMessage)
 {
     const std::string& pathStr = arg1.Get<std::string>();
-    context->savedPath = SdfPath(pathStr);
-    if (!context->savedPath.IsPrimPath()) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "'%s' is not a valid prim path", pathStr.c_str());
+    context.savedPath = SdfPath(pathStr);
+    if (!context.savedPath.IsPrimPath()) {
+        errorMessage = pathStr + " is not a valid prim path";
+        return false;
     }
+
+    return true;
 }
 
-void
+bool
 _PathSetPrimOrPropertyScenePath(const Sdf_ParserHelpers::Value& arg1,
-                                Sdf_TextParserContext *context)
+                                Sdf_TextParserContext& context,
+                                std::string& errorMessage)
 {
     const std::string& pathStr = arg1.Get<std::string>();
-    context->savedPath = SdfPath(pathStr);
+    context.savedPath = SdfPath(pathStr);
     // Valid paths are prim or property paths that do not contain variant
     // selections.
-    SdfPath const &path = context->savedPath;
+    SdfPath const &path = context.savedPath;
     bool pathValid = (path.IsPrimPath() || path.IsPropertyPath()) &&
         !path.ContainsPrimVariantSelection();
     if (!pathValid) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "'%s' is not a valid prim or property scene path",
-            pathStr.c_str());
+        errorMessage = pathStr + " is not a valid prim or property scene path";
+        return false;
     }
+
+    return true;
 }
 
 void
 _SetGenericMetadataListOpItems(const TfType& fieldType, 
-                               Sdf_TextParserContext *context)
+                               Sdf_TextParserContext& context)
 {
     // Chain together attempts to set list op items using 'or' to bail
     // out as soon as we successfully write out the list op we're holding.
-    _SetItemsIfListOp<SdfIntListOp>(fieldType, context)    ||
-    _SetItemsIfListOp<SdfInt64ListOp>(fieldType, context)  ||
-    _SetItemsIfListOp<SdfUIntListOp>(fieldType, context)   ||
-    _SetItemsIfListOp<SdfUInt64ListOp>(fieldType, context) ||
-    _SetItemsIfListOp<SdfStringListOp>(fieldType, context) ||
-    _SetItemsIfListOp<SdfTokenListOp>(fieldType, context);
+    std::string errorMessage;
+    _SetItemsIfListOp<SdfIntListOp>(fieldType, context, errorMessage)    ||
+    _SetItemsIfListOp<SdfInt64ListOp>(fieldType, context, errorMessage)  ||
+    _SetItemsIfListOp<SdfUIntListOp>(fieldType, context, errorMessage)   ||
+    _SetItemsIfListOp<SdfUInt64ListOp>(fieldType, context, errorMessage) ||
+    _SetItemsIfListOp<SdfStringListOp>(fieldType, context, errorMessage) ||
+    _SetItemsIfListOp<SdfTokenListOp>(fieldType, context, errorMessage);
 }
 
 bool
@@ -818,18 +847,18 @@ _IsGenericMetadataListOpType(const TfType& type,
 
 void
 _GenericMetadataStart(const Sdf_ParserHelpers::Value &name, SdfSpecType specType,
-                      Sdf_TextParserContext *context)
+                      Sdf_TextParserContext& context)
 {
-    context->genericMetadataKey = TfToken(name.Get<std::string>());
-    context->listOpType = SdfListOpTypeExplicit;
+    context.genericMetadataKey = TfToken(name.Get<std::string>());
+    context.listOpType = SdfListOpTypeExplicit;
 
     const SdfSchema& schema = SdfSchema::GetInstance();
     const SdfSchema::SpecDefinition &specDef = 
         *schema.GetSpecDefinition(specType);
-    if (specDef.IsMetadataField(context->genericMetadataKey)) {
+    if (specDef.IsMetadataField(context.genericMetadataKey)) {
         // Prepare to parse a known field
         const SdfSchema::FieldDefinition &fieldDef = 
-            *schema.GetFieldDefinition(context->genericMetadataKey);
+            *schema.GetFieldDefinition(context.genericMetadataKey);
         const TfType fieldType = fieldDef.GetFallbackValue().GetType();
 
         // For list op-valued metadata fields, set up the parser as if
@@ -848,67 +877,71 @@ _GenericMetadataStart(const Sdf_ParserHelpers::Value &name, SdfSpecType specType
     } else {
         // Prepare to parse only the string representation of this metadata
         // value, since it's an unregistered field.
-        context->values.StartRecordingString();
+        context.values.StartRecordingString();
     }
 }
 
-void
-_GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
+bool
+_GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext& context,
+    std::string& errorMessage)
 {
     const SdfSchema& schema = SdfSchema::GetInstance();
     const SdfSchema::SpecDefinition &specDef = 
         *schema.GetSpecDefinition(specType);
-    if (specDef.IsMetadataField(context->genericMetadataKey)) {
+    if (specDef.IsMetadataField(context.genericMetadataKey)) {
         // Validate known fields before storing them
         const SdfSchema::FieldDefinition &fieldDef = 
-            *schema.GetFieldDefinition(context->genericMetadataKey);
+            *schema.GetFieldDefinition(context.genericMetadataKey);
         const TfType fieldType = fieldDef.GetFallbackValue().GetType();
 
         if (_IsGenericMetadataListOpType(fieldType)) {
-            if (!fieldDef.IsValidListValue(context->currentValue)) {
-                SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                    "invalid value for field \"%s\"", 
-                    context->genericMetadataKey.GetText());
+            if (!fieldDef.IsValidListValue(context.currentValue)) {
+                errorMessage = "invalid value for field " + 
+                    std::string(context.genericMetadataKey.GetText());
+
+                return false;
             }
             else {
                 _SetGenericMetadataListOpItems(fieldType, context);
             }
         }
         else {
-            if (!fieldDef.IsValidValue(context->currentValue) ||
-                context->currentValue.IsEmpty()) {
-                SDF_TEXTFILEFORMATPARSER_ERR(context, 
-                    "invalid value for field \"%s\"", 
-                    context->genericMetadataKey.GetText());
+            if (!fieldDef.IsValidValue(context.currentValue) ||
+                context.currentValue.IsEmpty()) {
+                errorMessage = "invalid value for field " +
+                    std::string(context.genericMetadataKey.GetText());
+                
+                return false;
             }
             else {
                 _SetField(
-                    context->path, context->genericMetadataKey, 
-                    context->currentValue, context);
+                    context.path, context.genericMetadataKey, 
+                    context.currentValue, context);
             }
         }
-    } else if (specDef.IsValidField(context->genericMetadataKey)) {
+    } else if (specDef.IsValidField(context.genericMetadataKey)) {
         // Prevent the user from overwriting fields that aren't metadata
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "\"%s\" is registered as a non-metadata field", 
-            context->genericMetadataKey.GetText());
+        errorMessage = std::string(context.genericMetadataKey.GetText()) + 
+            " is registered as a non-metadata field";
+
+        return false;
     } else {
         // Stuff unknown fields into a SdfUnregisteredValue so they can pass
         // through loading and saving unmodified
         VtValue value;
-        if (context->currentValue.IsHolding<VtDictionary>()) {
+        if (context.currentValue.IsHolding<VtDictionary>()) {
             // If we parsed a dictionary, store it's actual value. Dictionaries
             // can be parsed fully because they contain type information.
             value = 
-                SdfUnregisteredValue(context->currentValue.Get<VtDictionary>());
+                SdfUnregisteredValue(context.currentValue.Get<VtDictionary>());
         } else {
             // Otherwise, we parsed a simple value or a shaped list of simple
             // values. We want to store the parsed string, but we need to
             // determine whether to unpack it into an SdfUnregisteredListOp
             // or to just store the string directly.
-            auto getOldValue = [context]() {
+            auto getOldValue = [&context]() {
                 VtValue v;
-                if (_HasField(context->path, context->genericMetadataKey,
+                if (_HasField(context.path, context.genericMetadataKey,
                               &v, context)
                     && TF_VERIFY(v.IsHolding<SdfUnregisteredValue>())) {
                     v = v.UncheckedGet<SdfUnregisteredValue>().GetValue();
@@ -919,8 +952,8 @@ _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
                 return v;
             };
 
-            auto getRecordedStringAsUnregisteredValue = [context]() {
-                std::string s = context->values.GetRecordedString();
+            auto getRecordedStringAsUnregisteredValue = [&context]() {
+                std::string s = context.values.GetRecordedString();
                 if (s == "None") { 
                     return std::vector<SdfUnregisteredValue>(); 
                 }
@@ -936,13 +969,13 @@ _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
             };
 
             VtValue oldValue = getOldValue();
-            if (context->listOpType == SdfListOpTypeExplicit) {
+            if (context.listOpType == SdfListOpTypeExplicit) {
                 // In this case, we can't determine whether the we've parsed
                 // an explicit list op statement or a simple value.
                 // We just store the recorded string directly, as that's the
                 // simplest thing to do.
                 value = 
-                    SdfUnregisteredValue(context->values.GetRecordedString());
+                    SdfUnregisteredValue(context.values.GetRecordedString());
             }
             else if (oldValue.IsEmpty()
                      || oldValue.IsHolding<SdfUnregisteredValueListOp>()) {
@@ -952,7 +985,7 @@ _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
                 SdfUnregisteredValueListOp listOp = 
                     oldValue.GetWithDefault<SdfUnregisteredValueListOp>();
                 listOp.SetItems(getRecordedStringAsUnregisteredValue(), 
-                                context->listOpType);
+                                context.listOpType);
                 value = SdfUnregisteredValue(listOp);
             }
             else {
@@ -965,37 +998,119 @@ _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context)
         }
 
         if (!value.IsEmpty()) {
-            _SetField(context->path, context->genericMetadataKey, 
+            _SetField(context.path, context.genericMetadataKey, 
                       value, context);
         }
     }
 
-    context->values.Clear();
-    context->currentValue = VtValue();
+    context.values.Clear();
+    context.currentValue = VtValue();
+
+    return true;
 }
 
-void _RaiseError(Sdf_TextParserContext *context, const char *msg)
+std::string
+_UnpadNamespacedName(const std::string& in)
 {
-    int errLineNumber = context->sdfLineNo;
-
-    std::string s = TfStringPrintf(
-        "%s in <%s> on line %i",
-        msg,
-        context->path.GetText(),
-        errLineNumber);
-
-    // Append file context, if known.
-    if (!context->fileContext.empty()) {
-        s += " in file " + context->fileContext;
+    // namespaced names are resolved by the lexer rules with
+    // spaces accepted around the namespaced delimeter `::`
+    // so we have to remove those spaces to get an unpadded name
+    std::vector<std::string> nameParts = TfStringSplit(in, "::");
+    std::string namespacedName = nameParts[0];
+    if (nameParts.size() > 1)
+    {
+        for (size_t i = 1; i < nameParts.size(); i++)
+        {
+            namespacedName = namespacedName + "::" + TfStringTrim(nameParts[i]);
+        }
     }
-    s += "\n";
 
-    // Return the line number in the error info.
-    TfDiagnosticInfo info(errLineNumber);
+    return namespacedName;
+}
 
-    TF_ERROR(info, TF_DIAGNOSTIC_RUNTIME_ERROR_TYPE, s);
+Sdf_ParserHelpers::Value
+_GetValueFromString(const std::string& in,
+    size_t lineNumber,
+    Sdf_TextParserContext& context)
+{
+    Sdf_ParserHelpers::Value value;
+    const std::string negativeZero = "-0";
+    const std::string negativeInfinity = "-inf";
+    const std::string positiveInfinity = "inf";
+    const std::string nan = "nan";
+    if (in == negativeZero)
+    {
+        value = double(-0.0);
+    }
+    else if(in == negativeInfinity)
+    {
+        value = -std::numeric_limits<double>::infinity();
+    }
+    else if (in == positiveInfinity)
+    {
+        value = std::numeric_limits<double>::infinity();
+    }
+    else if (in == nan)
+    {
+        value = std::numeric_limits<double>::quiet_NaN();
+    }
+    else if (TfStringContains(in, ".") || TfStringContains(in, "e") ||
+        TfStringContains(in, "E"))
+    {
+        value = TfStringToDouble(in);
+    }
+    else
+    {
+        // positive and negative integers are stored as long
+        // unless out of range
+        bool outOfRange = false;
+        if (TfStringStartsWith(in, "-"))
+        {
+            value = TfStringToInt64(in, &outOfRange);
+        }
+        else
+        {
+            value = TfStringToUInt64(in, &outOfRange);
+        }
 
-    context->seenError = true;
+        if (outOfRange)
+        {
+            TF_WARN("Integer literal '%s' on line %zu%s%s out of range, parsing "
+                "as double.  Consider exponential notation for large "
+                "floating point values.", in.c_str(), lineNumber,
+                context.fileContext.empty() ? "" : " in file ",
+                context.fileContext.empty() ? "" :
+                context.fileContext.c_str());
+
+            value = TfStringToDouble(in);
+        }
+    }
+
+    return value;
+}
+
+std::string
+_GetAssetRefFromString(const std::string& in)
+{
+    bool isTripleDelimited = TfStringStartsWith(in, "@@@");
+    return Sdf_EvalAssetPath(in.c_str(), in.length(), isTripleDelimited);
+}
+
+std::string
+_GetEvaluatedStringFromString(const std::string& in,
+    Sdf_TextParserContext& context)
+{
+    unsigned int numLines = 0;
+    size_t numDelimeters = 1;
+    if(TfStringStartsWith(in, "\"\"\"") || TfStringStartsWith(in, "'''"))
+    {
+        numDelimeters = 3;
+    }
+
+    std::string evaluatedString =
+        Sdf_EvalQuotedString(in.c_str(), in.length(), numDelimeters, &numLines);
+
+    return evaluatedString;
 }
 
 } // end namespace Sdf_TextFileFormatParser

--- a/pxr/usd/sdf/textParserHelpers.h
+++ b/pxr/usd/sdf/textParserHelpers.h
@@ -25,10 +25,12 @@
 #ifndef PXR_USD_SDF_TEXT_PARSER_HELPERS_H
 #define PXR_USD_SDF_TEXT_PARSER_HELPERS_H
 
+#include "pxr/base/tf/debug.h"
 #include "pxr/base/tf/enum.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/type.h"
 #include "pxr/base/vt/value.h"
+#include "pxr/usd/sdf/debugCodes.h"
 #include "pxr/usd/sdf/listOp.h"
 #include "pxr/usd/sdf/parserHelpers.h"
 #include "pxr/usd/sdf/path.h"
@@ -43,76 +45,110 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace Sdf_TextFileFormatParser {
 
-#define SDF_TEXTFILEFORMATPARSER_ERR(context, ...) \
-    _RaiseError(context, TfStringPrintf(__VA_ARGS__).c_str())
+#define Sdf_TextFileFormatParser_Err(context, input, position, ...) \
+    _RaiseError(context, input, position, TfStringPrintf(__VA_ARGS__).c_str())
 
 //--------------------------------------------------------------------
 // Helpers
 //--------------------------------------------------------------------
 
-bool _SetupValue(const std::string& typeName, Sdf_TextParserContext* context);
+bool _SetupValue(const std::string& typeName, 
+    Sdf_TextParserContext& context);
 void _MatchMagicIdentifier(const Sdf_ParserHelpers::Value& arg1, 
-    Sdf_TextParserContext *context);
-SdfPermission _GetPermissionFromString(const std::string & str,
-    Sdf_TextParserContext *context);
-TfEnum _GetDisplayUnitFromString(const std::string & name,
-    Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _GetPermissionFromString(const std::string & str,
+    SdfPermission& permission);
+bool _GetDisplayUnitFromString(const std::string & name,
+    TfEnum& value);
 void _ValueAppendAtomic(const Sdf_ParserHelpers::Value& arg1, 
-    Sdf_TextParserContext *context);
-void _ValueSetAtomic(Sdf_TextParserContext *context);
-void _PrimSetInheritListItems(SdfListOpType opType, Sdf_TextParserContext *context);
-void _InheritAppendPath(Sdf_TextParserContext *context);
-void _PrimSetSpecializesListItems(SdfListOpType opType,
-    Sdf_TextParserContext *context);
-void _SpecializesAppendPath(Sdf_TextParserContext *context);
-void _PrimSetReferenceListItems(SdfListOpType opType,
-    Sdf_TextParserContext *context);
-void _PrimSetPayloadListItems(SdfListOpType opType, Sdf_TextParserContext *context);
-void _PrimSetVariantSetNamesListItems(SdfListOpType opType,
-    Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _ValueSetAtomic(Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _PrimSetInheritListItems(SdfListOpType opType,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+void _InheritAppendPath(Sdf_TextParserContext& context);
+bool _PrimSetSpecializesListItems(SdfListOpType opType,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+void _SpecializesAppendPath(Sdf_TextParserContext& context);
+bool _PrimSetReferenceListItems(SdfListOpType opType,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _PrimSetPayloadListItems(SdfListOpType opType, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _PrimSetVariantSetNamesListItems(SdfListOpType opType,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
 void _RelationshipInitTarget(const SdfPath& targetPath,
-    Sdf_TextParserContext *context);
-void _RelationshipSetTargetsList(SdfListOpType opType, 
-    Sdf_TextParserContext *context);
-void _PrimSetVariantSelection(Sdf_TextParserContext *context);
-void _RelocatesAdd(const Sdf_ParserHelpers::Value& arg1,
-    const Sdf_ParserHelpers::Value& arg2, Sdf_TextParserContext *context);
-void _AttributeSetConnectionTargetsList(SdfListOpType opType, 
-    Sdf_TextParserContext *context);
-void _AttributeAppendConnectionPath(Sdf_TextParserContext *context);
-void _PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1,
-    Sdf_TextParserContext *context);
-void _DictionaryBegin(Sdf_TextParserContext *context);
-void _DictionaryEnd(Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _RelationshipSetTargetsList(SdfListOpType opType, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _PrimSetVariantSelection(Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _RelocatesAdd(const Sdf_ParserHelpers::Value& arg1,
+    const Sdf_ParserHelpers::Value& arg2, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _AttributeSetConnectionTargetsList(SdfListOpType opType, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+void _AttributeAppendConnectionPath(Sdf_TextParserContext& context,
+    size_t lineNumber);
+bool _PrimInitAttribute(const Sdf_ParserHelpers::Value &arg1,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+void _DictionaryBegin(Sdf_TextParserContext& context);
+void _DictionaryEnd(Sdf_TextParserContext& context);
 void _DictionaryInsertValue(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
 void _DictionaryInsertDictionary(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _DictionaryInitScalarFactory(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _DictionaryInitShapedFactory(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _ValueSetTuple(Sdf_TextParserContext *context);
-void _ValueSetList(Sdf_TextParserContext *context);
-void _ValueSetShaped(Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _DictionaryInitScalarFactory(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _DictionaryInitShapedFactory(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _ValueSetTuple(Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _ValueSetList(Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _ValueSetShaped(Sdf_TextParserContext& context,
+    std::string& errorMessage);
 void _ValueSetCurrentToSdfPath(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _PrimInitRelationship(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _PrimEndRelationship(Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _PrimInitRelationship(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+void _PrimEndRelationship(Sdf_TextParserContext& context);
 void _RelationshipAppendTargetPath(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
-void _PathSetPrim(const Sdf_ParserHelpers::Value& arg1, Sdf_TextParserContext *context);
-void _PathSetPrimOrPropertyScenePath(const Sdf_ParserHelpers::Value& arg1,
-    Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
+bool _PathSetPrim(const Sdf_ParserHelpers::Value& arg1, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+bool _PathSetPrimOrPropertyScenePath(const Sdf_ParserHelpers::Value& arg1,
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
 void _SetGenericMetadataListOpItems(const TfType& fieldType, 
-    Sdf_TextParserContext *context);
+    Sdf_TextParserContext& context);
 bool _IsGenericMetadataListOpType(const TfType& type,
     TfType* itemArrayType = nullptr);
-void _GenericMetadataStart(const Sdf_ParserHelpers::Value &name, SdfSpecType specType,
-    Sdf_TextParserContext *context);
-void _GenericMetadataEnd(SdfSpecType specType, Sdf_TextParserContext *context);
-void _RaiseError(Sdf_TextParserContext *context, const char *msg);
+void _GenericMetadataStart(const Sdf_ParserHelpers::Value &name, 
+    SdfSpecType specType,
+    Sdf_TextParserContext& context);
+bool _GenericMetadataEnd(SdfSpecType specType, 
+    Sdf_TextParserContext& context,
+    std::string& errorMessage);
+std::string _UnpadNamespacedName(const std::string& in);
+Sdf_ParserHelpers::Value _GetValueFromString(const std::string& in,
+    size_t lineNumber,
+    Sdf_TextParserContext& context);
+std::string _GetAssetRefFromString(const std::string& in);
+std::string _GetEvaluatedStringFromString(const std::string& in,
+    Sdf_TextParserContext& context);
 
 template <class T>
 bool
@@ -174,9 +210,10 @@ std::vector<T> _ToItemVector(const VtArray<T>& v)
 // Set a single ListOp vector in the list op for the current
 // path and specified key.
 template <class T>
-void
+bool
 _SetListOpItems(const TfToken &key, SdfListOpType type,
-                const T &itemList, Sdf_TextParserContext *context)
+                const T &itemList, Sdf_TextParserContext& context,
+                std::string& errorMessage)
 {
     typedef SdfListOp<typename T::value_type> ListOpType;
     typedef typename ListOpType::ItemVector ItemVector;
@@ -184,33 +221,36 @@ _SetListOpItems(const TfToken &key, SdfListOpType type,
     const ItemVector& items = _ToItemVector(itemList);
 
     if (_HasDuplicates(items)) {
-        SDF_TEXTFILEFORMATPARSER_ERR(context, 
-            "Duplicate items exist for field '%s' at '%s'",
-            key.GetText(), context->path.GetText());
+        errorMessage = "Duplicate items exist for field '" + 
+            key.GetString() + "' at '" + context.path.GetAsString() + "'";
+        
+        return false;
     }
 
-    ListOpType op = context->data->GetAs<ListOpType>(context->path, key);
+    ListOpType op = context.data->GetAs<ListOpType>(context.path, key);
     op.SetItems(items, type);
 
-    context->data->Set(context->path, key, VtValue::Take(op));
+    context.data->Set(context.path, key, VtValue::Take(op));
+
+    return true;
 }
 
 // Append a single item to the vector for the current path and specified key.
 template <class T>
 void
 _AppendVectorItem(const TfToken& key, const T& item,
-                  Sdf_TextParserContext *context)
+                  Sdf_TextParserContext& context)
 {
     std::vector<T> vec =
-        context->data->GetAs<std::vector<T> >(context->path, key);
+        context.data->GetAs<std::vector<T> >(context.path, key);
     vec.push_back(item);
 
-    context->data->Set(context->path, key, VtValue(vec));
+    context.data->Set(context.path, key, VtValue(vec));
 }
 
 inline void
 _SetDefault(const SdfPath& path, VtValue val,
-            Sdf_TextParserContext *context)
+            Sdf_TextParserContext& context)
 {
     // If is holding SdfPathExpression (or array of same), make absolute with
     // path.GetPrimPath() as anchor.
@@ -235,40 +275,41 @@ _SetDefault(const SdfPath& path, VtValue val,
         val.UncheckedSwap(valPath);
     }
     */
-    context->data->Set(path, SdfFieldKeys->Default, val);
+    context.data->Set(path, SdfFieldKeys->Default, val);
 }        
 
 template <class T>
 inline void
 _SetField(const SdfPath& path, const TfToken& key, const T& item,
-          Sdf_TextParserContext *context)
+          Sdf_TextParserContext& context)
 {
-    context->data->Set(path, key, VtValue(item));
+    context.data->Set(path, key, VtValue(item));
 }
 
 inline bool
 _HasField(const SdfPath& path, const TfToken& key, VtValue* value, 
-          Sdf_TextParserContext *context)
+          Sdf_TextParserContext& context)
 {
-    return context->data->Has(path, key, value);
+    return context.data->Has(path, key, value);
 }
 
 inline bool
-_HasSpec(const SdfPath& path, Sdf_TextParserContext *context)
+_HasSpec(const SdfPath& path, Sdf_TextParserContext& context)
 {
-    return context->data->HasSpec(path);
+    return context.data->HasSpec(path);
 }
 
 inline void
 _CreateSpec(const SdfPath& path, SdfSpecType specType, 
-            Sdf_TextParserContext *context)
+            Sdf_TextParserContext& context)
 {
-    context->data->CreateSpec(path, specType);
+    context.data->CreateSpec(path, specType);
 }
 
 template <class ListOpType>
 bool
-_SetItemsIfListOp(const TfType& type, Sdf_TextParserContext *context)
+_SetItemsIfListOp(const TfType& type, Sdf_TextParserContext& context,
+    std::string& errorMessage)
 {
     if (!type.IsA<ListOpType>()) {
         return false;
@@ -276,19 +317,19 @@ _SetItemsIfListOp(const TfType& type, Sdf_TextParserContext *context)
 
     typedef VtArray<typename ListOpType::value_type> ArrayType;
 
-    if (!TF_VERIFY(context->currentValue.IsHolding<ArrayType>() ||
-                   context->currentValue.IsEmpty())) {
+    if (!TF_VERIFY(context.currentValue.IsHolding<ArrayType>() ||
+                   context.currentValue.IsEmpty())) {
         return true;
     }
 
     ArrayType vtArray;
-    if (context->currentValue.IsHolding<ArrayType>()) {
-        vtArray = context->currentValue.UncheckedGet<ArrayType>();
+    if (context.currentValue.IsHolding<ArrayType>()) {
+        vtArray = context.currentValue.UncheckedGet<ArrayType>();
     }
 
-    _SetListOpItems(
-        context->genericMetadataKey, context->listOpType, vtArray, context);
-    return true;
+    return _SetListOpItems(
+        context.genericMetadataKey, context.listOpType, 
+        vtArray, context, errorMessage);
 }
 
 template <class ListOpType>
@@ -298,6 +339,49 @@ _GetListOpAndArrayTfTypes() {
         TfType::Find<ListOpType>(),
         TfType::Find<VtArray<typename ListOpType::value_type>>()
     };
+}
+
+template <class Input, class Position>
+void
+_RaiseError(Sdf_TextParserContext& context, const Input& in, 
+    const Position& pos, const char *msg)
+{
+    // to get the position of interest, we need
+    // the current position of the input iterator
+    // which we can get via in.at - but this gives
+    // only a character pointer, so the best end
+    // we have is the end of that line
+    std::string inputAtError =
+        std::string(in.at(pos), in.end_of_line(pos));
+    std::string s = TfStringPrintf(
+        "%s%s in <%s>",
+        msg,
+        (" at '" + inputAtError + "'").c_str(),
+        context.path.GetText());
+
+    s += "\n";
+
+    // Return the line number in the error info.
+    TfDiagnosticInfo info(pos.line);
+
+    TF_ERROR(info, TF_DIAGNOSTIC_RUNTIME_ERROR_TYPE, s);
+
+    TF_DEBUG(SDF_TEXT_FILE_FORMAT_RULES).Msg("%s\n", s.c_str());
+}
+
+template <class Input>
+void
+_ReportParseError(Sdf_TextParserContext& context, const Input& in, 
+    const std::string& text)
+{
+    if (!context.values.IsRecordingString())
+    {
+        // in this case, we don't have good information on the
+        // exact position this occurred at because the
+        // input here is the original content, not the
+        // action input
+        _RaiseError(context, in, in.position(), text.c_str());
+    }
 }
 
 } // end namespace Sdf_TextFileFormatParser

--- a/pxr/usdImaging/bin/testusdview/CMakeLists.txt
+++ b/pxr/usdImaging/bin/testusdview/CMakeLists.txt
@@ -428,16 +428,29 @@ pxr_register_test(testUsdviewFileArguments4
         PXR_USDVIEW_SUPPRESS_STATE_SAVING=1
 )
 
-pxr_register_test(testUsdviewFileArguments5
-    PYTHON
-    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py invalidSyntax.usda"
-    CLEAN_OUTPUT "(?:[A-Za-z]:)?/(?!refSphere2).*/"
-    STDERR_REDIRECT invalidSyntax_test_out
-    DIFF_COMPARE invalidSyntax_test_out
-    EXPECTED_RETURN_CODE 1
-    ENV
-        PXR_USDVIEW_SUPPRESS_STATE_SAVING=1
-)
+if(${PXR_ENABLE_LEGACY_TEXT_FILE_FORMAT_PARSER})
+    pxr_register_test(testUsdviewFileArguments5
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py invalidSyntax.usda"
+        CLEAN_OUTPUT "(?:[A-Za-z]:)?/(?!refSphere2).*/"
+        STDERR_REDIRECT invalidSyntax_test_out_legacy
+        DIFF_COMPARE invalidSyntax_test_out_legacy
+        EXPECTED_RETURN_CODE 1
+        ENV
+            PXR_USDVIEW_SUPPRESS_STATE_SAVING=1
+    )
+else()
+    pxr_register_test(testUsdviewFileArguments5
+        PYTHON
+        COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testInvalidFileArg.py invalidSyntax.usda"
+        CLEAN_OUTPUT "(?:[A-Za-z]:)?/.*(?=invalidSyntax)"
+        STDERR_REDIRECT invalidSyntax_test_out
+        DIFF_COMPARE invalidSyntax_test_out
+        EXPECTED_RETURN_CODE 1
+        ENV
+            PXR_USDVIEW_SUPPRESS_STATE_SAVING=1
+    )
+endif()
 
 pxr_register_test(testUsdviewFileArguments6
     PYTHON

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewFileArguments/baseline/invalidSyntax_test_out
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewFileArguments/baseline/invalidSyntax_test_out
@@ -1,2 +1,2 @@
 Error: Unable to open stage 'invalidSyntax.usda'
-syntax error at '@HelloWorld.usda@' in </refSphere2> on line 11 in file invalidSyntax.usda
+invalidSyntax.usda:11:22(156): expected None or list value at '@HelloWorld.usda@' in </refSphere2>

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewFileArguments/baseline/invalidSyntax_test_out_legacy
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewFileArguments/baseline/invalidSyntax_test_out_legacy
@@ -1,0 +1,2 @@
+Error: Unable to open stage 'invalidSyntax.usda'
+syntax error at '@HelloWorld.usda@' in </refSphere2> on line 11 in file invalidSyntax.usda


### PR DESCRIPTION
- Added additional text file format parser based on PEGTL
- Added CMake option and preprocessor definition for enabling legacy yacc parser
- Added tests specific to PEGTL parser

### Description of Change(s)

This change introduces a new sdf / usda text file format paser based on PEGTL.  While intended to replace the current lex / yacc parser, this PR enables both to sit side by side and can be compile-time enabled via a new CMake option (defaulting to use the PEGTL parser).  This change aligns the way text file scene descriptions are parsed with the way paths are now being parsed and removes the dependency on lex / yacc (with the compile option enabled).

- Added PEGTL Text File Format Parser
- Added CMake option and preprocessor definition for enabling yacc parser
- Added tests specific to PEGTL parser that allow testing of partial scene description rules

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
