### PR TITLE
Undo inlining of `TfIsUtf8CodePointXid{Start,Continue}`

### DIFF
--- a/pxr/base/tf/testenv/unicodeUtils.cpp
+++ b/pxr/base/tf/testenv/unicodeUtils.cpp
@@ -370,10 +370,12 @@ TestCharacterClasses()
     TF_AXIOM(!TfIsUtf8CodePointXidContinue(
         std::numeric_limits<uint32_t>::max()));
 
-    // also TF_MAX_CODE_POINT is our upper limit, and should be an invalid
-    // code point due to its being reserved
-    TF_AXIOM(!TfIsUtf8CodePointXidStart(TF_MAX_CODE_POINT));
-    TF_AXIOM(!TfIsUtf8CodePointXidContinue(TF_MAX_CODE_POINT));
+    // Test TfUtf8CodePoint::MaximumValue (the last valid) and
+    // TfUtf8CodePoint::MaximumValue + 1 (the first invalid)
+    TF_AXIOM(!TfIsUtf8CodePointXidStart(TfUtf8CodePoint::MaximumValue));
+    TF_AXIOM(!TfIsUtf8CodePointXidContinue(TfUtf8CodePoint::MaximumValue));
+    TF_AXIOM(!TfIsUtf8CodePointXidStart(TfUtf8CodePoint::MaximumValue + 1));
+    TF_AXIOM(!TfIsUtf8CodePointXidContinue(TfUtf8CodePoint::MaximumValue + 1));
 
     return true;
 }

--- a/pxr/base/tf/unicodeUtils.cpp
+++ b/pxr/base/tf/unicodeUtils.cpp
@@ -23,6 +23,7 @@
 //
 
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/unicodeCharacterClasses.h"
 #include "pxr/base/tf/unicodeUtils.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -220,6 +221,16 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                ((byte3 & 0x3f) << 6) + (byte4 & 0x3f);
     }
     return TfUtf8InvalidCodePoint.AsUInt32();
+}
+
+bool TfIsUtf8CodePointXidStart(uint32_t codePoint)
+{
+    return TfUnicodeGetXidStartFlagData().IsXidStartCodePoint(codePoint);
+}
+
+bool TfIsUtf8CodePointXidContinue(uint32_t codePoint)
+{
+    return TfUnicodeGetXidContinueFlagData().IsXidContinueCodePoint(codePoint);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeUtils.cpp
+++ b/pxr/base/tf/unicodeUtils.cpp
@@ -27,13 +27,50 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+std::ostream&
+operator<<(std::ostream& stream, const TfUtf8CodePoint codePoint)
+{
+    const auto value = codePoint.AsUInt32();
+    if (value < 0x80)
+    {
+        // 1-byte UTF-8 encoding
+        stream << static_cast<char>(value);
+    }
+    else if (value < 0x800)
+    {
+        // 2-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 6) | 0xc0)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x10000)
+    {
+        // 3-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 12) | 0xe0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else if (value < 0x110000)
+    {
+        // 4-byte UTF-8 encoding
+        stream << (static_cast<char>(static_cast<unsigned char>((value >> 18) | 0xf0)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 12) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>(((value >> 6) & 0x3f) | 0x80)));
+        stream << (static_cast<char>(static_cast<unsigned char>((value & 0x3f) | 0x80)));
+    }
+    else
+    {
+        stream << TfUtf8InvalidCodePoint;
+    }
+    return stream;
+}
+
 uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
 {
     // determine what encoding length the character is
     _EncodingLength encodingLength = this->_GetEncodingLength();
     if (encodingLength > std::distance(_it, _end)) {
         // error condition, would read bytes past the end of the range
-        return INVALID_CODE_POINT;
+        return TfUtf8InvalidCodePoint.AsUInt32();
     }
     if (encodingLength == 1)
     {
@@ -49,12 +86,12 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         if (byte1 < static_cast<unsigned char>('\xc2') ||
             byte1 > static_cast<unsigned char>('\xdf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
         if (byte2 < static_cast<unsigned char>('\x80') ||
             byte2 > static_cast<unsigned char>('\xbf'))
         {
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // the code point is constructed from the last 5 bits of byte1
@@ -77,7 +114,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if ((byte1 >= static_cast<unsigned char>('\xe1') &&
@@ -92,7 +129,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xed'))
@@ -104,13 +141,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte3 < static_cast<unsigned char>('\x80') ||
                 byte3 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 4 bits of byte1
@@ -137,7 +174,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 >= static_cast<unsigned char>('\xf1') &&
@@ -153,7 +190,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else if (byte1 == static_cast<unsigned char>('\xf4'))
@@ -168,13 +205,13 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
                 byte4 < static_cast<unsigned char>('\x80') ||
                 byte4 > static_cast<unsigned char>('\xbf'))
             {
-                return INVALID_CODE_POINT;
+                return TfUtf8InvalidCodePoint.AsUInt32();
             }
         }
         else
         {
             // byte 1 is invalid
-            return INVALID_CODE_POINT;
+            return TfUtf8InvalidCodePoint.AsUInt32();
         }
 
         // code point is constructed from the last 3 bits of byte 1
@@ -182,7 +219,7 @@ uint32_t TfUtf8CodePointIterator::_GetCodePoint() const
         return ((byte1 & 0x7) << 18) + ((byte2 & 0x3f) << 12) +
                ((byte3 & 0x3f) << 6) + (byte4 & 0x3f);
     }
-    return INVALID_CODE_POINT;
+    return TfUtf8InvalidCodePoint.AsUInt32();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/base/tf/unicodeUtils.h
+++ b/pxr/base/tf/unicodeUtils.h
@@ -30,7 +30,6 @@
 #include "pxr/pxr.h"
 #include "pxr/base/tf/api.h"
 #include "pxr/base/tf/diagnostic.h"
-#include "pxr/base/tf/unicodeCharacterClasses.h"
 
 #include <ostream>
 #include <string>
@@ -382,10 +381,7 @@ TfUtf8CodePointView::EndAsIterator() const
 /// That is, the character must have a category of Lu | Ll | Lt | Lm | Lo | Nl
 ///
 TF_API
-inline bool TfIsUtf8CodePointXidStart(uint32_t codePoint)
-{
-    return TfUnicodeGetXidStartFlagData().IsXidStartCodePoint(codePoint);
-}
+bool TfIsUtf8CodePointXidStart(uint32_t codePoint);
 
 /// Determines whether the given Unicode \a codePoint is in the XID_Continue
 /// character class.
@@ -397,10 +393,7 @@ inline bool TfIsUtf8CodePointXidStart(uint32_t codePoint)
 /// XID_Start | Nd | Mn | Mc | Pc
 ///
 TF_API
-inline bool TfIsUtf8CodePointXidContinue(uint32_t codePoint)
-{
-    return TfUnicodeGetXidContinueFlagData().IsXidContinueCodePoint(codePoint);
-}
+bool TfIsUtf8CodePointXidContinue(uint32_t codePoint);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 


### PR DESCRIPTION
### Description of Change(s)

#2857 was focused on reducing the cost / instruction count of initializing the range tables for the `Xid` character classes. It also inlined their usage in `unicodeUtils.{h,cpp}`. However, `unicodeCharacterClasses` is private and cannot be included in the header for `unicodeUtils` to be used outside of `Tf`.

This rolls back just that part of #2857.

It also removes the dependency on the `TF_MAX_CODE_POINT` symbol inherited from `unicodeCharacterClasses` to avoid including the private header in the test case.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
