### PR TITLE
Using get value producing attrs when checking texture assets in NormalMapTextureChecker

### DIFF
--- a/pxr/usd/bin/usdchecker/CMakeLists.txt
+++ b/pxr/usd/bin/usdchecker/CMakeLists.txt
@@ -144,3 +144,13 @@ pxr_register_test(testUsdChecker12
     EXPECTED_RETURN_CODE 1
 )
 
+pxr_install_test_dir(
+    SRC testenv/testUsdChecker
+    DEST testUsdChecker13
+)
+
+pxr_register_test(testUsdChecker13
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/usdchecker clean/cleanNormalMapReader.usda"
+    EXPECTED_RETURN_CODE 0
+)

--- a/pxr/usd/bin/usdchecker/testenv/testUsdChecker/clean/cleanNormalMapReader.usda
+++ b/pxr/usd/bin/usdchecker/testenv/testUsdChecker/clean/cleanNormalMapReader.usda
@@ -35,5 +35,34 @@ def "World"
             normal3f inputs:normal.connect = </World/material/NormalMap.outputs:rgb>
         }
     }
-}
 
+    # Normal map compliance checker should handle connected asset attributes.
+    def Material "assetOnMaterial"
+    {
+        asset inputs:file = @texture.jpg@
+
+        def Shader "ColorMap"
+        {
+            uniform token info:id = "UsdUVTexture"
+            asset inputs:file.connect = </World/assetOnMaterial.inputs:file>
+            float3 outputs:rgb
+        }
+
+        def Shader "NormalMap"
+        {
+            uniform token info:id = "UsdUVTexture"
+            token inputs:sourceColorSpace = "raw"
+            float4 inputs:scale = (2.0, 2.0, 2.0, 1.0)
+            float4 inputs:bias = (-1.0, -1.0, -1.0, 0.0)
+            asset inputs:file.connect = </World/assetOnMaterial.inputs:file>
+            float3 outputs:rgb
+        }
+
+        def Shader "Surface"
+        {
+            uniform token info:id = "UsdPreviewSurface"
+            color3f inputs:diffuseColor.connect = </World/assetOnMaterial/ColorMap.outputs:rgb>
+            normal3f inputs:normal.connect = </World/assetOnMaterial/NormalMap.outputs:rgb>
+        }
+    }
+}

--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -470,7 +470,7 @@ Specifically:
         if not valueProducingAttrs or len(valueProducingAttrs) != 1:
             return None
         # We require an input parameter producing the value.
-        if not UsdShade.Tokens.inputs.startswith(valueProducingAttrs[0].GetNamespace()):
+        if not UsdShade.Input.IsInput(valueProducingAttrs[0]):
             return None
         return valueProducingAttrs[0].Get(Usd.TimeCode.EarliestTime())
 

--- a/pxr/usd/usdUtils/complianceChecker.py
+++ b/pxr/usd/usdUtils/complianceChecker.py
@@ -458,13 +458,21 @@ Specifically:
         ext = Ar.GetResolver().GetExtension(asset.resolvedPath)
         # not an exhaustive list, but ones we typically can read
         return ext in ["bmp", "tga", "jpg", "jpeg", "png", "tif"]
-        
+
     def _GetInputValue(self, shader, inputName):
-        from pxr import Usd
+        from pxr import Usd, UsdShade
         input = shader.GetInput(inputName)
         if not input:
             return None
-        return input.Get(Usd.TimeCode.EarliestTime())
+        # Query value producing attributes for input values.
+        # This has to be a length of 1, otherwise no attribute is producing a value.
+        valueProducingAttrs = UsdShade.Utils.GetValueProducingAttributes(input)
+        if not valueProducingAttrs or len(valueProducingAttrs) != 1:
+            return None
+        # We require an input parameter producing the value.
+        if not UsdShade.Tokens.inputs.startswith(valueProducingAttrs[0].GetNamespace()):
+            return None
+        return valueProducingAttrs[0].Get(Usd.TimeCode.EarliestTime())
 
     def CheckPrim(self, prim):
         from pxr import UsdShade, Gf


### PR DESCRIPTION
### Description of Change(s)
The change modifies `NormalMapTextureChecker` to use GetValueProducingAttributes instead of querying the value of the asset parameters on the texture. This way, the NormalMapTextureChecker works better with material networks that expose asset parameters on the Material and connect them to shader parameters.

Questions:
- I'm checking the namespace of the producing attribute to see if it is an input parameter. Is there a better way to do this?
- What should we do about asset attributes produced by output parameters? Is that something we should allow, or generally, that's not expected to work? Could we configure the normal map texture checker to turn this feature on/off?

@asluk

### Fixes Issue(s)
No issue was created.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement