### PR TITLE
Update documentation for UTF-8 utilities

### DIFF
--- a/pxr/base/tf/overview.dox
+++ b/pxr/base/tf/overview.dox
@@ -94,7 +94,7 @@ The high-level grouping of C++ classes and functions is as follows:
 	<li> \link group_tf_DebuggingOutput \b Output \b For \b Debugging - \endlink 
 		TfDebug,  TF_DEBUG(),  TF_FUNC_NAME() 
 	<li> \link group_tf_String \b String \b Utilities - \endlink 
-		TfStringPrintf(),  TfHash, (and a large number of miscellaneous free functions) 
+		TfStringPrintf(), TfHash, TfUtf8CodePointView, (and a large number of miscellaneous free functions)
 	<li> \link group_tf_Containers \b Containers - \endlink 
 		TfByteData,  TfArray2,  TfArray3, TfTypeInfoMap
 	<li> \link group_tf_Stl \b STL \b Utilities - \endlink 


### PR DESCRIPTION
### Description of Change(s)

This change adds some additional examples and corrects some errors in the documentation.

- `TfUtf8CodePointIterator::operator*` suggested that it might throw an `out_of_range` exception, but that won't happen under the current implementation.
- Add `group_tf_String` grouping for UTF-8 utilities
- Add code examples

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
