### PR TITLE
Replace `boost::intrusive_ptr` with `TfDelegatedCountPtr` for `Sdf_Identity`

### DIFF
--- a/pxr/usd/sdf/declareHandles.h
+++ b/pxr/usd/sdf/declareHandles.h
@@ -30,6 +30,7 @@
 #include "pxr/usd/sdf/api.h"
 #include "pxr/base/arch/demangle.h"
 #include "pxr/base/arch/hints.h"
+#include "pxr/base/tf/delegatedCountPtr.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/weakPtrFacade.h"
 #include "pxr/base/tf/declarePtrs.h"
@@ -38,7 +39,6 @@
 #include <typeinfo>
 #include <type_traits>
 #include <vector>
-#include <boost/intrusive_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -47,10 +47,10 @@ class SdfSpec;
 template <class T> class TfRefPtr;
 class Sdf_Identity;
 
-// Sdf_Identities are held via intrusive_ptr so that we can carefully
+// Sdf_Identities are held via TfDelegatedCountPtr so that we can carefully
 // manage the ref-count to avoid race conditions -- see
 // Sdf_IdentityRegistry::Identify().
-typedef boost::intrusive_ptr<Sdf_Identity> Sdf_IdentityRefPtr;
+using Sdf_IdentityRefPtr = TfDelegatedCountPtr<Sdf_Identity>;
 
 /// \class SdfHandle
 ///

--- a/pxr/usd/sdf/identity.cpp
+++ b/pxr/usd/sdf/identity.cpp
@@ -66,15 +66,15 @@ public:
         if (iter != _ids.end()) {
             rawId = iter->second;
             ++rawId->_refCount;
-            Sdf_IdentityRefPtr ret(rawId, /* add_ref = */ false);
-            return ret;
+            return Sdf_IdentityRefPtr(
+                TfDelegatedCountDoNotIncrementTag, rawId);
         }
 
         TfAutoMallocTag2 tag("Sdf", "Sdf_IdentityRegistry::Identify");
         rawId = new Sdf_Identity(this, path);
         _ids[path] = rawId;
         _deadThreshold = std::max(_MinDeadThreshold, _ids.size() / 8);
-        return rawId;
+        return Sdf_IdentityRefPtr(TfDelegatedCountIncrementTag, rawId);
     }
 
     void UnregisterOrDelete() {
@@ -168,7 +168,7 @@ void Sdf_Identity::_Forget()
 
 void
 Sdf_Identity::_UnregisterOrDelete(Sdf_IdRegistryImpl *regImpl,
-                                  Sdf_Identity *id)
+                                  Sdf_Identity *id) noexcept
 {
     if (regImpl) {
         regImpl->UnregisterOrDelete();

--- a/pxr/usd/sdf/identity.h
+++ b/pxr/usd/sdf/identity.h
@@ -59,8 +59,8 @@ public:
     
 private:
     // Ref-counting ops manage _refCount.
-    friend void intrusive_ptr_add_ref(Sdf_Identity*);
-    friend void intrusive_ptr_release(Sdf_Identity*);
+    friend void TfDelegatedCountIncrement(Sdf_Identity*);
+    friend void TfDelegatedCountDecrement(Sdf_Identity*) noexcept;
 
     friend class Sdf_IdentityRegistry;
     friend class Sdf_IdRegistryImpl;
@@ -69,7 +69,8 @@ private:
         : _refCount(0), _path(path), _regImpl(regImpl) {}
     
     SDF_API
-    static void _UnregisterOrDelete(Sdf_IdRegistryImpl *reg, Sdf_Identity *id);
+    static void _UnregisterOrDelete(Sdf_IdRegistryImpl *reg, Sdf_Identity *id)
+    noexcept;
     void _Forget();
 
     mutable std::atomic_int _refCount;
@@ -77,11 +78,11 @@ private:
     Sdf_IdRegistryImpl *_regImpl;
 };
 
-// Specialize boost::intrusive_ptr operations.
-inline void intrusive_ptr_add_ref(PXR_NS::Sdf_Identity* p) {
+// Specialize TfDelegatedCountPtr operations.
+inline void TfDelegatedCountIncrement(PXR_NS::Sdf_Identity* p) {
     ++p->_refCount;
 }
-inline void intrusive_ptr_release(PXR_NS::Sdf_Identity* p) {
+inline void TfDelegatedCountDecrement(PXR_NS::Sdf_Identity* p) noexcept {
     // Once the count hits zero, p is liable to be destroyed at any point,
     // concurrently, by its owning registry if it happens to be doing a cleanup
     // pass.  Cache 'this' and the impl ptr in local variables so we have them


### PR DESCRIPTION
### Description of Change(s)

(Depends on #2891)

#2891 provided a `TfIntrusiveTrackingPtr` to support custom bookkeeping. This replaces the usage of `boost::intrusive_ptr` with `TfDelegatedCountPtr` for `Sdf_Identity`. As `TfDelegatedCountPtr` does not support implicit conversion from raw pointers, construction with explicit dispatch tags are now used.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
