### PR TITLE
Replace `boost::intrusive_ptr` with `TfDelegatedCountPtr` for `Sdf_PathNode`

### DIFF
--- a/pxr/usd/sdf/path.h
+++ b/pxr/usd/sdf/path.h
@@ -29,11 +29,10 @@
 #include "pxr/usd/sdf/pool.h"
 #include "pxr/usd/sdf/tokens.h"
 #include "pxr/base/arch/defines.h"
+#include "pxr/base/tf/delegatedCountPtr.h"
 #include "pxr/base/tf/stl.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/vt/traits.h"
-
-#include <boost/intrusive_ptr.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -49,14 +48,14 @@ class Sdf_PathNode;
 class SdfPathAncestorsRange;
 
 // Ref-counting pointer to a path node.
-// Intrusive ref-counts are used to keep the size of SdfPath
+// Delegated ref-counts are used to keep the size of SdfPath
 // the same as a raw pointer.  (shared_ptr, by comparison,
 // is the size of two pointers.)
 
-typedef boost::intrusive_ptr<const Sdf_PathNode> Sdf_PathNodeConstRefPtr;
+using Sdf_PathNodeConstRefPtr = TfDelegatedCountPtr<const Sdf_PathNode>;
 
-void intrusive_ptr_add_ref(Sdf_PathNode const *);
-void intrusive_ptr_release(Sdf_PathNode const *);
+void TfDelegatedCountIncrement(Sdf_PathNode const *);
+void TfDelegatedCountDecrement(Sdf_PathNode const *) noexcept;
 
 // Tags used for the pools of path nodes.
 struct Sdf_PathPrimTag;
@@ -181,7 +180,7 @@ private:
 
     inline void _AddRef(Sdf_PathNode const *p) const {
         if (Counted) {
-            intrusive_ptr_add_ref(p);
+            TfDelegatedCountIncrement(p);
         }
     }
 
@@ -191,7 +190,7 @@ private:
 
     inline void _DecRef() const {
         if (Counted) {
-            intrusive_ptr_release(get());
+            TfDelegatedCountDecrement(get());
         }
     }
 

--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -765,11 +765,17 @@ Sdf_PathNode::_WriteText(Buffer &out) const
 }
 
 Sdf_PrimPathNode::~Sdf_PrimPathNode() {
-    _Remove(this, *_primNodes, GetParentNode(), _name);
+    _Remove(this, *_primNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _name);
 }
 
 Sdf_PrimPropertyPathNode::~Sdf_PrimPropertyPathNode() {
-    _Remove(this, *_primPropertyNodes, GetParentNode(), _name);
+    _Remove(this, *_primPropertyNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _name);
 }
 
 const TfToken &
@@ -790,7 +796,10 @@ Sdf_PrimVariantSelectionNode::_WriteTextImpl(Buffer &out) const
 }
 
 Sdf_PrimVariantSelectionNode::~Sdf_PrimVariantSelectionNode() {
-    _Remove(this, *_primVarSelNodes, GetParentNode(), *_variantSelection);
+    _Remove(this, *_primVarSelNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            *_variantSelection);
 }
 
 template <class Buffer>
@@ -802,11 +811,17 @@ Sdf_TargetPathNode::_WriteTextImpl(Buffer &out) const {
 }
 
 Sdf_TargetPathNode::~Sdf_TargetPathNode() {
-    _Remove(this, *_targetNodes, GetParentNode(), _targetPath);
+    _Remove(this, *_targetNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _targetPath);
 }
 
 Sdf_RelationalAttributePathNode::~Sdf_RelationalAttributePathNode() {
-    _Remove(this, *_relAttrNodes, GetParentNode(), _name);
+    _Remove(this, *_relAttrNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _name);
 }
 
 template <class Buffer>
@@ -820,7 +835,10 @@ Sdf_MapperPathNode::_WriteTextImpl(Buffer &out) const {
 }
 
 Sdf_MapperPathNode::~Sdf_MapperPathNode() {
-    _Remove(this, *_mapperNodes, GetParentNode(), _targetPath);
+    _Remove(this, *_mapperNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _targetPath);
 }
 
 template <class Buffer>
@@ -830,7 +848,10 @@ Sdf_MapperArgPathNode::_WriteTextImpl(Buffer &out) const {
 }
 
 Sdf_MapperArgPathNode::~Sdf_MapperArgPathNode() {
-    _Remove(this, *_mapperArgNodes, GetParentNode(), _name);
+    _Remove(this, *_mapperArgNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()),
+            _name);
 }
 
 template <class Buffer>
@@ -841,7 +862,9 @@ Sdf_ExpressionPathNode::_WriteTextImpl(Buffer &out) const {
 }
 
 Sdf_ExpressionPathNode::~Sdf_ExpressionPathNode() {
-    _Remove(this, *_expressionNodes, GetParentNode());
+    _Remove(this, *_expressionNodes,
+            Sdf_PathNodeConstRefPtr(
+                TfDelegatedCountIncrementTag, GetParentNode()));
 }
 
 struct Sdf_Stats {
@@ -867,6 +890,7 @@ _GatherChildrenFrom(Sdf_PathNode const *parent,
         TF_FOR_ALL(i, mapAndMutex.map) {
             if (i->first.parent == parent)
                 result->emplace_back(
+                    TfDelegatedCountIncrementTag,
                     reinterpret_cast<Sdf_PathNode const *>(i->second.GetPtr()));
         }
     }

--- a/pxr/usd/sdf/pathNode.h
+++ b/pxr/usd/sdf/pathNode.h
@@ -26,11 +26,10 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
+#include "pxr/base/tf/delegatedCountPtr.h"
 #include "pxr/base/tf/functionRef.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/mallocTag.h"
-
-#include <boost/intrusive_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -245,7 +244,7 @@ public:
 
 protected:
     Sdf_PathNode(Sdf_PathNode const *parent, NodeType nodeType)
-        : _parent(parent)
+        : _parent(TfDelegatedCountIncrementTag, parent)
         , _refCount(1)
         , _elementCount(parent ? parent->_elementCount + 1 : 1)
         , _nodeType(nodeType)
@@ -299,8 +298,8 @@ protected:
     friend struct Sdf_PathNodePrivateAccess;
 
     // Ref-counting ops manage _refCount.
-    friend void intrusive_ptr_add_ref(const Sdf_PathNode*);
-    friend void intrusive_ptr_release(const Sdf_PathNode*);
+    friend void TfDelegatedCountIncrement(const Sdf_PathNode*);
+    friend void TfDelegatedCountDecrement(const Sdf_PathNode*) noexcept;
 
 private:
     static constexpr uint8_t _NodeTypeToFlags(NodeType nt) {
@@ -756,10 +755,10 @@ Sdf_PathNode::GetElement() const
 /// Diagnostic output.
 SDF_API void Sdf_DumpPathStats();
 
-inline void intrusive_ptr_add_ref(const PXR_NS::Sdf_PathNode* p) {
+inline void TfDelegatedCountIncrement(const PXR_NS::Sdf_PathNode* p) {
     p->_refCount.fetch_add(1, std::memory_order_relaxed);
 }
-inline void intrusive_ptr_release(const PXR_NS::Sdf_PathNode* p) {
+inline void TfDelegatedCountDecrement(const PXR_NS::Sdf_PathNode* p) noexcept {
     if ((p->_refCount.fetch_sub(1) & PXR_NS::Sdf_PathNode::RefCountMask) == 1) {
         p->_Destroy();
     }


### PR DESCRIPTION
### Description of Change(s)

(Depends on #2891)

#2891 provided a `TfDelegatedCountPtr` to support custom bookkeeping. This replaces the usage of `boost::intrusive_ptr` with `TfDelegatedCountPtr` in `Sdf_PathNode`. As `TfDelegatedCountPtr` doesn't support implicit conversion from raw pointers, construction with explicit dispatch tags are now used.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
