### PR TITLE
Replace `boost::intrusive_ptr` with `TfDelegatedCountPtr` in `Usd_CrateFile`

### DIFF
--- a/pxr/usd/usd/crateFile.cpp
+++ b/pxr/usd/usd/crateFile.cpp
@@ -488,7 +488,7 @@ CrateFile::_FileMapping::_Impl
     // If we take the source's count from 0 -> 1, add a reference to the
     // mapping.
     if (iresult.first->NewRef()) {
-        intrusive_ptr_add_ref(this);
+        TfDelegatedCountIncrement(this);
     }
     return &(*iresult.first);
 }
@@ -562,7 +562,7 @@ bool CrateFile::_FileMapping::_Impl::ZeroCopySource::operator==(
 void CrateFile::_FileMapping::_Impl::ZeroCopySource::_Detached(
     Vt_ArrayForeignDataSource *selfBase) {
     auto *self = static_cast<ZeroCopySource *>(selfBase);
-    intrusive_ptr_release(self->_mapping);
+    TfDelegatedCountDecrement(self->_mapping);
 }
 
 template <class FileMappingPtr>

--- a/pxr/usd/usd/crateFile.h
+++ b/pxr/usd/usd/crateFile.h
@@ -31,6 +31,7 @@
 #include "crateValueInliners.h"
 
 #include "pxr/base/arch/fileSystem.h"
+#include "pxr/base/tf/delegatedCountPtr.h"
 #include "pxr/base/tf/hash.h"
 #include "pxr/base/tf/pxrTslRobinMap/robin_map.h"
 #include "pxr/base/tf/token.h"
@@ -43,8 +44,6 @@
 #include "pxr/usd/sdf/assetPath.h"
 #include "pxr/usd/sdf/path.h"
 #include "pxr/usd/sdf/types.h"
-
-#include <boost/intrusive_ptr.hpp>
 
 #include <tbb/concurrent_unordered_set.h>
 #include <tbb/spin_rw_mutex.h>
@@ -403,15 +402,15 @@ private:
             // other code reading/writing the file.)
             void _DetachReferencedRanges();
             
-            // This class is managed by a combination of boost::intrusive_ptr
+            // This class is managed by a combination of TfDelegatedCountPtr
             // and manual reference counting -- see explicit calls to
-            // intrusive_ptr_add_ref/release in the .cpp file.
+            // TfDelegatedCount{Increment,Decrement} in the .cpp file.
             friend inline void
-            intrusive_ptr_add_ref(_Impl const *m) {
+            TfDelegatedCountIncrement(_Impl const *m) {
                 m->_refCount.fetch_add(1, std::memory_order_relaxed);
             }
             friend inline void
-            intrusive_ptr_release(_Impl const *m) {
+            TfDelegatedCountDecrement(_Impl const *m) noexcept {
                 if (m->_refCount.fetch_sub(1, std::memory_order_release) == 1) {
                     std::atomic_thread_fence(std::memory_order_acquire);
                     delete m;
@@ -432,7 +431,8 @@ private:
         // Construct with new mapping.
         explicit _FileMapping(ArchConstFileMapping &&mapping,
                               int64_t offset=0, int64_t length=-1) noexcept
-            : _impl(new _Impl(std::move(mapping), offset, length)) {}
+            : _impl(TfDelegatedCountIncrementTag,
+                    new _Impl(std::move(mapping), offset, length)) {}
 
         _FileMapping(_FileMapping &&other) noexcept
             : _impl(std::move(other._impl)) {
@@ -477,7 +477,7 @@ private:
         }
 
     private:
-        boost::intrusive_ptr<_Impl> _impl;
+        TfDelegatedCountPtr<_Impl> _impl;
     };
     
     ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description of Change(s)

(Depends on #2891)

#2891 provided a `TfDelegatedCountPtr ` to support custom bookkeeping. This replaces the usage of `boost::intrusive_ptr` with `TfDelegatedCountPtr ` in `Usd_CrateFile`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
