### PR TITLE
Replace `boost::intrusive_ptr` with `TfDelegatedCountPtr` for `Usd_PrimData`

### DIFF
--- a/pxr/usd/usd/primData.h
+++ b/pxr/usd/usd/primData.h
@@ -40,8 +40,6 @@
 
 #include "pxr/usd/sdf/path.h"
 
-#include <boost/intrusive_ptr.hpp>
-
 #include <atomic>
 #include <cstdint>
 #include <vector>
@@ -326,10 +324,10 @@ private:
     Usd_PrimFlagBits _flags;
 
     // intrusive_ptr core primitives implementation.
-    friend void intrusive_ptr_add_ref(const Usd_PrimData *prim) {
+    friend void TfDelegatedCountIncrement(const Usd_PrimData *prim) {
         prim->_refCount.fetch_add(1, std::memory_order_relaxed);
     }
-    friend void intrusive_ptr_release(const Usd_PrimData *prim) {
+    friend void TfDelegatedCountDecrement(const Usd_PrimData *prim) noexcept {
         if (prim->_refCount.fetch_sub(1, std::memory_order_release) == 1)
             delete prim;
     }

--- a/pxr/usd/usd/primDataHandle.h
+++ b/pxr/usd/usd/primDataHandle.h
@@ -26,9 +26,8 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/api.h"
+#include "pxr/base/tf/delegatedCountPtr.h"
 #include "pxr/base/tf/hash.h"
-
-#include <boost/intrusive_ptr.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -37,9 +36,9 @@ class SdfPath;
 // To start we always validate.
 #define USD_CHECK_ALL_PRIM_ACCESSES
 
-// Forward declare boost::intrusive_ptr requirements.  Defined in primData.h.
-void intrusive_ptr_add_ref(const class Usd_PrimData *prim);
-void intrusive_ptr_release(const class Usd_PrimData *prim);
+// Forward declare TfDelegatedCountPtr requirements.  Defined in primData.h.
+void TfDelegatedCountIncrement(const class Usd_PrimData *prim);
+void TfDelegatedCountDecrement(const class Usd_PrimData *prim) noexcept;
 
 // Forward declarations for Usd_PrimDataHandle's use.  Defined in primData.h.
 USD_API
@@ -50,9 +49,9 @@ bool Usd_IsDead(Usd_PrimData const *p);
 typedef Usd_PrimData *Usd_PrimDataPtr;
 typedef const Usd_PrimData *Usd_PrimDataConstPtr;
 
-// convenience typedefs for intrusive_ptr.
-typedef boost::intrusive_ptr<Usd_PrimData> Usd_PrimDataIPtr;
-typedef boost::intrusive_ptr<const Usd_PrimData> Usd_PrimDataConstIPtr;
+// convenience typedefs for TfDelegatedCountPtr.
+using Usd_PrimDataIPtr = TfDelegatedCountPtr<Usd_PrimData>;
+using Usd_PrimDataConstIPtr = TfDelegatedCountPtr<const Usd_PrimData>;
 
 // Private helper class that holds a reference to prim data.  UsdObject (and by
 // inheritance its subclasses) hold an instance of this class.  It lets
@@ -65,18 +64,18 @@ public:
 
     // Construct a null handle.
     Usd_PrimDataHandle() {}
-    // Convert/construct a handle from a prim data intrusive ptr.
+    // Convert/construct a handle from a prim data delegated count ptr.
     Usd_PrimDataHandle(const Usd_PrimDataIPtr &primData)
         : _p(primData) {}
-    // Convert/construct a handle from a prim data intrusive ptr.
+    // Convert/construct a handle from a prim data delegated count ptr.
     Usd_PrimDataHandle(const Usd_PrimDataConstIPtr &primData)
         : _p(primData) {}
     // Convert/construct a handle from a prim data raw ptr.
     Usd_PrimDataHandle(Usd_PrimDataPtr primData)
-        : _p(Usd_PrimDataConstIPtr(primData)) {}
+        : _p(TfDelegatedCountIncrementTag, primData) {}
     // Convert/construct a handle from a prim data raw ptr.
     Usd_PrimDataHandle(Usd_PrimDataConstPtr primData)
-        : _p(Usd_PrimDataConstIPtr(primData)) {}
+        : _p(TfDelegatedCountIncrementTag, primData) {}
 
     // Reset this handle to null.
     void reset() { _p.reset(); }

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -2786,7 +2786,8 @@ UsdStage::_InstantiatePrim(const SdfPath &primPath)
     Usd_PrimDataPtr p = new Usd_PrimData(this, primPath);
 
     // Insert entry into the map -- should always succeed.
-    TF_VERIFY(_primMap.emplace(primPath, p),
+    TF_VERIFY(_primMap.emplace(primPath,
+                               Usd_PrimDataIPtr{TfDelegatedCountIncrementTag, p}),
               "Newly instantiated prim <%s> already present in _primMap",
               primPath.GetText());
     return p;


### PR DESCRIPTION
### Description of Change(s)

(Depends on #2891)

#2891 provided a `TfDelegatedCountPtr` to support custom bookkeeping. This replaces the usage of `boost::intrusive_ptr` with `TfDelegatedCountPtr` in `Usd_PrimData`. As `TfDelegatedCountPtr` doesn't support implicit conversion from raw pointers, construction with explicit dispatch tags are now used.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
