### PR TITLE
Add explicit `TfHash` overload for `std::string_view`

### DIFF
--- a/pxr/base/tf/hash.h
+++ b/pxr/base/tf/hash.h
@@ -32,10 +32,11 @@
 #include "pxr/base/tf/api.h"
 
 #include <cstring>
-#include <string>
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
+#include <string_view>
 #include <typeindex>
 #include <type_traits>
 #include <utility>
@@ -135,6 +136,14 @@ inline void
 TfHashAppend(HashState &h, const std::string& s)
 {
     return h.AppendContiguous(s.c_str(), s.length());
+}
+
+// Support for hashing std::string_view
+template <class HashState>
+inline void
+TfHashAppend(HashState& h, const std::string_view& sv)
+{
+    return h.AppendContiguous(sv.data(), sv.size());
 }
 
 // Support for hashing pointers, but we explicitly delete the version for

--- a/pxr/base/tf/testenv/hash.cpp
+++ b/pxr/base/tf/testenv/hash.cpp
@@ -242,6 +242,8 @@ Test_TfHash()
 
     std::string str("hello world");
     printf("hash(std::string): %zu\n", h(str));
+    printf("hash(std::string_view): %zu\n", h(std::string_view(str)));
+    TF_AXIOM(h(str) == h(std::string_view(str)));
 
     printf("hash(float zero): %zu\n", h(-0.0f));
     printf("hash(float neg zero): %zu\n", h(0.0f));


### PR DESCRIPTION
### Description of Change(s)

#2781 allowed `TfHash` to leverage `std::hash`.  That change allowed `std::string_view` to be hashable by `TfHash` indirectly via `std::hash`.  However, to leverage the specialized `AppendContinuous` implementation that `std::string` and C-strings use, a `TfHashAppend` specialization is required. This change adds that specialization.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
