### PR TITLE
Make static `TfToken` macros usable outside of `PXR_NS`

### DIFF
--- a/pxr/base/tf/pyStaticTokens.h
+++ b/pxr/base/tf/pyStaticTokens.h
@@ -81,7 +81,8 @@ private:
 
 #define _TF_PY_TOKENS_WRAP_MEMBER(r, key, name)                             \
     .add_static_property(TF_PP_STRINGIZE(name),                             \
-        boost::python::make_function(_TfPyWrapStaticToken((&key->name)),    \
+        boost::python::make_function(                                       \
+            PXR_NS::_TfPyWrapStaticToken((&key->name)),                     \
             boost::python::return_value_policy<                             \
                 boost::python::return_by_value>(),                          \
             boost::mpl::vector1<std::string>()))

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -84,10 +84,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define _TF_DECLARE_PUBLIC_TOKENS3(key, eiapi, seq)                         \
     _TF_DECLARE_TOKENS3(key, seq, eiapi)                                    \
-    extern eiapi TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    extern eiapi PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 #define _TF_DECLARE_PUBLIC_TOKENS2(key, seq)                                \
     _TF_DECLARE_TOKENS2(key, seq)                                           \
-    extern TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    extern PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 #define _TF_DECLARE_PUBLIC_TOKENS(N) _TF_DECLARE_PUBLIC_TOKENS##N
 #define _TF_DECLARE_PUBLIC_TOKENS_EVAL(N) _TF_DECLARE_PUBLIC_TOKENS(N)
 #define _TF_DECLARE_PUBLIC_TOKENS_EXPAND(x) x
@@ -102,7 +102,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \hideinitializer
 #define TF_DEFINE_PUBLIC_TOKENS(key, seq)                                   \
     _TF_DEFINE_TOKENS(key)                                                  \
-    TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 
 /// Macro to define private tokens.
 /// \hideinitializer
@@ -113,7 +113,7 @@ PXR_NAMESPACE_OPEN_SCOPE
         _TF_TOKENS_DECLARE_MEMBERS(seq)                                     \
     };                                                                      \
     }                                                                       \
-    static TfStaticData<_TF_TOKENS_STRUCT_NAME_PRIVATE(key)> key
+    static PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME_PRIVATE(key)> key
 
 ///////////////////////////////////////////////////////////////////////////////
 // Private Macros
@@ -139,17 +139,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 // be a tuple on the form (name, value) or just a name.
 //
 #define _TF_TOKENS_DECLARE_MEMBER(unused, elem)                             \
-    TfToken _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                \
+    PXR_NS::TfToken _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                        \
         TF_PP_TUPLE_ELEM(0, elem), elem){                                   \
             _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                \
                 TF_PP_TUPLE_ELEM(1, elem), TF_PP_STRINGIZE(elem)),          \
-            TfToken::Immortal};
+            PXR_NS::TfToken::Immortal};
 #define _TF_TOKENS_DECLARE_TOKEN_MEMBERS(seq)                               \
     TF_PP_SEQ_FOR_EACH(_TF_TOKENS_DECLARE_MEMBER, ~, seq)
 
 #define _TF_TOKENS_FORWARD_TOKEN(unused, elem) TF_PP_TUPLE_ELEM(0, elem),
 #define _TF_TOKENS_DECLARE_ALL_TOKENS(seq)                                  \
-    std::vector<TfToken> allTokens =                                        \
+    std::vector<PXR_NS::TfToken> allTokens =                                \
         {TF_PP_SEQ_FOR_EACH(_TF_TOKENS_FORWARD_TOKEN, ~, seq)};
 
 // Private macro used to declare the list of members as TfTokens

--- a/pxr/base/tf/wrapTestPyStaticTokens.cpp
+++ b/pxr/base/tf/wrapTestPyStaticTokens.cpp
@@ -27,18 +27,12 @@
 
 #include "pxr/base/tf/pyStaticTokens.h"
 
-PXR_NAMESPACE_OPEN_SCOPE
-
 #define TF_TEST_TOKENS                  \
     (orange)                            \
     ((pear, "d'Anjou"))                 
 
 TF_DECLARE_PUBLIC_TOKENS(tfTestStaticTokens, TF_API, TF_TEST_TOKENS);
 TF_DEFINE_PUBLIC_TOKENS(tfTestStaticTokens, TF_TEST_TOKENS);
-
-PXR_NAMESPACE_CLOSE_SCOPE
-
-PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 struct _DummyScope {


### PR DESCRIPTION
### Description of Change(s)

The static `TfToken` macros make unqualified lookups to various types in the `PXR_NS` namespace. This limits their usage in headers to the `PXR_NS` (source `.cpp` files can use the `PXR_NAMESPACE_USING_DIRECTIVE` macro). This prefixes all usage of types in macros with `PXR_NS` to enable usage in headers.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
