### PR TITLE
Added nullptr check for _FindEntry (like _InsertEntry and related)

### DIFF
--- a/pxr/usd/usdGeom/bboxCache.cpp
+++ b/pxr/usd/usdGeom/bboxCache.cpp
@@ -1120,6 +1120,9 @@ UsdGeomBBoxCache::_Resolve(
     
     // If the bound is in the cache, return it.
     entry = _FindEntry(primContext);
+    if (entry == nullptr) {
+        return false;
+    }
     *bboxes = entry->bboxes;
     return (!bboxes->empty());
 }


### PR DESCRIPTION
### Description of Change(s)

Added nullptr check for `_FindEntry` (`_InsertEntry` and others all assume that the operation might fail, makes sense to include the `_FindEntry` as well). This can also happen (albeit erroneously and unsupportedly) in multithreaded situations and possibly in resource constrained conditions.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
