### PR TITLE
Change value type of `TfUtf8CodePointIterator` to `TfUtf8CodePoint`

### DIFF
--- a/pxr/base/tf/unicodeUtils.h
+++ b/pxr/base/tf/unicodeUtils.h
@@ -98,6 +98,14 @@ TF_API std::ostream& operator<<(std::ostream&, const TfUtf8CodePoint);
 constexpr TfUtf8CodePoint TfUtf8InvalidCodePoint{
     TfUtf8CodePoint::ReplacementValue};
 
+/// Constructs a TfUtf8CodePoint from an ASCII charcter (0-127).
+constexpr TfUtf8CodePoint TfUtf8CodePointFromAscii(const char value)
+{
+    return static_cast<unsigned char>(value) < 128 ?
+           TfUtf8CodePoint(static_cast<unsigned char>(value)) :
+           TfUtf8InvalidCodePoint;
+}
+
 /// Defines an iterator over a UTF-8 encoded string that extracts unicode
 /// code point values.
 ///
@@ -108,10 +116,10 @@ constexpr TfUtf8CodePoint TfUtf8InvalidCodePoint{
 class TfUtf8CodePointIterator final {
 public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type = uint32_t;
+    using value_type = TfUtf8CodePoint;
     using difference_type = std::ptrdiff_t;
     using pointer = void;
-    using reference = uint32_t;
+    using reference = TfUtf8CodePoint;
 
     /// Model iteration ending when the underlying iterator's end condition
     /// has been met.
@@ -131,14 +139,14 @@ public:
         }
 
     /// Retrieves the current UTF-8 character in the sequence as its Unicode
-    /// code point value. Returns `TfUtf8InvalidCodePoint.AsUInt32()` when the
+    /// code point value. Returns `TfUtf8InvalidCodePoint` when the
     /// byte sequence pointed to by the iterator cannot be decoded.
     ///
     /// A code point might be invalid because it's incorrectly encoded, exceeds
     /// the maximum allowed value, or is in the disallowed surrogate range.
-    uint32_t operator* () const
+    value_type operator* () const
     {
-        return _GetCodePoint();
+        return TfUtf8CodePoint{_GetCodePoint()};
     }
 
     /// Retrieves the wrapped string iterator.
@@ -306,8 +314,8 @@ private:
 ///
 /// \code{.cpp}
 /// std::string value{"∫dx"};
-/// for (const uint32_t codePoint : TfUtf8CodePointView{value}) {
-///     if (codePoint == TfUtf8InvalidCodePoint.AsUInt32()) {
+/// for (const auto codePoint : TfUtf8CodePointView{value}) {
+///     if (codePoint == TfUtf8InvalidCodePoint) {
 ///         TF_WARN("String cannot be decoded.");
 ///         break;
 ///     }
@@ -322,7 +330,7 @@ private:
 ///
 /// \code{.cpp}
 /// if (std::any_of(std::cbegin(codePointView), codePointView.EndAsIterator(),
-///     [](const auto c) { return c == TfUtf8InvalidCodePoint.AsUInt32(); }))
+///     [](const auto c) { return c == TfUtf8InvalidCodePoint; }))
 /// {
 ///     TF_WARN("String cannot be decoded");
 /// }
@@ -394,6 +402,10 @@ private:
 ///
 TF_API
 bool TfIsUtf8CodePointXidStart(uint32_t codePoint);
+inline bool TfIsUtf8CodePointXidStart(const TfUtf8CodePoint codePoint)
+{
+    return TfIsUtf8CodePointXidStart(codePoint.AsUInt32());
+}
 
 /// Determines whether the given Unicode \a codePoint is in the XID_Continue
 /// character class.
@@ -406,6 +418,10 @@ bool TfIsUtf8CodePointXidStart(uint32_t codePoint);
 ///
 TF_API
 bool TfIsUtf8CodePointXidContinue(uint32_t codePoint);
+inline bool TfIsUtf8CodePointXidContinue(const TfUtf8CodePoint codePoint)
+{
+    return TfIsUtf8CodePointXidContinue(codePoint.AsUInt32());
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/usd/sdf/tokens.h
+++ b/pxr/usd/sdf/tokens.h
@@ -79,10 +79,6 @@ TF_DECLARE_PUBLIC_TOKENS(SdfMetadataDisplayGroupTokens,
                          SDF_API,
                          SDF_METADATA_DISPLAYGROUP_TOKENS);
 
-// constants for identifier validation
-constexpr uint32_t SDF_NAMESPACE_DELIMITER_CODE_POINT = 0x003Au;
-constexpr uint32_t SDF_UNDERSCORE_CODE_POINT = 0x005Fu;
-
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // PXR_USD_SDF_TOKENS_H


### PR DESCRIPTION
### Description of Change(s)

`TfUtf8CodePointIterator` was originally written before the `TfUtf8CodePoint` class was introduced.  This change makes the value and reference type of the iterator a `TfUtf8CodePoint` directly instead of expecting clients to construct it themselves.

It also introduces a `TfUtf8CodePointFromAscii` helper function to make it easier to create code points from known ASCII characters.

This change also simplifies several test cases and usages.  For example, `_IsValidIdentifier` no longer has to branch.

Currently, both the iterator and the code point class employ validation to ensure that code points outside the unicode range or surrogate code points are not decoded. It may be desirable to avoid this redundancy so that the validation is delegated entirely to the code point class in a future change.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
