### PR TITLE
Autodesk: Bugfix: Enable customizing the suffix of constructor and destructor section name

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -217,3 +217,9 @@ if (${PXR_BUILD_PYTHON_DOCUMENTATION})
         set(PXR_BUILD_PYTHON_DOCUMENTATION "OFF" CACHE BOOL "" FORCE)
     endif()
 endif()
+
+# Customize the suffix of constructor and destructor section names
+if (DEFINED PXR_INIT_SECTION_NAME_SUFFIX)
+    message(STATUS "Setting initialization section name suffix to ${PXR_INIT_SECTION_NAME_SUFFIX}")
+    add_definitions(-DPXR_INIT_SECTION_NAME_SUFFIX=${PXR_INIT_SECTION_NAME_SUFFIX})
+endif()

--- a/pxr/base/arch/attributes.cpp
+++ b/pxr/base/arch/attributes.cpp
@@ -204,7 +204,7 @@ AddImage(const struct mach_header* mh, intptr_t slide)
         return;
     }
 
-    const auto entries = GetConstructorEntries(mh, slide, "__DATA", "pxrctor");
+    const auto entries = GetConstructorEntries(mh, slide, "__DATA", CONSTRUCTOR_SECTION_NAME);
 
     // Execute in priority order.
     for (size_t i = 0, n = entries.size(); i != n; ++i) {
@@ -219,7 +219,7 @@ static
 void
 RemoveImage(const struct mach_header* mh, intptr_t slide)
 {
-    const auto entries = GetConstructorEntries(mh, slide, "__DATA", "pxrdtor");
+    const auto entries = GetConstructorEntries(mh, slide, "__DATA", DESTRUCTOR_SECTION_NAME);
 
     // Execute in reverse priority order.
     for (size_t i = entries.size(); i-- != 0; ) {
@@ -365,7 +365,7 @@ RunConstructors(HMODULE hModule)
     // Do each HMODULE at most once.
     if (visited->insert(hModule).second) {
         // Execute in priority order.
-        const auto entries = GetConstructorEntries(hModule, ".pxrctor");
+        const auto entries = GetConstructorEntries(hModule, CONSTRUCTOR_SECTION_NAME);
         for (size_t i = 0, n = entries.size(); i != n; ++i) {
             if (entries[i].function && entries[i].version == 0u) {
                 entries[i].function();
@@ -384,7 +384,7 @@ RunDestructors(HMODULE hModule)
     // Do each HMODULE at most once.
     if (visited->insert(hModule).second) {
         // Execute in reverse priority order.
-        const auto entries = GetConstructorEntries(hModule, ".pxrdtor");
+        const auto entries = GetConstructorEntries(hModule, DESTRUCTOR_SECTION_NAME);
         for (size_t i = entries.size(); i-- != 0; ) {
             if (entries[i].function && entries[i].version == 0u) {
                 entries[i].function();


### PR DESCRIPTION
### Description of Change(s)

Background:

USD put some functions in a section 'pxrctor', which perform initialization work after loading the module.  Also, they are expected to be called only once.

Now say we have library A linked to USD build A; and executable B has its own USD build B with modified dylib name. USD build A and B are different.  USD build A would be loaded first, then get a function lists via iterating all sections named 'pxrctor' from all loaded modules, and then call each of them. ie. intialize them. After that, while loading USD build B, the initialization process would also get a function lists in the same way, and it would also contain functions lists collected from USD build A. Again, all functions would be called, including those from USD build A. That means those functions from USD build A would be called twice. This leads to a crash in our use case.

Solution:

Enable the ability to customize and append a suffix to the section name.  The corresponding build argument is
`--build-args=USD,"-DPXR_INIT_SECTION_NAME_SUFFIX=_v2"`

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
