### PR TITLE
Allow building USD without full-fat Xcode

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -118,8 +118,7 @@ def GetTargetArchPair(context):
 def SupportsMacOSUniversalBinaries():
     if not MacOS():
         return False
-    SDKVersionBytes  = subprocess.check_output(['xcrun', '--show-sdk-version'])
-    SDKVersion = SDKVersionBytes.decode('utf8').strip()
+    SDKVersion = GetCommandOutput('/usr/bin/xcrun --show-sdk-version')
     # Xcode/CommandLineTools 11 toolset came with SDK 10.15
     return (SDKVersion > '10.15')
 


### PR DESCRIPTION
When building from the command line only, you can install a much slimmed-down version of the Mac OS build environment, called CommandLineTools. E.g., this is what the homebrew package system does, and is usually preferable in a remote or headless environment. 

The USD build scripts run xcodebuild to get version info, which requires full-fat Xcode these days. Switching to using the always-available xcrun to get the SDK version instead allows building USD without needing that.

This is just a small suggested build change, lmk if you still need a contributor agreement, or think it's too trivial.

I've made the change minimal, but it might also be more robust to use 'packaging.version' to compare versions.

### Description of Change(s)
- xcodebuild isn't available when only the command-line tools are installed, rather than all of Xcode. Switch to using xcrun and the corresponding OSX SDK version instead.

### Fixes Issue(s)
- Allows building when the full 13 GB Xcode package isn't installed
