### PR TITLE
Build boost libs only when necessary

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -810,9 +810,7 @@ def InstallBoost_Helper(context, force, buildArgs):
             'link=shared',
             'runtime-link=shared',
             'threading=multi', 
-            'variant={variant}'.format(variant=boostBuildVariant),
-            '--with-atomic',
-            '--with-regex'
+            'variant={variant}'.format(variant=boostBuildVariant)
         ]
 
         if context.buildPython:
@@ -849,6 +847,7 @@ def InstallBoost_Helper(context, force, buildArgs):
             b2_settings.append("--with-thread")
 
         if context.enableOpenVDB:
+            b2_settings.append("--with-regex")
             b2_settings.append("--with-iostreams")
 
             # b2 with -sNO_COMPRESSION=1 fails with the following error message:


### PR DESCRIPTION
### Description of Change(s)
- Removed boost atomic. The commit it was added in indicates that it was needed for OpenImageIO, but the current version doesn't link or include anything from boost atomic. None of the other libraries seem to use it either. boost filesystem has a dependency on boost atomic if not compiled with C++ 20, so it is still built anyways for now.
- Moved the boost regex switch to openvdb, could not find any other libraries using it.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
