### PR TITLE
Replace `boost::intrusive_ptr` with `TfDelegatedCountPtr` in `pcp`

### DIFF
--- a/pxr/usd/pcp/mapExpression.h
+++ b/pxr/usd/pcp/mapExpression.h
@@ -28,7 +28,7 @@
 #include "pxr/usd/pcp/api.h"
 #include "pxr/usd/pcp/mapFunction.h"
 
-#include <boost/intrusive_ptr.hpp>
+#include "pxr/base/tf/delegatedCountPtr.h"
 
 #include <tbb/atomic.h>
 #include <tbb/spin_mutex.h>
@@ -185,7 +185,7 @@ private:
     friend struct Pcp_VariableImpl;
 
     class _Node;
-    typedef boost::intrusive_ptr<_Node> _NodeRefPtr;
+    using _NodeRefPtr = TfDelegatedCountPtr<_Node>;
 
     explicit PcpMapExpression(const _NodeRefPtr & node) : _node(node) {}
 
@@ -201,6 +201,11 @@ private: // data
     class _Node {
         _Node(const _Node&) = delete;
         _Node& operator=(const _Node&) = delete;
+
+        // Ref-counting ops manage _refCount.
+        // Need to friend them here to have access to _refCount.
+        friend PCP_API void TfDelegatedCountIncrement(_Node*);
+        friend PCP_API void TfDelegatedCountDecrement(_Node*) noexcept;
     public:
         // The Key holds all the state needed to uniquely identify
         // this (sub-)expression.
@@ -257,11 +262,6 @@ private: // data
         // will always contains the root identity.
         static bool _ExpressionTreeAlwaysHasIdentity(const Key& key);
 
-        // Ref-counting ops manage _refCount.
-        // Need to friend them here to have access to _refCount.
-        friend PCP_API void intrusive_ptr_add_ref(_Node*);
-        friend PCP_API void intrusive_ptr_release(_Node*);
-
         // Registry of node instances, identified by Key.
         // Note: variable nodes are not tracked by the registry.
         struct _NodeMap;
@@ -276,8 +276,8 @@ private: // data
     };
 
     // Need to friend them here to have visibility to private class _Node.
-    friend PCP_API void intrusive_ptr_add_ref(_Node*);
-    friend PCP_API void intrusive_ptr_release(_Node*);
+    friend PCP_API void TfDelegatedCountIncrement(_Node*);
+    friend PCP_API void TfDelegatedCountDecrement(_Node*) noexcept;
 
     _NodeRefPtr _node;
 };


### PR DESCRIPTION
### Description of Change(s)

(Depends on https://github.com/PixarAnimationStudios/OpenUSD/pull/2891)

https://github.com/PixarAnimationStudios/OpenUSD/pull/2891 provided a `TfDelegatedCountPtr` to support custom bookkeeping. This replaces the usage of `boost::intrusive_ptr` with `TfDelegatedCountPtr` in `PcpMapExpression`. As `TfDelegatedCountPtr` doesn't support implicit conversion from raw pointers, construction with explicit dispatch tags are now used.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
