### PR TITLE
ts: fix for TsSimplify + testTsSimplify

### DIFF
--- a/pxr/base/ts/simplify.cpp
+++ b/pxr/base/ts/simplify.cpp
@@ -351,12 +351,16 @@ _ComputeErrorIfKeyRemoved(TsSpline* spline, TsTime t,
 
     TsKeyFrame kCopy  = *k;
     TsKeyFrame k0Copy;
+    bool k0CopyValid = false;
     TsKeyFrame k1Copy;
+    bool k1CopyValid = false;
     if (k0 != spline->end()) {
         k0Copy = *k0;
+        k0CopyValid = true;
     }
     if (k1 != spline->end()) {
         k1Copy = *k1;
+        k1CopyValid = true;
     }
 
     spline->RemoveKeyFrame(kCopy.GetTime());
@@ -376,10 +380,10 @@ _ComputeErrorIfKeyRemoved(TsSpline* spline, TsTime t,
     spline->SetKeyFrame( kCopy);
     // We may have set these in _SimplifySpan, so we want to set them back to
     // what they were before.
-    if (k0 != spline->end()) {
+    if (k0CopyValid) {
         spline->SetKeyFrame(k0Copy);
     }
-    if (k1 != spline->end()) {
+    if (k1CopyValid) {
         spline->SetKeyFrame(k1Copy);
     }
 


### PR DESCRIPTION
### Description of Change(s)

On windows debug builds, was getting a "Debug Assertion Failed" on [simplify.cpp, line 379](https://github.com/PixarAnimationStudios/OpenUSD/blob/35da196173554a40517cfe673610f3f2b3705b8e/pxr/base/ts/simplify.cpp#L379).  This is because this we were using iterators that have become invalid because the underlying data was altered.

### Fixes Issue(s)
- failure of testTsSimplify on windows debug builds

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
