### PR TITLE
Disable BOOST_UNORDERED_HAVE_PIECEWISE_CONSTRUCT for MacOS builds

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -890,7 +890,7 @@ def InstallBoost_Helper(context, force, buildArgs):
             # Must specify toolset=clang to ensure install_name for boost
             # libraries includes @rpath
             b2_settings.append("toolset=clang")
-
+            b2_settings.append(f"define=BOOST_UNORDERED_HAVE_PIECEWISE_CONSTRUCT=0")
             if macOSArch:
                 b2_settings.append("cxxflags=\"{0}\"".format(macOSArch))
                 b2_settings.append("cflags=\"{0}\"".format(macOSArch))


### PR DESCRIPTION
### Description of Change(s)

When building with Boost 1.82 or prior on macOS with clang 15 or higher, Boost will fail to compile due to the missing `std::piecewise_construct` constant.

std::piecewise_construct_t is an empty class tag type used to disambiguate between different functions that take two tuple arguments, and is present. std::piecewise_construct is a constant instant of it that doesn't seem to exist.

Since this is just a sentinal type, boost provides falling back to its own implementation. In theory this patch doesn't need to be platform specific, but for now I've set it to macOS only.


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
