### PR TITLE
Add documentation for USD_DEFAULT_FILE_FORMAT

### DIFF
--- a/docs/usdfaq.rst
+++ b/docs/usdfaq.rst
@@ -109,6 +109,25 @@ files which contain references to plain :filename:`.usd` assets, those assets
 can be converted between binary and text without changing the sources which
 refer to them.
 
+When authoring USD, the underlying format or encoding of the :filename:`.usd` 
+extension can be specified using :usdcpp:`FileFormatArguments` as observed 
+in :usdcpp:`SdfLayer::CreateNew` or :usdcpp:`SdfLayer::Export`, for example.
+
+Developers can also use the :envvar:`USD_DEFAULT_FILE_FORMAT` environment variable to control the 
+default underlying format. The environment variable is used when the underlying format is not 
+explicitly specified through :usdcpp:`FileFormatArguments`. Valid values for the 
+:envvar:`USD_DEFAULT_FILE_FORMAT` environment variable and their behaviors are detailed below:
+
+  +--------------------------------+--------------------------------+
+  | USD_DEFAULT_FILEFORMAT Value   | :filename:`.usd` encoding used |
+  +================================+================================+
+  | <unset>                        | Random-access "Crate" binary   |
+  +--------------------------------+--------------------------------+
+  | usdc                           | Random-access "Crate" binary   |
+  +--------------------------------+--------------------------------+
+  | usda                           | Human-readable UTF-8 text      |
+  +--------------------------------+--------------------------------+
+
 What character encoding does :filename:`.usda` support?
 #######################################################
 


### PR DESCRIPTION
### Description of Change(s)
Add USD_DEFAULT_FILE_FORMAT documentation as a part of a related question in the FAQ.
### Fixes Issue(s)
- #2922

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
