### PR TITLE
Update Selected Renderer on File load / reload

### DIFF
--- a/pxr/usdImaging/bin/testusdview/CMakeLists.txt
+++ b/pxr/usdImaging/bin/testusdview/CMakeLists.txt
@@ -274,6 +274,11 @@ pxr_install_test_dir(
 )
 
 pxr_install_test_dir(
+    SRC testenv/testUsdviewResetSelectedRendererOnLoad
+    DEST testUsdviewResetSelectedRendererOnLoad
+)
+
+pxr_install_test_dir(
     SRC testenv/testUsdviewLights
     DEST testUsdviewLights
 )
@@ -611,6 +616,12 @@ pxr_register_test(testUsdviewAnimatedBounds
 pxr_register_test(testUsdviewMeshBounds
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewMeshBounds.py meshBounds.usda"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdviewResetSelectedRendererOnLoad
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/bin/testusdview --testScript testUsdviewResetSelectedRendererOnLoad.py test.usda"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewResetSelectedRendererOnLoad/test.usda
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewResetSelectedRendererOnLoad/test.usda
@@ -1,0 +1,28 @@
+#usda 1.0
+(
+    upAxis = "Z"
+)
+
+def Xform "Implicits" (
+    add variantSets = "shapeVariant"
+)
+{
+    variantSet "shapeVariant" = {
+        "Sphere" {
+            def Sphere "Ball"
+            {
+            }
+        }
+    }
+}
+
+def Sphere "frontSphere" {
+    double3 xformOp:translate = (2, 2, 2)
+     uniform token[] xformOpOrder = ["xformOp:translate"]
+}
+
+def Sphere "backSphere" {
+    double3 xformOp:translate = (3, 4, 3)
+     uniform token[] xformOpOrder = ["xformOp:translate"]
+}
+

--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewResetSelectedRendererOnLoad/testUsdviewResetSelectedRendererOnLoad.py
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewResetSelectedRendererOnLoad/testUsdviewResetSelectedRendererOnLoad.py
@@ -1,0 +1,53 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+from pxr import Sdf
+from pxr.Usdviewq.qt import QtWidgets
+
+def testUsdviewInputFunction(appController):
+    _verifyCurrentRendererIsDefault(appController)
+
+    numberOfRenderers = len(appController._stageView.GetRendererPlugins())
+
+    if numberOfRenderers > 1:
+        newRendererPlugin = appController._stageView.GetRendererPlugins()[1]
+        appController._stageView.SetRendererPlugin(newRendererPlugin)
+
+        _verifyCurrentRendererIsNotDefault(appController)
+        _emitReopen_StageAction(appController)
+
+        _verifyCurrentRendererIsDefault(appController)
+
+def _verifyCurrentRendererIsDefault(appController):
+    action = appController._ui.rendererPluginActionGroup.actions()[0]
+    assert action.isChecked()
+
+def _verifyCurrentRendererIsNotDefault(appController):
+    action = appController._ui.rendererPluginActionGroup.actions()[0]
+    assert not action.isChecked()
+
+def _emitReopen_StageAction(appController):
+    appController._ui.actionReopen_Stage.triggered.emit() 
+    QtWidgets.QApplication.processEvents()

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1152,6 +1152,7 @@ class AppController(QtCore.QObject):
 
     def _drawFirstImage(self):
         if self._stageView:
+            self._stageView.signalRendererInitialized.connect(self._updateCurrentSelectedRenderer)
             self._stageView.setUpdatesEnabled(True)
         with BusyContext():
             try:
@@ -1483,6 +1484,14 @@ class AppController(QtCore.QObject):
             self._configureRendererCommands()
             self._configurePauseAction()
             self._configureStopAction()
+    
+    def _updateCurrentSelectedRenderer(self):
+        if hasattr(self._ui, 'rendererPluginActionGroup'):
+            currentRendererId = self._stageView.GetCurrentRendererId()
+            for action in self._ui.rendererPluginActionGroup.actions():
+                if action.pluginType == currentRendererId:
+                    action.setChecked(True)
+                    break
 
     # Renderer AOV support
     def _rendererAovChanged(self, aov):

--- a/pxr/usdImaging/usdviewq/stageView.py
+++ b/pxr/usdImaging/usdviewq/stageView.py
@@ -719,6 +719,8 @@ class StageView(QGLWidget):
 
     signalFrustumChanged = QtCore.Signal()
 
+    signalRendererInitialized = QtCore.Signal()
+
     @property
     def renderParams(self):
         return self._renderParams
@@ -972,6 +974,9 @@ class StageView(QGLWidget):
         # This is because ImagingGL / TaskController are spawned via prims in
         # Presto, so we default AOVs OFF until everything is AOV ready.
         self.SetRendererAov(self.rendererAovName)
+
+        # Let the controller know to set the checkbox on the renderer
+        self.signalRendererInitialized.emit()
 
     def _scaleMouseCoords(self, point):
         return point * QtWidgets.QApplication.instance().devicePixelRatio()


### PR DESCRIPTION
### Description of Change(s)
- added a signal in stageView to call back to update the UI in the case the renderer has changed
- this happens on file load / reload when the renderer is set to null and reinitialized again when the first frame is drawn, it's reinitialized to Storm but the UI was not being notified of the change

### Fixes Issue(s)
- #1052

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
