### PR TITLE
tf: aarch64 fix for cases where CNTFRQ_EL0 returns bogus value

### DIFF
--- a/pxr/base/arch/testenv/testTiming.cpp
+++ b/pxr/base/arch/testenv/testTiming.cpp
@@ -32,6 +32,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 int main()
 {
+    ARCH_AXIOM(ArchGetNanosecondsPerTick() > 0.0);
+    // If you're not even doing 1 tick a second, it's probably a bogus value
+    ARCH_AXIOM(ArchGetNanosecondsPerTick() < 1e9);
     // Verify conversions for many tick counts.
     for (size_t ticks = 0ul; ticks != 1ul << 24u; ++ticks) {
         ARCH_AXIOM( (uint64_t) ArchTicksToNanoseconds(ticks) == 


### PR DESCRIPTION
### Description of Change(s)

As noted in this commit in the linux kernel:

https://github.com/torvalds/linux/commit/c6f97add0f2ac83b98b06dbdda58fa47638ae7b0

...the value of CNTFRQ_EL0 is sometimes unreliable.  The linux kernel instead reads the tick rate from the device tree, and if that fails, only then falls back on CNTFRQ_EL0.

Since we already have measurement-based code, and reading from the device tree seemed tricky, we instead check if CNTFRQ_EL0 seems "sane" (ie, > 1Hz), and if not, fall back on the measurement code used in all other linux flavors.

I ran across this issue when running an aarch64 vm running on aarch64 hardware - I'm not sure if the issue was with the actual hardware or just the VMWare vm.  In this case, CNTFRQ_EL0 was returning a negative value.  Not sure if all "bad" values will be as obvious, but this change is at least an improvement.

### Fixes Issue(s)
- Arch timing functions and TfStopwatch on linux aarch64 VMs (and possibly other aarch64 platforms?)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
