### PR TITLE
[al] Invalid Prims Validation in UsdImagingMaterialAdapter::GetMaterialResource()

### DIFF
--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -335,8 +335,12 @@ UsdImagingMaterialAdapter::GetMaterialResource(UsdPrim const &prim,
                                                UsdTimeCode time) const
 {
     TRACE_FUNCTION();
-    if (!prim || !_GetSceneMaterialsEnabled()) {
+    if (!prim) {
         TF_RUNTIME_ERROR("Received prim is null.");
+        return VtValue();
+    }
+
+    if (!_GetSceneMaterialsEnabled()) {
         return VtValue();
     }
 

--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -336,6 +336,7 @@ UsdImagingMaterialAdapter::GetMaterialResource(UsdPrim const &prim,
 {
     TRACE_FUNCTION();
     if (!prim || !_GetSceneMaterialsEnabled()) {
+        TF_RUNTIME_ERROR("Received prim is null.");
         return VtValue();
     }
 

--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -335,7 +335,7 @@ UsdImagingMaterialAdapter::GetMaterialResource(UsdPrim const &prim,
                                                UsdTimeCode time) const
 {
     TRACE_FUNCTION();
-    if (!_GetSceneMaterialsEnabled()) {
+    if (!prim || !_GetSceneMaterialsEnabled()) {
         return VtValue();
     }
 


### PR DESCRIPTION
### Description of Change(s)
We came crossed this issue in our pipeline where there is a possibility that the `UsdPrim` passed in to `UsdImagingMaterialAdapter::GetMaterialResource()` could be invalid so we'd like to propose a prim validation check here.

### Fixes Issue(s)
- crashes in maya when displaying textures in the viewport. 


- [ ] I have verified that all unit tests pass with the proposed changes
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
