### PR TITLE
Fix a potential crash when updating skinned primitives.

### DIFF
--- a/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
+++ b/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
@@ -188,6 +188,16 @@ HdSceneIndexAdapterSceneDelegate::_PrimAdded(
             } else if (existingType == HdPrimTypeTokens->instancer) {
                 GetRenderIndex()._RemoveInstancer(indexPath);
             }
+
+            // If the prim type of an existing entry changed, also clear any
+            // cached data associated with it, e.g. computed primvars.
+            entry.primvarDescriptors.clear();
+            entry.primvarDescriptorsState.store(
+                _PrimCacheEntry::ReadStateUnread);
+            entry.extCmpPrimvarDescriptors.clear();
+            entry.extCmpPrimvarDescriptorsState.store(
+                _PrimCacheEntry::ReadStateUnread);
+
         } else {
             insertIfNeeded = false;
         }


### PR DESCRIPTION
This fixes the crash reported in #2809, which contains the example file and steps to reproduce.
We've had this patch in Houdini for a couple weeks and haven't encountered any issues in testing

### Description of Change(s)

With 6b3afc2f, skinned primitives are now replaced by an entry with no type and no data source instead of being removed, since they have child prims (the skinning computation Sprims).
When doing so, the entry's cache of computed primvars was never cleared.

This could result in a crash in scenarios such as switching to displaying the result of a BakeSkinning operation. In this case, the skinned primitive changes type from e.g. a Mesh (with a computed primvar for the skinned positions) to empty, and then back to Mesh (which should have no computed primvars). Since the entry's primvar cache was never cleared, this incorrectly returns a stale list of computed primvars for the updated mesh which later produces a crash.

When the prim type of an existing entry is being changed, the cached primvars are now also cleared out while removing the old prim from the render index, to produce the same behaviour as if a new entry was inserted

### Fixes Issue(s)
- Fixes #2809

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
