### PR TITLE
Incorporate change to set umask properly when creating USD files

### DIFF
--- a/pxr/base/tf/atomicRenameUtil.cpp
+++ b/pxr/base/tf/atomicRenameUtil.cpp
@@ -96,7 +96,7 @@ Tf_AtomicRenameFileOver(std::string const &srcFileName,
     } else {
         const mode_t mask = umask(0);
         umask(mask);
-        fileMode = DEFFILEMODE - mask;
+        fileMode = DEFFILEMODE & ~mask;
     }
 
     if (chmod(srcFileName.c_str(), fileMode) != 0) {


### PR DESCRIPTION
### Description of Change(s)

Incorporate change to set umask properly when creating USD files, as
described here: https://github.com/PixarAnimationStudios/USD/issues/1604,
using bitwise negation rather than numeric subtraction (which is equivalent in
some cases, but not all).

### Fixes Issue(s)
- 1604

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
