### PR TITLE
Ignore reparse points on network file systems. The destination is unl…

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -83,8 +83,7 @@ Tf_HasAttribute(
     if (path.back() == '/' || path.back() == '\\')
         resolveSymlinks = true;
 
-    const DWORD attribs =
-        GetFileAttributesW(ArchWindowsUtf8ToUtf16(path).c_str());
+    DWORD attribs = GetFileAttributesW(ArchWindowsUtf8ToUtf16(path).c_str());
     if (attribs == INVALID_FILE_ATTRIBUTES) {
         if (attribute == 0 &&
             (GetLastError() == ERROR_FILE_NOT_FOUND ||
@@ -94,6 +93,21 @@ Tf_HasAttribute(
         }
         return false;
     }
+
+    // Ignore reparse points on network volumes. They can't be resolved
+    // properly, so simply remove the reparse point attribute and treat
+    // if like a regular file/directory.
+    if ((attribs & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+        // Calling PathIsNetworkPath sometimes sets the "last error" to an
+        // error code indicating an incomplete overlapped I/O function. We
+        // want to ignore this error.
+        DWORD olderr = GetLastError();
+        if (PathIsNetworkPathW(ArchWindowsUtf8ToUtf16(path).c_str())) {
+            attribs &= ~FILE_ATTRIBUTE_REPARSE_POINT;
+        }
+        SetLastError(olderr);
+    }
+
     if (!resolveSymlinks || (attribs & FILE_ATTRIBUTE_REPARSE_POINT) == 0) {
         return attribute == 0 || (attribs & attribute) == expected;
     }

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -108,6 +108,15 @@ Tf_HasAttribute(
         SetLastError(olderr);
     }
 
+    // Because we remove the REPARSE_POINT attribute above for reparse points
+    // on network shares, the behavior of this bit of code will be slightly
+    // different than for reparse points on non-network volumes. We will not
+    // try to follow the link and get the attributes of the destination. This
+    // will result in a link to an invalid destination directory claiming that
+    // the directory exists. It might be possible to use some other function
+    // to test for the existence of the destination directory in this case
+    // (such as FindFirstFile), but doing this doesn't seem to be relevent
+    // to how USD uses this method.
     if (!resolveSymlinks || (attribs & FILE_ATTRIBUTE_REPARSE_POINT) == 0) {
         return attribute == 0 || (attribs & attribute) == expected;
     }

--- a/pxr/base/tf/fileUtils.h
+++ b/pxr/base/tf/fileUtils.h
@@ -42,6 +42,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// If \p resolveSymlinks is false (default), the path is checked using
 /// lstat(). if \p resolveSymlinks is true, the path is checked using stat(),
 /// which resolves all symbolic links in the path.
+///
+/// On Windows, if the path points to a reparse point symlink on a network
+/// share, even if resolveSymlinks is true we are unable to follow the
+/// symlink, and so will return true even if the destination of the symlink
+/// does not exist.
 TF_API
 bool TfPathExists(std::string const& path, bool resolveSymlinks = false);
 
@@ -50,6 +55,11 @@ bool TfPathExists(std::string const& path, bool resolveSymlinks = false);
 /// If \p resolveSymlinks is false (default), the path is checked using
 /// lstat(). if \p resolveSymlinks is true, the path is checked using stat(),
 /// which resolves all symbolic links in the path.
+///
+/// On Windows, if the path points to a reparse point symlink on a network
+/// share, even if resolveSymlinks is true we are unable to follow the
+/// symlink, and so will return true even if the destination of the symlink
+/// does not exist.
 TF_API
 bool TfIsDir(std::string const& path, bool resolveSymlinks = false);
 
@@ -58,10 +68,21 @@ bool TfIsDir(std::string const& path, bool resolveSymlinks = false);
 /// If \p resolveSymlinks is false (default), the path is checked using
 /// lstat(). if \p resolveSymlinks is true, the path is checked using stat(),
 /// which resolves all symbolic links in the path.
+///
+/// On Windows, if the path points to a reparse point symlink on a network
+/// share, even if resolveSymlinks is true we are unable to follow the
+/// symlink, and so will return true even if the destination of the symlink
+/// does not exist.
 TF_API
 bool TfIsFile(std::string const& path, bool resolveSymlinks = false);
 
 /// Returns true if the path exists and is a symbolic link.
+///
+/// On Windows, if the path points to a reparse point symlink on a network
+/// share, we are unable to follow the symlink, so we will return false for
+/// this directory even though it is a link. This is because any attempt to
+/// actually follow this link will fail, so it is safer to pretend it is not
+/// actually a link.
 TF_API
 bool TfIsLink(std::string const& path);
 


### PR DESCRIPTION
### Description of Change(s)

Ignore reparse points on network file systems. The destination is unlikely
to be accessible from the remote machine. So for example, machine A points
to a network location on machine B (//B/share/path/to/some/directory). But on
machine B, the directory "C:/path/to/some" that corresponds to
"//B/share/path/to/some" is a reparse point that maps to "D:/another/location".
If machine A tries to "simplify" this path using knownledge of the reparse point,
it ends up with a path like "D:/another/location/directory", which is totally
meaningless on machine A. So in this case we have to just ignore the reparse
point and machine A can only access the directory using the full path 
"//B/shared/path/to/some/directory".

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
