### PR TITLE
Improve performance of generating the sublayer change notices

### DIFF
--- a/pxr/usd/pcp/changes.cpp
+++ b/pxr/usd/pcp/changes.cpp
@@ -2131,6 +2131,10 @@ PcpChanges::_DidChangeSublayer(
     // us because some changes introduce new dependencies that wouldn't
     // have been registered yet using the normal means -- such as unmuting
     // a sublayer.
+    //
+    // When flagging "significant" changes, we don't need to recurseOnIndex
+    // because adding a prim to the didChangeSignificantly set implies that
+    // all descendants have also changed significantly.
 
     bool anyFound = false;
     TF_FOR_ALL(layerStack, layerStacks) {
@@ -2139,7 +2143,7 @@ PcpChanges::_DidChangeSublayer(
             SdfPath::AbsoluteRootPath(), 
             PcpDependencyTypeAnyIncludingVirtual,
             /* recurseOnSite */ true,
-            /* recurseOnIndex */ true,
+            /* recurseOnIndex */ !(*significant),
             /* filter */ true);
         for (const auto &dep: deps) {
             if (!dep.indexPath.IsAbsoluteRootOrPrimPath()) {


### PR DESCRIPTION
### Description of Change(s)

Improve performance of generating the change notice when adding or removing sublayers from a stage. We don't need to explicitly enumerate descendant prims in the face of a significant change because marking a prim as significantly change implies all its descendants have also changed significantly.

### Fixes Issue(s)
- #2932 

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
