### PR TITLE
Use "DCCFPS" metadata to set TCPS value in alembic reader code

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -952,7 +952,12 @@ _ReaderContext::Open(const std::string& filePath, std::string* errorLog,
     // Get info.
     uint32_t apiVersion;
     std::string writer, version, date, comment;
+    double fps = 0.0;
+#if ALEMBIC_LIBRARY_VERSION >= 10712
+    GetArchiveInfo(archive, writer, version, apiVersion, date, comment, fps);
+#else
     GetArchiveInfo(archive, writer, version, apiVersion, date, comment);
+#endif
 
     // Report.
     if (IsFlagSet(UsdAbc_AlembicContextFlagNames->verbose)) {
@@ -989,9 +994,13 @@ _ReaderContext::Open(const std::string& filePath, std::string* errorLog,
             root.getProperties().getPropertyHeader("Usd")) {
         const MetaData& metadata = property->getMetaData();
         _pseudoRoot->metadata[SdfFieldKeys->TimeCodesPerSecond] = 24.0;
-       _GetDoubleMetadata(metadata, _pseudoRoot->metadata,
+        _GetDoubleMetadata(metadata, _pseudoRoot->metadata,
                            SdfFieldKeys->TimeCodesPerSecond);
-       _timeScale = _pseudoRoot->metadata[SdfFieldKeys->TimeCodesPerSecond].Get<double>();
+        _timeScale = _pseudoRoot->metadata[SdfFieldKeys->TimeCodesPerSecond].Get<double>();
+    }
+    else if (fps != 0.0) {
+        _pseudoRoot->metadata[SdfFieldKeys->TimeCodesPerSecond] = fps;
+        _timeScale = _pseudoRoot->metadata[SdfFieldKeys->TimeCodesPerSecond].Get<double>();
     }
 
     // Collect instancing information.


### PR DESCRIPTION
### Description of Change(s)
If an alembic file has authored the "DCCFPS" metadata in its config info, use that value as the TimeCodesPerSecond value of the equivalent USD data. This prevents unintended time scaling of Alembic files when translating them from Alembic (which stores samples times in seconds) into USD (which stores sample times in samples). This change does not remove support for the old "Usd" metadata section, which takes precedence to avoid unnecessary behavior changes, and change only takes effect if building against Alembic 1.7.12 or later (when DCCFPS was introduced).

### Fixes Issue(s)
- #1023 

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
