### PR TITLE
Autodesk: Custom pick region to search over for Hit Prims

### DIFF
--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -603,6 +603,40 @@ HdxPickTask::Execute(HdTaskContext* ctx)
 
     GfVec2i dimensions = _contextParams.resolution;
     GfVec4i viewport(0, 0, dimensions[0], dimensions[1]);
+    
+    auto useSearchRect = [&](const GfVec4i& sRect, const GfVec4i& vRect )->bool {
+        
+        // invalid search size or not initialized
+        if(sRect[2] < 0 || sRect[3] < 0)
+            return false;
+
+        // sRect x cordinate extremes  contained in vRect
+        if(sRect[0] < vRect[0] || sRect[0] > vRect[0] + vRect[2])
+            return false;
+
+        if((sRect[0] + sRect[2]) < vRect[0] || (sRect[0] + sRect[2]) > (vRect[0] + vRect[2]))
+            return false;
+
+        // sRect y coordinate extremes  contained in vRect
+        if(sRect[1] < vRect[1] || sRect[1] > vRect[1] + vRect[3])
+            return false;
+
+        if((sRect[1]+sRect[3]) < sRect[1] || (sRect[1]+sRect[3]) > (vRect[1] + vRect[3]))
+            return false;
+
+        return true;
+    };
+
+    if( _contextParams.searchRect[2] > 0 && _contextParams.searchRect[3] > 0 ) {
+        if( useSearchRect( _contextParams.searchRect, viewport ) )
+            viewport = _contextParams.searchRect;
+        else {
+            TF_WARN("Specified Search Rect [%d, %d, %d %d]  not inside viewport [%d, %d, %d %d] ",
+                    _contextParams.searchRect[0], _contextParams.searchRect[1],
+                    _contextParams.searchRect[2], _contextParams.searchRect[3],
+                    viewport[0], viewport[1], viewport[2], viewport[3] );
+        }
+    }
 
     // Are we using stencil conditioning?
     bool needStencilConditioning =
@@ -744,7 +778,6 @@ HdxPickResult::HdxPickResult(
     _subRect[1] = std::max(0, _subRect[1]);
     _subRect[2] = std::min(_bufferSize[0]-_subRect[0], _subRect[2]);
     _subRect[3] = std::min(_bufferSize[1]-_subRect[1], _subRect[3]);
-
     _eyeToWorld = viewMatrix.GetInverse();
     _ndcToWorld = (viewMatrix * projectionMatrix).GetInverse();
 }

--- a/pxr/imaging/hdx/pickTask.h
+++ b/pxr/imaging/hdx/pickTask.h
@@ -231,6 +231,10 @@ struct HdxPrimOriginInfo
 ///         or region. The number of hits returned depends on the resolution
 ///         used and may have duplicates.
 ///
+/// 'searchRect': The searchRect is specified as a subset of the viewport to narrow down
+///         the search for any pickItems from the buffer into outHits. A width, height of
+///         -1 for the searchRect indicates an invalid specfied searchRect.
+///
 struct HdxPickTaskContextParams
 {
     using DepthMaskCallback = std::function<void(void)>;
@@ -246,6 +250,7 @@ struct HdxPickTaskContextParams
         , depthMaskCallback(nullptr)
         , collection()
         , outHits(nullptr)
+        , searchRect({0,0,-1,-1})
     {}
 
     GfVec2i resolution;
@@ -258,6 +263,7 @@ struct HdxPickTaskContextParams
     DepthMaskCallback depthMaskCallback;
     HdRprimCollection collection;
     HdxPickHitVector *outHits;
+    GfVec4i searchRect;
 };
 
 /// \class HdxPickTask


### PR DESCRIPTION
### Description of Change(s)

We now add a new GfVec4i to specify a search area in the pickTaskContextParams. This is to narrow the search over the desired pick location. The search is now supported in the pickTask when we pick item across all modes - closest to camera, closest to center, etc.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
