### PR TITLE
Boost: Use Headers instead of building when not required

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -756,8 +756,15 @@ def InstallBoost_Helper(context, force, buildArgs):
         "*/libs/wave/test/testwave/testfiles/utf8-test-*"
     ]
 
+    headersOnly = not (context.buildOIIO or context.enableOpenVDB or context.buildPython)
+
     with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
                                              dontExtract=dontExtract)):
+        if headersOnly:
+            headersDir = os.path.abspath("./boost")
+            CopyDirectory(context, headersDir, "include/boost")
+            return
+
         if Windows():
             bootstrap = "bootstrap.bat"
         else:


### PR DESCRIPTION
### Description of Change(s)

When building USD without Python, OIIO or VDB, Boost libs aren't required. In this scenario, it is preferable to just copy over the headers instead and save some time and complexity.

Edit: as subsequently requested, removed the filtering. With filtering, this can reduce the header size from 180M to 37M. Without filtering, the only benefit is that you don't spend time building with B2 when you don't end up using any of its output.

This also has a significant benefit that it allows the core USD build to be supported on platforms that Boost doesn't natively build on yet like iOS and visionOS. It means that the build_usd.py script doesn't need to carry as many patches to Boost itself if someone is just building the core USD library.

This is similar to [PR 2914](https://github.com/PixarAnimationStudios/OpenUSD/pull/2914) but can short circuit the entire bootstrap and b2 process, which may still error on platforms that b2 doesn't understand.


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
