### PR TITLE
Apple: Remove unused CREATE_FRAMEWORK parameters

### DIFF
--- a/pxr/base/plug/CMakeLists.txt
+++ b/pxr/base/plug/CMakeLists.txt
@@ -56,7 +56,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestPlugDso1
-    CREATE_FRAMEWORK
     INSTALL_PREFIX PlugPlugins
     LIBRARIES
         tf

--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -88,7 +88,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestArAdvancedAPI
-    CREATE_FRAMEWORK
     INSTALL_PREFIX ArPlugins
     LIBRARIES
         tf
@@ -98,7 +97,6 @@ pxr_build_test_shared_lib(TestArAdvancedAPI
 ) 
 
 pxr_build_test_shared_lib(TestArPackageResolver
-    CREATE_FRAMEWORK
     INSTALL_PREFIX ArPlugins
     LIBRARIES
         tf
@@ -108,7 +106,6 @@ pxr_build_test_shared_lib(TestArPackageResolver
 ) 
 
 pxr_build_test_shared_lib(TestArOptionalImplementation
-    CREATE_FRAMEWORK
     INSTALL_PREFIX ArPlugins
     LIBRARIES
         tf
@@ -186,7 +183,6 @@ pxr_register_test(testArOptionalImplementation_5
 # builds, so we only enable this test on shared library builds.
 if (BUILD_SHARED_LIBS)
     pxr_build_test_shared_lib(TestArURIResolver
-        CREATE_FRAMEWORK
         INSTALL_PREFIX ArPlugins
         LIBRARIES
             tf

--- a/pxr/usd/pcp/CMakeLists.txt
+++ b/pxr/usd/pcp/CMakeLists.txt
@@ -123,7 +123,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestPcpDynamicFileFormatPlugin
-    CREATE_FRAMEWORK
     INSTALL_PREFIX PcpPlugins
     LIBRARIES
         tf
@@ -135,7 +134,6 @@ pxr_build_test_shared_lib(TestPcpDynamicFileFormatPlugin
 )
 
 pxr_build_test_shared_lib(TestPcpStreamingLayerReload
-    CREATE_FRAMEWORK
     INSTALL_PREFIX PcpPlugins
     LIBRARIES
         tf

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -232,7 +232,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestSdfFileFormatCapabilities
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdfPlugins
     LIBRARIES
         sdf
@@ -243,7 +242,6 @@ pxr_build_test_shared_lib(TestSdfFileFormatCapabilities
 )
 
 pxr_build_test_shared_lib(TestSdfNoAssetFileFormat
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdfPlugins
     LIBRARIES
         sdf
@@ -254,7 +252,6 @@ pxr_build_test_shared_lib(TestSdfNoAssetFileFormat
 )
 
 pxr_build_test_shared_lib(TestSdfStreamingFileFormat
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdfPlugins
     LIBRARIES
         sdf
@@ -265,7 +262,6 @@ pxr_build_test_shared_lib(TestSdfStreamingFileFormat
 )
 
 pxr_build_test_shared_lib(TestSdfTargetFileFormat
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdfPlugins
     LIBRARIES
         sdf
@@ -276,7 +272,6 @@ pxr_build_test_shared_lib(TestSdfTargetFileFormat
 )
 
 pxr_build_test_shared_lib(TestSdfResolver
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdfPlugins
     LIBRARIES
         ar

--- a/pxr/usd/sdr/CMakeLists.txt
+++ b/pxr/usd/sdr/CMakeLists.txt
@@ -46,7 +46,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestSdrRegistry
-    CREATE_FRAMEWORK
     INSTALL_PREFIX SdrPlugins
     LIBRARIES
         tf

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -267,7 +267,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestUsdProceduralExternalAssetsFileFormatPlugin
-    CREATE_FRAMEWORK
     INSTALL_PREFIX UsdPlugins
     LIBRARIES
         sdf
@@ -279,7 +278,6 @@ pxr_build_test_shared_lib(TestUsdProceduralExternalAssetsFileFormatPlugin
 )
 
 pxr_build_test_shared_lib(TestUsdResolverChangedResolver
-    CREATE_FRAMEWORK
     INSTALL_PREFIX UsdPlugins
     LIBRARIES
         ar

--- a/pxr/usd/usdUtils/CMakeLists.txt
+++ b/pxr/usd/usdUtils/CMakeLists.txt
@@ -102,7 +102,6 @@ pxr_test_scripts(
 )
 
 pxr_build_test_shared_lib(TestUsdUtilsDependenciesCustomResolver
-    CREATE_FRAMEWORK
     INSTALL_PREFIX UsdUtilsPlugins
     LIBRARIES
         ar


### PR DESCRIPTION
### Description of Change(s)

We discovered this unused CREATE_FRAMEWORK argument in several CMake files. I'd like to remove these pre-emptively for possibly adding framework build support to OpenUSD in the future to avoid confusion.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
