### PR TITLE
Fix DeprecationWarning caused by a regex containing an invalid escape sequence

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1201,7 +1201,7 @@ class AppController(QtCore.QObject):
             # fix up bad input on the users behalf since any leading, trailing
             # or duplicate | operators result in a match for every layer and
             # thus break the stage.
-            pattern =  re.sub('^\||(?<=\|)\|+|\|$', '', pattern)
+            pattern =  re.sub(r'^\||(?<=\|)\|+|\|$', '', pattern)
             if not pattern:
                 return
             matcher = re.compile(pattern)


### PR DESCRIPTION
### Description of Change(s)
Fix DeprecationWarning caused by a regex containing an invalid escape sequence.

Prefix the regex with "r" so it is interpreted as a raw string.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
