### PR TITLE
Fix a bug where the skinning computation could produce an incorrect time sample

### DIFF
--- a/pxr/imaging/hd/timeSampleArray.cpp
+++ b/pxr/imaging/hd/timeSampleArray.cpp
@@ -26,8 +26,11 @@
 
 #include "pxr/base/gf/half.h"
 #include "pxr/base/gf/matrix2d.h"
+#include "pxr/base/gf/matrix2f.h"
 #include "pxr/base/gf/matrix3d.h"
+#include "pxr/base/gf/matrix3f.h"
 #include "pxr/base/gf/matrix4d.h"
+#include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/quatd.h"
 #include "pxr/base/gf/quatf.h"
 #include "pxr/base/gf/quath.h"
@@ -116,9 +119,10 @@ HdResampleNeighbors(float alpha, const VtValue& v0, const VtValue& v1)
 
     // The list of supported types to interpolate.
     using _InterpTypes =
-        _TypeList<float, double, GfHalf, GfMatrix2d, GfMatrix3d, GfMatrix4d,
-                  GfVec2d, GfVec2f, GfVec2h, GfVec3d, GfVec3f, GfVec3h, GfVec4d,
-                  GfVec4f, GfVec4h, GfQuatd, GfQuatf, GfQuath>;
+        _TypeList<float, double, GfHalf, GfMatrix2f, GfMatrix3f, GfMatrix4f,
+                  GfMatrix2d, GfMatrix3d, GfMatrix4d, GfVec2d, GfVec2f, GfVec2h,
+                  GfVec3d, GfVec3f, GfVec3h, GfVec4d, GfVec4f, GfVec4h, GfQuatd,
+                  GfQuatf, GfQuath>;
 
     VtValue result;
     _Resample(alpha, v0, v1, t0, &result, _InterpTypes());

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -1862,6 +1862,17 @@ _InitIdentityXforms(
                            GfMatrix4f(1));
 }
 
+double
+UsdSkelImagingSkeletonAdapter::_GetDefaultSampleTime(UsdTimeCode time)
+{
+  // For computation inputs which are constant, report their sample time offset
+  // as the beginning of the interval. The boundaries are always included as
+  // time samples for the animation (see _UnionTimeSamples()) so this
+  // ensures we don't introduce an extra time sample to the computation.
+  const GfInterval interval = _GetCurrentTimeSamplingInterval();
+  return interval.GetMin() - time.GetValue();
+}
+
 size_t
 UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
     UsdPrim const& prim,
@@ -1907,7 +1918,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
                                         skinnedPrimCachePath, time);
         size_t numPoints = restPoints.size();
         sampleValues[0] = VtValue(numPoints);
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 
@@ -2007,7 +2018,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
                                     skinnedPrimData->skinningQuery,
                                     &skinningXforms);
                 sampleValues[0] = VtValue::Take(skinningXforms);
-                sampleTimes[0] = 0.f;
+                sampleTimes[0] = _GetDefaultSampleTime(time);
                 return 1;
             }
         }
@@ -2046,7 +2057,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
 
             } else {
                 sampleValues[0] = VtValue(VtFloatArray());
-                sampleTimes[0] = 0.f;
+                sampleTimes[0] = _GetDefaultSampleTime(time);
                 return 1;
             }
         }
@@ -2125,7 +2136,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
         // Rest points aren't expected to be time-varying.
         sampleValues[0] =
             VtValue(_GetSkinnedPrimPoints(prim, skinnedPrimCachePath, time));
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 
@@ -2137,7 +2148,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
             skinnedPrimData->skinningQuery.GetSkinningMethod();
 
         sampleValues[0] = VtValue(skinningMethod);
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 
@@ -2150,7 +2161,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
 
         // Skinning computations use float precision.
         sampleValues[0] = GfMatrix4f(geomBindXform);
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 
@@ -2179,7 +2190,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
             sampleValues[0] = VtValue(usesConstantJointPrimvar);
         }
 
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 
@@ -2206,7 +2217,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
             sampleValues[0] = VtValue(static_cast<int>(ranges.size()));
         }
 
-        sampleTimes[0] = 0.f;
+        sampleTimes[0] = _GetDefaultSampleTime(time);
         return 1;
     }
 

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
@@ -399,6 +399,10 @@ private:
             float *sampleTimes,
             VtValue *sampleValues);
 
+    /// Returns the sample time offset that should be reported for computation
+    /// inputs which are not time-varying.
+    double _GetDefaultSampleTime(UsdTimeCode time);
+
 
     // ---------------------------------------------------------------------- //
     /// Populated skeleton state


### PR DESCRIPTION
### Description of Change(s)
- In `SampleExtComputationInput()`, inputs to the skinning computation which aren't time-varying (e.g. the bind transform) reported a single sample at a time offset of 0.

  The choice of 0 (the current time) here could produce unexpected behaviour. If none of the time-sampled computation inputs (e.g. joint transforms) actually had a sample at that time, this would cause `HdExtComputationUtils::SampleComputedPrimvar()` to evaluate and return an additional time sample for the computation.

  For example, if the sampling interval was (-0.25, 0.25) and the joint transforms were also time-sampled at [-0.25, 0.25], `SampleComputedPrimvar()` would return three samples at [-0.25, 0, 0.25]
This could be confusing for users when configuring render options such as the maximum number of samples to use for motion blur, since this extra time sample doesn't actually exist anywhere on the stage.

  An easy solution is to instead report these constant inputs as having a single time sample at the beginning of the sampling interval. Sampling always includes the boundary times so this eliminates the possibility of adding an extra sample.

- This issue also revealed a related bug where this extra sample had an unexpected pose, and was identical to the previous time sample rather than interpolating the joint transforms. Using the example above, when `SampleComputedPrimvar()` evaluates the computation at `sampleTime=0`, inputs such as the skinning transforms would first be interpolated since they only have time samples at [-0.25, 0.25]. The skinning transforms actually ended up being held at -0.25 rather than interpolated, since `float` variants of `GfMatrix` types were not registered with `hdTimeSampleArray` for interpolation. 

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
