### PR TITLE
Apple: Introduce APPLE_EMBEDDED parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ then build and install USD into `/path/to/my_usd_install_dir`.
 > python USD/build_scripts/build_usd.py /path/to/my_usd_install_dir
 ```
 
-##### MacOS:
+##### macOS:
 
 In a terminal, run `xcode-select` to ensure command line developer tools are
 installed. Then run the script.
@@ -140,6 +140,16 @@ then build and install USD into `/path/to/my_usd_install_dir`.
 ```
 > python USD/build_scripts/build_usd.py /path/to/my_usd_install_dir
 ```
+
+###### iOS
+
+When building from a macOS system, you can cross compile for iOS based platforms.
+
+iOS builds currently do not support Imaging.
+Additionally, they will not support Python bindings or command line tools.
+
+To build for iOS, add the `--build-target iOS` parameter.
+
 
 ##### Windows:
 

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -35,20 +35,26 @@ import os
 import platform
 import shlex
 import subprocess
+import re
+from typing import Optional, List
 
 TARGET_NATIVE = "native"
 TARGET_X86 = "x86_64"
 TARGET_ARM64 = "arm64"
 TARGET_UNIVERSAL = "universal"
+TARGET_IOS = "ios"
+
+EMBEDDED_PLATFORMS = [TARGET_IOS]
 
 def GetBuildTargets():
     return [TARGET_NATIVE,
             TARGET_X86,
             TARGET_ARM64,
-            TARGET_UNIVERSAL]
+            TARGET_UNIVERSAL,
+            TARGET_IOS]
 
 def GetBuildTargetDefault():
-    return TARGET_NATIVE;
+    return TARGET_NATIVE
 
 def MacOS():
     return platform.system() == "Darwin"
@@ -56,15 +62,11 @@ def MacOS():
 def GetLocale():
     return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
 
-def GetCommandOutput(command):
-    """Executes the specified command and returns output or None."""
+def GetCommandOutput(command, **kwargs):
     try:
-        return subprocess.check_output(
-            shlex.split(command),
-            stderr=subprocess.STDOUT).decode(GetLocale(), 'replace').strip()
-    except subprocess.CalledProcessError:
-        pass
-    return None
+        return subprocess.check_output(command, stderr=subprocess.STDOUT, **kwargs).decode(GetLocale(), 'replace').strip()
+    except:
+        return None
 
 def GetTargetArmArch():
     # Allows the arm architecture string to be overridden by
@@ -72,7 +74,7 @@ def GetTargetArmArch():
     return os.environ.get('MACOS_ARM_ARCHITECTURE') or TARGET_ARM64
 
 def GetHostArch():
-    macArch = GetCommandOutput('arch').strip()
+    macArch = GetCommandOutput(["arch"])
     if macArch == "i386" or macArch == TARGET_X86:
         macArch = TARGET_X86
     else:
@@ -85,7 +87,7 @@ def GetTargetArch(context):
     else:
         if context.targetX86:
             macTargets = TARGET_X86
-        if context.targetARM64:
+        if context.targetARM64 or context.targetIos:
             macTargets = GetTargetArmArch()
         if context.targetUniversal:
             macTargets = TARGET_X86 + ";" + GetTargetArmArch()
@@ -106,6 +108,8 @@ def GetTargetArchPair(context):
         primaryArch = TARGET_X86
     if context.targetARM64:
         primaryArch = GetTargetArmArch()
+    if context.targetIos:
+        primaryArch = TARGET_IOS
     if context.targetUniversal:
         primaryArch = GetHostArch()
         if (primaryArch == TARGET_X86):
@@ -118,18 +122,33 @@ def GetTargetArchPair(context):
 def SupportsMacOSUniversalBinaries():
     if not MacOS():
         return False
-    XcodeOutput = GetCommandOutput('/usr/bin/xcodebuild -version')
+    XcodeOutput = GetCommandOutput(["/usr/bin/xcodebuild", "-version"])
     XcodeFind = XcodeOutput.rfind('Xcode ', 0, len(XcodeOutput))
     XcodeVersion = XcodeOutput[XcodeFind:].split(' ')[1]
     return (XcodeVersion > '11.0')
+
+
+def GetSDKRoot(context) -> Optional[str]:
+    sdk = "macosx"
+    if context.buildTarget == TARGET_IOS:
+        sdk = "iphoneos"
+
+    for arg in (context.cmakeBuildArgs or '').split():
+        if "CMAKE_OSX_SYSROOT" in arg:
+            override = arg.split('=')[1].strip('"').strip()
+            if override:
+                sdk = override
+    return GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+
 
 def SetTarget(context, targetName):
     context.targetNative = (targetName == TARGET_NATIVE)
     context.targetX86 = (targetName == TARGET_X86)
     context.targetARM64 = (targetName == GetTargetArmArch())
     context.targetUniversal = (targetName == TARGET_UNIVERSAL)
+    context.targetIos = (targetName == TARGET_IOS)
     if context.targetUniversal and not SupportsMacOSUniversalBinaries():
-        self.targetUniversal = False
+        context.targetUniversal = False
         raise ValueError(
                 "Universal binaries only supported in macOS 11.0 and later.")
 
@@ -150,25 +169,62 @@ def ExtractFilesRecursive(path, cond):
                 files.append(os.path.join(r, file))
     return files
 
-def CodesignFiles(files):
-    SDKVersion  = subprocess.check_output(
-        ['xcodebuild', '-version']).strip()[6:10]
-    codeSignIDs = subprocess.check_output(
-        ['security', 'find-identity', '-vp', 'codesigning'])
+def _GetCodeSignStringFromTerminal():
+    codeSignIDs = GetCommandOutput(['security', 'find-identity', '-vp', 'codesigning'])
+    return codeSignIDs
 
-    codeSignID = "-"
+def GetCodeSignID():
     if os.environ.get('CODE_SIGN_ID'):
-        codeSignID = os.environ.get('CODE_SIGN_ID')
-    elif float(SDKVersion) >= 11.0 and \
-                codeSignIDs.find(b'Apple Development') != -1:
-        codeSignID = "Apple Development"
-    elif codeSignIDs.find(b'Mac Developer') != -1:
-        codeSignID = "Mac Developer"
+        return os.environ.get('CODE_SIGN_ID')
+
+    codeSignIDs = _GetCodeSignStringFromTerminal()
+    if not codeSignIDs:
+        return "-"
+    for codeSignID in codeSignIDs.splitlines():
+        if "CSSMERR_TP_CERT_REVOKED" in codeSignID:
+            continue
+        if ")" not in codeSignID:
+            continue
+        codeSignID = codeSignID.split()[1]
+        break
+    else:
+        raise RuntimeError("Could not find a valid codesigning ID")
+
+    return codeSignID or "-"
+
+def GetCodeSignIDHash():
+    codeSignIDs = _GetCodeSignStringFromTerminal()
+    try:
+        return re.findall(r'\(.*?\)', codeSignIDs)[0][1:-1]
+    except:
+        raise Exception("Unable to parse codesign ID hash")
+
+def GetDevelopmentTeamID():
+    if os.environ.get("DEVELOPMENT_TEAM"):
+        return os.environ.get("DEVELOPMENT_TEAM")
+    codesignID = GetCodeSignIDHash()
+
+    certs = subprocess.check_output(["security", "find-certificate", "-c", codesignID, "-p"])
+    subject = GetCommandOutput(["openssl", "x509", "-subject"], input=certs)
+    subject = subject.splitlines()[0]
+
+    # Extract the Organizational Unit (OU field) from the cert
+    try:
+        team = [elm for elm in subject.split(
+            '/') if elm.startswith('OU')][0].split('=')[1]
+        if team is not None and team != "":
+            return team
+    except Exception as ex:
+        raise Exception("No development team found with exception " + ex)
+
+def CodesignFiles(files):
+    codeSignID = GetCodeSignID()
 
     for f in files:
         subprocess.call(['codesign', '-f', '-s', '{codesignid}'
-                              .format(codesignid=codeSignID), f],
+                        .format(codesignid=codeSignID), f],
                         stdout=devout, stderr=devout)
+
 
 def Codesign(install_path, verbose_output=False):
     if not MacOS():
@@ -217,3 +273,12 @@ def CreateUniversalBinaries(context, libNames, x86Dir, armDir):
                                 instDir=context.instDir, libName=targetName),
                        outputName)
     return lipoCommands
+
+def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
+    system_name = None
+    if context.buildTarget == TARGET_IOS:
+        system_name = "iOS"
+
+    if system_name:
+        args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")
+    return args

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -758,7 +758,7 @@ def InstallBoost_Helper(context, force, buildArgs):
 
     headersOnly = not (context.buildOIIO or context.enableOpenVDB or context.buildPython)
 
-    with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force, 
+    with CurrentWorkingDirectory(DownloadURL(BOOST_URL, context, force,
                                              dontExtract=dontExtract)):
         if headersOnly:
             # We don't need all the headers, so we elide some for space

--- a/cmake/defaults/ProjectDefaults.cmake
+++ b/cmake/defaults/ProjectDefaults.cmake
@@ -42,6 +42,17 @@ if(APPLE)
     if (CMAKE_HOST_SYSTEM_VERSION VERSION_GREATER_EQUAL 20)
         set(CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS "-o linker-signed")
     endif()
+
+    # Cross Compilation as defined in CMake docs
+    # https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-visionos-or-watchos
+    # Note: All these SDKs may not be supported by OpenUSD, but are all listed here for future proofing
+    set(APPLE_EMBEDDED OFF)
+    if (CMAKE_SYSTEM_NAME MATCHES "iOS"
+            OR CMAKE_SYSTEM_NAME MATCHES "tvOS"
+            OR CMAKE_SYSTEM_NAME MATCHES "visionOS"
+            OR CMAKE_SYSTEM_NAME MATCHES "watchOS")
+        set(APPLE_EMBEDDED ON)
+    endif ()
 endif()
 
 # Allow local includes from source directory.

--- a/pxr/base/arch/align.cpp
+++ b/pxr/base/arch/align.cpp
@@ -26,11 +26,12 @@
 #include "pxr/base/arch/defines.h"
 #include "pxr/base/arch/error.h"
 
-#if defined(ARCH_OS_DARWIN)
+#if defined(ARCH_OS_IPHONE)
+#elif defined(ARCH_OS_DARWIN)
 #   include <sys/malloc.h>
 #else
 #   include <malloc.h>
-#endif /* defined(ARCH_OS_DARWIN) */
+#endif /* defined(ARCH_OS_IPHONE) */
 
 #include <cstdlib>
 

--- a/pxr/base/arch/debugger.cpp
+++ b/pxr/base/arch/debugger.cpp
@@ -34,7 +34,9 @@
 #if defined(ARCH_OS_LINUX) || defined(ARCH_OS_DARWIN)
 #include "pxr/base/arch/inttypes.h"
 #include <sys/types.h>
+#if !defined(ARCH_OS_IPHONE)
 #include <sys/ptrace.h>
+#endif
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <cstdio>

--- a/pxr/base/arch/defines.h
+++ b/pxr/base/arch/defines.h
@@ -34,7 +34,10 @@
 #include "TargetConditionals.h"
 #define ARCH_OS_DARWIN
 #if TARGET_OS_IPHONE
-#define ARCH_OS_IOS
+// TARGET_OS_IPHONE refers to all iOS derivative platforms
+// TARGET_OS_IOS refers to iPhone/iPad
+// For now, we only specialize for the umbrella TARGET_OS_IPHONE group
+#define ARCH_OS_IPHONE
 #else
 #define ARCH_OS_OSX
 #endif

--- a/pxr/base/arch/mallocHook.cpp
+++ b/pxr/base/arch/mallocHook.cpp
@@ -33,11 +33,12 @@
 #endif
 #include <cstring>
 
-#if defined(ARCH_OS_DARWIN)
+#if defined(ARCH_OS_IPHONE)
+#elif defined(ARCH_OS_DARWIN)
 #   include <sys/malloc.h>
 #else
 #   include <malloc.h>
-#endif /* defined(ARCH_OS_DARWIN) */
+#endif /* defined(ARCH_OS_IPHONE) */
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/garch/glPlatformContextDarwin.mm
+++ b/pxr/imaging/garch/glPlatformContextDarwin.mm
@@ -27,7 +27,7 @@
 #include "pxr/pxr.h"
 #include "glPlatformContextDarwin.h"
 
-#ifdef ARCH_OS_IOS
+#ifdef ARCH_OS_IPHONE
 typedef EAGLContext NSGLContext;
 #else
 typedef NSOpenGLContext NSGLContext;
@@ -90,7 +90,7 @@ GarchNSGLContextState::IsValid() const
 void
 GarchNSGLContextState::MakeCurrent()
 {
-#if ARCH_OS_IOS
+#if ARCH_OS_IPHONE
     [EAGLContext setCurrentContext:_detail->context];
 #else
     [_detail->context makeCurrentContext];

--- a/pxr/imaging/hgiMetal/capabilities.mm
+++ b/pxr/imaging/hgiMetal/capabilities.mm
@@ -50,7 +50,7 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
     if (@available(macOS 100.100, ios 12.0, *)) {
         unifiedMemory = true;
     } else if (@available(macOS 10.15, ios 13.0, *)) {
-#if defined(ARCH_OS_IOS) || (defined(__MAC_10_15) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_15)
+#if defined(ARCH_OS_IPHONE) || (defined(__MAC_10_15) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_15)
         unifiedMemory = [device hasUnifiedMemory];
 #else
         unifiedMemory = [device isLowPower];

--- a/pxr/imaging/hgiMetal/shaderGenerator.mm
+++ b/pxr/imaging/hgiMetal/shaderGenerator.mm
@@ -375,7 +375,7 @@ _ComputeHeader(id<MTLDevice> device, HgiShaderStage stage)
     }
 
     if (@available(macos 100.100, ios 12.0, *)) {
-        header  << "#define ARCH_OS_IOS\n";
+        header  << "#define ARCH_OS_IPHONE\n";
         // Define all iOS 12 feature set enums onwards
         if ([device supportsFeatureSet:MTLFeatureSet(12)])
             header << "#define METAL_FEATURESET_IOS_GPUFAMILY1_v5\n";

--- a/pxr/imaging/hio/stbImage.cpp
+++ b/pxr/imaging/hio/stbImage.cpp
@@ -439,7 +439,7 @@ Hio_StbImage::ReadCropped(int const cropTop,
     // thus we explicitly call stbi__vertical_flip below - assuming
     // that no other client called stbi_set_flip_vertically_on_load(true).
     
-#if defined(ARCH_OS_IOS)
+#if defined(ARCH_OS_IPHONE)
     stbi_convert_iphone_png_to_rgb(true);
 #endif
 


### PR DESCRIPTION
### Description of Change(s)

This PR adds a new `APPLE_EMBEDDED` variable in CMake to  allow for switching configuration logic accordingly.
This will be required for potential follow up PRs that introduce imaging and framework builds.

Requires https://github.com/PixarAnimationStudios/OpenUSD/pull/2949 to be merged in first. I could split this out, but it's not very functional for other PRs until that one is merged first. So I opted to base it on that to have a nice tree.

I've added checks for all the known cross compilation targets that CMake supports for Apple platforms , even if there aren't plans to support all of them in OpenUSD in the immediate future. This enables less churn in future PRs.

Changes are confined to the last commit in the tree.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
