### PR TITLE
Fix sizing of result array when calling GetScenePrimPaths with some invalid  instance indices

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -2674,7 +2674,7 @@ UsdImagingInstanceAdapter::GetScenePrimPaths(
                     }
                 }
 
-                result.resize(validIndices);
+                result.resize(instanceIndices.size());
                 _GetScenePrimPathsFn primPathsFn(
                     this, requestedIndicesMap, minIdx, result, proto.path);
                 _RunForAllInstancesToDraw(instancerPrim, &primPathsFn);

--- a/pxr/usdImaging/usdImaging/instanceAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/instanceAdapter.cpp
@@ -2654,6 +2654,10 @@ UsdImagingInstanceAdapter::GetScenePrimPaths(
                 }
             }
 
+            // Ensure the result vector is the same size as instanceIndices
+            // even if there are no valid instance indices.
+            result.resize(instanceIndices.size());
+
             // at least one index was valid, get the prim paths
             if (validIndices > 0) {
                 // For each valid requested index provide a mapping into the result vector
@@ -2674,7 +2678,6 @@ UsdImagingInstanceAdapter::GetScenePrimPaths(
                     }
                 }
 
-                result.resize(instanceIndices.size());
                 _GetScenePrimPathsFn primPathsFn(
                     this, requestedIndicesMap, minIdx, result, proto.path);
                 _RunForAllInstancesToDraw(instancerPrim, &primPathsFn);


### PR DESCRIPTION
### Description of Change(s)
Fix sizing of result array when calling GetScenePrimPaths with some invalid  instance indices. We always need the result to be the size of the original request array, not the size of the number of valid entries in the array. This fixes crashes that could occur because the entries in the "instance index to result vector index" map expect the result entries to line up with the entries in the original request, and thus would operate past the end of the array.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
