### PR TITLE
Make usdMtlx pass usdchecker

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -26,6 +26,7 @@
 #include "pxr/usd/usdMtlx/reader.h"
 #include "pxr/usd/usdMtlx/utils.h"
 
+#include "pxr/usd/usdGeom/metrics.h"
 #include "pxr/usd/usdGeom/primvar.h"
 #include "pxr/usd/usdGeom/primvarsAPI.h"
 #include "pxr/usd/usdShade/material.h"
@@ -786,7 +787,7 @@ _NodeGraphBuilder::Build(ShaderNamesByOutputName* outputs)
         }
     }
     else {
-        usdPrim = _usdStage->DefinePrim(_usdPath);
+        usdPrim = UsdShadeNodeGraph::Define(_usdStage, _usdPath).GetPrim();
     }
 
     // Build the graph of nodes.
@@ -2646,6 +2647,13 @@ UsdMtlxRead(
 
     // Translate all materials.
     ReadMaterials(mtlxDoc, context);
+
+    // Set layer metadata before potential early exit, note this won't survive
+    // composition across a reference, but is required to pass usdchecker
+    UsdGeomSetStageUpAxis(stage, UsdGeomGetFallbackUpAxis());
+    UsdGeomSetStageMetersPerUnit(stage, UsdGeomLinearUnits::centimeters);
+    stage->SetDefaultPrim(stage->GetPrimAtPath(internalPath));
+
 
     // If there are no looks then we're done.
     if (mtlxDoc->getLooks().empty()) {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
@@ -23,11 +23,14 @@
 # language governing permissions and limitations under the Apache License.
 
 from __future__ import print_function
-from pxr import Ar, Tf, Sdf, Usd, UsdMtlx, UsdShade
+from pxr import Ar, Tf, Sdf, Usd, UsdGeom, UsdMtlx, UsdShade
 import unittest
 
 def _EmptyLayer():
     stage = Usd.Stage.CreateInMemory()
+    UsdGeom.SetStageUpAxis(stage, UsdGeom.GetFallbackUpAxis())
+    UsdGeom.SetStageMetersPerUnit(stage, UsdGeom.LinearUnits.centimeters)
+    stage.SetDefaultPrim(Usd.Prim())
     return stage.GetRootLayer().ExportToString()
 
 class TestFileFormat(unittest.TestCase):


### PR DESCRIPTION
### Description of Change(s)

The USD MaterialX plugin would generate output files that would not pass usdchecker.
This PR (thanks to Lee Kerley) makes the following changes:

1. Top level NodeGraph is given a schema type. Otherwise it would fail the container check in usdchecker
2. Authors default prim so that it can be referenced reliably
3. Authors metersPerUnit and upAxis. Neither are necessary for materials, but I feel like it is good that usdcat outputs files that pass the checker to reduce confusion for people.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
