### PR TITLE
Autodesk: Revise test case comparison parameters to avoid false positive

### DIFF
--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -642,8 +642,8 @@ pxr_register_test(testUsdImagingGLBasicDrawing
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage basicDrawing/basicDrawing.usda -write testUsdImagingGLBasicDrawing.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing.png
-    FAIL 1
-    FAIL_PERCENT 1
+    FAIL 0.2
+    FAIL_PERCENT 0.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     ENV
@@ -681,7 +681,7 @@ pxr_register_test(testUsdImagingGLBasicDrawing_clipped
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawing_clipped.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.9
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLBasicDrawing
@@ -773,8 +773,8 @@ pxr_register_test(testUsdImagingGLBasicLighting
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -stage basicDrawing.usda -write testUsdImagingGLBasicLighting.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicLighting.png
-    FAIL 1
-    FAIL_PERCENT 1
+    FAIL 0.5
+    FAIL_PERCENT 0.1
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLBasicLighting
@@ -818,7 +818,7 @@ pxr_register_test(testUsdImagingGL_moreCurves
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCurves
@@ -829,7 +829,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_refined
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_refined.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.9
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCurves
@@ -840,7 +840,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_faketubes
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_faketubes.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.9
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCurves
@@ -851,7 +851,7 @@ pxr_register_test(testUsdImagingGL_moreCurves_tubes
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_moreCurves_tubes.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.9
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCurves
@@ -862,7 +862,7 @@ pxr_register_test(testUsdImagingGL_pinnedCurves
     IMAGE_DIFF_COMPARE
         testUsdImagingGL_pinnedCurves.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.2
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCurves
@@ -873,7 +873,7 @@ pxr_register_test(testUsdImagingGLPoints
     IMAGE_DIFF_COMPARE
         testUsdImagingGLPoints.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.9
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPoints
@@ -1196,7 +1196,7 @@ pxr_register_test(testUsdImagingGLSubdivisionSchemeNone
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivisionSchemeNone_1.png
         testUsdImagingGLSubdivisionSchemeNone_1.3.png
-    FAIL 1
+    FAIL 0.3
     FAIL_PERCENT 1
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
@@ -1208,7 +1208,7 @@ pxr_register_test(testUsdImagingGLSubdivisionSchemeNone_NoLights
     IMAGE_DIFF_COMPARE
         testUsdImagingGLSubdivisionSchemeNone_NoLights_1.png
         testUsdImagingGLSubdivisionSchemeNone_NoLights_1.3.png
-    FAIL 1
+    FAIL 0.2
     FAIL_PERCENT 1
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
@@ -1282,9 +1282,8 @@ pxr_register_test(testUsdImagingGLFlatShading
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -shading flat -stage primitives.usda -write testUsdImagingGLFlatShading.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFlatShading.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLFlatShading
 )
@@ -1293,9 +1292,8 @@ pxr_register_test(testUsdImagingGLShadeMaterial
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage coloredCubes.usda -write testUsdImagingGLShadeMaterial.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLShadeMaterial.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
+    FAIL 0.3
+    FAIL_PERCENT 0.9
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLShadeMaterial
     ENV
@@ -2143,7 +2141,6 @@ pxr_register_test(testUsdImagingGLPointInstancer_pi_pi_time
         pi_pi_time_001.png
     FAIL .05
     FAIL_PERCENT .03
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPointInstancer
 )
@@ -2430,7 +2427,6 @@ pxr_register_test(testUsdImagingGLPointInstancer_SceneIndex_pi_pi_time
         pi_pi_time_001.png
     FAIL .05
     FAIL_PERCENT .03
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPointInstancer_SceneIndex
     ENV
@@ -2503,7 +2499,6 @@ pxr_register_test(testUsdImagingGLResync
         world_2.png
     FAIL .05
     FAIL_PERCENT .03
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLResync
 )
@@ -2516,7 +2511,6 @@ pxr_register_test(testUsdImagingGLResync_instancer
         instancer_2.png
     FAIL .05
     FAIL_PERCENT .03
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLResync
 )
@@ -2556,9 +2550,8 @@ pxr_register_test(testUsdImagingGLPrimvarSharing_refined
         refined_000.png
         refined_001.png
         refined_002.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPrimvarSharing
     ENV
@@ -2722,9 +2715,8 @@ pxr_register_test(testUsdImagingGLNormals
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testNormals.usda -write testNormals.png"
     IMAGE_DIFF_COMPARE
         testNormals.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLNormals
 )
@@ -2832,7 +2824,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Displacement
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.7
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -3112,7 +3104,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Displacement
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 0.7
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -3671,9 +3663,8 @@ pxr_register_test(testUsdImagingGLUsdLux
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage usdLux.usda -write usdLux.png"
     IMAGE_DIFF_COMPARE
         usdLux.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdLux
 )
@@ -3801,9 +3792,8 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm_baked
         usdSkel_arm_baked_001.png
         usdSkel_arm_baked_003.png
         usdSkel_arm_baked_007.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdSkel
     ENV
@@ -3816,9 +3806,8 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_arm
         usdSkel_arm_extComp_CPU_001.png
         usdSkel_arm_extComp_CPU_003.png
         usdSkel_arm_extComp_CPU_007.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdSkel
     ENV
@@ -3829,9 +3818,8 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompCPU_twoBends
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -lighting -camlight -shading wireOnSurface -stage twoBends.usda -write usdSkel_twoBends_extComp_CPU.png"
     IMAGE_DIFF_COMPARE
         usdSkel_twoBends_extComp_CPU.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdSkel
     ENV
@@ -3844,9 +3832,8 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_arm_baked
         usdSkel_arm_baked_001.png
         usdSkel_arm_baked_003.png
         usdSkel_arm_baked_007.png
-    FAIL 1
+    FAIL 0.1
     FAIL_PERCENT 1
-    PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdSkel
     ENV
@@ -3951,7 +3938,6 @@ pxr_register_test(testUsdImagingGLMaterialStrengthOrder
     ENV
         USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX=true
 )
-
 
 pxr_register_test(testUsdImagingGLInstancePrimvars
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -frameAll -stage test.usda -write testUsdImagingGLInstancePrimvars.png"
@@ -4111,9 +4097,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_none
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_none.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_none.png
-    FAIL 1
-    FAIL_PERCENT 2
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.2
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4123,9 +4108,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_guides
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_guides.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_guides.png
-    FAIL 1
-    FAIL_PERCENT 2
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4135,9 +4119,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_render
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_render.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_render.png
-    FAIL 1
-    FAIL_PERCENT 2
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4147,9 +4130,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_proxy
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_proxy.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.35
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4159,9 +4141,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_all
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes.usd -write testUsdImagingGLInheritedPurpose_all.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_all.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4173,9 +4154,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_none
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_none.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_none.png
-    FAIL 1
-    FAIL_PERCENT 1.1
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.2
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4185,9 +4165,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_guides
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose hide -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_guides.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_guides.png
-    FAIL 1
-    FAIL_PERCENT 1.25
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4197,9 +4176,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_render
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose show -proxyPurpose hide -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_render.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_render.png
-    FAIL 1
-    FAIL_PERCENT 1.85
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4209,9 +4187,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_proxy
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose hide -renderPurpose hide -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_proxy.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_proxy.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4221,9 +4198,8 @@ pxr_register_test(testUsdImagingGLInheritedPurpose_Instanced_all
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -guidesPurpose show -renderPurpose show -proxyPurpose show -offscreen -lighting -frameAll -stage InheritedPurposes_Instanced.usd -write testUsdImagingGLInheritedPurpose_all.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLInheritedPurpose_all.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
+    FAIL 0.1
+    FAIL_PERCENT 0.4
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLInheritedPurpose
 )
@@ -4811,7 +4787,7 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxGeomprop.usda -write mxGeomprop.png"
         IMAGE_DIFF_COMPARE
             mxGeomprop.png
-        FAIL 0.5
+        FAIL 0.3
         FAIL_PERCENT 0.005
         WARN 0.05
         WARN_PERCENT 0.02


### PR DESCRIPTION
### Description of Change(s)

Problems:
As comparing test case output with baseline, the OIIO tool idiff consume a few options, e.g. -fail, -failpercent, -p (perceptual) and so on. From very beginning, the options value inputs are not reasonable to catch all of pixel changes. The false positive is found when using an alternative hgi backend. That is, a number of cases were passed, but rendering images are not correct. The results are not real positive.

Solutions:
Change test input parameters to be stricter in CMake file to successfully detect errors in the generated images. Another side, remove some perceptual options they are not proper to test for specific cases.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
