### PR TITLE
sdrOsl CMakeLists builds with Imath 3

### DIFF
--- a/pxr/usd/plugin/sdrOsl/CMakeLists.txt
+++ b/pxr/usd/plugin/sdrOsl/CMakeLists.txt
@@ -5,6 +5,12 @@ if(NOT PXR_ENABLE_OSL_SUPPORT)
     return()
 endif()
 
+if (Imath_FOUND)
+    set(__OSL_IMATH_LIBS "Imath::Imath")
+else()
+    set(__OSL_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
+endif()
+
 pxr_plugin(sdrOsl
     LIBRARIES
         gf
@@ -13,11 +19,12 @@ pxr_plugin(sdrOsl
         ar
         ndr
         sdr
+        ${__OSL_IMATH_LIBS}
         ${OSL_QUERY_LIBRARY}
         ${OIIO_LIBRARIES}
 
     INCLUDE_DIRS
-        ${OPENEXR_INCLUDE_DIR}
+        ${__OSL_IMATH_INCLUDE}
         ${OSL_INCLUDE_DIR}
         ${OIIO_INCLUDE_DIRS}
 


### PR DESCRIPTION
### Description of Change(s)
Pull https://github.com/PixarAnimationStudios/OpenUSD/pull/1829 fixed various CMake scripts to build with Imath/OpenEXR 3.x, however sdrOsl was not fixed.

These changes allow sdrOsl to build with Imath independently.

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/2977

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
