### PR TITLE
use MSVC preprocessor version when choosing macro versions in Tf's preprocessorUtilsLite.h

### DIFF
--- a/pxr/base/arch/defines.h
+++ b/pxr/base/arch/defines.h
@@ -107,4 +107,16 @@
 #define ARCH_HAS_MMAP_MAP_POPULATE
 #endif
 
+// When using MSVC, provide an easy way to detect whether the older
+// "traditional" preprocessor is being used as opposed to the newer, more
+// standards-conforming preprocessor. The traditional preprocessor may require
+// custom versions of macros.
+// See here for more detail about MSVC's preprocessors:
+// https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
+#if defined(ARCH_COMPILER_MSVC)
+    #if !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
+    #define ARCH_PREPROCESSOR_MSVC_TRADITIONAL
+    #endif
+#endif
+
 #endif // PXR_BASE_ARCH_DEFINES_H 

--- a/pxr/base/tf/preprocessorUtilsLite.h
+++ b/pxr/base/tf/preprocessorUtilsLite.h
@@ -45,7 +45,7 @@
 /// Expand and convert the argument to a string, using a most minimal macro.
 #define TF_PP_STRINGIZE(x) TF_PP_STRINGIZE_IMPL(x)
 
-#ifdef ARCH_COMPILER_MSVC
+#ifdef ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 
 /// Expand to the number of arguments passed.  For example,
 /// TF_PP_VARIADIC_SIZE(foo, bar, baz) expands to 3.  Supports up to 64
@@ -70,7 +70,7 @@
 /// and TF_PP_VARIADIC_ELEM(1, a, b, c) expands to b.
 #define TF_PP_VARIADIC_ELEM(n, ...) TF_PP_CAT(TF_PP_VAE_, n)(__VA_ARGS__,)
 
-#endif // ARCH_COMPILER_MSVC
+#endif // ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 
 #define TF_PP_VARIADIC_SIZE_IMPL(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62, a63, size, ...) size
 
@@ -139,7 +139,7 @@
 #define TF_PP_VAE_62(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62, ...) a62
 #define TF_PP_VAE_63(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61, a62, a63, ...) a63
 
-#ifdef ARCH_COMPILER_MSVC
+#ifdef ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 
 #define TF_PP_FE_0(_macro, ...)
 #define TF_PP_FE_1(_macro, a) _macro(a)
@@ -275,7 +275,7 @@
 
 #endif
 
-#ifdef ARCH_COMPILER_MSVC
+#ifdef ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 
 /// Expand the macro \p x on every variadic argument.  For example
 /// TF_PP_FOR_EACH(MACRO, foo, bar, baz) expands to MACRO(foo) MACRO(bar)
@@ -415,7 +415,7 @@
     _TF_PP_SEQ_EXPAND(_TF_PP_SEQ_DISCARD_HEAD _TF_PP_SEQ_PARTITION_HEAD(seq))
 
 #define _TF_PP_SEQ_FE_0(_macro, ...)
-#ifdef ARCH_COMPILER_MSVC
+#ifdef ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 #define _TF_PP_SEQ_FE_1(_macro, data, seq) TF_PP_CAT(_macro(data, _TF_PP_SEQ_HEAD(seq)),)
 // # Generates _TF_PP_SEQ_FE_{2:229} (MSVC)
 // python3 -c 'print("\n".join(f"#define _TF_PP_SEQ_FE_{i}(_macro, data, seq) TF_PP_CAT(_macro(data, _TF_PP_SEQ_HEAD(seq)),) TF_PP_CAT(_TF_PP_SEQ_FE_{i-1}(_macro, data, _TF_PP_SEQ_TAIL(seq)),)" for i in range(2, 230)))'
@@ -889,7 +889,7 @@
 /// #undef _PRINT
 /// \endcode
 /// Limited to sequences of up to 229 elements
-#ifdef ARCH_COMPILER_MSVC
+#ifdef ARCH_PREPROCESSOR_MSVC_TRADITIONAL
 #define _TF_PP_SEQ_FOR_EACH_IMPL(_macro, size, data, seq)                   \
     TF_PP_CAT(TF_PP_CAT(_TF_PP_SEQ_FE_, size),(_macro, data, seq))
 #define TF_PP_SEQ_FOR_EACH(_macro, data, seq)                               \


### PR DESCRIPTION
Hello!

When building with relatively recent versions of MSVC, one of two different versions of preprocessor may be in use. The older "traditional" preprocessor may in some cases treat macros differently versus other toolchains, particularly in cases that are officially undefined according to the language standard. In the past, this required specific versions of macros for MSVC. The newer, more standards-conforming preprocessor exhibits behavior much more closely aligned with other toolchains.

This new preprocessor was available in experimental form as early as Visual Studio 2017 version 15.8, but it is considered feature complete as of Visual Studio 2019 version 16.5. The compiler option `/Zc:preprocessor` can be used to enable the new preprocessor.

Enabling the new preprocessor currently causes compilation of OpenUSD to fail however, since it does not handle the custom set of macros for MSVC the same way as the traditional preprocessor. Here is an example of the kind of errors and warnings that are emitted:

```
C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debugCodes.h(37,1): error C4002: too many arguments for function-like macro invocation 'TF_PP_CAT_IMPL' [D:\OpenUSD_test_inst\build\OpenUSD\pxr\base\tf\tf.vcxproj]
  (compiling source file 'C:/Users/MattJohnson/Developer/OpenUSD/pxr/base/tf/scriptModuleLoader.cpp')
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debug.h(394,1):
  in expansion of macro 'TF_DEBUG_CODES'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debug.h(432,1):
  in expansion of macro 'TF_CONDITIONALLY_COMPILE_TIME_ENABLED_DEBUG_CODES'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\preprocessorUtilsLite.h(297,1):
  in expansion of macro 'TF_PP_FOR_EACH'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\preprocessorUtilsLite.h(40,1):
  in expansion of macro 'TF_PP_CAT'

C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debugCodes.h(53,1): warning C5103: pasting '"TF_DISCOVERY_TERSE"' and '"TF_DISCOVERY_DETAILED"' does not result in a valid preprocessing token [D:\OpenUSD_test_inst\build\OpenUSD\pxr\base\tf\tf.vcxproj]
  (compiling source file 'C:/Users/MattJohnson/Developer/OpenUSD/pxr/base/tf/scriptModuleLoader.cpp')
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debug.h(394,1):
  in expansion of macro 'TF_DEBUG_CODES'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\debug.h(432,1):
  in expansion of macro 'TF_CONDITIONALLY_COMPILE_TIME_ENABLED_DEBUG_CODES'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\preprocessorUtilsLite.h(297,1):
  in expansion of macro 'TF_PP_FOR_EACH'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\preprocessorUtilsLite.h(40,1):
  in expansion of macro 'TF_PP_CAT'
  C:\Users\MattJohnson\Developer\OpenUSD\pxr\base\tf\preprocessorUtilsLite.h(35,1):
  in expansion of macro 'TF_PP_CAT_IMPL'
```

This patch was used to enable MSVC's new preprocessor:
```
diff --git a/cmake/defaults/msvcdefaults.cmake b/cmake/defaults/msvcdefaults.cmake
index 0f7fb7ef6..682d814a6 100644
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -49,6 +49,9 @@ if (${PXR_STRICT_BUILD_MODE})
     set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /WX")
 endif()

+# Turn on the conforming preprocessor.
+set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:preprocessor")
+
 # The Visual Studio preprocessor does not conform to the C++ standard,
 # resulting in warnings like:
 #

```

The changes here define `ARCH_PREPROCESSOR_MSVC_TRADITIONAL` when building with MSVC using its traditional
preprocessor. This then replaces the use of `ARCH_COMPILER_MSVC` in `preprocessorUtilsLite.h` so that only in cases where we're
compiling with MSVC *and* using its traditional preprocessor do we use the alternate macros. Otherwise when using MSVC's newer, more standards-conforming preprocessor, we use the same macros as other toolchains.

See here for more detail about MSVC's preprocessors:
https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview

I ran the unit tests for each of two separate builds with these changes in place, once without the patch above causing the traditional preprocessor to be used and again with the patch applied to enable the new preprocessor. All tests passed for both runs.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
