### PR TITLE
Require strict URI scheme validation for `ArResolver`

### DIFF
--- a/pxr/usd/ar/testenv/testArURIResolver.py
+++ b/pxr/usd/ar/testenv/testArURIResolver.py
@@ -87,21 +87,10 @@ class TestArURIResolver(unittest.TestCase):
         invalid_utf8_path = "test-π-utf8:/abc.xyz"
         invalid_numeric_prefix_path = "113-test:/abc.xyz"
         invalid_colon_path = "other:test:/abc.xyz"
-        if Tf.GetEnvSetting("PXR_AR_DISABLE_STRICT_SCHEME_VALIDATION"):
-            self.assertEqual(resolver.Resolve(invalid_underbar_path),
-                             invalid_underbar_path)
-            self.assertEqual(resolver.Resolve(invalid_utf8_path),
-                             invalid_utf8_path)
-            self.assertEqual(resolver.Resolve(invalid_numeric_prefix_path),
-                             invalid_numeric_prefix_path)
-            # Even when strict scheme validation mode is disabled
-            # schemes with colons in them may fail to resolve
-            self.assertFalse(resolver.Resolve(invalid_colon_path))
-        else:
-            self.assertFalse(resolver.Resolve(invalid_underbar_path))
-            self.assertFalse(resolver.Resolve(invalid_utf8_path))
-            self.assertFalse(resolver.Resolve(invalid_numeric_prefix_path))
-            self.assertFalse(resolver.Resolve(invalid_colon_path))
+        self.assertFalse(resolver.Resolve(invalid_underbar_path))
+        self.assertFalse(resolver.Resolve(invalid_utf8_path))
+        self.assertFalse(resolver.Resolve(invalid_numeric_prefix_path))
+        self.assertFalse(resolver.Resolve(invalid_colon_path))
 
     def testGetRegisteredURISchemes(self):
         "Tests that all URI schemes for discovered plugins are returned"


### PR DESCRIPTION
### Description of Change(s)

#2453 validated URI schemes against the RFC 3986 and RFC 3987 specification by default. An environment variable could be set to make scheme validation more permissive. This change removes that environment variable, requiring all schemes identifiers to adhere to the specification.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
