### PR TITLE
[hdTiny] Remove LD_PRELOAD from testHdTiny

### DIFF
--- a/extras/imaging/examples/hdTiny/CMakeLists.txt
+++ b/extras/imaging/examples/hdTiny/CMakeLists.txt
@@ -35,7 +35,6 @@ pxr_install_test_dir(
 if (APPLE)
     pxr_register_test(testHdTiny
         ENV
-            DYLD_INSERT_LIBRARIES=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.dylib
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
         STDOUT_REDIRECT output.txt
@@ -44,7 +43,6 @@ if (APPLE)
 elseif (UNIX)
     pxr_register_test(testHdTiny
         ENV
-            LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.so
             ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
         STDOUT_REDIRECT output.txt


### PR DESCRIPTION
### Description of Change(s)

`testHdTiny` was setting the `LD_PRELOAD` environment variable to that path pointing at `tinyHd.so`. Setting `LD_PRELOAD` seems to be unnecessary as `hdTiny` produces a plugInfo.json which should correctly load `tinyHd.so`. The `testHdTiny` test also passes without the use of `LD_PRELOAD`

This was initially discovered from https://github.com/PixarAnimationStudios/OpenUSD/pull/2994. Address sanitizers require the use of `LD_PRELOAD` to properly patch memory allocation function. `testHdTiny` would always fail with address sanitizers enabled since it overwrites `LD_PRELOAD`

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
