### PR TITLE
[hd, hdx] Move tracing macros in InsertTask<T>

### DIFF
--- a/pxr/imaging/hd/renderIndex.cpp
+++ b/pxr/imaging/hd/renderIndex.cpp
@@ -540,12 +540,17 @@ HdRenderIndex::_Clear()
 
 void
 HdRenderIndex::_TrackDelegateTask(HdSceneDelegate* delegate,
-                                    SdfPath const& taskId,
-                                    HdTaskSharedPtr const& task)
+                                  SdfPath const& taskId,
+                                  HdTaskCreateFnc taskCreateFnc)
 {
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
     if (taskId == SdfPath()) {
         return;
     }
+
+    HdTaskSharedPtr task = taskCreateFnc(delegate, taskId);
     _tracker.TaskInserted(taskId, task->GetInitialDirtyBitsMask());
     _taskMap.emplace(taskId, _TaskInfo{delegate, task});
 }

--- a/pxr/imaging/hdx/unitTestDelegate.cpp
+++ b/pxr/imaging/hdx/unitTestDelegate.cpp
@@ -61,47 +61,6 @@ TF_DEFINE_PRIVATE_TOKENS(
 );
 
 
-// XXX: These mostly-empty subclasses are here to prevent a link-time
-// optimization with HdRenderIndex::InsertTask<T>(), hdx/taskController.cpp and
-// HD_TRACE_FUNCTION() for address sanitized builds of USD. Without these
-// classes the linker will incorrectly "optimize" calls to the expanded
-// HD_TRACE_FUNCTION() in GetRenderIndex()->InsertTask<HdxPickTask>() for
-// taskController.cpp.
-class Hdx_UnitTestPickTask : public HdxPickTask {
-public:
-    HDX_API
-    Hdx_UnitTestPickTask(HdSceneDelegate *delegate, SdfPath const &id)
-        : HdxPickTask(delegate, id) {}
-};
-
-class Hdx_UnitTestShadowTask : public HdxShadowTask {
-public:
-    HDX_API
-    Hdx_UnitTestShadowTask(HdSceneDelegate *delegate, SdfPath const &id)
-        : HdxShadowTask(delegate, id) {}
-};
-
-class Hdx_UnitTestSimpleLightTask : public HdxSimpleLightTask {
-public:
-    HDX_API
-    Hdx_UnitTestSimpleLightTask(HdSceneDelegate *delegate, SdfPath const &id)
-        : HdxSimpleLightTask(delegate, id) {}
-};
-
-class Hdx_UnitTestSelectionTask : public HdxSelectionTask {
-public:
-    HDX_API
-    Hdx_UnitTestSelectionTask(HdSceneDelegate *delegate, SdfPath const &id)
-        : HdxSelectionTask(delegate, id) {}
-};
-
-class Hdx_UnitTestRenderTask : public HdxRenderTask {
-public:
-    HDX_API
-    Hdx_UnitTestRenderTask(HdSceneDelegate *delegate, SdfPath const &id)
-        : HdxRenderTask(delegate, id) {}
-};
-
 static void
 _CreateGrid(int nx, int ny, VtVec3fArray *points,
             VtIntArray *numVerts, VtIntArray *verts)
@@ -447,7 +406,7 @@ Hdx_UnitTestDelegate::SetDrawTarget(SdfPath const &id, TfToken const &key,
 void
 Hdx_UnitTestDelegate::AddRenderTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<Hdx_UnitTestRenderTask>(this, id);
+    GetRenderIndex().InsertTask<HdxRenderTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     cache[HdTokens->collection]
         = HdRprimCollection(HdTokens->geometry, 
@@ -472,7 +431,7 @@ Hdx_UnitTestDelegate::AddRenderSetupTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddSimpleLightTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<Hdx_UnitTestSimpleLightTask>(this, id);
+    GetRenderIndex().InsertTask<HdxSimpleLightTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     HdxSimpleLightTaskParams params;
     params.cameraPath = _cameraId;
@@ -486,7 +445,7 @@ Hdx_UnitTestDelegate::AddSimpleLightTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddShadowTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<Hdx_UnitTestShadowTask>(this, id);
+    GetRenderIndex().InsertTask<HdxShadowTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     HdxShadowTaskParams params;
     cache[HdTokens->params] = VtValue(params);
@@ -495,7 +454,7 @@ Hdx_UnitTestDelegate::AddShadowTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddSelectionTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<Hdx_UnitTestSelectionTask>(this, id);
+    GetRenderIndex().InsertTask<HdxSelectionTask>(this, id);
 }
 
 void
@@ -512,7 +471,7 @@ Hdx_UnitTestDelegate::AddDrawTargetTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddPickTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<Hdx_UnitTestPickTask>(this, id);
+    GetRenderIndex().InsertTask<HdxPickTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
 
     HdxPickTaskParams params;

--- a/pxr/imaging/hdx/unitTestDelegate.cpp
+++ b/pxr/imaging/hdx/unitTestDelegate.cpp
@@ -58,7 +58,49 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     (renderBufferDescriptor)
-);    
+);
+
+
+// XXX: These mostly-empty subclasses are here to prevent a link-time
+// optimization with HdRenderIndex::InsertTask<T>(), hdx/taskController.cpp and
+// HD_TRACE_FUNCTION() for address sanitized builds of USD. Without these
+// classes the linker will incorrectly "optimize" calls to the expanded
+// HD_TRACE_FUNCTION() in GetRenderIndex()->InsertTask<HdxPickTask>() for
+// taskController.cpp.
+class Hdx_UnitTestPickTask : public HdxPickTask {
+public:
+    HDX_API
+    Hdx_UnitTestPickTask(HdSceneDelegate *delegate, SdfPath const &id)
+        : HdxPickTask(delegate, id) {}
+};
+
+class Hdx_UnitTestShadowTask : public HdxShadowTask {
+public:
+    HDX_API
+    Hdx_UnitTestShadowTask(HdSceneDelegate *delegate, SdfPath const &id)
+        : HdxShadowTask(delegate, id) {}
+};
+
+class Hdx_UnitTestSimpleLightTask : public HdxSimpleLightTask {
+public:
+    HDX_API
+    Hdx_UnitTestSimpleLightTask(HdSceneDelegate *delegate, SdfPath const &id)
+        : HdxSimpleLightTask(delegate, id) {}
+};
+
+class Hdx_UnitTestSelectionTask : public HdxSelectionTask {
+public:
+    HDX_API
+    Hdx_UnitTestSelectionTask(HdSceneDelegate *delegate, SdfPath const &id)
+        : HdxSelectionTask(delegate, id) {}
+};
+
+class Hdx_UnitTestRenderTask : public HdxRenderTask {
+public:
+    HDX_API
+    Hdx_UnitTestRenderTask(HdSceneDelegate *delegate, SdfPath const &id)
+        : HdxRenderTask(delegate, id) {}
+};
 
 static void
 _CreateGrid(int nx, int ny, VtVec3fArray *points,
@@ -405,7 +447,7 @@ Hdx_UnitTestDelegate::SetDrawTarget(SdfPath const &id, TfToken const &key,
 void
 Hdx_UnitTestDelegate::AddRenderTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<HdxRenderTask>(this, id);
+    GetRenderIndex().InsertTask<Hdx_UnitTestRenderTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     cache[HdTokens->collection]
         = HdRprimCollection(HdTokens->geometry, 
@@ -430,7 +472,7 @@ Hdx_UnitTestDelegate::AddRenderSetupTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddSimpleLightTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<HdxSimpleLightTask>(this, id);
+    GetRenderIndex().InsertTask<Hdx_UnitTestSimpleLightTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     HdxSimpleLightTaskParams params;
     params.cameraPath = _cameraId;
@@ -444,7 +486,7 @@ Hdx_UnitTestDelegate::AddSimpleLightTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddShadowTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<HdxShadowTask>(this, id);
+    GetRenderIndex().InsertTask<Hdx_UnitTestShadowTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
     HdxShadowTaskParams params;
     cache[HdTokens->params] = VtValue(params);
@@ -453,7 +495,7 @@ Hdx_UnitTestDelegate::AddShadowTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddSelectionTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<HdxSelectionTask>(this, id);
+    GetRenderIndex().InsertTask<Hdx_UnitTestSelectionTask>(this, id);
 }
 
 void
@@ -470,7 +512,7 @@ Hdx_UnitTestDelegate::AddDrawTargetTask(SdfPath const &id)
 void
 Hdx_UnitTestDelegate::AddPickTask(SdfPath const &id)
 {
-    GetRenderIndex().InsertTask<HdxPickTask>(this, id);
+    GetRenderIndex().InsertTask<Hdx_UnitTestPickTask>(this, id);
     _ValueCache &cache = _valueCacheMap[id];
 
     HdxPickTaskParams params;


### PR DESCRIPTION
### Description of Change(s)

This PR fixes a very hard to identify issue with link time optimization (-flto) for `hdx/taskController.cpp` where `GetRenderIndex()->InsertTask<HdxTask>()` would fail with cryptic error messages for release builds of USD with address sanitizers.

Effectively, `GetRenderIndex()->InsertTask<HdxPickTask>()` is defined in `hdx/unitTestDelegate.cpp` and `hdx/taskController.cpp`. The linker will, understandably, optimize out the symbol(s) in `hdx/taskController.o` since `hdx/unitTestDelegate.o` defines it first. This causes a linker error since it's `GetRenderIndex()->InsertTask<HdxPickTask>()` has been instrumented with ASan inside of `taskController.cpp`

An example of the error for a release build with address sanitizers enabled:

```bash
`_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_11HdxPickTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__' referenced in section `.data.rel.local' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o: defined in discarded section `.rodata._ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_11HdxPickTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__[_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_11HdxPickTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE16TraceKeyData_596]' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o
`_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxShadowTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__' referenced in section `.data.rel.local' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o: defined in discarded section `.rodata._ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxShadowTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__[_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxShadowTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE16TraceKeyData_596]' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o
`_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_18HdxSimpleLightTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__' referenced in section `.data.rel.local' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o: defined in discarded section `.rodata._ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_18HdxSimpleLightTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__[_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_18HdxSimpleLightTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE16TraceKeyData_596]' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o
`_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_16HdxSelectionTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__' referenced in section `.data.rel.local' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o: defined in discarded section `.rodata._ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_16HdxSelectionTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__[_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_16HdxSelectionTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE16TraceKeyData_596]' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o
`_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxRenderTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__' referenced in section `.data.rel.local' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o: defined in discarded section `.rodata._ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxRenderTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE8__func__[_ZZN32pxrInternal_v0_24__pxrReserved__13HdRenderIndex10InsertTaskINS_13HdxRenderTaskEEEvPNS_15HdSceneDelegateERKNS_7SdfPathEE16TraceKeyData_596]' of pxr/imaging/hdx/CMakeFiles/hdx.dir/taskController.cpp.o
```

The root of the issue is caused by the [HD_TRACE_FUNCTION in renderIndex.h](https://github.com/PixarAnimationStudios/OpenUSD/blob/v24.03/pxr/imaging/hd/renderIndex.h#L596). With this macro disabled, a release build of USD with address sanitizers will not encounter this error.

To circumvent this, the `HD_TRACE_FUNCTION` and `HF_MALLOC_TAG_FUNCTION` macros have been relocated into `_TrackDelegateTask`. The `_TrackDelegateTask` function now accepts a task creation function to create the actual `HdTask `. This prevents the weird link-time optimization error shown above.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
