### PR TITLE
Autodesk: Add support for controlling how floats and doubles are streamed out

### DIFF
--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -947,32 +947,115 @@ Tf_GetDoubleToStringConverter()
     return conv;
 }
 
-void
-Tf_ApplyDoubleToStringConverter(float val, char* buffer, int bufferSize)
+bool Tf_IsNegative(const char* const buffer) {
+    return buffer[0] == '-';
+}
+
+bool Tf_IsZero(const char* const buffer)
 {
-    const auto& conv = Tf_GetDoubleToStringConverter();
-    pxr_double_conversion::StringBuilder builder(buffer, bufferSize);
-    // This should only fail if we provide an insufficient buffer.
-    TF_VERIFY(conv.ToShortestSingle(val, &builder),
-              "double_conversion failed");
+    // As text representations of numbers can vary, we only check
+    // that the string does not contain numbers 1-9.
+    //
+    // Though a non-zero exponent on 0 is still 0, and we could thus
+    // break once when reach the exponent, we expect zeroes to also
+    // use an exponent of 0 for consistency; this is already the
+    // current behavior of the string conversion implementation.
+    for (const char* it = buffer; *it; it++) {
+        if ('1' <= *it && *it <= '9') {
+            return false;
+        }
+    }
+    return true;
+}
+
+void Tf_StripNegativeSign(char* buffer) {
+    if (!Tf_IsNegative(buffer)) {
+        return;
+    }
+    // Left-shift all characters by one position, clobbering the first one.
+    for (char* it = buffer; *it; it++) {
+        *it = *(it + 1);
+    } 
 }
 
 void
-Tf_ApplyDoubleToStringConverter(double val, char* buffer, int bufferSize)
+Tf_ApplyDoubleToStringConverter(float val, char* buffer, int bufferSize, const TfDecimalToStringConfig& toStringConfig)
 {
     const auto& conv = Tf_GetDoubleToStringConverter();
     pxr_double_conversion::StringBuilder builder(buffer, bufferSize);
-    // This should only fail if we provide an insufficient buffer.
-    TF_VERIFY(conv.ToShortest(val, &builder),
-              "double_conversion failed");
+    constexpr const char* missingDigitsErrorMessage = "Decimal to string mode requires a number of digits to use but none was specified.";
+    constexpr const char* conversionErrorMessage = "Float conversion to string failed.";
+    switch (toStringConfig.mode) {
+        case TfDecimalToStringMode::SHORTEST:
+            TF_VERIFY(conv.ToShortestSingle(val, &builder), conversionErrorMessage);
+            break;
+        case TfDecimalToStringMode::FIXED:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToFixed(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        case TfDecimalToStringMode::EXPONENTIAL:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToExponential(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        case TfDecimalToStringMode::PRECISION:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToPrecision(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        default:
+            TF_CODING_ERROR("Tried converting a float to a string with a non-existent mode.");
+            break;
+    }
+    builder.Finalize();
+    if (!toStringConfig.allowNegativeZero && Tf_IsNegative(buffer) && Tf_IsZero(buffer)) {
+        Tf_StripNegativeSign(buffer);
+    }
+}
+
+void
+Tf_ApplyDoubleToStringConverter(double val, char* buffer, int bufferSize, const TfDecimalToStringConfig& toStringConfig)
+{
+    const auto& conv = Tf_GetDoubleToStringConverter();
+    pxr_double_conversion::StringBuilder builder(buffer, bufferSize);
+    constexpr const char* missingDigitsErrorMessage = "Decimal to string mode requires a number of digits to use but none was specified.";
+    constexpr const char* conversionErrorMessage = "Double conversion to string failed.";
+    switch (toStringConfig.mode) {
+        case TfDecimalToStringMode::SHORTEST:
+            TF_VERIFY(conv.ToShortest(val, &builder), conversionErrorMessage);
+            break;
+        case TfDecimalToStringMode::FIXED:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToFixed(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        case TfDecimalToStringMode::EXPONENTIAL:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToExponential(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        case TfDecimalToStringMode::PRECISION:
+            if (TF_VERIFY(toStringConfig.digits.has_value(), missingDigitsErrorMessage)) {
+                TF_VERIFY(conv.ToPrecision(val, toStringConfig.digits.value(), &builder), conversionErrorMessage);
+            }
+            break;
+        default:
+            TF_CODING_ERROR("Tried converting a double to a string with a non-existent mode.");
+            break;
+    }
+    builder.Finalize();
+    if (!toStringConfig.allowNegativeZero && Tf_IsNegative(buffer) && Tf_IsZero(buffer)) {
+        Tf_StripNegativeSign(buffer);
+    }
 }
 
 std::string
-TfStringify(float val)
+TfStringify(float val, TfDecimalToStringConfig toStringConfig/* = {}*/)
 {
     constexpr int bufferSize = 128;
     char buffer[bufferSize];
-    Tf_ApplyDoubleToStringConverter(val, buffer, bufferSize);
+    Tf_ApplyDoubleToStringConverter(val, buffer, bufferSize, toStringConfig);
     return std::string(buffer);
 }
 
@@ -1004,12 +1087,19 @@ TfDoubleToString(
 }
 
 std::string
-TfStringify(double val)
+TfStringify(double val, TfDecimalToStringConfig toStringConfig/* = {}*/)
 {
     constexpr int bufferSize = 128;
     char buffer[bufferSize];
-    Tf_ApplyDoubleToStringConverter(val, buffer, bufferSize);
+    Tf_ApplyDoubleToStringConverter(val, buffer, bufferSize, toStringConfig);
     return std::string(buffer);
+}
+
+thread_local TfDecimalToStringConfig TfStreamFloat::_toStringConfig{};
+
+TfDecimalToStringConfig& TfStreamFloat::ToStringConfig()
+{
+    return _toStringConfig;
 }
 
 std::ostream& 
@@ -1017,8 +1107,15 @@ operator<<(std::ostream& o, TfStreamFloat t)
 {
     constexpr int bufferSize = 128;
     char buffer[bufferSize];
-    Tf_ApplyDoubleToStringConverter(t.value, buffer, bufferSize);
+    Tf_ApplyDoubleToStringConverter(t.value, buffer, bufferSize, TfStreamFloat::ToStringConfig());
     return o << buffer;
+}
+
+thread_local TfDecimalToStringConfig TfStreamDouble::_toStringConfig{};
+
+TfDecimalToStringConfig& TfStreamDouble::ToStringConfig()
+{
+    return _toStringConfig;
 }
 
 std::ostream& 
@@ -1026,7 +1123,7 @@ operator<<(std::ostream& o, TfStreamDouble t)
 {
     constexpr int bufferSize = 128;
     char buffer[bufferSize];
-    Tf_ApplyDoubleToStringConverter(t.value, buffer, bufferSize);
+    Tf_ApplyDoubleToStringConverter(t.value, buffer, bufferSize, TfStreamDouble::ToStringConfig());
     return o << buffer;
 }
 

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -39,6 +39,7 @@
 #include <cstdarg>
 #include <cstring>
 #include <list>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -585,10 +586,24 @@ TfStringify(const T& v)
 TF_API std::string TfStringify(bool v);
 /// \overload
 TF_API std::string TfStringify(std::string const&);
+
+enum class TfDecimalToStringMode {
+    SHORTEST,
+    FIXED,
+    EXPONENTIAL,
+    PRECISION
+};
+
+struct TfDecimalToStringConfig {
+    TfDecimalToStringMode mode{TfDecimalToStringMode::SHORTEST};
+    std::optional<int> digits{};
+    bool allowNegativeZero{true};
+};
+
 /// \overload
-TF_API std::string TfStringify(float);
+TF_API std::string TfStringify(float, TfDecimalToStringConfig toStringConfig = {});
 /// \overload
-TF_API std::string TfStringify(double);
+TF_API std::string TfStringify(double, TfDecimalToStringConfig toStringConfig = {});
 
 /// Writes the string representation of \c d to \c buffer of length \c len. 
 /// If \c emitTrailingZero is true, the string representation will end with .0 
@@ -601,22 +616,38 @@ TF_API bool TfDoubleToString(
 
 /// \struct TfStreamFloat
 /// 
-/// A type which offers streaming for floats in a canonical
-/// format that can safely roundtrip with the minimal number of digits.
+/// A type which offers configurable streaming for floats in a canonical format.
+/// The default values of \ref TfDecimalToStringConfig allow for safe roundtripping
+/// with the minimal number of digits.
 struct TfStreamFloat {
     explicit TfStreamFloat(float f) : value(f) {}
     float value;
+
+    /// Returns a reference to the thread-local string conversion configuration.
+    TF_API
+    static TfDecimalToStringConfig& ToStringConfig();
+
+private:
+    static thread_local TfDecimalToStringConfig _toStringConfig;
 };
 
 TF_API std::ostream& operator<<(std::ostream& o, TfStreamFloat t);
 
 /// \struct TfStreamDouble
 ///
-/// A type which offers streaming for doubles in a canonical
-/// format that can safely roundtrip with the minimal number of digits.
+/// A type which offers configurable streaming for doubles in a canonical format.
+/// The default values of \ref TfDecimalToStringConfig allow for safe roundtripping
+/// with the minimal number of digits.
 struct TfStreamDouble {
     explicit TfStreamDouble(double d) : value(d) {}
     double value;
+
+    /// Returns a reference to the thread-local string conversion configuration.
+    TF_API
+    static TfDecimalToStringConfig& ToStringConfig();
+
+private:
+    static thread_local TfDecimalToStringConfig _toStringConfig;
 };
 
 TF_API std::ostream& operator<<(std::ostream& o, TfStreamDouble t);

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -36,6 +36,22 @@
 using namespace std;
 PXR_NAMESPACE_USING_DIRECTIVE
 
+static void TestFloatStreaming(float originalValue, const char* const textRepresentation, float readValue)
+{
+    std::stringstream sstr;
+    sstr << TfStreamFloat(originalValue);
+    TF_AXIOM(sstr.str() == textRepresentation);
+    TF_AXIOM(static_cast<float>(TfStringToDouble(sstr.str())) == readValue);
+}
+
+static void TestDoubleStreaming(double originalValue, const char* const textRepresentation, double readValue)
+{
+    std::stringstream sstr;
+    sstr << TfStreamDouble(originalValue);
+    TF_AXIOM(sstr.str() == textRepresentation);
+    TF_AXIOM(TfStringToDouble(sstr.str()) == readValue);
+}
+
 static bool
 TestNumbers()
 {
@@ -84,6 +100,70 @@ TestNumbers()
 
     sstr << TfStreamFloat(0.84066f);
     TF_AXIOM(float(TfStringToDouble(sstr.str())) == 0.84066f);
+
+    TfDecimalToStringConfig shortestConfig = { TfDecimalToStringMode::SHORTEST, {}, true };
+    TfStreamDouble::ToStringConfig() = shortestConfig;
+    TfStreamFloat::ToStringConfig() = shortestConfig;
+    TestDoubleStreaming(0.1, "0.1", 0.1);
+    TestDoubleStreaming(2.7468493, "2.7468493", 2.7468493);
+    TestDoubleStreaming(-0.00008, "-0.00008", -0.00008);
+    TestDoubleStreaming(-0.0, "-0", -0.0);
+    TestFloatStreaming(0.1f, "0.1", 0.1f);
+    TestFloatStreaming(2.7468493f, "2.7468493", 2.7468493f);
+    TestFloatStreaming(-0.00008f, "-0.00008", -0.00008f);
+    TestFloatStreaming(-0.0f, "-0", -0.0f);
+    TfStreamDouble::ToStringConfig().allowNegativeZero = false;
+    TfStreamFloat::ToStringConfig().allowNegativeZero = false;
+    TestDoubleStreaming(-0.0, "0", 0.0);
+    TestFloatStreaming(-0.0f, "0", 0.0f);
+
+    TfDecimalToStringConfig fixedConfig = { TfDecimalToStringMode::FIXED, 3, true };
+    TfStreamDouble::ToStringConfig() = fixedConfig;
+    TfStreamFloat::ToStringConfig() = fixedConfig;
+    TestDoubleStreaming(0.1, "0.100", 0.1);
+    TestDoubleStreaming(2.7468493, "2.747", 2.747);
+    TestDoubleStreaming(-0.00008, "-0.000", 0.0);
+    TestDoubleStreaming(-0.0, "-0.000", -0.0);
+    TestFloatStreaming(0.1f, "0.100", 0.1f);
+    TestFloatStreaming(2.7468493f, "2.747", 2.747f);
+    TestFloatStreaming(-0.00008f, "-0.000", 0.0f);
+    TestFloatStreaming(-0.0f, "-0.000", -0.0f);
+    TfStreamDouble::ToStringConfig().allowNegativeZero = false;
+    TfStreamFloat::ToStringConfig().allowNegativeZero = false;
+    TestDoubleStreaming(-0.00008, "0.000", 0.0);
+    TestFloatStreaming(-0.00008f, "0.000", 0.0f);
+
+    TfDecimalToStringConfig exponentialConfig = { TfDecimalToStringMode::EXPONENTIAL, 5, true };
+    TfStreamDouble::ToStringConfig() = exponentialConfig;
+    TfStreamFloat::ToStringConfig() = exponentialConfig;
+    TestDoubleStreaming(0.1, "1.00000e-1", 0.1);
+    TestDoubleStreaming(2.7468493, "2.74685e0", 2.74685);
+    TestDoubleStreaming(-0.00008, "-8.00000e-5", -0.00008);
+    TestDoubleStreaming(-0.0, "-0.00000e0", -0.0);
+    TestFloatStreaming(0.1f, "1.00000e-1", 0.1f);
+    TestFloatStreaming(2.7468493f, "2.74685e0", 2.74685f);
+    TestFloatStreaming(-0.00008f, "-8.00000e-5", -0.00008f);
+    TestFloatStreaming(-0.0f, "-0.00000e0", -0.0f);
+    TfStreamDouble::ToStringConfig().allowNegativeZero = false;
+    TfStreamFloat::ToStringConfig().allowNegativeZero = false;
+    TestDoubleStreaming(-0.0, "0.00000e0", 0.0);
+    TestFloatStreaming(-0.0f, "0.00000e0", 0.0f);
+
+    TfDecimalToStringConfig precisionConfig = { TfDecimalToStringMode::PRECISION, 2, true };
+    TfStreamDouble::ToStringConfig() = precisionConfig;
+    TfStreamFloat::ToStringConfig() = precisionConfig;
+    TestDoubleStreaming(0.1, "1.0e-1", 0.1);
+    TestDoubleStreaming(2.7468493, "2.7", 2.7);
+    TestDoubleStreaming(-0.00008, "-8.0e-5", -0.00008);
+    TestDoubleStreaming(-0.0, "-0.0", -0.0);
+    TestFloatStreaming(0.1f, "1.0e-1", 0.1f);
+    TestFloatStreaming(2.7468493f, "2.7", 2.7f);
+    TestFloatStreaming(-0.00008f, "-8.0e-5", -0.00008f);
+    TestFloatStreaming(-0.0f, "-0.0", -0.0f);
+    TfStreamDouble::ToStringConfig().allowNegativeZero = false;
+    TfStreamFloat::ToStringConfig().allowNegativeZero = false;
+    TestDoubleStreaming(-0.0, "0.0", 0.0);
+    TestFloatStreaming(-0.0f, "0.0", 0.0f);
 
     constexpr int bufferSize = 25;
     char buffer[bufferSize];


### PR DESCRIPTION
### Description of Change(s)

This PR adds a few options to control the format in which floats and doubles are streamed out by USD through the `TfStreamFloat` and `TfStreamDouble` classes. This PR strictly adds extra functionality and does not break the existing API and behavior; if no custom configuration is provided, the defaults will behave the same as before.

The original motivation behind this change was to allow us to dump Hydra data sources to text using the `HdDebugPrintDataSource` method, but using a given precision, in order to account for platform and architecture discrepancies. This in turn allows us to use the data source text dumps as reference values for tests.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
