### PR TITLE
Fix rendering of Unlit shaders (Issue 3015)

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -409,8 +409,12 @@ HdStMaterialXShaderGen<Base>::_EmitMxInitFunction(
     Base::emitComment("Convert HdData to MxData", mxStage);
 
     // Initialize the position of the view in worldspace
-    emitLine("u_viewPosition = vec3(HdGet_worldToViewInverseMatrix()"
-             " * vec4(0.0, 0.0, 0.0, 1.0))", mxStage);
+    const mx::VariableBlock& uniforms = mxStage.getUniformBlock(mx::HW::PRIVATE_UNIFORMS);
+    if (uniforms.find(mx::HW::T_VIEW_POSITION) != nullptr) {
+        emitLine("u_viewPosition = vec3(HdGet_worldToViewInverseMatrix()"
+                " * vec4(0.0, 0.0, 0.0, 1.0))", mxStage);
+    }
+
     
     // Calculate the worldspace position, normal and tangent vectors
     const std::string texcoordName =


### PR DESCRIPTION
### Description of Change(s)

This PR makes sure that the shadergen checks that the View Position constant is present before it writes code that depends on it.

This fixes cases for shaders like unlit that do not depend on view direction in the rest of their shader code. 

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3015

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
