### PR TITLE
OCIO DisplayViewTransform uses display name as colourspace if display_colorspace is <USE_DISPLAY_NAME> in OCIO config

### DIFF
--- a/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
+++ b/pxr/usdImaging/usdviewq/viewSettingsDataModel.py
@@ -463,7 +463,9 @@ class ViewSettingsDataModel(StateSource, QtCore.QObject):
         """Specifies the OCIO settings to be used. Setting the OCIO 'display'
            requires a 'view' to be specified."""
 
-        if colorSpace:
+        if colorSpace and colorSpace == "<USE_DISPLAY_NAME>":
+                self._ocioSettings._colorSpace = display
+        elif colorSpace:
             self._ocioSettings._colorSpace = colorSpace
 
         if display:


### PR DESCRIPTION
OCIO DisplayViewTransform uses display name as colourspace if display_colorspace is <USE_DISPLAY_NAME> in OCIO config

### Description of Change(s)
OCIO 2 allows View transforms in an OCIO config to set their display_colorspace to <USE_DISPLAY_NAME> to use the Display name to find the display colorspace. Usdview does not handle this, and therefore errors stating that it can't find a colorspace named <USE_DISPLAY_NAME>. 

This change adds a simple check to use the display name as the colorspace in Usdview if the incoming colorspace is <USE_DISPLAY_NAME>.

### Fixes Issue(s)
- No existing issues that I can find

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
