### PR TITLE
Add missing <algorithm> include

### DIFF
--- a/pxr/imaging/hd/sortedIds.cpp
+++ b/pxr/imaging/hd/sortedIds.cpp
@@ -24,6 +24,8 @@
 #include "pxr/imaging/hd/sortedIds.h"
 #include "pxr/imaging/hd/perfLog.h"
 
+#include <algorithm>
+
 static const ptrdiff_t INVALID_DELETE_POINT = -1;
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hgiVulkan/garbageCollector.cpp
+++ b/pxr/imaging/hgiVulkan/garbageCollector.cpp
@@ -36,6 +36,7 @@
 #include "pxr/base/arch/hints.h"
 #include "pxr/base/tf/diagnostic.h"
 
+#include <algorithm>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
On newer msvc toolchains there is a C2039/C3861 error about `iter_swap` not being a member of `std`.

### Description of Change(s)

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
