### PR TITLE
Autodesk: Optimize RenderIndex removal

### DIFF
--- a/pxr/imaging/hd/sortedIds.h
+++ b/pxr/imaging/hd/sortedIds.h
@@ -75,6 +75,7 @@ public:
 
 private:
     SdfPathVector           _ids;
+    std::unordered_map<SdfPath, size_t, SdfPath::Hash> _idIndices;
     size_t                  _sortedCount;
     ptrdiff_t               _afterLastDeletePoint;
 

--- a/pxr/imaging/hd/testenv/testHdSceneIndex.cpp
+++ b/pxr/imaging/hd/testenv/testHdSceneIndex.cpp
@@ -594,7 +594,7 @@ TestPrefixingSceneIndex()
     // 
     if (!_CompareValue("TESTING GetChildPrimPaths('/E/F/G/A'))",
             prefixingSceneIndex.GetChildPrimPaths(SdfPath("/E/F/G/A")), 
-            SdfPathVector({SdfPath("/E/F/G/A/C"), SdfPath("/E/F/G/A/B")})
+            SdfPathVector({SdfPath("/E/F/G/A/B"), SdfPath("/E/F/G/A/C")})
             )) {
         return false;
     }


### PR DESCRIPTION
### Description of Change(s)

There are two parts to this optimization.

- Optimize SceneIndex removal:
   - Modify _Entry storage for better alignment;
   - Use double link for the tree in `SdfPathTable`.

- Optimize RenderIndex removal:
    - Add indices container to avoid linear search.

There are mainly two issues in `SdfPathTable` and `Hd_SortedIds` separately.

1. `SdfPathTable`:
The one-way linked list in the node results in a linear search. This will cause O(n^2) time when deleting items one by one. To fix this problem, we replace it with double-way linked lists.
Besides, storing the exact value in the data structure may trigger the page fault more frequently, especially when data size increases. We then replace that with a fixed-size pointer.

2. `Hd_SortedIds`:
The swap and pop-up strategy for deleting single items also causes problems. This will break the order for most cases, and as a result, subsequent removals will fall into the linear search, or a `HdRenderIndex::GetRprimIds()` will require sorting the items. To resolve this problem with limited influence, we add an index container for fast query, while keeping the current partial sort strategy for fast insert and ranged deletion.

**Result**
Following is a brief view of what our changes bring to USD. We gain a significant improvement (~3.5x) when data size goes to 100k+:
![image](https://github.com/PixarAnimationStudios/OpenUSD/assets/85182970/d433ea47-3211-420f-9e62-781337c3ff4f)

- Data Size: flatten item count to remove (i.e. with the same prefix thus in the same list).
- Time(ns): average time of 9 iterations running the benchmark case.
- With/Without SceneIndex: `HD_ENABLE_SCENE_INDEX_EMULATION` true/false.
- Test environment: Mac Mini M2 (4p core + 4e core, 24G), Ventura 13.5.

And now, the difference between with and without SceneIndex simulation looks reasonable, with a ratio of ~2 and both maintaining a linear relationship with the amount of data:
![image](https://github.com/PixarAnimationStudios/OpenUSD/assets/85182970/2146a882-baeb-45e9-bf29-f4a3137fa76b)

As this change is supposed to cause no regression, the following are the results in even tiny data size:

![image](https://github.com/PixarAnimationStudios/OpenUSD/assets/85182970/da77ab25-404e-473a-aa86-463d97b74a3e)
![image](https://github.com/PixarAnimationStudios/OpenUSD/assets/85182970/692e2102-d1cb-417b-ac4e-a2b228033eff)

Considering the extra data and the unit (ns), some tiny differences are reasonable.

**Reference**

- Test code (with google benchmark)

```
const int testAmount = 1 << 16;
const std::string prefix = isFlattened ? "/prim_" : "/root/prim_";
SdfPathVector pathList;

// Prepare data set.
for (int i = 0; i < testAmount; ++i)
{
    SdfPath id(prefix + std::to_string(i));
    pRenderIndex->InsertRprim(HdPrimTypeTokens->mesh, pSceneDelegate, id);
    pathList.push_back(id);
}
pRenderIndex->SyncAll(&tasks, &taskContext);

// Timing block
{
    for (int i = 0; i < testAmount; ++i)
        pRenderIndex->RemoveRprim(pathList[i]);
}

pRenderIndex->SyncAll(&tasks, &taskContext);
```

Corresponding topic in AOUSD:
- [Performance of removing rprim from RenderIndex](https://forum.aousd.org/t/performance-of-removing-rprim-from-renderindex/1034)

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
