### PR TITLE
Make boost an optional dependency of OpenUSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Dependencies
 Required:
  - C/C++ compiler
  - [CMake](https://cmake.org/documentation/)
- - [Boost](https://boost.org)
  - [Intel TBB](https://www.threadingbuildingblocks.org/)
 
 Optional:
  - [Python](https://python.org)
+ - [Boost](https://boost.org)
 
 See [3rd Party Library and Application Versions](VERSIONS.md) for version information.
 

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2240,7 +2240,10 @@ if extraPythonPaths:
 
 # Determine list of dependencies that are required based on options
 # user has selected.
-requiredDependencies = [ZLIB, BOOST, TBB]
+requiredDependencies = [ZLIB, TBB]
+
+if context.buildPython:
+    requiredDependencies += [BOOST]
 
 if context.buildAlembic:
     if context.enableHDF5:
@@ -2546,7 +2549,7 @@ if pythonDependencies:
 
 # Ensure directory structure is created and is writable.
 for dir in [context.usdInstDir, context.instDir, context.srcDir, 
-            context.buildDir]:
+            context.buildDir, os.path.join(context.instDir, 'lib')]:
     try:
         if os.path.isdir(dir):
             testFile = os.path.join(dir, "canwrite")

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -20,10 +20,11 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 set(PXR_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
 
-# Find Boost package before getting any boost specific components as we need to
-# disable boost-provided cmake config, based on the boost version found.
-find_package(Boost REQUIRED)
-
+if(PXR_ENABLE_PYTHON_SUPPORT OR PXR_ENABLE_OPENVDB_SUPPORT OR PXR_BUILD_OPENIMAGEIO_PLUGIN)
+    # Find Boost package before getting any boost specific components as we need to
+    # disable boost-provided cmake config, based on the boost version found.
+    find_package(Boost REQUIRED)
+endif()
 # Boost provided cmake files (introduced in boost version 1.70) result in 
 # inconsistent build failures on different platforms, when trying to find boost 
 # component dependencies like python, etc. Refer some related


### PR DESCRIPTION
### Description of Change(s)

This PR makes `boost` an optional dependency when not building with python, openvdb, or openimageio. This changes the `build_usd` script to explicitly create the `lib` directory with the correct permissions, as downstream builds (like `tbb`) expected this to have already been created by the `boost` step.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
