### PR TITLE
usdedit: Handle spaces in the file path to executables

### DIFF
--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -25,7 +25,7 @@
 
 from __future__ import print_function
 
-import os, sys
+import os, subprocess, sys
 from pxr.UsdUtils.toolPaths import FindUsdBinary
 
 # lookup usdcat and a suitable text editor. if none are available, 
@@ -67,10 +67,9 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
     (usdaFile, usdaFileName) = tempfile.mkstemp(
         prefix=fullPrefix, suffix='.usda', dir=os.getcwd())
 
-    # No need for an open file descriptor, as it locks the file in Windows.
+    subprocess.call([usdcatCmd, usdFileName], stdout=usdaFile)
+
     os.close(usdaFile)
- 
-    os.system(usdcatCmd + ' ' + usdFileName + '> ' + usdaFileName)
 
     if readOnly:
         os.chmod(usdaFileName, 0o444)
@@ -87,7 +86,7 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
 def _editTemporaryFile(editorCmd, usdaFileName):
     # check the timestamp before updating a file's mtime
     initialTimeStamp = os.path.getmtime(usdaFileName)
-    os.system(editorCmd + ' ' + usdaFileName)
+    subprocess.call([editorCmd, usdaFileName])
     newTimeStamp = os.path.getmtime(usdaFileName)
     
     # indicate whether the file was changed

--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -67,7 +67,7 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
     (usdaFile, usdaFileName) = tempfile.mkstemp(
         prefix=fullPrefix, suffix='.usda', dir=os.getcwd())
 
-    subprocess.call([usdcatCmd, usdFileName], stdout=usdaFile)
+    subprocess.run([usdcatCmd, usdFileName], stdout=usdaFile)
 
     os.close(usdaFile)
 
@@ -86,7 +86,7 @@ def _generateTemporaryFile(usdcatCmd, usdFileName, readOnly, prefix):
 def _editTemporaryFile(editorCmd, usdaFileName):
     # check the timestamp before updating a file's mtime
     initialTimeStamp = os.path.getmtime(usdaFileName)
-    subprocess.call([editorCmd, usdaFileName])
+    subprocess.run([editorCmd, usdaFileName])
     newTimeStamp = os.path.getmtime(usdaFileName)
     
     # indicate whether the file was changed


### PR DESCRIPTION
### Description of Change(s)

Correctly handle the case when the path to the editor has a space in it. This can often happen because of paths starting with `C:\Program Files\...`

### Fixes Issue(s)
- #2757

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes

Three failures, but they look unrelated?

```
        453 - testUsdZipFile (Failed)
        711 - testUsdviewNavigationKeys (Failed)
        727 - testUsdResolverExample (Failed)
```

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
