### PR TITLE
Specify `analyze_t` in `Xid` parsing rules

### DIFF
--- a/pxr/usd/sdf/pathParser.h
+++ b/pxr/usd/sdf/pathParser.h
@@ -44,6 +44,9 @@ namespace PEGTL_NS = tao::TAO_PEGTL_NAMESPACE;
 // Helper rules for parsing UTF8 content
 struct XidStart
 {
+    using analyze_t =
+        PEGTL_NS::analysis::generic<PEGTL_NS::analysis::rule_type::any>;
+
     template <typename ParseInput>
     static bool match(ParseInput& in)
     {
@@ -70,6 +73,9 @@ struct XidStart
 
 struct XidContinue
 {
+    using analyze_t =
+        PEGTL_NS::analysis::generic<PEGTL_NS::analysis::rule_type::any>;
+
     template <typename ParseInput>
     static bool match(ParseInput& in)
     {

--- a/pxr/usd/sdf/testenv/testSdfPathParser.cpp
+++ b/pxr/usd/sdf/testenv/testSdfPathParser.cpp
@@ -27,6 +27,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/path.h"
+#include "pxr/usd/sdf/pathParser.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/stringUtils.h"
 
@@ -67,7 +68,7 @@ void testPaths(char const *paths[], bool expectEmpty) {
 
 int main()
 {
-
+    TF_AXIOM(Sdf_PathParser::PEGTL_NS::analyze<Sdf_PathParser::Path>() == 0);
     char const *good[] = {
         ".",
         "/",


### PR DESCRIPTION
### Description of Change(s)
PEGTL offers an `analyze` utility that can detect some errors in grammars. It requires a hint about how a grammar matches against its input via `analyze_t`. Rules that consume input that it matches against are classified as "any" rules.

This change updates the `XidStart` and `XidContinue` rules defined in the path parser and adds a call to `analyze()` in `testSdfPathParser`. `analyze()` returns 0, if there are no errors.  Updating the path grammar will allow the forthcoming PEGTL parser #3005 to similarly validate against `analyze()`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
