### PR TITLE
Autodesk: Fix MaterialX shader generation for simple surface shaders like "ND_convert_color3_surfaceshader"

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -401,8 +401,10 @@ HdStMaterialXShaderGen<Base>::_EmitMxInitFunction(
     Base::emitComment("Convert HdData to MxData", mxStage);
 
     // Initialize the position of the view in worldspace
-    emitLine("u_viewPosition = vec3(HdGet_worldToViewInverseMatrix()"
-             " * vec4(0.0, 0.0, 0.0, 1.0))", mxStage);
+    if (mxStage.getUniformBlock(mx::HW::PRIVATE_UNIFORMS).find(mx::HW::T_VIEW_POSITION)) {
+        emitLine("u_viewPosition = vec3(HdGet_worldToViewInverseMatrix()"
+            " * vec4(0.0, 0.0, 0.0, 1.0))", mxStage);
+    }
     
     // Calculate the worldspace position, normal and tangent vectors
     const std::string texcoordName =
@@ -413,11 +415,13 @@ HdStMaterialXShaderGen<Base>::_EmitMxInitFunction(
         mxStage);
 
     // Add the vd declaration that translates HdVertexData -> MxVertexData
-    std::string mxVertexDataName = "mx" + vertexData.getName();
-    _EmitMxVertexDataDeclarations(vertexData, mxVertexDataName, 
-                                  vertexData.getInstance(), 
-                                  mx::Syntax::COMMA, mxStage);
-    Base::emitLineBreak(mxStage);
+    if (!vertexData.empty()) {
+        std::string mxVertexDataName = "mx" + vertexData.getName();
+        _EmitMxVertexDataDeclarations(vertexData, mxVertexDataName,
+            vertexData.getInstance(),
+            mx::Syntax::COMMA, mxStage);
+        Base::emitLineBreak(mxStage);
+    }
 
     // Initialize MaterialX parameters with HdGet_ equivalents
     Base::emitComment("Initialize Material Parameters", mxStage);
@@ -769,10 +773,10 @@ HdStMaterialXShaderGen<Base>::_EmitDataStructsAndFunctionDefinitions(
         emitLine(mxVertexDataName + " " + vertexData.getInstance(), mxStage);
         Base::emitLineBreak(mxStage);
         Base::emitLineBreak(mxStage);
-
-        // add the mxInit function to convert Hd -> Mx data
-        _EmitMxInitFunction(vertexData, mxStage);
     }
+
+    // add the mxInit function to convert Hd -> Mx data
+    _EmitMxInitFunction(vertexData, mxStage);
 
     // Emit lighting and shadowing code
     if (lighting) {


### PR DESCRIPTION
### Description of Change(s)

"ND_convert_color3_surfaceshader" MaterialX node fails shader generation in HdStorm

The usda file with a material fixed by this code change:

```
#usda 1.0

def Capsule "Capsule1" (
    prepend apiSchemas = ["MaterialBindingAPI"]
)
{
    rel material:binding = </mtl/standard_surface1>
}

def Scope "mtl"
{
    def Material "standard_surface1" (
        prepend apiSchemas = ["NodeGraphNodeAPI"]
        customData = {
            dictionary Autodesk = {
                string ldx_inputPos = "177 300.5"
                string ldx_outputPos = "955 301"
            }
        }
    )
    {
        token outputs:mtlx:surface (
            sdrMetadata = {
                string uiorder = "3"
            }
        )
        token outputs:mtlx:surface.connect = </mtl/standard_surface1/convert1.outputs:out>
        uniform float2 ui:nodegraph:node:pos = (0.055555556, 0.055555556)

        def Shader "convert1" (
            prepend apiSchemas = ["NodeGraphNodeAPI"]
        )
        {
            uniform token info:id = "ND_convert_color3_surfaceshader"
            color3f inputs:in = (1, 0, 0)
            token outputs:out
            uniform float2 ui:nodegraph:node:pos = (2.586111, 1.0666667)
        }
    }
}
```

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
