### PR TITLE
Autodesk: Prevent undesired materialx garbage collection

### DIFF
--- a/pxr/imaging/hdSt/materialNetwork.cpp
+++ b/pxr/imaging/hdSt/materialNetwork.cpp
@@ -1107,7 +1107,7 @@ HdStMaterialNetwork::ProcessMaterialNetwork(
 
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
         if (!isVolume) {
-            HdSt_ApplyMaterialXFilter(&surfaceNetwork, materialId,
+            _materialXGfx = HdSt_ApplyMaterialXFilter(&surfaceNetwork, materialId,
                                       *surfTerminal, surfTerminalPath,
                                       &_materialParams, resourceRegistry);
         }

--- a/pxr/imaging/hdSt/materialNetwork.h
+++ b/pxr/imaging/hdSt/materialNetwork.h
@@ -31,6 +31,10 @@
 #include "pxr/imaging/hdSt/textureIdentifier.h"
 #include "pxr/base/vt/dictionary.h"
 
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+#include <MaterialXGenShader/Shader.h>
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStResourceRegistry;
@@ -119,6 +123,9 @@ private:
     TextureDescriptorVector _textureDescriptors;
     HioGlslfxSharedPtr _surfaceGfx;
     size_t _surfaceGfxHash;
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+    MaterialX::ShaderPtr _materialXGfx;
+#endif
 };
 
 

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -961,7 +961,7 @@ _GenerateMaterialXShader(
         mtlxDoc, stdLibraries, searchPaths, mxHdInfo, apiName);
 }
 
-void
+mx::ShaderPtr
 HdSt_ApplyMaterialXFilter(
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& materialPath,
@@ -1063,7 +1063,10 @@ HdSt_ApplyMaterialXFilter(
             // Replace the original terminalNode with this newTerminalNode
             hdNetwork->nodes[terminalNodePath] = newTerminalNode;
         }
+
+        return glslfxShader;
     }
+    return nullptr;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/materialXFilter.h
+++ b/pxr/imaging/hdSt/materialXFilter.h
@@ -54,7 +54,7 @@ struct HdSt_MxShaderGenInfo {
 
 /// MaterialX Filter
 /// Converting a MaterialX node to one with a generated MaterialX glslfx file
-void HdSt_ApplyMaterialXFilter(
+MaterialX::ShaderPtr HdSt_ApplyMaterialXFilter(
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& materialPath,
     HdMaterialNode2 const& terminalNode,


### PR DESCRIPTION
### Description of Change(s)

Summary: Add a member variable for HdMaterialNetwork to hold the generated MaterialX Shader to prevent unnecessary garbage collection.

With the current code base, every time we re-apply an existing material, the MaterialX::ShaderPtr is still considered as "the first instance"

https://github.com/PixarAnimationStudios/OpenUSD/blob/0b18ad3f840c24eb25e16b795a5b0821cf05126e/pxr/imaging/hdSt/materialXFilter.cpp#L1008

even the underlying HdMaterialNetwork is cached on application side. The reason is that after every drawcall, there is a garbage collection process (https://github.com/PixarAnimationStudios/OpenUSD/blob/release/pxr/imaging/hdSt/resourceRegistry.cpp#L1098).
The previously unapplied material (MaterialX::ShaderPtr) is garbage collected because HdStorm considered that nobody needs it anymore even though, as I said, the HdMaterialNetwork is cached. This is not the case for PreviewSurace or any other custom glslfx because there is member variable called _surfaceGfx which holds a reference of the generated glslfx thus the reference count is at least 2 and the ResourceRegistry won't garbage collect it.

To address this issue, we can simply add a member variable in HdMaterialNetwork to hold the generated MaterialX glslfx shared_ptr just like the _surfaceGfx to prevent the unnecessary garbage collection for MaterialX shader as well.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
