### PR TITLE
Apple: Core visionOS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ then build and install USD into `/path/to/my_usd_install_dir`.
 > python OpenUSD/build_scripts/build_usd.py /path/to/my_usd_install_dir
 ```
 
-##### MacOS:
+##### macOS:
 
 In a terminal, run `xcode-select` to ensure command line developer tools are
 installed. Then run the script.
@@ -140,6 +140,16 @@ then build and install USD into `/path/to/my_usd_install_dir`.
 ```
 > python OpenUSD/build_scripts/build_usd.py /path/to/my_usd_install_dir
 ```
+
+###### iOS
+
+When building from a macOS system, you can cross compile for iOS based platforms.
+
+iOS builds currently do not support Imaging.
+Additionally, they will not support Python bindings or command line tools.
+
+To build for iOS, add the `--build-target iOS` parameter.
+
 
 ##### Windows:
 

--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ then build and install USD into `/path/to/my_usd_install_dir`.
 > python OpenUSD/build_scripts/build_usd.py /path/to/my_usd_install_dir
 ```
 
-###### iOS
+###### iOS and visionOS
 
 When building from a macOS system, you can cross compile for iOS based platforms.
 
 iOS builds currently do not support Imaging.
 Additionally, they will not support Python bindings or command line tools.
 
-To build for iOS, add the `--build-target iOS` parameter.
-
+* To build for iOS, add the `--build-target iOS` parameter.
+* To build for visionOS, add the `--build-target visionOS` parameter.
 
 ##### Windows:
 

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -26,15 +26,17 @@ TARGET_X86 = "x86_64"
 TARGET_ARM64 = "arm64"
 TARGET_UNIVERSAL = "universal"
 TARGET_IOS = "iOS"
+TARGET_VISIONOS = "visionOS"
 
-EMBEDDED_PLATFORMS = [TARGET_IOS]
+EMBEDDED_PLATFORMS = [TARGET_IOS, TARGET_VISIONOS]
 
 def GetBuildTargets():
     return [TARGET_NATIVE,
             TARGET_X86,
             TARGET_ARM64,
             TARGET_UNIVERSAL,
-            TARGET_IOS]
+            TARGET_IOS,
+            TARGET_VISIONOS]
 
 def GetBuildTargetDefault():
     return TARGET_NATIVE
@@ -118,6 +120,8 @@ def GetSDKRoot(context) -> Optional[str]:
     sdk = "macosx"
     if context.buildTarget == TARGET_IOS:
         sdk = "iphoneos"
+    elif context.buildTarget == TARGET_VISIONOS:
+        sdk = "xros"
 
     for arg in (context.cmakeBuildArgs or '').split():
         if "CMAKE_OSX_SYSROOT" in arg:
@@ -133,6 +137,7 @@ def SetTarget(context, targetName):
     context.targetARM64 = (targetName == GetTargetArmArch())
     context.targetUniversal = (targetName == TARGET_UNIVERSAL)
     context.targetIos = (targetName == TARGET_IOS)
+    context.targetVisionos = (targetName == TARGET_VISIONOS)
     if context.targetUniversal and not SupportsMacOSUniversalBinaries():
         context.targetUniversal = False
         raise ValueError(
@@ -262,8 +267,8 @@ def CreateUniversalBinaries(context, libNames, x86Dir, armDir):
 
 def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
     system_name = None
-    if context.buildTarget == TARGET_IOS:
-        system_name = "iOS"
+    if context.buildTarget in EMBEDDED_PLATFORMS:
+        system_name = context.buildTarget
 
     if system_name:
         args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -274,4 +274,11 @@ def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
         args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH")
         args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH")
         args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
+
+
+    # Signing needs to happen on all systems
+    if context.macOSCodesign:
+        args.append(f"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY={GetCodeSignID()}")
+        args.append(f"-DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM={GetDevelopmentTeamID()}")
+
     return args

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -18,20 +18,26 @@ import os
 import platform
 import shlex
 import subprocess
+import re
+from typing import Optional, List
 
 TARGET_NATIVE = "native"
 TARGET_X86 = "x86_64"
 TARGET_ARM64 = "arm64"
 TARGET_UNIVERSAL = "universal"
+TARGET_IOS = "iOS"
+
+EMBEDDED_PLATFORMS = [TARGET_IOS]
 
 def GetBuildTargets():
     return [TARGET_NATIVE,
             TARGET_X86,
             TARGET_ARM64,
-            TARGET_UNIVERSAL]
+            TARGET_UNIVERSAL,
+            TARGET_IOS]
 
 def GetBuildTargetDefault():
-    return TARGET_NATIVE;
+    return TARGET_NATIVE
 
 def MacOS():
     return platform.system() == "Darwin"
@@ -39,15 +45,12 @@ def MacOS():
 def GetLocale():
     return sys.stdout.encoding or locale.getdefaultlocale()[1] or "UTF-8"
 
-def GetCommandOutput(command):
+def GetCommandOutput(command, **kwargs):
     """Executes the specified command and returns output or None."""
     try:
-        return subprocess.check_output(
-            shlex.split(command),
-            stderr=subprocess.STDOUT).decode(GetLocale(), 'replace').strip()
-    except subprocess.CalledProcessError:
-        pass
-    return None
+        return subprocess.check_output(command, stderr=subprocess.STDOUT, **kwargs).decode(GetLocale(), 'replace').strip()
+    except:
+        return None
 
 def GetTargetArmArch():
     # Allows the arm architecture string to be overridden by
@@ -55,7 +58,7 @@ def GetTargetArmArch():
     return os.environ.get('MACOS_ARM_ARCHITECTURE') or TARGET_ARM64
 
 def GetHostArch():
-    macArch = GetCommandOutput('arch').strip()
+    macArch = GetCommandOutput(["arch"])
     if macArch == "i386" or macArch == TARGET_X86:
         macArch = TARGET_X86
     else:
@@ -63,12 +66,14 @@ def GetHostArch():
     return macArch
 
 def GetTargetArch(context):
+    if context.buildTarget in EMBEDDED_PLATFORMS:
+        return GetTargetArmArch()
     if context.targetNative:
         macTargets = GetHostArch()
     else:
         if context.targetX86:
             macTargets = TARGET_X86
-        if context.targetARM64:
+        if context.targetARM64 or context.buildTarget in EMBEDDED_PLATFORMS:
             macTargets = GetTargetArmArch()
         if context.targetUniversal:
             macTargets = TARGET_X86 + ";" + GetTargetArmArch()
@@ -89,6 +94,8 @@ def GetTargetArchPair(context):
         primaryArch = TARGET_X86
     if context.targetARM64:
         primaryArch = GetTargetArmArch()
+    if context.buildTarget in EMBEDDED_PLATFORMS:
+        primaryArch = GetTargetArmArch()
     if context.targetUniversal:
         primaryArch = GetHostArch()
         if (primaryArch == TARGET_X86):
@@ -101,18 +108,33 @@ def GetTargetArchPair(context):
 def SupportsMacOSUniversalBinaries():
     if not MacOS():
         return False
-    XcodeOutput = GetCommandOutput('/usr/bin/xcodebuild -version')
+    XcodeOutput = GetCommandOutput(["/usr/bin/xcodebuild", "-version"])
     XcodeFind = XcodeOutput.rfind('Xcode ', 0, len(XcodeOutput))
     XcodeVersion = XcodeOutput[XcodeFind:].split(' ')[1]
     return (XcodeVersion > '11.0')
+
+
+def GetSDKRoot(context) -> Optional[str]:
+    sdk = "macosx"
+    if context.buildTarget == TARGET_IOS:
+        sdk = "iphoneos"
+
+    for arg in (context.cmakeBuildArgs or '').split():
+        if "CMAKE_OSX_SYSROOT" in arg:
+            override = arg.split('=')[1].strip('"').strip()
+            if override:
+                sdk = override
+    return GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+
 
 def SetTarget(context, targetName):
     context.targetNative = (targetName == TARGET_NATIVE)
     context.targetX86 = (targetName == TARGET_X86)
     context.targetARM64 = (targetName == GetTargetArmArch())
     context.targetUniversal = (targetName == TARGET_UNIVERSAL)
+    context.targetIos = (targetName == TARGET_IOS)
     if context.targetUniversal and not SupportsMacOSUniversalBinaries():
-        self.targetUniversal = False
+        context.targetUniversal = False
         raise ValueError(
                 "Universal binaries only supported in macOS 11.0 and later.")
 
@@ -121,7 +143,7 @@ def GetTargetName(context):
             TARGET_X86 if context.targetX86 else
             GetTargetArmArch() if context.targetARM64 else
             TARGET_UNIVERSAL if context.targetUniversal else
-            "")
+            context.buildTarget)
 
 devout = open(os.devnull, 'w')
 
@@ -133,25 +155,62 @@ def ExtractFilesRecursive(path, cond):
                 files.append(os.path.join(r, file))
     return files
 
-def CodesignFiles(files):
-    SDKVersion  = subprocess.check_output(
-        ['xcodebuild', '-version']).strip()[6:10]
-    codeSignIDs = subprocess.check_output(
-        ['security', 'find-identity', '-vp', 'codesigning'])
+def _GetCodeSignStringFromTerminal():
+    codeSignIDs = GetCommandOutput(['security', 'find-identity', '-vp', 'codesigning'])
+    return codeSignIDs
 
-    codeSignID = "-"
+def GetCodeSignID():
     if os.environ.get('CODE_SIGN_ID'):
-        codeSignID = os.environ.get('CODE_SIGN_ID')
-    elif float(SDKVersion) >= 11.0 and \
-                codeSignIDs.find(b'Apple Development') != -1:
-        codeSignID = "Apple Development"
-    elif codeSignIDs.find(b'Mac Developer') != -1:
-        codeSignID = "Mac Developer"
+        return os.environ.get('CODE_SIGN_ID')
+
+    codeSignIDs = _GetCodeSignStringFromTerminal()
+    if not codeSignIDs:
+        return "-"
+    for codeSignID in codeSignIDs.splitlines():
+        if "CSSMERR_TP_CERT_REVOKED" in codeSignID:
+            continue
+        if ")" not in codeSignID:
+            continue
+        codeSignID = codeSignID.split()[1]
+        break
+    else:
+        raise RuntimeError("Could not find a valid codesigning ID")
+
+    return codeSignID or "-"
+
+def GetCodeSignIDHash():
+    codeSignIDs = _GetCodeSignStringFromTerminal()
+    try:
+        return re.findall(r'\(.*?\)', codeSignIDs)[0][1:-1]
+    except:
+        raise Exception("Unable to parse codesign ID hash")
+
+def GetDevelopmentTeamID():
+    if os.environ.get("DEVELOPMENT_TEAM"):
+        return os.environ.get("DEVELOPMENT_TEAM")
+    codesignID = GetCodeSignIDHash()
+
+    certs = subprocess.check_output(["security", "find-certificate", "-c", codesignID, "-p"])
+    subject = GetCommandOutput(["openssl", "x509", "-subject"], input=certs)
+    subject = subject.splitlines()[0]
+
+    # Extract the Organizational Unit (OU field) from the cert
+    try:
+        team = [elm for elm in subject.split(
+            '/') if elm.startswith('OU')][0].split('=')[1]
+        if team is not None and team != "":
+            return team
+    except Exception as ex:
+        raise Exception("No development team found with exception " + ex)
+
+def CodesignFiles(files):
+    codeSignID = GetCodeSignID()
 
     for f in files:
         subprocess.call(['codesign', '-f', '-s', '{codesignid}'
-                              .format(codesignid=codeSignID), f],
+                        .format(codesignid=codeSignID), f],
                         stdout=devout, stderr=devout)
+
 
 def Codesign(install_path, verbose_output=False):
     if not MacOS():
@@ -200,3 +259,19 @@ def CreateUniversalBinaries(context, libNames, x86Dir, armDir):
                                 instDir=context.instDir, libName=targetName),
                        outputName)
     return lipoCommands
+
+def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
+    system_name = None
+    if context.buildTarget == TARGET_IOS:
+        system_name = "iOS"
+
+    if system_name:
+        args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")
+        args.append(f"-DCMAKE_OSX_SYSROOT={GetSDKRoot(context)}")
+
+        # CMake gets confused trying to find things when setting the system name
+        # See https://discourse.cmake.org/t/find-package-stops-working-when-cmake-system-name-ios/4609/8
+        args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH")
+        args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH")
+        args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
+    return args

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -992,6 +992,31 @@ def InstallTBB_MacOS(context, force, buildArgs):
                   "ifeq ($(arch),$(filter $(arch),armv7 armv7s {0}))"
                         .format(apple_utils.GetTargetArmArch()))])
 
+        if context.buildTarget == apple_utils.TARGET_VISIONOS:
+            # Create visionOS config from iOS config
+            shutil.copy(
+                src="build/ios.macos.inc",
+                dst="build/visionos.macos.inc")
+
+            PatchFile("build/visionos.macos.inc",
+                      [("ios","visionos"),
+                       ("iOS", "visionOS"),
+                       ("iPhone", "XR"),
+                       ("IPHONEOS","XROS"),
+                       ("?= 8.0", "?= 1.0")])
+
+            # iOS clang just reuses the macOS one, so it's easier to copy it directly
+            shutil.copy(src="build/macos.clang.inc",
+                        dst="build/visionos.clang.inc")
+
+
+            PatchFile("build/visionos.clang.inc",
+                      [("ios","visionos"),
+                       ("-miphoneos-version-min=", "-target arm64-apple-xros"),
+                       ("iOS", "visionOS"),
+                       ("iPhone", "XR"),
+                       ("IPHONEOS","XROS")])
+
         (primaryArch, secondaryArch) = apple_utils.GetTargetArchPair(context)
 
         # tbb uses different arch names
@@ -2378,6 +2403,10 @@ if which("cmake"):
     elif MacOS():
         # Apple Silicon is not supported prior to 3.19
         cmake_required_version = (3, 19)
+
+        # visionOS support was added in CMake 3.28
+        if context.buildTarget == apple_utils.TARGET_VISIONOS:
+            cmake_required_version = (3, 28)
     else:
         # Linux, and vfx platform CY2020, are verified to work correctly with 3.14
         cmake_required_version = (3, 14)


### PR DESCRIPTION
### Description of Change(s)

This PR builds on the [Core iOS support PR](https://github.com/PixarAnimationStudios/OpenUSD/pull/2949) to add support for building the USD core for visionOS.

Thanks to Valentin Roussellet for the basis of the TBB patch.

It includes the following changes:

* Use CMake 3.28 (which adds visionOS support)
* Patch TBB to support visionOS. Note that clang requires new platforms to be provided via the target triplet.
* Add visionOS to the accepted platforms.

Note that  visionOS's SDK is called xros, much like how the iOS SDK is iphoneos for historical reasons.


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
