### PR TITLE
Support `string_view` initialization and lookup in `TfToken`

### DIFF
--- a/pxr/base/tf/testenv/token.cpp
+++ b/pxr/base/tf/testenv/token.cpp
@@ -108,6 +108,14 @@ Test_TfToken()
     TF_AXIOM(TfToken(strVec2[1]) == tokVec[1]);
     TF_AXIOM(TfToken(strVec2[2]) == tokVec[2]);
 
+    // Test safe construction from nullptr
+    TF_AXIOM(TfToken(nullptr) == TfToken());
+
+    // Test Find via string_view
+    TF_AXIOM(TfToken::Find("a_string_that_is_very_unlikely_to_exist") ==
+             TfToken());
+    TF_AXIOM(TfToken("string1") == TfToken::Find("string1"));
+
     return true;
 }
 


### PR DESCRIPTION
### Description of Change(s)
`TfToken` is designed to optimize storage and comparison of commonly used strings like property names, values, and other path components. It currently provides two constructors, one for NULL-terminated C-strings and the other for `std::string`.

There are cases where a token may need to be constructed from a part of a `std::string`. This often necessitates an intermediate heap-allocated copy when no allocation or copy is needed at all if the token already exists in the registry.  The path parser currently optimizes this case by introducing a stack allocated `char[32]` and copying and NULL-terminating strings short enough to fit in the buffer.  However, this has not been generalized outside of the path parser, is limited to short strings, and still requires a copy.

This change introduces a `std::string_view` constructor and associated utilities. It benefits the current implementation by unifying the C-string and `std::string` code paths, avoiding templating and specialization.

It also replaces `Find(std::string const&)` with the more general `Find(std::string_view)`.

A note is left in the `TfToken::_Rep` class about using a set that supports transparent hashing.  This would allow lookups to transparently compare `std::string_view` against a `TfToken::_Rep` without `_Rep` storing an extra `std::string_view` field.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
