### PR TITLE
Utilize `string_view` initialization of `TfToken` in path parsing

### DIFF
--- a/pxr/base/tf/testenv/token.cpp
+++ b/pxr/base/tf/testenv/token.cpp
@@ -108,6 +108,14 @@ Test_TfToken()
     TF_AXIOM(TfToken(strVec2[1]) == tokVec[1]);
     TF_AXIOM(TfToken(strVec2[2]) == tokVec[2]);
 
+    // Test safe construction from nullptr
+    TF_AXIOM(TfToken(nullptr) == TfToken());
+
+    // Test Find via string_view
+    TF_AXIOM(TfToken::Find("a_string_that_is_very_unlikely_to_exist") ==
+             TfToken());
+    TF_AXIOM(TfToken("string1") == TfToken::Find("string1"));
+
     return true;
 }
 

--- a/pxr/usd/sdf/pathParser.cpp
+++ b/pxr/usd/sdf/pathParser.cpp
@@ -13,6 +13,11 @@ using namespace PXR_PEGTL_NAMESPACE;
 
 namespace Sdf_PathParser {
 
+template <class Input>
+TfToken GetToken(Input const &in) {
+    return TfToken{in.string_view()};
+}
+
 template <>
 struct Action<ReflexiveRelative> {
     template <class Input>

--- a/pxr/usd/sdf/pathParser.h
+++ b/pxr/usd/sdf/pathParser.h
@@ -199,25 +199,6 @@ struct PPContext {
     std::string varName;
 };
 
-template <class Input>
-TfToken GetToken(Input const &in) {
-    constexpr int BufSz = 32;
-    char buf[BufSz];
-    size_t strSize = std::distance(in.begin(), in.end());
-    TfToken tok;
-    if (strSize < BufSz) {
-        // copy & null-terminate.
-        std::copy(in.begin(), in.end(), buf);
-        buf[strSize] = '\0';
-        tok = TfToken(buf);
-    }
-    else {
-        // fall back to string path.
-        tok = TfToken(in.string());
-    }
-    return tok;
-}
-
 template <class Rule>
 struct Action : PEGTL_NS::nothing<Rule> {};
 


### PR DESCRIPTION
### Description of Change(s)

(Depends on #3053)

`GetToken` tries to minimize dynamic allocations during path parsing by utilizing a stack allocated `char[32]` that can be explicitly NULL-terminated.  This optimization still involves a copy to the intermediate buffer and only works for short strings.

This changes `GetToken` to use the new `std::string_view` constructor for `TfToken` instead.  When the components of the path already exist in the registry, no copies or allocations are required. We've seen performance gains of about 4-8% in a simple test case where all the path components already exist as tokens.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
