### PR TITLE
Ensure that command wrapping only runs on Windows

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -141,7 +141,7 @@ function(pxr_python_bin BIN_NAME)
             COMMENT "Creating Python cmd wrapper"
             COMMAND
                 ${PYTHON_EXECUTABLE}
-                ${PROJECT_SOURCE_DIR}/cmake/macros/shebang.py
+                ${PROJECT_SOURCE_DIR}/cmake/macros/winpycmd.py
                 ${BIN_NAME}
                 ${outfile}.cmd
         )

--- a/cmake/macros/winpycmd.py
+++ b/cmake/macros/winpycmd.py
@@ -23,19 +23,22 @@
 #
 #
 # Usage:
-#   shebang shebang-str source.py dest.py
+#   wrappy file output.cmd
 #
-# This substitutes '/pxrpythonsubst' in <source.py> with <shebang-str>
-# and writes the result to <dest.py>.
+# This generates a file named <output.cmd> with the contents
+# '@python "%~dp0<file>"';  this is a Windows command script to execute
+# "python <file>" where <file> is in the same directory as the command script.
 
 import sys
+import platform
+import warnings
 
-if len(sys.argv) != 4:
-    print(f"Usage: {sys.argv[0]} {{shebang-str source.py dest}}",
-          file=sys.stderr)
+if not platform.system() == 'Windows':
+    warnings.warn(f"{sys.argv[0]} should only be run on Windows")
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} {{file output.cmd}}", file=sys.stderr)
     sys.exit(1)
 
-with open(sys.argv[2], 'r') as s:
-    with open(sys.argv[3], 'w') as d:
-        for line in s:
-            d.write(line.replace('/pxrpythonsubst', sys.argv[1]))
+with open(sys.argv[2], 'w') as f:
+    print(f'@python "%~dp0{sys.argv[1]}" %*', file=f)


### PR DESCRIPTION
### Description of Change(s)

The `shebang.py` script has two modes, one which does substitution of `\pxrpythonsubst`, the other which generates a wrapper command for Windows.  The mode is argument dependent.  However, if `cmake` fails to set `PXR_PYTHON_SHEBANG`, the wrong mode can get executed and a build with errors will silently be installed.

This change separates the unrelated windows only components out of `shebang.py` into a sibling `winpycmd.py` script.  It also adds a warning to `winpycmd` to alert users that it's being run on a non-Windows platform.

With this fix, the build will now fail (instead of silently installing a build with errors) when `PXR_PYTHON_SHEBANG` cannot be correctly set.

### Fixes Issue(s)
- #3047 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
