### PR TITLE
Don't let UsdUtilsModifyAssetPaths change the length of asset array attributes/metadata

### DIFF
--- a/pxr/usd/usdUtils/assetLocalization.cpp
+++ b/pxr/usd/usdUtils/assetLocalization.cpp
@@ -505,10 +505,19 @@ UsdUtils_LocalizationContext::_ProcessAssetValue(
 
                 const std::vector<std::string> processedDeps = 
                     _delegate->ProcessValuePathArrayElement(
-                            layer, keyPath, rawAssetPath, dependencies);
+                            layer, keyPath, rawAssetPath,
+                            dependencies);
                 
                 _EnqueueDependency(layer, rawAssetPath);
                 _EnqueueDependencies(layer, processedDeps);
+            }
+            else {
+                // We want to preserve empty asset paths in arrays, as they
+                // may be meaningful (e.g. in primvars that need to be a
+                // specific length).
+                _delegate->ProcessValuePathArrayElement(
+                        layer, keyPath, rawAssetPath,
+                        std::vector<std::string>());
             }
         }
 

--- a/pxr/usd/usdUtils/assetLocalizationDelegate.cpp
+++ b/pxr/usd/usdUtils/assetLocalizationDelegate.cpp
@@ -271,9 +271,11 @@ UsdUtils_WritableLocalizationDelegate::ProcessValuePathArrayElement(
         return _AllDependenciesForInfo(info);
     }
     else {
+        // We don't want to remove empty paths from arrays. They may be
+        // meaningful, for example in primvar attributes.
+        _currentPathArray.emplace_back(SdfAssetPath());
         return {};
     }
-    
 }
 
 void 
@@ -587,6 +589,11 @@ UsdUtils_ReadOnlyLocalizationDelegate::ProcessValuePathArrayElement(
     const std::string &authoredPath,
     const std::vector<std::string> &dependencies)
 {    
+    // We may get passed an empty authored path if an array has some
+    // explicitly empty elements.
+    if (authoredPath.empty())
+        return std::vector<std::string>();
+
     return _AllDependenciesForInfo(_pathCache.GetProcessedInfo(layer, 
         {authoredPath, dependencies}, UsdUtils_DependencyType::Reference));
 }

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsModifyAssetPaths/baseline/removal.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsModifyAssetPaths/baseline/removal.usda
@@ -1,7 +1,13 @@
 #usda 1.0
 
 def Xform "Model" (
+    assetInfo = {
+        asset[] payloadAssetDependencies = [@@, @@]
+    }
     customData = {
+        dictionary d = {
+            asset[] bar = [@@, @@]
+        }
         dictionary emptyDict = {
         }
     }
@@ -9,10 +15,17 @@ def Xform "Model" (
     references = None
 )
 {
-    asset[] bar
+    asset[] bar = [@@, @@]
     asset[] emptyArr = []
-    asset foo
-    asset[] varBar
+    asset foo (
+        customData = {
+            asset[] bar = [@@, @@]
+        }
+    )
+    asset[] varBar.timeSamples = {
+        1: [@@, @@],
+        2: [@@, @@],
+    }
     asset varFoo
 }
 


### PR DESCRIPTION
### Description of Change(s)
When modifying asset paths in a layer, don't remove empty elements from arrays. The empty elements may be meaningful, as in primvars that must be a specific length. Updated the output of the ModifyAssetPaths "removal" test, which validates the behavior of this API when modified asset paths are empty.

Arguably, this change should perhaps be limited to USD attributes (not metadata), but depending on the use case changing the array length is still throwing away what may be important information in a pipeline.

I also considered whether an array that has all values set to empty asset paths should remove the attribute. This seems more defensible to me, but again, I'm not sure the length of the array couldn't still be considered useful information that is worth preserving in some circumstances.

I'm open to different answers on these two questions, and I believe each could be addressed without too drastic changes to this PR.

### Fixes Issue(s)
- #3060 

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
