### PR TITLE
Changed the way we name downloaded zip files in `build_usd.py` to avoid file name collisions.

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -49,6 +49,7 @@ import sys
 import sysconfig
 import zipfile
 
+from urllib.parse import urlparse
 from urllib.request import urlopen
 from shutil import which
 
@@ -539,13 +540,16 @@ def DownloadURL(url, context, force, extractDir = None,
     Returns the absolute path to the directory where files have 
     been extracted."""
     with CurrentWorkingDirectory(context.srcDir):
-        # Extract filename from URL.
-        filename = url.split("/")[-1]
+        # Parse the information of the url
+        pURL = urlparse(url)
 
-        # Change filename for a file form a github/gitlab repository. 
+        # Extract filename from URL path.
+        filename = pURL.path.split("/")[-1]
+
+        # Change filename for a file form a github repository. 
         # Filename becomes projectName-version to avoid file collision.
-        if ("github" or "gitlab") in url:
-            filename = url.split("/")[4] + "-" + filename
+        if pURL.netloc == "github.com":
+            filename = pURL.path.split("/")[2] + "-" + filename
 
         # See if file already exists. 
         if force and os.path.exists(filename):

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -539,8 +539,15 @@ def DownloadURL(url, context, force, extractDir = None,
     Returns the absolute path to the directory where files have 
     been extracted."""
     with CurrentWorkingDirectory(context.srcDir):
-        # Extract filename from URL and see if file already exists. 
-        filename = url.split("/")[-1]       
+        # Extract filename from URL.
+        filename = url.split("/")[-1]
+
+        # Change filename for a file form a github/gitlab repository. 
+        # Filename becomes projectName-version to avoid file collision.
+        if ("github" or "gitlab") in url:
+            filename = url.split("/")[4] + "-" + filename
+
+        # See if file already exists. 
         if force and os.path.exists(filename):
             os.remove(filename)
 


### PR DESCRIPTION
### Description of Change(s)

Changed the way we name downloaded zip files in `build_usd.py` to minimise the chance of file collision. Files from a GitHub or GitLab repository previously only had their version numbers as their names. Now, they will incorporate the project name and the version.

I assume other URLs provide this (i.e., Boost and HDF5).

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/457

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
