### PR TITLE
Fix resource leak in hdSt 

### DIFF
--- a/pxr/imaging/hdSt/renderBuffer.cpp
+++ b/pxr/imaging/hdSt/renderBuffer.cpp
@@ -61,7 +61,9 @@ HdStRenderBuffer::HdStRenderBuffer(
 {
 }
 
-HdStRenderBuffer::~HdStRenderBuffer() = default;
+HdStRenderBuffer::~HdStRenderBuffer() {
+    _resourceRegistry->GarbageCollect();
+}
 
 void
 HdStRenderBuffer::Sync(HdSceneDelegate *sceneDelegate,

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -1135,6 +1135,8 @@ HdStResourceRegistry::_GarbageCollect()
     _uniformSsboBufferArrayRegistry.GarbageCollect();
     _singleBufferArrayRegistry.GarbageCollect();
 
+    _textureHandleRegistry->GetTextureObjectRegistry()->GarbageCollect();
+
     // Garbage collection may reallocate buffers, so we must submit blit work.
     SubmitBlitWork();
 }


### PR DESCRIPTION
### Description of Change(s)


Garbage collect the texture handle registry and resource registry to prevent memory leaks.

Submitting on behalf of Maddy Adams

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged. 
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
