### PR TITLE
Autodesk: Add render-selected-edge-from-face global env var

### DIFF
--- a/pxr/imaging/hdSt/meshShaderKey.cpp
+++ b/pxr/imaging/hdSt/meshShaderKey.cpp
@@ -25,6 +25,7 @@
 
 #include "pxr/imaging/hd/mesh.h"
 #include "pxr/imaging/hdSt/meshShaderKey.h"
+#include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/staticTokens.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -158,6 +159,14 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((noScalarOverrideFS,          "Fragment.NoScalarOverride"))
 );
 
+static bool 
+_IsRenderSelectedEdgeFromFaceEnabled()
+{
+    static bool isEnabled =
+        TfGetenvBool("HDST_RENDER_SELECTED_EDGE_FROM_FACE", true);
+    return isEnabled;
+}
+
 HdSt_MeshShaderKey::HdSt_MeshShaderKey(
     HdSt_GeometricShader::PrimitiveType primitiveType,
     TfToken shadingTerminal,
@@ -221,8 +230,9 @@ HdSt_MeshShaderKey::HdSt_MeshShaderKey(
                              geomStyle == HdMeshGeomStyleHullEdgeOnSurf;
 
     // Selected edges can be highlighted even if not otherwise displayed
-    const bool renderSelectedEdges = geomStyle == HdMeshGeomStyleSurf ||
-                                     geomStyle == HdMeshGeomStyleHull;
+    const bool renderSelectedEdges = _IsRenderSelectedEdgeFromFaceEnabled() &&
+                                     (geomStyle == HdMeshGeomStyleSurf ||
+                                     geomStyle == HdMeshGeomStyleHull);
 
     /* Normals configurations:
      * Smooth normals:


### PR DESCRIPTION
### Description of Change(s)

To improve the performance of using Geometry Shader in HdStorm, expose an environment variable to enable/disable render-selected-edge-from-face feature, which may trigger geometry shader.

In HdStorm, when rendering mesh using HdMeshGeomStyleSurf/HdMeshGeomStyleHull geomStyle, the Geometry Shader might be enabled to support the render-selected-edge-from-face feature, this could bring performance overhead if the application doesn't need that feature, so, adding an environment variable to enable/disable render-selected-edge-from-face feature in HdStorm,

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
