### PR TITLE
Autodesk: Optimize MaterialX shader generation in Storm by comparing topologies

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -289,13 +289,15 @@ _AddMaterialXNode(
         }
     }
 
-    // MaterialX nodes that use textures are assumed to have a filename input
-    if (mxNodeDef->getNodeGroup() == "texture2d") {
-        if (mxHdData) {
-            // Save the corresponding MaterialX and Hydra names for ShaderGen
-            mxHdData->mxHdTextureMap[mxNodeName] = connectionName;
-            // Save the path to adjust parameters after traversing the network
-            mxHdData->hdTextureNodes.insert(hdNodePath);
+    // MaterialX nodes that use textures can have more than one filename input
+    if (mxHdData) {
+        for (auto const& input: mxNodeDef->getActiveInputs()) {
+            if (input->getType() == "filename") {
+                // Save the corresponding MaterialX and Hydra names for ShaderGen
+                mxHdData->mxHdTextureMap[mxNodeName].insert(input->getName());
+                // Save the path to adjust parameters after traversing the network
+                mxHdData->hdTextureNodes.insert(hdNodePath);
+            }
         }
     }
 

--- a/pxr/imaging/hdMtlx/hdMtlx.h
+++ b/pxr/imaging/hdMtlx/hdMtlx.h
@@ -67,13 +67,11 @@ HdMtlxConvertToString(VtValue const& hdParameterValue);
 
 // Storing MaterialX-Hydra texture and primvar information
 struct HdMtlxTexturePrimvarData {
-    HdMtlxTexturePrimvarData() 
-        : mxHdTextureMap(MaterialX::StringMap()), // Mx-Hd texture name mapping
-          hdTextureNodes(std::set<SdfPath>()),    // Paths to HdTexture Nodes
-          hdPrimvarNodes(std::set<SdfPath>()) {}  // Paths to HdPrimvar nodes
-    MaterialX::StringMap mxHdTextureMap;
-    std::set<SdfPath> hdTextureNodes;
-    std::set<SdfPath> hdPrimvarNodes;
+    HdMtlxTexturePrimvarData() = default;
+    using TextureMap = std::map<std::string, std::set<std::string>>;
+    TextureMap mxHdTextureMap; // Mx-Hd texture name mapping
+    std::set<SdfPath> hdTextureNodes; // Paths to HdTexture Nodes
+    std::set<SdfPath> hdPrimvarNodes; // Paths to HdPrimvar nodes
 };
 
 /// Creates and returns a MaterialX Document from the given HdMaterialNetwork2 

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -2966,7 +2966,7 @@ pxr_register_test(testHdStMaterialXShaderGen_SStextured
     TESTENV testHdStMaterialXShaderGen
 )
 pxr_register_test(testHdStMaterialXShaderGen_UsdPSglass
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStMaterialXShaderGen --filename usd_preview_surface_glass.mtlx --materialTag translucent"
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStMaterialXShaderGen --filename usd_preview_surface_glass.mtlx"
     STDOUT_REDIRECT shadergen_UsdPSglass.out
     EXPECTED_RETURN_CODE 0
     POST_COMMAND "diff -B -b shadergen_UsdPSglass.out ${CMAKE_INSTALL_PREFIX}/tests/ctest/testHdStMaterialXShaderGen/baseline/shadergen_UsdPSglass.out"

--- a/pxr/imaging/hdSt/materialNetwork.cpp
+++ b/pxr/imaging/hdSt/materialNetwork.cpp
@@ -674,8 +674,21 @@ _MakeMaterialParamsForTexture(
     NdrTokenVec const& assetIdentifierPropertyNames = 
         sdrNode->GetAssetIdentifierInputNames();
 
-    if (assetIdentifierPropertyNames.size() == 1) {
-        TfToken const& fileProp = assetIdentifierPropertyNames[0];
+    if (!assetIdentifierPropertyNames.empty()) {
+        TfToken fileProp = assetIdentifierPropertyNames[0];
+
+        // Some MaterialX nodes can have multiple file inputs. Take the first
+        // one that matches the param name. If we lookup a <trilinear> texture
+        // against an output named "N42_fileY", we will find the right one.
+        if (assetIdentifierPropertyNames.size() > 1) {
+            for (auto const& propName: assetIdentifierPropertyNames) {
+                if (TfStringEndsWith(outputName.GetString(), propName)) {
+                    fileProp = propName;
+                    break;
+                }
+            }
+        }
+
         auto const& it = node.parameters.find(fileProp);
         if (it != node.parameters.end()){
             const VtValue &v = it->second;

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -508,11 +508,9 @@ HdStMaterialXShaderGen<Base>::_EmitMxVertexDataDeclarations(
     }
 
     for (size_t i = 0; i < block.size(); ++i) {
-        line += _EmitMxVertexDataLine(block[i], separator);
-        // remove the separator from the last data line
-        if (i == block.size() - 1) {
-            line = line.substr(0, line.size() - separator.size());
-        }
+        auto const& lineSeparator =
+            (i == block.size() - 1) ? mx::EMPTY_STRING : separator;
+        line += _EmitMxVertexDataLine(block[i], lineSeparator);
     }
 
     // add ending ) or }
@@ -548,6 +546,10 @@ HdStMaterialXShaderGen<Base>::_EmitMxVertexDataLine(
 
         hdVariableDef  = "HdGet_points()" + separator;
     }
+    else if (mxVariableName.compare(mx::HW::T_NORMAL_OBJECT) == 0) {
+
+        hdVariableDef  = "HdGet_normals()" + separator;
+    }
     else if (mxVariableName.compare(0, mx::HW::T_TEXCOORD.size(), 
                                     mx::HW::T_TEXCOORD) == 0) {
         
@@ -555,12 +557,14 @@ HdStMaterialXShaderGen<Base>::_EmitMxVertexDataLine(
         // the st primvar
         hdVariableDef = TfStringPrintf("\n"
                 "    #ifdef HD_HAS_%s\n"
-                "        HdGet_%s(),\n"
+                "        HdGet_%s()%s\n"
                 "    #else\n"
-                "        %s(0.0),\n"
+                "        %s(0.0)%s\n"
                 "    #endif\n        ", 
                 _defaultTexcoordName.c_str(), _defaultTexcoordName.c_str(),
-                Base::_syntax->getTypeName(variable->getType()).c_str());
+                separator.c_str(),
+                Base::_syntax->getTypeName(variable->getType()).c_str(),
+                separator.c_str());
     }
     else if (mxVariableName.compare(0, mx::HW::T_IN_GEOMPROP.size(), 
                                     mx::HW::T_IN_GEOMPROP) == 0) {
@@ -584,12 +588,14 @@ HdStMaterialXShaderGen<Base>::_EmitMxVertexDataLine(
         }
         hdVariableDef = TfStringPrintf("\n"
                 "    #ifdef HD_HAS_%s\n"
-                "        HdGet_%s(),\n"
+                "        HdGet_%s()%s\n"
                 "    #else\n"
-                "        %s,\n"
+                "        %s%s\n"
                 "    #endif\n        ", 
                 geompropName.c_str(), geompropName.c_str(),
-                defaultValueString.c_str());
+                separator.c_str(),
+                defaultValueString.c_str(),
+                separator.c_str());
     }
     else {
         const std::string valueStr = variable->getValue() 

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPSdefault.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPSdefault.out
@@ -70,7 +70,6 @@ float displacement;
 float occlusion;
 
 // Uniform block: PrivateUniforms
-float u_alphaThreshold = 0.001000;
 mat4 u_envMatrix = mat4(-1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 0.000000, -1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000);
 int u_envRadianceMips;
 int u_envRadianceSamples;
@@ -1614,12 +1613,7 @@ vec4 surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     mxInit(Peye, Neye);
     surfaceshader SR_default_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMP_UsdPreviewSurface_surfaceshader(diffuseColor, emissiveColor, useSpecularWorkflow, specularColor, metallic, roughness, clearcoat, clearcoatRoughness, opacity, opacityThreshold, ior, normal, displacement, occlusion, SR_default_out);
-    float outAlpha = clamp(1.0 - dot(SR_default_out.transparency, vec3(0.3333)), 0.0, 1.0);
-    vec4 mxOut = vec4(SR_default_out.color, outAlpha);
-    if (outAlpha < u_alphaThreshold)
-    {
-        discard;
-    }
+    vec4 mxOut = vec4(SR_default_out.color, 1.0);
     mxOut = ApplyColorOverrides(mxOut);
     return mxOut;
 }

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPStextured.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPStextured.out
@@ -92,7 +92,6 @@ int image_roughness_frameoffset;
 int image_roughness_frameendaction;
 
 // Uniform block: PrivateUniforms
-float u_alphaThreshold = 0.001000;
 mat4 u_envMatrix = mat4(-1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 0.000000, -1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000);
 int u_envRadianceMips;
 int u_envRadianceSamples;
@@ -1707,12 +1706,7 @@ vec4 surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     NG_tiledimage_float(image_roughness_file, image_roughness_default, geomprop_UV0_out1, image_roughness_uvtiling, image_roughness_uvoffset, image_roughness_realworldimagesize, image_roughness_realworldtilesize, image_roughness_filtertype, image_roughness_framerange, image_roughness_frameoffset, image_roughness_frameendaction, image_roughness_out);
     surfaceshader SR_brass1_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMP_UsdPreviewSurface_surfaceshader(image_color_out, emissiveColor, useSpecularWorkflow, specularColor, metallic, image_roughness_out, clearcoat, clearcoatRoughness, opacity, opacityThreshold, ior, normal, displacement, occlusion, SR_brass1_out);
-    float outAlpha = clamp(1.0 - dot(SR_brass1_out.transparency, vec3(0.3333)), 0.0, 1.0);
-    vec4 mxOut = vec4(SR_brass1_out.color, outAlpha);
-    if (outAlpha < u_alphaThreshold)
-    {
-        discard;
-    }
+    vec4 mxOut = vec4(SR_brass1_out.color, 1.0);
     mxOut = ApplyColorOverrides(mxOut);
     return mxOut;
 }

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_texcoord.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_texcoord.out
@@ -76,7 +76,6 @@ vec2 mult1_in2;
 float mod1_in2;
 
 // Uniform block: PrivateUniforms
-float u_alphaThreshold = 0.001000;
 mat4 u_envMatrix = mat4(-1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 0.000000, -1.000000, 0.000000, 0.000000, 0.000000, 0.000000, 1.000000);
 int u_envRadianceMips;
 int u_envRadianceSamples;
@@ -1637,12 +1636,7 @@ vec4 surfaceShader(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     vec3 swizz_xxx_out = vec3(mod1_out, mod1_out, mod1_out);
     surfaceshader surface_shader_node_out = surfaceshader(vec3(0.0),vec3(0.0));
     IMP_UsdPreviewSurface_surfaceshader(swizz_xxx_out, emissiveColor, useSpecularWorkflow, specularColor, metallic, roughness, clearcoat, clearcoatRoughness, opacity, opacityThreshold, ior, normal, displacement, occlusion, surface_shader_node_out);
-    float outAlpha = clamp(1.0 - dot(surface_shader_node_out.transparency, vec3(0.3333)), 0.0, 1.0);
-    vec4 mxOut = vec4(surface_shader_node_out.color, outAlpha);
-    if (outAlpha < u_alphaThreshold)
-    {
-        discard;
-    }
+    vec4 mxOut = vec4(surface_shader_node_out.color, 1.0);
     mxOut = ApplyColorOverrides(mxOut);
     return mxOut;
 }

--- a/pxr/usd/usdMtlx/parser.cpp
+++ b/pxr/usd/usdMtlx/parser.cpp
@@ -400,9 +400,9 @@ ParseMetadata(
 {
     const auto& value = element->getAttribute(attribute);
     if (!value.empty()) {
-        // Change the 'texture2d' role for stdlib MaterialX Texture nodes
+        // Change the 'texture2d' and 'texture3d' roles for stdlib MaterialX Texture nodes
         // to 'texture' for Sdr.
-        if (key == SdrNodeMetadata->Role && value == "texture2d") {
+        if (key == SdrNodeMetadata->Role && (value == "texture2d" || value == "texture3d")) {
             builder->metadata[key] = "texture";
         }
         else {


### PR DESCRIPTION
### Description of Change(s)

Fixes:

- MaterialX: Storm fails to reuse GLSL shaders for networks differing only on node names #2330
- Storm shader compilation errors when using MaterialX triplanar projection node. #3004
- Improve transparency detection and fix generation

Using a topo-trimmed network resulted in all shaders being generated with opaque semantics. The shaders are now created with the right transparent hardware settings.

Also improved transparency detection at the `_GetMaterialTag` level by adding more checks for known surfaces and delegating to MaterialX when dealing with custom shaders, but without generating the full MaterialX document.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/2330
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3004

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
