### PR TITLE
Remove `boost/noncopyable.h` from python related headers

### DIFF
--- a/pxr/base/tf/pyOptional.h
+++ b/pxr/base/tf/pyOptional.h
@@ -29,7 +29,6 @@
 #include "pxr/pxr.h"
 
 #include "pxr/base/tf/pyUtils.h"
-#include <boost/noncopyable.hpp>
 #include <boost/optional.hpp>
 #include <boost/python/converter/from_python.hpp>
 #include <boost/python/extract.hpp>
@@ -65,8 +64,10 @@ struct register_python_conversion
 };
 
 template <typename T>
-struct python_optional : public boost::noncopyable
+struct python_optional
 {
+    python_optional(const python_optional&) = delete;
+    python_optional& operator=(const python_optional&) = delete;
     template <typename Optional>
     struct optional_to_python
     {

--- a/pxr/base/tf/pyWrapContext.h
+++ b/pxr/base/tf/pyWrapContext.h
@@ -28,8 +28,6 @@
 
 #include "pxr/base/tf/singleton.h"
 
-#include <boost/noncopyable.hpp>
-
 #include <string>
 #include <vector>
 
@@ -37,7 +35,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 // This is used internally by the Tf python wrapping infrastructure.
 
-class Tf_PyWrapContextManager : public boost::noncopyable {
+class Tf_PyWrapContextManager {
+    Tf_PyWrapContextManager(const Tf_PyWrapContextManager&) = delete;
+    Tf_PyWrapContextManager&
+    operator=(const Tf_PyWrapContextManager&) = delete;
 
   public:
 


### PR DESCRIPTION
### Description of Change(s)
#3028 demonstrated that OpenUSD can be built without boost. However, some transitive inclusions through python only headers are causing boost headers to end up in the `pch.h` files.

This removes the unnecessary include of `boost/noncopyable` in favor of explicitly deleting the copy constructor and assignment operator.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
