### PR TITLE
Support namespaces in `propertyNamespacePrefix` for `usdGenSchema`

### DIFF
--- a/pxr/usd/usd/codegenTemplates/schemaClass.cpp
+++ b/pxr/usd/usd/codegenTemplates/schemaClass.cpp
@@ -28,10 +28,6 @@
 #include "pxr/usd/sdf/types.h"
 #include "pxr/usd/sdf/assetPath.h"
 
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
-#include "pxr/base/tf/staticTokens.h"
-
-{% endif %}
 {% if useExportAPI %}
 {{ namespaceOpen }}
 
@@ -52,13 +48,6 @@ TF_REGISTRY_FUNCTION(TfType)
 {% endif %}
 }
 
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
-TF_DEFINE_PRIVATE_TOKENS(
-    _schemaTokens,
-    ({{ cls.propertyNamespacePrefix }})
-);
-
-{% endif %}
 /* virtual */
 {{ cls.cppClassName }}::~{{ cls.cppClassName }}()
 {
@@ -73,10 +62,10 @@ TF_DEFINE_PRIVATE_TOKENS(
         TF_CODING_ERROR("Invalid stage");
         return {{ cls.cppClassName }}();
     }
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     TfToken name;
     if (!Is{{ cls.usdPrimTypeName }}Path(path, &name)) {
-        TF_CODING_ERROR("Invalid {{ cls.propertyNamespacePrefix }} path <%s>.", path.GetText());
+        TF_CODING_ERROR("Invalid {{ cls.propertyNamespace.prefix }} path <%s>.", path.GetText());
         return {{ cls.cppClassName }}();
     }
     return {{ cls.cppClassName }}(stage->GetPrimAtPath(path.GetPrimPath()), name);
@@ -123,7 +112,7 @@ std::vector<{{ cls.cppClassName }}>
         stage->DefinePrim(path, usdPrimTypeName));
 }
 {% endif %}
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
 
 /* static */
 bool 
@@ -167,9 +156,9 @@ bool
     }
 
     if (tokens.size() >= 2
-        && tokens[0] == _schemaTokens->{{ cls.propertyNamespacePrefix }}) {
+        && tokens[0] == {{ tokensPrefix }}Tokens->{{ cls.propertyNamespace.token }}) {
         *name = TfToken(propertyName.substr(
-            _schemaTokens->{{ cls.propertyNamespacePrefix }}.GetString().size() + 1));
+           {{ tokensPrefix }}Tokens->{{ cls.propertyNamespace.token }}.GetString().size() + 1));
         return true;
     }
 
@@ -244,7 +233,7 @@ const TfType &
 {
     return _GetStaticTfType();
 }
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
 
 /// Returns the property name prefixed with the correct namespace prefix, which
 /// is composed of the the API's propertyNamespacePrefix metadata and the
@@ -265,7 +254,7 @@ _GetNamespacedPropertyName(const TfToken instanceName, const TfToken propName)
 UsdAttribute
 {{ cls.cppClassName }}::Get{{ Proper(attr.apiName) }}Attr() const
 {
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     return GetPrim().GetAttribute(
         _GetNamespacedPropertyName(
             GetName(),
@@ -279,7 +268,7 @@ UsdAttribute
 UsdAttribute
 {{ cls.cppClassName }}::Create{{ Proper(attr.apiName) }}Attr(VtValue const &defaultValue, bool writeSparsely) const
 {
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     return UsdSchemaBase::_CreateAttr(
                        _GetNamespacedPropertyName(
                             GetName(),
@@ -304,7 +293,7 @@ UsdAttribute
 UsdRelationship
 {{ cls.cppClassName }}::Get{{ Proper(rel.apiName) }}Rel() const
 {
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     return GetPrim().GetRelationship(
         _GetNamespacedPropertyName(
             GetName(),
@@ -318,7 +307,7 @@ UsdRelationship
 UsdRelationship
 {{ cls.cppClassName }}::Create{{ Proper(rel.apiName) }}Rel() const
 {
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     return GetPrim().CreateRelationship(
                        _GetNamespacedPropertyName(
                            GetName(),

--- a/pxr/usd/usd/codegenTemplates/schemaClass.h
+++ b/pxr/usd/usd/codegenTemplates/schemaClass.h
@@ -88,7 +88,7 @@ public:
     /// {{ cls.cppClassName }}::Get(
     ///    prim.GetStage(),
     ///    prim.GetPath().AppendProperty(
-    ///        "{{ cls.propertyNamespacePrefix }}:name"));
+    ///        "{{ cls.propertyNamespace.prefix }}:name"));
     ///
     /// for a \em valid \p prim, but will not immediately throw an error for
     /// an invalid \p prim
@@ -161,9 +161,9 @@ public:
     /// Return a {{ cls.cppClassName }} holding the prim adhering to this
     /// schema at \p path on \p stage.  If no prim exists at \p path on
     /// \p stage, or if the prim at that path does not adhere to this schema,
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     /// return an invalid schema object.  \p path must be of the format
-    /// <path>.{{ cls.propertyNamespacePrefix }}:name .
+    /// <path>.{{ cls.propertyNamespace.prefix }}:name .
     ///
     /// This is shorthand for the following:
     ///
@@ -234,7 +234,7 @@ public:
     static {{ cls.cppClassName }}
     Define(const UsdStagePtr &stage, const SdfPath &path);
 {% endif %}
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
     /// Checks if the given name \p baseName is the base name of a property
     /// of {{ cls.usdPrimTypeName }}.
     {% if useExportAPI -%}

--- a/pxr/usd/usd/codegenTemplates/wrapSchemaClass.cpp
+++ b/pxr/usd/usd/codegenTemplates/wrapSchemaClass.cpp
@@ -66,7 +66,7 @@ _Create{{ Proper(attr.apiName) }}Attr({{ cls.cppClassName }} &self,
 }
 {% endif %}
 {% endfor %}
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
 
 static bool _WrapIs{{ cls.usdPrimTypeName }}Path(const SdfPath &path) {
     TfToken collectionName;
@@ -254,7 +254,7 @@ void wrap{{ cls.cppClassName }}()
              &This::Create{{ Proper(rel.apiName) }}Rel)
 {% endif %}
 {% endfor %}
-{% if cls.isMultipleApply and cls.propertyNamespacePrefix %}
+{% if cls.isMultipleApply and cls.propertyNamespace %}
         .def("Is{{ cls.usdPrimTypeName }}Path", _WrapIs{{ cls.usdPrimTypeName }}Path)
             .staticmethod("Is{{ cls.usdPrimTypeName }}Path")
 {% endif %}

--- a/pxr/usd/usd/collectionAPI.cpp
+++ b/pxr/usd/usd/collectionAPI.cpp
@@ -28,8 +28,6 @@
 #include "pxr/usd/sdf/types.h"
 #include "pxr/usd/sdf/assetPath.h"
 
-#include "pxr/base/tf/staticTokens.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Register the schema with the TfType system.
@@ -39,11 +37,6 @@ TF_REGISTRY_FUNCTION(TfType)
         TfType::Bases< UsdAPISchemaBase > >();
     
 }
-
-TF_DEFINE_PRIVATE_TOKENS(
-    _schemaTokens,
-    (collection)
-);
 
 /* virtual */
 UsdCollectionAPI::~UsdCollectionAPI()
@@ -131,9 +124,9 @@ UsdCollectionAPI::IsCollectionAPIPath(
     }
 
     if (tokens.size() >= 2
-        && tokens[0] == _schemaTokens->collection) {
+        && tokens[0] == UsdTokens->collection) {
         *name = TfToken(propertyName.substr(
-            _schemaTokens->collection.GetString().size() + 1));
+           UsdTokens->collection.GetString().size() + 1));
         return true;
     }
 

--- a/pxr/usd/usd/usdGenSchema.py
+++ b/pxr/usd/usd/usdGenSchema.py
@@ -41,6 +41,7 @@ generated that will compile and work with USD Core successfully:
 """
 
 from __future__ import print_function
+import dataclasses
 import sys, os, re, inspect
 import keyword
 from argparse import ArgumentParser
@@ -293,14 +294,14 @@ def _CamelCase(aString):
 Token = namedtuple('Token', ['id', 'value', 'desc'])
 
 def _GetNameAndGeneratedSchemaPropNameForPropInfo(sdfPropName, classInfo):
-    if classInfo.propertyNamespacePrefix:
+    if classInfo.propertyNamespace:
         # A property namespace prefix will only exist for multiple apply API
         # schemas and is used to create the instanceable namespace prefix 
         # prepended to all its properties. We prepend this instanceable 
         # prefix to the raw name here.
         generatedSchemaPropName = \
             Usd.SchemaRegistry.MakeMultipleApplyNameTemplate(
-                classInfo.propertyNamespacePrefix, sdfPropName)
+                classInfo.propertyNamespace.prefix, sdfPropName)
         # Since the property info's name is used to create the identifier 
         # used for tokens and such, we make it from the instanced property 
         # name with the instance name placeholder replaced with 
@@ -480,6 +481,17 @@ def _InheritsOwnFamily(p):
         p.GetPath().name)
     return family in allInheritedFamilies
 
+@dataclasses.dataclass
+class MultiApplyPropertyNamespace:
+    prefix : str
+    token : str
+
+    @classmethod
+    def Create(cls, prefix, useLiteralIdentifier):
+        return cls(prefix, _MakeValidToken(prefix, useLiteralIdentifier)) \
+               if prefix else None
+
+
 class ClassInfo(object):
     def __init__(self, usdPrim, sdfPrim, useLiteralIdentifier=False):
         # First validate proper class naming...
@@ -601,8 +613,10 @@ class ClassInfo(object):
                 not self.isAPISchemaBase and not self.isTypedBase
         self.apiSchemaType = self.customData.get(API_SCHEMA_TYPE, 
                 SINGLE_APPLY if self.isApi else None)
-        self.propertyNamespacePrefix = \
-            self.customData.get(PROPERTY_NAMESPACE_PREFIX)
+        self.propertyNamespace = MultiApplyPropertyNamespace.Create(
+            self.customData.get(PROPERTY_NAMESPACE_PREFIX),
+            useLiteralIdentifier
+        )
         self.apiAutoApply = self.customData.get(API_AUTO_APPLY)
         self.apiCanOnlyApply = self.customData.get(API_CAN_ONLY_APPLY)
         self.apiAllowedInstanceNames = self.customData.get(
@@ -616,7 +630,7 @@ class ClassInfo(object):
                 sdfPrim.path)
 
         if self.apiSchemaType != MULTIPLE_APPLY:
-            if self.propertyNamespacePrefix:
+            if self.propertyNamespace:
                 raise _GetSchemaDefException(
                     "%s should only be used as a customData field on "
                     "multiple-apply API schemas." % PROPERTY_NAMESPACE_PREFIX,
@@ -795,7 +809,7 @@ def _MakeMultipleApplySchemaNameTemplate(apiSchemaName):
 # use the USD prim because we need to know all override properties for the 
 # flattened schema class, so this will include any overrides provided purely 
 # through inheritance.
-def _GetAPISchemaOverridePropertyNames(usdPrim, propertyNamespacePrefix):
+def _GetAPISchemaOverridePropertyNames(usdPrim, propertyNamespace):
     apiSchemaOverridePropertyNames = []
 
     for usdProp in usdPrim.GetProperties():
@@ -845,9 +859,9 @@ def _GetAPISchemaOverridePropertyNames(usdPrim, propertyNamespacePrefix):
         # schemas. If so, the property names need to be converted into their
         # template names to match the properties that will be in the 
         # generatedSchema.
-        if propertyNamespacePrefix:
+        if propertyNamespace:
             propName = Usd.SchemaRegistry.MakeMultipleApplyNameTemplate(
-                propertyNamespacePrefix, propName)
+                propertyNamespace.prefix, propName)
 
         # Add the property name to the list.
         apiSchemaOverridePropertyNames.append(propName)
@@ -880,13 +894,13 @@ def ParseUsd(usdFilePath):
         # make sure that if we have a multiple-apply schema with a property
         # namespace prefix that the prim actually has some properties
         if classInfo.apiSchemaType == MULTIPLE_APPLY:
-            if classInfo.propertyNamespacePrefix and \
+            if classInfo.propertyNamespace and \
                 len(sdfPrim.properties) == 0:
                     raise _GetSchemaDefException(
                         "Multiple-apply schemas that have the "
                         "propertyNamespacePrefix metadata fields must have at "
                         "least one property", sdfPrim.path)
-            if not classInfo.propertyNamespacePrefix and \
+            if not classInfo.propertyNamespace and \
                 not len(sdfPrim.properties) == 0:
                     raise _GetSchemaDefException(
                         "Multiple-apply schemas that do not"
@@ -967,7 +981,7 @@ def ParseUsd(usdFilePath):
         # schemas.
         classInfo.apiSchemaOverridePropertyNames = \
             _GetAPISchemaOverridePropertyNames(
-                usdPrim, classInfo.propertyNamespacePrefix)
+                usdPrim, classInfo.propertyNamespace)
     
     for classInfo in classes:
         # If this is an applied API schema that does not inherit from 
@@ -1265,9 +1279,9 @@ def GatherTokens(classes, libName, libTokens,
 
         # Add property namespace prefix token for multiple-apply API
         # schema to token set
-        if cls.propertyNamespacePrefix:
-            _AddToken(tokenDict, cls.tokens, cls.propertyNamespacePrefix,
-                      cls.propertyNamespacePrefix,
+        if cls.propertyNamespace:
+            _AddToken(tokenDict, cls.tokens, cls.propertyNamespace.token,
+                      cls.propertyNamespace.prefix,
                       "Property namespace prefix for the %s schema." \
                               % cls.cppClassName, True)
 

--- a/pxr/usd/usdPhysics/driveAPI.cpp
+++ b/pxr/usd/usdPhysics/driveAPI.cpp
@@ -28,8 +28,6 @@
 #include "pxr/usd/sdf/types.h"
 #include "pxr/usd/sdf/assetPath.h"
 
-#include "pxr/base/tf/staticTokens.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Register the schema with the TfType system.
@@ -39,11 +37,6 @@ TF_REGISTRY_FUNCTION(TfType)
         TfType::Bases< UsdAPISchemaBase > >();
     
 }
-
-TF_DEFINE_PRIVATE_TOKENS(
-    _schemaTokens,
-    (drive)
-);
 
 /* virtual */
 UsdPhysicsDriveAPI::~UsdPhysicsDriveAPI()
@@ -131,9 +124,9 @@ UsdPhysicsDriveAPI::IsPhysicsDriveAPIPath(
     }
 
     if (tokens.size() >= 2
-        && tokens[0] == _schemaTokens->drive) {
+        && tokens[0] == UsdPhysicsTokens->drive) {
         *name = TfToken(propertyName.substr(
-            _schemaTokens->drive.GetString().size() + 1));
+           UsdPhysicsTokens->drive.GetString().size() + 1));
         return true;
     }
 

--- a/pxr/usd/usdPhysics/limitAPI.cpp
+++ b/pxr/usd/usdPhysics/limitAPI.cpp
@@ -28,8 +28,6 @@
 #include "pxr/usd/sdf/types.h"
 #include "pxr/usd/sdf/assetPath.h"
 
-#include "pxr/base/tf/staticTokens.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Register the schema with the TfType system.
@@ -39,11 +37,6 @@ TF_REGISTRY_FUNCTION(TfType)
         TfType::Bases< UsdAPISchemaBase > >();
     
 }
-
-TF_DEFINE_PRIVATE_TOKENS(
-    _schemaTokens,
-    (limit)
-);
 
 /* virtual */
 UsdPhysicsLimitAPI::~UsdPhysicsLimitAPI()
@@ -123,9 +116,9 @@ UsdPhysicsLimitAPI::IsPhysicsLimitAPIPath(
     }
 
     if (tokens.size() >= 2
-        && tokens[0] == _schemaTokens->limit) {
+        && tokens[0] == UsdPhysicsTokens->limit) {
         *name = TfToken(propertyName.substr(
-            _schemaTokens->limit.GetString().size() + 1));
+           UsdPhysicsTokens->limit.GetString().size() + 1));
         return true;
     }
 

--- a/pxr/usd/usdShade/coordSysAPI.cpp
+++ b/pxr/usd/usdShade/coordSysAPI.cpp
@@ -28,8 +28,6 @@
 #include "pxr/usd/sdf/types.h"
 #include "pxr/usd/sdf/assetPath.h"
 
-#include "pxr/base/tf/staticTokens.h"
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Register the schema with the TfType system.
@@ -39,11 +37,6 @@ TF_REGISTRY_FUNCTION(TfType)
         TfType::Bases< UsdAPISchemaBase > >();
     
 }
-
-TF_DEFINE_PRIVATE_TOKENS(
-    _schemaTokens,
-    (coordSys)
-);
 
 /* virtual */
 UsdShadeCoordSysAPI::~UsdShadeCoordSysAPI()
@@ -121,9 +114,9 @@ UsdShadeCoordSysAPI::IsCoordSysAPIPath(
     }
 
     if (tokens.size() >= 2
-        && tokens[0] == _schemaTokens->coordSys) {
+        && tokens[0] == UsdShadeTokens->coordSys) {
         *name = TfToken(propertyName.substr(
-            _schemaTokens->coordSys.GetString().size() + 1));
+           UsdShadeTokens->coordSys.GetString().size() + 1));
         return true;
     }
 
@@ -332,7 +325,7 @@ UsdShadeCoordSysAPI::GetLocalBindings() const
     }
 
     for (const UsdProperty &prop:
-         GetPrim().GetAuthoredPropertiesInNamespace(_schemaTokens->coordSys)) {
+         GetPrim().GetAuthoredPropertiesInNamespace(UsdShadeTokens->coordSys)) {
         if (UsdRelationship rel = prop.As<UsdRelationship>()) {
             targets.clear();
             if (rel.GetForwardedTargets(&targets) && !targets.empty()) {
@@ -449,7 +442,7 @@ UsdShadeCoordSysAPI::FindBindingsWithInheritance() const
     for (UsdPrim prim = GetPrim(); prim; prim = prim.GetParent()) {
         SdfPathVector targets;
         for (UsdProperty prop : prim.GetAuthoredPropertiesInNamespace(
-                    _schemaTokens->coordSys)) {
+                    UsdShadeTokens->coordSys)) {
             if (UsdRelationship rel = prop.As<UsdRelationship>()) {
                 // Check if name is already bound; skip if bound.
                 bool nameIsAlreadyBound = false;
@@ -542,7 +535,7 @@ UsdShadeCoordSysAPI::HasLocalBindings() const
     }
 
     for (const UsdProperty &prop:
-         GetPrim().GetAuthoredPropertiesInNamespace(_schemaTokens->coordSys)) {
+         GetPrim().GetAuthoredPropertiesInNamespace(UsdShadeTokens->coordSys)) {
         if (UsdRelationship rel = prop.As<UsdRelationship>()) {
             if (rel) {
                 if (checker == 2) {
@@ -711,7 +704,7 @@ UsdShadeCoordSysAPI::BlockBinding() const
 TfToken
 UsdShadeCoordSysAPI::GetCoordSysRelationshipName(const std::string &name)
 {
-    return TfToken(_schemaTokens->coordSys.GetString() + ":" + name);
+    return TfToken(UsdShadeTokens->coordSys.GetString() + ":" + name);
 }
 
 /* static */


### PR DESCRIPTION
### Description of Change(s)

The current implementation of `usdGenSchema` assumes that `propertyNamespacePrefix` used in multiple apply schemas is a valid identifier and it can be used as a token name directly. This prevents property namespaces from containing the otherwise valid `:`.

This PR changes `propertyNamespacePrefix` to be a dataclass that stores both the prefix value a valid token name that can be threaded through the schema generation process.

With this change, a library's public static tokens can be used directly and there's no need for the private `_schemaTokens` internal to the class anymore.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
