### PR TITLE
Autodesk: Add HgiAttachmentResolveFilter for depth texture in HgiMetal

### DIFF
--- a/pxr/imaging/hgi/attachmentDesc.cpp
+++ b/pxr/imaging/hgi/attachmentDesc.cpp
@@ -44,7 +44,8 @@ bool operator==(
             lhs.srcAlphaBlendFactor == rhs.srcAlphaBlendFactor &&
             lhs.dstAlphaBlendFactor == rhs.dstAlphaBlendFactor &&
             lhs.alphaBlendOp == rhs.alphaBlendOp &&
-            lhs.blendConstantColor == rhs.blendConstantColor;
+            lhs.blendConstantColor == rhs.blendConstantColor &&
+            lhs.resolveFilter == rhs.resolveFilter;
 }
 
 bool operator!=(
@@ -72,7 +73,8 @@ std::ostream& operator<<(
         << "srcAlphaBlendFactor: " << attachment.srcAlphaBlendFactor << ", "
         << "dstAlphaBlendFactor: " << attachment.dstAlphaBlendFactor << ", "
         << "alphaBlendOp: " << attachment.alphaBlendOp << ", "
-        << "blendConstantColor: " << attachment.blendConstantColor <<
+        << "blendConstantColor: " << attachment.blendConstantColor << ", "
+        << "resolveFilter: " << attachment.resolveFilter <<
     "}";
     return out;
 }

--- a/pxr/imaging/hgi/attachmentDesc.h
+++ b/pxr/imaging/hgi/attachmentDesc.h
@@ -80,6 +80,7 @@ struct HgiAttachmentDesc
     , dstAlphaBlendFactor(HgiBlendFactorZero)
     , alphaBlendOp(HgiBlendOpAdd)
     , blendConstantColor(0.0f, 0.0f, 0.0f, 0.0f)
+    , resolveFilter(HgiAttachmentResolveFilterDefault)
     {}
 
     HgiFormat format;
@@ -96,6 +97,7 @@ struct HgiAttachmentDesc
     HgiBlendFactor dstAlphaBlendFactor;
     HgiBlendOp alphaBlendOp;
     GfVec4f blendConstantColor;
+    HgiAttachmentResolveFilter resolveFilter;
 };
 
 using HgiAttachmentDescVector = std::vector<HgiAttachmentDesc>;

--- a/pxr/imaging/hgi/enums.h
+++ b/pxr/imaging/hgi/enums.h
@@ -297,6 +297,34 @@ enum HgiAttachmentStoreOp
     HgiAttachmentStoreOpCount
 };
 
+/// \enum HgiAttachmentResolveFilter
+///
+/// Describes what will happen to the attachment pixel data after MSAA resolving.
+///
+/// <ul>
+/// <li>HgiAttachmentResolveFilterDefault:
+///   The attachment pixel value will be determined by the default mode which can vary across different APIs.</li>
+/// <li>HgiAttachmentResolveFilterSample0:
+///   The attachment pixel value will be the value of the first sample.</li>
+/// <li>HgiAttachmentResolveFilterMin:
+///   The attachment pixel value will be the minimum value of all the samples.</li>
+/// <li>HgiAttachmentResolveFilterMax:
+///   The attachment pixel value will be the maximum value of all the samples.</li>
+/// <li>HgiAttachmentResolveFilterAverage:
+///   The attachment pixel value will be the average value of all the samples..</li>
+/// </ul>
+///
+enum HgiAttachmentResolveFilter
+{
+    HgiAttachmentResolveFilterDefault = 0,
+    HgiAttachmentResolveFilterSample0,
+    HgiAttachmentResolveFilterMin,
+    HgiAttachmentResolveFilterMax,
+    HgiAttachmentResolveFilterAverage,
+    
+    HgiAttachmentResolveFilterCount
+};
+
 /// \enum HgiBufferUsageBits
 ///
 /// Describes the properties and usage of the buffer.

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -72,6 +72,19 @@ _SetVertexBindings(id<MTLRenderCommandEncoder> encoder,
     }
 }
 
+static MTLMultisampleDepthResolveFilter
+_HgiMultiSampleResolveFilterToMTLMultiSampleDepthResolveFilter(HgiAttachmentResolveFilter filter)
+{
+    if (filter == HgiAttachmentResolveFilterSample0)
+        return MTLMultisampleDepthResolveFilterSample0;
+    else if (filter == HgiAttachmentResolveFilterMin)
+        return MTLMultisampleDepthResolveFilterMin;
+    else if (filter == HgiAttachmentResolveFilterMax)
+        return MTLMultisampleDepthResolveFilterMax;
+    else
+        return MTLMultisampleDepthResolveFilterSample0;
+}
+
 HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
     HgiMetal* hgi,
     HgiGraphicsCmdsDesc const& desc)
@@ -207,6 +220,12 @@ HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
 
             metalDepthAttachment.resolveTexture =
                 resolveTexture->GetTextureId();
+            
+            if (hgiDepthAttachment.resolveFilter != HgiAttachmentResolveFilterDefault)
+            {
+                metalDepthAttachment.depthResolveFilter = 
+                    _HgiMultiSampleResolveFilterToMTLMultiSampleDepthResolveFilter(hgiDepthAttachment.resolveFilter);
+            }
             
             if (hgiDepthAttachment.storeOp == HgiAttachmentStoreOpStore) {
                 metalDepthAttachment.storeAction =


### PR DESCRIPTION
### Description of Change(s)

Depth Priority is broken after MSAA resolve of the depth buffer. This changeset adds HgiAttachmentResolveFilter enumeration to the HgiAttachmentDesc and add MSAA resolver support for the depth texture in HgiMetal.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
