### PR TITLE
Autodesk: Add native visualisation for versions 23 and 24.

### DIFF
--- a/extras/natvis/USD-23.natvis
+++ b/extras/natvis/USD-23.natvis
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Pixar Type Visualization for Visual Studio and VSCode
+-->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <!--
+    TfPointerAndBits is used throughout USD to pack a few bits of data in the low bits of each pointer.
+    This of course confuses the heck out of Visual Studio, so here we teach VS what the actual pointer value is.
+    This lets you use anything derived from TfPointerAndBits as if it were a normal pointer in the Watch window.
+    Additionally, we automatically expand it as if it were a normal pointer and add a fake [bits] field at the end in
+    case you care what those bits are.
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfPointerAndBits&lt;*&gt;">
+    <SmartPointer Usage="Full">
+      ($T1*)((ULONGLONG)_ptrAndBits &amp; ~7)
+    </SmartPointer>
+    <Expand HideRawView="true">
+      <ExpandedItem Condition="_ptrAndBits > 7">
+        ($T1*)((ULONGLONG)_ptrAndBits &amp; ~7)
+      </ExpandedItem>
+      <Item Name="[bits]">
+        (UCHAR)((UCHAR)(_ptrAndBits) &amp; 7)
+      </Item>
+    </Expand>
+  </Type>
+
+  <!--
+    TfToken displays the token string as its value
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfToken">
+    <DisplayString>{((pxrInternal_v0_23__pxrReserved__::TfToken::_Rep*)((ULONGLONG)_rep._ptrAndBits &amp; ~7))->_cstr,sb}</DisplayString>
+  </Type>
+
+  <!--
+    SdfValueTypeName displays the actual type name as its value
+    This is dependent on a TfToken being the second element in Sdf_ValueTypeImpl, the first element being a pointer
+    We don't have the actual implementation available in a debugging context unless we're debugging inside libsdf.dll
+    Forgive me!
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::SdfValueTypeName">
+    <DisplayString>{*(pxrInternal_v0_23__pxrReserved__::TfToken*)(((void**)_impl)+1)}</DisplayString>
+  </Type>
+
+  <!--
+    HdSceneIndexObserver data
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdSceneIndexObserver::AddedPrimEntry">
+    <DisplayString>{primPath} ({primType})</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdSceneIndexObserver::RemovedPrimEntry">
+    <DisplayString>{primPath}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdSceneIndexObserver::DirtiedPrimEntry">
+    <DisplayString>{primPath}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdSceneIndexObserver::RenamedPrimEntry">
+    <DisplayString>{oldPrimPath} to {newPrimPath}</DisplayString>
+  </Type>
+
+  <!--
+    HdDataSourceLocator
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdDataSourceLocator">
+    <Expand>
+      <ExpandedItem>_tokens</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::HdDataSourceLocatorSet">
+    <DisplayString>{_locators}</DisplayString>
+    <Expand>
+       <ExpandedItem>_locators</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <!--
+    Display the property name for UsdAttribute
+    We ought to add the attribute value too, but it might not be easy; the code that gets that is super complicated
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::UsdObject">
+    <DisplayString>{_prim}:{_propName,sb}</DisplayString>
+  </Type>
+
+  <!--
+    Display the path and type of Usd_PrimData
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Usd_PrimData">
+    <DisplayString>[{*_primTypeInfo}]{_path}</DisplayString>
+  </Type>
+
+  <!--
+    Usd_PrimDataHandle holds a boost intrusive_ptr, which holds a pointer to the actual Usd_PrimData
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Usd_PrimDataHandle">
+    <SmartPointer Usage="Full">
+      _p.px
+    </SmartPointer>
+  </Type>
+
+  <!--
+    TfRefPtr smart pointer
+    There are a few specializations so we mark it optional just in case this doesn't parse
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfRefPtr&lt;*&gt;">
+    <SmartPointer Usage="Full" Optional="true">
+      _refBase
+    </SmartPointer>
+  </Type>
+
+  <!--
+    SdfLayer show identifier
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::SdfLayer">
+    <DisplayString Condition="_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Myres &lt; _assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._BUF_SIZE">id: {_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Bx._Buf,na}</DisplayString>
+    <DisplayString Condition="_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Myres &gt;= _assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._BUF_SIZE">id: {_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Bx._Ptr,na}</DisplayString>
+  </Type>
+
+  <!--
+    UsdStage show root name to help identify a stage
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::UsdStage">
+    <DisplayString>root {*_rootLayer}</DisplayString>
+  </Type>
+
+  <!--
+    TfType and related
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfType::_TypeInfo">
+    <!-- _TypeInfo is unfortunately opaque to VisualStudio, offset to find typename string member -->
+    <DisplayString>{*((std::string*)(((char*)this) + sizeof(pxrInternal_v0_23__pxrReserved__::TfType))),sb}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfType">
+    <DisplayString>{_info,na}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::UsdPrimTypeInfo">
+    <DisplayString>{_typeId.primTypeName,na}</DisplayString>
+  </Type>
+
+  <!--
+    UsdPrim show prim type and path
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::UsdPrim">
+    <DisplayString>{_prim-&gt;_path}</DisplayString>
+  </Type>
+
+  <!--
+    UsdSchemaBase for typed prims
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::UsdSchemaBase">
+    <DisplayString>{_primData}</DisplayString>
+  </Type>
+
+  <!--
+    Following types are for SdfPath display
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_PathNodeHandleImpl&lt;*&gt;">
+    <DisplayString>{_poolHandle}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::RootNode">
+    <DisplayString>/</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode">
+    <Intrinsic Name="GetParentPrim" Expression="(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)node-&gt;_parent.px">
+      <Parameter Name="node" Type="const pxrInternal_v0_23__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <DisplayString Condition="_elementCount == 0">/</DisplayString>
+    <DisplayString Condition="_elementCount == 1">/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 2">/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 3">/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 4">/{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 5">/{GetParentPrim(GetParentPrim(GetParentPrim(GetParentPrim(this))))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount &gt; 5">/.[{_elementCount}]./{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <Expand>
+      <Item Name="parent" Condition="_parent.px != nullptr &amp;&amp; _parent.px._nodeType == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)_parent.px</Item>
+      <Item Name="parent" Condition="_parent.px != nullptr &amp;&amp; _parent.px._nodeType == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimPropertyNode">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPropertyPathNode*)_parent.px</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_PrimPropertyPathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_PrimVariantSelectionNode">
+    <DisplayString>{_variantSelection}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_TargetPathNode">
+    <DisplayString>{_targetPath}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_RelationalAttributePathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_MapperPathNode">
+    <DisplayString>{_targetPath}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_MapperArgPathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_ExpressionPathNode">
+    <DisplayString>[Expr]</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::Sdf_Pool&lt;*,*,*,*&gt;::Handle">
+    <Intrinsic Name="GetRegionMask" Expression="(1 &lt;&lt; $T3) - 1" />
+    <Intrinsic Name="GetRegion" Expression="value &amp; GetRegionMask()" />
+    <Intrinsic Name="GetIndex" Expression="value &gt;&gt; $T3" />
+    <Intrinsic Name="GetPtr" Expression="usd_sdf.dll!pxrInternal_v0_23__pxrReserved__::Sdf_Pool&lt;$T1,$T2,$T3,$T4&gt;::_regionStarts[GetRegion()] + (GetIndex() * $T2)" />
+    <Intrinsic Name="GetPathNode" Expression="(pxrInternal_v0_23__pxrReserved__::Sdf_PathNode*)GetPtr()" />
+    <Intrinsic Name="GetNodeType" Expression="(pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::NodeType)GetPathNode()-&gt;_nodeType" />
+    <Intrinsic Name="GetPrimNode" Expression="(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)GetPtr()" />
+    <Intrinsic Name="GetParent" Expression="node-&gt;_parent.px">
+      <Parameter Name="node" Type="const pxrInternal_v0_23__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <Intrinsic Name="GetParentPrim" Expression="(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)node-&gt;_parent.px">
+      <Parameter Name="node" Type="const pxrInternal_v0_23__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <DisplayString Condition="GetPtr() == nullptr">null</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::RootNode">/</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 1">/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 2">/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 3">/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 4">/{GetParentPrim(GetParentPrim(GetParentPrim(GetPathNode())))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount &gt; 4">.../{GetParentPrim(GetParentPrim(GetParentPrim(GetPathNode())))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimPropertyNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_PrimPropertyPathNode*)GetPtr())-&gt;_name}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimVariantSelectionNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_PrimVariantSelectionNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::TargetNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_TargetPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::RelationalAttributeNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_RelationalAttributePathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::MapperNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_MapperPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::MapperArgNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_MapperArgPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::ExpressionNode">{((pxrInternal_v0_23__pxrReserved__::Sdf_ExpressionPathNode*)GetPtr())}</DisplayString>
+    <Expand>
+      <Item Name="RootPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::RootNode">(pxrInternal_v0_23__pxrReserved__::Sdf_RootPathNode*)GetPtr()</Item>
+      <Item Name="PrimPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimNode">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)GetPtr()</Item>
+      <Item Name="PrimPropertyPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimPropertyNode">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPropertyPathNode*)GetPtr()</Item>
+      <Item Name="PrimVariantSelectionNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::PrimVariantSelectionNode">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimVariantSelectionNode*)GetPtr()</Item>
+      <Item Name="TargetPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::TargetNode">(pxrInternal_v0_23__pxrReserved__::Sdf_TargetPathNode*)GetPtr()</Item>
+      <Item Name="RelationalAttributePathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::RelationalAttributeNode">(pxrInternal_v0_23__pxrReserved__::Sdf_RelationalAttributePathNode*)GetPtr()</Item>
+      <Item Name="MapperPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::MapperNode">(pxrInternal_v0_23__pxrReserved__::Sdf_MapperPathNode*)GetPtr()</Item>
+      <Item Name="MapperArgPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::MapperArgNode">(pxrInternal_v0_23__pxrReserved__::Sdf_MapperArgPathNode*)GetPtr()</Item>
+      <Item Name="ExpressionPathNode" Condition="GetNodeType() == pxrInternal_v0_23__pxrReserved__::Sdf_PathNode::ExpressionNode">(pxrInternal_v0_23__pxrReserved__::Sdf_ExpressionPathNode*)GetPtr()</Item>
+      <Item Name="parent1" Condition="GetParent(GetPathNode()) != 0">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetPathNode()))</Item>
+      <Item Name="parent2" Condition="GetParent(GetParent(GetPathNode())) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetPathNode())))</Item>
+      <Item Name="parent3" Condition="GetParent(GetParent(GetParent(GetPathNode()))) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetPathNode()))))</Item>
+      <Item Name="parent4" Condition="GetParent(GetParent(GetParent(GetParent(GetPathNode())))) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))</Item>
+      <Item Name="parent5" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))</Item>
+      <Item Name="parent6" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))))</Item>
+      <Item Name="parent7" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))) != nullptr">(pxrInternal_v0_23__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))))</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::SdfPath">
+    <DisplayString Condition="_propPart._poolHandle.value != 0">{_primPart,sb}.{_propPart,sb}</DisplayString>
+    <DisplayString Condition="_propPart._poolHandle.value == 0">{_primPart,sb}</DisplayString>
+  </Type>
+
+  <!--
+  Array Types
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::VtArray&lt;*&gt;">
+    <DisplayString>{{ size={_shapeData.totalSize} }}</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>_shapeData.totalSize</Size>
+        <ValuePointer>_data</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!--
+    TfSmallVector
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::TfSmallVector&lt;*,*&gt;">
+      <DisplayString>size={_size}</DisplayString>
+      <Expand>
+          <ArrayItems Condition="_capacity &lt;= $T2">
+              <Size>_size</Size>
+              <ValuePointer>($T1*)_data._local</ValuePointer>
+          </ArrayItems>
+          <ArrayItems Condition="_capacity &gt; $T2">
+              <Size>_size</Size>
+              <ValuePointer>_data._remote</ValuePointer>
+          </ArrayItems>
+      </Expand>
+  </Type>
+  
+
+  <!--
+  Expand GfVecX types so that you can see its values with one less click
+  -->
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec2d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec3d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec4d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec2f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec3f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec4f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec2i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec3i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfVec4i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfMatrix4d">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 3]">
+        <DisplayString>{_mtx._data[12]},     {_mtx._data[13]},     {_mtx._data[14]},     {_mtx._data[15]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfMatrix4f">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 3]">
+        <DisplayString>{_mtx._data[12]},     {_mtx._data[13]},     {_mtx._data[14]},     {_mtx._data[15]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfMatrix3d">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_23__pxrReserved__::GfMatrix3f">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+</AutoVisualizer>

--- a/extras/natvis/USD-24.natvis
+++ b/extras/natvis/USD-24.natvis
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Pixar Type Visualization for Visual Studio and VSCode
+-->
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <!--
+    TfPointerAndBits is used throughout USD to pack a few bits of data in the low bits of each pointer.
+    This of course confuses the heck out of Visual Studio, so here we teach VS what the actual pointer value is.
+    This lets you use anything derived from TfPointerAndBits as if it were a normal pointer in the Watch window.
+    Additionally, we automatically expand it as if it were a normal pointer and add a fake [bits] field at the end in
+    case you care what those bits are.
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfPointerAndBits&lt;*&gt;">
+    <SmartPointer Usage="Full">
+      ($T1*)((ULONGLONG)_ptrAndBits &amp; ~7)
+    </SmartPointer>
+    <Expand HideRawView="true">
+      <ExpandedItem Condition="_ptrAndBits > 7">
+        ($T1*)((ULONGLONG)_ptrAndBits &amp; ~7)
+      </ExpandedItem>
+      <Item Name="[bits]">
+        (UCHAR)((UCHAR)(_ptrAndBits) &amp; 7)
+      </Item>
+    </Expand>
+  </Type>
+
+  <!--
+    TfToken displays the token string as its value
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfToken">
+    <DisplayString>{((pxrInternal_v0_24__pxrReserved__::TfToken::_Rep*)((ULONGLONG)_rep._ptrAndBits &amp; ~7))->_cstr,sb}</DisplayString>
+  </Type>
+
+  <!--
+    SdfValueTypeName displays the actual type name as its value
+    This is dependent on a TfToken being the second element in Sdf_ValueTypeImpl, the first element being a pointer
+    We don't have the actual implementation available in a debugging context unless we're debugging inside libsdf.dll
+    Forgive me!
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::SdfValueTypeName">
+    <DisplayString>{*(pxrInternal_v0_24__pxrReserved__::TfToken*)(((void**)_impl)+1)}</DisplayString>
+  </Type>
+
+  <!--
+    HdSceneIndexObserver data
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdSceneIndexObserver::AddedPrimEntry">
+    <DisplayString>{primPath} ({primType})</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdSceneIndexObserver::RemovedPrimEntry">
+    <DisplayString>{primPath}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdSceneIndexObserver::DirtiedPrimEntry">
+    <DisplayString>{primPath}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdSceneIndexObserver::RenamedPrimEntry">
+    <DisplayString>{oldPrimPath} to {newPrimPath}</DisplayString>
+  </Type>
+
+  <!--
+    HdDataSourceLocator
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdDataSourceLocator">
+    <Expand>
+      <ExpandedItem>_tokens</ExpandedItem>
+    </Expand>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::HdDataSourceLocatorSet">
+    <DisplayString>{_locators}</DisplayString>
+    <Expand>
+       <ExpandedItem>_locators</ExpandedItem>
+    </Expand>
+  </Type>
+
+  <!--
+    Display the property name for UsdAttribute
+    We ought to add the attribute value too, but it might not be easy; the code that gets that is super complicated
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::UsdObject">
+    <DisplayString>{_prim}:{_propName,sb}</DisplayString>
+  </Type>
+
+  <!--
+    Display the path and type of Usd_PrimData
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Usd_PrimData">
+    <DisplayString>[{*_primTypeInfo}]{_path}</DisplayString>
+  </Type>
+
+  <!--
+    Usd_PrimDataHandle holds a boost intrusive_ptr, which holds a pointer to the actual Usd_PrimData
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Usd_PrimDataHandle">
+    <SmartPointer Usage="Full">
+      _p.px
+    </SmartPointer>
+  </Type>
+
+  <!--
+    TfRefPtr smart pointer
+    There are a few specializations so we mark it optional just in case this doesn't parse
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfRefPtr&lt;*&gt;">
+    <SmartPointer Usage="Full" Optional="true">
+      _refBase
+    </SmartPointer>
+  </Type>
+
+  <!--
+    SdfLayer show identifier
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::SdfLayer">
+    <DisplayString Condition="_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Myres &lt; _assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._BUF_SIZE">id: {_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Bx._Buf,na}</DisplayString>
+    <DisplayString Condition="_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Myres &gt;= _assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._BUF_SIZE">id: {_assetInfo._Mypair._Myval2->identifier._Mypair._Myval2._Bx._Ptr,na}</DisplayString>
+  </Type>
+
+  <!--
+    UsdStage show root name to help identify a stage
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::UsdStage">
+    <DisplayString>root {*_rootLayer}</DisplayString>
+  </Type>
+
+  <!--
+    TfType and related
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfType::_TypeInfo">
+    <!-- _TypeInfo is unfortunately opaque to VisualStudio, offset to find typename string member -->
+    <DisplayString>{*((std::string*)(((char*)this) + sizeof(pxrInternal_v0_24__pxrReserved__::TfType))),sb}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfType">
+    <DisplayString>{_info,na}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::UsdPrimTypeInfo">
+    <DisplayString>{_typeId.primTypeName,na}</DisplayString>
+  </Type>
+
+  <!--
+    UsdPrim show prim type and path
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::UsdPrim">
+    <DisplayString>{_prim-&gt;_path}</DisplayString>
+  </Type>
+
+  <!--
+    UsdSchemaBase for typed prims
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::UsdSchemaBase">
+    <DisplayString>{_primData}</DisplayString>
+  </Type>
+
+  <!--
+    Following types are for SdfPath display
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_PathNodeHandleImpl&lt;*&gt;">
+    <DisplayString>{_poolHandle}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::RootNode">
+    <DisplayString>/</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode">
+    <Intrinsic Name="GetParentPrim" Expression="(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)node-&gt;_parent.px">
+      <Parameter Name="node" Type="const pxrInternal_v0_24__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <DisplayString Condition="_elementCount == 0">/</DisplayString>
+    <DisplayString Condition="_elementCount == 1">/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 2">/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 3">/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 4">/{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount == 5">/{GetParentPrim(GetParentPrim(GetParentPrim(GetParentPrim(this))))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <DisplayString Condition="_elementCount &gt; 5">/.[{_elementCount}]./{GetParentPrim(GetParentPrim(GetParentPrim(this)))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(this))-&gt;_name,sb}/{GetParentPrim(this)-&gt;_name,sb}/{_name,sb}</DisplayString>
+    <Expand>
+      <Item Name="parent" Condition="_parent.px != nullptr &amp;&amp; _parent.px._nodeType == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)_parent.px</Item>
+      <Item Name="parent" Condition="_parent.px != nullptr &amp;&amp; _parent.px._nodeType == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimPropertyNode">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPropertyPathNode*)_parent.px</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_PrimPropertyPathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_PrimVariantSelectionNode">
+    <DisplayString>{_variantSelection}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_TargetPathNode">
+    <DisplayString>{_targetPath}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_RelationalAttributePathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_MapperPathNode">
+    <DisplayString>{_targetPath}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_MapperArgPathNode">
+    <DisplayString>{_name}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_ExpressionPathNode">
+    <DisplayString>[Expr]</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::Sdf_Pool&lt;*,*,*,*&gt;::Handle">
+    <Intrinsic Name="GetRegionMask" Expression="(1 &lt;&lt; $T3) - 1" />
+    <Intrinsic Name="GetRegion" Expression="value &amp; GetRegionMask()" />
+    <Intrinsic Name="GetIndex" Expression="value &gt;&gt; $T3" />
+    <Intrinsic Name="GetPtr" Expression="usd_sdf.dll!pxrInternal_v0_24__pxrReserved__::Sdf_Pool&lt;$T1,$T2,$T3,$T4&gt;::_regionStarts[GetRegion()] + (GetIndex() * $T2)" />
+    <Intrinsic Name="GetPathNode" Expression="(pxrInternal_v0_24__pxrReserved__::Sdf_PathNode*)GetPtr()" />
+    <Intrinsic Name="GetNodeType" Expression="(pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::NodeType)GetPathNode()-&gt;_nodeType" />
+    <Intrinsic Name="GetPrimNode" Expression="(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)GetPtr()" />
+    <Intrinsic Name="GetParent" Expression="node-&gt;_parent._pointer">
+      <Parameter Name="node" Type="const pxrInternal_v0_24__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <Intrinsic Name="GetParentPrim" Expression="(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)node-&gt;_parent._pointer">
+      <Parameter Name="node" Type="const pxrInternal_v0_24__pxrReserved__::Sdf_PathNode*" />
+    </Intrinsic>
+    <DisplayString Condition="GetPtr() == nullptr">null</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::RootNode">/</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 1">/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 2">/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 3">/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount == 4">/{GetParentPrim(GetParentPrim(GetParentPrim(GetPathNode())))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode &amp;&amp; GetPathNode()-&gt;_elementCount &gt; 4">.../{GetParentPrim(GetParentPrim(GetParentPrim(GetPathNode())))-&gt;_name,sb}/{GetParentPrim(GetParentPrim(GetPathNode()))-&gt;_name,sb}/{GetParentPrim(GetPathNode())-&gt;_name,sb}/{GetPrimNode()-&gt;_name,sb}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimPropertyNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_PrimPropertyPathNode*)GetPtr())-&gt;_name}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimVariantSelectionNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_PrimVariantSelectionNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::TargetNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_TargetPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::RelationalAttributeNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_RelationalAttributePathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::MapperNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_MapperPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::MapperArgNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_MapperArgPathNode*)GetPtr())}</DisplayString>
+    <DisplayString Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::ExpressionNode">{((pxrInternal_v0_24__pxrReserved__::Sdf_ExpressionPathNode*)GetPtr())}</DisplayString>
+    <Expand>
+      <Item Name="RootPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::RootNode">(pxrInternal_v0_24__pxrReserved__::Sdf_RootPathNode*)GetPtr()</Item>
+      <Item Name="PrimPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimNode">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)GetPtr()</Item>
+      <Item Name="PrimPropertyPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimPropertyNode">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPropertyPathNode*)GetPtr()</Item>
+      <Item Name="PrimVariantSelectionNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::PrimVariantSelectionNode">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimVariantSelectionNode*)GetPtr()</Item>
+      <Item Name="TargetPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::TargetNode">(pxrInternal_v0_24__pxrReserved__::Sdf_TargetPathNode*)GetPtr()</Item>
+      <Item Name="RelationalAttributePathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::RelationalAttributeNode">(pxrInternal_v0_24__pxrReserved__::Sdf_RelationalAttributePathNode*)GetPtr()</Item>
+      <Item Name="MapperPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::MapperNode">(pxrInternal_v0_24__pxrReserved__::Sdf_MapperPathNode*)GetPtr()</Item>
+      <Item Name="MapperArgPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::MapperArgNode">(pxrInternal_v0_24__pxrReserved__::Sdf_MapperArgPathNode*)GetPtr()</Item>
+      <Item Name="ExpressionPathNode" Condition="GetNodeType() == pxrInternal_v0_24__pxrReserved__::Sdf_PathNode::ExpressionNode">(pxrInternal_v0_24__pxrReserved__::Sdf_ExpressionPathNode*)GetPtr()</Item>
+      <Item Name="parent1" Condition="GetParent(GetPathNode()) != 0">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetPathNode()))</Item>
+      <Item Name="parent2" Condition="GetParent(GetParent(GetPathNode())) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetPathNode())))</Item>
+      <Item Name="parent3" Condition="GetParent(GetParent(GetParent(GetPathNode()))) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetPathNode()))))</Item>
+      <Item Name="parent4" Condition="GetParent(GetParent(GetParent(GetParent(GetPathNode())))) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))</Item>
+      <Item Name="parent5" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))</Item>
+      <Item Name="parent6" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode())))))))</Item>
+      <Item Name="parent7" Condition="GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))) != nullptr">(pxrInternal_v0_24__pxrReserved__::Sdf_PrimPathNode*)(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetParent(GetPathNode()))))))))</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::SdfPath">
+    <DisplayString Condition="_primPart._poolHandle.value != 0">{_primPart,sb}.{_propPart,sb}</DisplayString>
+    <DisplayString Condition="_primPart._poolHandle.value == 0">{_primPart,sb}</DisplayString>
+  </Type>
+
+  <!--
+  Array Types
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::VtArray&lt;*&gt;">
+    <DisplayString>{{ size={_shapeData.totalSize} }}</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>_shapeData.totalSize</Size>
+        <ValuePointer>_data</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!--
+    TfSmallVector
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::TfSmallVector&lt;*,*&gt;">
+      <DisplayString>size={_size}</DisplayString>
+      <Expand>
+          <ArrayItems Condition="_capacity &lt;= $T2">
+              <Size>_size</Size>
+              <ValuePointer>($T1*)_data._local</ValuePointer>
+          </ArrayItems>
+          <ArrayItems Condition="_capacity &gt; $T2">
+              <Size>_size</Size>
+              <ValuePointer>_data._remote</ValuePointer>
+          </ArrayItems>
+      </Expand>
+  </Type>
+  
+
+  <!--
+  Expand GfVecX types so that you can see its values with one less click
+  -->
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec2d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec3d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec4d">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec2f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec3f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec4f">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec2i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec3i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]} }}</DisplayString>
+  </Type>
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfVec4i">
+    <DisplayString>{{ x = {_data[0]}, y = {_data[1]}, z = {_data[2]}, w = {_data[3]} }}</DisplayString>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfMatrix4d">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 3]">
+        <DisplayString>{_mtx._data[12]},     {_mtx._data[13]},     {_mtx._data[14]},     {_mtx._data[15]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfMatrix4f">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 3]">
+        <DisplayString>{_mtx._data[12]},     {_mtx._data[13]},     {_mtx._data[14]},     {_mtx._data[15]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfMatrix3d">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="pxrInternal_v0_24__pxrReserved__::GfMatrix3f">
+    <Expand>
+      <Synthetic Name="[Row 0]">
+        <DisplayString>{_mtx._data[0]},     {_mtx._data[1]},     {_mtx._data[2]},     {_mtx._data[3]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 1]">
+        <DisplayString>{_mtx._data[4]},     {_mtx._data[5]},     {_mtx._data[6]},     {_mtx._data[7]}</DisplayString>
+      </Synthetic>
+      <Synthetic Name="[Row 2]">
+        <DisplayString>{_mtx._data[8]},     {_mtx._data[9]},     {_mtx._data[10]},     {_mtx._data[11]}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+</AutoVisualizer>

--- a/extras/natvis/readme.md
+++ b/extras/natvis/readme.md
@@ -1,0 +1,36 @@
+# Visual Studio Native Visualization for USD
+Natvis files create custom views of objects in the C++ debugger, for example a string instead of a memory pointer. See [here](https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2022) for more details.
+
+## How to Use
+Download the file(s) for the version(s) you are interested in. After downloading, right click > Properties, check Unblock, OK.
+Copy the file to C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\Packages\Debugger\Visualizers - adjust as needed if you installed Visual Studio elsewhere.
+
+## Multiple Versions
+Sometimes a developer needs to work with multiple versions of USD - for example one in the production code of the main app, and another version in some development branch. For this reason, we want to keep distinct files for each USD version.
+* When improving an existing version, update the existing file.
+* Create new files for a new USd versions, or if making breaking changes.
+
+NOTE: OpenUSD uses versions in its namespaces, e.g. `pxrInternal_v0_23` for version 23.
+To make a natvis file for a new version start by renaming all the namespaces as appropriate, then check if other changes are needed too.
+
+
+# Contributing
+
+## Natvis reference
+Microsoft has an [online resource](https://learn.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects) that describes the natvis file format.
+Some other resources: https://www.cppstories.com/2021/natvis-tutorial/
+The other `*.natvis` files provided by Microsoft in your visual studio directory will also be useful as examples.
+
+## Editing
+Editing can be done in any text editor.
+
+## Efficient development iteration
+Natvis files get (re)loaded on every debug run. But that can get tedious.
+A convenient approach to test changes is to have the debugger stopped at a callstack where variables of the class one is trying to support are available in a watch window (e.g., the `Locals` or `Auto` watch windows).
+After making edits to the `*.natvis` file one can issue the `.natvisreload` command in the immediate window to reload all `*.natvis` files.
+Switching back to the watch window will reveal the effect.
+Repeat as needed.
+
+## Debugging / syntax checking
+While doing this it is a good idea to enable `Natvis diagnostic messages` by setting that value in `Tools -> Options -> Debugging -> Output Window` to `Error` or `Verbose`.
+That will cause diagnostic messages to appear in the `Output` window. Note that visualizations are only used when needed (when trying to display a variable of the type).


### PR DESCRIPTION
### Description of Change(s)

Developers using Visual Studio find it very helpful to have the .natvis files for debugging. This changeset provides them for USD versions 23 and 24.

Note: This is an alternative to https://github.com/PixarAnimationStudios/OpenUSD/pull/1654 , supporting different versions instead of just one.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
