### PR TITLE
Apple: Fix shader compile bug when using EDF in Storm

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -692,7 +692,6 @@ HdStMaterialXShaderGen<Base>::_EmitConstantsUniformsAndTypeDefs(
                 mxContext.getOptions().hwDirectionalAlbedoMethod)),
             mxStage, false);
     Base::emitLineBreak(mxStage);
-    Base::emitTypeDefinitions(mxContext, mxStage);
 
     // Add all constants and ensure that values are initialized
     const mx::VariableBlock& constants = mxStage.getConstantBlock();
@@ -945,6 +944,10 @@ HdStMaterialXShaderGenGlsl::_EmitMxFunctions(
     mx::ShaderGenerator::emitLibraryInclude(
         "stdlib/" + mx::GlslShaderGenerator::TARGET
         + "/lib/mx_math.glsl", mxContext, mxStage);
+
+    // Add type definitions
+    emitTypeDefinitions(mxContext, mxStage);
+
     _EmitConstantsUniformsAndTypeDefs(
         mxContext, mxStage, _syntax->getConstantQualifier());
 
@@ -1105,6 +1108,9 @@ HdStMaterialXShaderGenMsl::_EmitGlslfxMetalShader(
     // Add a per-light shadowOcclusion value to the lightData uniform block
     addStageUniform(mx::HW::LIGHT_DATA, mx::Type::FLOAT,
         "shadowOcclusion", mxStage);
+
+    // Add type definitions
+    emitTypeDefinitions(mxContext, mxStage);
 
     // Add type definitions
     emitConstantBufferDeclarations(mxContext, resourceBindingCtx, mxStage);


### PR DESCRIPTION
Fixes the handling of MaterialX nodes that expose an EDF parameter

Thanks to Lee Kerley for the fix

### Description of Change(s)

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3105

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
