### PR TITLE
update URL to USD Assets Working Group "Primvar Interpolation" asset in the render user guide

### DIFF
--- a/docs/user_guides/render_user_guide.rst
+++ b/docs/user_guides/render_user_guide.rst
@@ -625,7 +625,7 @@ from RenderMan. These are:
   interpolated over each face of the mesh. Bilinear interpolation is used for 
   interpolation between the four values.
 
-For a graphical illustration of these modes, see `Primvar Interpolation <https://github.com/usd-wg/assets/tree/main/test_assets/PrimvarInterpolation>`__
+For a graphical illustration of these modes, see `Primvar Interpolation <https://github.com/usd-wg/assets/tree/main/docs/PrimvarInterpolation>`__
 
 As :usda:`faceVarying` allows for per-vertex-per-face values, you can use this 
 interpolation to create discontinuous vertex UVs or normals. For example, with 


### PR DESCRIPTION
This asset was moved from "test_assets" to "docs" in commit https://github.com/usd-wg/assets/commit/75bba2e73b27a93641b17e33e3d8a791134831af

- [ ] I have verified that all unit tests pass with the proposed changes
- [ x ] I have submitted a signed Contributor License Agreement
