### PR TITLE
NVIDIA: Fix SdfCopySpec issues about overwriting field SdfFieldKeys->TargetPaths/ConnectionPaths

### DIFF
--- a/pxr/usd/sdf/copyUtils.cpp
+++ b/pxr/usd/sdf/copyUtils.cpp
@@ -69,14 +69,10 @@ std::vector<TfToken>
 _GetValueFieldNames(
     const SdfLayerHandle& layer, const SdfPath& path)
 {
-    std::vector<TfToken> valueFields;
     const SdfSchemaBase& schema = layer->GetSchema();
-    const std::vector<TfToken> allFields = layer->ListFields(path);
-    for (const TfToken& field : allFields) {
-        if (!schema.HoldsChildren(field)) {
-            valueFields.push_back(field);
-        }
-    }
+    std::vector<TfToken> valueFields = layer->ListFields(path);
+    valueFields.erase(std::remove_if(std::begin(valueFields), std::end(valueFields),
+        [&schema](const auto& field) { return schema.HoldsChildren(field); }), std::end(valueFields));
 
     TfTokenFastArbitraryLessThan lessThan;
     std::sort(valueFields.begin(), valueFields.end(), lessThan);
@@ -92,14 +88,10 @@ std::vector<TfToken>
 _GetChildrenFieldNames(
     const SdfLayerHandle& layer, const SdfPath& path)
 {
-    std::vector<TfToken> childrenFields;
     const SdfSchemaBase& schema = layer->GetSchema();
-    const std::vector<TfToken> allFields = layer->ListFields(path);
-    for (const TfToken& field : allFields) {
-        if (schema.HoldsChildren(field)) {
-            childrenFields.push_back(field);
-        }
-    }
+    std::vector<TfToken> childrenFields = layer->ListFields(path);
+    childrenFields.erase(std::remove_if(std::begin(childrenFields), std::end(childrenFields),
+        [&schema](const auto& field) { return !schema.HoldsChildren(field); }), std::end(childrenFields));
 
     TfTokenFastArbitraryLessThan lessThan;
     std::sort(childrenFields.begin(), childrenFields.end(), lessThan);

--- a/pxr/usd/sdf/testenv/testSdfCopyUtils.py
+++ b/pxr/usd/sdf/testenv/testSdfCopyUtils.py
@@ -789,6 +789,30 @@ class TestSdfCopyUtils(unittest.TestCase):
                     "variability" : Sdf.VariabilityVarying
                 }
             })
+    
+    def test_RelationshipTargetOverwrite(self):
+        """Tests overwriting relationship target from source to target (in USDC) layer.
+        This test should not fail with exceptions as there was an issue about copying to
+        an non-empty relationship target.
+        """
+
+        layerContent = '''#usda 1.0
+
+        def "target" {}
+
+        def "source" {
+            rel myrel
+        }
+
+        def "dest" {
+            rel myrel = </target>
+        }
+        '''
+
+        usdcFileFormat = Sdf.FileFormat.FindById("usdc")
+        layer = Sdf.Layer.CreateAnonymous("usdc_layer", usdcFileFormat)
+        layer.ImportFromString(textwrap.dedent(layerContent))
+        self.assertTrue(Sdf.CopySpec(layer, "/source", layer, "/dest"))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)
The whole process of SdfCopySpec can be summarized as the following steps:

* Getting all fields to be copied, including value fields and children fields.
* Copying value fields firstly.
* Then copying children fields.

It's possible that the children fields fetched in step 1 is cleared in step 2, so step 3 is failed with copying a non-existent children field. This fix is to delay the fetch of children fields after step 2 so step 3 will be done on the correct children fields.

### Fixes Issue(s)
- [SdfCopySpec issues about overwriting field SdfFieldKeys->TargetPaths/ConnectionPaths](https://github.com/PixarAnimationStudios/OpenUSD/issues/3095)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
