### PR TITLE
Autodesk: Fix MSVC build with pch

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -540,7 +540,11 @@ function(_pxr_enable_precompiled_header TARGET_NAME)
     # Headers live in subdirectories.
     set(rel_output_header_path "${PXR_PREFIX}/${TARGET_NAME}/${output_header_name}")
     set(abs_output_header_path "${PROJECT_BINARY_DIR}/include/${rel_output_header_path}")
-    set(abs_precompiled_path ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${CMAKE_BUILD_TYPE}/${precompiled_name})
+    if(MSVC)
+        set(abs_precompiled_path ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${precompiled_name})
+    else()
+        set(abs_precompiled_path ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${CMAKE_BUILD_TYPE}/${precompiled_name})
+    endif()
 
     # Additional compile flags to use precompiled header.  This will be
     set(compile_flags "")


### PR DESCRIPTION
### Description of Change(s)

Fix Windows build failure when PCH is ON when using ninja.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3408 (Updated 2024-11-22)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
