### PR TITLE
Autodesk: Lavapipe support on macOS

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -265,10 +265,7 @@ if (PXR_BUILD_IMAGING)
             endforeach()
 
             # Find the OS specific libs we need
-            if (APPLE)
-                find_library(MVK_LIBRARIES NAMES MoltenVK PATHS $ENV{VULKAN_SDK}/lib)
-                list(APPEND VULKAN_LIBS ${MVK_LIBRARIES})
-            elseif (UNIX AND NOT APPLE)
+            if (UNIX AND NOT APPLE)
                 find_package(X11 REQUIRED)
                 list(APPEND VULKAN_LIBS ${X11_LIBRARIES})
             elseif (WIN32)

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -111,11 +111,9 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     TF_VERIFY(
         vkVulkan11Features.shaderDrawParameters);
 
-    #if !defined(VK_USE_PLATFORM_MACOS_MVK)
-        TF_VERIFY(
-            vkIndexingFeatures.shaderSampledImageArrayNonUniformIndexing &&
-            vkIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing);
-    #endif
+    TF_VERIFY(
+        vkIndexingFeatures.shaderSampledImageArrayNonUniformIndexing &&
+        vkIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing);
 
     TF_VERIFY(
         vkVertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor);

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -88,7 +88,7 @@ _SupportsPresentation(
                     "vkGetPhysicalDeviceXlibPresentationSupportKHR");
         return vkGetPhysicalDeviceXlibPresentationSupportKHR(
                     physicalDevice, familyIndex, dsp, visualID);
-    #elif defined(VK_USE_PLATFORM_MACOS_MVK)
+    #elif defined(VK_USE_PLATFORM_METAL_EXT)
         // Presentation currently always supported on Metal / MoltenVk
         return true;
     #else
@@ -187,9 +187,12 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     queueInfo.queueCount = 1;
     queueInfo.pQueuePriorities = queuePriorities;
 
-    std::vector<const char*> extensions = {
-        VK_KHR_SWAPCHAIN_EXTENSION_NAME
-    };
+    std::vector<const char*> extensions;
+
+    // Not available if we're surfaceless (minimal Lavapipe build for example).
+    if (IsSupportedExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+        extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    }
 
     // Allow certain buffers/images to have dedicated memory allocations to
     // improve performance on some GPUs.
@@ -300,14 +303,12 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     features.features.fragmentStoresAndAtomics =
         _capabilities->vkDeviceFeatures.fragmentStoresAndAtomics;
 
-    #if !defined(VK_USE_PLATFORM_MACOS_MVK)
-        // Needed for buffer address feature
-        features.features.shaderInt64 =
-            _capabilities->vkDeviceFeatures.shaderInt64;
-        // Needed for gl_primtiveID
-        features.features.geometryShader =
-            _capabilities->vkDeviceFeatures.geometryShader;
-    #endif
+    // Needed for buffer address feature
+    features.features.shaderInt64 =
+        _capabilities->vkDeviceFeatures.shaderInt64;
+    // Needed for gl_primtiveID
+    features.features.geometryShader =
+        _capabilities->vkDeviceFeatures.geometryShader;
 
     VkDeviceCreateInfo createInfo = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
     createInfo.queueCreateInfoCount = 1;

--- a/pxr/imaging/hgiVulkan/instance.cpp
+++ b/pxr/imaging/hgiVulkan/instance.cpp
@@ -28,6 +28,7 @@
 #include "pxr/base/tf/iterator.h"
 
 #include <vector>
+#include <algorithm>
 
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/pxr/imaging/hgiVulkan/vulkan.h
+++ b/pxr/imaging/hgiVulkan/vulkan.h
@@ -32,7 +32,7 @@
 #elif defined(ARCH_OS_LINUX)
     #define VK_USE_PLATFORM_XLIB_KHR
 #elif defined(ARCH_OS_OSX)
-    #define VK_USE_PLATFORM_MACOS_MVK
+    #define VK_USE_PLATFORM_METAL_EXT
 #else
     #error Unsupported Platform
 #endif


### PR DESCRIPTION
### Description of Change(s)

⚠ Note: This PR is for feature-hgi-vulkan branch.

The main goal is to enable Lavapipe (Vulkan driver) as a software rasterizer on all supported platforms, for testing purposes. This PR addresses macOS support by fixing some Vulkan instance and device creation issues/bugs.

Enabling MoltenVK support could be useful for testing, but it's not a priority, and there are issues with geometry shaders support preventing that, which this PR does not address. `HgiVulkan` currently assumes that geometry shaders are always supported, although it is actually an [optional feature](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceFeatures.html). If a feature check is added, then this could be fixed.

Lavapipe doesn't support Metal surfaces (`VK_EXT_metal_surface`), but display still works thanks to the `HgiInterop` Vulkan path:
- After building the list of desired instance extensions, remove any that are not actually available. This mostly serves to remove the `VK_EXT_metal_surface` extension when using Lavapipe, since it doesn't support it.
- Make the `VK_KHR_swapchain` device extension optional. It is not available if Lavapipe is built without any selected platforms, as it won't support any surface output.

Update Vulkan support to the latest recommendations for macOS, based on [this document](https://www.lunarg.com/wp-content/uploads/2024/03/The-State-of-Vulkan-on-Apple-LunarG-Richard-Wright-03-18-2024.pdf) from LunarG:
- Do no statically link with the MoltenVK libraries. The desired Vulkan driver should instead by loaded through the ICD loader. This is mandatory for loading the Lavapipe drivers.
- Replace the deprecated `VK_MVK_macos_surface` instance extension with `VK_EXT_metal_surface`.
- Add the `VK_KHR_portability_enumeration` instance extension on macOS. This is [required for MoltenVK](https://github.com/KhronosGroup/MoltenVK/blob/main/Docs/MoltenVK_Runtime_UserGuide.md?plain=1#L389-L395), but not for Lavapipe (it's a [Vulkan 1.3 conformant implementation](https://www.khronos.org/conformance/adopters/conformant-products#submission_696)).
- `VK_EXT_descriptor_indexing` is available on Lavapipe and MoltenVK (partial support), remove the conditional compilation for macOS.

With these changes, using Lavapipe, USDView launches and can display some test scenes, although more testing is required to identify remaining issues. Unit tests also all pass, although many graphics tests are skipped on macOS.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
