### PR TITLE
usdGeom, usdShade: add validators related to UsdGeomSubsets

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -64,6 +64,9 @@ pxr_library(usdGeom
     PUBLIC_HEADERS
         api.h
 
+    CPPFILES
+        validators.cpp
+
     PYTHON_CPPFILES
         moduleDeps.cpp
 

--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -192,6 +192,14 @@ pxr_build_test(testUsdGeomHasAPI
         testenv/testUsdGeomHasAPI.cpp
 )
 
+pxr_build_test(testUsdGeomValidators
+    LIBRARIES
+        usd
+        usdGeom
+    CPPFILES
+        testenv/testUsdGeomValidators.cpp
+)
+
 pxr_install_test_dir(
     SRC testenv/testUsdGeomBasisCurves
     DEST testUsdGeomBasisCurves
@@ -332,6 +340,11 @@ pxr_register_test(testUsdGeomIsA
 
 pxr_register_test(testUsdGeomHasAPI
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomHasAPI"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdGeomValidators
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomValidators"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -54,6 +54,7 @@ pxr_library(usdGeom
         sphere
         subset
         tetMesh
+        validatorTokens
         visibilityAPI
         xform
         xformable

--- a/pxr/usd/usdGeom/plugInfo.json
+++ b/pxr/usd/usdGeom/plugInfo.json
@@ -401,6 +401,15 @@
                             "UsdGeomImageable"
                         ]
                     },
+                    "SubsetParentIsImageable": {
+                        "doc": "Validates that GeomSubset prims are direct descendants of an Imageable prim.",
+                        "keywords": [
+                            "UsdGeomSubset"
+                        ],
+                        "schemaTypes": [
+                            "UsdGeomSubset"
+                        ]
+                    },
                     "keywords": [
                         "UsdGeomValidators"
                     ]

--- a/pxr/usd/usdGeom/plugInfo.json
+++ b/pxr/usd/usdGeom/plugInfo.json
@@ -390,6 +390,20 @@
                         ], 
                         "schemaKind": "abstractTyped"
                     }
+                },
+                "Validators": {
+                    "SubsetFamilies": {
+                        "doc": "Validates all of the geom subset families authored beneath an Imageable prim.",
+                        "keywords": [
+                            "UsdGeomSubset"
+                        ],
+                        "schemaTypes": [
+                            "UsdGeomImageable"
+                        ]
+                    },
+                    "keywords": [
+                        "UsdGeomValidators"
+                    ]
                 }
             }, 
             "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@", 

--- a/pxr/usd/usdGeom/subset.cpp
+++ b/pxr/usd/usdGeom/subset.cpp
@@ -803,8 +803,11 @@ UsdGeomSubset::ValidateFamily(
         return false;
     }
 
+    // Get subsets of *all* element types in the family so we can detect
+    // whether any are authored that do not match the given element type.
     const std::vector<UsdGeomSubset> familySubsets =
-        UsdGeomSubset::GetGeomSubsets(geom, elementType, familyName);
+        UsdGeomSubset::GetGeomSubsets(
+            geom, /* elementType = */ TfToken(), familyName);
     const TfToken familyType = GetFamilyType(geom, familyName);
     const bool familyIsRestricted = (familyType != UsdGeomTokens->unrestricted);
 

--- a/pxr/usd/usdGeom/subset.cpp
+++ b/pxr/usd/usdGeom/subset.cpp
@@ -749,7 +749,7 @@ UsdGeomSubset::ValidateSubsets(
                     valid = false;
                     if (reason) {
                         *reason += TfStringPrintf("Found overlapping index %d "
-                            "in GeomSubset at path <%s> at time %s.\n", index,
+                            "in GeomSubset at path <%s> at time %s.", index,
                             subset.GetPath().GetText(), TfStringify(t).c_str());
                     }
                 }
@@ -773,7 +773,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the element count %ld at time %s.\n", 
+                    "greater than the element count %ld at time %s.",
                     elementCount, TfStringify(t).c_str());
             }
         }
@@ -781,7 +781,7 @@ UsdGeomSubset::ValidateSubsets(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "less than 0 at time %s.\n", TfStringify(t).c_str());
+                    "less than 0 at time %s.", TfStringify(t).c_str());
             }
         }
     }
@@ -798,7 +798,7 @@ UsdGeomSubset::ValidateFamily(
     std::string * const reason)
 {
     if (!_ValidateGeomType(geom, elementType)) {
-        *reason += TfStringPrintf("Invalid geom type for elementType %s.\n", 
+        *reason += TfStringPrintf("Invalid geom type for elementType %s.",
                 elementType.GetText());
         return false;
     }
@@ -821,7 +821,7 @@ UsdGeomSubset::ValidateFamily(
         valid = false;
         if (reason) {
             *reason += TfStringPrintf("Unable to determine element count "
-                "at earliest time for geom <%s>.\n", geom.GetPath().GetText());
+                "at earliest time for geom <%s>.", geom.GetPath().GetText());
         }
     }
 
@@ -865,7 +865,7 @@ UsdGeomSubset::ValidateFamily(
                     if (reason) {
                         *reason += TfStringPrintf("Indices attribute has an "
                             "odd number of elements in GeomSubset at path <%s> "
-                            "at time %s with elementType edge.\n",
+                            "at time %s with elementType edge.",
                             subset.GetPath().GetText(), TfStringify(t).c_str());
                     }
                 }
@@ -882,7 +882,7 @@ UsdGeomSubset::ValidateFamily(
                         valid = false;
                         if (reason) {
                             *reason += TfStringPrintf("Found duplicate index %d "
-                                "in GeomSubset at path <%s> at time %s.\n", index,
+                                "in GeomSubset at path <%s> at time %s.", index,
                                 subset.GetPath().GetText(), TfStringify(t).c_str());
                         }
                     }
@@ -902,7 +902,7 @@ UsdGeomSubset::ValidateFamily(
             if (reason) {
                 *reason += TfStringPrintf("Geometry <%s> has no elements at "
                     "time %s, but the \"%s\" GeomSubset family contains "
-                    "indices.\n", geom.GetPath().GetText(),
+                    "indices.", geom.GetPath().GetText(),
                     TfStringify(t).c_str(), familyName.GetText());
             }
         }
@@ -915,7 +915,7 @@ UsdGeomSubset::ValidateFamily(
                 valid = false;
                 if (reason) {
                     *reason += TfStringPrintf("Number of unique indices at time %s "
-                        "does not match the element count %ld.\n",
+                        "does not match the element count %ld.",
                         TfStringify(t).c_str(), elementCount);
                 }
             }
@@ -933,7 +933,7 @@ UsdGeomSubset::ValidateFamily(
                             valid = false;
                             if (reason) {
                                 *reason += TfStringPrintf("Found duplicate edge index (%d, %d) "
-                                    "in GeomSubset at path <%s> at time %s.\n", edge[0], edge[1],
+                                    "in GeomSubset at path <%s> at time %s.", edge[0], edge[1],
                                     subset.GetPath().GetText(), TfStringify(t).c_str());
                             }
                         }
@@ -952,7 +952,7 @@ UsdGeomSubset::ValidateFamily(
                     valid = false;
                     if (reason) {
                         *reason += TfStringPrintf("At least one edge in family %s at time %s "
-                            "does not exist on the parent prim.\n",
+                            "does not exist on the parent prim.",
                             familyName.GetText(), TfStringify(t).c_str());
                     }
                 }
@@ -970,7 +970,7 @@ UsdGeomSubset::ValidateFamily(
                     valid = false;
                     if (reason) {
                         *reason += TfStringPrintf("Number of unique indices at time %s "
-                            "does not match the element count %ld.\n",
+                            "does not match the element count %ld.",
                             TfStringify(t).c_str(), elementCount);
                     }
                 }
@@ -992,7 +992,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "greater than the element count %ld at time %s.\n",
+                    "greater than the element count %ld at time %s.",
                     elementCount, TfStringify(t).c_str());
             }
         }
@@ -1002,7 +1002,7 @@ UsdGeomSubset::ValidateFamily(
             valid = false;
             if (reason) {
                 *reason += TfStringPrintf("Found one or more indices that are "
-                    "less than 0 at time %s.\n", TfStringify(t).c_str());
+                    "less than 0 at time %s.", TfStringify(t).c_str());
             }
         }
     }
@@ -1010,7 +1010,7 @@ UsdGeomSubset::ValidateFamily(
     if (!hasIndicesAtAnyTime) {
         valid = false;
         if (reason) {
-            *reason += TfStringPrintf("No indices in family at any time.\n");
+            *reason += TfStringPrintf("No indices in family at any time.");
         }
     }
 

--- a/pxr/usd/usdGeom/subset.cpp
+++ b/pxr/usd/usdGeom/subset.cpp
@@ -831,8 +831,8 @@ UsdGeomSubset::ValidateFamily(
         subset.GetElementTypeAttr().Get(&subsetElementType);
         if (subsetElementType != elementType) {
             if (reason) {
-                *reason = TfStringPrintf("Subset at path <%s> has elementType "
-                    "%s, which does not match '%s'.",
+                *reason = TfStringPrintf("GeomSubset at path <%s> has "
+                    "elementType '%s', which does not match '%s'.",
                     subset.GetPath().GetText(), subsetElementType.GetText(),
                     elementType.GetText());
             }

--- a/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
@@ -1,0 +1,300 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/sdf/layer.h"
+#include "pxr/usd/sdf/path.h"
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validator.h"
+#include "pxr/usd/usdGeom/validatorTokens.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void
+TestUsdGeomValidators()
+{
+    // This should be updated with every new validator added with the
+    // UsdGeomValidators keyword.
+    const std::set<TfToken> expectedUsdGeomValidatorNames = {
+        UsdGeomValidatorNameTokens->subsetFamilies
+    };
+
+    // This should be updated with every new validator added with the
+    // UsdGeomSubset keyword.
+    const std::set<TfToken> expectedUsdGeomSubsetNames = {
+        UsdGeomValidatorNameTokens->subsetFamilies
+    };
+
+    const UsdValidationRegistry& registry =
+        UsdValidationRegistry::GetInstance();
+
+    // Since other validators can be registered with the same keywords,
+    // our validators registered in usdGeom are/may be a subset of the
+    // entire set.
+    std::set<TfToken> validatorMetadataNameSet;
+
+    UsdValidatorMetadataVector metadata =
+        registry.GetValidatorMetadataForKeyword(
+            UsdGeomValidatorKeywordTokens->UsdGeomValidators);
+    for (const UsdValidatorMetadata& metadata : metadata) {
+        validatorMetadataNameSet.insert(metadata.name);
+    }
+
+    TF_AXIOM(std::includes(validatorMetadataNameSet.begin(),
+                           validatorMetadataNameSet.end(),
+                           expectedUsdGeomValidatorNames.begin(),
+                           expectedUsdGeomValidatorNames.end()));
+
+    // Repeat the test using a different keyword.
+    validatorMetadataNameSet.clear();
+
+    metadata = registry.GetValidatorMetadataForKeyword(
+        UsdGeomValidatorKeywordTokens->UsdGeomSubset);
+    for (const UsdValidatorMetadata& metadata : metadata) {
+        validatorMetadataNameSet.insert(metadata.name);
+    }
+
+    TF_AXIOM(std::includes(validatorMetadataNameSet.begin(),
+                           validatorMetadataNameSet.end(),
+                           expectedUsdGeomSubsetNames.begin(),
+                           expectedUsdGeomSubsetNames.end()));
+}
+
+static const std::string subsetsLayerContents =
+R"usda(#usda 1.0
+(
+    defaultPrim = "SubsetsTest"
+    metersPerUnit = 0.01
+    upAxis = "Z"
+)
+
+def Xform "SubsetsTest" (
+    kind = "component"
+)
+{
+    def Xform "Geom"
+    {
+        def Mesh "Cube"
+        {
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+
+            uniform token subsetFamily:incompletePartition:familyType = "partition"
+            uniform token subsetFamily:nonOverlappingWithDuplicates:familyType = "nonOverlapping"
+
+            def GeomSubset "emptyIndicesAtAllTimes"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "emptyIndicesAtAllTimes"
+            }
+
+            def GeomSubset "incompletePartition_1"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "incompletePartition"
+                int[] indices = [0, 1]
+            }
+
+            def GeomSubset "incompletePartition_2"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "incompletePartition"
+                int[] indices = [4, 5]
+            }
+
+            def GeomSubset "mixedElementTypes_1"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "mixedElementTypes"
+                int[] indices = [0, 1, 2]
+            }
+
+            def GeomSubset "mixedElementTypes_2"
+            {
+                uniform token elementType = "point"
+                uniform token familyName = "mixedElementTypes"
+                int[] indices = [0, 1, 2]
+            }
+
+            def GeomSubset "nonOverlappingWithDuplicates_1"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "nonOverlappingWithDuplicates"
+                int[] indices = [0, 3]
+            }
+
+            def GeomSubset "nonOverlappingWithDuplicates_2"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "nonOverlappingWithDuplicates"
+                int[] indices = [3, 5]
+            }
+
+            def GeomSubset "onlyNegativeIndices"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "onlyNegativeIndices"
+                int[] indices = [-1, -2, -3, -4, -5]
+            }
+
+            def GeomSubset "outOfRangeIndices"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "outOfRangeIndices"
+                int[] indices = [3, 4, 5, 6, 7]
+            }
+        }
+
+        def Mesh "NullMesh"
+        {
+            def GeomSubset "noElementsInGeometry"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "noElementsInGeometry"
+                int[] indices = [0, 1, 2, 3]
+            }
+        }
+
+        def Mesh "VaryingMesh"
+        {
+            int[] faceVertexCounts.timeSamples = {
+                1: [4],
+                2: [4, 4],
+                3: [4, 4, 4]
+            }
+
+            def GeomSubset "noDefaultTimeElementsInGeometry"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "noDefaultTimeElementsInGeometry"
+                int[] indices = [0]
+                int[] indices.timeSamples = {
+                    1: [0],
+                    2: [1],
+                    3: [2]
+                }
+            }
+        }
+
+        def Material "NonImageable"
+        {
+            def GeomSubset "parentIsNotImageable"
+            {
+                uniform token elementType = "face"
+                uniform token familyName = "parentIsNotImageable"
+                int[] indices = [0]
+            }
+        }
+    }
+}
+)usda";
+
+void
+TestUsdGeomSubsetFamilies()
+{
+    UsdValidationRegistry& registry = UsdValidationRegistry::GetInstance();
+    const UsdValidator* validator = registry.GetOrLoadValidatorByName(
+        UsdGeomValidatorNameTokens->subsetFamilies);
+    TF_AXIOM(validator);
+
+    SdfLayerRefPtr layer = SdfLayer::CreateAnonymous(".usda");
+    layer->ImportFromString(subsetsLayerContents);
+    UsdStageRefPtr usdStage = UsdStage::Open(layer);
+    TF_AXIOM(usdStage);
+
+    {
+        const UsdPrim usdPrim = usdStage->GetPrimAtPath(
+            SdfPath("/SubsetsTest/Geom/Cube"));
+
+        const std::vector<std::string> expectedErrorMsgs = {
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'emptyIndicesAtAllTimes': No indices in family at any time.",
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'incompletePartition': Number of unique indices at time DEFAULT does not match the element count 6.",
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'mixedElementTypes': GeomSubset at path </SubsetsTest/Geom/Cube/mixedElementTypes_2> has elementType 'point', which does not match 'face'.",
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'nonOverlappingWithDuplicates': Found duplicate index 3 in GeomSubset at path </SubsetsTest/Geom/Cube/nonOverlappingWithDuplicates_2> at time DEFAULT.",
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'onlyNegativeIndices': Found one or more indices that are less than 0 at time DEFAULT.",
+            "Imageable prim </SubsetsTest/Geom/Cube> has invalid subset family 'outOfRangeIndices': Found one or more indices that are greater than the element count 6 at time DEFAULT."
+        };
+
+        const UsdValidationErrorVector errors = validator->Validate(usdPrim);
+        TF_AXIOM(errors.size() == expectedErrorMsgs.size());
+
+        for (size_t errorIndex = 0u;
+                errorIndex < expectedErrorMsgs.size();
+                ++errorIndex) {
+            const UsdValidationError& error = errors[errorIndex];
+            TF_AXIOM(error.GetType() == UsdValidationErrorType::Error);
+            TF_AXIOM(error.GetSites().size() == 1u);
+            const UsdValidationErrorSite& errorSite = error.GetSites()[0u];
+            TF_AXIOM(errorSite.IsValid());
+            TF_AXIOM(errorSite.IsPrim());
+            TF_AXIOM(errorSite.GetPrim().GetPath() == usdPrim.GetPath());
+            TF_AXIOM(error.GetMessage() == expectedErrorMsgs[errorIndex]);
+        }
+    }
+
+    {
+        const UsdPrim usdPrim = usdStage->GetPrimAtPath(
+            SdfPath("/SubsetsTest/Geom/NullMesh"));
+
+        const UsdValidationErrorVector errors = validator->Validate(usdPrim);
+        TF_AXIOM(errors.size() == 1u);
+        const UsdValidationError& error = errors[0u];
+        TF_AXIOM(error.GetType() == UsdValidationErrorType::Error);
+        TF_AXIOM(error.GetSites().size() == 1u);
+        const UsdValidationErrorSite& errorSite = error.GetSites()[0u];
+        TF_AXIOM(errorSite.IsValid());
+        TF_AXIOM(errorSite.IsPrim());
+        TF_AXIOM(errorSite.GetPrim().GetPath() == usdPrim.GetPath());
+        const std::string expectedErrorMsg =
+            "Imageable prim </SubsetsTest/Geom/NullMesh> has invalid subset "
+            "family 'noElementsInGeometry': Unable to determine element "
+            "count at earliest time for geom </SubsetsTest/Geom/NullMesh>.";
+        TF_AXIOM(error.GetMessage() == expectedErrorMsg);
+    }
+
+    {
+        const UsdPrim usdPrim = usdStage->GetPrimAtPath(
+            SdfPath("/SubsetsTest/Geom/VaryingMesh"));
+
+        const UsdValidationErrorVector errors = validator->Validate(usdPrim);
+        TF_AXIOM(errors.size() == 1u);
+        const UsdValidationError& error = errors[0u];
+        TF_AXIOM(error.GetType() == UsdValidationErrorType::Error);
+        TF_AXIOM(error.GetSites().size() == 1u);
+        const UsdValidationErrorSite& errorSite = error.GetSites()[0u];
+        TF_AXIOM(errorSite.IsValid());
+        TF_AXIOM(errorSite.IsPrim());
+        TF_AXIOM(errorSite.GetPrim().GetPath() == usdPrim.GetPath());
+        const std::string expectedErrorMsg =
+            "Imageable prim </SubsetsTest/Geom/VaryingMesh> has invalid "
+            "subset family 'noDefaultTimeElementsInGeometry': Geometry "
+            "</SubsetsTest/Geom/VaryingMesh> has no elements at time "
+            "DEFAULT, but the \"noDefaultTimeElementsInGeometry\" "
+            "GeomSubset family contains indices.";
+        TF_AXIOM(error.GetMessage() == expectedErrorMsg);
+    }
+}
+
+int
+main()
+{
+    TestUsdGeomValidators();
+    TestUsdGeomSubsetFamilies();
+    printf("OK\n");
+    return EXIT_SUCCESS;
+};

--- a/pxr/usd/usdGeom/validatorTokens.cpp
+++ b/pxr/usd/usdGeom/validatorTokens.cpp
@@ -1,0 +1,16 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/usd/usdGeom/validatorTokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PUBLIC_TOKENS(UsdGeomValidatorNameTokens,
+                        USD_GEOM_VALIDATOR_NAME_TOKENS);
+TF_DEFINE_PUBLIC_TOKENS(UsdGeomValidatorKeywordTokens,
+                        USD_GEOM_VALIDATOR_KEYWORD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdGeom/validatorTokens.h
+++ b/pxr/usd/usdGeom/validatorTokens.h
@@ -16,11 +16,12 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define USD_GEOM_VALIDATOR_NAME_TOKENS                   \
-    ((subsetFamilies, "usdGeom:SubsetFamilies"))
+#define USD_GEOM_VALIDATOR_NAME_TOKENS                             \
+    ((subsetFamilies, "usdGeom:SubsetFamilies"))                   \
+    ((subsetParentIsImageable, "usdGeom:SubsetParentIsImageable"))
 
-#define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                \
-    (UsdGeomSubset)                                      \
+#define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                          \
+    (UsdGeomSubset)                                                \
     (UsdGeomValidators)
 
 ///\def

--- a/pxr/usd/usdGeom/validatorTokens.h
+++ b/pxr/usd/usdGeom/validatorTokens.h
@@ -1,0 +1,43 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_USD_USD_GEOM_VALIDATOR_TOKENS_H
+#define PXR_USD_USD_GEOM_VALIDATOR_TOKENS_H
+
+/// \file
+
+#include "pxr/pxr.h"
+
+#include "pxr/base/tf/staticTokens.h"
+#include "pxr/usd/usdGeom/api.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+#define USD_GEOM_VALIDATOR_NAME_TOKENS                   \
+    ((subsetFamilies, "usdGeom:SubsetFamilies"))
+
+#define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                \
+    (UsdGeomSubset)                                      \
+    (UsdGeomValidators)
+
+///\def
+/// Tokens representing validator names. Note that for plugin provided
+/// validators, the names must be prefixed by usdGeom:, which is the name of
+/// the usdGeom plugin.
+TF_DECLARE_PUBLIC_TOKENS(UsdGeomValidatorNameTokens, USDGEOM_API,
+                         USD_GEOM_VALIDATOR_NAME_TOKENS);
+
+///\def
+/// Tokens representing keywords associated with any validator in the usdGeom
+/// plugin. Clients can use this to inspect validators contained within a
+/// specific keyword, or use these to be added as keywords to any new
+/// validator.
+TF_DECLARE_PUBLIC_TOKENS(UsdGeomValidatorKeywordTokens, USDGEOM_API,
+                         USD_GEOM_VALIDATOR_KEYWORD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/usd/usdGeom/validators.cpp
+++ b/pxr/usd/usdGeom/validators.cpp
@@ -1,0 +1,95 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usd/schemaRegistry.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validator.h"
+#include "pxr/usd/usdGeom/imageable.h"
+#include "pxr/usd/usdGeom/subset.h"
+#include "pxr/usd/usdGeom/validatorTokens.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+static
+UsdValidationErrorVector
+_SubsetFamilies(const UsdPrim& usdPrim)
+{
+    if (!(usdPrim && usdPrim.IsInFamily<UsdGeomImageable>(
+            UsdSchemaRegistry::VersionPolicy::All))) {
+        return {};
+    }
+
+    const UsdGeomImageable imageable(usdPrim);
+    if (!imageable) {
+        return {};
+    }
+
+    const TfToken::Set subsetFamilyNames =
+        UsdGeomSubset::GetAllGeomSubsetFamilyNames(imageable);
+
+    // Sort the family names so that they are in dictionary order, making
+    // the order in which they are validated more predictable.
+    TfTokenVector subsetFamilyNamesVec(
+        subsetFamilyNames.begin(), subsetFamilyNames.end());
+    std::sort(
+        subsetFamilyNamesVec.begin(), subsetFamilyNamesVec.end(),
+        TfDictionaryLessThan());
+
+    UsdValidationErrorVector errors;
+
+    for (const TfToken& subsetFamilyName : subsetFamilyNamesVec) {
+        const std::vector<UsdGeomSubset> familySubsets =
+            UsdGeomSubset::GetGeomSubsets(
+                imageable,
+                /* elementType = */ TfToken(),
+                /* familyName = */ subsetFamilyName);
+
+        // Determine the element type of the family by looking at the
+        // first subset.
+        TfToken elementType;
+        familySubsets[0u].GetElementTypeAttr().Get(&elementType);
+
+        std::string reason;
+        if (!UsdGeomSubset::ValidateFamily(
+                imageable, elementType, subsetFamilyName, &reason)) {
+            const UsdValidationErrorSites primErrorSites = {
+                UsdValidationErrorSite(usdPrim.GetStage(), usdPrim.GetPath())
+            };
+
+            errors.emplace_back(
+                UsdValidationErrorType::Error,
+                primErrorSites,
+                TfStringPrintf(
+                    "Imageable prim <%s> has invalid subset family '%s': %s",
+                    usdPrim.GetPath().GetText(),
+                    subsetFamilyName.GetText(),
+                    reason.c_str())
+            );
+        }
+    }
+
+    return errors;
+}
+
+TF_REGISTRY_FUNCTION(UsdValidationRegistry)
+{
+    UsdValidationRegistry& registry = UsdValidationRegistry::GetInstance();
+
+    registry.RegisterPluginValidator(
+        UsdGeomValidatorNameTokens->subsetFamilies,
+        _SubsetFamilies);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdShade/plugInfo.json
+++ b/pxr/usd/usdShade/plugInfo.json
@@ -134,6 +134,15 @@
                             "UsdShadeShader"
                         ]
                     }, 
+                    "SubsetMaterialBindFamilyName": {
+                        "doc": "Geom subsets with authored material bindings should have the 'materialBind' family name.",
+                        "keywords": [
+                            "UsdGeomSubset"
+                        ],
+                        "schemaTypes": [
+                            "UsdGeomSubset"
+                        ]
+                    },
                     "keywords": [
                         "UsdShadeValidators"
                     ]

--- a/pxr/usd/usdShade/plugInfo.json
+++ b/pxr/usd/usdShade/plugInfo.json
@@ -143,6 +143,15 @@
                             "UsdGeomSubset"
                         ]
                     },
+                    "SubsetsMaterialBindFamily": {
+                        "doc": "Geom subsets of the 'materialBind' family should have a restricted family type and element type 'face'.",
+                        "keywords": [
+                            "UsdGeomSubset"
+                        ],
+                        "schemaTypes": [
+                            "UsdGeomImageable"
+                        ]
+                    },
                     "keywords": [
                         "UsdShadeValidators"
                     ]

--- a/pxr/usd/usdShade/plugInfo.json
+++ b/pxr/usd/usdShade/plugInfo.json
@@ -128,6 +128,9 @@
                     }
                 }, 
                 "Validators": {
+                    "MaterialBindingRelationships": {
+                        "doc": "All properties named 'material:binding' or in that namespace should be relationships."
+                    },
                     "ShaderSdrCompliance": {
                         "doc": "Shader prim's input types must be conforming to their appropriate sdf types in the respective sdr shader.", 
                         "schemaTypes": [

--- a/pxr/usd/usdShade/validatorTokens.h
+++ b/pxr/usd/usdShade/validatorTokens.h
@@ -18,7 +18,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define USD_SHADE_VALIDATOR_NAME_TOKENS                                       \
     ((shaderSdrCompliance, "usdShade:ShaderSdrCompliance"))                   \
-    ((subsetMaterialBindFamilyName, "usdShade:SubsetMaterialBindFamilyName"))
+    ((subsetMaterialBindFamilyName, "usdShade:SubsetMaterialBindFamilyName")) \
+    ((subsetsMaterialBindFamily, "usdShade:SubsetsMaterialBindFamily"))
 
 #define USD_SHADE_VALIDATOR_KEYWORD_TOKENS                                    \
     (UsdShadeValidators)

--- a/pxr/usd/usdShade/validatorTokens.h
+++ b/pxr/usd/usdShade/validatorTokens.h
@@ -16,10 +16,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define USD_SHADE_VALIDATOR_NAME_TOKENS                   \
-    ((shaderSdrCompliance, "usdShade:ShaderSdrCompliance"))
+#define USD_SHADE_VALIDATOR_NAME_TOKENS                                       \
+    ((shaderSdrCompliance, "usdShade:ShaderSdrCompliance"))                   \
+    ((subsetMaterialBindFamilyName, "usdShade:SubsetMaterialBindFamilyName"))
 
-#define USD_SHADE_VALIDATOR_KEYWORD_TOKENS                \
+#define USD_SHADE_VALIDATOR_KEYWORD_TOKENS                                    \
     (UsdShadeValidators)
 
 ///\def 

--- a/pxr/usd/usdShade/validatorTokens.h
+++ b/pxr/usd/usdShade/validatorTokens.h
@@ -17,6 +17,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 #define USD_SHADE_VALIDATOR_NAME_TOKENS                                       \
+    ((materialBindingRelationships, "usdShade:MaterialBindingRelationships")) \
     ((shaderSdrCompliance, "usdShade:ShaderSdrCompliance"))                   \
     ((subsetMaterialBindFamilyName, "usdShade:SubsetMaterialBindFamilyName")) \
     ((subsetsMaterialBindFamily, "usdShade:SubsetsMaterialBindFamily"))


### PR DESCRIPTION
The validators added in `usdGeom` and `usdShade` here check various aspects of `UsdGeomSubset`s:
- The set of all subset family names is fetched for an `Imageable`, and each family is checked for validity (using `UsdGeomSubset::ValidateFamily()`).
- `GeomSubset`s must be authored as direct descendants of an `Imageable` prim.
- If the `materialBind` subset family is authored on an `Imageable`, it is checked to ensure that it is of a restricted type (either `nonOverlapping` or `partition`), since it is invalid for an element of geometry to be bound to multiple materials. Those subsets are also checked to ensure that they are of element type `face`, since material bindings may
only be applied to geometric faces.
- If a `GeomSubset` has authored material bindings but no authored subset family name, it is suggested that the family name should be set to `materialBind` to ensure that the material bindings are visible to renderers. The material bindings will have no effect otherwise.

This replaces #2739, reworking what was there in the older compliance checker Python framework into the new C++ validation framework.

- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
