### PR TITLE
Autodesk: Remove the duplicate code in basisCurves.glslfx

### DIFF
--- a/pxr/imaging/hdSt/shaders/basisCurves.glslfx
+++ b/pxr/imaging/hdSt/shaders/basisCurves.glslfx
@@ -1186,8 +1186,6 @@ void main(void)
 #ifdef HD_HAS_displayOpacity
     color.a = HdGet_displayOpacity();
 #endif
-    color.rgb = ApplyColorOverrides(color).rgb;
-
     vec3 Peye = inData.Peye.xyz / inData.Peye.w;
 
     // We would like to have a better oriented normal here, however to keep the
@@ -1196,9 +1194,7 @@ void main(void)
 
     vec4 patchCoord = vec4(0);
 
-    color.rgb = mix(color.rgb,
-                    ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord).rgb,
-                    GetLightingBlendAmount());
+    color = ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord);
 
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {
@@ -1239,16 +1235,12 @@ void main(void)
 #ifdef HD_HAS_displayOpacity
     color.a = HdGet_displayOpacity();
 #endif
-    color.rgb = ApplyColorOverrides(color).rgb;
-
     vec3 Peye = inData.Peye.xyz / inData.Peye.w;
 
     vec3 Neye = fragmentNormal(Peye, inData.Neye, v);
 
     vec4 patchCoord = vec4(0);
-    color.rgb = mix(color.rgb, 
-                    ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord).rgb,
-                    GetLightingBlendAmount());
+    color = ShadingTerminal(vec4(Peye, 1), Neye, color, patchCoord);
 
 #ifdef HD_MATERIAL_TAG_MASKED   
     if (ShouldDiscardByAlpha(color)) {


### PR DESCRIPTION
### Description of Change(s)

Fix alpha channel is missing in ShadingTerminal function of basisCurves.glslfx.

In change 56e3997c678b154f875ada0bd16af61505e20d1a, some common shading code are moved to terminals.glslfx. But he forgot to remove the corresponding snippets in BasisCurves.Fragment of BasisCurves.glslfx. And then in the following change, the removed snippets for Curves.Fragment.Wire is incorrectly returned back at change b3e6feeb69c905b6d74e0a9d668dd9e6690fa33e. In this change, we remove the redundant code in BasisCurves.glslfx, so that ApplyColorOverrides and LightBlending will not be twicely called.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
