### PR TITLE
Fix the code for calculating mesh points on Capsule_1 prims

### DIFF
--- a/pxr/imaging/geomUtil/capsuleMeshGenerator.cpp
+++ b/pxr/imaging/geomUtil/capsuleMeshGenerator.cpp
@@ -104,7 +104,7 @@ GeomUtilCapsuleMeshGenerator::_GeneratePointsImpl(
 
         // Now, the latidude at which to clip the sphere is the angle of
         // this point from the horizontal:
-        latitudeRange = acos(rDiff / height);
+        latitudeRange = atan(rDiff / height);
     }
 
     // Bottom point:


### PR DESCRIPTION
Fix the code for calculating mesh points on Capsule_1 prims with different
top and bottom radii. The code to calculate the angle between the spheres was incorrect.

### Description of Change(s)
The code used to use acos(rdiff/height) to calculate the angle between the top and bottom spheres, but rdiff/height is opposite/adjacent for the angle of interest, and so needed to use atan to return the correct value.

### Fixes Issue(s)
- #3113 

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
