### PR TITLE
Fix Tf_RegistryManagerImpl singleton instance not being deleted

### DIFF
--- a/pxr/base/tf/registryManager.cpp
+++ b/pxr/base/tf/registryManager.cpp
@@ -170,6 +170,10 @@ public:
          return TfSingleton<Tf_RegistryManagerImpl>::GetInstance();
     }
 
+    static void DeleteInstance() {
+        TfSingleton<Tf_RegistryManagerImpl>::DeleteInstance();
+    }
+
     /// Stores the active library's registration functions and runs those
     /// that are subscribed to then makes no library active. Returns an
     /// identifier that can be passed to \c UnloadLibrary().
@@ -548,7 +552,10 @@ TfRegistryManager::TfRegistryManager()
 
 TfRegistryManager::~TfRegistryManager()
 {
-    // Do nothing
+    // Delete the actual instance.
+    // If we get here, then this instance is being deleted, which means nobody
+    // can use TfRegistryManager any more.
+    Tf_RegistryManagerImpl::DeleteInstance();
 }
 
 TfRegistryManager&


### PR DESCRIPTION
### Description of Change(s)

Delete the dynamically allocated Tf_RegistryManagerImpl singleton instance when the static TfRegistryManager singleton instance which uses it is destroyed.

### Fixes Issue(s)
- 3088

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
