### PR TITLE
feat: adding stageMetadata validator for usdGeom

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -54,6 +54,7 @@ pxr_library(usdGeom
         sphere
         subset
         tetMesh
+        validatorTokens
         visibilityAPI
         xform
         xformable
@@ -62,6 +63,9 @@ pxr_library(usdGeom
         
     PUBLIC_HEADERS
         api.h
+
+    CPPFILES
+        validators.cpp
 
     PYTHON_CPPFILES
         moduleDeps.cpp
@@ -186,6 +190,14 @@ pxr_build_test(testUsdGeomHasAPI
         usdGeom
     CPPFILES
         testenv/testUsdGeomHasAPI.cpp
+)
+
+pxr_build_test(testUsdGeomValidators
+    LIBRARIES
+        usd
+        usdGeom
+    CPPFILES
+        testenv/testUsdGeomValidators.cpp
 )
 
 pxr_install_test_dir(
@@ -404,5 +416,10 @@ pxr_register_test(testUsdGeomImageable
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomImageable"
     EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdGeomValidators
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomValidators"
+        EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdGeom/plugInfo.json
+++ b/pxr/usd/usdGeom/plugInfo.json
@@ -393,7 +393,7 @@
                 },
                 "Validators": {
                     "StageMetadataChecker": {
-                        "doc": "All stages should declare their 'upAxis' and 'metersPerUnit' and stages meant for consumer-level packaging should always have upAxis set to 'Y'."
+                        "doc": "All stages must declare their 'upAxis' and 'metersPerUnit'."
                     },
                     "keywords": [
                         "UsdGeomValidators"

--- a/pxr/usd/usdGeom/plugInfo.json
+++ b/pxr/usd/usdGeom/plugInfo.json
@@ -390,6 +390,14 @@
                         ], 
                         "schemaKind": "abstractTyped"
                     }
+                },
+                "Validators": {
+                    "StageMetadataChecker": {
+                        "doc": "All stages should declare their 'upAxis' and 'metersPerUnit' and stages meant for consumer-level packaging should always have upAxis set to 'Y'."
+                    },
+                    "keywords": [
+                        "UsdGeomValidators"
+                    ]
                 }
             }, 
             "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@", 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
@@ -1,0 +1,62 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usd/usd/validator.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usdGeom/validatorTokens.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usdGeom/metrics.h"
+#include "pxr/usd/usdGeom/tokens.h"
+
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static
+void TestUsdStageMetadata()
+{
+    // Get stageMetadataChecker
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    const UsdValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdGeomValidatorNameTokens->stageMetadataChecker);
+    TF_AXIOM(validator);
+
+    // Create an empty stage
+    UsdStageRefPtr usdStage = UsdStage::CreateInMemory();
+
+    UsdValidationErrorVector errors = validator->Validate(usdStage);
+
+    // Verify both metersPerUnit and upAxis errors are present
+    TF_AXIOM(errors.size() == 2);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    const std::string expectedMetersPerUnitErrorMsg = "Stage does not specify its linear scale in metersPerUnit.";
+    TF_AXIOM(errors[0].GetMessage() == expectedMetersPerUnitErrorMsg);
+    TF_AXIOM(errors[1].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[1].GetSites().size() == 1);
+    TF_AXIOM(errors[1].GetSites()[0].IsValid());
+    const std::string expectedUpAxisErrorMsg = "Stage does not specify an upAxis.";
+    TF_AXIOM(errors[1].GetMessage() == expectedUpAxisErrorMsg);
+
+    // Fix the errors
+    UsdGeomSetStageMetersPerUnit(usdStage, 0.01);
+    UsdGeomSetStageUpAxis(usdStage, UsdGeomTokens->y);
+
+    errors = validator->Validate(usdStage);
+
+    // Verify the errors are fixed
+    TF_AXIOM(errors.size() == 0);
+}
+
+int
+main()
+{
+    TestUsdStageMetadata();
+
+    std::cout << "OK\n";
+}

--- a/pxr/usd/usdGeom/validatorTokens.cpp
+++ b/pxr/usd/usdGeom/validatorTokens.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Andrew Beers on 6/20/24.
+//
+
+#include "pxr/usd/usdGeom/validatorTokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+    TF_DEFINE_PUBLIC_TOKENS(UsdGeomValidatorNameTokens, USDGEOM_VALIDATOR_NAMES_TOKENS);
+    TF_DEFINE_PUBLIC_TOKENS(UsdGeomValidatorKeywordTokens,
+                            USDGEOM_VALIDATOR_KEYWORD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdGeom/validatorTokens.cpp
+++ b/pxr/usd/usdGeom/validatorTokens.cpp
@@ -1,5 +1,8 @@
 //
-// Created by Andrew Beers on 6/20/24.
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
 //
 
 #include "pxr/usd/usdGeom/validatorTokens.h"

--- a/pxr/usd/usdGeom/validatorTokens.h
+++ b/pxr/usd/usdGeom/validatorTokens.h
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#ifndef USDGEOM_VALIDATOR_TOKENS_H
+#define USDGEOM_VALIDATOR_TOKENS_H
+
+/// \file
+
+#include "pxr/pxr.h"
+#include "pxr/usd/usdGeom/api.h"
+#include "pxr/base/tf/staticTokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+#define USD_GEOM_VALIDATOR_NAME_TOKENS                   \
+    ((stageMetadataChecker, "usdGeom:StageMetadataChecker"))
+
+#define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                \
+    (UsdGeomValidators)
+
+///\def
+/// Tokens representing validator names. Note that for plugin provided
+/// validators, the names must be prefixed by usdGeom:, which is the name of
+/// the usdGeom plugin.
+    TF_DECLARE_PUBLIC_TOKENS(UsdGeomValidatorNameTokens, USDGEOM_API,
+                             USD_GEOM_VALIDATOR_NAME_TOKENS);
+
+///\def
+/// Tokens representing keywords associated with any validator in the usdGeom
+/// plugin. Clients can use this to inspect validators contained within a
+/// specific keywords, or use these to be added as keywords to any new
+/// validator.
+    TF_DECLARE_PUBLIC_TOKENS(UsdGeomValidatorKeywordTokens, USDGEOM_API,
+                             USD_GEOM_VALIDATOR_KEYWORD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/usd/usdGeom/validators.cpp
+++ b/pxr/usd/usdGeom/validators.cpp
@@ -1,0 +1,45 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usdGeom/validatorTokens.h"
+#include "pxr/usd/usdGeom/tokens.h"
+#include "pxr/usd/usd/validator.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+    static
+    UsdValidationErrorVector
+    _GetStageMetadataErrors(const UsdStagePtr &usdStage)
+    {
+        UsdValidationErrorVector errors;
+        if (!usdStage->HasAuthoredMetadata(
+                UsdGeomTokens->metersPerUnit)) {
+            errors.emplace_back(UsdValidationErrorType::Error,
+                                UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
+                                "Stage does not specify its linear scale in "
+                                "metersPerUnit.");
+        }
+        if (!usdStage->HasAuthoredMetadata(
+                UsdGeomTokens->upAxis)) {
+            errors.emplace_back(UsdValidationErrorType::Error,
+                                UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
+                                "Stage does not specify an upAxis.");
+        }
+
+        return errors;
+    }
+
+    TF_REGISTRY_FUNCTION(UsdValidationRegistry)
+    {
+        UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+        registry.RegisterPluginValidator(
+                UsdGeomValidatorNameTokens->stageMetadataChecker, _GetStageMetadataErrors);
+    }
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdGeom/validators.cpp
+++ b/pxr/usd/usdGeom/validators.cpp
@@ -13,33 +13,33 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-    static
-    UsdValidationErrorVector
-    _GetStageMetadataErrors(const UsdStagePtr &usdStage)
-    {
-        UsdValidationErrorVector errors;
-        if (!usdStage->HasAuthoredMetadata(
-                UsdGeomTokens->metersPerUnit)) {
-            errors.emplace_back(UsdValidationErrorType::Error,
-                                UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
-                                "Stage does not specify its linear scale in "
-                                "metersPerUnit.");
-        }
-        if (!usdStage->HasAuthoredMetadata(
-                UsdGeomTokens->upAxis)) {
-            errors.emplace_back(UsdValidationErrorType::Error,
-                                UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
-                                "Stage does not specify an upAxis.");
-        }
-
-        return errors;
+static
+UsdValidationErrorVector
+_GetStageMetadataErrors(const UsdStagePtr &usdStage)
+{
+    UsdValidationErrorVector errors;
+    if (!usdStage->HasAuthoredMetadata(
+            UsdGeomTokens->metersPerUnit)) {
+        errors.emplace_back(UsdValidationErrorType::Error,
+                            UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
+                            TfStringPrintf("Stage with root layer <%s> does not specify its linear scale in "
+                            "metersPerUnit.", usdStage->GetRootLayer()->GetIdentifier().c_str()));
+    }
+    if (!usdStage->HasAuthoredMetadata(
+            UsdGeomTokens->upAxis)) {
+        errors.emplace_back(UsdValidationErrorType::Error,
+                            UsdValidationErrorSites{UsdValidationErrorSite(usdStage, SdfPath("/"))},
+                            TfStringPrintf("Stage with root layer <%s> does not specify an upAxis.", usdStage->GetRootLayer()->GetIdentifier().c_str()));
     }
 
-    TF_REGISTRY_FUNCTION(UsdValidationRegistry)
-    {
-        UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
-        registry.RegisterPluginValidator(
-                UsdGeomValidatorNameTokens->stageMetadataChecker, _GetStageMetadataErrors);
-    }
+    return errors;
+}
+
+TF_REGISTRY_FUNCTION(UsdValidationRegistry)
+{
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    registry.RegisterPluginValidator(
+            UsdGeomValidatorNameTokens->stageMetadataChecker, _GetStageMetadataErrors);
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
- Part 2 of #3122, including upAxis & metersPerUnit checks in a new usdGeom validator structure
- added unit tests
- added associated changes to plugInfo.json & CMakeLists.txt

### Fixes Issue(s)
- #3122 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
