### PR TITLE
Fix compiler warning return type is int and trying to return a size_t

### DIFF
--- a/pxr/usd/ndr/property.h
+++ b/pxr/usd/ndr/property.h
@@ -105,7 +105,7 @@ public:
     /// indicate a dynamically-sized array. For types that are not a fixed-size
     /// array or dynamic array, this returns 0.
     NDR_API
-    int GetArraySize() const { return _arraySize; }
+    int GetArraySize() const { return static_cast<int>(_arraySize); }
 
     /// Gets a string with basic information about this property. Helpful for
     /// things like adding this property to a log.


### PR DESCRIPTION
### Description of Change(s)

### Fixes Issue(s)
- Fixes compiler warning pxr\usd\ndr\property.h(108,30): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
