### PR TITLE
cmake: ensure directory holding pch.pch file is created

### DIFF
--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -523,7 +523,8 @@ function(_pxr_enable_precompiled_header TARGET_NAME)
     # Headers live in subdirectories.
     set(rel_output_header_path "${PXR_PREFIX}/${TARGET_NAME}/${output_header_name}")
     set(abs_output_header_path "${PROJECT_BINARY_DIR}/include/${rel_output_header_path}")
-    set(abs_precompiled_path ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${CMAKE_BUILD_TYPE}/${precompiled_name})
+    set(abs_precompiled_directory ${PROJECT_BINARY_DIR}/include/${PXR_PREFIX}/${TARGET_NAME}/${CMAKE_BUILD_TYPE})
+    set(abs_precompiled_path ${abs_precompiled_directory}/${precompiled_name})
 
     # Additional compile flags to use precompiled header.  This will be
     set(compile_flags "")
@@ -540,6 +541,12 @@ function(_pxr_enable_precompiled_header TARGET_NAME)
     # Use FALSE if we have an external precompiled header we can use.
     if(TRUE)
         if(MSVC)
+            # Make sure the directory with the pch.pch file is created
+            add_custom_command(
+                OUTPUT "${abs_precompiled_directory}"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${abs_precompiled_directory}"
+            )
+
             # Copy the header to precompile.
             add_custom_command(
                 OUTPUT "${abs_output_header_path}"
@@ -556,6 +563,7 @@ function(_pxr_enable_precompiled_header TARGET_NAME)
             add_custom_command(
                 OUTPUT "${abs_output_source_path}"
                 COMMAND ${CMAKE_COMMAND} -E touch ${abs_output_source_path}
+                DEPENDS "${abs_precompiled_directory}"
             )
 
             # The trigger file gets a special compile flag (/Yc).


### PR DESCRIPTION
### Description of Change(s)

When specifying a precompiled header output via `cl /Fp${folder}/${filename}`, cl won't automatically create `${folder}`.  Ensure we do this, or `cl` will error.

This may be an issue only with VS2022 or Windows 11, as I've never encountered this before, and I those are the main new variables.  (Note that I was also build with Ninja, though I've been doing that for a while, and haven't changed the version in a while.)

### Versions

- USD: latest dev (5332d627cb28991e812acd67b8971e87367d9191)
- CMake:  3.27.9
- OS: Windows 11, 23H2, Build 22631.3737
- Visual Studio: 2022 LTSC 17.8.11+34931.61
- .NET Framework: 4.8.09032
- Visual C++: 2022   00476-80000-00000-AA016
- Ninja: 1.10.2

### Fixes Issue(s)
- Without this, I got the following error when compiling with precompiled headers enabled:

```
[479/4528] Building CXX object pxr\base\arch\CMakeFiles\arch.dir\pch.cpp.obj
FAILED: pxr/base/arch/CMakeFiles/arch.dir/pch.cpp.obj
C:\OpenUSD\_build\host-deps\msvc\VC\Tools\MSVC\bin\HostX64\x64\cl.exe  /nologo /TP -DARCH_EXPORTS=1 -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_PYTHON_NO_PY_SIGNATURES -DGLX_GLXEXT_PROTOTYPES -DGL_GLEXT_PROTOTYPES -DMFB_ALT_PACKAGE_NAME=arch -DMFB_PACKAGE_MODULE=Arch -DMFB_PACKAGE_NAME=arch -DNOMINMAX -DOPENEXR_DLL -DPXR_BUILD_LOCATION=usd -DPXR_GL_SUPPORT_ENABLED -DPXR_MATERIALX_SUPPORT_ENABLED -DPXR_OIIO_PLUGIN_ENABLED -DPXR_PLUGIN_BUILD_LOCATION=../plugin/usd -DWIN32_LEAN_AND_MEAN -DYY_NO_UNISTD_H -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -Darch_EXPORTS -IC:\OpenUSD\_build\USD\include /EHsc /Zc:rvalueCast /Zc:strictStrings /Zc:inline- /W3 /bigobj /Zi /MP /Gm- /wd4003 /wd4244 /wd4305 /wd4267 /wd4506 /wd4091 /wd4273 /wd4180 /wd4334 -DTBB_SUPPRESS_DEPRECATED_MESSAGES=1 /MD /O2 /Ob2 /DNDEBUG -std:c++17 /Yc"pxr/base/arch/pch.h" /FI"pxr/base/arch/pch.h" /Fp"C:/OpenUSD/_build/USD/include/pxr/base/arch/Release/pch.pch" /showIncludes /Fopxr\base\arch\CMakeFiles\arch.dir\pch.cpp.obj /Fdpxr\base\arch\CMakeFiles\arch.dir\ /FS -c C:\OpenUSD\_build\USD\pxr\base\arch\pch.cpp
c1xx: fatal error C1083: Cannot open compiler intermediate file: 'C:/OpenUSD/_build/USD/include/pxr/base/arch/Release/pch.pch': No such file or directory
```


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 