### PR TITLE
Expose bindings to `ArAsset`, to support performing `OpenAsset(resolvedPath)` from Python

### DIFF
--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -52,11 +52,15 @@ pxr_library(ar
     PYTHON_PUBLIC_CLASSES
         pyResolverContext
 
+    PYTHON_PRIVATE_HEADERS
+        pyAsset.h
+
     PYTHON_CPPFILES
         moduleDeps.cpp
 
     PYMODULE_CPPFILES
         module.cpp
+        wrapAsset.cpp
         wrapAssetInfo.cpp
         wrapDefaultResolverContext.cpp
         wrapDefaultResolver.cpp
@@ -83,6 +87,7 @@ pxr_test_scripts(
     testenv/testArAssetInfo.py
     testenv/testArAdvancedAPI.py
     testenv/testArDefaultResolver.py
+    testenv/testArOpenAsset.py
     testenv/testArPackageUtils.py
     testenv/testArResolvedPath.py
     testenv/testArResolverContext.py

--- a/pxr/usd/ar/module.cpp
+++ b/pxr/usd/ar/module.cpp
@@ -12,6 +12,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 TF_WRAP_MODULE
 {
+    TF_WRAP(Asset);
     TF_WRAP(AssetInfo);
     TF_WRAP(ResolvedPath);
     TF_WRAP(Timestamp);

--- a/pxr/usd/ar/pyAsset.h
+++ b/pxr/usd/ar/pyAsset.h
@@ -1,0 +1,99 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_USD_AR_PY_ASSET_H
+#define PXR_USD_AR_PY_ASSET_H
+
+/// \file ar/pyAsset.h
+/// Structures for creating Python bindings for objects inheriting from
+/// \c ArAsset.
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/pyUtils.h"
+#include "pxr/usd/ar/asset.h"
+
+#include <boost/python/return_arg.hpp>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class Ar_PyAsset
+/// Data structure for exposing ArAsset objects exposed via ArResolver APIs to
+/// Python.
+class Ar_PyAsset
+{
+public:
+    /// Create a Python representation of the given \c ArAsset resource.
+    /// \param asset \c ArAsset for which to create a Python representation.
+    explicit Ar_PyAsset(std::shared_ptr<ArAsset> asset): _asset{std::move(asset)} {}
+
+    /// Return a buffer with the contents of the asset, or raise a
+    /// \c ValueError if the content could not be retrieved.
+    /// \return A buffer with the contents of the asset.
+    boost::python::object GetBuffer() const
+    {
+        // In case of invalid asset reference, raise an exception to the Python
+        // caller that an operation was attempted on an object whose context is
+        // not appropriately opened:
+        if (!_asset) {
+            TfPyThrowValueError("Failed to open asset");
+        }
+
+        // In case of invalid asset buffer, raise an exception to the Python
+        // caller that the buffer held by the asset could not be retrieved.
+        //
+        /// \see ArAsset::GetBuffer()
+        std::shared_ptr<const char> buffer = _asset->GetBuffer();
+        if (!buffer) {
+            TfPyThrowValueError("Failed to retrieve asset buffer");
+        }
+
+        // Create a Python bytes object from the buffer:
+        return boost::python::object(
+            boost::python::handle<>(
+                PyBytes_FromStringAndSize(buffer.get(), _asset->GetSize())));
+    }
+
+    /// Return a flag indicating whether the asset is considered valid.
+    /// \return \c true if the asset is considered valid, \c false otherwise.
+    bool IsValid() const
+    {
+        // When performing this smoke test, ensure that the referenced ArAsset
+        // is valid.
+        //
+        /// \see ArResolver::OpenAsset()
+        return _asset != nullptr;
+    }
+
+    /// Enter the Python Context Manager for the representation of the
+    /// \c ArAsset.
+    /// \return A reference to the Python Context Manager for the
+    /// representation of the \c ArAsset.
+    void Enter()
+    {
+        if (!_asset) {
+            TfPyThrowValueError("Failed to open asset");
+        }
+    }
+
+    /// Exit the Python Context Manager for the representation of the
+    /// \c ArAsset.
+    bool Exit(
+        boost::python::object& /* exc_type */,
+        boost::python::object& /* exc_value */,
+        boost::python::object& /* exc_tb */)
+    {
+        _asset.reset();
+        // Re-raise exceptions:
+        return false;
+    }
+
+private:
+    std::shared_ptr<ArAsset> _asset;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_AR_PY_ASSET_H

--- a/pxr/usd/ar/testenv/testArOpenAsset.py
+++ b/pxr/usd/ar/testenv/testArOpenAsset.py
@@ -1,0 +1,174 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+#
+import json
+import os
+import tempfile
+import unittest
+
+from pxr import Ar
+
+class TestArOpenAsset(unittest.TestCase):
+
+    def setUp(self) -> None:
+        # Create a temporary directory containing a JSON test file, along with
+        # a binary file:
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self._json_file_path = os.path.join(self._temp_dir.name, 'text.json')
+        self._empty_file_path = os.path.join(self._temp_dir.name, 'empty.txt')
+        self._binary_file_path = os.path.join(self._temp_dir.name, 'binary.bin')
+
+        # Write some sample JSON data to the test file.
+        #
+        # NOTE: The included UTF-8 string is represented by the following byte
+        # sequence:
+        #    * 'H', 'e', 'l', 'l', 'o', ',', and '!' are all 1-byte characters
+        #      (ASCII).
+        #    * '世' and '界' are 3-byte characters (East Asian characters).
+        #    * '🌍' is a 4-byte character (emoji representing "Earth Globe
+        #      Europe-Africa").
+        #
+        # The overall byte sequence for this UTF-8 string is: 
+        #    * "Hello, \\u4e16\\u754c! \\ud83c\\udf0d"
+        self._json_data = {
+            'name': 'example',
+            'value': 1234,
+            'utf-8': 'Hello, 世界! 🌍',
+            'child-object': {
+                'key': 'value',
+            },
+        }
+        with open(self._json_file_path, 'w') as json_file:
+            json.dump(self._json_data, json_file)
+
+        # Write a file with no content:
+        open(self._empty_file_path, 'w').close()
+
+        # Write some sample binary data to the test file, including characters
+        # that would result in UTF-8 decoding errors such as:
+        #    > UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in
+        #    > position 0: invalid continuation byte
+        #
+        # Equivalent string of the following byte representation: 'ÃÇéあ',
+        # where:
+        #    * 'Ã' represents an 'A' with tilde in UTF-8, but can represent a
+        #      different character in Latin-1.
+        #    * 'Ç' represents a 'C' with cedilla in Latin-1, although would be
+        #      different in UTF-8.
+        #    * 'é' represents the byte 0xE9 in ISO-8859-1 (Latin-1), although
+        #      in UTF-8, 0xE9 is not a valid single byte but part of a
+        #      multi-byte sequence.
+        #    * 'あ' is represented by the byte 0x82A0 in Shift JIS.
+        self._binary_data = b'\xc3\xc7\xe9\x82A0' 
+        with open(self._binary_file_path, 'wb') as binary_file:
+            binary_file.write(self._binary_data)
+
+    def tearDown(self) -> None:
+        # Cleanup the temporary directory:
+        self._temp_dir.cleanup()
+
+    def _get_resolved_text_filepath(self) -> Ar.ResolvedPath:
+        """
+        Return the resolved path of the Attribute referencing the JSON file.
+        """
+        return Ar.ResolvedPath(self._json_file_path)
+
+    def _get_resolved_empty_filepath(self) -> Ar.ResolvedPath:
+        """
+        Return the resolved path of the Attribute referencing an empty file.
+        """
+        return Ar.ResolvedPath(self._empty_file_path)
+
+    def _get_non_existing_text_filepath(self) -> Ar.ResolvedPath:
+        """Return the resolved path of an non-existing asset."""
+        non_existing_json_file = os.path.join(self._temp_dir.name, 'non-existing-asset.json')
+        return Ar.ResolvedPath(non_existing_json_file)
+
+    def _get_resolved_binary_filepath(self) -> Ar.ResolvedPath:
+        """
+        Return the resolved path of the Attribute referencing the JSON file.
+        """
+        return Ar.ResolvedPath(self._binary_file_path)
+
+    def test_reading_an_existing_asset_returns_a_valid_context(self) -> None:
+        """
+        Validate that reading an existing asset returns a valid context and
+        does not raise an exception.
+        """
+        json_file = self._get_resolved_text_filepath()
+        with Ar.GetResolver().OpenAsset(resolvedPath=json_file) as json_asset:
+            self.assertTrue(json_asset, 'Expected asset to be valid')
+
+    def test_reading_non_existing_asset_raises_exception(self) -> None:
+        """
+        Validate that attempting to read a non-existing asset raises an
+        exception.
+        """
+        non_existing_json_file = self._get_non_existing_text_filepath()
+        with self.assertRaisesRegex(ValueError, 'Failed to open asset'):
+            Ar.GetResolver().OpenAsset(resolvedPath=non_existing_json_file)
+
+    def test_reading_asset_with_no_content_returns_a_valid_context(self) -> None:
+        """
+        Validate that attempting to read a file with no content returns a valid
+        operation.
+        """
+        empty_text_file = self._get_resolved_empty_filepath()
+        with Ar.GetResolver().OpenAsset(resolvedPath=empty_text_file) as empty_asset:
+            self.assertTrue(empty_asset, 'Expected asset to be valid')
+
+    def test_ar_asset_buffer_can_be_accessed_for_text_content(self) -> None:
+        """
+        Validate that the referenced asset content matches the actual JSON
+        file in the temporary test directory.
+        """
+        json_file = self._get_resolved_text_filepath()
+        with Ar.GetResolver().OpenAsset(resolvedPath=json_file) as json_asset:
+            self.assertTrue(json_asset, 'Expected asset to be valid')
+
+            json_content = json_asset.GetBuffer()
+
+        self.assertEqual(json_content.decode(), json.dumps(self._json_data))
+        self.assertIn(b'Hello, \\u4e16\\u754c! \\ud83c\\udf0d', json_content)
+
+    def test_ar_asset_buffer_can_be_accessed_for_binary_content(self) -> None:
+        """
+        Validate that the referenced asset content matches the actual binary
+        file in the temporary test directory.
+        """
+        binary_file = self._get_resolved_binary_filepath()
+        with Ar.GetResolver().OpenAsset(resolvedPath=binary_file) as binary_asset:
+            self.assertTrue(binary_asset, 'Expected asset to be valid')
+
+            binary_content = binary_asset.GetBuffer()
+
+            self.assertEqual(binary_content, self._binary_data)
+
+    def test_ar_asset_context_manager_releases_resource_upon_exiting(self) -> None:
+        """
+        Validate that asset resources are freed upon exiting their initial
+        context manager scope.
+        """
+        json_file = self._get_resolved_text_filepath()
+        asset = Ar.GetResolver().OpenAsset(resolvedPath=json_file)
+
+        # Ensure the asset is deemed valid when consuming its resources within
+        # an initial scoped context:
+        with asset:
+            self.assertTrue(
+                asset,
+                'Expected asset to be valid before release of context manager scope')
+
+        # Ensure the asset is deemed invalid after exiting its initial scoped
+        # context:
+        with self.assertRaisesRegex(ValueError, 'Failed to open asset'):
+            with asset:
+                pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/ar/wrapAsset.cpp
+++ b/pxr/usd/ar/wrapAsset.cpp
@@ -8,6 +8,8 @@
 
 #include "pxr/usd/ar/pyAsset.h"
 
+#include <boost/python.hpp>
+
 using namespace boost::python;
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/pxr/usd/ar/wrapAsset.cpp
+++ b/pxr/usd/ar/wrapAsset.cpp
@@ -1,0 +1,28 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+
+#include "pxr/usd/ar/pyAsset.h"
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void wrapAsset()
+{
+    typedef Ar_PyAsset This;
+
+    class_<This>
+        ("Ar_PyAsset", init<std::shared_ptr<ArAsset>>())
+
+        .def("GetBuffer", &This::GetBuffer)
+
+        .def("__bool__", &This::IsValid)
+        .def("__enter__", &This::Enter, return_self<>())
+        .def("__exit__", &This::Exit)
+        ;
+}


### PR DESCRIPTION
### Description of Change(s)

This PR exposes Python bindings for `ArAsset` of the Asset Resolver module, ultimately enabling operations such as `ArResolver.OpenAsset(resolvedPath)` to allow reading `ArAsset` buffers from Python (which was previously only available from C++).

The proposed changes enable features such as querying contents of assets referenced within USD Stages by way of the path resolution behaviors already implemented within Asset Resolvers.

#### Python Sample

This PR enables the following type of workflow from Python (see unit tests included in the PR for practical examples).

**Assumptions:**
 * The existence of a Stage containing a `"/TestPrim"` Prim with a `"custom:jsonFilePath"` Attribute referencing a JSON asset.
 * A JSON asset located on disk with the following content:
```json
{
    "name": "example",
    "value": 1234,
    "child-object": {
        "key": "value"
    }
}
```

The following Python snippet illustrates using the `OpenAsset(resolvedPath: Ar.ResolvedPath)`, which was previously not exposed:
```python
# [...]

# Retrieve the content of the ArAsset referenced by the Attribute on the Stage:
with Ar.GetResolver().OpenAsset(resolvedPath=resolved_json_asset_path) as json_asset:
    print(f'JSON asset data: {json_asset.GetBuffer()}')
```

Which produces the following output:
```console
JSON asset data: {"name": "example", "value": 1234, "child-object": {"key": "value"}}
```


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
