### PR TITLE
Apple: Use Node name instead of NodeDef name for SurfaceShaders

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -26,6 +26,7 @@
 #include "pxr/usd/usd/editContext.h"
 #include "pxr/usd/usd/specializes.h"
 #include "pxr/usd/usd/stage.h"
+#include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/pathUtils.h"
 
@@ -1511,15 +1512,22 @@ _Context::AddShaderNode(const mx::ConstNodePtr& mtlxShaderNode)
         return UsdShadeShader();
     }
 
-    // Choose the name of the shader.  In MaterialX this is just
+    // Choose the name of the shader.
+    //
+    // In MaterialX this is just
     // mtlxShaderNode->getName() and has no meaning other than to uniquely
-    // identify the shader.  In USD to support materialinherit we must
-    // ensure that shaders have the same name if one should compose over
+    // identify the shader.  In USD to support Material Inheritance
+    // https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#material-inheritance
+    // we must ensure that shaders have the same name if one should compose over
     // the other.  MaterialX composes over if a shader node refers to the
-    // same nodedef so in USD we use the nodedef's name.  This name isn't
+    // same nodedef so in USD we use the nodedef's name.  This name wasn't
     // ideal since it's just an arbitrary unique name;  the nodedef's
-    // node name is more meaningful.
-    const auto name = _MakeName(mtlxNodeDef);
+    // node name was more meaningful.
+    //
+    // However this naming isn't always intuitive for conversions.
+    // Therefore you may toggle between them with this env variable.
+    const auto name = (TfGetenvBool("PXR_MTLX_SUPPORT_MATERIAL_INHERITS", false)) ?
+        _MakeName(mtlxNodeDef) : _MakeName(mtlxShaderNode);
 
     // Create the shader if it doesn't exist and copy node def values.
     auto shaderImplPath = _shadersPath.AppendChild(name);

--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -26,7 +26,6 @@
 #include "pxr/usd/usd/editContext.h"
 #include "pxr/usd/usd/specializes.h"
 #include "pxr/usd/usd/stage.h"
-#include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/pathUtils.h"
 
@@ -1512,22 +1511,7 @@ _Context::AddShaderNode(const mx::ConstNodePtr& mtlxShaderNode)
         return UsdShadeShader();
     }
 
-    // Choose the name of the shader.
-    //
-    // In MaterialX this is just
-    // mtlxShaderNode->getName() and has no meaning other than to uniquely
-    // identify the shader.  In USD to support Material Inheritance
-    // https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#material-inheritance
-    // we must ensure that shaders have the same name if one should compose over
-    // the other.  MaterialX composes over if a shader node refers to the
-    // same nodedef so in USD we use the nodedef's name.  This name wasn't
-    // ideal since it's just an arbitrary unique name;  the nodedef's
-    // node name was more meaningful.
-    //
-    // However this naming isn't always intuitive for conversions.
-    // Therefore you may toggle between them with this env variable.
-    const auto name = (TfGetenvBool("PXR_MTLX_SUPPORT_MATERIAL_INHERITS", false)) ?
-        _MakeName(mtlxNodeDef) : _MakeName(mtlxShaderNode);
+    const auto name = _MakeName(mtlxShaderNode);
 
     // Create the shader if it doesn't exist and copy node def values.
     auto shaderImplPath = _shadersPath.AppendChild(name);


### PR DESCRIPTION
### Description of Change(s)

Change the translated name of surface shaders from the node defs name to the Node's name, toggleable by setting an env var of `PXR_MTLX_SUPPORT_MATERIAL_INHERITS`

UsdMtlx was using the node defs name for surface shaders as an attempt to support [material inheritance](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#material-inheritance), the logic was using the most generic name possible to allow easier overriding.

Unfortunately this causes issues where the imported names for just the surface shader does not match the input mtlx file.

While I understand the original rationale, I think that until we find a better heuristic, there is more value in keeping the naming consistent and intuitive. I do not believe material inheritance is a common feature in MtlX libraries, and certainly does not feature in the set of mtlx files provided by the MaterialX library or with OpenUSD.

For pipelines that require this, I suggest they instead set the PXR_MTLX_SUPPORT_MATERIAL_INHERITS boolean env var, until a better heuristic can be found.


### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3100

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
