### PR TITLE
Autodesk: Delay-load vulkan dlls on Windows

### DIFF
--- a/pxr/imaging/hgiInterop/CMakeLists.txt
+++ b/pxr/imaging/hgiInterop/CMakeLists.txt
@@ -20,7 +20,10 @@ if (PXR_ENABLE_GL_SUPPORT)
 endif()
 
 if (PXR_ENABLE_VULKAN_SUPPORT)
-    list(APPEND optionalLibraries hgiVulkan)
+    # We hope that on Windows, the vulkan dlls can be delay loaded.
+    if (NOT WIN32)
+        list(APPEND optionalLibraries hgiVulkan)
+    endif()
     list(APPEND optionalCppFiles vulkan.cpp)
     list(APPEND optionalPrivateHeaders vulkan.h)
 endif()


### PR DESCRIPTION
### Description of Change(s)

Remove the dependency of hgiVulkan in hgiInterop on Windows, so that the vulkan dlls can be delay loaded.
On Windows, it is possible to have both hgiVulkan and hgiDX. Delay loading allow the user to select their preferred hgi at run time.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
