### PR TITLE
feat: add validator SkelBindingAPIAppliedChecker

### DIFF
--- a/pxr/usd/usdSkel/CMakeLists.txt
+++ b/pxr/usd/usdSkel/CMakeLists.txt
@@ -99,13 +99,12 @@ pxr_library(usdSkel
 )
 
 pxr_build_test(testUsdSkelValidators
-        LIBRARIES
-        sdr
-        tf
-        usd
-        usdSkel
-        CPPFILES
-        testenv/testUsdSkelValidators.cpp
+    LIBRARIES
+    tf
+    usd
+    usdSkel
+    CPPFILES
+    testenv/testUsdSkelValidators.cpp
 )
    
 pxr_test_scripts(
@@ -130,6 +129,11 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdSkelCache
     DEST testUsdSkelCache
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdSkelRoot
+    DEST testUsdSkelRoot
 )
 
 pxr_install_test_dir(

--- a/pxr/usd/usdSkel/CMakeLists.txt
+++ b/pxr/usd/usdSkel/CMakeLists.txt
@@ -37,6 +37,10 @@ pxr_library(usdSkel
         tokens
         topology
         utils
+        validatorTokens
+
+    CPPFILES
+        validators.cpp
 
     PUBLIC_HEADERS
         api.h
@@ -93,6 +97,16 @@ pxr_library(usdSkel
         images/influencesPrimvarLayout.svg
         images/unboundedInterpolationExample.svg
 )
+
+pxr_build_test(testUsdSkelValidators
+        LIBRARIES
+        sdr
+        tf
+        usd
+        usdSkel
+        CPPFILES
+        testenv/testUsdSkelValidators.cpp
+)
    
 pxr_test_scripts(
     testenv/testUsdSkelAnimMapper.py
@@ -116,11 +130,6 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testUsdSkelCache
     DEST testUsdSkelCache
-)
-
-pxr_install_test_dir(
-    SRC testenv/testUsdSkelRoot
-    DEST testUsdSkelRoot
 )
 
 pxr_install_test_dir(
@@ -189,3 +198,9 @@ pxr_register_test(testUsdSkelUtils
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelUtils"
     EXPECTED_RETURN_CODE 0
 )
+
+pxr_register_test(testUsdSkelValidators
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelValidators"
+    EXPECTED_RETURN_CODE 0
+)
+

--- a/pxr/usd/usdSkel/plugInfo.json
+++ b/pxr/usd/usdSkel/plugInfo.json
@@ -71,8 +71,8 @@
                     }
                 },
                 "Validators": {
-                    "SkelBindingApiAppliedChecker": {
-                        "doc": "Verify a prim has the SkelBindingAPI applied if it has a UsdSkelBinding property. If a prim has the SkelBindingAPI applied, make sure it's of type SkelRoot or under a SkelRoot."
+                    "SkelBindingApiAppliedValidator": {
+                        "doc": "Verify a prim has the SkelBindingAPI applied if it has a UsdSkelBinding property. If a prim has the SkelBindingAPI applied, make sure it's of type SkelRoot or parented by a SkelRoot."
                     },
                     "keywords": [
                         "UsdSkelValidators"

--- a/pxr/usd/usdSkel/plugInfo.json
+++ b/pxr/usd/usdSkel/plugInfo.json
@@ -69,6 +69,14 @@
                         "implementsComputeExtent": true, 
                         "schemaKind": "concreteTyped"
                     }
+                },
+                "Validators": {
+                    "SkelBindingApiAppliedChecker": {
+                        "doc": "Verify a prim has the SkelBindingAPI applied if it has a UsdSkelBinding property. If a prim has the SkelBindingAPI applied, make sure it's of type SkelRoot or under a SkelRoot."
+                    },
+                    "keywords": [
+                        "UsdSkelValidators"
+                    ]
                 }
             }, 
             "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@", 

--- a/pxr/usd/usdSkel/testenv/testUsdSkelValidators.cpp
+++ b/pxr/usd/usdSkel/testenv/testUsdSkelValidators.cpp
@@ -1,0 +1,88 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/sdr/registry.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validator.h"
+#include <pxr/usd/usdSkel/validatorTokens.h>
+#include <pxr/usd/usdSkel/root.h>
+#include <pxr/usd/usdSkel/bindingAPI.h>
+#include <pxr/usd/usdGeom/mesh.h>
+#include <pxr/usd/usdGeom/primvarsAPI.h>
+
+#include <algorithm>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void
+TestUsdSkelBindingAPIChecker()
+{
+    // Verify validator exists
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    const UsdValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdSkelValidatorNameTokens->skelBindingApiAppliedChecker);
+    TF_AXIOM(validator);
+
+    // Create Stage and mesh with a skel binding property
+    UsdStageRefPtr usdStage = UsdStage::CreateNew("/Users/andrewbeers/test.usda");
+    UsdGeomMesh mesh = UsdGeomMesh::Define(usdStage, SdfPath("/SkelRoot/Mesh"));
+    UsdGeomPrimvarsAPI primvarsApi(mesh);
+    UsdGeomPrimvar jointIndicesPrimvar = primvarsApi.CreatePrimvar(TfToken("skel:jointIndices"), SdfValueTypeNames->IntArray, UsdGeomTokens->vertex);
+    jointIndicesPrimvar.Set(VtIntArray{0, 1, 2});
+
+    UsdValidationErrorVector errors = validator->Validate(mesh.GetPrim());
+
+    // test and verify error for not having a skel binding api applied
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetSites()[0].IsPrim());
+    TF_AXIOM(errors[0].GetSites()[0].GetPrim().GetPath() ==
+             SdfPath("/SkelRoot/Mesh"));
+    std::string expectedErrorMsg = "Found a UsdSkelBinding property (primvars:skel:jointIndices)" \
+                                    ", but no SkelBindingAPI applied on the prim </SkelRoot/Mesh>." \
+                                    "(fails 'SkelBindingAPIAppliedChecker')";
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // apply skel binding api
+    UsdSkelBindingAPI skelBindingApi = UsdSkelBindingAPI::Apply(mesh.GetPrim());
+
+    errors = validator->Validate(mesh.GetPrim());
+
+    // test and verify error for not having a skel root parenting the mesh
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetSites()[0].IsPrim());
+    TF_AXIOM(errors[0].GetSites()[0].GetPrim().GetPath() ==
+             SdfPath("/SkelRoot/Mesh"));
+    expectedErrorMsg = "UsdSkelBindingAPI applied on prim: </SkelRoot/Mesh>, " \
+                "which is not of type SkelRoot or is not rooted at a prim " \
+                "of type SkelRoot, as required by the UsdSkel schema.(fails 'SkelBindingAPIAppliedChecker')";
+    const std::string message = errors[0].GetMessage();
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // add skel root as parent
+    UsdSkelRoot skelRoot = UsdSkelRoot::Define(usdStage, SdfPath("/SkelRoot"));
+    errors = validator->Validate(mesh.GetPrim());
+
+    // verify 0 errors
+    TF_AXIOM(errors.size() == 0);
+}
+
+int
+main()
+{
+    TestUsdSkelBindingAPIChecker();
+    printf("OK\n");
+    return EXIT_SUCCESS;
+};

--- a/pxr/usd/usdSkel/testenv/testUsdSkelValidators.cpp
+++ b/pxr/usd/usdSkel/testenv/testUsdSkelValidators.cpp
@@ -32,7 +32,7 @@ TestUsdSkelValidators()
     }
 
     const std::set<TfToken> expectedValidatorNames =
-            {UsdSkelValidatorNameTokens->skelBindingApiAppliedChecker};
+            {UsdSkelValidatorNameTokens->skelBindingApiAppliedValidator};
 
     TF_AXIOM(std::includes(validatorMetadataNameSet.begin(),
                            validatorMetadataNameSet.end(),
@@ -41,12 +41,12 @@ TestUsdSkelValidators()
 }
 
 void
-TestUsdSkelBindingAPIChecker()
+TestUsdSkelBindingApiAppliedValidator()
 {
     // Verify that the validator exists.
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
     const UsdValidator *validator = registry.GetOrLoadValidatorByName(
-            UsdSkelValidatorNameTokens->skelBindingApiAppliedChecker);
+            UsdSkelValidatorNameTokens->skelBindingApiAppliedValidator);
     TF_AXIOM(validator);
 
     // Create Stage and mesh with a skel binding property
@@ -101,7 +101,7 @@ int
 main()
 {
     TestUsdSkelValidators();
-    TestUsdSkelBindingAPIChecker();
+    TestUsdSkelBindingApiAppliedValidator();
     printf("OK\n");
     return EXIT_SUCCESS;
 };

--- a/pxr/usd/usdSkel/validatorTokens.cpp
+++ b/pxr/usd/usdSkel/validatorTokens.cpp
@@ -1,0 +1,17 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usd/usdSkel/validatorTokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PUBLIC_TOKENS(UsdSkelValidatorNameTokens,
+                        USD_SKEL_VALIDATOR_NAME_TOKENS);
+TF_DEFINE_PUBLIC_TOKENS(UsdSkelValidatorKeywordTokens,
+                        USD_SKEL_VALIDATOR_KEYWORD_TOKENS);
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdSkel/validatorTokens.h
+++ b/pxr/usd/usdSkel/validatorTokens.h
@@ -1,0 +1,34 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef USDSKEL_VALIDATOR_TOKENS_H
+#define USDSKEL_VALIDATOR_TOKENS_H
+/// \file
+#include "pxr/pxr.h"
+#include "pxr/usd/usdSkel/api.h"
+#include "pxr/base/tf/staticTokens.h"
+PXR_NAMESPACE_OPEN_SCOPE
+
+#define USD_SKEL_VALIDATOR_NAME_TOKENS                   \
+     ((skelBindingApiAppliedChecker, "usdSkel:SkelBindingApiAppliedChecker"))
+#define USD_SKEL_VALIDATOR_KEYWORD_TOKENS                \
+     (UsdSkelValidators)
+
+///\def
+/// Tokens representing validator names. Note that for plugin provided
+/// validators, the names must be prefixed by usdSkel:, which is the name of
+/// the usdSkel plugin.
+TF_DECLARE_PUBLIC_TOKENS(UsdSkelValidatorNameTokens, USDSKEL_API,
+                         USD_SKEL_VALIDATOR_NAME_TOKENS);
+///\def
+/// Tokens representing keywords associated with any validator in the usdShade
+/// plugin. Clients can use this to inspect validators contained within a
+/// specific keywords, or use these to be added as keywords to any new
+/// validator.
+TF_DECLARE_PUBLIC_TOKENS(UsdSkelValidatorKeywordTokens, USDSKEL_API,
+                         USD_SKEL_VALIDATOR_KEYWORD_TOKENS);
+PXR_NAMESPACE_CLOSE_SCOPE
+#endif

--- a/pxr/usd/usdSkel/validatorTokens.h
+++ b/pxr/usd/usdSkel/validatorTokens.h
@@ -13,7 +13,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 #define USD_SKEL_VALIDATOR_NAME_TOKENS                   \
-     ((skelBindingApiAppliedChecker, "usdSkel:SkelBindingApiAppliedChecker"))
+     ((skelBindingApiAppliedValidator, "usdSkel:SkelBindingApiAppliedValidator"))
 #define USD_SKEL_VALIDATOR_KEYWORD_TOKENS                \
      (UsdSkelValidators)
 

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -4,14 +4,11 @@
 // Licensed under the terms set forth in the LICENSE.txt file available at
 // https://openusd.org/license.
 //
-
-#include "pxr/usd/sdr/shaderProperty.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/schemaRegistry.h"
 #include "pxr/usd/usd/validationError.h"
 #include "pxr/usd/usd/validationRegistry.h"
 #include "pxr/usd/usd/validator.h"
-#include "pxr/usd/sdr/registry.h"
 #include "pxr/base/tf/token.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/usd/usdSkel/validatorTokens.h"
@@ -29,27 +26,27 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
     UsdValidationErrorVector errors;
 
     if (!usdPrim.HasAPI<UsdSkelBindingAPI>()){
-        UsdSchemaRegistry& usdSchemaRegistry = UsdSchemaRegistry::GetInstance();
-        std::unique_ptr<UsdPrimDefinition> primDef = usdSchemaRegistry.BuildComposedPrimDefinition(TfToken(), {TfToken("SkelBindingAPI")});
-
-        std::vector<TfToken> skelPropertyNames = primDef->GetPropertyNames();
         std::vector<TfToken> primPropertyNames = usdPrim.GetPropertyNames();
-
+        static const std::unordered_set<TfToken, TfHash> skelPropertyNames = []() {
+            UsdSchemaRegistry& usdSchemaRegistry = UsdSchemaRegistry::GetInstance();
+            std::unique_ptr<UsdPrimDefinition> primDef = usdSchemaRegistry.BuildComposedPrimDefinition(TfToken(), {TfToken("SkelBindingAPI")});
+            std::vector<TfToken> vectorOfNames = primDef->GetPropertyNames();
+            return std::unordered_set<TfToken, TfHash>(vectorOfNames.begin(), vectorOfNames.end());
+        }();
+ 
         for (const TfToken &primToken : primPropertyNames){
-            for (const TfToken &skelToken : skelPropertyNames){
-                if (skelToken != primToken)
-                    continue;
-
-                errors.emplace_back(
-                        UsdValidationErrorType::Error,
-                        UsdValidationErrorSites{
-                                UsdValidationErrorSite(usdPrim.GetStage(),
-                                                       usdPrim.GetPath())
-                        },
-                        TfStringPrintf(("Found a UsdSkelBinding property (%s), "
-                            "but no SkelBindingAPI applied on the prim <%s>.(fails 'SkelBindingAPIAppliedChecker')"),
-                                       skelToken.GetText(), usdPrim.GetPath().GetText()));
+            if (skelPropertyNames.find(primToken) == skelPropertyNames.end()){
+                continue;
             }
+            errors.emplace_back(
+                    UsdValidationErrorType::Error,
+                    UsdValidationErrorSites{
+                            UsdValidationErrorSite(usdPrim.GetStage(),
+                                                   usdPrim.GetPath())
+                    },
+                    TfStringPrintf(("Found a UsdSkelBinding property (%s), "
+                                    "but no SkelBindingAPI applied on the prim <%s>."),
+                                   primToken.GetText(), usdPrim.GetPath().GetText()));
         }
     }
     else {
@@ -71,7 +68,7 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
                     },
                     TfStringPrintf(("UsdSkelBindingAPI applied on prim: <%s>, "
                             "which is not of type SkelRoot or is not rooted at a prim "
-                            "of type SkelRoot, as required by the UsdSkel schema.(fails 'SkelBindingAPIAppliedChecker')"),
+                            "of type SkelRoot, as required by the UsdSkel schema."),
                                    usdPrim.GetPath().GetText()));
         }
     }

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -33,7 +33,7 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
             std::vector<TfToken> vectorOfNames = primDef->GetPropertyNames();
             return std::unordered_set<TfToken, TfHash>(vectorOfNames.begin(), vectorOfNames.end());
         }();
- 
+
         for (const TfToken &primToken : primPropertyNames){
             if (skelPropertyNames.find(primToken) == skelPropertyNames.end()){
                 continue;
@@ -47,6 +47,7 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
                     TfStringPrintf(("Found a UsdSkelBinding property (%s), "
                                     "but no SkelBindingAPI applied on the prim <%s>."),
                                    primToken.GetText(), usdPrim.GetPath().GetText()));
+            break;
         }
     }
     else {

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -21,7 +21,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 static
 UsdValidationErrorVector
-_SkelBindingApiChecker(const UsdPrim &usdPrim)
+_SkelBindingApiAppliedValidator(const UsdPrim &usdPrim)
 {
     UsdValidationErrorVector errors;
 
@@ -82,8 +82,8 @@ TF_REGISTRY_FUNCTION(UsdValidationRegistry)
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
 
     registry.RegisterPluginValidator(
-            UsdSkelValidatorNameTokens->skelBindingApiAppliedChecker,
-            _SkelBindingApiChecker);
+            UsdSkelValidatorNameTokens->skelBindingApiAppliedValidator,
+            _SkelBindingApiAppliedValidator);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -26,14 +26,14 @@ _SkelBindingApiAppliedValidator(const UsdPrim &usdPrim)
     UsdValidationErrorVector errors;
 
     if (!usdPrim.HasAPI<UsdSkelBindingAPI>()){
-        std::vector<TfToken> primPropertyNames = usdPrim.GetPropertyNames();
         static const std::unordered_set<TfToken, TfHash> skelPropertyNames = []() {
             UsdSchemaRegistry& usdSchemaRegistry = UsdSchemaRegistry::GetInstance();
-            std::unique_ptr<UsdPrimDefinition> primDef = usdSchemaRegistry.BuildComposedPrimDefinition(TfToken(), {TfToken("SkelBindingAPI")});
-            std::vector<TfToken> vectorOfNames = primDef->GetPropertyNames();
-            return std::unordered_set<TfToken, TfHash>(vectorOfNames.begin(), vectorOfNames.end());
+            std::unique_ptr<UsdPrimDefinition> primDef = usdSchemaRegistry.BuildComposedPrimDefinition(TfToken(), {UsdSkelTokens->SkelBindingAPI});
+            const std::vector<TfToken> skelPropertyNamesVector = primDef->GetPropertyNames();
+            return std::unordered_set<TfToken, TfHash>(skelPropertyNamesVector.begin(), skelPropertyNamesVector.end());
         }();
 
+        const std::vector<TfToken> primPropertyNames = usdPrim.GetPropertyNames();
         for (const TfToken &primToken : primPropertyNames){
             if (skelPropertyNames.find(primToken) == skelPropertyNames.end()){
                 continue;

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -37,24 +37,25 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
 
         for (const TfToken &primToken : primPropertyNames){
             for (const TfToken &skelToken : skelPropertyNames){
-                if (skelToken == primToken){
-                    errors.emplace_back(
-                            UsdValidationErrorType::Error,
-                            UsdValidationErrorSites{
-                                    UsdValidationErrorSite(usdPrim.GetStage(),
-                                                           usdPrim.GetPath())
-                            },
-                            TfStringPrintf("Found a UsdSkelBinding property (%s), " \
-                            "but no SkelBindingAPI applied on the prim <%s>.(fails 'SkelBindingAPIAppliedChecker')",
-                                           skelToken.GetText(), usdPrim.GetPath().GetText()));
-                }
+                if (skelToken != primToken)
+                    continue;
+
+                errors.emplace_back(
+                        UsdValidationErrorType::Error,
+                        UsdValidationErrorSites{
+                                UsdValidationErrorSite(usdPrim.GetStage(),
+                                                       usdPrim.GetPath())
+                        },
+                        TfStringPrintf(("Found a UsdSkelBinding property (%s), "
+                            "but no SkelBindingAPI applied on the prim <%s>.(fails 'SkelBindingAPIAppliedChecker')"),
+                                       skelToken.GetText(), usdPrim.GetPath().GetText()));
             }
         }
     }
     else {
         if (usdPrim.GetTypeName() != UsdSkelTokens->SkelRoot) {
             UsdPrim parentPrim = usdPrim.GetParent();
-            while (!parentPrim.IsPseudoRoot()) {
+            while (parentPrim && !parentPrim.IsPseudoRoot()) {
                 if (parentPrim.GetTypeName() != UsdSkelTokens->SkelRoot) {
                     parentPrim = parentPrim.GetParent();
                 }
@@ -68,9 +69,9 @@ _SkelBindingApiChecker(const UsdPrim &usdPrim)
                             UsdValidationErrorSite(usdPrim.GetStage(),
                                                    usdPrim.GetPath())
                     },
-                    TfStringPrintf("UsdSkelBindingAPI applied on prim: <%s>, " \
-            "which is not of type SkelRoot or is not rooted at a prim " \
-            "of type SkelRoot, as required by the UsdSkel schema.(fails 'SkelBindingAPIAppliedChecker')",
+                    TfStringPrintf(("UsdSkelBindingAPI applied on prim: <%s>, "
+                            "which is not of type SkelRoot or is not rooted at a prim "
+                            "of type SkelRoot, as required by the UsdSkel schema.(fails 'SkelBindingAPIAppliedChecker')"),
                                    usdPrim.GetPath().GetText()));
         }
     }

--- a/pxr/usd/usdSkel/validators.cpp
+++ b/pxr/usd/usdSkel/validators.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usd/sdr/shaderProperty.h"
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usd/schemaRegistry.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validator.h"
+#include "pxr/usd/sdr/registry.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/base/tf/stringUtils.h"
+#include "pxr/usd/usdSkel/validatorTokens.h"
+#include "pxr/usd/usdSkel/bindingAPI.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+static
+UsdValidationErrorVector
+_SkelBindingApiChecker(const UsdPrim &usdPrim)
+{
+    UsdValidationErrorVector errors;
+
+    if (!usdPrim.HasAPI<UsdSkelBindingAPI>()){
+        UsdSchemaRegistry& usdSchemaRegistry = UsdSchemaRegistry::GetInstance();
+        std::unique_ptr<UsdPrimDefinition> primDef = usdSchemaRegistry.BuildComposedPrimDefinition(TfToken(), {TfToken("SkelBindingAPI")});
+
+        std::vector<TfToken> skelPropertyNames = primDef->GetPropertyNames();
+        std::vector<TfToken> primPropertyNames = usdPrim.GetPropertyNames();
+
+        for (const TfToken &primToken : primPropertyNames){
+            for (const TfToken &skelToken : skelPropertyNames){
+                if (skelToken == primToken){
+                    errors.emplace_back(
+                            UsdValidationErrorType::Error,
+                            UsdValidationErrorSites{
+                                    UsdValidationErrorSite(usdPrim.GetStage(),
+                                                           usdPrim.GetPath())
+                            },
+                            TfStringPrintf("Found a UsdSkelBinding property (%s), " \
+                            "but no SkelBindingAPI applied on the prim <%s>.(fails 'SkelBindingAPIAppliedChecker')",
+                                           skelToken.GetText(), usdPrim.GetPath().GetText()));
+                }
+            }
+        }
+    }
+    else {
+        if (usdPrim.GetTypeName() != UsdSkelTokens->SkelRoot) {
+            UsdPrim parentPrim = usdPrim.GetParent();
+            while (!parentPrim.IsPseudoRoot()) {
+                if (parentPrim.GetTypeName() != UsdSkelTokens->SkelRoot) {
+                    parentPrim = parentPrim.GetParent();
+                }
+                else {
+                    return errors;
+                }
+            }
+            errors.emplace_back(
+                    UsdValidationErrorType::Error,
+                    UsdValidationErrorSites{
+                            UsdValidationErrorSite(usdPrim.GetStage(),
+                                                   usdPrim.GetPath())
+                    },
+                    TfStringPrintf("UsdSkelBindingAPI applied on prim: <%s>, " \
+            "which is not of type SkelRoot or is not rooted at a prim " \
+            "of type SkelRoot, as required by the UsdSkel schema.(fails 'SkelBindingAPIAppliedChecker')",
+                                   usdPrim.GetPath().GetText()));
+        }
+    }
+
+    return errors;
+}
+
+TF_REGISTRY_FUNCTION(UsdValidationRegistry)
+{
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+
+    registry.RegisterPluginValidator(
+            UsdSkelValidatorNameTokens->skelBindingApiAppliedChecker,
+            _SkelBindingApiChecker);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
add validator SkelBindingAPIAppliedChecker
- added a validation check for when a skel binding property is present but the skel binding api is not applied
- added a validation check for when a skel binding api is applied to a prim that is not parented by a skel root
- added a unit test

### Fixes Issue(s)
- https://github.com/orgs/PixarAnimationStudios/projects/3/views/1?pane=issue&itemId=65425045
- 
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
