### PR TITLE
Apple: Include the USD patch version in the namespace

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -67,7 +67,7 @@ if (PXR_ENABLE_NAMESPACES)
     if (PXR_SET_INTERNAL_NAMESPACE)
         set(PXR_INTERNAL_NAMESPACE ${PXR_SET_INTERNAL_NAMESPACE})
     else()
-        set(PXR_INTERNAL_NAMESPACE "pxrInternal_v${PXR_MAJOR_VERSION}_${PXR_MINOR_VERSION}")
+        set(PXR_INTERNAL_NAMESPACE "pxrInternal_v${PXR_MAJOR_VERSION}_${PXR_MINOR_VERSION}_${PXR_PATCH_VERSION}")
     endif()
 
     message(STATUS "C++ namespace configured to (external) ${PXR_EXTERNAL_NAMESPACE}, (internal) ${PXR_INTERNAL_NAMESPACE}")


### PR DESCRIPTION
### Description of Change(s)

USD has set its internal namespace to include the major (always 0), and minor (year) versions, but hasn't thus far included the patch version.

Since USD doesn't follow semver, the patch version is actually quite important, as there may be ABI changes between USD versions within the same year.

Including the patch version will improve the intended nature of the namespacing IMHO. For example, 24.3 and 24.11 may be quite dramatically different in terms of ABI and API, but include the same namespace

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
