### PR TITLE
[hdEmbree] fix for random number generation (previously: hdEmbree-UsdLux-PR02)

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/config.cpp
+++ b/pxr/imaging/plugin/hdEmbree/config.cpp
@@ -20,26 +20,40 @@ TF_INSTANTIATE_SINGLETON(HdEmbreeConfig);
 // Each configuration variable has an associated environment variable.
 // The environment variable macro takes the variable name, a default value,
 // and a description...
-TF_DEFINE_ENV_SETTING(HDEMBREE_SAMPLES_TO_CONVERGENCE, 100,
-        "Samples per pixel before we stop rendering (must be >= 1)");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_SAMPLES_TO_CONVERGENCE,
+    HdEmbreeDefaultSamplesToConvergence,
+    "Samples per pixel before we stop rendering (must be >= 1)");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_TILE_SIZE, 8,
-        "Size (per axis) of threading work units (must be >= 1)");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_TILE_SIZE,
+    HdEmbreeDefaultTileSize,
+    "Size (per axis) of threading work units (must be >= 1)");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_AMBIENT_OCCLUSION_SAMPLES, 16,
-        "Ambient occlusion samples per camera ray (must be >= 0; a value of 0 disables ambient occlusion)");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_AMBIENT_OCCLUSION_SAMPLES,
+    HdEmbreeDefaultAmbientOcclusionSamples,
+    "Ambient occlusion samples per camera ray (must be >= 0;"
+    " a value of 0 disables ambient occlusion)");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_JITTER_CAMERA, 1,
-        "Should HdEmbree jitter camera rays while rendering? (values >0 are true)");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_JITTER_CAMERA,
+    HdEmbreeDefaultJitterCamera,
+    "Should HdEmbree jitter camera rays while rendering?");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_USE_FACE_COLORS, 1,
-        "Should HdEmbree use face colors while rendering? (values > 0 are true)");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_USE_FACE_COLORS,
+    HdEmbreeDefaultUseFaceColors,
+    "Should HdEmbree use face colors while rendering?");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_CAMERA_LIGHT_INTENSITY, 300,
-        "Intensity of the camera light, specified as a percentage of <1,1,1>.");
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_CAMERA_LIGHT_INTENSITY,
+    HdEmbreeDefaultCameraLightIntensity,
+    "Intensity of the camera light, specified as a percentage of <1,1,1>.");
 
-TF_DEFINE_ENV_SETTING(HDEMBREE_PRINT_CONFIGURATION, 0,
-        "Should HdEmbree print configuration on startup? (values > 0 are true)");
+TF_DEFINE_ENV_SETTING(HDEMBREE_PRINT_CONFIGURATION,
+    false,
+    "Should HdEmbree print configuration on startup?");
 
 HdEmbreeConfig::HdEmbreeConfig()
 {
@@ -50,12 +64,12 @@ HdEmbreeConfig::HdEmbreeConfig()
             TfGetEnvSetting(HDEMBREE_TILE_SIZE));
     ambientOcclusionSamples = std::max(0,
             TfGetEnvSetting(HDEMBREE_AMBIENT_OCCLUSION_SAMPLES));
-    jitterCamera = (TfGetEnvSetting(HDEMBREE_JITTER_CAMERA) > 0);
-    useFaceColors = (TfGetEnvSetting(HDEMBREE_USE_FACE_COLORS) > 0);
+    jitterCamera = (TfGetEnvSetting(HDEMBREE_JITTER_CAMERA));
+    useFaceColors = (TfGetEnvSetting(HDEMBREE_USE_FACE_COLORS));
     cameraLightIntensity = (std::max(100,
             TfGetEnvSetting(HDEMBREE_CAMERA_LIGHT_INTENSITY)) / 100.0f);
 
-    if (TfGetEnvSetting(HDEMBREE_PRINT_CONFIGURATION) > 0) {
+    if (TfGetEnvSetting(HDEMBREE_PRINT_CONFIGURATION)) {
         std::cout
             << "HdEmbree Configuration: \n"
             << "  samplesToConvergence       = "

--- a/pxr/imaging/plugin/hdEmbree/config.cpp
+++ b/pxr/imaging/plugin/hdEmbree/config.cpp
@@ -51,6 +51,15 @@ TF_DEFINE_ENV_SETTING(
     HdEmbreeDefaultCameraLightIntensity,
     "Intensity of the camera light, specified as a percentage of <1,1,1>.");
 
+TF_DEFINE_ENV_SETTING(
+    HDEMBREE_RANDOM_NUMBER_SEED,
+    HdEmbreeDefaultRandomNumberSeed,
+    "Seed to give to the random number generator. A value of anything other"
+        " than -1, combined with setting PXR_WORK_THREAD_LIMIT=1, should"
+        " give deterministic / repeatable results. A value of -1 (the"
+        " default) will allow the implementation to set a value that varies"
+        " from invocation to invocation and thread to thread.");
+
 TF_DEFINE_ENV_SETTING(HDEMBREE_PRINT_CONFIGURATION,
     false,
     "Should HdEmbree print configuration on startup?");
@@ -68,6 +77,7 @@ HdEmbreeConfig::HdEmbreeConfig()
     useFaceColors = (TfGetEnvSetting(HDEMBREE_USE_FACE_COLORS));
     cameraLightIntensity = (std::max(100,
             TfGetEnvSetting(HDEMBREE_CAMERA_LIGHT_INTENSITY)) / 100.0f);
+    randomNumberSeed = TfGetEnvSetting(HDEMBREE_RANDOM_NUMBER_SEED);
 
     if (TfGetEnvSetting(HDEMBREE_PRINT_CONFIGURATION)) {
         std::cout
@@ -84,6 +94,8 @@ HdEmbreeConfig::HdEmbreeConfig()
             <<    useFaceColors           << "\n"
             << "  cameraLightIntensity      = "
             <<    cameraLightIntensity    << "\n"
+            << "  randomNumberSeed          = "
+            <<    randomNumberSeed        << "\n"
             ;
     }
 }

--- a/pxr/imaging/plugin/hdEmbree/config.h
+++ b/pxr/imaging/plugin/hdEmbree/config.h
@@ -12,6 +12,15 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// NOTE: types here restricted to bool/int/string, as also used for
+// TF_DEFINE_ENV_SETTING
+constexpr int HdEmbreeDefaultSamplesToConvergence = 100;
+constexpr int HdEmbreeDefaultTileSize = 8;
+constexpr int HdEmbreeDefaultAmbientOcclusionSamples = 16;
+constexpr bool HdEmbreeDefaultJitterCamera = true;
+constexpr bool HdEmbreeDefaultUseFaceColors = true;
+constexpr int HdEmbreeDefaultCameraLightIntensity = 300;
+
 /// \class HdEmbreeConfig
 ///
 /// This class is a singleton, holding configuration parameters for HdEmbree.
@@ -27,6 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 class HdEmbreeConfig {
 public:
+
     /// \brief Return the configuration singleton.
     static const HdEmbreeConfig &GetInstance();
 
@@ -34,38 +44,40 @@ public:
     /// converged?
     ///
     /// Override with *HDEMBREE_SAMPLES_TO_CONVERGENCE*.
-    unsigned int samplesToConvergence;
+    unsigned int samplesToConvergence = HdEmbreeDefaultSamplesToConvergence;
 
     /// How many pixels are in an atomic unit of parallel work?
     /// A work item is a square of size [tileSize x tileSize] pixels.
     ///
     /// Override with *HDEMBREE_TILE_SIZE*.
-    unsigned int tileSize;
+    unsigned int tileSize = HdEmbreeDefaultTileSize;
 
     /// How many ambient occlusion rays should we generate per
     /// camera ray?
     ///
     /// Override with *HDEMBREE_AMBIENT_OCCLUSION_SAMPLES*.
-    unsigned int ambientOcclusionSamples;
+    unsigned int ambientOcclusionSamples = HdEmbreeDefaultAmbientOcclusionSamples;
 
     /// Should the renderpass jitter camera rays for antialiasing?
     ///
-    /// Override with *HDEMBREE_JITTER_CAMERA*. Integer values greater than
-    /// zero are considered "true".
-    bool jitterCamera;
+    /// Override with *HDEMBREE_JITTER_CAMERA*. The case-insensitive strings
+    /// "true", "yes", "on", and "1" are considered true; an empty value uses
+    /// the default, and all other values are false.
+    bool jitterCamera = HdEmbreeDefaultJitterCamera;
 
     /// Should the renderpass use the color primvar, or flat white colors?
     /// (Flat white shows off ambient occlusion better).
     ///
-    /// Override with *HDEMBREE_USE_FACE_COLORS*. Integer values greater than
-    /// zero are considered "true".
-    bool useFaceColors;
+    /// Override with *HDEMBREE_USE_FACE_COLORS*.  The case-insensitive strings
+    /// "true", "yes", "on", and "1" are considered true; an empty value uses
+    /// the default, and all other values are false.
+    bool useFaceColors = HdEmbreeDefaultUseFaceColors;
 
     /// What should the intensity of the camera light be, specified as a
     /// percent of <1, 1, 1>.  For example, 300 would be <3, 3, 3>.
     ///
     /// Override with *HDEMBREE_CAMERA_LIGHT_INTENSITY*.
-    float cameraLightIntensity;
+    float cameraLightIntensity = HdEmbreeDefaultCameraLightIntensity;
 
 private:
     // The constructor initializes the config variables with their

--- a/pxr/imaging/plugin/hdEmbree/config.h
+++ b/pxr/imaging/plugin/hdEmbree/config.h
@@ -20,6 +20,7 @@ constexpr int HdEmbreeDefaultAmbientOcclusionSamples = 16;
 constexpr bool HdEmbreeDefaultJitterCamera = true;
 constexpr bool HdEmbreeDefaultUseFaceColors = true;
 constexpr int HdEmbreeDefaultCameraLightIntensity = 300;
+constexpr int HdEmbreeDefaultRandomNumberSeed = -1;
 
 /// \class HdEmbreeConfig
 ///
@@ -78,6 +79,15 @@ public:
     ///
     /// Override with *HDEMBREE_CAMERA_LIGHT_INTENSITY*.
     float cameraLightIntensity = HdEmbreeDefaultCameraLightIntensity;
+
+    /// Seed to give to the random number generator. A value of anything other
+    /// than -1, combined with setting PXR_WORK_THREAD_LIMIT=1, should give
+    /// deterministic / repeatable results. A value of -1 (the default) will
+    /// allow the implementation to set a value that varies from invocation to
+    /// invocation and thread to thread.
+    ///
+    /// Override with *HDEMBREE_RANDOM_NUMBER_SEED*.
+    int randomNumberSeed = HdEmbreeDefaultRandomNumberSeed;
 
 private:
     // The constructor initializes the config variables with their

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.cpp
@@ -99,7 +99,7 @@ void
 HdEmbreeRenderDelegate::_Initialize()
 {
     // Initialize the settings and settings descriptors.
-    _settingDescriptors.resize(4);
+    _settingDescriptors.resize(5);
     _settingDescriptors[0] = { "Enable Scene Colors",
         HdEmbreeRenderSettingsTokens->enableSceneColors,
         VtValue(HdEmbreeConfig::GetInstance().useFaceColors) };
@@ -112,6 +112,9 @@ HdEmbreeRenderDelegate::_Initialize()
     _settingDescriptors[3] = { "Samples To Convergence",
         HdRenderSettingsTokens->convergedSamplesPerPixel,
         VtValue(int(HdEmbreeConfig::GetInstance().samplesToConvergence)) };
+    _settingDescriptors[4] = { "Random Number Seed",
+        HdEmbreeRenderSettingsTokens->randomNumberSeed,
+        VtValue(HdEmbreeConfig::GetInstance().randomNumberSeed) };
     _PopulateDefaultSettings(_settingDescriptors);
 
     // Initialize the embree library handle (_rtcDevice).

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.h
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.h
@@ -23,7 +23,8 @@ class HdEmbreeRenderParam;
 #define HDEMBREE_RENDER_SETTINGS_TOKENS \
     (enableAmbientOcclusion)            \
     (enableSceneColors)                 \
-    (ambientOcclusionSamples)
+    (ambientOcclusionSamples)           \
+    (randomNumberSeed)
 
 // Also: HdRenderSettingsTokens->convergedSamplesPerPixel
 

--- a/pxr/imaging/plugin/hdEmbree/renderPass.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderPass.cpp
@@ -113,6 +113,10 @@ HdEmbreeRenderPass::_Execute(HdRenderPassStateSharedPtr const& renderPassState,
             renderDelegate->GetRenderSetting<bool>(
                 HdEmbreeRenderSettingsTokens->enableSceneColors, true));
 
+        _renderer->SetRandomNumberSeed(
+            renderDelegate->GetRenderSetting<unsigned int>(
+                HdEmbreeRenderSettingsTokens->randomNumberSeed, (unsigned int)-1));
+
         needStartRender = true;
     }
 

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -515,7 +515,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread, int sampleNum,
 
     // Create a uniform distribution for jitter calculations.
     std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+    auto uniform_float = [&random, &uniform_dist]() { return uniform_dist(random); };
 
     // _RenderTiles gets a range of tiles; iterate through them.
     for (unsigned int tile = tileStart; tile < tileEnd; ++tile) {
@@ -935,7 +935,7 @@ HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
 {
     // Create a uniform random distribution for AO calculations.
     std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+    auto uniform_float = [&random, &uniform_dist]() { return uniform_dist(random); };
 
     // 0 ambient occlusion samples means disable the ambient occlusion term.
     if (_ambientOcclusionSamples < 1) {

--- a/pxr/imaging/plugin/hdEmbree/renderer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderer.h
@@ -81,6 +81,12 @@ public:
     ///                            everything as white.
     void SetEnableSceneColors(bool enableSceneColors);
 
+    /// Sets a number to seed the random number generator with.
+    ///   \param randomNumberSeed If -1, then the random number generator
+    ///                           is seeded in a non-deterministic way;
+    ///                           otherwise, it is seeded with this value.
+    void SetRandomNumberSeed(int randomNumberSeed);
+
     /// Rendering entrypoint: add one sample per pixel to the whole sample
     /// buffer, and then loop until the image is converged.  After each pass,
     /// the image will be resolved into a color buffer.
@@ -115,7 +121,7 @@ private:
     // work. For each tile, iterate over pixels in the tile, generating camera
     // rays, and following them/calculating color with _TraceRay. This function
     // renders all tiles between tileStart and tileEnd.
-    void _RenderTiles(HdRenderThread *renderThread,
+    void _RenderTiles(HdRenderThread *renderThread, int sampleNum,
                       size_t tileStart, size_t tileEnd);
 
     // Cast a ray into the scene and if it hits an object, write to the bound
@@ -184,6 +190,8 @@ private:
     int _ambientOcclusionSamples;
     // Should we enable scene colors?
     bool _enableSceneColors;
+    // If other than -1, use this to seed the random number generator with.
+    int _randomNumberSeed;
 
     // How many samples have been completed.
     std::atomic<int> _completedSamples;


### PR DESCRIPTION
> [!WARNING]
> Closing this PR as it's duplicate was merged (https://github.com/PixarAnimationStudios/OpenUSD/pull/3211)

> [!IMPORTANT] 
> This is a duplicate of this PR:
>
> - https://github.com/PixarAnimationStudios/OpenUSD/pull/3211
>
> ...except that PR was pulled out the UsdLux-HdEmbree PR "chain", to make for easier standalone integration, as it has no other PR dependencies, and fixes an outstanding bug.
>
> I will close this PR if the other is merged first, and vice-versa.


### Description of Change(s)

use of std::bind was copying the underlying random number generator before use, resulting in the exact same sequence getting reused for, ie, every AO calculation within a given tile-group

### Fixes Issue(s)
- non-randomized behavior in hdEmbree - not very noticeable with just AO calculations, but caused significant problems for upcoming hdEmbree + UsdLux changes

---------------------------------------------------------------

### Related PRs:

This PR is part of a chain of PRs that provide a reference implementation of UsdLux as part of hdEmbree.

| :arrow_backward: **Previous PR in chain:**  |  :arrow_down_small: **This PR changes only:** | :arrow_forward: **Next PR in chain:** |
|-----------------------------|------------------------------|------------------------|
|  https://github.com/PixarAnimationStudios/OpenUSD/pull/3183 | [Diff vs Previous](https://github.com/NVIDIA-Omniverse/OpenUSD/pull/2) <p> Due to a github limitation, this PR must include all previous PRs in the chain.  To see JUST the changes in this PR vs the previous in the chain, click this link  | https://github.com/PixarAnimationStudios/OpenUSD/pull/3185 |

:chains: **All PRs in this chain:**
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3199

:page_with_curl: **Documentation PR:**
This chain of PRs (implementing UsdLux support in hdEmbree), was made separate from the PR documenting expected UsdLux behavior:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3182

:eight_spoked_asterisk: **All UsdLux update related PRs:**
To see ALL UsdLux update related PRs (documentation AND reference implementation) in one place, see:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3200

:hourglass: **Original PR:**
These PRs are an update of this original PR:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/2758

---------------------------------------------------------------


### But... why??

**Why make these PRs in the first place?**

The current specifications of the various UsdLux prims + attributes are imprecise or vague in many places, and as a result, actual implementations of them by various renderers have diverged, sometimes quite significantly.  For instance, here is Intel's [4004 Moore Lane](https://dpel.aswf.io/4004-moore-lane/) scene, with the same UsdLux lights defined, in 3 different renderers:

Karma:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_karma.jpg?raw=true" alt="4004 Moore Lane, rendered in Karma" width="300">

Arnold:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_arnold.jpg?raw=true" alt="4004 Moore Lane, rendered in Arnold" width="300">

Omniverse RTX:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_rtx.jpg?raw=true" alt="4004 Moore Lane, rendered in Omniverse RTX" width="300">

For a full descpription of the problem, see here:
- [Problem Statement](https://github.com/anderslanglands/light_comparison/blob/main/README.md#problem-statement)

**Why so many PRs?**
This was my attempt to break up a rather large change into smaller, more easily reviewable changes, that can be merged in incrementally, to help ease the burden for code reviewers.

If you find this confusing, and would rather just one big PR (ie, just this one), or have them organized in some other way, please let me know!

**Why are the documentation changes in their own PR?**
In some ways, the [documentation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3182) are the heart of this effort - we wish to specify more exactly what the various UsdLux prims and attributes represent.  However, building consensus on this may take time - so we expect some dialogue on the exact language or formulas.

Because that may take time, the [hdEmbree reference implementation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3199) are separate, and broken up, so we can hopefully start integrating portions of them even before final consensus has been reached on the final form of the specification.

**Why are the documentation changes not broken up into smaller pieces, like the hdEmbree reference implementation changes?**
Because I wasn't sure if that would be desirable or not!  If people think that would be helpful, I can do so - perhaps breaking out by schema or individual attribute?

---------------------------------------------------------------
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
