### PR TITLE
[hdEmbree] ensure we respect PXR_WORK_THREAD_LIMIT (hdEmbree-UsdLux-PR05)

### DIFF
--- a/pxr/base/work/threadLimits.cpp
+++ b/pxr/base/work/threadLimits.cpp
@@ -71,14 +71,14 @@ WorkGetPhysicalConcurrencyLimit()
 #endif
 }
 
-// This function always returns an actual thread count >= 1.
+// This function always returns either 0 (meaning "no change") or >= 1
 static unsigned
 Work_NormalizeThreadCount(const int n)
 {
     // Zero means "no change", and n >= 1 means exactly n threads, so simply
     // pass those values through unchanged.
     // For negative integers, subtract the absolute value from the total number
-    // of available cores (denoting all but n cores). If n == number of cores,
+    // of available cores (denoting all but n cores). If |n| >= number of cores,
     // clamp to 1 to set single-threaded mode.
     return n >= 0 ? n : std::max<int>(1, n + WorkGetPhysicalConcurrencyLimit());
 }


### PR DESCRIPTION
> [!IMPORTANT] 
> This is a duplicate of this PR:
>
> - https://github.com/PixarAnimationStudios/OpenUSD/pull/3370
>
> ...except that PR was pulled out the UsdLux-HdEmbree PR "chain", to make for easier standalone integration, as it has no other PR dependencies, and fixes an outstanding bug.
>
> I will close this PR if the other is merged first, and vice-versa.

### Description of Change(s)

Fixes an issue where pre-oneTBB, threads spawned from the non-root thread (such as the render thread) would not respect PXR_WORK_THREAD_LIMIT

### Fixes Issue(s)
- renderThread-spawned processes don't respect PXR_WORK_THREAD_LIMIT

---------------------------------------------------------------

### Related PRs:

This PR is part of a chain of PRs that provide a reference implementation of UsdLux as part of hdEmbree.

| :arrow_backward: **Previous PR in chain:**  |  :arrow_down_small: **This PR changes only:** | :arrow_forward: **Next PR in chain:** |
|-----------------------------|------------------------------|------------------------|
|  https://github.com/PixarAnimationStudios/OpenUSD/pull/3234| [Diff vs Previous](https://github.com/NVIDIA-Omniverse/OpenUSD/pull/18) <p> Due to a github limitation, this PR must include all previous PRs in the chain.  To see JUST the changes in this PR vs the previous in the chain, click this link  | https://github.com/PixarAnimationStudios/OpenUSD/pull/3186 |

:chains: **All PRs in this chain:**
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3199

:page_with_curl: **Documentation PR:**
This chain of PRs (implementing UsdLux support in hdEmbree), was made separate from the PR documenting expected UsdLux behavior:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3182

:eight_spoked_asterisk: **All UsdLux update related PRs:**
To see ALL UsdLux update related PRs (documentation AND reference implementation) in one place, see:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3200

:hourglass: **Original PR:**
These PRs are an update of this original PR:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/2758

---------------------------------------------------------------


### But... why??

**Why make these PRs in the first place?**

The current specifications of the various UsdLux prims + attributes are imprecise or vague in many places, and as a result, actual implementations of them by various renderers have diverged, sometimes quite significantly.  For instance, here is Intel's [4004 Moore Lane](https://dpel.aswf.io/4004-moore-lane/) scene, with the same UsdLux lights defined, in 3 different renderers:

Karma:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_karma.jpg?raw=true" alt="4004 Moore Lane, rendered in Karma" width="300">

Arnold:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_arnold.jpg?raw=true" alt="4004 Moore Lane, rendered in Arnold" width="300">

Omniverse RTX:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_rtx.jpg?raw=true" alt="4004 Moore Lane, rendered in Omniverse RTX" width="300">

For a full descpription of the problem, see here:
- [Problem Statement](https://github.com/anderslanglands/light_comparison/blob/main/README.md#problem-statement)

**Why so many PRs?**
This was my attempt to break up a rather large change into smaller, more easily reviewable changes, that can be merged in incrementally, to help ease the burden for code reviewers.

If you find this confusing, and would rather just one big PR (ie, just this one), or have them organized in some other way, please let me know!

**Why are the documentation changes in their own PR?**
In some ways, the [documentation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3182) are the heart of this effort - we wish to specify more exactly what the various UsdLux prims and attributes represent.  However, building consensus on this may take time - so we expect some dialogue on the exact language or formulas.

Because that may take time, the [hdEmbree reference implementation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3199) are separate, and broken up, so we can hopefully start integrating portions of them even before final consensus has been reached on the final form of the specification.

**Why are the documentation changes not broken up into smaller pieces, like the hdEmbree reference implementation changes?**
Because I wasn't sure if that would be desirable or not!  If people think that would be helpful, I can do so - perhaps breaking out by schema or individual attribute?

---------------------------------------------------------------
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
