### PR TITLE
Modernize TBB CMake setup by exclusively relying on CMake namespace targets

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -102,16 +102,10 @@ endif()
 
 
 # --TBB
-find_package(TBB CONFIG)
-if(TBB_DIR)
-    # Found in CONFIG mode.
-    set(TBB_tbb_LIBRARY TBB::tbb)
-    set(PXR_FIND_TBB_IN_CONFIG ON)
-else()
+find_package(TBB CONFIG COMPONENTS tbb)
+if(NOT TBB_FOUND)
     find_package(TBB REQUIRED COMPONENTS tbb)
-    set(PXR_FIND_TBB_IN_CONFIG OFF)
 endif()
-add_definitions(${TBB_DEFINITIONS})
 
 # --math
 if(WIN32)

--- a/pxr/base/plug/CMakeLists.txt
+++ b/pxr/base/plug/CMakeLists.txt
@@ -8,10 +8,7 @@ pxr_library(plug
         js
         trace
         work
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         interfaceFactory

--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -114,10 +114,7 @@ pxr_library(tf
     LIBRARIES
         arch
         ${WINLIBS}
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         anyUniquePtr

--- a/pxr/base/trace/CMakeLists.txt
+++ b/pxr/base/trace/CMakeLists.txt
@@ -6,10 +6,7 @@ pxr_library(trace
         arch
         js
         tf
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         aggregateTree

--- a/pxr/base/vt/CMakeLists.txt
+++ b/pxr/base/vt/CMakeLists.txt
@@ -7,10 +7,7 @@ pxr_library(vt
         tf
         gf
         trace
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         array

--- a/pxr/base/work/CMakeLists.txt
+++ b/pxr/base/work/CMakeLists.txt
@@ -5,10 +5,7 @@ pxr_library(work
     LIBRARIES
         tf
         trace
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         detachedTask

--- a/pxr/imaging/hd/CMakeLists.txt
+++ b/pxr/imaging/hd/CMakeLists.txt
@@ -15,10 +15,7 @@ pxr_library(hd
         hf
         pxOsd
         sdr
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         aov

--- a/pxr/imaging/hdGp/CMakeLists.txt
+++ b/pxr/imaging/hdGp/CMakeLists.txt
@@ -7,10 +7,7 @@ pxr_library(hdGp
     LIBRARIES
         hd
         hf
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         generativeProcedural

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -46,12 +46,11 @@ pxr_library(hdSt
         sdr
         tf
         trace
-        ${TBB_tbb_LIBRARY}
+        TBB::tbb
         ${OPENSUBDIV_LIBRARIES}
         ${optionalLibs}
 
     INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
         ${OPENSUBDIV_INCLUDE_DIR}
         ${optionalIncludeDirs}
 

--- a/pxr/imaging/hdsi/CMakeLists.txt
+++ b/pxr/imaging/hdsi/CMakeLists.txt
@@ -14,6 +14,7 @@ pxr_library(hdsi
         hf
         hd
         pxOsd
+        TBB::tbb
 
     PUBLIC_CLASSES
         computeSceneIndexDiff

--- a/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdEmbree/CMakeLists.txt
@@ -21,11 +21,9 @@ pxr_plugin(hdEmbree
         hf
         hd
         hdx
-        ${TBB_tbb_LIBRARY}
         ${EMBREE_LIBRARY}
 
     INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
         ${EMBREE_INCLUDE_DIR}
 
     PUBLIC_CLASSES

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -79,15 +79,6 @@
 #include <embree3/rtcore.h>
 #include <embree3/rtcore_geometry.h>
 #include <embree3/rtcore_ray.h>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/imaging/plugin/hdStorm/CMakeLists.txt
+++ b/pxr/imaging/plugin/hdStorm/CMakeLists.txt
@@ -26,10 +26,8 @@ pxr_plugin(hdStorm
         hd
         hdSt
         ${OPENSUBDIV_LIBRARIES}
-        ${TBB_tbb_LIBRARY}
 
     INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
         ${OPENSUBDIV_INCLUDE_DIR}
 
     PUBLIC_CLASSES

--- a/pxr/imaging/plugin/hdStorm/pch.h
+++ b/pxr/imaging/plugin/hdStorm/pch.h
@@ -70,10 +70,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/spin_mutex.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -18,6 +18,8 @@ set(PXR_VERSION "@PXR_VERSION@")
 
 include(CMakeFindDependencyMacro)
 
+find_dependency(TBB)
+
 # If Python support was enabled for this USD build, find the import
 # targets by invoking the appropriate FindPython module. Use the same
 # LIBRARY and INCLUDE_DIR settings from the original build if they

--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -8,10 +8,7 @@ pxr_library(ar
         tf
         plug
         vt
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         asset

--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -35,6 +35,7 @@
 #include "pxr/base/tf/unicodeUtils.h"
 
 #include <tbb/concurrent_hash_map.h>
+#include <tbb/enumerable_thread_specific.h>
 
 #include <memory>
 #include <mutex>

--- a/pxr/usd/pcp/CMakeLists.txt
+++ b/pxr/usd/pcp/CMakeLists.txt
@@ -9,10 +9,7 @@ pxr_library(pcp
         sdf
         work
         ar
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
         
     PUBLIC_HEADERS
         api.h

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -12,10 +12,7 @@ pxr_library(sdf
         vt
         work
         ar
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         abstractData

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -16,10 +16,7 @@ pxr_library(usd
         ts
         vt
         work
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         attribute
@@ -425,6 +422,7 @@ pxr_build_test(testUsdThreadedAuthoring
         work
         sdf
         usd
+        TBB::tbb
     CPPFILES
         testenv/testUsdThreadedAuthoring.cpp
 )

--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -13,10 +13,7 @@ pxr_library(usdGeom
         trace
         usd
         work
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         debugCodes

--- a/pxr/usd/usdHydra/pch.h
+++ b/pxr/usd/usdHydra/pch.h
@@ -72,17 +72,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdLux/pch.h
+++ b/pxr/usd/usdLux/pch.h
@@ -74,17 +74,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdMedia/pch.h
+++ b/pxr/usd/usdMedia/pch.h
@@ -73,17 +73,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdMtlx/pch.h
+++ b/pxr/usd/usdMtlx/pch.h
@@ -94,18 +94,6 @@
 #include <MaterialXFormat/Util.h>
 #include <MaterialXFormat/XmlIo.h>
 #endif // PXR_MATERIALX_SUPPORT_ENABLED
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdPhysics/CMakeLists.txt
+++ b/pxr/usd/usdPhysics/CMakeLists.txt
@@ -14,10 +14,6 @@ pxr_library(usdPhysics
         usdGeom
         usdShade
         work
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
 
     PUBLIC_CLASSES
         metrics

--- a/pxr/usd/usdPhysics/pch.h
+++ b/pxr/usd/usdPhysics/pch.h
@@ -73,18 +73,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdProc/pch.h
+++ b/pxr/usd/usdProc/pch.h
@@ -73,17 +73,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdRender/pch.h
+++ b/pxr/usd/usdRender/pch.h
@@ -74,17 +74,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdRi/pch.h
+++ b/pxr/usd/usdRi/pch.h
@@ -73,17 +73,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdShade/CMakeLists.txt
+++ b/pxr/usd/usdShade/CMakeLists.txt
@@ -12,11 +12,8 @@ pxr_library(usdShade
         sdr
         usd
         usdGeom
-        ${TBB_tbb_LIBRARY}
+        TBB::tbb
     
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
-
     PUBLIC_CLASSES
         connectableAPIBehavior
         input

--- a/pxr/usd/usdSkel/CMakeLists.txt
+++ b/pxr/usd/usdSkel/CMakeLists.txt
@@ -14,10 +14,7 @@ pxr_library(usdSkel
         sdf
         usd
         usdGeom
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         animMapper

--- a/pxr/usd/usdUI/pch.h
+++ b/pxr/usd/usdUI/pch.h
@@ -71,17 +71,6 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usd/usdUtils/CMakeLists.txt
+++ b/pxr/usd/usdUtils/CMakeLists.txt
@@ -10,10 +10,7 @@ pxr_library(usdUtils
         usd
         usdGeom
         usdShade
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         authoring

--- a/pxr/usdImaging/usdAppUtils/pch.h
+++ b/pxr/usdImaging/usdAppUtils/pch.h
@@ -89,17 +89,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -22,10 +22,7 @@ pxr_library(usdImaging
         usdShade
         usdVol
         ar
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
+        TBB::tbb
 
     PUBLIC_CLASSES
         adapterRegistry

--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -31,10 +31,6 @@ pxr_library(usdImagingGL
         usdShade
         usdImaging
         ar
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
 
     PUBLIC_CLASSES
         engine

--- a/pxr/usdImaging/usdImagingGL/pch.h
+++ b/pxr/usdImaging/usdImagingGL/pch.h
@@ -79,18 +79,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdProcImaging/pch.h
+++ b/pxr/usdImaging/usdProcImaging/pch.h
@@ -75,18 +75,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdRiPxrImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdRiPxrImaging/CMakeLists.txt
@@ -19,10 +19,6 @@ pxr_library(usdRiPxrImaging
         usdImaging
         usdVol
         ar
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
 
     PUBLIC_CLASSES
         pxrAovLightAdapter

--- a/pxr/usdImaging/usdRiPxrImaging/pch.h
+++ b/pxr/usdImaging/usdRiPxrImaging/pch.h
@@ -75,18 +75,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdSkelImaging/pch.h
+++ b/pxr/usdImaging/usdSkelImaging/pch.h
@@ -75,20 +75,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/parallel_for.h>
-#include <tbb/parallel_for_each.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdVolImaging/pch.h
+++ b/pxr/usdImaging/usdVolImaging/pch.h
@@ -75,18 +75,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_map.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdImaging/usdviewq/pch.h
+++ b/pxr/usdImaging/usdviewq/pch.h
@@ -74,17 +74,6 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <tbb/blocked_range.h>
-#include <tbb/cache_aligned_allocator.h>
-#include <tbb/concurrent_hash_map.h>
-#include <tbb/concurrent_queue.h>
-#include <tbb/concurrent_unordered_set.h>
-#include <tbb/concurrent_vector.h>
-#include <tbb/enumerable_thread_specific.h>
-#include <tbb/spin_mutex.h>
-#include <tbb/spin_rw_mutex.h>
-#include <tbb/task.h>
-#include <tbb/task_group.h>
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
 #include "pxr/base/tf/pySafePython.h"
 #endif // PXR_PYTHON_SUPPORT_ENABLED

--- a/pxr/usdValidation/usdValidation/CMakeLists.txt
+++ b/pxr/usdValidation/usdValidation/CMakeLists.txt
@@ -9,10 +9,6 @@ pxr_library(usdValidation
         gf
         usd
         work
-        ${TBB_tbb_LIBRARY}
-
-    INCLUDE_DIRS
-        ${TBB_INCLUDE_DIRS}
 
     PUBLIC_CLASSES
         context 

--- a/third_party/renderman-26/plugin/hdPrman/CMakeLists.txt
+++ b/third_party/renderman-26/plugin/hdPrman/CMakeLists.txt
@@ -80,6 +80,7 @@ pxr_plugin(${PXR_PACKAGE}
         usdRi
         usdVol
         usdVolImaging
+        TBB::tbb
         ${optionalLibs}
 
     INCLUDE_DIRS


### PR DESCRIPTION
### Description of Change(s)

Using CMake namespace target is the modern approach, it forwards definitions, include directories and link libraries transitively to consumers.
One `TBB::tbb` is already produced by the `FindTBB.cmake` module.
As the main CMakeLists.txt already requires CMake 3.14 this should already be available to all CMake clients.

Additionally try to resolve TBB Config package before trying the module one.
Miscellaneous associated cleanups are made with remaining commits.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
