### PR TITLE
[hdEmbree] fix for random number generation (hdEmbree-UsdLux-PR01)

### DIFF
--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -503,7 +503,7 @@ HdEmbreeRenderer::_RenderTiles(HdRenderThread *renderThread,
 
     // Create a uniform distribution for jitter calculations.
     std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+    auto uniform_float = [&random, &uniform_dist]() { return uniform_dist(random); };
 
     // _RenderTiles gets a range of tiles; iterate through them.
     for (unsigned int tile = tileStart; tile < tileEnd; ++tile) {
@@ -923,7 +923,7 @@ HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
 {
     // Create a uniform random distribution for AO calculations.
     std::uniform_real_distribution<float> uniform_dist(0.0f, 1.0f);
-    std::function<float()> uniform_float = std::bind(uniform_dist, random);
+    auto uniform_float = [&random, &uniform_dist]() { return uniform_dist(random); };
 
     // 0 ambient occlusion samples means disable the ambient occlusion term.
     if (_ambientOcclusionSamples < 1) {


### PR DESCRIPTION
> [!IMPORTANT] 
> This is a duplicate of this PR:
>
> - https://github.com/PixarAnimationStudios/OpenUSD/pull/3184
>
> ...except that this one was re-ordered to be first in the PR "chain", to make for easier standalone integration, as it has no other PR dependencies, and fixes an outstanding bug.
> (Previously: this was a standalone version of what used to be PR02 in chain.  Was promoted to the first in chain)

### Description of Change(s)

use of std::bind was copying the underlying random number generator before use, resulting in the exact same sequence getting reused for, ie, every AO calculation within a given tile-group

### Fixes Issue(s)
- repeated random sequences used in hdEmbree

### Related PRs:

This PR is part of a chain of PRs that provide a reference implementation of UsdLux as part of hdEmbree.

| :arrow_backward: **Previous PR in chain:**  |  :arrow_down_small: **This PR changes only:** | :arrow_forward: **Next PR in chain:** |
|-----------------------------|------------------------------|------------------------|
| (None)   |[Diff vs origin/dev](https://github.com/PixarAnimationStudios/OpenUSD/pull/3211/files)  | https://github.com/PixarAnimationStudios/OpenUSD/pull/3183 |

:chains: **All PRs in this chain:**
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3199

:page_with_curl: **Documentation PR:**
This chain of PRs (implementing UsdLux support in hdEmbree), was made separate from the PR documenting expected UsdLux behavior:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3182

:eight_spoked_asterisk: **All UsdLux update related PRs:**
To see ALL UsdLux update related PRs (documentation AND reference implementation) in one place, see:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/3200

:hourglass: **Original PR:**
These PRs are an update of this original PR:
- https://github.com/PixarAnimationStudios/OpenUSD/pull/2758

---------------------------------------------------------------


### But... why??

**Why make these PRs in the first place?**

The current specifications of the various UsdLux prims + attributes are imprecise or vague in many places, and as a result, actual implementations of them by various renderers have diverged, sometimes quite significantly.  For instance, here is Intel's [4004 Moore Lane](https://dpel.aswf.io/4004-moore-lane/) scene, with the same UsdLux lights defined, in 3 different renderers:

Karma:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_karma.jpg?raw=true" alt="4004 Moore Lane, rendered in Karma" width="300">

Arnold:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_arnold.jpg?raw=true" alt="4004 Moore Lane, rendered in Arnold" width="300">

Omniverse RTX:
<img src="https://github.com/anderslanglands/light_comparison/blob/main/renders/moore-lane/moore-lane_rtx.jpg?raw=true" alt="4004 Moore Lane, rendered in Omniverse RTX" width="300">

For a full descpription of the problem, see here:
- [Problem Statement](https://github.com/anderslanglands/light_comparison/blob/main/README.md#problem-statement)

**Why so many PRs?**
This was my attempt to break up a rather large change into smaller, more easily reviewable changes, that can be merged in incrementally, to help ease the burden for code reviewers.

If you find this confusing, and would rather just one big PR (ie, just this one), or have them organized in some other way, please let me know!

**Why are the documentation changes in their own PR?**
In some ways, the [documentation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3182) are the heart of this effort - we wish to specify more exactly what the various UsdLux prims and attributes represent.  However, building consensus on this may take time - so we expect some dialogue on the exact language or formulas.

Because that may take time, the [hdEmbree reference implementation changes](https://github.com/PixarAnimationStudios/OpenUSD/pull/3199) are separate, and broken up, so we can hopefully start integrating portions of them even before final consensus has been reached on the final form of the specification.

**Why are the documentation changes not broken up into smaller pieces, like the hdEmbree reference implementation changes?**
Because I wasn't sure if that would be desirable or not!  If people think that would be helpful, I can do so - perhaps breaking out by schema or individual attribute?

---------------------------------------------------------------
<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement

