### PR TITLE
Autodesk: Configurable anisotropic filtering

### DIFF
--- a/pxr/imaging/hd/material.cpp
+++ b/pxr/imaging/hd/material.cpp
@@ -270,6 +270,7 @@ _GetSamplerParameters(
                  nodeTypeId, parameters, sdrNode, nodePath),
              _ResolveMagSamplerParameter(
                  nodeTypeId, parameters, sdrNode, nodePath),
+             /*maxAnisotropy*/16,
              HdBorderColorTransparentBlack, 
              /*enableCompare*/false, 
              HdCmpFuncNever };

--- a/pxr/imaging/hd/types.cpp
+++ b/pxr/imaging/hd/types.cpp
@@ -109,7 +109,8 @@ HdSamplerParameters::HdSamplerParameters()
 
 HdSamplerParameters::HdSamplerParameters(
     HdWrap wrapS, HdWrap wrapT, HdWrap wrapR, 
-    HdMinFilter minFilter, HdMagFilter magFilter, 
+    HdMinFilter minFilter, HdMagFilter magFilter,
+    uint32_t maxAnisotropy,
     HdBorderColor borderColor,
     bool enableCompare, HdCompareFunction compareFunction)
     : wrapS(wrapS)
@@ -117,6 +118,7 @@ HdSamplerParameters::HdSamplerParameters(
     , wrapR(wrapR)
     , minFilter(minFilter)
     , magFilter(magFilter)
+    , maxAnisotropy(maxAnisotropy)
     , borderColor(borderColor)
     , enableCompare(enableCompare)
     , compareFunction(compareFunction)
@@ -131,6 +133,7 @@ HdSamplerParameters::operator==(const HdSamplerParameters &other) const
         (wrapR == other.wrapR) &&
         (minFilter == other.minFilter) &&
         (magFilter == other.magFilter) &&
+        (maxAnisotropy == other.maxAnisotropy) &&
         (borderColor == other.borderColor) &&
         (enableCompare == other.enableCompare) &&
         (compareFunction == other.compareFunction);

--- a/pxr/imaging/hd/types.h
+++ b/pxr/imaging/hd/types.h
@@ -117,13 +117,15 @@ public:
     HdBorderColor borderColor;
     bool enableCompare;
     HdCompareFunction compareFunction;
+    uint32_t maxAnisotropy;
 
     HD_API
     HdSamplerParameters();   
 
     HD_API
     HdSamplerParameters(HdWrap wrapS, HdWrap wrapT, HdWrap wrapR, 
-        HdMinFilter minFilter, HdMagFilter magFilter, 
+        HdMinFilter minFilter, HdMagFilter magFilter,
+        uint32_t maxAnisotropy=16,
         HdBorderColor borderColor=HdBorderColorTransparentBlack,
         bool enableCompare=false, 
         HdCompareFunction compareFunction=HdCmpFuncNever);

--- a/pxr/imaging/hdSt/material.cpp
+++ b/pxr/imaging/hdSt/material.cpp
@@ -104,6 +104,7 @@ _GetTextureHandleHash(
         samplerParams.wrapR,
         samplerParams.minFilter,
         samplerParams.magFilter,
+        samplerParams.maxAnisotropy,
         samplerParams.borderColor,
         samplerParams.enableCompare,
         samplerParams.compareFunction);

--- a/pxr/imaging/hdSt/renderPassShader.cpp
+++ b/pxr/imaging/hdSt/renderPassShader.cpp
@@ -297,7 +297,7 @@ HdStRenderPassShader::UpdateAovInputTextures(
     for (const auto &namedTextureIdentifier : namedTextureIdentifiers) {
         static const HdSamplerParameters samplerParameters(
             HdWrapClamp, HdWrapClamp, HdWrapClamp,
-            HdMinFilterNearest, HdMagFilterNearest);
+            HdMinFilterNearest, HdMagFilterNearest, /*maxAnisotropy*/1);
 
         // Allocate texture handle for given identifier.
         HdStTextureHandleSharedPtr textureHandle =

--- a/pxr/imaging/hdSt/samplerObject.cpp
+++ b/pxr/imaging/hdSt/samplerObject.cpp
@@ -67,6 +67,7 @@ _ToHgiSamplerDesc(HdSamplerParameters const &samplerParameters)
         HdStHgiConversions::GetHgiSamplerAddressMode(samplerParameters.wrapT);
     desc.addressModeW =
         HdStHgiConversions::GetHgiSamplerAddressMode(samplerParameters.wrapR);
+    desc.maxAnisotropy = samplerParameters.maxAnisotropy;
     desc.borderColor =
         HdStHgiConversions::GetHgiBorderColor(samplerParameters.borderColor);
     desc.enableCompare = samplerParameters.enableCompare;
@@ -198,6 +199,7 @@ HdSamplerParameters PTEX_SAMPLER_PARAMETERS(
     HdWrapClamp,
     HdMinFilterLinear,
     HdMagFilterLinear,
+    /*maxAnisotropy*/16,
     HdBorderColorTransparentBlack, 
     /*enableCompare*/false, 
     HdCmpFuncNever);
@@ -209,6 +211,7 @@ HdSamplerParameters LAYOUT_SAMPLER_PARAMETERS(
     HdWrapRepeat,
     HdMinFilterNearest,
     HdMagFilterNearest,
+    /*maxAnisotropy*/1,
     HdBorderColorTransparentBlack, 
     /*enableCompare*/false, 
     HdCmpFuncNever);
@@ -255,6 +258,7 @@ HdSamplerParameters UDIM_SAMPLER_PARAMETERS(
     HdWrapClamp,
     HdMinFilterLinearMipmapLinear,
     HdMagFilterLinear,
+    /*maxAnisotropy*/16,
     HdBorderColorTransparentBlack, 
     /*enableCompare*/false, 
     HdCmpFuncNever);

--- a/pxr/imaging/hdSt/simpleLightingShader.cpp
+++ b/pxr/imaging/hdSt/simpleLightingShader.cpp
@@ -321,7 +321,7 @@ _MakeNamedTextureHandle(
 
     const HdSamplerParameters samplerParameters(
         wrapModeS, wrapModeT, wrapModeR,
-        minFilter, HdMagFilterLinear);
+        minFilter, HdMagFilterLinear, /*maxAnisotropy*/1);
 
     HdStTextureHandleSharedPtr const textureHandle =
         resourceRegistry->AllocateTextureHandle(
@@ -451,7 +451,7 @@ HdStSimpleLightingShader::AllocateTextureHandles(HdRenderIndex const &renderInde
 
         static const HdSamplerParameters envSamplerParameters(
             HdWrapRepeat, HdWrapClamp, HdWrapClamp,
-            HdMinFilterLinearMipmapLinear, HdMagFilterLinear);
+            HdMinFilterLinearMipmapLinear, HdMagFilterLinear, /*maxAnisotropy*/1);
 
         _domeLightEnvironmentTextureHandle =
             resourceRegistry->AllocateTextureHandle(
@@ -539,7 +539,7 @@ HdStSimpleLightingShader::AllocateTextureHandles(HdRenderIndex const &renderInde
             // for just-allocated texture objects.
             HdSamplerParameters const shadowSamplerParameters{
                 HdWrapClamp, HdWrapClamp, HdWrapClamp,
-                HdMinFilterLinear, HdMagFilterLinear,
+                HdMinFilterLinear, HdMagFilterLinear, /*maxAnisotropy*/1,
                 HdBorderColorOpaqueWhite, /*enableCompare*/true, 
                 HdCmpFuncLEqual};
 
@@ -648,4 +648,3 @@ HdStSimpleLightingShader::GetNamedTextureHandles() const
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/imaging/hgi/sampler.cpp
+++ b/pxr/imaging/hgi/sampler.cpp
@@ -8,6 +8,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+TF_DEFINE_ENV_SETTING(HGI_MAX_ANISOTROPY, 16,
+                      "Maximum anisotropic filtering ratio for all samplers");
+
+
 HgiSampler::HgiSampler(HgiSamplerDesc const& desc)
     : _descriptor(desc)
 {
@@ -30,7 +34,8 @@ bool operator==(const HgiSamplerDesc& lhs,
             lhs.mipFilter == rhs.mipFilter &&
             lhs.addressModeU == rhs.addressModeU &&
             lhs.addressModeV == rhs.addressModeV &&
-            lhs.addressModeW == rhs.addressModeW
+            lhs.addressModeW == rhs.addressModeW &&
+            lhs.maxAnisotropy == rhs.maxAnisotropy
     ;
 }
 

--- a/pxr/imaging/hgi/sampler.h
+++ b/pxr/imaging/hgi/sampler.h
@@ -8,6 +8,9 @@
 #define PXR_IMAGING_HGI_SAMPLER_H
 
 #include "pxr/pxr.h"
+
+#include "pxr/base/tf/envSetting.h"
+
 #include "pxr/imaging/hgi/api.h"
 #include "pxr/imaging/hgi/enums.h"
 #include "pxr/imaging/hgi/handle.h"
@@ -18,6 +21,12 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+/// Sets the maximum anisotropic filtering ratio for all samplers.
+/// By default this is 16x. The actual value used depends on the
+/// device limits. A value of 1 effectively disables anisotropic sampling.
+///
+HGI_API
+extern TfEnvSetting<int> HGI_MAX_ANISOTROPY;
 
 /// \struct HgiSamplerDesc
 ///
@@ -42,6 +51,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///    Enables sampler comparison against a reference value during lookups.</li>
 /// <li>compareFunction: 
 ///    The comparison function to apply if sampler compare is enabled.</li>
+/// <li>maxAnisotropy:
+///    Maximum anisotropic filtering ratio. The default value of 16 corresponds
+///    to the previously internal default value. The actual value used is subject
+///    to the device maximum supported anisotropy and the HGI_MAX_ANISOTROPY
+///    setting. A value of 1 effectively disables anisotropic sampling.</li>
 /// </ul>
 ///
 struct HgiSamplerDesc
@@ -56,6 +70,7 @@ struct HgiSamplerDesc
         , borderColor(HgiBorderColorTransparentBlack)
         , enableCompare(false)
         , compareFunction(HgiCompareFunctionNever)
+        , maxAnisotropy(16)
     {}
 
     std::string debugName;
@@ -68,6 +83,7 @@ struct HgiSamplerDesc
     HgiBorderColor borderColor;
     bool enableCompare;
     HgiCompareFunction compareFunction;
+    uint32_t maxAnisotropy;
 };
 
 HGI_API

--- a/pxr/imaging/hgiGL/sampler.cpp
+++ b/pxr/imaging/hgiGL/sampler.cpp
@@ -14,6 +14,8 @@
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/tf/diagnostic.h"
 
+#include <algorithm>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -68,11 +70,13 @@ HgiGLSampler::HgiGLSampler(HgiSamplerDesc const& desc)
     // when the filters are "nearest" to ensure those filters are used.
     if (minFilter != GL_NEAREST && minFilter != GL_NEAREST_MIPMAP_NEAREST &&
         magFilter != GL_NEAREST) {
-        static const float maxAnisotropy = 16.0;
+        float aniso = 2.0f;
+        glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &aniso);
         glSamplerParameterf(
             _samplerId,
             GL_TEXTURE_MAX_ANISOTROPY_EXT,
-            maxAnisotropy);
+            std::min({aniso, static_cast<float>(desc.maxAnisotropy),
+                    static_cast<float>(TfGetEnvSetting(HGI_MAX_ANISOTROPY))}));
     }
 
     glSamplerParameteri(

--- a/pxr/imaging/hgiGL/texture.cpp
+++ b/pxr/imaging/hgiGL/texture.cpp
@@ -6,6 +6,7 @@
 //
 #include "pxr/imaging/garch/glApi.h"
 
+#include "pxr/imaging/hgi/sampler.h"
 #include "pxr/imaging/hgiGL/diagnostic.h"
 #include "pxr/imaging/hgiGL/conversions.h"
 #include "pxr/imaging/hgiGL/texture.h"
@@ -13,6 +14,7 @@
 #include <algorithm>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
 
 static
 void
@@ -254,7 +256,8 @@ HgiGLTexture::HgiGLTexture(HgiTextureDesc const & desc)
             glTextureParameterf(
                 _textureId,
                 GL_TEXTURE_MAX_ANISOTROPY_EXT,
-                aniso);
+                std::min(aniso,
+                    static_cast<float>(TfGetEnvSetting(HGI_MAX_ANISOTROPY))));
         }
 
         const uint16_t mips = desc.mipLevels;

--- a/pxr/imaging/hgiMetal/sampler.mm
+++ b/pxr/imaging/hgiMetal/sampler.mm
@@ -38,8 +38,9 @@ HgiMetalSampler::HgiMetalSampler(HgiMetal *hgi, HgiSamplerDesc const& desc)
     if ((desc.minFilter != HgiSamplerFilterNearest ||
          desc.mipFilter == HgiMipFilterLinear) &&
          desc.magFilter != HgiSamplerFilterNearest) {
-        static const int maxAnisotropy = 16;
-        smpDesc.maxAnisotropy = maxAnisotropy;
+        static const uint32_t maxAnisotropy = 16;
+        smpDesc.maxAnisotropy = std::min({maxAnisotropy, desc.maxAnisotropy,
+            static_cast<uint32_t>(TfGetEnvSetting(HGI_MAX_ANISOTROPY))});
     }
     
     HGIMETAL_DEBUG_LABEL(smpDesc, _descriptor.debugName.c_str());

--- a/pxr/imaging/hgiVulkan/sampler.cpp
+++ b/pxr/imaging/hgiVulkan/sampler.cpp
@@ -52,7 +52,9 @@ HgiVulkanSampler::HgiVulkanSampler(
         HgiVulkanCapabilities const& caps = device->GetDeviceCapabilities();
         sampler.anisotropyEnable = caps.vkDeviceFeatures.samplerAnisotropy;
         sampler.maxAnisotropy = sampler.anisotropyEnable ?
-            caps.vkDeviceProperties.limits.maxSamplerAnisotropy : 1.0f; 
+            std::min({caps.vkDeviceProperties.limits.maxSamplerAnisotropy,
+                static_cast<float>(desc.maxAnisotropy),
+                static_cast<float>(TfGetEnvSetting(HGI_MAX_ANISOTROPY))}) : 1.0f;
     }
 
     TF_VERIFY(


### PR DESCRIPTION
### Description of Change(s)

Make anisotropic filtering configurable. See issue #3180 for rationale.

Expose maxAnisotropy in HgiSamplerDesc
Define an environment setting HGI_MAX_ANISOTROPY as an override for the implementation max anisotropy
Update current users of textures/samplers to disable anisotropy when not needed (like dome lighting texture)

### Fixes Issue(s)

Mostly fixes #3180, but more work should be done to configure anisotropic filtering from the materials (can be a separate issue).
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X ] I have submitted a signed Contributor License Agreement
