### PR TITLE
Conform SdfLayer and UsdStage dtors to C++ Standard.

### DIFF
--- a/pxr/usd/sdf/layer.cpp
+++ b/pxr/usd/sdf/layer.cpp
@@ -198,7 +198,7 @@ SdfLayer::SdfLayer(
     _MarkCurrentStateAsClean();
 }
 
-SdfLayer::~SdfLayer()
+SdfLayer::~SdfLayer() noexcept
 {
     TF_PY_ALLOW_THREADS_IN_SCOPE();
 

--- a/pxr/usd/sdf/layer.h
+++ b/pxr/usd/sdf/layer.h
@@ -84,7 +84,7 @@ class SdfLayer
 public:
     /// Destructor
     SDF_API
-    virtual ~SdfLayer(); 
+    virtual ~SdfLayer() noexcept; 
 
     /// Noncopyable
     SdfLayer(const SdfLayer&) = delete;

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -682,7 +682,7 @@ UsdStage::UsdStage(const SdfLayerRefPtr& rootLayer,
     _cache->SetVariantFallbacks(GetGlobalVariantFallbacks());
 }
 
-UsdStage::~UsdStage()
+UsdStage::~UsdStage() noexcept
 {
     TF_DEBUG(USD_STAGE_LIFETIMES).Msg(
         "UsdStage::~UsdStage(rootLayer=@%s@, sessionLayer=@%s@)\n",

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -397,7 +397,7 @@ public:
                InitialLoadSet load=LoadAll);
     
     USD_API
-    virtual ~UsdStage();
+    virtual ~UsdStage() noexcept;
 
     /// Calls SdfLayer::Reload on all layers contributing to this stage,
     /// except session layers and sublayers of session layers.


### PR DESCRIPTION
* Without these `noexcept` exception specifications, **SdfLayer** and **UsdStage** fail to compile when compiling with for example, **Swift/Clang** with the following error:
  ```
  error: exception specification is more lax than base version
  ```
* Please see [this reference](https://timsong-cpp.github.io/cppwp/n4659/except.spec#4) where this is mentioned in the standard:

  > 18.4 Exception speciﬁcations [except.spec]
  > ...
  > 4. If a virtual function has a non-throwing exception speciﬁcation, all declarations,
  > including the deﬁnition, of any function that overrides that virtual function in any
  > derived class shall have a non-throwing exception speciﬁcation, unless the overriding
  > function is deﬁned as deleted. 


### Description of Change(s)

- Add `noexcept` exception specifications to the virtual dtors of **SdfLayer** and **UsdStage**.

<hr/>

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
