### PR TITLE
Support building with objc-arc, enable by default.

### DIFF
--- a/pxr/imaging/garch/CMakeLists.txt
+++ b/pxr/imaging/garch/CMakeLists.txt
@@ -62,3 +62,12 @@ pxr_library(garch
     PYMODULE_FILES
         __init__.py
 )
+
+if(APPLE)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        if (TARGET garch)
+            # Build garch with ObjC ARC (Automatic Reference Counting) enabled.
+            target_compile_options(garch PUBLIC "-fobjc-arc")
+        endif()
+    endif()
+endif()

--- a/pxr/imaging/garch/glPlatformContextDarwin.mm
+++ b/pxr/imaging/garch/glPlatformContextDarwin.mm
@@ -104,7 +104,7 @@ GarchSelectCoreProfileMacVisual()
     attribs[c++] = NSOpenGLPFADoubleBuffer;
     attribs[c++] = 0;
 
-    return [[NSOpenGLPixelFormat alloc] initWithAttributes:attribs];
+    return (__bridge void*)[[NSOpenGLPixelFormat alloc] initWithAttributes:attribs];
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
+++ b/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
@@ -75,7 +75,9 @@ Garch_GetModifierKeys(NSUInteger flags)
 
     _callback->OnInitializeGL();
 
+#if !__has_feature(objc_arc)
     [pf release];
+#endif // !__has_feature(objc_arc)
 
     return self;
 }

--- a/pxr/imaging/hgiInterop/metal.mm
+++ b/pxr/imaging/hgiInterop/metal.mm
@@ -362,8 +362,10 @@ HgiInteropMetal::HgiInteropMetal(Hgi* hgi)
         [_defaultLibrary newFunctionWithName:@"copyDepth"];
     _computeColorCopyProgram =
         [_defaultLibrary newFunctionWithName:@"copyColour"];
-    
+
+#if !__has_feature(objc_arc)
     [options release];
+#endif // !__has_feature(objc_arc)
     options = nil;
 
     
@@ -398,7 +400,9 @@ HgiInteropMetal::HgiInteropMetal(Hgi* hgi)
                                       options:MTLPipelineOptionNone
                                    reflection:reflData
                                         error:&error];
+#if !__has_feature(objc_arc)
     [computePipelineStateDescriptor release];
+#endif // !__has_feature(objc_arc)
 
     if (!_computePipelineStateColor) {
         NSString *errStr = [error localizedDescription];
@@ -435,11 +439,15 @@ HgiInteropMetal::_FreeTransientTextureCacheRefs()
     }
     
     if (_mtlAliasedColorTexture) {
+#if !__has_feature(objc_arc)
         [_mtlAliasedColorTexture release];
+#endif // !__has_feature(objc_arc)
         _mtlAliasedColorTexture = nil;
     }
     if (_mtlAliasedDepthRegularFloatTexture) {
+#if !__has_feature(objc_arc)
         [_mtlAliasedDepthRegularFloatTexture release];
+#endif // !__has_feature(objc_arc)
         _mtlAliasedDepthRegularFloatTexture = nil;
     }
 
@@ -790,10 +798,10 @@ HgiInteropMetal::CompositeToInterop(
     id<MTLTexture> colorTexture = nil;
     id<MTLTexture> depthTexture = nil;
     if (color) {
-        colorTexture = id<MTLTexture>(color->GetRawResource());
+        colorTexture = ((__bridge id<MTLTexture>)reinterpret_cast<void *>(color->GetRawResource()));
     }
     if (depth) {
-        depthTexture = id<MTLTexture>(depth->GetRawResource());
+        depthTexture = ((__bridge id<MTLTexture>)reinterpret_cast<void *>(depth->GetRawResource()));
     }
 
     id<MTLCommandBuffer> commandBuffer = _hgiMetal->GetPrimaryCommandBuffer();

--- a/pxr/imaging/hgiMetal/CMakeLists.txt
+++ b/pxr/imaging/hgiMetal/CMakeLists.txt
@@ -66,3 +66,10 @@ pxr_library(hgiMetal
 
     DISABLE_PRECOMPILED_HEADERS
 )
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    if (TARGET hgiMetal)
+        # Build hgiMetal with ObjC ARC (Automatic Reference Counting) enabled.
+        target_compile_options(hgiMetal PUBLIC "-fobjc-arc")
+    endif()
+endif()

--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -34,7 +34,9 @@ HgiMetalBlitCmds::~HgiMetalBlitCmds()
     TF_VERIFY(_blitEncoder == nil, "Encoder created, but never commited.");
     
     if (_label) {
+#if !__has_feature(objc_arc)
         [_label release];
+#endif // !__has_feature(objc_arc)
         _label = nil;
     }
 }
@@ -52,7 +54,9 @@ HgiMetalBlitCmds::_CreateEncoder()
 
         if (_label) {
             [_blitEncoder pushDebugGroup:_label];
+#if !__has_feature(objc_arc)
             [_label release];
+#endif // !__has_feature(objc_arc)
             _label = nil;
         }
         if (!_secondaryCommandBuffer) {
@@ -168,7 +172,9 @@ HgiMetalBlitCmds::CopyTextureGpuToCpu(
         {
             const char* src = (const char*) [cpuBuffer contents];
             memcpy(dst, src, byteSize);
+#if !__has_feature(objc_arc)
             [cpuBuffer release];
+#endif // !__has_feature(objc_arc)
         }];
 }
 
@@ -268,7 +274,9 @@ HgiMetalBlitCmds::CopyTextureCpuToGpu(
                              levelCount:1];
     [blitCommandEncoder endEncoding];
     [commandBuffer commit];
+#if !__has_feature(objc_arc)
     [tempTextureId release];
+#endif // !__has_feature(objc_arc)
 }
 
 void
@@ -357,7 +365,7 @@ void HgiMetalBlitCmds::CopyBufferCpuToGpu(
         [metalBuffer->GetBufferId()
              respondsToSelector:@selector(didModifyRange:)]) {
         NSRange range = NSMakeRange(dstOffset, copyOp.byteSize);
-        id<MTLResource> resource = metalBuffer->GetBufferId();
+        id<MTLBuffer> resource = metalBuffer->GetBufferId();
         
         ARCH_PRAGMA_PUSH
         ARCH_PRAGMA_INSTANCE_METHOD_NOT_FOUND

--- a/pxr/imaging/hgiMetal/buffer.mm
+++ b/pxr/imaging/hgiMetal/buffer.mm
@@ -46,7 +46,9 @@ HgiMetalBuffer::HgiMetalBuffer(HgiMetal *hgi, HgiBufferDesc const & desc)
 HgiMetalBuffer::~HgiMetalBuffer()
 {
     if (_bufferId != nil) {
+#if !__has_feature(objc_arc)
         [_bufferId release];
+#endif // !__has_feature(objc_arc)
         _bufferId = nil;
     }
 }

--- a/pxr/imaging/hgiMetal/computePipeline.mm
+++ b/pxr/imaging/hgiMetal/computePipeline.mm
@@ -39,7 +39,9 @@ HgiMetalComputePipeline::HgiMetalComputePipeline(
                                       options:MTLPipelineOptionNone
                                    reflection:nil
                                         error:&error];
+#if !__has_feature(objc_arc)
     [stateDesc release];
+#endif // !__has_feature(objc_arc)
 
     if (!_computePipelineState) {
         NSString *err = [error localizedDescription];

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -239,11 +239,13 @@ HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
 HgiMetalGraphicsCmds::~HgiMetalGraphicsCmds()
 {
     TF_VERIFY(_encoders.empty(), "Encoder created, but never commited.");
-    
+
+#if !__has_feature(objc_arc)
     [_renderPassDescriptor release];
     if (_debugLabel) {
         [_debugLabel release];
     }
+#endif // !__has_feature(objc_arc)
 }
 
 void
@@ -355,7 +357,9 @@ HgiMetalGraphicsCmds::_SetNumberParallelEncoders(uint32_t numEncoders)
     }
     
     if (_debugLabel) {
+#if !__has_feature(objc_arc)
         [_debugLabel release];
+#endif // !__has_feature(objc_arc)
         _debugLabel = nil;
     }
 }
@@ -793,7 +797,9 @@ HgiMetalGraphicsCmds::PopDebugGroup()
         HGIMETAL_DEBUG_POP_GROUP(GetEncoder());
     }
     if (_debugLabel) {
+#if !__has_feature(objc_arc)
         [_debugLabel release];
+#endif // !__has_feature(objc_arc)
         _debugLabel = nil;
     }
 }

--- a/pxr/imaging/hgiMetal/graphicsPipeline.mm
+++ b/pxr/imaging/hgiMetal/graphicsPipeline.mm
@@ -36,6 +36,7 @@ HgiMetalGraphicsPipeline::HgiMetalGraphicsPipeline(
 
 HgiMetalGraphicsPipeline::~HgiMetalGraphicsPipeline()
 {
+#if !__has_feature(objc_arc)
     if (_renderPipelineState) {
         [_renderPipelineState release];
     }
@@ -48,6 +49,7 @@ HgiMetalGraphicsPipeline::~HgiMetalGraphicsPipeline()
     if (_constantTessFactors) {
         [_constantTessFactors release];
     }
+#endif // !__has_feature(objc_arc)
 }
 
 void
@@ -314,7 +316,9 @@ HgiMetalGraphicsPipeline::_CreateRenderPipelineState(HgiMetal *hgi)
     _renderPipelineState = [device
         newRenderPipelineStateWithDescriptor:stateDesc
         error:&error];
+#if !__has_feature(objc_arc)
     [stateDesc release];
+#endif // !__has_feature(objc_arc) 
     
     if (!_renderPipelineState) {
         NSString *err = [error localizedDescription];
@@ -381,7 +385,9 @@ HgiMetalGraphicsPipeline::_CreateDepthStencilState(HgiMetal *hgi)
     id<MTLDevice> device = hgi->GetPrimaryDevice();
     _depthStencilState = [device
         newDepthStencilStateWithDescriptor:depthStencilStateDescriptor];
+#if !__has_feature(objc_arc)
     [depthStencilStateDescriptor release];
+#endif // !__has_feature(objc_arc)
 
     TF_VERIFY(_depthStencilState,
         "Failed to created depth stencil state");

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -89,7 +89,9 @@ HgiMetal::HgiMetal(id<MTLDevice> device)
     _commandQueue = [_device newCommandQueueWithMaxCommandBufferCount:
                      commandBufferPoolSize];
     _commandBuffer = [_commandQueue commandBuffer];
+#if !__has_feature(objc_arc)
     [_commandBuffer retain];
+#endif // !__has_feature(objc_arc)
 
     _capabilities.reset(new HgiMetalCapabilities(_device));
     _indirectCommandEncoder.reset(new HgiMetalIndirectCommandEncoder(this));
@@ -99,21 +101,27 @@ HgiMetal::HgiMetal(id<MTLDevice> device)
     argumentDescBuffer.dataType = MTLDataTypePointer;
     _argEncoderBuffer = [_device newArgumentEncoderWithArguments:
                         @[argumentDescBuffer]];
+#if !__has_feature(objc_arc)
     [argumentDescBuffer release];
+#endif // !__has_feature(objc_arc)
 
     MTLArgumentDescriptor *argumentDescSampler =
         [[MTLArgumentDescriptor alloc] init];
     argumentDescSampler.dataType = MTLDataTypeSampler;
     _argEncoderSampler = [_device newArgumentEncoderWithArguments:
                          @[argumentDescSampler]];
+#if !__has_feature(objc_arc)
     [argumentDescSampler release];
+#endif // !__has_feature(objc_arc)
 
     MTLArgumentDescriptor *argumentDescTexture =
         [[MTLArgumentDescriptor alloc] init];
     argumentDescTexture.dataType = MTLDataTypeTexture;
     _argEncoderTexture = [_device newArgumentEncoderWithArguments:
                          @[argumentDescTexture]];
+#if !__has_feature(objc_arc)
     [argumentDescTexture release];
+#endif // !__has_feature(objc_arc)
 
     HgiMetalSetupMetalDebug();
     
@@ -131,17 +139,20 @@ HgiMetal::~HgiMetal()
 {
     [_commandBuffer commit];
     [_commandBuffer waitUntilCompleted];
+#if !__has_feature(objc_arc)
     [_commandBuffer release];
     [_captureScopeFullFrame release];
     [_commandQueue release];
     [_argEncoderBuffer release];
     [_argEncoderSampler release];
     [_argEncoderTexture release];
-    
+#endif // !__has_feature(objc_arc)
     {
         std::lock_guard<std::mutex> lock(_freeArgMutex);
         while(_freeArgBuffers.size()) {
+#if !__has_feature(objc_arc)
             [_freeArgBuffers.top() release];
+#endif // !__has_feature(objc_arc)
             _freeArgBuffers.pop();
         }
     }
@@ -400,7 +411,9 @@ id<MTLCommandBuffer>
 HgiMetal::GetSecondaryCommandBuffer()
 {
     id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+#if !__has_feature(objc_arc)
     [commandBuffer retain];
+#endif // !__has_feature(objc_arc)
     return commandBuffer;
 }
 
@@ -426,9 +439,13 @@ HgiMetal::CommitPrimaryCommandBuffer(
     }
 
     CommitSecondaryCommandBuffer(_commandBuffer, waitType);
+#if !__has_feature(objc_arc)
     [_commandBuffer release];
+#endif // !__has_feature(objc_arc)
     _commandBuffer = [_commandQueue commandBuffer];
+#if !__has_feature(objc_arc)
     [_commandBuffer retain];
+#endif // !__has_feature(objc_arc)
 
     _workToFlush = false;
 }
@@ -466,7 +483,9 @@ HgiMetal::CommitSecondaryCommandBuffer(
 void
 HgiMetal::ReleaseSecondaryCommandBuffer(id<MTLCommandBuffer> commandBuffer)
 {
+#if !__has_feature(objc_arc)
     [commandBuffer release];
+#endif // !__has_feature(objc_arc)
 }
 
 id<MTLArgumentEncoder>

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -388,7 +388,9 @@ HgiMetalIndirectCommandEncoder::_GetFunction(
                                            error:&error];
         
         _functions.resize(6);
+#if !__has_feature(objc_arc)
         [options release];
+#endif // !__has_feature(objc_arc)
         options = nil;
         
         if (!_library) {
@@ -490,7 +492,9 @@ HgiMetalIndirectCommandEncoder::_AllocateCommandBuffer(uint32_t drawCount)
             [_device newIndirectCommandBufferWithDescriptor:descriptor
                                             maxCommandCount:roundedSize
                                                     options:MTLResourceStorageModePrivate];
+#if !__has_feature(objc_arc)
         [descriptor release];
+#endif // !__has_feature(objc_arc)
         descriptor = nil;
     }
 

--- a/pxr/imaging/hgiMetal/sampler.mm
+++ b/pxr/imaging/hgiMetal/sampler.mm
@@ -45,19 +45,24 @@ HgiMetalSampler::HgiMetalSampler(HgiMetal *hgi, HgiSamplerDesc const& desc)
     HGIMETAL_DEBUG_LABEL(smpDesc, _descriptor.debugName.c_str());
     
     _samplerId= [hgi->GetPrimaryDevice() newSamplerStateWithDescriptor:smpDesc];
-
+#if !__has_feature(objc_arc)
     [smpDesc release];
+#endif // !__has_feature(objc_arc)
 }
 
 HgiMetalSampler::~HgiMetalSampler()
 {
     if (_label) {
+#if !__has_feature(objc_arc)
         [_label release];
+#endif // !__has_feature(objc_arc)
         _label = nil;
     }
 
     if (_samplerId != nil) {
+#if !__has_feature(objc_arc)
         [_samplerId release];
+#endif // !__has_feature(objc_arc)
         _samplerId = nil;
     }
 }

--- a/pxr/imaging/hgiMetal/shaderFunction.mm
+++ b/pxr/imaging/hgiMetal/shaderFunction.mm
@@ -46,8 +46,9 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
             [hgi->GetPrimaryDevice() newLibraryWithSource:@(shaderCode)
                                                         options:options
                                                         error:&error];
-
+#if !__has_feature(objc_arc)
         [options release];
+#endif // !__has_feature(objc_arc)
         options = nil;
 
         NSString *entryPoint = nullptr;
@@ -83,8 +84,9 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
         else {
             HGIMETAL_DEBUG_LABEL(_shaderId, _descriptor.debugName.c_str());
         }
-        
+#if !__has_feature(objc_arc)
         [library release];
+#endif // !__has_feature(objc_arc)
     }
 
     // Clear these pointers in our copy of the descriptor since we
@@ -96,7 +98,9 @@ HgiMetalShaderFunction::HgiMetalShaderFunction(
 
 HgiMetalShaderFunction::~HgiMetalShaderFunction()
 {
+#if !__has_feature(objc_arc)
     [_shaderId release];
+#endif // !__has_feature(objc_arc)
     _shaderId = nil;
 }
 

--- a/pxr/imaging/hgiMetal/texture.mm
+++ b/pxr/imaging/hgiMetal/texture.mm
@@ -211,7 +211,9 @@ HgiMetalTexture::HgiMetalTexture(HgiMetal *hgi, HgiTextureDesc const & desc)
                                  levelCount:mipLevels];
         [blitCommandEncoder endEncoding];
         [commandBuffer commit];
+#if !__has_feature(objc_arc)
         [tempTextureId release];
+#endif // !__has_feature(objc_arc)
     }
     
     if (!(usage & MTLTextureUsageRenderTarget)) {
@@ -254,7 +256,9 @@ HgiMetalTexture::HgiMetalTexture(HgiMetal *hgi, HgiTextureViewDesc const & desc)
 HgiMetalTexture::~HgiMetalTexture()
 {
     if (_textureId != nil) {
+#if !__has_feature(objc_arc)
         [_textureId release];
+#endif // !__has_feature(objc_arc)
         _textureId = nil;
     }
 }


### PR DESCRIPTION
* Changes to support building with **ObjC ARC** (Automatic Reference Counting), also known as **Clang** compiler flag **`-fobjc-arc`**.

### Description of Change(s)

* Modified the CMake build to set target compile options on the [**`hgiMetal`**](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-b76b05995b99418d248b48a3ed86cb1add51579472c15f01c3d1cc8de1480f6bR70-R75) and [**`garch`**](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-206f97d3ecb733214a977fc5daec9ddee915946c1348416fdb0e98c90be21992R66-R73) targets, to enable **`-fobjc-arc`** by default on Apple platforms, when the compiler matches any of the **Clang** derivatives.

* **HgiMetal** was originally not compiling without [this revision](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-9ef0251cb9e02f61313f3aa4efdc130b8deeee2c767e6926c332cae0c0cf5639R368), it appears the usage of **`MTLResource`** here was not what was intended as far as I'm aware -- at least from the following call made to **`didModifyRange`**, which does not exist on **`MTLResource`** but it does exist on **`MTLBuffer`**, so I have changed it to **`MTLBuffer`** instead. I believe this means we can get rid of these [**Arch** pragmas](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-9ef0251cb9e02f61313f3aa4efdc130b8deeee2c767e6926c332cae0c0cf5639R370-R373) as well.

* Guarded all `retain` and `release` calls with `!__has_feature(objc_arc)` which are otherwise a compiler error, forbidden when ARC is enabled.

* **HgiMetal**: [Modified the implicit casting](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-05f4dee6d2ee428c06962e3764fb1b4910b53ccea4e319a671915f76debcfd5aL793-R804) from **`GetRawResource() -> uint64_t`** to the `id<MTLTexture>` variables (**`colorTexture`** and **`depthTexture`**) within **`HgiInteropMetal.CompositeToInterop()`** to first cast them to `void *`, and then to `id<MTLTexture>` bridging casts.
  **Edit 8.12.24 10:05AM (PDT)**: Minor [revision](https://github.com/PixarAnimationStudios/OpenUSD/compare/b5818afd844dd6bf7dd7ad43620414c39a493558..7e5f7905dd3aa4f01a9982e169be0fadcab2bb7a), to use a `reinterpret_cast` instead of the C-style cast.

* **Garch**: [Modified the return statement](https://github.com/PixarAnimationStudios/OpenUSD/pull/3220/files#diff-7097b9ac459193d46568b8f65a3cd3c74d48a3e81e6154c26981853794f76ef0R107) of **`GarchSelectCoreProfileMacVisual()`** to do a `void *` bridging cast.

<hr/>

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
