### PR TITLE
Specialized TfStringify for integral types to prevent locale dependent writes

### DIFF
--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -913,65 +913,6 @@ TfStringify(std::string const& s)
     return s;
 }
 
-template <typename T>
-std::string
-_TfStringifyIntegralImpl(const T value)
-{
-    std::ostringstream stream;
-    stream.imbue(std::locale::classic());
-    stream << value;
-
-    return stream.str();
-}
-
-std::string
-TfStringify(short val)
-{
-    return _TfStringifyIntegralImpl<short>(val);
-}
-
-std::string
-TfStringify(unsigned short val)
-{
-    return _TfStringifyIntegralImpl<unsigned short>(val);
-}
-
-std::string
-TfStringify(int val)
-{
-    return _TfStringifyIntegralImpl<int>(val);
-}
-
-std::string
-TfStringify(unsigned int val)
-{
-    return _TfStringifyIntegralImpl<unsigned int>(val);
-}
-
-std::string
-TfStringify(long val)
-{
-    return _TfStringifyIntegralImpl<long>(val);
-}
-
-std::string
-TfStringify(unsigned long val)
-{
-    return _TfStringifyIntegralImpl<unsigned long>(val);
-}
-
-std::string
-TfStringify(long long val)
-{
-    return _TfStringifyIntegralImpl<long long>(val);
-}
-
-std::string
-TfStringify(unsigned long long val)
-{
-    return _TfStringifyIntegralImpl<unsigned long long>(val);
-}
-
 static
 const
 pxr_double_conversion::DoubleToStringConverter& 

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -917,18 +917,11 @@ template <typename T>
 std::string
 _TfStringifyIntegralImpl(const T value)
 {
-    // plus one because for signed values, digits10 will give one less
-    // than what is actually needed in cases where the amount of characters
-    // could represent an overflow
-    constexpr size_t maxSize = std::numeric_limits<T>::digits10 + 1 +
-        (std::numeric_limits<T>::is_signed ? 1 : 0);
+    std::ostringstream stream;
+    stream.imbue(std::locale::classic());
+    stream << value;
 
-    std::string result(maxSize, '\0');
-    auto [ptr, ec] = std::to_chars(result.data(), result.data() + maxSize, value);
-    TF_DEV_AXIOM(ec == std::errc());
-    result.resize(std::distance(result.data(), ptr));
-
-    return result;
+    return stream.str();
 }
 
 std::string

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -28,7 +28,6 @@
 #include <type_traits>
 #include <vector>
 #include <memory>
-#include <charconv>
 
 #include "pxrDoubleConversion/double-conversion.h"
 #include "pxrDoubleConversion/utils.h"

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <vector>
 #include <memory>
+#include <charconv>
 
 #include "pxrDoubleConversion/double-conversion.h"
 #include "pxrDoubleConversion/utils.h"
@@ -910,6 +911,72 @@ std::string
 TfStringify(std::string const& s)
 {
     return s;
+}
+
+template <typename T>
+std::string
+_TfStringifyIntegralImpl(const T& value)
+{
+    // plus one because for signed values, digits10 will give one less
+    // than what is actually needed in cases where the amount of characters
+    // could represent an overflow
+    constexpr size_t maxSize = std::numeric_limits<T>::digits10 + 1 +
+        (std::numeric_limits<T>::is_signed ? 1 : 0);
+
+    std::string result(maxSize, '\0');
+    auto [ptr, ec] = std::to_chars(result.data(), result.data() + maxSize, value);
+    TF_DEV_AXIOM(ec == std::errc());
+    result.resize(std::distance(result.data(), ptr));
+
+    return result;
+}
+
+std::string
+TfStringify(short val)
+{
+    return _TfStringifyIntegralImpl<short>(val);
+}
+
+std::string
+TfStringify(unsigned short val)
+{
+    return _TfStringifyIntegralImpl<unsigned short>(val);
+}
+
+std::string
+TfStringify(int val)
+{
+    return _TfStringifyIntegralImpl<int>(val);
+}
+
+std::string
+TfStringify(unsigned int val)
+{
+    return _TfStringifyIntegralImpl<unsigned int>(val);
+}
+
+std::string
+TfStringify(long val)
+{
+    return _TfStringifyIntegralImpl<long>(val);
+}
+
+std::string
+TfStringify(unsigned long val)
+{
+    return _TfStringifyIntegralImpl<unsigned long>(val);
+}
+
+std::string
+TfStringify(long long val)
+{
+    return _TfStringifyIntegralImpl<long long>(val);
+}
+
+std::string
+TfStringify(unsigned long long val)
+{
+    return _TfStringifyIntegralImpl<unsigned long long>(val);
 }
 
 static

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -915,7 +915,7 @@ TfStringify(std::string const& s)
 
 template <typename T>
 std::string
-_TfStringifyIntegralImpl(const T& value)
+_TfStringifyIntegralImpl(const T value)
 {
     // plus one because for signed values, digits10 will give one less
     // than what is actually needed in cases where the amount of characters

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <locale>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -559,6 +560,7 @@ TfStringify(const T& v)
     }
     else {
         std::ostringstream stream;
+        stream.imbue(std::locale::classic());
         stream << v;
         return stream.str();
     }
@@ -572,22 +574,6 @@ TF_API std::string TfStringify(std::string const&);
 TF_API std::string TfStringify(float);
 /// \overload
 TF_API std::string TfStringify(double);
-/// \overload
-TF_API std::string TfStringify(short);
-/// \overload
-TF_API std::string TfStringify(unsigned short);
-/// \overload
-TF_API std::string TfStringify(int);
-/// \overload
-TF_API std::string TfStringify(unsigned int);
-/// \overload
-TF_API std::string TfStringify(long);
-/// \overload
-TF_API std::string TfStringify(unsigned long);
-/// \overload
-TF_API std::string TfStringify(long long);
-/// \overload
-TF_API std::string TfStringify(unsigned long long);
 
 /// Writes the string representation of \c d to \c buffer of length \c len. 
 /// If \c emitTrailingZero is true, the string representation will end with .0 

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -572,6 +572,22 @@ TF_API std::string TfStringify(std::string const&);
 TF_API std::string TfStringify(float);
 /// \overload
 TF_API std::string TfStringify(double);
+/// \overload
+TF_API std::string TfStringify(short);
+/// \overload
+TF_API std::string TfStringify(unsigned short);
+/// \overload
+TF_API std::string TfStringify(int);
+/// \overload
+TF_API std::string TfStringify(unsigned int);
+/// \overload
+TF_API std::string TfStringify(long);
+/// \overload
+TF_API std::string TfStringify(unsigned long);
+/// \overload
+TF_API std::string TfStringify(long long);
+/// \overload
+TF_API std::string TfStringify(unsigned long long);
 
 /// Writes the string representation of \c d to \c buffer of length \c len. 
 /// If \c emitTrailingZero is true, the string representation will end with .0 

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -417,7 +417,7 @@ TestStrings()
     
     // verify that TfStringify is agnostic to locale for
     // numerical values - note that the locale system
-    // takes over responsibility for deleting the std::numpunct instance
+    // takes over responsibility for deleting the separate_thousands instance
     std::locale originalLocale;
     std::locale::global(std::locale(std::locale(""), new separate_thousands));
     try

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <sstream>
 #include <stdio.h>
+#include <locale>
 
 using namespace std;
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -264,6 +265,14 @@ DoPrintfStr(const char *fmt, ...)
     return ret;
 }
 
+template <typename T>
+bool
+_RoundtripStringifyLimits()
+{
+    return (TfUnstringify<T>(TfStringify(std::numeric_limits<T>::min())) == std::numeric_limits<T>::min()) &&
+        (TfUnstringify<T>(TfStringify(std::numeric_limits<T>::max())) == std::numeric_limits<T>::max());
+}
+
 static bool
 TestStrings()
 {
@@ -386,6 +395,35 @@ TestStrings()
     TF_AXIOM(TfUnstringify<char>("a") == 'a');
     TF_AXIOM(TfStringify("string") == "string");
     TF_AXIOM(TfUnstringify<string>("string") == "string");
+    TF_AXIOM(TfStringify(1000) == "1000");
+    
+    // make sure we can represent the min and max of each type
+    TF_AXIOM(_RoundtripStringifyLimits<short>());
+    TF_AXIOM(_RoundtripStringifyLimits<int>());
+    TF_AXIOM(_RoundtripStringifyLimits<long>());
+    TF_AXIOM(_RoundtripStringifyLimits<long long>());
+    TF_AXIOM(_RoundtripStringifyLimits<unsigned short>());
+    TF_AXIOM(_RoundtripStringifyLimits<unsigned int>());
+    TF_AXIOM(_RoundtripStringifyLimits<unsigned long>());
+    TF_AXIOM(_RoundtripStringifyLimits<unsigned long long>());
+    
+    // verify that TfStringify is agnostic to locale for
+    // numerical values
+    std::locale originalLocale;
+    std::locale::global(std::locale(""));
+    try
+    {
+        TF_AXIOM(TfStringify(1000.56) == "1000.56");
+        TF_AXIOM(TfStringify(1000) == "1000");
+        std::locale::global(originalLocale);
+    }
+    catch(...)
+    {
+        std::locale::global(originalLocale);
+        throw;
+    }
+    TF_AXIOM(TfStringify(1000) == "1000");
+    TF_AXIOM(TfStringify(1000.56) == "1000.56");
 
     bool unstringRet = true;
     TfUnstringify<int>("this ain't no int", &unstringRet);


### PR DESCRIPTION
### Description of Change(s)

Specializes TfStringify for common integral types to prevent locale dependent writes of numeric data.

### Fixes Issue(s)
- #3214 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
