### PR TITLE
Add `TfEnum` for validation error

### DIFF
--- a/pxr/usd/usd/validationError.cpp
+++ b/pxr/usd/usd/validationError.cpp
@@ -5,9 +5,18 @@
 // https://openusd.org/license.
 //
 
+#include "pxr/base/tf/enum.h"
 #include "pxr/usd/usd/validationError.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfEnum)
+{
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::None, "None");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Error, "Error");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Warn, "Warn");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Info, "Info");
+}
 
 UsdValidationErrorSite::UsdValidationErrorSite(
     const SdfLayerHandle &layer, const SdfPath &objectPath) :
@@ -39,24 +48,8 @@ UsdValidationError::UsdValidationError(const UsdValidationErrorType &type,
 std::string
 UsdValidationError::GetErrorAsString() const
 {
-    std::string errorTypeAsString;
-    switch(_errorType) {
-        case UsdValidationErrorType::None:
-            return _errorMsg;
-            break;
-        case UsdValidationErrorType::Error:
-            errorTypeAsString = "Error";
-            break;
-        case UsdValidationErrorType::Warn:
-            errorTypeAsString = "Warn";
-            break;
-        case UsdValidationErrorType::Info:
-            errorTypeAsString = "Info";
-            break;
-    }
-
-    const std::string separator = ": ";
-    return errorTypeAsString + separator + _errorMsg;
+    return _errorType == UsdValidationErrorType::None ? _errorMsg : TfStringPrintf(
+        "%s: %s", TfEnum::GetDisplayName(_errorType).c_str(), _errorMsg.c_str());
 }
 
 void


### PR DESCRIPTION
### Description of Change(s)

Register `UsdValidationErrorType` as `TfEnum` and simplify function `UsdValidationError::GetErrorAsString`.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
****