### PR TITLE
Clang Modules: Remove includes within pxr namespace.

### DIFF
--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -15,6 +15,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/arch/export.h"
+#include "pxr/base/arch/api.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -259,8 +260,6 @@ struct Arch_ConstructorEntry {
         static void _name(__VA_ARGS__)
 
 #elif defined(ARCH_OS_WINDOWS)
-    
-#    include "pxr/base/arch/api.h"
     
 // Entry for a constructor/destructor in the custom section.
     __declspec(align(16))

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -38,8 +38,6 @@
 #include <stringapiset.h>
 #endif
 
-PXR_NAMESPACE_OPEN_SCOPE
-
 /// \addtogroup group_arch_SystemFunctions
 ///@{
 #if !defined(ARCH_OS_WINDOWS)
@@ -59,6 +57,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     #define W_OK    2       // Test for write permission.
     #define R_OK    4       // Test for read permission.
 #endif
+
+PXR_NAMESPACE_OPEN_SCOPE
 
 #if defined(ARCH_OS_WINDOWS)
     #define ARCH_GLOB_NOCHECK   1

--- a/pxr/usd/sdf/mapEditor.cpp
+++ b/pxr/usd/sdf/mapEditor.cpp
@@ -9,7 +9,9 @@
 #include "pxr/usd/sdf/mapEditor.h"
 #include "pxr/usd/sdf/path.h"
 #include "pxr/usd/sdf/schema.h"
+#include "pxr/usd/sdf/types.h"
 
+#include "pxr/base/vt/dictionary.h"
 #include "pxr/base/vt/value.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/mallocTag.h"
@@ -178,8 +180,6 @@ Sdf_CreateMapEditor(const SdfSpecHandle& owner, const TfToken& field)
     template std::unique_ptr<Sdf_MapEditor<MapType> >                \
         Sdf_CreateMapEditor(const SdfSpecHandle&, const TfToken&);   \
 
-#include "pxr/base/vt/dictionary.h"
-#include "pxr/usd/sdf/types.h"
 SDF_INSTANTIATE_MAP_EDITOR(VtDictionary); 
 SDF_INSTANTIATE_MAP_EDITOR(SdfVariantSelectionMap); 
 SDF_INSTANTIATE_MAP_EDITOR(SdfRelocatesMap); 


### PR DESCRIPTION
* When compiling with **Swift/Clang** (**`-fmodule`**), it is an error to include modules within namespaces:
  ```
  error: import of module appears within namespace
  ```

### Description of Change(s)

- **Arch.FileSystem**: Moved the namespace block: **`PXR_NAMESPACE_OPEN_SCOPE`** below the includes (**imports**) of **`Darwin.C.limits`** and **`Glibc.limits`**, so those modules are not imported inside of the **`pxr`** namespace.

- **Sdf.MapEditor**: ~~Closed the namespace block: **`PXR_NAMESPACE_CLOSE_SCOPE`** before the includes, and then re-opened the namespace block: **`PXR_NAMESPACE_OPEN_SCOPE`** immediately after the includes.~~ Per @nvmkuruc's [suggestion](https://github.com/PixarAnimationStudios/OpenUSD/pull/3218#discussion_r1713937224), it was deemed cleaner to simply move the includes to the top of the file.

##### Update 8.29.24
- **Arch.Attributes**: I had just noticed another include in the pxr namespace block that had creeped up on me when compiling for Windows, moved the include for **api.h** up to the top of the file, above the **`PXR_NAMESPACE_OPEN_SCOPE`** block.

<hr/>

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
