### PR TITLE
usdShade: Include connectable validation from usdchecker PrimEncapsulationRule

### DIFF
--- a/pxr/usd/usdShade/plugInfo.json
+++ b/pxr/usd/usdShade/plugInfo.json
@@ -128,6 +128,9 @@
                     }
                 }, 
                 "Validators": {
+                    "ConnectableValidator": {
+                        "doc": "Connectable prims (e.g. Shader, Material, etc) can only be nested inside other Container-like Connectable prims. Container-like prims include Material, NodeGraph, Light, LightFilter. Shader is not a Container-like prim."
+                    },
                     "MaterialBindingApiAppliedValidator": {
                         "doc": "Verify a prim has the MaterialBindingAPI applied if it has a material binding relationship."
                     }, 

--- a/pxr/usd/usdShade/testenv/testUsdShadeValidators.cpp
+++ b/pxr/usd/usdShade/testenv/testUsdShadeValidators.cpp
@@ -424,7 +424,7 @@ TestUsdShadeConnectableValidator()
 
     // Create a Material > Shader > Shader hierarchy
     UsdShadeMaterial::Define(usdStage, SdfPath("/RootMaterial"));
-    UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Shader"));
+    const UsdShadeShader& topShader = UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Shader"));
     const UsdShadeShader& insideShader = UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Shader/InsideShader"));
 
     // Verify error that does not allow a connectable to be parented by non-container connectable
@@ -439,6 +439,10 @@ TestUsdShadeConnectableValidator()
     std::string expectedErrorMsg =
             "Connectable Shader </RootMaterial/Shader/InsideShader> cannot reside under a non-Container Connectable Shader";
     TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // Verify the first Shader is valid
+    errors = validator->Validate(topShader.GetPrim());
+    TF_AXIOM(errors.size() == 0);
 
     // Create a Material > Scope > Shader hierarchy
     usdStage->RemovePrim(SdfPath("/RootMaterial/Shader/InsideShader"));

--- a/pxr/usd/usdShade/testenv/testUsdShadeValidators.cpp
+++ b/pxr/usd/usdShade/testenv/testUsdShadeValidators.cpp
@@ -16,6 +16,7 @@
 #include "pxr/usd/usd/validationRegistry.h"
 #include "pxr/usd/usd/validator.h"
 #include "pxr/usd/usdGeom/validatorTokens.h"
+#include "pxr/usd/usdGeom/scope.h"
 #include "pxr/usd/usdShade/shader.h"
 #include "pxr/usd/usdShade/shaderDefUtils.h"
 #include "pxr/usd/usdShade/tokens.h"
@@ -41,7 +42,8 @@ TestUsdShadeValidators()
         UsdShadeValidatorNameTokens->materialBindingRelationships,
         UsdShadeValidatorNameTokens->shaderSdrCompliance,
         UsdShadeValidatorNameTokens->subsetMaterialBindFamilyName,
-        UsdShadeValidatorNameTokens->subsetsMaterialBindFamily
+        UsdShadeValidatorNameTokens->subsetsMaterialBindFamily,
+        UsdShadeValidatorNameTokens->connectableValidator
     };
 
     // This should be updated with every new validator added with the
@@ -410,6 +412,55 @@ TestUsdShadeMaterialBindingAPIAppliedValidator()
     TF_AXIOM(errors.size() == 0);
 }
 
+void
+TestUsdShadeConnectableValidator()
+{
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    const UsdValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdShadeValidatorNameTokens->connectableValidator);
+    TF_AXIOM(validator);
+
+    UsdStageRefPtr usdStage = UsdStage::CreateInMemory();
+
+    // Create a Material > Shader > Shader hierarchy
+    UsdShadeMaterial::Define(usdStage, SdfPath("/RootMaterial"));
+    UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Shader"));
+    const UsdShadeShader& insideShader = UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Shader/InsideShader"));
+
+    // Verify error that does not allow a connectable to be parented by non-container connectable
+    UsdValidationErrorVector errors = validator->Validate(insideShader.GetPrim());
+
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetSites()[0].IsPrim());
+    TF_AXIOM(errors[0].GetSites()[0].GetPrim().GetPath() == SdfPath("/RootMaterial/Shader/InsideShader"));
+    std::string expectedErrorMsg =
+            "Connectable Shader </RootMaterial/Shader/InsideShader> cannot reside under a non-Container Connectable Shader";
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // Create a Material > Scope > Shader hierarchy
+    usdStage->RemovePrim(SdfPath("/RootMaterial/Shader/InsideShader"));
+    usdStage->RemovePrim(SdfPath("/RootMaterial/Shader"));
+    UsdGeomScope::Define(usdStage, SdfPath("/RootMaterial/Scope"));
+    const UsdShadeShader& insideScopeShader = UsdShadeShader::Define(usdStage, SdfPath("/RootMaterial/Scope/InsideShader"));
+
+    // Verify error that does not allow a connectable to have any non-connectable container ancestors
+    errors = validator->Validate(insideScopeShader.GetPrim());
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetSites()[0].IsPrim());
+    TF_AXIOM(errors[0].GetSites()[0].GetPrim().GetPath() == SdfPath("/RootMaterial/Scope/InsideShader"));
+    expectedErrorMsg =
+            "Connectable Shader </RootMaterial/Scope/InsideShader> can only have Connectable Container ancestors up to "
+            "Material ancestor </RootMaterial>, but its parent Scope is a Scope.";
+    std::string message = errors[0].GetMessage();
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+}
+
 int
 main()
 {
@@ -419,5 +470,7 @@ main()
     TestUsdShadeShaderPropertyCompliance();
     TestUsdShadeSubsetMaterialBindFamilyName();
     TestUsdShadeSubsetsMaterialBindFamily();
+    TestUsdShadeConnectableValidator();
+
     return EXIT_SUCCESS;
 };

--- a/pxr/usd/usdShade/validatorTokens.h
+++ b/pxr/usd/usdShade/validatorTokens.h
@@ -16,7 +16,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define USD_SHADE_VALIDATOR_NAME_TOKENS                   \
+#define USD_SHADE_VALIDATOR_NAME_TOKENS \
+    ((connectableValidator, "usdShade:ConnectableValidator")) \
     ((materialBindingApiAppliedValidator, "usdShade:MaterialBindingApiAppliedValidator")) \
     ((materialBindingRelationships, "usdShade:MaterialBindingRelationships")) \
     ((shaderSdrCompliance, "usdShade:ShaderSdrCompliance"))                   \

--- a/pxr/usd/usdShade/validators.cpp
+++ b/pxr/usd/usdShade/validators.cpp
@@ -34,61 +34,75 @@ static
 UsdValidationErrorVector
 _ConnectableValidator(const UsdPrim& usdPrim)
 {
+    const UsdShadeConnectableAPI& connectable =
+            UsdShadeConnectableAPI(usdPrim);
+
+    if (!connectable){
+        return {};
+    }
+
+    const UsdPrim& parentPrim = usdPrim.GetParent();
+
+    if (!parentPrim || parentPrim.IsPseudoRoot()){
+        return {};
+    }
+
+    UsdShadeConnectableAPI parentConnectable =
+            UsdShadeConnectableAPI(parentPrim);
     UsdValidationErrorVector errors;
-
-    const UsdShadeConnectableAPI& connectable = UsdShadeConnectableAPI(usdPrim);
-
-    if (!usdPrim.GetTypeName().IsEmpty() && connectable) {
-        const UsdPrim& parentPrim = usdPrim.GetParent();
-
-        if (parentPrim && !parentPrim.IsPseudoRoot()) {
-            UsdShadeConnectableAPI parentConnectable = UsdShadeConnectableAPI(parentPrim);
-            if (parentPrim.GetTypeName().IsEmpty()){
-                parentConnectable = UsdShadeConnectableAPI();
+    if (parentConnectable && !parentConnectable.IsContainer()) {
+        // It is a violation of the UsdShade OM which enforces
+        // encapsulation of connectable prims under a Container-type
+        // connectable prim.
+        errors.emplace_back(
+                UsdValidationErrorType::Error,
+                UsdValidationErrorSites{
+                        UsdValidationErrorSite(usdPrim.GetStage(),
+                                                usdPrim.GetPath())
+                },
+                TfStringPrintf("Connectable %s <%s> cannot reside "
+                                "under a non-Container Connectable %s",
+                                usdPrim.GetTypeName().GetText(),
+                                usdPrim.GetPath().GetText(),
+                                parentPrim.GetTypeName().GetText()));
+    }
+    else if (!parentConnectable) {
+        std::function<void(const UsdPrim&)> verifyValidAncestor =
+                [&](const UsdPrim& currentAncestor) -> void {
+            if (!currentAncestor || currentAncestor.IsPseudoRoot()) {
+                return;
             }
-
-            if (parentConnectable && !parentConnectable.IsContainer()) {
+            const UsdShadeConnectableAPI& ancestorConnectable =
+                    UsdShadeConnectableAPI(currentAncestor);
+            if (ancestorConnectable) {
+                // it's only OK to have a non-connectable parent if all
+                // the rest of your ancestors are also non-connectable.
+                // The error message we give is targeted at the most common
+                // infraction, using Scope or other grouping prims inside
+                // a Container like a Material
                 errors.emplace_back(
                         UsdValidationErrorType::Error,
-                        UsdValidationErrorSites{
+                        UsdValidationErrorSites {
                                 UsdValidationErrorSite(usdPrim.GetStage(),
-                                                       usdPrim.GetPath())
+                                                        usdPrim.GetPath())
                         },
-                        TfStringPrintf("Connectable %s <%s> cannot reside "
-                                       "under a non-Container Connectable %s",
-                                       usdPrim.GetTypeName().GetText(),
-                                       usdPrim.GetPath().GetText(),
-                                       parentPrim.GetTypeName().GetText()));
+                        TfStringPrintf("Connectable %s <%s> can only have"
+                                        " Connectable Container ancestors"
+                                        " up to %s ancestor <%s>, but its"
+                                        " parent %s is a %s.",
+                                        usdPrim.GetTypeName().GetText(),
+                                        usdPrim.GetPath().GetText(),
+                                        currentAncestor.GetTypeName().GetText(),
+                                        currentAncestor.GetPath().GetText(),
+                                        parentPrim.GetName().GetText(),
+                                        parentPrim.GetTypeName().GetText()));
+                return;
             }
-            else if (!parentConnectable) {
-                UsdPrim currentAncestor = parentPrim.GetParent();
-                while(currentAncestor && !currentAncestor.IsPseudoRoot()) {
-                    if (!currentAncestor.GetTypeName().IsEmpty()) {
-                        const UsdShadeConnectableAPI& ancestorConnectable = UsdShadeConnectableAPI(currentAncestor);
-                        if (ancestorConnectable) {
-                            errors.emplace_back(
-                                    UsdValidationErrorType::Error,
-                                    UsdValidationErrorSites {
-                                            UsdValidationErrorSite(usdPrim.GetStage(),
-                                                                   usdPrim.GetPath())
-                                    },
-                                    TfStringPrintf("Connectable %s <%s> can only have"
-                                                   " Connectable Container ancestors"
-                                                   " up to %s ancestor <%s>, but its"
-                                                   " parent %s is a %s.",
-                                                   usdPrim.GetTypeName().GetText(),
-                                                   usdPrim.GetPath().GetText(),
-                                                   currentAncestor.GetTypeName().GetText(),
-                                                   currentAncestor.GetPath().GetText(),
-                                                   parentPrim.GetName().GetText(),
-                                                   parentPrim.GetTypeName().GetText()));
-                            break;
-                        }
-                    }
-                    currentAncestor = currentAncestor.GetParent();
-                }
-            }
-        }
+
+            verifyValidAncestor(currentAncestor.GetParent());
+        };
+
+        verifyValidAncestor(parentPrim.GetParent());
     }
 
     return errors;


### PR DESCRIPTION
### Description of Change(s)
- adding necessary validation files for connectable validation (no nested shaders, no shaders inside scopes)

### Fixes Issue(s)
- https://github.com/orgs/PixarAnimationStudios/projects/3?pane=issue&itemId=65424985

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
