### PR TITLE
Autodesk: Avoid evicting graphics pipelines in use in resource garbage collection

### DIFF
--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -132,6 +132,10 @@ HdStResourceRegistry::~HdStResourceRegistry()
     // they cleanup all GPU resources. Since that mechanism isn't in place
     // yet, we call GarbageCollect to emulate this behavior.
     GarbageCollect();
+    // Recycle count were set to 1 in order for graphics pipelines in use to not
+    // be immediately evicted. As such, we run garbage collection twice on
+    // shutdown in order to clear the cache.
+    GarbageCollect();
 }
 
 void HdStResourceRegistry::InvalidateShaderRegistry()

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -1104,8 +1104,13 @@ HdStResourceRegistry::_GarbageCollect()
     // Cleanup Hgi resources
     _resourceBindingsRegistry.GarbageCollect(
         std::bind(&_DestroyResourceBindings, _hgi, std::placeholders::_1));
+    
+    // Graphics pipelines are bound at draw time and will always be evicted here
+    // (for Metal, Vulkan). Using a recycle count of one prevents pipelines in
+    // use from being evicted from the registry.
     _graphicsPipelineRegistry.GarbageCollect(
-        std::bind(&_DestroyGraphicsPipeline, _hgi, std::placeholders::_1));
+        std::bind(&_DestroyGraphicsPipeline, _hgi, std::placeholders::_1), 1);
+    
     _computePipelineRegistry.GarbageCollect(
         std::bind(&_DestroyComputePipeline, _hgi, std::placeholders::_1));
 


### PR DESCRIPTION
### Description of Change(s)

Removing use of GC_Threshold for the graphics pipeline registry. Replaced by use of recycle count (see.GarbageCollect call) to hold pipelines in use in the cache and prevent eviction by garbage collection.

This change will improve performance of USD editing as well. Without it, all graphics pipelines are evicted from the cache whenever garbage collection is called.

Graphics pipelines are bound at draw time and will always be evicted here by the GarbageCollector (for Metal, Vulkan). Using a recycle count of one prevents pipelines in use from being evicted from the registry. I removed the previous fix based on GC_Threshold. I did not encounter any issues with other resources in the registry and garbage collection so I this only applies to graphics pipelines.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
