### PR TITLE
[hdEmbree][build_usd] add to build_usd.py status message (standalone)

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2578,6 +2578,7 @@ summaryMsg += """\
       OpenVDB support:          {enableOpenVDB}
       OpenImageIO support:      {buildOIIO} 
       OpenColorIO support:      {buildOCIO} 
+      Embree support:           {buildEmbree}
       PRMan support:            {buildPrman}
     UsdImaging                  {buildUsdImaging}
       usdview:                  {buildUsdview}
@@ -2641,6 +2642,7 @@ summaryMsg = summaryMsg.format(
     enableOpenVDB=("On" if context.enableOpenVDB else "Off"),
     buildOIIO=("On" if context.buildOIIO else "Off"),
     buildOCIO=("On" if context.buildOCIO else "Off"),
+    buildEmbree=("On" if context.buildEmbree else "Off"),
     buildPrman=("On" if context.buildPrman else "Off"),
     buildUsdImaging=("On" if context.buildUsdImaging else "Off"),
     buildUsdview=("On" if context.buildUsdview else "Off"),


### PR DESCRIPTION
> [!IMPORTANT] 
> This is a duplicate of this PR:
>
> - https://github.com/PixarAnimationStudios/OpenUSD/pull/3234
>
> ...except pulled out the UsdLux-HdEmbree PR "chain", to make for easier standalone integration, as it has no other PR dependencies, and is a simple/small change.
>
> I will close this PR if the other is merged first, and vice-versa.

### Description of Change(s)

Add hdEmbree to build_usd.py status message

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
