### PR TITLE
Add python binding for `UsdValidationError`

### DIFF
--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -158,6 +158,7 @@ pxr_library(usd
         wrapTyped.cpp
         wrapUsdFileFormat.cpp
         wrapUtils.cpp
+        wrapValidationError.cpp
         wrapValidator.cpp
         wrapVariantSets.cpp
         wrapVersion.cpp 
@@ -273,6 +274,7 @@ pxr_test_scripts(
     testenv/testUsdTimeSamples.py
     testenv/testUsdTimeValueAuthoring.py
     testenv/testUsdUsdzFileFormat.py
+    testenv/testUsdValidationError.py
     testenv/testUsdValidatorMetadata.py
     testenv/testUsdValueClips.py
     testenv/testUsdVariantEditing.py
@@ -1338,5 +1340,11 @@ pxr_register_test(testUsdOpaqueAttributes
 pxr_register_test(testUsdValidatorMetadata
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValidatorMetadata"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdValidationError
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValidationError"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -158,6 +158,7 @@ pxr_library(usd
         wrapTyped.cpp
         wrapUsdFileFormat.cpp
         wrapUtils.cpp
+        wrapValidator.cpp
         wrapVariantSets.cpp
         wrapVersion.cpp 
         wrapZipFile.cpp
@@ -272,6 +273,7 @@ pxr_test_scripts(
     testenv/testUsdTimeSamples.py
     testenv/testUsdTimeValueAuthoring.py
     testenv/testUsdUsdzFileFormat.py
+    testenv/testUsdValidatorMetadata.py
     testenv/testUsdValueClips.py
     testenv/testUsdVariantEditing.py
     testenv/testUsdVariantFallbacks.py
@@ -1330,5 +1332,11 @@ pxr_register_test(testUsdUsdzResolver
 pxr_register_test(testUsdOpaqueAttributes
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdOpaqueAttributes"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdValidatorMetadata
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValidatorMetadata"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usd/module.cpp
+++ b/pxr/usd/usd/module.cpp
@@ -38,6 +38,7 @@ TF_WRAP_MODULE
     TF_WRAP(UsdSpecializes);
     TF_WRAP(UsdPrimRange);
     TF_WRAP(UsdVariantSets);
+    TF_WRAP(UsdValidator);
 
     // SchemaBase, APISchemaBase and subclasses.
     TF_WRAP(UsdSchemaBase);

--- a/pxr/usd/usd/module.cpp
+++ b/pxr/usd/usd/module.cpp
@@ -38,6 +38,7 @@ TF_WRAP_MODULE
     TF_WRAP(UsdSpecializes);
     TF_WRAP(UsdPrimRange);
     TF_WRAP(UsdVariantSets);
+    TF_WRAP(UsdValidationError);
     TF_WRAP(UsdValidator);
 
     // SchemaBase, APISchemaBase and subclasses.

--- a/pxr/usd/usd/testenv/testUsdValidationError.py
+++ b/pxr/usd/usd/testenv/testUsdValidationError.py
@@ -1,0 +1,210 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+import unittest
+
+from pxr import Plug, Sdf, Usd
+
+
+class TestUsdValidationError(unittest.TestCase):
+    def test_create_default_error_site(self):
+        errorSite = Usd.ValidationErrorSite()
+        self.assertFalse(errorSite.IsValid())
+        self.assertFalse(errorSite.IsValidSpecInLayer())
+        self.assertFalse(errorSite.IsPrim())
+        self.assertFalse(errorSite.IsProperty())
+        self.assertFalse(errorSite.GetPropertySpec())
+        self.assertFalse(errorSite.GetPrimSpec())
+        self.assertFalse(errorSite.GetProperty())
+        self.assertFalse(errorSite.GetPrim())
+        self.assertFalse(errorSite.GetLayer())
+        self.assertFalse(errorSite.GetStage())
+
+    def _verify_error_site_with_layer(self, errorSite: Usd.ValidationErrorSite, layer: Sdf.Layer, objectPath: Sdf.Path):
+        self.assertTrue(errorSite.IsValid())
+        self.assertTrue(errorSite.IsValidSpecInLayer())
+        self.assertFalse(errorSite.IsPrim())
+        self.assertFalse(errorSite.IsProperty())
+        expected_property_spec = layer.GetPropertyAtPath(objectPath) if objectPath.IsPropertyPath() else None
+        self.assertEqual(errorSite.GetPropertySpec(), expected_property_spec)
+        expected_prim_spec = layer.GetPrimAtPath(objectPath) if objectPath.IsPrimPath() else None
+        self.assertEqual(errorSite.GetPrimSpec(), expected_prim_spec)
+        self.assertFalse(errorSite.GetProperty())
+        self.assertFalse(errorSite.GetPrim())
+        self.assertEqual(errorSite.GetLayer(), layer)
+        self.assertFalse(errorSite.GetStage())
+
+    def test_create_error_site_with_layer_and_prim_spec(self):
+        stage = Usd.Stage.CreateInMemory()
+        test_prim_path = Sdf.Path("/test")
+        stage.DefinePrim(test_prim_path, "Xform")
+        errorSite = Usd.ValidationErrorSite(stage.GetRootLayer(), test_prim_path)
+        self._verify_error_site_with_layer(errorSite, stage.GetRootLayer(), test_prim_path)
+
+    def test_create_error_site_with_layer_and_property_spec(self):
+        stage = Usd.Stage.CreateInMemory()
+        test_prim_path = Sdf.Path("/test")
+        test_prim = stage.DefinePrim(test_prim_path, "Xform")
+        test_attr = test_prim.CreateAttribute("attr", Sdf.ValueTypeNames.Int)
+        test_attr_path = test_attr.GetPath()
+        errorSite = Usd.ValidationErrorSite(stage.GetRootLayer(), test_attr_path)
+        self._verify_error_site_with_layer(errorSite, stage.GetRootLayer(), test_attr_path)
+
+    def _verify_error_site_with_stage(self, errorSite: Usd.ValidationErrorSite, stage: Usd.Stage, objectPath: Sdf.Path):
+        self.assertTrue(errorSite.IsValid())
+        self.assertFalse(errorSite.IsValidSpecInLayer())
+        self.assertEqual(errorSite.IsPrim(), objectPath.IsPrimPath())
+        self.assertEqual(errorSite.IsProperty(), objectPath.IsPropertyPath())
+        self.assertFalse(errorSite.GetPropertySpec())
+        self.assertFalse(errorSite.GetPrimSpec())
+        expected_property = stage.GetPropertyAtPath(objectPath) if objectPath.IsPropertyPath() else Usd.Property()
+        self.assertEqual(errorSite.GetProperty(), expected_property)
+        expected_prim = stage.GetPrimAtPath(objectPath) if objectPath.IsPrimPath() else Usd.Prim()
+        self.assertEqual(errorSite.GetPrim(), expected_prim)
+        self.assertFalse(errorSite.GetLayer())
+        self.assertEqual(errorSite.GetStage(), stage)
+
+    def _verify_error_site_with_stage_and_layer(self, errorSite: Usd.ValidationErrorSite, stage: Usd.Stage, layer: Sdf.Layer, objectPath: Sdf.Path):
+        self.assertTrue(errorSite.IsValid())
+        self.assertTrue(errorSite.IsValidSpecInLayer())
+        self.assertEqual(errorSite.IsPrim(), objectPath.IsPrimPath())
+        self.assertEqual(errorSite.IsProperty(), objectPath.IsPropertyPath())
+
+        expected_property_spec = layer.GetPropertyAtPath(objectPath) if objectPath.IsPropertyPath() else None
+        self.assertEqual(expected_property_spec, errorSite.GetPropertySpec())
+        expected_prim_spec = layer.GetPrimAtPath(objectPath) if objectPath.IsPrimPath() else None
+        self.assertEqual(expected_prim_spec, errorSite.GetPrimSpec())
+        expected_property = stage.GetPropertyAtPath(objectPath) if objectPath.IsPropertyPath() else Usd.Property()
+        self.assertEqual(expected_property, errorSite.GetProperty())
+        expected_prim = stage.GetPrimAtPath(objectPath) if objectPath.IsPrimPath() else Usd.Prim()
+        self.assertEqual(expected_prim, errorSite.GetPrim())
+
+        self.assertEqual(errorSite.GetLayer(), layer)
+        self.assertEqual(errorSite.GetStage(), stage)
+
+    def test_create_error_site_with_stage_and_prim(self):
+        stage = Usd.Stage.CreateInMemory()
+        test_prim_path = Sdf.Path("/test")
+        stage.DefinePrim(test_prim_path, "Xform")
+        errorSite = Usd.ValidationErrorSite(stage, test_prim_path)
+        self._verify_error_site_with_stage(errorSite, stage, test_prim_path)
+
+        # With layer also
+        errorSite = Usd.ValidationErrorSite(stage, test_prim_path, stage.GetRootLayer())
+        self._verify_error_site_with_stage_and_layer(errorSite, stage, stage.GetRootLayer(), test_prim_path)
+
+    def test_create_error_site_with_stage_and_property(self):
+        stage = Usd.Stage.CreateInMemory()
+        test_prim_path = Sdf.Path("/test")
+        test_prim = stage.DefinePrim(test_prim_path, "Xform")
+        test_attr = test_prim.CreateAttribute("attr", Sdf.ValueTypeNames.Int)
+        test_attr_path = test_attr.GetPath()
+        errorSite = Usd.ValidationErrorSite(stage, test_attr_path)
+        self._verify_error_site_with_stage(errorSite, stage, test_attr_path)
+
+        # With layer also
+        errorSite = Usd.ValidationErrorSite(stage, test_attr_path, stage.GetRootLayer())
+        self._verify_error_site_with_stage_and_layer(errorSite, stage, stage.GetRootLayer(), test_attr_path)
+
+    def test_create_error_site_with_invalid_args(self):
+        stage = Usd.Stage.CreateInMemory()
+        test_prim_path = Sdf.Path("/test")
+        stage.DefinePrim(test_prim_path, "Xform")
+        errors = {
+            "Wrong Stage Type": {
+                "stage": "wrong stage",
+                "layer": stage.GetRootLayer(),
+                "objectPath": test_prim_path
+            },
+            "Wrong Layer Type": {
+                "stage": stage,
+                "layer": "wrong layer",
+                "objectPath": test_prim_path
+            },
+            "Wrong Path Type": {
+                "stage": stage,
+                "layer": stage.GetRootLayer(),
+                "objectPath": 123
+            },
+        }
+
+        for error_category, args in errors.items():
+            with self.subTest(errorType=error_category):
+                with self.assertRaises(Exception):
+                    Usd.ValidationErrorSite(**args)
+
+    def _verify_validation_error(self, error, errorType=Usd.ValidationErrorType.None_, errorSites=[], errorMessage=""):
+        self.assertEqual(error.GetType(), errorType)
+        self.assertEqual(error.GetSites(), errorSites)
+        self.assertEqual(error.GetMessage(), errorMessage)
+        if errorType != Usd.ValidationErrorType.None_:
+            self.assertTrue(error.GetErrorAsString())
+            self.assertFalse(error.HasNoError())
+        else:
+            self.assertFalse(error.GetErrorAsString())
+            self.assertTrue(error.HasNoError())
+
+    def test_create_default_validation_error(self):
+        validation_error = Usd.ValidationError()
+        self._verify_validation_error(validation_error)
+
+    def test_create_validation_error_with_keyword_args(self):
+        errors = [
+            {
+                "errorType": Usd.ValidationErrorType.None_,
+                "errorSites": [],
+                "errorMessage": ""
+            },
+            {
+                "errorType": Usd.ValidationErrorType.Error,
+                "errorSites": [Usd.ValidationErrorSite()],
+                "errorMessage": "This is an error."
+            },
+            {
+                "errorType": Usd.ValidationErrorType.Warn,
+                "errorSites": [Usd.ValidationErrorSite()],
+                "errorMessage": "This is a warning."
+            },
+            {
+                "errorType": Usd.ValidationErrorType.Info,
+                "errorSites": [Usd.ValidationErrorSite(), Usd.ValidationErrorSite()],
+                "errorMessage": "This is an info."
+            },
+        ]
+
+        for error in errors:
+            with self.subTest(errorType=error["errorType"]):
+                validation_error = Usd.ValidationError(**error)
+                self._verify_validation_error(validation_error, **error)
+
+    def test_create_validation_error_with_invalid_args(self):
+        errors = {
+            "Wrong Error Type": {
+                "errorType": "wrong_type",
+                "errorSites": [],
+                "errorMessage": ""
+            },
+            "Wrong Sites Type": {
+                "errorType": Usd.ValidationErrorType.None_,
+                "errorSites": "wong_type",
+                "errorMessage": ""
+            },
+            "Wrong Message Type": {
+                "errorType": Usd.ValidationErrorType.None_,
+                "errorSites": [],
+                "errorMessage": 123
+            },
+        }
+
+        for error_category, error in errors.items():
+            with self.subTest(errorType=error_category):
+                with self.assertRaises(Exception):
+                    Usd.ValidationError(**error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
+++ b/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
@@ -23,8 +23,8 @@ class TestUsdValidatorMetadata(unittest.TestCase):
     ):
         self.assertEqual(metadata.name, name)
         self.assertEqual(metadata.doc, doc)
-        self.assertEqual(metadata.GetKeywords(), keywords)
-        self.assertEqual(metadata.GetSchemaTypes(), schemaTypes)
+        self.assertEqual(metadata.keywords, keywords)
+        self.assertEqual(metadata.schemaTypes, schemaTypes)
         self.assertEqual(metadata.plugin, plugin)
         self.assertEqual(metadata.isSuite, isSuite)
 
@@ -89,70 +89,37 @@ class TestUsdValidatorMetadata(unittest.TestCase):
                 with self.assertRaises(Exception):
                     Usd.ValidatorMetadata(**args)
 
-    def test_metadata_name_getter_and_setter(self):
+    def test_metadata_name_immutable(self):
         metadata = Usd.ValidatorMetadata()
-        for name in ["validator1", "validator2"]:
-            metadata.name = name
-            self.assertEqual(metadata.name, name)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.name = 123
+            metadata.name = "test"
 
-    def test_metadata_doc_getter_and_setter(self):
+    def test_metadata_doc_immutable(self):
         metadata = Usd.ValidatorMetadata()
-        for doc in ["doc1", "doc2"]:
-            metadata.doc = doc
-            self.assertEqual(metadata.doc, doc)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.doc = 123
+            metadata.doc = "doc"
 
-    def test_metadata_keywords_getter_and_setter(self):
+    def test_metadata_keywords_immutable(self):
         metadata = Usd.ValidatorMetadata()
-        for keywords in [["keyword1"], ["keyword2"]]:
-            metadata.SetKeywords(keywords)
-            self.assertEqual(metadata.GetKeywords(), keywords)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.SetKeywords(123)
-        with self.assertRaises(Exception):
-            metadata.SetKeywords("123")
+            metadata.keywords = ["keywords"]
 
-    def test_metadata_schemaTypes_getter_and_setter(self):
+    def test_metadata_schemaTypes_immutable(self):
         metadata = Usd.ValidatorMetadata()
-        for schema_types in [["PrimType1"], ["PrimType2"]]:
-            metadata.SetSchemaTypes(schema_types)
-            self.assertEqual(metadata.GetSchemaTypes(), schema_types)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.SetKeywords(123)
-        with self.assertRaises(Exception):
-            metadata.SetKeywords("123")
+            metadata.schemaTypes = "PrimType1"
 
-    def test_metadata_plugin_getter_and_setter(self):
+    def test_metadata_plugin_immutable(self):
         all_plugins = Plug.Registry().GetAllPlugins()
         expected_plugin = all_plugins[0] if all_plugins else None
         metadata = Usd.ValidatorMetadata()
-        metadata.plugin = expected_plugin
-        self.assertEqual(metadata.plugin, expected_plugin)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.SetKeywords(123)
+            metadata.plugin = expected_plugin
 
-    def test_metadata_is_suite_getter_and_setter(self):
+    def test_metadata_is_suite_immutable(self):
         metadata = Usd.ValidatorMetadata()
-        for suite in [True, False]:
-            metadata.isSuite = suite
-            self.assertEqual(metadata.isSuite, suite)
-
-        # Invalid type
         with self.assertRaises(Exception):
-            metadata.SetKeywords("123")
+            metadata.isSuite = True
 
 
 if __name__ == "__main__":

--- a/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
+++ b/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
@@ -23,8 +23,8 @@ class TestUsdValidatorMetadata(unittest.TestCase):
     ):
         self.assertEqual(metadata.name, name)
         self.assertEqual(metadata.doc, doc)
-        self.assertEqual(metadata.keywords, keywords)
-        self.assertEqual(metadata.schemaTypes, schemaTypes)
+        self.assertEqual(metadata.GetKeywords(), keywords)
+        self.assertEqual(metadata.GetSchemaTypes(), schemaTypes)
         self.assertEqual(metadata.plugin, plugin)
         self.assertEqual(metadata.isSuite, isSuite)
 
@@ -112,26 +112,26 @@ class TestUsdValidatorMetadata(unittest.TestCase):
     def test_metadata_keywords_getter_and_setter(self):
         metadata = Usd.ValidatorMetadata()
         for keywords in [["keyword1"], ["keyword2"]]:
-            metadata.keywords = keywords
-            self.assertEqual(metadata.keywords, keywords)
+            metadata.SetKeywords(keywords)
+            self.assertEqual(metadata.GetKeywords(), keywords)
 
         # Invalid type
         with self.assertRaises(Exception):
-            metadata.keywords = 123
+            metadata.SetKeywords(123)
         with self.assertRaises(Exception):
-            metadata.keywords = "123"
+            metadata.SetKeywords("123")
 
     def test_metadata_schemaTypes_getter_and_setter(self):
         metadata = Usd.ValidatorMetadata()
         for schema_types in [["PrimType1"], ["PrimType2"]]:
-            metadata.schemaTypes = schema_types
-            self.assertEqual(metadata.schemaTypes, schema_types)
+            metadata.SetSchemaTypes(schema_types)
+            self.assertEqual(metadata.GetSchemaTypes(), schema_types)
 
         # Invalid type
         with self.assertRaises(Exception):
-            metadata.keywords = 123
+            metadata.SetKeywords(123)
         with self.assertRaises(Exception):
-            metadata.keywords = "123"
+            metadata.SetKeywords("123")
 
     def test_metadata_plugin_getter_and_setter(self):
         all_plugins = Plug.Registry().GetAllPlugins()
@@ -142,7 +142,7 @@ class TestUsdValidatorMetadata(unittest.TestCase):
 
         # Invalid type
         with self.assertRaises(Exception):
-            metadata.keywords = 123
+            metadata.SetKeywords(123)
 
     def test_metadata_is_suite_getter_and_setter(self):
         metadata = Usd.ValidatorMetadata()
@@ -152,7 +152,7 @@ class TestUsdValidatorMetadata(unittest.TestCase):
 
         # Invalid type
         with self.assertRaises(Exception):
-            metadata.keywords = "123"
+            metadata.SetKeywords("123")
 
 
 if __name__ == "__main__":

--- a/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
+++ b/pxr/usd/usd/testenv/testUsdValidatorMetadata.py
@@ -1,0 +1,159 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+import unittest
+
+from pxr import Plug, Sdf, Usd
+
+
+class TestUsdValidatorMetadata(unittest.TestCase):
+    def _verify_metadata(
+        self,
+        metadata: Usd.ValidatorMetadata,
+        name="",
+        doc="",
+        keywords=[],
+        schemaTypes=[],
+        plugin=None,
+        isSuite=False
+    ):
+        self.assertEqual(metadata.name, name)
+        self.assertEqual(metadata.doc, doc)
+        self.assertEqual(metadata.keywords, keywords)
+        self.assertEqual(metadata.schemaTypes, schemaTypes)
+        self.assertEqual(metadata.plugin, plugin)
+        self.assertEqual(metadata.isSuite, isSuite)
+
+    def test_create_default_metadata(self):
+        metadata = Usd.ValidatorMetadata()
+        self._verify_metadata(metadata)
+
+    def test_create_metadata_with_valid_keyword_args(self):
+        all_plugins = Plug.Registry().GetAllPlugins()
+        expected_plugin = all_plugins[0] if all_plugins else None
+        valid_metadatas = [
+            {
+                "name": "empty_validator"
+            },
+            {
+                "name": "validator1",
+                "doc": "This is a test validator.",
+                "keywords": ["validator1", "test"],
+                "schemaTypes": ["SomePrimType"],
+                "plugin": None,
+                "isSuite": False
+            },
+            {
+                "name": "validator2",
+                "doc": "This is another test validator.",
+                "keywords": ["validator2", "test"],
+                "schemaTypes": ["NewPrimType"],
+                "plugin": expected_plugin,
+                "isSuite": False
+            }
+        ]
+
+        for args in valid_metadatas:
+            with self.subTest(name=args["name"]):
+                metadata = Usd.ValidatorMetadata(**args)
+                self._verify_metadata(metadata, **args)
+
+    def test_create_metadata_with_invalid_keyword_args(self):
+        invalid_metadatas = {
+            "Wrong Name Type": {
+                "name": 123
+            },
+            "Wrong Doc Type": {
+                "doc": 123
+            },
+            "Wrong Keywords Type": {
+                "keywords": 123
+            },
+            "Wrong Schema Types": {
+                "schemaTypes": 123
+            },
+            "Wrong Plugin Type": {
+                "plugin": 123
+            },
+            "Wrong IsSuite Type": {
+                "isSuite": "wrong type"
+            }
+        }
+
+        for error_category, args in invalid_metadatas.items():
+            with self.subTest(error_type=error_category):
+                with self.assertRaises(Exception):
+                    Usd.ValidatorMetadata(**args)
+
+    def test_metadata_name_getter_and_setter(self):
+        metadata = Usd.ValidatorMetadata()
+        for name in ["validator1", "validator2"]:
+            metadata.name = name
+            self.assertEqual(metadata.name, name)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.name = 123
+
+    def test_metadata_doc_getter_and_setter(self):
+        metadata = Usd.ValidatorMetadata()
+        for doc in ["doc1", "doc2"]:
+            metadata.doc = doc
+            self.assertEqual(metadata.doc, doc)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.doc = 123
+
+    def test_metadata_keywords_getter_and_setter(self):
+        metadata = Usd.ValidatorMetadata()
+        for keywords in [["keyword1"], ["keyword2"]]:
+            metadata.keywords = keywords
+            self.assertEqual(metadata.keywords, keywords)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.keywords = 123
+        with self.assertRaises(Exception):
+            metadata.keywords = "123"
+
+    def test_metadata_schemaTypes_getter_and_setter(self):
+        metadata = Usd.ValidatorMetadata()
+        for schema_types in [["PrimType1"], ["PrimType2"]]:
+            metadata.schemaTypes = schema_types
+            self.assertEqual(metadata.schemaTypes, schema_types)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.keywords = 123
+        with self.assertRaises(Exception):
+            metadata.keywords = "123"
+
+    def test_metadata_plugin_getter_and_setter(self):
+        all_plugins = Plug.Registry().GetAllPlugins()
+        expected_plugin = all_plugins[0] if all_plugins else None
+        metadata = Usd.ValidatorMetadata()
+        metadata.plugin = expected_plugin
+        self.assertEqual(metadata.plugin, expected_plugin)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.keywords = 123
+
+    def test_metadata_is_suite_getter_and_setter(self):
+        metadata = Usd.ValidatorMetadata()
+        for suite in [True, False]:
+            metadata.isSuite = suite
+            self.assertEqual(metadata.isSuite, suite)
+
+        # Invalid type
+        with self.assertRaises(Exception):
+            metadata.keywords = "123"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/usd/validationError.cpp
+++ b/pxr/usd/usd/validationError.cpp
@@ -5,9 +5,18 @@
 // https://openusd.org/license.
 //
 
+#include "pxr/base/tf/enum.h"
 #include "pxr/usd/usd/validationError.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfEnum)
+{
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::None, "None");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Error, "Error");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Warn, "Warn");
+    TF_ADD_ENUM_NAME(UsdValidationErrorType::Info, "Info");
+}
 
 UsdValidationErrorSite::UsdValidationErrorSite(
     const SdfLayerHandle &layer, const SdfPath &objectPath) :
@@ -39,24 +48,8 @@ UsdValidationError::UsdValidationError(const UsdValidationErrorType &type,
 std::string
 UsdValidationError::GetErrorAsString() const
 {
-    std::string errorTypeAsString;
-    switch(_errorType) {
-        case UsdValidationErrorType::None:
-            return _errorMsg;
-            break;
-        case UsdValidationErrorType::Error:
-            errorTypeAsString = "Error";
-            break;
-        case UsdValidationErrorType::Warn:
-            errorTypeAsString = "Warn";
-            break;
-        case UsdValidationErrorType::Info:
-            errorTypeAsString = "Info";
-            break;
-    }
-
-    const std::string separator = ": ";
-    return errorTypeAsString + separator + _errorMsg;
+    return _errorType == UsdValidationErrorType::None ? _errorMsg : TfStringPrintf(
+        "%s: %s", TfEnum::GetDisplayName(_errorType).c_str(), _errorMsg.c_str());
 }
 
 void

--- a/pxr/usd/usd/wrapValidationError.cpp
+++ b/pxr/usd/usd/wrapValidationError.cpp
@@ -1,0 +1,54 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validator.h"
+
+#include "pxr/base/tf/pyContainerConversions.h"
+#include "pxr/base/tf/pyEnum.h"
+#include "pxr/base/tf/pyPtrHelpers.h"
+#include "pxr/base/tf/pyResultConversions.h"
+
+#include <boost/python/class.hpp>
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void wrapUsdValidationError()
+{
+    TfPyWrapEnum<UsdValidationErrorType>("ValidationErrorType");
+
+    class_<UsdValidationErrorSite>("ValidationErrorSite", no_init)
+        .def(init<>())
+        .def(init<const SdfLayerHandle &, const SdfPath &>(args("layer", "objectPath")))
+        .def(init<const UsdStagePtr &, const SdfPath &, const SdfLayerHandle &>((arg("stage"), arg("objectPath"), arg("layer") = SdfLayerHandle{})))
+        .def("IsValid", &UsdValidationErrorSite::IsValid)
+        .def("IsValidSpecInLayer", &UsdValidationErrorSite::IsValidSpecInLayer)
+        .def("IsPrim", &UsdValidationErrorSite::IsPrim)
+        .def("IsProperty", &UsdValidationErrorSite::IsProperty)
+        .def("GetPropertySpec", &UsdValidationErrorSite::GetPropertySpec)
+        .def("GetPrimSpec", &UsdValidationErrorSite::GetPrimSpec)
+        .def("GetLayer", &UsdValidationErrorSite::GetLayer, return_value_policy<return_by_value>())
+        .def("GetStage", &UsdValidationErrorSite::GetStage, return_value_policy<return_by_value>())
+        .def("GetPrim", &UsdValidationErrorSite::GetPrim)
+        .def("GetProperty", &UsdValidationErrorSite::GetProperty)
+        .def(self == self)
+        .def(self != self);
+
+    TfPyRegisterStlSequencesFromPython<UsdValidationErrorSite>();
+    class_<UsdValidationError>("ValidationError", no_init)
+        .def(init<>())
+        .def(init<const UsdValidationErrorType &, const UsdValidationErrorSites &, const std::string &>(args("errorType", "errorSites", "errorMessage")))
+        .def(self == self)
+        .def(self != self)
+        .def("GetType", &UsdValidationError::GetType)
+        .def("GetSites", make_function(&UsdValidationError::GetSites, return_value_policy<TfPySequenceToList>()))
+        .def("GetMessage", &UsdValidationError::GetMessage, return_value_policy<return_by_value>())
+        .def("GetErrorAsString", &UsdValidationError::GetErrorAsString)
+        .def("HasNoError", &UsdValidationError::HasNoError);
+}

--- a/pxr/usd/usd/wrapValidator.cpp
+++ b/pxr/usd/usd/wrapValidator.cpp
@@ -1,0 +1,106 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+#include "pxr/usd/usd/validator.h"
+
+#include "pxr/base/tf/pyContainerConversions.h"
+#include "pxr/base/tf/pyPtrHelpers.h"
+#include "pxr/base/tf/pyResultConversions.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/make_constructor.hpp>
+#include <boost/python/operators.hpp>
+#include <boost/python/object.hpp>
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace
+{
+
+    UsdValidatorMetadata *
+    _NewMetadata(
+        const TfToken &name,
+        const PlugPluginPtr &plugin,
+        const TfTokenVector &keywords,
+        const TfToken &doc,
+        const TfTokenVector &schemaTypes,
+        bool isSuite)
+    {
+        return new UsdValidatorMetadata{name, plugin, keywords, doc, schemaTypes, isSuite};
+    }
+
+    TfToken
+    _GetMetadataName(const UsdValidatorMetadata &metadata)
+    {
+        return metadata.name;
+    }
+
+    void
+    _SetMetadataName(UsdValidatorMetadata &metadata, const TfToken &name)
+    {
+        metadata.name = name;
+    }
+
+    TfTokenVector
+    _GetMetadataKeywords(const UsdValidatorMetadata &metadata)
+    {
+        return metadata.keywords;
+    }
+
+    void
+    _SetMetadataKeywords(UsdValidatorMetadata &metadata, const TfTokenVector &keywords)
+    {
+        metadata.keywords = keywords;
+    }
+
+    TfTokenVector
+    _GetMetadataSchemaTypes(const UsdValidatorMetadata &metadata)
+    {
+        return metadata.schemaTypes;
+    }
+
+    void
+    _SetMetadataSchemaTypes(UsdValidatorMetadata &metadata, const TfTokenVector &schemaTypes)
+    {
+        metadata.schemaTypes = schemaTypes;
+    }
+
+    PlugPluginPtr
+    _GetMetadataPlugin(const UsdValidatorMetadata &metadata)
+    {
+        return metadata.pluginPtr;
+    }
+
+    void
+    _SetMetadataPlugin(UsdValidatorMetadata &metadata, const PlugPluginPtr &plugin)
+    {
+        metadata.pluginPtr = plugin;
+    }
+
+} // anonymous namespace
+
+void wrapUsdValidator()
+{
+    class_<UsdValidatorMetadata>("ValidatorMetadata", no_init)
+        .def("__init__", make_constructor(&_NewMetadata, default_call_policies(),
+                                          (arg("name") = TfToken(),
+                                           arg("plugin") = PlugPluginPtr(),
+                                           arg("keywords") = TfTokenVector(),
+                                           arg("doc") = TfToken(),
+                                           arg("schemaTypes") = TfTokenVector(),
+                                           arg("isSuite") = false)))
+        .add_property("name", &_GetMetadataName, &_SetMetadataName)
+        .add_property("plugin", &_GetMetadataPlugin, &_SetMetadataPlugin)
+        .add_property("keywords", make_function(
+            &_GetMetadataKeywords, return_value_policy<TfPySequenceToList>()), _SetMetadataKeywords)
+        .def_readwrite("doc", &UsdValidatorMetadata::doc)
+        .add_property("schemaTypes", make_function(
+            &_GetMetadataSchemaTypes, return_value_policy<TfPySequenceToList>()), _SetMetadataSchemaTypes)
+        .def_readwrite("isSuite", &UsdValidatorMetadata::isSuite);
+}

--- a/pxr/usd/usd/wrapValidator.cpp
+++ b/pxr/usd/usd/wrapValidator.cpp
@@ -35,54 +35,6 @@ namespace
         return new UsdValidatorMetadata{name, plugin, keywords, doc, schemaTypes, isSuite};
     }
 
-    TfToken
-    _GetMetadataName(const UsdValidatorMetadata &metadata)
-    {
-        return metadata.name;
-    }
-
-    void
-    _SetMetadataName(UsdValidatorMetadata &metadata, const TfToken &name)
-    {
-        metadata.name = name;
-    }
-
-    TfTokenVector
-    _GetMetadataKeywords(const UsdValidatorMetadata &metadata)
-    {
-        return metadata.keywords;
-    }
-
-    void
-    _SetMetadataKeywords(UsdValidatorMetadata &metadata, const TfTokenVector &keywords)
-    {
-        metadata.keywords = keywords;
-    }
-
-    TfTokenVector
-    _GetMetadataSchemaTypes(const UsdValidatorMetadata &metadata)
-    {
-        return metadata.schemaTypes;
-    }
-
-    void
-    _SetMetadataSchemaTypes(UsdValidatorMetadata &metadata, const TfTokenVector &schemaTypes)
-    {
-        metadata.schemaTypes = schemaTypes;
-    }
-
-    PlugPluginPtr
-    _GetMetadataPlugin(const UsdValidatorMetadata &metadata)
-    {
-        return metadata.pluginPtr;
-    }
-
-    void
-    _SetMetadataPlugin(UsdValidatorMetadata &metadata, const PlugPluginPtr &plugin)
-    {
-        metadata.pluginPtr = plugin;
-    }
-
 } // anonymous namespace
 
 void wrapUsdValidator()
@@ -95,12 +47,14 @@ void wrapUsdValidator()
                                            arg("doc") = TfToken(),
                                            arg("schemaTypes") = TfTokenVector(),
                                            arg("isSuite") = false)))
-        .add_property("name", &_GetMetadataName, &_SetMetadataName)
-        .add_property("plugin", &_GetMetadataPlugin, &_SetMetadataPlugin)
-        .def("GetKeywords", &_GetMetadataKeywords, return_value_policy<TfPySequenceToList>())
-        .def("SetKeywords", &_SetMetadataKeywords)
-        .def_readwrite("doc", &UsdValidatorMetadata::doc)
-        .def("GetSchemaTypes", &_GetMetadataSchemaTypes, return_value_policy<TfPySequenceToList>())
-        .def("SetSchemaTypes", &_SetMetadataSchemaTypes)
-        .def_readwrite("isSuite", &UsdValidatorMetadata::isSuite);
+        .add_property("name", make_getter(
+            &UsdValidatorMetadata::name, return_value_policy<return_by_value>()))
+        .add_property("plugin", make_getter(
+            &UsdValidatorMetadata::pluginPtr, return_value_policy<return_by_value>()))
+        .add_property("keywords", make_getter(
+            &UsdValidatorMetadata::keywords, return_value_policy<TfPySequenceToList>()))
+        .def_readonly("doc", &UsdValidatorMetadata::doc)
+        .add_property("schemaTypes", make_getter(
+            &UsdValidatorMetadata::schemaTypes, return_value_policy<TfPySequenceToList>()))
+        .def_readonly("isSuite", &UsdValidatorMetadata::isSuite);
 }

--- a/pxr/usd/usd/wrapValidator.cpp
+++ b/pxr/usd/usd/wrapValidator.cpp
@@ -97,10 +97,10 @@ void wrapUsdValidator()
                                            arg("isSuite") = false)))
         .add_property("name", &_GetMetadataName, &_SetMetadataName)
         .add_property("plugin", &_GetMetadataPlugin, &_SetMetadataPlugin)
-        .add_property("keywords", make_function(
-            &_GetMetadataKeywords, return_value_policy<TfPySequenceToList>()), _SetMetadataKeywords)
+        .def("GetKeywords", &_GetMetadataKeywords, return_value_policy<TfPySequenceToList>())
+        .def("SetKeywords", &_SetMetadataKeywords)
         .def_readwrite("doc", &UsdValidatorMetadata::doc)
-        .add_property("schemaTypes", make_function(
-            &_GetMetadataSchemaTypes, return_value_policy<TfPySequenceToList>()), _SetMetadataSchemaTypes)
+        .def("GetSchemaTypes", &_GetMetadataSchemaTypes, return_value_policy<TfPySequenceToList>())
+        .def("SetSchemaTypes", &_SetMetadataSchemaTypes)
         .def_readwrite("isSuite", &UsdValidatorMetadata::isSuite);
 }


### PR DESCRIPTION
### Description of Change(s)

Add Python binding for `UsdValidationError`, `UsdValidationErrorSite`, and `UsdValidationErrorType`.

It is stacked on https://github.com/PixarAnimationStudios/OpenUSD/pull/3223, and https://github.com/PixarAnimationStudios/OpenUSD/pull/3232 for adding Python bindings for validator framework.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
