### PR TITLE
Add python bindings for `UsdValidator`, `UsdValidatorSuite` and `UsdValidationRegistry`

### DIFF
--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -157,6 +157,7 @@ pxr_library(usd
         wrapUsdFileFormat.cpp
         wrapUtils.cpp
         wrapValidationError.cpp
+        wrapValidationRegistry.cpp
         wrapValidator.cpp
         wrapVariantSets.cpp
         wrapVersion.cpp 
@@ -273,6 +274,7 @@ pxr_test_scripts(
     testenv/testUsdTimeValueAuthoring.py
     testenv/testUsdUsdzFileFormat.py
     testenv/testUsdValidationError.py
+    testenv/testUsdValidationRegistryPy.py
     testenv/testUsdValidatorMetadata.py
     testenv/testUsdValueClips.py
     testenv/testUsdVariantEditing.py
@@ -1344,5 +1346,21 @@ pxr_register_test(testUsdValidatorMetadata
 pxr_register_test(testUsdValidationError
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValidationError"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_build_test_shared_lib(TestUsdValidationRegistryPy
+    INSTALL_PREFIX UsdPlugins
+    LIBRARIES
+        tf
+        usd
+
+    CPPFILES
+        testenv/testUsdValidationRegistryPy.cpp
+)
+
+pxr_register_test(testUsdValidationRegistryPy
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdValidationRegistryPy"
     EXPECTED_RETURN_CODE 0
 )

--- a/pxr/usd/usd/module.cpp
+++ b/pxr/usd/usd/module.cpp
@@ -39,6 +39,7 @@ TF_WRAP_MODULE
     TF_WRAP(UsdPrimRange);
     TF_WRAP(UsdVariantSets);
     TF_WRAP(UsdValidationError);
+    TF_WRAP(UsdValidationRegistry);
     TF_WRAP(UsdValidator);
 
     // SchemaBase, APISchemaBase and subclasses.

--- a/pxr/usd/usd/testenv/TestUsdValidationRegistryPy_plugInfo.json
+++ b/pxr/usd/usd/testenv/TestUsdValidationRegistryPy_plugInfo.json
@@ -1,0 +1,20 @@
+{
+    "Plugins": [
+        {
+            "Type": "library",
+            "Name": "testValidationRegistryPyPlugin",
+            "Root": "@TEST_PLUG_INFO_ROOT@",
+            "ResourcePath": "@TEST_PLUG_INFO_RESOURCE_PATH@",
+            "LibraryPath": "@TEST_PLUG_INFO_LIBRARY_PATH@",
+            "Info": {
+                "Validators": {
+                    "PlaceholderValidator": {
+                        "doc": "Placeholder to initialize plugin.",
+                        "keywords": ["PlaceHolderValidator"],
+                        "isSuite": false
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/pxr/usd/usd/testenv/testUsdValidationRegistryPy.cpp
+++ b/pxr/usd/usd/testenv/testUsdValidationRegistryPy.cpp
@@ -1,0 +1,74 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/pxr.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validator.h"
+
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TF_REGISTRY_FUNCTION(UsdValidationRegistry)
+{
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    {
+        const UsdValidateStageTaskFn stageTaskFn =
+            [](const UsdStagePtr &usdStage)
+        {
+            return UsdValidationErrorVector{UsdValidationError(
+                UsdValidationErrorType::Error,
+                {UsdValidationErrorSite(usdStage, SdfPath("/"))},
+                "This is an error on the stage")};
+        };
+
+        // Register the validator
+        TfErrorMark m;
+        UsdValidatorMetadata metadata{
+            TfToken("TestValidator1"),
+            nullptr,
+            {TfToken("IncludedInAll"), TfToken("SomeKeyword1")},
+            "TestValidator1 for keywords metadata parsing",
+            {},
+            false};
+        registry.RegisterValidator(metadata, stageTaskFn);
+        TF_AXIOM(m.IsClean());
+    }
+    {
+        const UsdValidatePrimTaskFn primTaskFn = [](const UsdPrim & /*prim*/)
+        { return UsdValidationErrorVector{}; };
+
+        // Register the validator
+        TfErrorMark m;
+        UsdValidatorMetadata metadata{
+            TfToken("TestValidator2"),
+            nullptr,
+            {TfToken("IncludedInAll")},
+            "TestValidator2 for schemaType metadata parsing",
+            {TfToken("SomePrimType"), TfToken("SomeAPISchema")},
+            false};
+        registry.RegisterValidator(metadata, primTaskFn);
+        TF_AXIOM(m.IsClean());
+    }
+    {
+        const std::vector<const UsdValidator *> containedValidators =
+            registry.GetOrLoadValidatorsByName(
+                {TfToken("TestValidator1"),
+                 TfToken("TestValidator2")});
+        TfErrorMark m;
+        UsdValidatorMetadata metadata{
+            TfToken("TestValidatorSuite"),
+            nullptr,
+            {TfToken("IncludedInAll"), TfToken("SuiteValidator")},
+            "Suite of TestValidator1 and TestValidator2",
+            {},
+            true};
+        registry.RegisterValidatorSuite(metadata, containedValidators);
+        TF_AXIOM(m.IsClean());
+    }
+}

--- a/pxr/usd/usd/testenv/testUsdValidationRegistryPy.py
+++ b/pxr/usd/usd/testenv/testUsdValidationRegistryPy.py
@@ -1,0 +1,149 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+import os
+import unittest
+
+from pxr import Plug, Usd
+
+
+class TestUsdValidationRegistryPy(unittest.TestCase):
+    VALIDATOR1_NAME = "TestValidator1"
+    VALIDATOR2_NAME = "TestValidator2"
+    VALIDATOR_SUITE_NAME = "TestValidatorSuite"
+    PLUGIN_NAME = "testValidationPlugin"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        Plug.Registry().RegisterPlugins(
+            os.path.dirname(__file__)
+            + "/UsdPlugins/lib/TestUsdValidationRegistryPy/Resources/"
+        )
+
+        validationRegistry = Usd.ValidationRegistry()
+        validationRegistry.GetOrLoadAllValidators()
+
+    def test_QueryValidatorsAndSuites(self):
+        validationRegistry = Usd.ValidationRegistry()
+        self.assertFalse(validationRegistry.HasValidator("invalid_validator"))
+
+        allValidators = validationRegistry.GetOrLoadAllValidators()
+        self.assertTrue(allValidators)
+
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            self.VALIDATOR1_NAME
+        )
+        self.assertTrue(validator)
+
+        validators = validationRegistry.GetOrLoadValidatorsByName(
+            [self.VALIDATOR1_NAME, self.VALIDATOR2_NAME]
+        )
+        self.assertEqual(len(validators), 2)
+
+        allSuites = validationRegistry.GetOrLoadAllValidatorSuites()
+        self.assertTrue(allSuites)
+
+        validatorSuite = validationRegistry.GetOrLoadValidatorSuiteByName(
+            self.VALIDATOR_SUITE_NAME
+        )
+        self.assertTrue(validatorSuite)
+        self.assertIn(validatorSuite, allSuites)
+
+        validatorSuites = validationRegistry.GetOrLoadValidatorSuitesByName(
+            [self.VALIDATOR_SUITE_NAME]
+        )
+        self.assertTrue(validatorSuites)
+        for suite in validatorSuites:
+            self.assertIn(suite, allSuites)
+
+    def test_QueryMetadata(self):
+        validationRegistry = Usd.ValidationRegistry()
+        invalidMetadata = validationRegistry.GetValidatorMetadata(
+            "invalid_validator"
+        )
+        self.assertFalse(invalidMetadata)
+
+        metadata: Usd.ValidatorMetadata = (
+            validationRegistry.GetValidatorMetadata(self.VALIDATOR1_NAME)
+        )
+        expectedKeywords = ["IncludedInAll", "SomeKeyword1"]
+        self.assertEqual(metadata.keywords, expectedKeywords)
+
+        allMetadatas = validationRegistry.GetAllValidatorMetadata()
+        self.assertTrue(allMetadatas)
+
+        metadatas = validationRegistry.GetValidatorMetadataForPlugin(
+            "InvalidPlugin"
+        )
+        self.assertFalse(metadatas)
+
+        metadatas = validationRegistry.GetValidatorMetadataForKeyword(
+            "InvalidKeyword"
+        )
+        self.assertFalse(metadatas)
+        metadatas = validationRegistry.GetValidatorMetadataForKeyword(
+            "SomeKeyword1"
+        )
+        self.assertTrue(metadatas)
+        metadatas = validationRegistry.GetValidatorMetadataForKeywords(
+            expectedKeywords
+        )
+        self.assertTrue(metadatas)
+
+        metadatas = validationRegistry.GetValidatorMetadataForSchemaType(
+            "InvalidSchemaType"
+        )
+        self.assertFalse(metadatas)
+        metadatas = validationRegistry.GetValidatorMetadataForSchemaType(
+            "SomePrimType"
+        )
+        self.assertTrue(metadatas)
+        metadatas = validationRegistry.GetValidatorMetadataForSchemaTypes(
+            ["SomePrimType"]
+        )
+        self.assertTrue(metadatas)
+
+    # We put tests for Usd.Validator and Usd.ValidatorSuite here as we cannot construct
+    # validator directly but only through registry.
+    def test_ValidatorAndSuite(self):
+        validationRegistry = Usd.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            self.VALIDATOR1_NAME
+        )
+        self.assertTrue(validator)
+        self.assertEqual(
+            validator.GetMetadata().keywords,
+            ["IncludedInAll", "SomeKeyword1"],
+        )
+
+        stage = Usd.Stage.CreateInMemory()
+        prim = stage.DefinePrim("/test")
+
+        errors = validator.ValidatePrim(prim)
+        self.assertFalse(errors)
+
+        errors = validator.ValidateLayer(stage.GetRootLayer())
+        self.assertFalse(errors)
+
+        errors = validator.ValidateStage(stage)
+        self.assertTrue(errors)
+
+        validatorSuite = validationRegistry.GetOrLoadValidatorSuiteByName(
+            self.VALIDATOR_SUITE_NAME
+        )
+        self.assertEqual(
+            validatorSuite.GetMetadata().keywords,
+            ["IncludedInAll", "SuiteValidator"],
+        )
+
+        validators = validatorSuite.GetContainedValidators()
+        self.assertEqual(len(validators), 2)
+        self.assertIn(validator, validators)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/usd/testenv/testUsdValidationRegistryPy.py
+++ b/pxr/usd/usd/testenv/testUsdValidationRegistryPy.py
@@ -20,8 +20,10 @@ class TestUsdValidationRegistryPy(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         Plug.Registry().RegisterPlugins(
-            os.path.dirname(__file__)
-            + "/UsdPlugins/lib/TestUsdValidationRegistryPy/Resources/"
+            os.path.join(
+                os.path.dirname(__file__),
+                "UsdPlugins/lib/TestUsdValidationRegistryPy/Resources/",
+            )
         )
 
         validationRegistry = Usd.ValidationRegistry()
@@ -38,6 +40,7 @@ class TestUsdValidationRegistryPy(unittest.TestCase):
             self.VALIDATOR1_NAME
         )
         self.assertTrue(validator)
+        self.assertEqual(eval(repr(validator)), validator)
 
         validators = validationRegistry.GetOrLoadValidatorsByName(
             [self.VALIDATOR1_NAME, self.VALIDATOR2_NAME]

--- a/pxr/usd/usd/validationRegistry.h
+++ b/pxr/usd/usd/validationRegistry.h
@@ -316,10 +316,12 @@ public:
 
     /// Return true if a UsdValidator is registered with the name \p
     /// validatorName; false otherwise.
+    USD_API
     bool HasValidator(const TfToken &validatorName) const;
 
     /// Return true if a UsdValidatorSuite is registered with the name \p
     /// validatorSuiteName; false otherwise.
+    USD_API
     bool HasValidatorSuite(const TfToken &suiteName) const;
 
     /// Returns a vector of const pointer to UsdValidator corresponding to all

--- a/pxr/usd/usd/wrapValidationError.cpp
+++ b/pxr/usd/usd/wrapValidationError.cpp
@@ -66,6 +66,7 @@ void wrapUsdValidationError()
         .def("GetMessage", &UsdValidationError::GetMessage, 
              return_value_policy<return_by_value>())
         .def("GetErrorAsString", &UsdValidationError::GetErrorAsString)
+        .def("GetValidator", &UsdValidationError::GetValidator, return_value_policy<reference_existing_object>())
         .def("HasNoError", &UsdValidationError::HasNoError)
         .def(self == self)
         .def(self != self);

--- a/pxr/usd/usd/wrapValidationRegistry.cpp
+++ b/pxr/usd/usd/wrapValidationRegistry.cpp
@@ -1,0 +1,150 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usd/validationError.h"
+#include "pxr/usd/usd/validationRegistry.h"
+#include "pxr/usd/usd/validator.h"
+
+#include "pxr/base/tf/pyContainerConversions.h"
+#include "pxr/base/tf/pyFunction.h"
+#include "pxr/base/tf/pyPtrHelpers.h"
+#include "pxr/base/tf/pyResultConversions.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python/object.hpp>
+#include <boost/python/raw_function.hpp>
+
+#include <vector>
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace
+{
+
+list _GetOrLoadAllValidators(UsdValidationRegistry &validationRegistry)
+{
+    list result;
+    for (const auto *validator : validationRegistry.GetOrLoadAllValidators())
+    {
+        result.append(pointer_wrapper(validator));
+    }
+    return result;
+}
+
+list _GetOrLoadValidatorsByName(UsdValidationRegistry &validationRegistry,
+                                const TfTokenVector &validatorNames)
+{
+    list result;
+    for (const auto *validator :
+         validationRegistry.GetOrLoadValidatorsByName(validatorNames))
+    {
+        result.append(pointer_wrapper(validator));
+    }
+    return result;
+}
+
+list _GetOrLoadAllValidatorSuites(UsdValidationRegistry &validationRegistry)
+{
+    list result;
+    for (const auto *validator :
+         validationRegistry.GetOrLoadAllValidatorSuites())
+    {
+        result.append(pointer_wrapper(validator));
+    }
+    return result;
+}
+
+list _GetOrLoadValidatorSuitesByName(UsdValidationRegistry &validationRegistry,
+                                     const TfTokenVector &suiteNames)
+{
+    list result;
+    for (const auto *validatorSuite :
+         validationRegistry.GetOrLoadValidatorSuitesByName(suiteNames))
+    {
+        result.append(pointer_wrapper(validatorSuite));
+    }
+    return result;
+}
+
+object _GetValidatorMetadata(const UsdValidationRegistry &validationRegistry,
+                             const TfToken &name)
+{
+    UsdValidatorMetadata metadata;
+    bool success = validationRegistry.GetValidatorMetadata(name, &metadata);
+    if (success)
+    {
+        return object(metadata);
+    }
+
+    return object();
+}
+
+UsdValidationRegistry &_GetRegistrySingleton(object const & /* classObj */)
+{
+    return UsdValidationRegistry::GetInstance();
+}
+
+object _DummyInit(tuple const & /* args */, dict const & /* kw */)
+{
+    return object();
+}
+
+} // anonymous namespace
+
+void wrapUsdValidationRegistry()
+{
+    class_<UsdValidationRegistry, boost::noncopyable>("ValidationRegistry",
+                                                      no_init)
+        .def("__new__", &_GetRegistrySingleton,
+             return_value_policy<reference_existing_object>())
+        .staticmethod("__new__")
+        .def("__init__", raw_function(_DummyInit))
+        .def("HasValidator", &UsdValidationRegistry::HasValidator,
+             (args("validatorName")))
+        .def("HasValidatorSuite", &UsdValidationRegistry::HasValidatorSuite,
+             (args("suiteName")))
+        .def("GetOrLoadAllValidators", &_GetOrLoadAllValidators)
+        .def("GetOrLoadValidatorByName",
+             &UsdValidationRegistry::GetOrLoadValidatorByName,
+             return_value_policy<reference_existing_object>(),
+             (args("validatorName")))
+        .def("GetOrLoadValidatorsByName", &_GetOrLoadValidatorsByName,
+             (args("validatorNames")))
+        .def("GetOrLoadAllValidatorSuites", &_GetOrLoadAllValidatorSuites)
+        .def("GetOrLoadValidatorSuiteByName",
+             &UsdValidationRegistry::GetOrLoadValidatorSuiteByName,
+             return_value_policy<reference_existing_object>(),
+             (args("suiteName")))
+        .def("GetOrLoadValidatorSuitesByName", &_GetOrLoadValidatorSuitesByName,
+             (args("suiteNames")))
+        .def("GetValidatorMetadata", &_GetValidatorMetadata, (args("name")))
+        .def("GetAllValidatorMetadata",
+             &UsdValidationRegistry::GetAllValidatorMetadata,
+             return_value_policy<TfPySequenceToList>())
+        .def("GetValidatorMetadataForPlugin",
+             &UsdValidationRegistry::GetValidatorMetadataForPlugin,
+             return_value_policy<TfPySequenceToList>(), (args("pluginName")))
+        .def("GetValidatorMetadataForKeyword",
+             &UsdValidationRegistry::GetValidatorMetadataForKeyword,
+             return_value_policy<TfPySequenceToList>(), (args("keyword")))
+        .def("GetValidatorMetadataForSchemaType",
+             &UsdValidationRegistry::GetValidatorMetadataForSchemaType,
+             return_value_policy<TfPySequenceToList>(), (args("schemaType")))
+        .def("GetValidatorMetadataForPlugins",
+             &UsdValidationRegistry::GetValidatorMetadataForPlugins,
+             return_value_policy<TfPySequenceToList>(), (args("pluginNames")))
+        .def("GetValidatorMetadataForKeywords",
+             &UsdValidationRegistry::GetValidatorMetadataForKeywords,
+             return_value_policy<TfPySequenceToList>(), (args("keywords")))
+        .def("GetValidatorMetadataForSchemaTypes",
+             &UsdValidationRegistry::GetValidatorMetadataForSchemaTypes,
+             return_value_policy<TfPySequenceToList>(), (args("schemaTypes")));
+}

--- a/pxr/usd/usd/wrapValidator.cpp
+++ b/pxr/usd/usd/wrapValidator.cpp
@@ -25,6 +25,13 @@ using namespace pxr_boost::python;
 namespace
 {
 
+    std::string _Repr(const UsdValidator &self)
+    {
+        return TfStringPrintf(
+            "%sValidationRegistry().GetOrLoadValidatorByName('%s')",
+            TF_PY_REPR_PREFIX.c_str(), self.GetMetadata().name.GetText());
+    }
+    
     UsdValidatorMetadata *
     _NewMetadata(
         const TfToken &name,
@@ -109,7 +116,8 @@ void wrapUsdValidator()
              return_value_policy<TfPySequenceToList>())
         .def("ValidateStage", _ValidateStage,
              return_value_policy<TfPySequenceToList>())
-        .def("__eq__", &_ValidatorEqual);
+        .def("__eq__", &_ValidatorEqual)
+        .def("__repr__", &_Repr);
 
     class_<UsdValidatorSuite, boost::noncopyable>("ValidatorSuite", no_init)
         .def("GetMetadata", &_GetValidatorSuiteMetadata,


### PR DESCRIPTION
### Description of Change(s)

Add python bindings for `UsdValidator`, `UsdValidatorSuite` and `UsdValidationRegistry`.

It is stacked on https://github.com/PixarAnimationStudios/OpenUSD/pull/3223, https://github.com/PixarAnimationStudios/OpenUSD/pull/3232, and https://github.com/PixarAnimationStudios/OpenUSD/pull/3236 for adding Python bindings for validator framework.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
