### PR TITLE
Apple: Usdmtlx updates to pass usdchecker

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -9,6 +9,7 @@
 #include "pxr/usd/usdMtlx/reader.h"
 #include "pxr/usd/usdMtlx/utils.h"
 
+#include "pxr/usd/usdGeom/metrics.h"
 #include "pxr/usd/usdGeom/primvar.h"
 #include "pxr/usd/usdGeom/primvarsAPI.h"
 #include "pxr/usd/usdShade/material.h"
@@ -740,11 +741,11 @@ _NodeGraphBuilder::Build(ShaderNamesByOutputName* outputs)
         return UsdPrim();
     }
 
-    const bool isInsideNodeGraph = _mtlxContainer->isA<mx::NodeGraph>();
+    const bool isExplicitNodeGraph = _mtlxContainer->isA<mx::NodeGraph>();
 
     // Create the USD nodegraph.
     UsdPrim usdPrim;
-    if (isInsideNodeGraph) {
+    if (isExplicitNodeGraph) {
         // Create the nodegraph.
         auto usdNodeGraph = UsdShadeNodeGraph::Define(_usdStage, _usdPath);
         if (!usdNodeGraph) {
@@ -769,7 +770,7 @@ _NodeGraphBuilder::Build(ShaderNamesByOutputName* outputs)
         }
     }
     else {
-        usdPrim = _usdStage->DefinePrim(_usdPath);
+        usdPrim = UsdShadeNodeGraph::Define(_usdStage, _usdPath).GetPrim();
     }
 
     // Build the graph of nodes.
@@ -783,19 +784,7 @@ _NodeGraphBuilder::Build(ShaderNamesByOutputName* outputs)
         _AddNode(mtlxNode, usdPrim);
     }
     _ConnectNodes();
-
-    if (isInsideNodeGraph) {
-        _ConnectTerminals(_mtlxContainer, UsdShadeConnectableAPI(usdPrim));
-    }
-    else if (outputs) {
-        // Collect the outputs on the existing shader nodes.
-        for (mx::OutputPtr& mtlxOutput :
-                _mtlxContainer->getChildrenOfType<mx::Output>()) {
-            if (auto nodeName = _Attr(mtlxOutput, names.nodename)) {
-                (*outputs)[_Name(mtlxOutput)] = TfToken(nodeName);
-            }
-        }
-    }
+    _ConnectTerminals(_mtlxContainer, UsdShadeConnectableAPI(usdPrim));
 
     return usdPrim;
 }
@@ -2622,6 +2611,13 @@ UsdMtlxRead(
 
     // Translate all materials.
     ReadMaterials(mtlxDoc, context);
+
+    if (!mtlxDoc->getChildren().empty()) {
+        // This metadata is required to pass usdchecker
+        UsdGeomSetStageUpAxis(stage, UsdGeomGetFallbackUpAxis());
+        UsdGeomSetStageMetersPerUnit(stage, UsdGeomLinearUnits::centimeters);
+        stage->SetDefaultPrim(stage->GetPrimAtPath(internalPath));
+    }
 
     // If there are no looks then we're done.
     if (mtlxDoc->getLooks().empty()) {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
@@ -116,17 +116,51 @@ class TestFileFormat(unittest.TestCase):
         # Make sure each input is connected as expected
         inputToSource = {
             'weight_1':
-            '/MaterialX/Materials/layered/NodeGraphs/layered_layer1_gradient',
+                ('/MaterialX/Materials/layered/NodeGraphs','o_layered_layer1_gradient'),
             'weight_2':
-            '/MaterialX/Materials/layered/NodeGraphs/layered_layer2_gradient',
+                ('/MaterialX/Materials/layered/NodeGraphs','o_layered_layer2_gradient'),
             'weight_3':
-            '/MaterialX/Materials/layered/NodeGraphs/layered_layer3_gradient'
+                ('/MaterialX/Materials/layered/NodeGraphs','o_layered_layer3_gradient')
         }
         for inputName, source in inputToSource.items():
             input = nodeGraph.GetInput(inputName)
             self.assertEqual(input.HasConnectedSource(), True)
             self.assertEqual(
-                input.GetConnectedSources()[0][0].source.GetPath(), source)
+                input.GetConnectedSources()[0][0].source.GetPath(), source[0])
+            self.assertEqual(
+                input.GetConnectedSources()[0][0].sourceName, source[1])
+
+    def test_OutputSources(self):
+        """
+        Test MaterialX conversion of shader inputs coming from a variety of
+        output sources.
+        """
+        stage = UsdMtlx._TestFile("OutputSources.mtlx")
+        path = Sdf.Path('/MaterialX/Materials/layered/ND_layerShader')
+        node = UsdShade.Shader.Get(stage, path)
+
+        # Make sure each input is connected as expected
+        inputToSource = {
+            'weight_1': (
+                '/MaterialX/Materials/layered/test_ng',
+                'o_layered_layer1_gradient'
+            ),
+            'weight_2': (
+                '/MaterialX/Materials/layered/NodeGraphs',
+                'o_layered_layer2_gradient'
+            ),
+            'weight_3': (
+                '/MaterialX/Materials/layered/NodeGraphs/layered_layer3_gradient',
+                'out'
+            )
+        }
+        for inputName, source in inputToSource.items():
+            input = node.GetInput(inputName)
+            self.assertEqual(input.HasConnectedSource(), True)
+            self.assertEqual(
+                input.GetConnectedSources()[0][0].source.GetPath(), source[0])
+            self.assertEqual(
+                input.GetConnectedSources()[0][0].sourceName, source[1])
 
     def test_MultiOutputNodes(self):
         """

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.py
@@ -136,7 +136,7 @@ class TestFileFormat(unittest.TestCase):
         output sources.
         """
         stage = UsdMtlx._TestFile("OutputSources.mtlx")
-        path = Sdf.Path('/MaterialX/Materials/layered/ND_layerShader')
+        path = Sdf.Path('/MaterialX/Materials/layered/layered_sr')
         node = UsdShade.Shader.Get(stage, path)
 
         # Make sure each input is connected as expected

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/OutputSources.mtlx
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/OutputSources.mtlx
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="test_ng">
+    <ramplr name="layered_layer1_gradient" type="color3" />
+    <output name="o_layered_layer1_gradient" type="color3" nodename="layered_layer1_gradient" />
+  </nodegraph>
+  <ramplr name="layered_layer2_gradient" type="color3" />
+  <output name="o_layered_layer2_gradient" type="color3" nodename="layered_layer2_gradient" />
+  <ramplr name="layered_layer3_gradient" type="color3" />
+  <nodedef name="ND_layerShader" node="layerShader">
+    <input name="weight_1" type="color3" />
+    <input name="weight_2" type="color3" />
+    <input name="weight_3" type="color3" />
+    <output name="out" type="surfaceshader" />
+  </nodedef>
+  <layerShader name="layered_sr" type="surfaceshader">
+    <!-- An output coming from within an "explicit" node graph. -->
+    <input name="weight_1" type="color3" nodegraph="test_ng" output="o_layered_layer1_gradient" />
+    <!-- An output coming from an "output" outside of an explicit node graph. -->
+    <input name="weight_2" type="color3" output="o_layered_layer2_gradient" />
+    <!-- A direct connection to a node's 'out'. -->
+    <input name="weight_3" type="color3" nodename="layered_layer3_gradient" />
+  </layerShader>
+  <surfacematerial name="layered" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="layered_sr" />
+  </surfacematerial>
+</materialx>

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/CustomNodeDef.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/CustomNodeDef.usda
@@ -1,4 +1,9 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
 
 def "MaterialX"
 {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/GraphlessNodes.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/GraphlessNodes.usda
@@ -1,4 +1,9 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
 
 def "MaterialX"
 {
@@ -59,7 +64,7 @@ def "MaterialX"
         }
     }
 
-    def "NodeGraphs"
+    def NodeGraph "NodeGraphs"
     {
         def Shader "redClorVal"
         {

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include.usda
@@ -4,6 +4,9 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include_From_Usdz.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Include_From_Usdz.usda
@@ -4,6 +4,9 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/Looks.usda
@@ -4,6 +4,9 @@
     customLayerData = {
         string colorSpace = "acescg"
     }
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
 )
 
 def "MaterialX"

--- a/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/usd_preview_surface_gold.usda
+++ b/pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/usd_preview_surface_gold.usda
@@ -1,4 +1,9 @@
 #usda 1.0
+(
+    defaultPrim = "MaterialX"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
 
 def "MaterialX"
 {


### PR DESCRIPTION
### Description of Change(s)
`usdchecker` currently fails some fairly trivial things that can be fixed when converting a MaterialX document using `UsdMtlx`.  

* Add layer metadata that is missing
* Define the `NodeGraphs` prim as a UsdShade `NodeGraph` to pass the Connectable Shader test.

Also fixed an compiler warning in `materialXFilter.cpp` where a variable was being used before initialized.

### Fixes Issue(s)
usdchecker currently reports errors with layers created from MaterialX documents. 
```
> usdchecker pxr/usd/usdMtlx/testenv/testUsdMtlxFileFormat.testenv/baseline/GraphlessNodes.usda
Stage does not specify an upAxis. (fails 'StageMetadataChecker')
Stage does not specify its linear scale in metersPerUnit. (fails 'StageMetadataChecker')
Stage has missing or invalid defaultPrim. (fails 'StageMetadataChecker')
Connectable Shader </MaterialX/Materials/surface_material_node/NodeGraphs/redClorVal> can only have Connectable Container ancestors up to Material ancestor </MaterialX/Materials/surface_material_node>, but its parent NodeGraphs is a . (fails 'PrimEncapsulationChecker')
Connectable Shader </MaterialX/Materials/surface_material_node/NodeGraphs/blueColorVal> can only have Connectable Container ancestors up to Material ancestor </MaterialX/Materials/surface_material_node>, but its parent NodeGraphs is a . (fails 'PrimEncapsulationChecker')
Connectable Shader </MaterialX/Materials/surface_material_node/NodeGraphs/multi1> can only have Connectable Container ancestors up to Material ancestor </MaterialX/Materials/surface_material_node>, but its parent NodeGraphs is a . (fails 'PrimEncapsulationChecker')
Connectable Shader </MaterialX/Materials/surface_material_node/NodeGraphs/myDiffColor> can only have Connectable Container ancestors up to Material ancestor </MaterialX/Materials/surface_material_node>, but its parent NodeGraphs is a . (fails 'PrimEncapsulationChecker')
Connectable Shader </MaterialX/Materials/surface_material_node/NodeGraphs/mySpecColor> can only have Connectable Container ancestors up to Material ancestor </MaterialX/Materials/surface_material_node>, but its parent NodeGraphs is a . (fails 'PrimEncapsulationChecker')
Failed!
```

-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
