### PR TITLE
[usdLux] UsdLuxCylinderLight - bounds computation puts length along x axis

### DIFF
--- a/pxr/usd/usdLux/cylinderLight.cpp
+++ b/pxr/usd/usdLux/cylinderLight.cpp
@@ -190,7 +190,7 @@ _ComputeLocalExtent(const float radius,
                     VtVec3fArray *extent)
 {
     extent->resize(2);
-    (*extent)[1] = GfVec3f(radius, radius, length * 0.5f);
+    (*extent)[1] = GfVec3f(length * 0.5f, radius, radius);
     (*extent)[0] = -(*extent)[1];
     return true;
 }

--- a/pxr/usd/usdLux/testenv/testUsdLuxLight.py
+++ b/pxr/usd/usdLux/testenv/testUsdLuxLight.py
@@ -374,7 +374,7 @@ class TestUsdLuxLight(unittest.TestCase):
 
         cylLight.CreateRadiusAttr(4.0)
         cylLight.CreateLengthAttr(10.0)
-        _VerifyExtentAndBBox(cylLight, [(-4.0, -4.0, -5.0), (4.0, 4.0, 5.0)])
+        _VerifyExtentAndBBox(cylLight, [(-5.0, -4.0, -4.0), (5.0, 4.0, 4.0)])
 
         sphereLight.CreateRadiusAttr(3.0)
         _VerifyExtentAndBBox(sphereLight, [(-3.0, -3.0, -3.0), (3.0, 3.0, 3.0)])


### PR DESCRIPTION
### Description of Change(s)
UsdLuxCylinderLight - bounds computation puts length along x axis, to match documentation

### Fixes Issue(s)
- #3233 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
