### PR TITLE
Apple: Change robin_hash.h distance_type to int64_t to prevent overflow loop

### DIFF
--- a/pxr/base/tf/pxrTslRobinMap/robin_hash.h
+++ b/pxr/base/tf/pxrTslRobinMap/robin_hash.h
@@ -174,7 +174,7 @@ class bucket_entry : public bucket_entry_hash<StoreHash> {
 
  public:
   using value_type = ValueType;
-  using distance_type = std::int16_t;
+  using distance_type = std::int64_t;
 
   bucket_entry() noexcept
       : bucket_hash(),


### PR DESCRIPTION
### Description of Change(s)

Robin hash has a distance type that is declared as an int16_t. This causes anything that calls into it with 32k or higher entries to wrap around and form an infinite loop, locking up the current process.

Alternatively, the latest robin_hash code has checks for this, so this might be a stopgap till the project can upgrade the version used. 

This appears to mostly happen on Clang, but I assume that's because GCC might have other behaviour on wrap, and we haven't tested MSVC.

I don't notice a performance regression with this patch. Timing of common benchmarks stays largely the same, and memory usage seems very similar too. I don't believe this type is used for longer term storage outside of the functions it's used in.

Thanks to Damien for finding this as half the cause to the issues below. Both issues below still have their respective performance issues elsewhere in the code, but at least no longer loop infinitely.

### Fixes Issue(s)
Fixes the issue of an infinite loop in both these issues, but not the remaining performance issue that both have.
- https://github.com/PixarAnimationStudios/OpenUSD/issues/2662
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3249

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
