### PR TITLE
perf: cherry pick of robin-map's optimization from upstream, use er…

### DIFF
--- a/pxr/base/tf/pxrTslRobinMap/robin_hash.h
+++ b/pxr/base/tf/pxrTslRobinMap/robin_hash.h
@@ -817,6 +817,10 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     return try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
   }
 
+  void erase_fast(iterator pos) {
+    erase_from_bucket(pos);
+  }
+
   /**
    * Here to avoid `template<class K> size_type erase(const K& key)` being used
    * when we use an `iterator` instead of a `const_iterator`.
@@ -832,8 +836,6 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     if (pos.m_bucket->empty()) {
       ++pos;
     }
-
-    m_try_shrink_on_next_insert = true;
 
     return pos;
   }
@@ -913,8 +915,6 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
     auto it = find(key, hash);
     if (it != end()) {
       erase_from_bucket(it);
-      m_try_shrink_on_next_insert = true;
-
       return 1;
     } else {
       return 0;
@@ -1207,6 +1207,7 @@ class robin_hash : private Hash, private KeyEqual, private GrowthPolicy {
       previous_ibucket = ibucket;
       ibucket = next_bucket(ibucket);
     }
+    m_try_shrink_on_next_insert = true;
   }
 
   template <class K, class... Args>

--- a/pxr/base/tf/pxrTslRobinMap/robin_map.h
+++ b/pxr/base/tf/pxrTslRobinMap/robin_map.h
@@ -339,6 +339,15 @@ class robin_map {
 
   iterator erase(iterator pos) { return m_ht.erase(pos); }
   iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+
+  /**
+   * Erase the element at position 'pos'. In contrast to the regular erase()
+   * function, erase_fast() does not return an iterator. This allows it to be
+   * faster especially in hash tables with a low load factor, where finding the
+   * next nonempty bucket would be costly.
+   */
+  void erase_fast(iterator pos) { return m_ht.erase_fast(pos); }
+
   iterator erase(const_iterator first, const_iterator last) {
     return m_ht.erase(first, last);
   }

--- a/pxr/base/tf/pxrTslRobinMap/robin_set.h
+++ b/pxr/base/tf/pxrTslRobinMap/robin_set.h
@@ -263,6 +263,15 @@ class robin_set {
 
   iterator erase(iterator pos) { return m_ht.erase(pos); }
   iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+
+  /**
+   * Erase the element at position 'pos'. In contrast to the regular erase()
+   * function, erase_fast() does not return an iterator. This allows it to be
+   * faster especially in hash sets with a low load factor, where finding the
+   * next nonempty bucket would be costly.
+   */
+  void erase_fast(iterator pos) { return m_ht.erase_fast(pos); }
+
   iterator erase(const_iterator first, const_iterator last) {
     return m_ht.erase(first, last);
   }

--- a/pxr/usd/sdf/identity.cpp
+++ b/pxr/usd/sdf/identity.cpp
@@ -109,7 +109,7 @@ public:
         newIdStatus.first->second->_path = newPath;
         
         // Erase the old identity map entry.
-        _ids.erase(oldIdIt);
+        _ids.erase_fast(oldIdIt);
     }
 
 private:

--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -278,7 +278,7 @@ _Remove(const Sdf_PathNode *pathNode,
     auto iter = mapAndMutex.map.find(pat);
     if (iter != mapAndMutex.map.end() &&
         iter->second.GetPtr() == reinterpret_cast<char const *>(pathNode)) {
-        mapAndMutex.map.erase(iter);
+        mapAndMutex.map.erase_fast(iter);
     }
 }
 

--- a/pxr/usd/usd/crateData.cpp
+++ b/pxr/usd/usd/crateData.cpp
@@ -255,7 +255,7 @@ public:
         }
         _lastSet = _data.end();
         auto tmpFields(std::move(oldIter->second));
-        _data.erase(oldIter);
+        _data.erase_fast(oldIter);
         auto iresult = _data.emplace(newPath, std::move(tmpFields));
         TF_VERIFY(iresult.second);
     }


### PR DESCRIPTION
…ase_fast instead of erase when iter is not needed as a return value to improve the performance of erase operation

### Description of Change(s)
robin_hash_map's erase has performace issues, see: https://github.com/Tessil/robin-map?tab=readme-ov-file#performance-pitfalls
Cherry-pick https://github.com/Tessil/robin-map/pull/76 and replace erase with erase_fast

### Fixes Issue(s)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
