### PR TITLE
[hdSt] Set GL_UNPACK_ALIGNMENT=1 to avoid texture distortion

### DIFF
--- a/pxr/imaging/hgiGL/ops.cpp
+++ b/pxr/imaging/hgiGL/ops.cpp
@@ -137,6 +137,8 @@ HgiGLOps::CopyTextureCpuToGpu(HgiTextureCpuToGpuOp const& copyOp)
         HgiGLTexture* dstTexture = static_cast<HgiGLTexture*>(
             copyOp.gpuDestinationTexture.Get());
 
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
         switch(desc.type) {
         case HgiTextureType2D:
             if (isCompressed) {

--- a/pxr/imaging/hgiGL/texture.cpp
+++ b/pxr/imaging/hgiGL/texture.cpp
@@ -272,6 +272,8 @@ HgiGLTexture::HgiGLTexture(HgiTextureDesc const & desc)
             desc.dimensions,
             desc.layerCount);
 
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
         // Upload texel data
         if (desc.initialData && desc.pixelsByteSize > 0) {
             // Upload each (available) mip


### PR DESCRIPTION
### Description of Change(s)
Set GL_UNPACK_ALIGNMENT to 1 before uploading textures to GPU.

### Fixes Issue(s)
- #3260

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
Tests run on Windows with these failures
```
        552 - testUsdZipFile (Failed)
        837 - testUsdviewNavigationKeys (Failed)
        853 - testUsdResolverExample (Failed)
```
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
