### PR TITLE
Autodesk: Bugfix for MaterialX shadows in Metal

### DIFF
--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -663,7 +663,8 @@ HdStMaterialXShaderGen<Base>::emitLine(
     // 'occlusion' represents shadow occlusion. We don't use MaterialX's
     // shadow implementation (hwShadowMap is false). Instead, use our own 
     // per-light occlusion value calculated in mxInit() and stored in lightData
-    if (_emittingSurfaceNode && str == "vec3 L = lightShader.direction") {
+    // Metal uses float3, Glsl uses vec3
+    if (_emittingSurfaceNode && (str == "vec3 L = lightShader.direction" || str == "float3 L = lightShader.direction" )) {
         emitLine(
             "occlusion = u_lightData[activeLightIndex].shadowOcclusion", stage);
     }


### PR DESCRIPTION
### Description of Change(s)

See Issue https://github.com/PixarAnimationStudios/OpenUSD/issues/3176 for steps to reproduce. MaterialX shadows weren't appearing, but USD handles them properly. 

The issue is that the MaterialX shader generation is looking for `vec3` (used by Glsl) when Metal uses `float3`.

https://github.com/AcademySoftwareFoundation/MaterialX/blob/de64c319eaf07e2afcae0be3dc5165d78569f008/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp#L252

https://github.com/AcademySoftwareFoundation/MaterialX/blob/de64c319eaf07e2afcae0be3dc5165d78569f008/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.cpp#L253

Fixed files from [Issue](https://github.com/PixarAnimationStudios/OpenUSD/issues/3176):
![image](https://github.com/user-attachments/assets/e4427cfd-9c5c-4412-a37f-35e9db707633)
![image](https://github.com/user-attachments/assets/510be778-c585-4eda-9862-e7f19092567c)

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3176

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
