### PR TITLE
nonLockingLinux__execve: Use register for ARM asm(reg) vars

### DIFF
--- a/pxr/base/arch/stackTrace.cpp
+++ b/pxr/base/arch/stackTrace.cpp
@@ -592,10 +592,10 @@ nonLockingLinux__execve (const char *file,
 
 #if defined (ARCH_CPU_ARM)
     {
-        long __file_result asm ("x0") = (long)file;
-        char* const* __argv asm ("x1") = argv;
-        char* const* __envp asm ("x2") = envp;
-        long __num_execve asm ("x8") = 221;
+        register long __file_result asm ("x0") = (long)file;
+        register char* const* __argv asm ("x1") = argv;
+        register char* const* __envp asm ("x2") = envp;
+        register long __num_execve asm ("x8") = 221;
         __asm__ __volatile__ (
             "svc 0"
             : "=r" (__file_result)


### PR DESCRIPTION
### Description of Change(s)

Variables assigned to a register with `asm()` (like `asm("x0")`) should be `register` not automatic. 

https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html

clang emits a warning for this, which will turn into an error with `-Werror`. gcc emits no warning/error.

https://godbolt.org/z/4zE94szzo

### Fixes Issue(s)
- Fixes broken build with `clang -Werror` on ARM.

- [X] I have verified that all unit tests pass with the proposed changes
- [X] I have submitted a signed Contributor License Agreement
