### PR TITLE
cmake: add some missed source files

### DIFF
--- a/pxr/base/gf/CMakeLists.txt
+++ b/pxr/base/gf/CMakeLists.txt
@@ -84,6 +84,7 @@ pxr_library(gf
         ostreamHelpers
 
     PRIVATE_HEADERS
+        colorSpace_data.h
         ilmbase_eLut.h
         ilmbase_toFloat.h
         nc/nanocolor.h

--- a/pxr/base/js/CMakeLists.txt
+++ b/pxr/base/js/CMakeLists.txt
@@ -29,6 +29,7 @@ pxr_library(js
         rapidjson/filewritestream.h
         rapidjson/fwd.h
         rapidjson/internal/biginteger.h
+        rapidjson/internal/clzll.h
         rapidjson/internal/diyfp.h
         rapidjson/internal/dtoa.h
         rapidjson/internal/ieee754.h

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -103,6 +103,7 @@ pxr_library(usd
         crateDataTypes.h
         crateValueInliners.h
         listEditImpl.h
+        shared.h
         wrapUtils.h
         testenv/TestUsdResolverChangedResolver.h
 


### PR DESCRIPTION
### Description of Change(s)

Add some previously missing source files to the explicit lists of source files in various CMakeLists.txt.

### Fixes Issue(s)

This probably doesn't fix a visible issue in OpenUSD itself. It does help with downstream libraries that integrate portions of OpenUSD as source. In the case of [Drake](https://drake.mit.edu), its build system relies on file lists from OpenUSD's CMakeLists.txt files.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
