### PR TITLE
work: move work thread limit within namespace

### DIFF
--- a/pxr/base/work/threadLimits.cpp
+++ b/pxr/base/work/threadLimits.cpp
@@ -29,6 +29,8 @@
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
+PXR_NAMESPACE_OPEN_SCOPE
+
 // The environment variable used to limit the number of threads the application
 // may spawn:
 //           0 - no change, i.e. defaults to maximum physical concurrency
@@ -47,8 +49,6 @@ TF_DEFINE_ENV_SETTING(
     "cores, or the process's affinity mask, whichever is smaller. Note that "
     "the environment variable (if set to a non-zero value) will override any "
     "value passed to Work thread-limiting API calls.");
-
-PXR_NAMESPACE_OPEN_SCOPE
 
 // We create a global_control or task_scheduler_init instance at static
 // initialization time if PXR_WORK_THREAD_LIMIT is set to a nonzero value.


### PR DESCRIPTION
### Description of Change(s)

Puts the PXR_WORK_THREAD_LIMIT symbol within the  PXR_NAMESPACE.  

Other TF_DEFINE_ENV_SETTING() invocations are within the namespace; this is the only one I've found that is not.

### Fixes Issue(s)
Partial fix for #3279.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
