### PR TITLE
nanocolor: fix namespace and symbol leaks

### DIFF
--- a/pxr/base/gf/nc/nanocolor.c
+++ b/pxr/base/gf/nc/nanocolor.c
@@ -587,7 +587,7 @@ NcM33f NcGetXYZToRGBMatrix(const NcColorSpace* cs) {
     return NcM3ffInvert(NcGetRGBToXYZMatrix(cs));
 }
 
-NcM33f GetRGBtoRGBMatrix(const NcColorSpace* src, const NcColorSpace* dst) {
+static NcM33f GetRGBtoRGBMatrix(const NcColorSpace* src, const NcColorSpace* dst) {
     NcM33f t = NcM33fMultiply(NcM3ffInvert(NcGetRGBToXYZMatrix(src)),
                                  NcGetXYZToRGBMatrix(dst));
     return t;
@@ -803,7 +803,7 @@ void NcTransformColorsWithAlpha(const NcColorSpace* dst, const NcColorSpace* src
     }
 }
 
-NcRGB NcNormalizeLuminance(const NcColorSpace* cs, NcRGB rgb, float luminance) {
+static NcRGB NcNormalizeLuminance(const NcColorSpace* cs, NcRGB rgb, float luminance) {
     if (!cs)
         return rgb;
     
@@ -945,7 +945,7 @@ typedef struct {
     float v;
 } NcYuvPrime;
 
-NcYxy _NcYuv2Yxy(NcYuvPrime c) {
+static NcYxy _NcYuv2Yxy(NcYuvPrime c) {
     float d = 6.f * c.u - 16.f * c.v + 12.f;
     return (NcYxy) {
         c.Y,
@@ -969,7 +969,7 @@ NcYxy NcKelvinToYxy(float T, float luminance) {
     return _NcYuv2Yxy((NcYuvPrime) {luminance, u, 3.f * v / 2.f });
 }
 
-NcYxy NcNormalizeYxy(NcYxy c) {
+static NcYxy NcNormalizeYxy(NcYxy c) {
     return (NcYxy) {
         c.Y,
         c.Y * c.x / c.y,

--- a/pxr/base/gf/nc/nanocolor.h
+++ b/pxr/base/gf/nc/nanocolor.h
@@ -10,15 +10,14 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include "pxr/pxr.h"
+
 // NCNAMESPACE is allows the introduction of a namespace to the symbols so that 
 // multiple libraries can include the nanocolor library without symbol 
 // conflicts. The default is nc_1_0_ to indicate the 1.0 version of Nanocolor.
 //
-// pxr: note that the PXR namespace macros are in pxr/pxr.h which
-// is a C++ only header; so the generated namespace prefixes can't be
-// used here.
 #ifndef NCNAMESPACE
-#define NCNAMESPACE pxr_nc_1_0_
+#define NCNAMESPACE PXR_NS
 #endif
 
 // The NCCONCAT macro is used to apply a namespace to the symbols in the public

--- a/pxr/pxr.h.in
+++ b/pxr/pxr.h.in
@@ -40,12 +40,16 @@
 #define PXR_INTERNAL_NS @PXR_INTERNAL_NAMESPACE@__pxrReserved__
 #define PXR_NS_GLOBAL ::PXR_NS
 
+#ifdef __cplusplus
+
 namespace PXR_INTERNAL_NS { }
 
 // The root level namespace for all source in the USD distribution.
 namespace PXR_NS {
     using namespace PXR_INTERNAL_NS;
 }
+
+#endif
 
 #define PXR_NAMESPACE_OPEN_SCOPE   namespace PXR_INTERNAL_NS {
 #define PXR_NAMESPACE_CLOSE_SCOPE  }  


### PR DESCRIPTION
### Description of Change(s)

- Extend the project-wide namespace scheme to nanocolor
- Make the pxr.h header plain-C compatible to help with the above
- Mark some C-file-only functions `static`

### Fixes Issue(s)
Partial fix for #3279.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
