### PR TITLE
pegtl: fix namespace problems

### DIFF
--- a/pxr/base/pegtl/README.md
+++ b/pxr/base/pegtl/README.md
@@ -39,7 +39,9 @@ This file defines the namespace name that PEGTL uses:
 #include "pxr/pxr.h"
 
 #if PXR_USE_NAMESPACES
-#define PXR_PEGTL_NAMESPACE PXR_INTERNAL_NS ## _pegtl
+#define PXR_PEGTL_impl_PASTE2(x, y) x ## y
+#define PXR_PEGTL_impl_PASTE(x, y) PXR_PEGTL_impl_PASTE2(x, y)
+#define PXR_PEGTL_NAMESPACE PXR_PEGTL_impl_PASTE(PXR_INTERNAL_NS, _pegtl)
 #else
 #define PXR_PEGTL_NAMESPACE pxr_pegtl
 #endif

--- a/pxr/base/pegtl/build-workaround.cpp
+++ b/pxr/base/pegtl/build-workaround.cpp
@@ -10,5 +10,8 @@
 // adding this, an "empty" .so gets built and other libs can link it.
 
 #include "pxr/base/arch/export.h"
+#include "pxr/base/pegtl/pegtl/config.hpp"
 
+namespace PXR_PEGTL_NAMESPACE {
 ARCH_EXPORT int __pxr_pegtl_workaround__;
+}

--- a/pxr/base/pegtl/pegtl/config.hpp
+++ b/pxr/base/pegtl/pegtl/config.hpp
@@ -9,7 +9,9 @@
 #include "pxr/pxr.h"
 
 #if PXR_USE_NAMESPACES
-#define PXR_PEGTL_NAMESPACE PXR_INTERNAL_NS ## _pegtl
+#define PXR_PEGTL_impl_PASTE2(x, y) x ## y
+#define PXR_PEGTL_impl_PASTE(x, y) PXR_PEGTL_impl_PASTE2(x, y)
+#define PXR_PEGTL_NAMESPACE PXR_PEGTL_impl_PASTE(PXR_INTERNAL_NS, _pegtl)
 #else
 #define PXR_PEGTL_NAMESPACE pxr_pegtl
 #endif


### PR DESCRIPTION
### Description of Change(s)

- Fix preprocessor-time composition of PXR_PEGTL_NAMESPACE
-- the prior solution failed to do name expansion, always yielding a not-configurable `PXR_INTERNAL_NS_pegtl`
- Put the "workaround" symbol into the namespace

### Fixes Issue(s)
Partial fix for #3279.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
