### PR TITLE
hdSt: add include for std.function in glslProgram.

### DIFF
--- a/pxr/imaging/hdSt/glslProgram.h
+++ b/pxr/imaging/hdSt/glslProgram.h
@@ -14,6 +14,8 @@
 #include "pxr/imaging/hgi/shaderProgram.h"
 #include "pxr/imaging/hgi/enums.h"
 
+#include <functional>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HdStResourceRegistry;


### PR DESCRIPTION
Without this change, the **Swift**/**Clang** compiler errors because it cannot find `std.function` used within **hdSt's** `glslProgram.h` header, in the [alias declaration for **`PopulateDescriptorCallback`**](https://github.com/PixarAnimationStudios/OpenUSD/pull/3283/files#diff-1fc91b2b85110cc0c351da3e6ea1308341de8e43450c42d90b37bf470ff94df3R71-R72).

### Description of Change(s)

- **HdSt.GLSLProgram**: Added a missing include for `<functional>`.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
