### PR TITLE
Autodesk: [hdx] Refactor screen space task to remove index buffer

### DIFF
--- a/pxr/imaging/hdx/colorCorrectionTask.h
+++ b/pxr/imaging/hdx/colorCorrectionTask.h
@@ -145,9 +145,6 @@ private:
     std::string _CreateOpenColorIOShaderCode(std::string &ocioGpuShaderText,
                                              HgiShaderFunctionDesc &fragDesc);
 
-    // Utility function to create buffer resources.
-    bool _CreateBufferResources();
-
     // Utility to create resource bindings
     bool _CreateResourceBindings(HgiTextureHandle const& aovTexture);
 
@@ -178,8 +175,6 @@ private: // data
     _OCIOResources _ocioResources;
 
     HgiAttachmentDesc _attachment0;
-    HgiBufferHandle _indexBuffer;
-    HgiBufferHandle _vertexBuffer;
     HgiSamplerHandle _aovSampler;
 
     struct TextureSamplerInfo

--- a/pxr/imaging/hdx/effectsShader.cpp
+++ b/pxr/imaging/hdx/effectsShader.cpp
@@ -336,6 +336,17 @@ HdxEffectsShader::_CreateAndSubmitGraphicsCmds(
     _gfxCmds.reset();
 }
 
+
+void
+HdxEffectsShader::_DrawWithoutVertexBuffer(
+    uint32_t vertexCount,
+    uint32_t baseVertex,
+    uint32_t instanceCount,
+    uint32_t baseInstance)
+{
+    _gfxCmds->Draw(vertexCount, baseVertex, instanceCount, baseInstance);
+}
+
 void
 HdxEffectsShader::_DrawNonIndexed(
     const HgiBufferHandle& vertexBuffer,
@@ -345,7 +356,6 @@ HdxEffectsShader::_DrawNonIndexed(
     uint32_t baseInstance)
 {
     _gfxCmds->BindVertexBuffers({{vertexBuffer, 0, 0}});
-
     _gfxCmds->Draw(vertexCount, baseVertex, instanceCount, baseInstance);
 }
 
@@ -360,7 +370,6 @@ HdxEffectsShader::_DrawIndexed(
     uint32_t baseInstance)
 {
     _gfxCmds->BindVertexBuffers({{vertexBuffer, 0, 0}});
-
     _gfxCmds->DrawIndexed(indexBuffer, indexCount, indexBufferByteOffset,
                           baseVertex, instanceCount, baseInstance);
 }

--- a/pxr/imaging/hdx/effectsShader.h
+++ b/pxr/imaging/hdx/effectsShader.h
@@ -130,6 +130,14 @@ protected:
     HDX_API
     virtual void _RecordDrawCmds() = 0;
 
+    // Invokes HgiGraphicsCmds::Draw.
+    HDX_API
+    void _DrawWithoutVertexBuffer(
+        uint32_t vertexCount,
+        uint32_t baseVertex,
+        uint32_t instanceCount,
+        uint32_t baseInstance);
+
     // Sets the vertex buffer and invokes HgiGraphicsCmds::Draw.
     HDX_API
     void _DrawNonIndexed(

--- a/pxr/imaging/hdx/fullscreenShader.h
+++ b/pxr/imaging/hdx/fullscreenShader.h
@@ -147,14 +147,8 @@ private:
     HdxFullscreenShader(const HdxFullscreenShader&) = delete;
     HdxFullscreenShader& operator=(const HdxFullscreenShader&) = delete;
 
-    // Utility function to create buffer resources.
-    void _CreateBufferResources();
-
     // Utility to set resource bindings.
     void _SetResourceBindings();
-
-    // Utility to create default vertex buffer descriptor.
-    void _SetVertexBufferDescriptor();
 
     // Utility to create and get the default texture sampler.
     HgiSamplerHandle _GetDefaultSampler();
@@ -182,7 +176,6 @@ private:
     TfToken _glslfxPath;
     TfToken _shaderName;
 
-    HgiBufferHandle _indexBuffer;
     HgiBufferHandle _vertexBuffer;
     HgiShaderProgramHandle _shaderProgram;
     HgiSamplerHandle _defaultSampler;

--- a/pxr/imaging/hdx/shaders/colorCorrection.glslfx
+++ b/pxr/imaging/hdx/shaders/colorCorrection.glslfx
@@ -25,8 +25,8 @@
 
 void main(void)
 {
-    gl_Position = position;
-    uvOut = uvIn;
+    uvOut = vec2((hd_VertexID << 1) & 2, hd_VertexID & 2);
+    gl_Position = vec4(uvOut * 2.0f + -1.0f, 0.0f, 1.0f);
 }
 
 -- glsl ColorCorrection.Fragment

--- a/pxr/imaging/hdx/shaders/fullscreen.glslfx
+++ b/pxr/imaging/hdx/shaders/fullscreen.glslfx
@@ -28,8 +28,8 @@
 
 void main(void)
 {
-    gl_Position = position;
-    uvOut = uvIn;
+    uvOut = vec2((hd_VertexID << 1) & 2, hd_VertexID & 2);
+    gl_Position = vec4(uvOut * 2.0f + -1.0f, 0.0f, 1.0f);
 }
 
 -- glsl Composite.FragmentNoDepth

--- a/pxr/imaging/hdx/shaders/visualize.glslfx
+++ b/pxr/imaging/hdx/shaders/visualize.glslfx
@@ -34,8 +34,8 @@
 
 void main(void)
 {
-    gl_Position = position;
-    uvOut = uvIn;
+    uvOut = vec2((hd_VertexID << 1) & 2, hd_VertexID & 2);
+    gl_Position = vec4(uvOut * 2.0f + -1.0f, 0.0f, 1.0f);
 }
 
 -- glsl Visualize.Fragment.Depth

--- a/pxr/imaging/hdx/visualizeAovTask.h
+++ b/pxr/imaging/hdx/visualizeAovTask.h
@@ -127,8 +127,6 @@ private:
     HgiGraphicsPipelineHandle _pipeline;
 
     // Kernel independent resources
-    HgiBufferHandle _indexBuffer;
-    HgiBufferHandle _vertexBuffer;
     HgiSamplerHandle _sampler;
 
     float _screenSize[2];


### PR DESCRIPTION
### Description of Change(s)

* Avoid creating index and vertex buffer unnecessarily for full screen render passes
* Remove need of vertex buffer following this article: https://www.saschawillems.de/blog/2016/08/13/vulkan-tutorial-on-rendering-a-fullscreen-quad-without-buffers/

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
