### PR TITLE
Added AVIF to allowed USDZ image file types

### DIFF
--- a/docs/spec_usdz.rst
+++ b/docs/spec_usdz.rst
@@ -60,15 +60,15 @@ Usdz Specification
 A usdz package is an uncompressed zip archive that is allowed to contain the
 following file types:
 
- +-------------+--------------------------------+
- | Kind        | Allowed File Types             |
- +=============+================================+
- | USD         | **usda**, **usdc**, **usd**    |
- +-------------+--------------------------------+
- | Image       | **png**, **jpeg**, **exr**     |
- +-------------+--------------------------------+
- | Audio       | **M4A**, **MP3**, **WAV**      |
- +-------------+--------------------------------+
+ +-------------+----------------------------------------+
+ | Kind        | Allowed File Types                     |
+ +=============+========================================+
+ | USD         | **usda**, **usdc**, **usd**            |
+ +-------------+----------------------------------------+
+ | Image       | **png**, **jpeg**, **exr**, **avif**   |
+ +-------------+----------------------------------------+
+ | Audio       | **M4A**, **MP3**, **WAV**              |
+ +-------------+----------------------------------------+
 
 The rest of the section goes into more detail about the specification.
 
@@ -211,8 +211,8 @@ currently. Allowable file types are currently:
       OS updates)  
 
     * **png**, **jpeg** (any of the multiple common extensions for 
-      jpeg), and **OpenEXR** files for images/textures. See 
-      :ref:`Working With Image File Formats<image_file_formats>` for more 
+      jpeg), **OpenEXR** and **AV1 Image (AVIF)** files for images/textures. 
+      See :ref:`Working With Image File Formats<image_file_formats>` for more 
       details on supported image file formats.
 
     * **M4A, MP3, WAV** files for embedded audio (given in order of preferred 

--- a/docs/user_guides/render_user_guide.rst
+++ b/docs/user_guides/render_user_guide.rst
@@ -1138,11 +1138,29 @@ compression is applied. It is expected that more complex treatment of OpenEXR
 files including the construction of multilayer files will be completed by 
 pipeline tools.
 
+AV1 Image File Format (AVIF)
+============================
+
+The AV1 Image Format is a royalty-free open-source picture format, with modern 
+compression, flexible color specification, high dynamic range values, depth 
+images and alpha channels, and support for layered and sequential images. 
+
+The supported feature set in Hydra's builtin texture manager is currently 
+restricted to single frame images, which are decoded to linear Rec709 RGB or 
+RGBA if an alpha channel is present.
+
+Reading is implemented through the use of libaom, and libavif. 
+YUV to RGB decoding is accomplished by libyuv. 
+
+libaom is the reference codec library created by the Alliance for Open Media. 
+libavif is a portable C implementation of the AV1 Image File Format.
+
 See also:
 
 - `OpenEXR reference <https://openexr.com/en/latest/index.html#openexr>`__
 - `Rec709 standard <https://www.itu.int/rec/R-REC-BT.709-6-201506-I/en>`__
 - `Wikipedia entry on Rec709 standard <https://en.wikipedia.org/wiki/Rec._709>`__
+- `AV1 Image File Format specification <https://aomediacodec.github.io/av1-avif/>`__
 
 .. _render_camera:
 

--- a/pxr/imaging/plugin/hioAvif/README.md
+++ b/pxr/imaging/plugin/hioAvif/README.md
@@ -5,7 +5,7 @@ This library implements reading AVIF image files for Hio.
 The AV1 Image Format is a royalty-free open-source picture format, with modern compression, flexible color specification, high dynamic range values, 
 depth images and alpha channels, and support for layered and sequential images.
 
-The supported feature set here is currently restricted to single frame iamges,
+The supported feature set here is currently restricted to single frame images,
 which are decoded to linear Rec709 RGB or RGBA if an alpha channel is present.
 
 Reading is implemented through the use of libaom, and libavif.


### PR DESCRIPTION
### Description of Change(s)

This change is adding AV1 Image File Format (AVIF) to the list of allowed image file types in USDZ.

The AV1 Image Format is a royalty-free open-source picture format, with modern compression, flexible color specification, high dynamic range values, depth images and alpha channels, and support for layered and sequential images. 

HioAvif was introduced in OpenUSD 24.08 ([commit](https://github.com/PixarAnimationStudios/OpenUSD/commit/1cba8a9a1ce170eb61400175d7d3a3b7a0641a2b)) which enabled reading of `.avif` image files in Hio. Thanks to @meshula for his work.

### Fixes Issue(s)
- 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
