### PR TITLE
Ensure HdSceneIndexAdapterSceneDelegate::GetMaterialResource considers all contexts

### DIFF
--- a/pxr/imaging/hd/materialSchema.cpp
+++ b/pxr/imaging/hd/materialSchema.cpp
@@ -41,10 +41,12 @@ HdMaterialSchema::GetMaterialNetwork()
 }
 
 HdMaterialNetworkSchema
-HdMaterialSchema::GetMaterialNetwork(TfToken const &context)
+HdMaterialSchema::GetMaterialNetwork(TfTokenVector const &contexts)
 {
-    if (auto b = _GetTypedDataSource<HdContainerDataSource>(context)) {
-        return HdMaterialNetworkSchema(b);
+    for (TfToken const &context : contexts) {
+        if (auto b = _GetTypedDataSource<HdContainerDataSource>(context)) {
+            return HdMaterialNetworkSchema(b);
+        }
     }
 
     // If we can't find the context-specific binding, return the fallback.

--- a/pxr/imaging/hd/materialSchema.cpp
+++ b/pxr/imaging/hd/materialSchema.cpp
@@ -41,6 +41,20 @@ HdMaterialSchema::GetMaterialNetwork()
 }
 
 HdMaterialNetworkSchema
+HdMaterialSchema::GetMaterialNetwork(TfToken const &context)
+{
+    if (auto b = _GetTypedDataSource<HdContainerDataSource>(context)) {
+        return HdMaterialNetworkSchema(b);
+    }
+
+    // If we can't find the context-specific binding, return the fallback.
+    return
+        HdMaterialNetworkSchema(
+            _GetTypedDataSource<HdContainerDataSource>(
+                HdMaterialSchemaTokens->universalRenderContext));
+}
+
+HdMaterialNetworkSchema
 HdMaterialSchema::GetMaterialNetwork(TfTokenVector const &contexts)
 {
     for (TfToken const &context : contexts) {

--- a/pxr/imaging/hd/materialSchema.h
+++ b/pxr/imaging/hd/materialSchema.h
@@ -145,7 +145,7 @@ public:
     HdMaterialNetworkSchema GetMaterialNetwork();
 
     HD_API
-    HdMaterialNetworkSchema GetMaterialNetwork(TfToken const &context);
+    HdMaterialNetworkSchema GetMaterialNetwork(TfTokenVector const &contexts);
 
 // --(END CUSTOM CODE: Schema Methods)--
 

--- a/pxr/imaging/hd/materialSchema.h
+++ b/pxr/imaging/hd/materialSchema.h
@@ -145,6 +145,9 @@ public:
     HdMaterialNetworkSchema GetMaterialNetwork();
 
     HD_API
+    HdMaterialNetworkSchema GetMaterialNetwork(TfToken const &context);
+
+    HD_API
     HdMaterialNetworkSchema GetMaterialNetwork(TfTokenVector const &contexts);
 
 // --(END CUSTOM CODE: Schema Methods)--

--- a/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
+++ b/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
@@ -1190,14 +1190,7 @@ HdSceneIndexAdapterSceneDelegate::GetMaterialResource(SdfPath const & id)
     // Query for a material network to match the requested render contexts
     const TfTokenVector renderContexts =
         GetRenderIndex().GetRenderDelegate()->GetMaterialRenderContexts();
-    HdMaterialNetworkSchema netSchema(nullptr);
-    for (TfToken const& networkSelector : renderContexts) {
-        netSchema = matSchema.GetMaterialNetwork(networkSelector);
-        if (netSchema) {
-            // Found a matching network
-            break;
-        }
-    }
+    HdMaterialNetworkSchema netSchema = matSchema.GetMaterialNetwork(renderContexts);
     if (!netSchema.IsDefined()) {
         return VtValue();
     }


### PR DESCRIPTION
### Description of Change(s)

Moving the responsibility for iterating over the render delegate's material contexts out of the scene delegate and into the material schema, to ensure the fallback network is only returned after *all* the delegate's contexts have been considered (and failed).

### Fixes Issue(s)

Fixes #3286 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
