### PR TITLE
Fix TfMallocTag.Tls.Find static method on Darwin.

### DIFF
--- a/pxr/base/arch/defines.h
+++ b/pxr/base/arch/defines.h
@@ -79,12 +79,6 @@
 #define ARCH_HAS_GNU_STL_EXTENSIONS
 #endif
 
-// The current version of Apple clang does not support the thread_local
-// keyword.
-#if !(defined(ARCH_OS_DARWIN) && defined(ARCH_COMPILER_CLANG))
-#define ARCH_HAS_THREAD_LOCAL
-#endif
-
 // The MAP_POPULATE flag for mmap calls only exists on Linux platforms.
 #if defined(ARCH_OS_LINUX)
 #define ARCH_HAS_MMAP_MAP_POPULATE

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -556,7 +556,6 @@ class TfMallocTag::Tls {
 public:
     static
     TfMallocTag::_ThreadData &Find() {
-#if defined(ARCH_HAS_THREAD_LOCAL)
         // This thread_local must be placed in static TLS to prevent re-entry.
         // Starting in glibc 2.25, dynamic TLS allocation uses malloc.  Making
         // this allocation after malloc tags have been initialized results in
@@ -576,10 +575,6 @@ public:
             : ArchAlignedAlloc(alignof(_ThreadData), sizeof(_ThreadData));
         data = new (dataBuffer) _ThreadData();
         return *data;
-#else
-        TF_FATAL_ERROR("TfMallocTag not supported on platforms "
-                       "without thread_local");
-#endif
     }
 };
 


### PR DESCRIPTION
The original reasoning for disabling this was because originally **`thread_local`** was not available in Apple's (now ancient) Clang **pre-Xcode 8**, however now all modern versions of Apple's Clang do have support for **`thread_local`**.

### Description of Change(s)

- The static method for **`TfMallocTag::Tls::Find()`** now returns the per-thread data for **`TfMallocTag`** on all **Darwin** platforms, which before this change, has always returned nothing (and was silently failing).
- Remove the **`ARCH_HAS_THREAD_LOCAL`** preprocessor.
- Remove any/all conditional compilation checks for **`ARCH_HAS_THREAD_LOCAL`**.

<hr/>

### Note

I had noticed the following two **Tf** test cases are failing, but this is unrelated to this revision, as they were failing before this revision was introduced.

```swift
99% tests passed, 2 tests failed out of 791

Total Test time (real) = 1495.16 sec

The following tests FAILED:
	 15 - TfAtomicOfstreamWrapper (Failed)
	 56 - TfSafeOutputFile (Failed)
```

<hr/>

### Fixes Issue(s)

- #3323

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
