### PR TITLE
Simplify grammar when parsing large strings

### DIFF
--- a/pxr/usd/sdf/textFileFormatParser.h
+++ b/pxr/usd/sdf/textFileFormatParser.h
@@ -70,26 +70,10 @@ struct Ampersand : PEGTL_NS::one<'&'> {};
 
 // character classes
 struct Digit : PEGTL_NS::digit {};
-struct HexDigit : PEGTL_NS::xdigit {};
-struct OctDigit : PEGTL_NS::range<0, 7> {};
 struct Eol : PEGTL_NS::one<'\r', '\n'> {};
 struct Eolf : PEGTL_NS::eolf {};
 struct Utf8 : PEGTL_NS::utf8::any {};
 struct Utf8NoEolf : PEGTL_NS::minus<Utf8, Eol> {};
-
-// Escape character sets as defined by `TfEscapeStringReplaceChar` plus quotes
-struct EscapeSingleCharacter :
-    PEGTL_NS::seq<
-        PEGTL_NS::one<'\\', 'a', 'b', 'f', 'n', 'r', 't', 'v', '\'', '"'>> {};
-struct EscapeHex :
-    PEGTL_NS::seq<PEGTL_NS::one<'x'>,
-                  PEGTL_NS::rep_opt<2, HexDigit>> {};
-struct EscapeOct :
-    PEGTL_NS::seq<OctDigit,
-                  PEGTL_NS::rep_opt<2, OctDigit>> {};
-struct Escaped :
-    PEGTL_NS::seq<PEGTL_NS::one<'\\'>,
-                  PEGTL_NS::sor<EscapeSingleCharacter, EscapeHex, EscapeOct>> {};
 
 // keyword
 struct KeywordAdd : PXR_PEGTL_KEYWORD("add") {};
@@ -215,29 +199,19 @@ struct MathKeywordNan : PXR_PEGTL_KEYWORD("nan") {};
 // Comment = PythonStyleComment /
 //           CppStyleSingleLineComment /
 //           CppStyleMultiLineComment
-struct CppStyleMultilineOpen :
-    PEGTL_NS::seq<PEGTL_NS::one<'/'>, PEGTL_NS::one<'*'>> {};
-struct CppStyleMultilineClose :
-    PEGTL_NS::seq<PEGTL_NS::one<'*'>, PEGTL_NS::one<'/'>> {};
+struct CppStyleMultilineOpen : PEGTL_NS::string<'/', '*'> {};
+struct CppStyleMultilineClose : PEGTL_NS::string<'*', '/'> {};
 struct SingleLineContents : PEGTL_NS::star<PEGTL_NS::not_at<Eolf>, Utf8> {};
-struct PythonStyleComment :PEGTL_NS::disable<
+struct PythonStyleComment : PEGTL_NS::disable<
     PEGTL_NS::one<'#'>, SingleLineContents> {};
 struct CppStyleSingleLineComment : PEGTL_NS::disable<
     PEGTL_NS::two<'/'>, SingleLineContents> {};
 struct CppStyleMultiLineComment : PEGTL_NS::disable<
     CppStyleMultilineOpen,
     PEGTL_NS::until<CppStyleMultilineClose, Utf8>>{};
-// Use to avoid '/' backtracking
-struct CppStyleComment :
-    PEGTL_NS::seq<
-        PEGTL_NS::one<'/'>,
-        PEGTL_NS::sor<
-            PEGTL_NS::disable<PEGTL_NS::one<'*'>,
-                              PEGTL_NS::until<CppStyleMultilineClose, Utf8>>,
-            PEGTL_NS::disable<PEGTL_NS::one<'/'>, SingleLineContents>
-        >
-    > {};
-struct Comment : PEGTL_NS::sor<PythonStyleComment, CppStyleComment> {};
+struct Comment : PEGTL_NS::sor<PythonStyleComment,
+                               CppStyleSingleLineComment,
+                               CppStyleMultiLineComment> {};
     
 // whitespace rules
 // TokenSeparator represents whitespace between tokens,
@@ -305,7 +279,7 @@ struct ExponentPart : PEGTL_NS::opt_must<
     PEGTL_NS::plus<Digit>> {};
 struct NumberStandard : PEGTL_NS::seq<
     PEGTL_NS::plus<Digit>,
-    PEGTL_NS::opt_must<Sdf_PathParser::Dot, PEGTL_NS::star<Digit>>,
+    PEGTL_NS::opt<Sdf_PathParser::Dot, PEGTL_NS::star<Digit>>,
     ExponentPart> {};
 struct NumberLeadingDot : PEGTL_NS::seq<
     PEGTL_NS::if_must<Sdf_PathParser::Dot, PEGTL_NS::plus<Digit>>,
@@ -331,36 +305,42 @@ struct Number : PEGTL_NS::sor<
 //	 """ DoubleQuoteMultiLineStringChar* """ /
 //   ' SingleQuoteSingleLineStringChar* ' /
 //	''' SingleQuoteMultiLineStringChar* '
-struct MultilineContents : PEGTL_NS::sor<Escaped, Utf8> {};
-struct ThreeSingleQuotes :
-    PEGTL_NS::seq<SingleQuote, SingleQuote, SingleQuote> {};
-struct ThreeDoubleQuotes :
-    PEGTL_NS::seq<DoubleQuote, DoubleQuote, DoubleQuote> {};
-struct MultilineSingleQuoteString : PEGTL_NS::if_must<
-    ThreeSingleQuotes,
-    PEGTL_NS::until<ThreeSingleQuotes, MultilineContents>> {};
-struct MultilineDoubleQuoteString : PEGTL_NS::if_must<
-    ThreeDoubleQuotes,
-    PEGTL_NS::until<ThreeDoubleQuotes, MultilineContents>> {};
-struct SinglelineContents : PEGTL_NS::sor<Escaped, Utf8NoEolf> {};
-struct SinglelineSingleQuoteString : PEGTL_NS::if_must<
-    SingleQuote,
-    PEGTL_NS::until<SingleQuote, SinglelineContents>> {};
-struct SinglelineDoubleQuoteString : PEGTL_NS::if_must<
-    DoubleQuote,
-    PEGTL_NS::until<DoubleQuote, SinglelineContents>> {};
-struct SingleQuoteString : PEGTL_NS::sor<
+template <char QuoteCharacter>
+struct MultilineString : PEGTL_NS::if_must<
+    PEGTL_NS::three<QuoteCharacter>,
+    PEGTL_NS::until<
+        PEGTL_NS::three<QuoteCharacter>,
+        PEGTL_NS::sor<
+            PEGTL_NS::two<'\\'>,
+            PEGTL_NS::string<'\\', QuoteCharacter>,
+            Utf8>
+        >
+> {};
+template <char QuoteCharacter>
+struct SinglelineString : PEGTL_NS::if_must<
+    PEGTL_NS::one<QuoteCharacter>,
+    PEGTL_NS::until<
+        PEGTL_NS::one<QuoteCharacter>,
+        PEGTL_NS::sor<
+            PEGTL_NS::two<'\\'>,
+            PEGTL_NS::string<'\\', QuoteCharacter>,
+            Utf8NoEolf>
+        >
+> {};
+
+struct SinglelineSingleQuoteString : SinglelineString<'\''> {};
+struct SinglelineDoubleQuoteString : SinglelineString<'\"'> {};
+struct MultilineSingleQuoteString : MultilineString<'\''> {};
+struct MultilineDoubleQuoteString : MultilineString<'\"'> {};
+
+struct String : PEGTL_NS::sor<
     MultilineSingleQuoteString,
-    SinglelineSingleQuoteString> {};
-struct DoubleQuoteString : PEGTL_NS::sor<
+    SinglelineSingleQuoteString,
     MultilineDoubleQuoteString,
     SinglelineDoubleQuoteString> {};
-struct String : PEGTL_NS::sor<
-    SingleQuoteString,
-    DoubleQuoteString> {};
 
 // // asset references
-struct AtAtAt : PEGTL_NS::seq<At, At, At> {};
+struct AtAtAt : PEGTL_NS::three<'@'> {};
 struct EscapeAtAtAt :
     PEGTL_NS::seq<PEGTL_NS::one<'\\'>, AtAtAt> {};
 


### PR DESCRIPTION
### Description of Change(s)

A performance regression was observed when parsing large strings after the merging of #3005.

Parsing time for the schema registry layers (which has large documentation strings) went from ~4-5ms to over 7ms.

This was traced back to the `String` parsing grammar.  One notable difference from the PEGTL implementation and the original implementation was that even though it permissively let any character be "escaped" by `\`, it was explicit in the grammar about those that would be considered valid for replacement by `TfEscapeStringReplaceChar`. This was unnecessary and appeared to slow down the parser. (Were the grammar ever to become less permissive, it also had a bug-- as `OctDigit` was incorrectly specified.)  These unnecessary checks and rules have now been removed.

This change includes some additional optimizations and simplifications to the grammar.
* Preferring `PEGTL_NS::string` (and the wrappers `PEGTL_NS::two` and `PEGTL_NS::three`) over sequences of individual `PEGTL_NS::one` characters.
* Replacing `opt_must` with `opt` in the number parsing grammar.  An early version of the PEGTL grammar had required `plus<digit>.` to be followed by another digit (likely via `plus<digit>`).  Once it became optional (ie. `plus` became `star`), the `must` was spurious.
* Some complexity was originally added to the comment parsing to minimize backtracking when matching comments, but we suspect the `PEGTL:_NS::string` matching will be efficient and simpler.

```
env PXR_ENABLE_GLOBAL_TRACE=1 PXR_WORK_THREAD_LIMIT=1 python3 -c "from pxr import Usd; Usd.SchemaRegistry()"
```
```
    4.410 ms     4.410 ms      14 samples    |   | pxrInternal_v0_24_11__pxrReserved__::Sdf_ParseLayer
```

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
