### PR TITLE
Reduce copies of string values during text parsing

### DIFF
--- a/pxr/usd/sdf/textFileFormatParser.cpp
+++ b/pxr/usd/sdf/textFileFormatParser.cpp
@@ -299,18 +299,20 @@ struct TextParserAction<String>
         // obtain the text inside of the quotes
         // we have to first check for multi-line quotes
         // so we know what to pass to Sdf_EvalQuotedString
-        std::string inputString = in.string();
         std::string evaluatedString;
-        if (TfStringStartsWith(inputString, "'''") ||
-            TfStringStartsWith(inputString, "\"\"\""))
+        std::string_view inputString = in.string_view();
+        // firstThree will be clipped to inputString's size so no bound checks
+        // are needed.
+        if(const auto firstThree = inputString.substr(0, 3);
+           firstThree == "\"\"\"" || firstThree == "'''")
         {
             evaluatedString = Sdf_EvalQuotedString(
-                inputString.c_str(), inputString.length(), 3, nullptr);
+                inputString.data(), inputString.length(), 3, nullptr);
         }
         else
         {
             evaluatedString = Sdf_EvalQuotedString(
-                inputString.c_str(), inputString.length(), 1, nullptr);
+                inputString.data(), inputString.length(), 1, nullptr);
         }
 
         if (context.parsingContext.back() ==
@@ -319,7 +321,7 @@ struct TextParserAction<String>
             context.data->Set(
                 context.path,
                 SdfFieldKeys->Documentation,
-                VtValue(evaluatedString));
+                VtValue(std::move(evaluatedString)));
         }
         else if (context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::Metadata)
@@ -327,7 +329,7 @@ struct TextParserAction<String>
             context.data->Set(
                 context.path,
                 SdfFieldKeys->Comment,
-                VtValue(evaluatedString));
+                VtValue(std::move(evaluatedString)));
         }
         else if (context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::PrimSpec)
@@ -353,7 +355,7 @@ struct TextParserAction<String>
             context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::VariantSetsMetadata)
         {
-            context.nameVector.emplace_back(evaluatedString);
+            context.nameVector.emplace_back(std::move(evaluatedString));
         }
         else if (context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::VariantSetStatement)
@@ -372,10 +374,10 @@ struct TextParserAction<String>
                 throw PEGTL_NS::parse_error(allow.GetWhyNot(), in);
             }
 
-            context.currentVariantSetNames.push_back(evaluatedString);
+            context.currentVariantSetNames.push_back(std::move(evaluatedString));
             context.currentVariantNames.emplace_back();
             context.path = context.path.AppendVariantSelection(
-                evaluatedString, "");
+                context.currentVariantSetNames.back(), "");
         }
         else if (context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::VariantStatementList)
@@ -1073,10 +1075,10 @@ struct TextParserAction<AssetRef>
             context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::PayloadListOpMetadata)
         {
-            std::string inputString = in.string();
-            bool isTripleDelimited = TfStringStartsWith(inputString, "@@@");
+            std::string_view inputString = in.string_view();
+            bool isTripleDelimited = (inputString.substr(0, 3) == "@@@");
             std::string evaluatedAssetPath = Sdf_EvalAssetPath(
-                inputString.c_str(),
+                inputString.data(),
                 inputString.length(),
                 isTripleDelimited);
 
@@ -1095,21 +1097,21 @@ struct TextParserAction<AssetRef>
                     throw PEGTL_NS::parse_error(errorMessage, in);
             }
 
-            context.layerRefPath = evaluatedAssetPath;
+            context.layerRefPath = std::move(evaluatedAssetPath);
             context.layerRefOffset = SdfLayerOffset();
             context.savedPath = SdfPath::EmptyPath();
         }
         else if(context.parsingContext.back() ==
             Sdf_TextParserCurrentParsingContext::SubLayerMetadata)
         {
-            std::string inputString = in.string();
-            bool isTripleDelimited = TfStringStartsWith(inputString, "@@@");
+            std::string_view inputString = in.string_view();
+            bool isTripleDelimited = (inputString.substr(0, 3) == "@@@");
             std::string evaluatedAssetPath = Sdf_EvalAssetPath(
-                inputString.c_str(),
+                inputString.data(),
                 inputString.length(),
                 isTripleDelimited);
 
-            context.layerRefPath = evaluatedAssetPath;
+            context.layerRefPath = std::move(evaluatedAssetPath);
             context.layerRefOffset = SdfLayerOffset();
         }
     }
@@ -1149,16 +1151,18 @@ struct TextParserAction<StringValue>
     template <class Input>
     static void apply(const Input& in, Sdf_TextParserContext& context)
     {
-        std::string inputString = in.string();
+        std::string_view inputString = in.string_view();
         size_t numDelimeters = 1;
-        if(TfStringStartsWith(inputString, "\"\"\"") || 
-            TfStringStartsWith(inputString, "'''"))
+        // firstThree will be clipped to inputString's size so no bound checks
+        // are needed.
+        if(const auto firstThree = inputString.substr(0, 3);
+           firstThree == "\"\"\"" || firstThree == "'''")
         {
             numDelimeters = 3;
         }
 
         std::string evaluatedString = Sdf_EvalQuotedString(
-            inputString.c_str(),
+            inputString.data(),
             inputString.length(),
             numDelimeters);
 
@@ -1178,10 +1182,10 @@ struct TextParserAction<AssetRefValue>
         // the ParserValueContext needs asset paths to be stored
         // as SdfAssetPath instead of std::string to be able to
         // distinguish between them
-        std::string inputString = in.string();
-        bool isTripleDelimited = TfStringStartsWith(inputString, "@@@");
+        std::string_view inputString = in.string_view();
+        bool isTripleDelimited = (inputString.substr(0, 3) == "@@@");
         std::string evaluatedAssetPath = Sdf_EvalAssetPath(
-            inputString.c_str(),
+            inputString.data(),
             inputString.length(),
             isTripleDelimited);
 


### PR DESCRIPTION
### Description of Change(s)

While investigating the parser performance for #3293, we also looked at reducing the number of copies of large documentation strings observed in the schema registry.

With this change, `string_view` is used in many cases instead of creating a copy and `std::move` is used instead of copying the evaluated string.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
