### PR TITLE
Autodesk: Add per RenderPass shadow control

### DIFF
--- a/pxr/imaging/hd/renderPassState.cpp
+++ b/pxr/imaging/hd/renderPassState.cpp
@@ -68,6 +68,7 @@ HdRenderPassState::HdRenderPassState()
     , _stepSize(0.f)
     , _stepSizeLighting(0.f)
     , _multiSampleEnabled(true)
+    , _receiveShadows(true)
 {
 }
 

--- a/pxr/imaging/hd/renderPassState.h
+++ b/pxr/imaging/hd/renderPassState.h
@@ -332,6 +332,9 @@ public:
     void SetMultiSampleEnabled(bool enabled);
     bool GetMultiSampleEnabled() const { return _multiSampleEnabled; }
 
+    void SetReceiveShadows(bool enabled) { _receiveShadows = enabled; }
+    bool GetReceiveShadows() const { return _receiveShadows; }
+
 protected:
     // ---------------------------------------------------------------------- //
     // Camera and framing state 
@@ -412,6 +415,8 @@ protected:
     float _stepSizeLighting;
 
     bool _multiSampleEnabled;
+
+    bool _receiveShadows;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/fallbackLightingShader.cpp
+++ b/pxr/imaging/hdSt/fallbackLightingShader.cpp
@@ -78,5 +78,11 @@ HdSt_FallbackLightingShader::AddBindings(
     // no-op
 }
 
+void 
+HdSt_FallbackLightingShader::SetReceiveShadows(bool enabled)
+{
+    // nothing
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hdSt/fallbackLightingShader.h
+++ b/pxr/imaging/hdSt/fallbackLightingShader.h
@@ -48,6 +48,9 @@ public:
     void SetCamera(GfMatrix4d const &worldToViewMatrix,
                    GfMatrix4d const &projectionMatrix) override;
 
+    HDST_API
+    void SetReceiveShadows(bool enabled) override;
+
 private:
     std::unique_ptr<HioGlslfx> _glslfx;
 };

--- a/pxr/imaging/hdSt/lightingShader.h
+++ b/pxr/imaging/hdSt/lightingShader.h
@@ -31,6 +31,8 @@ public:
     virtual void SetCamera(GfMatrix4d const &worldToViewMatrix,
                            GfMatrix4d const &projectionMatrix) = 0;
 
+    virtual void SetReceiveShadows(bool enabled) = 0;
+
 private:
 
     // No copying

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -14,6 +14,7 @@
 #include "pxr/imaging/hdSt/glConversions.h"
 #include "pxr/imaging/hdSt/hgiConversions.h"
 #include "pxr/imaging/hdSt/fallbackLightingShader.h"
+#include "pxr/imaging/hdSt/simpleLightingShader.h"
 #include "pxr/imaging/hdSt/renderBuffer.h"
 #include "pxr/imaging/hdSt/renderPassShader.h"
 #include "pxr/imaging/hdSt/renderPassState.h"
@@ -487,6 +488,9 @@ HdStRenderPassState::SetLightingShader(HdStLightingShaderSharedPtr const &lighti
     } else {
         _lightingShader = _fallbackLightingShader;
     }
+
+    if (_lightingShader)
+        _lightingShader->SetReceiveShadows(GetReceiveShadows());
 }
 
 void 

--- a/pxr/imaging/hdSt/simpleLightingShader.h
+++ b/pxr/imaging/hdSt/simpleLightingShader.h
@@ -121,10 +121,14 @@ public:
         return _shadowAovBindings;
     }
 
+    HDST_API
+    void SetReceiveShadows(bool enabled) override;
+
 private:
     SdfPath _GetAovPath(TfToken const &aov, size_t shadowIndex) const;
     void _ResizeOrCreateBufferForAov(size_t shadowIndex) const;
     void _CleanupAovBindings();
+    bool _ReceiveShadows() const;
 
     GlfSimpleLightingContextRefPtr _lightingContext; 
     bool _useLighting;
@@ -151,6 +155,8 @@ private:
 
     HdRenderPassAovBindingVector _shadowAovBindings;
     std::vector<std::unique_ptr<HdStRenderBuffer>> _shadowAovBuffers;
+
+    bool _receiveShadows;
 };
 
 

--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -321,6 +321,12 @@ HdSt_TestLightingShader::SetLight(int light,
     }
 }
 
+void
+HdSt_TestLightingShader::SetReceiveShadows(bool enabled)
+{
+
+}
+
 // --------------------------------------------------------------------------
 
 HdSt_TextureTestDriver::HdSt_TextureTestDriver() :

--- a/pxr/imaging/hdSt/unitTestHelper.h
+++ b/pxr/imaging/hdSt/unitTestHelper.h
@@ -594,6 +594,8 @@ public:
     /// Prepare lighting resource buffers
     void Prepare();
 
+    void SetReceiveShadows(bool enabled) override;
+
 private:
     struct Light {
         GfVec3f dir;

--- a/pxr/imaging/hdx/renderSetupTask.cpp
+++ b/pxr/imaging/hdx/renderSetupTask.cpp
@@ -175,6 +175,8 @@ HdxRenderSetupTask::SyncParams(HdSceneDelegate* delegate,
         renderPassState->SetMultiSampleEnabled(
             params.useAovMultiSample && !params.enableIdRender);
 
+        renderPassState->SetReceiveShadows(params.receiveShadows);
+
         if (HdStRenderPassState * const hdStRenderPassState =
                     dynamic_cast<HdStRenderPassState*>(renderPassState.get())) {
 
@@ -264,9 +266,9 @@ HdxRenderSetupTask::_GetRenderPassState(HdRenderIndex* renderIndex)
 
 std::ostream& operator<<(std::ostream& out, const HdxRenderTaskParams& pv)
 {
-    out << "RenderTask Params: (...) " 
-        << pv.overrideColor << " " 
-        << pv.wireframeColor << " " 
+    out << "RenderTask Params: (...) "
+        << pv.overrideColor << " "
+        << pv.wireframeColor << " "
         << pv.pointColor << " "
         << pv.pointSize << " "
         << pv.enableLighting << " "
@@ -275,8 +277,8 @@ std::ostream& operator<<(std::ostream& out, const HdxRenderTaskParams& pv)
         << pv.enableSceneMaterials << " "
         << pv.enableSceneLights << " "
 
-        << pv.maskColor << " " 
-        << pv.indicatorColor << " " 
+        << pv.maskColor << " "
+        << pv.indicatorColor << " "
         << pv.pointSelectedSize << " "
 
         << pv.depthBiasUseDefault << " "
@@ -309,7 +311,9 @@ std::ostream& operator<<(std::ostream& out, const HdxRenderTaskParams& pv)
         << pv.framing.dataWindow << " "
         << pv.framing.pixelAspectRatio << " "
         << pv.viewport << " "
-        << pv.cullStyle << " ";
+        << pv.cullStyle << " "
+
+        << pv.receiveShadows << " ";
 
     for (auto const& a : pv.aovBindings) {
         out << a << " ";
@@ -368,7 +372,8 @@ bool operator==(const HdxRenderTaskParams& lhs, const HdxRenderTaskParams& rhs)
            lhs.framing                  == rhs.framing                  &&
            lhs.viewport                 == rhs.viewport                 &&
            lhs.cullStyle                == rhs.cullStyle                &&
-           lhs.overrideWindowPolicy     == rhs.overrideWindowPolicy;
+           lhs.overrideWindowPolicy     == rhs.overrideWindowPolicy     &&
+           lhs.receiveShadows           == rhs.receiveShadows;
 }
 
 bool operator!=(const HdxRenderTaskParams& lhs, const HdxRenderTaskParams& rhs) 

--- a/pxr/imaging/hdx/renderSetupTask.h
+++ b/pxr/imaging/hdx/renderSetupTask.h
@@ -162,6 +162,7 @@ struct HdxRenderTaskParams
         // Camera framing and viewer state
         , viewport(0.0)
         , cullStyle(HdCullStyleBackUnlessDoubleSided)
+        , receiveShadows(true)
         {}
 
     // ---------------------------------------------------------------------- //
@@ -243,6 +244,8 @@ struct HdxRenderTaskParams
     GfVec4d viewport;
     HdCullStyle cullStyle;
     std::optional<CameraUtilConformWindowPolicy> overrideWindowPolicy;
+    // True if shadowing is enabled.
+    bool receiveShadows;
 };
 
 // VtValue requirements

--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -1856,6 +1856,7 @@ UsdImagingGLEngine::_MakeHydraUsdImagingGLRenderParams(
     // - params.camera
     // - params.viewport
 
+    params.receiveShadows = renderParams.receiveShadows;
     return params;
 }
 

--- a/pxr/usdImaging/usdImagingGL/renderParams.h
+++ b/pxr/usdImaging/usdImagingGL/renderParams.h
@@ -95,6 +95,7 @@ public:
     BBoxVector bboxes;
     GfVec4f bboxLineColor;
     float bboxLineDashSize;
+    bool receiveShadows;
 
     inline UsdImagingGLRenderParams();
 
@@ -132,7 +133,8 @@ UsdImagingGLRenderParams::UsdImagingGLRenderParams() :
     clearColor(0,0,0,1),
     lut3dSizeOCIO(65),
     bboxLineColor(1),
-    bboxLineDashSize(3)
+    bboxLineDashSize(3),
+    receiveShadows(true)
 {
 }
 
@@ -171,7 +173,8 @@ UsdImagingGLRenderParams::operator==(const UsdImagingGLRenderParams &other)
         && lut3dSizeOCIO               == other.lut3dSizeOCIO
         && bboxes                      == other.bboxes
         && bboxLineColor               == other.bboxLineColor
-        && bboxLineDashSize            == other.bboxLineDashSize;
+        && bboxLineDashSize            == other.bboxLineDashSize
+        && receiveShadows              == other.receiveShadows;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

Add a per RenderPass level shadowing control so that we can decide which RenderPasses receive shadows and which do not.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
