### PR TITLE
Adding color4f(array) support to the _FactoryMap

### DIFF
--- a/pxr/usdImaging/usdImaging/dataSourceAttribute.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceAttribute.cpp
@@ -42,6 +42,8 @@ static _FactoryMap _CreateFactoryMap()
     map[SdfValueTypeNames->BoolArray] = _FactoryImpl<VtArray<bool>>;
     map[SdfValueTypeNames->Color3fArray] = _FactoryImpl<VtArray<GfVec3f>>;
     map[SdfValueTypeNames->Color3f] = _FactoryImpl<GfVec3f>;
+    map[SdfValueTypeNames->Color4fArray] = _FactoryImpl<VtArray<GfVec4f>>;
+    map[SdfValueTypeNames->Color4f] = _FactoryImpl<GfVec4f>;
     map[SdfValueTypeNames->Double] = _FactoryImpl<double>;
     map[SdfValueTypeNames->Double2] = _FactoryImpl<GfVec2d>;
     map[SdfValueTypeNames->DoubleArray] = _FactoryImpl<VtArray<double>>;


### PR DESCRIPTION
### Description of Change(s)

Copy-paste to add Color4f/Color4fArray to the _FactoryMap of convertible types to support shader nodes with color4f parameters.

### Fixes Issue(s)
Fixes #3298 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
