### PR TITLE
Improve Alembic plugin to read assets with ArResolver to support other sources except local files

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -860,6 +860,8 @@ private:
     _PrimMap _prims;
     Prim* _pseudoRoot;
     UsdAbc_TimeSamples _allTimeSamples;
+
+    std::vector<std::shared_ptr<ArAsset>> _assetHolders;
 };
 
 static
@@ -895,6 +897,7 @@ _ReaderContext::_OpenAndGetMappedFilePath(const std::string& filePath)
             {
                 // If file handle is presented, use mapped file path instead of original one.
                 const std::string mappedFilePath = ArchGetFileName(fileHandle);
+                _assetHolders.emplace_back(std::move(asset));
 
                 return mappedFilePath;
             }
@@ -1540,6 +1543,7 @@ _ReaderContext::_Clear()
     _allTimeSamples.clear();
     _instanceSources.clear();
     _instances.clear();
+    _assetHolders.clear();
 }
 
 const _ReaderContext::Prim*

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -894,8 +894,11 @@ _ReaderContext::_OpenAndGetMappedFilePath(const std::string& filePath)
             ArGetResolver().OpenAsset(ArResolvedPath(filePath));
         if (asset)
         {
-            FILE* fileHandle = asset->GetFileUnsafe().first;
-            if (fileHandle && ftell(fileHandle) == 0)
+            FILE* fileHandle; size_t fileOffset;
+            std::tie(fileHandle, fileOffset) = asset->GetFileUnsafe();
+            // Check file offset also to ensure that the .abc file
+            // we're looking at isn't embedded in a .usdz or other package
+            if (fileHandle && fileOffset == 0)
             {
                 // If file handle is presented, use mapped file path instead of original one.
                 const std::string mappedFilePath = ArchGetFileName(fileHandle);


### PR DESCRIPTION
### Description of Change(s)

Alembic plugin only accepts assets that are from local paths. In order to fix this, we need to use ArResolver/ArAsset to read/write contents so customized resolver can read assets from other locations. However, interfaces of Alembic library have limitations that can only accept local urls or `std::istream`. This PR uses the following solution:

  Open assets with `ArResolver`. Instead of reading them into the memory, we get the mapped file path with [ArchGetFileName](https://github.com/PixarAnimationStudios/OpenUSD/blob/59992d2178afcebd89273759f2bddfe730e59aa8/pxr/base/arch/fileSystem.h#L177) from `ArAsset::GetFileUnsafe`. 

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/2961

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
