### PR TITLE
Autodesk: Fix RemoveInputScene

### DIFF
--- a/pxr/imaging/hd/mergingSceneIndex.cpp
+++ b/pxr/imaging/hd/mergingSceneIndex.cpp
@@ -137,14 +137,14 @@ HdMergingSceneIndex::RemoveInputScene(const HdSceneIndexBaseRefPtr &sceneIndex)
         return;
     }
 
+    std::vector<SdfPath> removalTestQueue = { it->sceneRoot };
+
     sceneIndex->RemoveObserver(HdSceneIndexObserverPtr(&_observer));
     _inputs.erase(it);
 
     if (!_IsObserved()) {
         return;
     }
-
-    std::vector<SdfPath> removalTestQueue = { it->sceneRoot };
 
     // prims unique to this input get removed
     HdSceneIndexObserver::RemovedPrimEntries removedEntries;


### PR DESCRIPTION
### Description of Change(s)

Move the initialization of variable removalTestQueue before deleting the iterator it was using.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
