### PR TITLE
Adding python bindings for VtArray<SdfPathExpression> objects.

### DIFF
--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -134,6 +134,7 @@ pxr_library(sdf
         module.cpp
         wrapArrayAssetPath.cpp
         wrapArrayPath.cpp
+        wrapArrayPathExpression.cpp
         wrapArrayTimeCode.cpp
         wrapAssetPath.cpp
         wrapAttributeSpec.cpp
@@ -196,6 +197,7 @@ pxr_test_scripts(
     testenv/testSdfPath2.py
     testenv/testSdfPath2Construct.py
     testenv/testSdfPathExpression.py
+    testenv/testSdfPathExpressionArray.py
     testenv/testSdfPayload.py
     testenv/testSdfPrim.py
     testenv/testSdfReference.py
@@ -470,6 +472,11 @@ pxr_register_test(testSdfPathExpression
 
 pxr_register_test(testSdfPathExpression_Cpp
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPathExpression_Cpp"
+)
+
+pxr_register_test(testSdfPathExpressionArray
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfPathExpressionArray"
 )
 
 pxr_register_test(testSdfParsing

--- a/pxr/usd/sdf/module.cpp
+++ b/pxr/usd/sdf/module.cpp
@@ -14,6 +14,7 @@ TF_WRAP_MODULE
 {
     TF_WRAP( ArrayAssetPath );
     TF_WRAP( ArrayPath );
+    TF_WRAP( ArrayPathExpression );
     TF_WRAP( ArrayTimeCode );
     TF_WRAP( AssetPath );
     TF_WRAP( ChangeBlock );

--- a/pxr/usd/sdf/pathExpression.cpp
+++ b/pxr/usd/sdf/pathExpression.cpp
@@ -39,6 +39,11 @@ TF_REGISTRY_FUNCTION(TfType)
     TfType::Define<VtArray<SdfPathExpression>>();
 }
 
+TF_REGISTRY_FUNCTION(VtValue)
+{
+    VtValue::RegisterSimpleCast<std::string, SdfPathExpression>();
+}
+
 SdfPathExpression::ExpressionReference const &
 SdfPathExpression::ExpressionReference::Weaker()
 {

--- a/pxr/usd/sdf/pathExpression.cpp
+++ b/pxr/usd/sdf/pathExpression.cpp
@@ -39,11 +39,6 @@ TF_REGISTRY_FUNCTION(TfType)
     TfType::Define<VtArray<SdfPathExpression>>();
 }
 
-TF_REGISTRY_FUNCTION(VtValue)
-{
-    VtValue::RegisterSimpleCast<std::string, SdfPathExpression>();
-}
-
 SdfPathExpression::ExpressionReference const &
 SdfPathExpression::ExpressionReference::Weaker()
 {

--- a/pxr/usd/sdf/testenv/testSdfPathExpressionArray.py
+++ b/pxr/usd/sdf/testenv/testSdfPathExpressionArray.py
@@ -1,0 +1,32 @@
+#!/pxrpythonsubst
+#
+# Copyright 2024 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+from pxr import Sdf, Tf
+import sys, unittest
+
+MatchEval = Sdf._MakeBasicMatchEval
+
+class TestSdfPathExpressionArray(unittest.TestCase):
+
+    def test_Basics(self):
+        # Create arrays
+        exprs1 = Sdf.PathExpressionArray((Sdf.PathExpression('/foo'),
+                                         Sdf.PathExpression('/bar')))
+        exprs2 = Sdf.PathExpressionArray(('/foo', '/bar'))
+        self.assertEqual(exprs1, exprs2)
+
+        # Simple use of PathExpressionArray attributes.
+        l = Sdf.Layer.CreateAnonymous()
+        p = Sdf.CreatePrimInLayer(l, '/foo')
+        a = Sdf.AttributeSpec(p, 'a', Sdf.ValueTypeNames.PathExpressionArray)
+        a.default = (Sdf.PathExpression('/foo'), Sdf.PathExpression('/bar'))
+        b = Sdf.AttributeSpec(p, 'b', Sdf.ValueTypeNames.PathExpressionArray)
+        b.default = ('/foo', '/bar')
+        self.assertEqual(a.default, b.default)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pxr/usd/sdf/testenv/testSdfPathExpressionArray.py
+++ b/pxr/usd/sdf/testenv/testSdfPathExpressionArray.py
@@ -1,6 +1,6 @@
 #!/pxrpythonsubst
 #
-# Copyright 2024 Pixar
+# Copyright 2025 Pixar
 #
 # Licensed under the terms set forth in the LICENSE.txt file available at
 # https://openusd.org/license.
@@ -16,17 +16,16 @@ class TestSdfPathExpressionArray(unittest.TestCase):
         # Create arrays
         exprs1 = Sdf.PathExpressionArray((Sdf.PathExpression('/foo'),
                                          Sdf.PathExpression('/bar')))
-        exprs2 = Sdf.PathExpressionArray(('/foo', '/bar'))
-        self.assertEqual(exprs1, exprs2)
+        with self.assertRaises(TypeError,
+            msg="Implicit conversions from string should fail"):
+            exprs2 = Sdf.PathExpressionArray(('/foo', '/bar'))
 
         # Simple use of PathExpressionArray attributes.
         l = Sdf.Layer.CreateAnonymous()
         p = Sdf.CreatePrimInLayer(l, '/foo')
         a = Sdf.AttributeSpec(p, 'a', Sdf.ValueTypeNames.PathExpressionArray)
         a.default = (Sdf.PathExpression('/foo'), Sdf.PathExpression('/bar'))
-        b = Sdf.AttributeSpec(p, 'b', Sdf.ValueTypeNames.PathExpressionArray)
-        b.default = ('/foo', '/bar')
-        self.assertEqual(a.default, b.default)
+        self.assertEqual(a.default, exprs1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pxr/usd/sdf/wrapArrayPathExpression.cpp
+++ b/pxr/usd/sdf/wrapArrayPathExpression.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/pxr.h"
+#include "pxr/usd/sdf/pathExpression.h"
+#include "pxr/base/vt/array.h"
+#include "pxr/base/vt/wrapArray.h"
+#include "pxr/base/vt/valueFromPython.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace Vt_WrapArray {
+    template <>
+    std::string GetVtArrayName< VtArray<SdfPathExpression> >() {
+        return "PathExpressionArray";
+    }
+}
+
+template<>
+SdfPathExpression VtZero() {
+    return SdfPathExpression();
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+void wrapArrayPathExpression() {
+    VtWrapArray<VtArray<SdfPathExpression> >();
+    VtValueFromPythonLValue<VtArray<SdfPathExpression> >();
+}

--- a/pxr/usd/sdf/wrapArrayPathExpression.cpp
+++ b/pxr/usd/sdf/wrapArrayPathExpression.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2025 Pixar
 //
 // Licensed under the terms set forth in the LICENSE.txt file available at
 // https://openusd.org/license.

--- a/pxr/usd/sdf/wrapPathExpression.cpp
+++ b/pxr/usd/sdf/wrapPathExpression.cpp
@@ -13,6 +13,7 @@
 #include "pxr/base/tf/pyEnum.h"
 #include "pxr/base/tf/pyFunction.h"
 #include "pxr/base/tf/pyUtils.h"
+#include "pxr/base/vt/wrapArray.h"
 
 #include "pxr/usd/sdf/pathExpression.h"
 #include "pxr/usd/sdf/pathExpressionEval.h"
@@ -32,6 +33,11 @@ using namespace pxr_boost::python;
 using PathExpr = SdfPathExpression;
 using ExpressionReference = PathExpr::ExpressionReference;
 using PathPattern = PathExpr::PathPattern;
+
+TF_REGISTRY_FUNCTION(VtValue)
+{
+    VtRegisterValueCastsFromPythonSequencesToArray<SdfPathExpression>();
+}
 
 static std::string
 _Repr(SdfPathExpression const &self) {
@@ -199,6 +205,9 @@ void wrapPathExpression()
         .def(self == self)
         .def(self != self)
         ;
+
+    implicitly_convertible<std::string, SdfPathExpression>();
+
     VtValueFromPython<SdfPathExpression>();
 
     TfPyWrapEnum<PathExpr::Op>();

--- a/pxr/usd/sdf/wrapPathExpression.cpp
+++ b/pxr/usd/sdf/wrapPathExpression.cpp
@@ -206,8 +206,6 @@ void wrapPathExpression()
         .def(self != self)
         ;
 
-    implicitly_convertible<std::string, SdfPathExpression>();
-
     VtValueFromPython<SdfPathExpression>();
 
     TfPyWrapEnum<PathExpr::Op>();


### PR DESCRIPTION
### Description of Change(s)
Adding python bindings for VtArray<SdfPathExpression> objects.

Without these additions, it is not possible to use python to get or set attributes or metadata of type Sdf.ValueTypeNames.PathExpressionArray. There is obviously no pressing need for this as there are no schemas (that I am aware of) that use this data type, but since this is a valid data type, it seemed to me that it should be possible to use it in python.

- [ X ] I have verified that all unit tests pass with the proposed changes
- [ X ] I have submitted a signed Contributor License Agreement
