### PR TITLE
Optimize Sdf_PathNode::GetPathToken() by avoiding unnecessary memory allocation

### DIFF
--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -438,10 +438,6 @@ namespace {
 // nullptr property node pointer) plus all the properties that hang off it.
 struct _PropToTokenTable
 {
-    void Init() {
-        _data = std::make_shared<_Data>();
-    }
-
     // Note that this function returns a TfToken lvalue reference that needs to
     // live/be valid as long as this object is around.
     template <class Fn>
@@ -475,7 +471,7 @@ private:
         tbb::spin_mutex mutex;
     };
 
-    std::shared_ptr<_Data> _data;
+    std::shared_ptr<_Data> _data { new _Data };
 };
 
 } // anon
@@ -498,12 +494,8 @@ Sdf_PathNode::GetPathToken(Sdf_PathNode const *primPart,
     TfAutoMallocTag tag2("Sdf_PathNode::GetPathToken");
 
     _PrimToPropTokenTables::accessor primAccessor;
-    bool newValue = _pathTokenTable->insert(
-        primAccessor, std::make_pair(primPart, _PropToTokenTable()));
+    _pathTokenTable->insert(primAccessor, primPart);
     auto &propToTokenTable = primAccessor->second;
-    if (newValue) {
-        propToTokenTable.Init();
-    }
     // Release the primAccessor here, since the call to _CreatePathToken below
     // can cause reentry here (for embedded target paths).
     primAccessor.release();


### PR DESCRIPTION
### Description of Change(s)

GetPathToken no longer does a memory allocation when the token already exists. A benchmark that calls SdfPath::GetString repeatedly on a large amount of SdfPaths shows 2.3x improvement on Windows.

Note that the following unit tests fail on Windows with or without the changes:

158 - testWorkThreadLimitsRawTBBMax (Failed)
767 - testUsdviewNavigationKeys (Failed)
783 - testUsdResolverExample (Failed)

### Fixes Issue(s)

None.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
