### PR TITLE
Autodesk: Fix leaking Vulkan buffer from HdSt_PipelineDrawBatch

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -2825,14 +2825,12 @@ pxr_register_test(testHdStFaceCulling_FrontUnlessDoubleSided
 pxr_register_test(testHdStFrustumCullingCPU
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStFrustumCulling --offscreen"
     EXPECTED_RETURN_CODE 0
-    TESTENV testHdStFaceCulling
     ENV
         HD_ENABLE_GPU_FRUSTUM_CULLING=0
 )
 pxr_register_test(testHdStFrustumCullingGPU
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStFrustumCulling --offscreen"
     EXPECTED_RETURN_CODE 0
-    TESTENV testHdStFrustumCulling
     ENV
         HD_ENABLE_GPU_FRUSTUM_CULLING=1
         HD_ENABLE_GPU_COUNT_VISIBLE_INSTANCES=1

--- a/pxr/imaging/hdSt/dispatchBuffer.cpp
+++ b/pxr/imaging/hdSt/dispatchBuffer.cpp
@@ -177,6 +177,7 @@ HdStDispatchBuffer::HdStDispatchBuffer(
         HgiBufferUsageStorage | HgiBufferUsageVertex | HgiBufferUsageIndirect;
     bufDesc.byteSize = dataSize;
     bufDesc.vertexStride = stride;
+    bufDesc.debugName = "Dispatch";
     HgiBufferHandle buffer = _resourceRegistry->GetHgi()->CreateBuffer(bufDesc);
 
     // monolithic resource

--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -96,7 +96,11 @@ HdSt_PipelineDrawBatch::HdSt_PipelineDrawBatch(
     _Init(drawItemInstance);
 }
 
-HdSt_PipelineDrawBatch::~HdSt_PipelineDrawBatch() = default;
+HdSt_PipelineDrawBatch::~HdSt_PipelineDrawBatch()
+{
+    if (_resultBuffer) _DestroyBuffer(_resultBuffer);
+    if (_tessFactorsBuffer) _DestroyBuffer(_tessFactorsBuffer);
+}
 
 /*virtual*/
 void
@@ -943,6 +947,9 @@ HdSt_PipelineDrawBatch::PrepareDraw(
     HdStResourceRegistrySharedPtr const & resourceRegistry)
 {
     TRACE_FUNCTION();
+
+    // Needed to cleanup resources in the destructor
+    _resourceRegistry = resourceRegistry;
 
     if (!_dispatchBuffer) {
         _CompileBatch(resourceRegistry);
@@ -1877,7 +1884,8 @@ HdSt_PipelineDrawBatch::_BeginGPUCountVisibleInstances(
 
         _resultBuffer =
             resourceRegistry->RegisterBufferResource(
-                _tokens->drawIndirectResult, tupleType, HgiBufferUsageStorage);
+                _tokens->drawIndirectResult, tupleType, HgiBufferUsageStorage,
+                "PipelineDrawBatch Visible Instances");
     }
 
     // Reset visible item count
@@ -1920,6 +1928,18 @@ HdSt_PipelineDrawBatch::_EndGPUCountVisibleInstances(
     resourceRegistry->SubmitBlitWork(HgiSubmitWaitTypeWaitUntilCompleted);
 
     *result = count;
+}
+
+void
+HdSt_PipelineDrawBatch::_DestroyBuffer(
+    const HdStBufferResourceSharedPtr & bufferResource)
+{
+    if (!TF_VERIFY(bufferResource) || !TF_VERIFY(_resourceRegistry))
+        return;
+
+    HgiBufferHandle& buffer = bufferResource->GetHandle();
+    _resourceRegistry->GetHgi()->DestroyBuffer(&buffer);
+    bufferResource->SetAllocation(HgiBufferHandle(), 0);
 }
 
 void

--- a/pxr/imaging/hdSt/pipelineDrawBatch.h
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.h
@@ -155,6 +155,10 @@ private:
         HdStResourceRegistrySharedPtr const & resourceRegistry,
         size_t * result);
 
+    void _DestroyBuffer(const HdStBufferResourceSharedPtr & bufferResource);
+
+    HdStResourceRegistrySharedPtr _resourceRegistry;
+
     HdStDispatchBufferSharedPtr _dispatchBuffer;
     HdStDispatchBufferSharedPtr _dispatchBufferCullInput;
 

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -519,7 +519,8 @@ HdStBufferResourceSharedPtr
 HdStResourceRegistry::RegisterBufferResource(
     TfToken const &role, 
     HdTupleType tupleType,
-    HgiBufferUsage bufferUsage)
+    HgiBufferUsage bufferUsage,
+    std::string debugName)
 {
     HdStBufferResourceSharedPtr const result =
         std::make_shared<HdStBufferResource>(
@@ -530,6 +531,7 @@ HdStResourceRegistry::RegisterBufferResource(
     HgiBufferDesc bufDesc;
     bufDesc.usage = bufferUsage;
     bufDesc.byteSize = byteSize;
+    bufDesc.debugName = std::move(debugName);
     HgiBufferHandle buffer = _hgi->CreateBuffer(bufDesc);
 
     result->SetAllocation(buffer, byteSize);

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -318,7 +318,8 @@ public:
     HdStBufferResourceSharedPtr RegisterBufferResource(
         TfToken const &role, 
         HdTupleType tupleType,
-        HgiBufferUsage bufferUsage);
+        HgiBufferUsage bufferUsage,
+        std::string debugName = "");
 
     /// Remove any entries associated with expired dispatch buffers.
     HDST_API

--- a/pxr/imaging/hdSt/testenv/testHdStBarAllocationLimit.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStBarAllocationLimit.cpp
@@ -39,7 +39,7 @@ protected:
     void AddLargeCurve(HdUnitTestDelegate *delegate);
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -51,7 +51,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
    

--- a/pxr/imaging/hdSt/testenv/testHdStBasicDrawing.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStBasicDrawing.cpp
@@ -40,7 +40,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     HdSt_TestLightingShaderSharedPtr _lightingShader;
     std::vector<GfVec4d> _clipPlanes;
 
@@ -58,7 +58,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest() " << _reprName << "\n";
 
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStCurveDrawing.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStCurveDrawing.cpp
@@ -38,7 +38,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -50,7 +50,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStCurvePrimvarInterpolation.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStCurvePrimvarInterpolation.cpp
@@ -66,7 +66,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -78,7 +78,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStDisplayStyle.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStDisplayStyle.cpp
@@ -57,7 +57,7 @@ protected:
 private:
     TfToken _reprName;
     int _refineLevel;
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     std::string _outputFilePath;
 };
 
@@ -68,7 +68,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest()\n";
 
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStFaceCulling.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStFaceCulling.cpp
@@ -44,7 +44,7 @@ protected:
 private:
     GfVec3f _PopulateCullingTestSet(HdUnitTestDelegate * const delegate);
 
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     HdSt_TestLightingShaderSharedPtr _lightingShader;
     std::vector<GfVec4d> _clipPlanes;
 
@@ -167,7 +167,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest() " << _reprName << "\n";
 
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
 
     GfVec3f center(0);

--- a/pxr/imaging/hdSt/testenv/testHdStFrustumCulling.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStFrustumCulling.cpp
@@ -37,7 +37,7 @@ private:
     void ParseArgs(int argc, char *argv[]) override;
     int DrawScene();
 
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     bool _instance;
     bool _tinyPrim;
 };
@@ -55,7 +55,7 @@ _GetTranslate(float tx, float ty, float tz)
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver();
+    _driver = std::make_unique<HdSt_TestDriver>();
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
 
     if (_instance) {

--- a/pxr/imaging/hdSt/testenv/testHdStInitRepr.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStInitRepr.cpp
@@ -33,7 +33,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver     *_driver;
+    HdSt_TestDriverUniquePtr _driver;
     HdUnitTestDelegate *_delegate;
     HdRenderIndex       *_renderIndex;
     std::string          _outputFilePrefix;
@@ -63,7 +63,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest()\n";
 
-    _driver = new HdSt_TestDriver(HdReprTokens->hull);
+    _driver = std::make_unique<HdSt_TestDriver>(HdReprTokens->hull);
     _delegate = &_driver->GetDelegate();
 
     _renderIndex = &_delegate->GetRenderIndex();

--- a/pxr/imaging/hdSt/testenv/testHdStInstancing.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStInstancing.cpp
@@ -34,7 +34,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     bool _useInstancePrimvars;
 
     TfToken _reprName;
@@ -64,7 +64,7 @@ My_TestGLDrawing::My_TestGLDrawing()
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStInstancingUnbalanced.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStInstancingUnbalanced.cpp
@@ -32,7 +32,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -52,7 +52,7 @@ My_TestGLDrawing::My_TestGLDrawing()
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStMultipleFvarTopologies.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStMultipleFvarTopologies.cpp
@@ -37,7 +37,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -52,7 +52,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest() " << _reprName << "\n";
 
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStPrimGather.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStPrimGather.cpp
@@ -108,7 +108,7 @@ private:
     void AddPrim(size_t col, size_t row);
     void UpdateCollection();
 
-    HdSt_TestDriver *_driver;
+    HdSt_TestDriverUniquePtr _driver;
     HdUnitTestDelegate *_sceneDelegates[NUM_NESTED_DELEAGATES];
     HdRprimCollection     _collection;
     HdRenderPassSharedPtr _renderPass;
@@ -149,7 +149,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest()\n";
 
-    _driver = new HdSt_TestDriver(HdReprSelector(HdReprTokens->hull));
+    _driver = std::make_unique<HdSt_TestDriver>(HdReprSelector(HdReprTokens->hull));
 
     // Create delegates
     _sceneDelegates[0] = &_driver->GetDelegate();

--- a/pxr/imaging/hdSt/testenv/testHdStPtex.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStPtex.cpp
@@ -52,7 +52,7 @@ protected:
     void ParseArgs(int argc, char *argv[]) override;
 
 private:
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -68,7 +68,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStQualifiers.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStQualifiers.cpp
@@ -99,7 +99,7 @@ protected:
 
 private:
     bool _testResult;
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
     std::string _outputFilePath;
     std::vector<MemberWithQualifiers> _testMembers;
 };
@@ -107,7 +107,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver();
+    _driver = std::make_unique<HdSt_TestDriver>();
     GfVec3f center(0);
 
     // center camera

--- a/pxr/imaging/hdSt/testenv/testHdStShaders.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStShaders.cpp
@@ -54,7 +54,7 @@ private:
     void toggleUseSceneMaterials();
     void rebindMaterial(SdfPath const &rprimId, SdfPath const &materialId);
 
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     std::vector<HdStLightingShaderSharedPtr> _lightingShaders;
 
@@ -71,7 +71,7 @@ private:
 void
 My_TestGLDrawing::InitTest()
 {
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 

--- a/pxr/imaging/hdSt/testenv/testHdStTransition.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStTransition.cpp
@@ -105,7 +105,7 @@ protected:
 private:
     bool next();
 
-    HdSt_TestDriver* _driver;
+    HdSt_TestDriverUniquePtr _driver;
 
     TfToken _reprName;
     int _refineLevel;
@@ -121,7 +121,7 @@ My_TestGLDrawing::InitTest()
 {
     std::cout << "My_TestGLDrawing::InitTest()\n";
 
-    _driver = new HdSt_TestDriver(_reprName);
+    _driver = std::make_unique<HdSt_TestDriver>(_reprName);
     HdUnitTestDelegate &delegate = _driver->GetDelegate();
     delegate.SetRefineLevel(_refineLevel);
 
@@ -186,7 +186,7 @@ My_TestGLDrawing::next()
     g_time += 1.0f;
 
     while (_nextCommand < _commands.size()) {
-        if (_commands[_nextCommand++]->Run(_driver)) return true;
+        if (_commands[_nextCommand++]->Run(_driver.get())) return true;
     }
     return false;
 }

--- a/pxr/imaging/hdSt/unitTestHelper.h
+++ b/pxr/imaging/hdSt/unitTestHelper.h
@@ -555,6 +555,8 @@ private:
     void _CreateRenderPassState();
 };
 
+using HdSt_TestDriverUniquePtr = std::unique_ptr<HdSt_TestDriver>;
+
 // --------------------------------------------------------------------------
 
 /// \class HdSt_TestLightingShader


### PR DESCRIPTION
### Description of Change(s)

This went undetected by the validation layer because the tests were also leaking the Vulkan instance and device, so they were never destroyed, and the validation check never kicked in. So fix the leaking tests too.

This also fixes an occasional crash from a driver trying to use a resource after the tests had exited main(), because the HgiVulkan leak also meant no synchronization.

Added some more buffer naming to help debug the leak and included it in the PR as it's useful for debugging.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
