### PR TITLE
[docs] update VERSIONS.md to note that OpenUSD requires Jinja2 >= 3.0

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -31,7 +31,7 @@ Our test machines have the following software versions installed.
 | Alembic       | 1.8.5                | 1.8.5                        | 1.8.5                          |
 | OpenEXR       | 3.1.11               | 3.1.11                       | 3.1.11                         |
 | MaterialX     | 1.38.10              | 1.38.10                      | 1.38.10                        |
-| Jinja2        | 2.0                  |                              |                                |
+| Jinja2        | >=3.0                |                              |                                |
 | Flex          | 2.5.39               |                              |                                |
 | Bison         | 2.4.1                |                              |                                |
 | Doxygen       | 1.9.6                |                              |                                |


### PR DESCRIPTION
### Description of Change(s)

OpenUSD makes use of `jinja2.pass_context`:

- https://github.com/PixarAnimationStudios/OpenUSD/blob/v24.08/pxr/imaging/hd/hdGenSchema.py#L9
- https://github.com/PixarAnimationStudios/OpenUSD/blob/v24.08/third_party/renderman-25/plugin/hdPrman/rileyGenPrim.py#L10
- https://github.com/PixarAnimationStudios/OpenUSD/blob/v24.08/third_party/renderman-26/plugin/hdPrman/rileyGenPrim.py#L10

... which did not exist before 3.0
(was previously named `contextfunction`):

- https://github.com/pallets/jinja/commit/788d8bc1728490196f75ba4f8b7b1794a1974f0a

### Fixes Issue(s)
- Incompatible jinja2 version listed in VERSIONS.md

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
