### PR TITLE
Apple: Correct re-declaration of structs as classes

### DIFF
--- a/pxr/imaging/hd/sortedIds.h
+++ b/pxr/imaging/hd/sortedIds.h
@@ -72,7 +72,7 @@ public:
     void Clear();
 
 private:
-    class _UpdateImpl;
+    struct _UpdateImpl;
 
     enum _EditMode { _NoMode, _InsertMode, _RemoveMode, _UpdateMode };
     

--- a/pxr/usd/usd/prim.h
+++ b/pxr/usd/usd/prim.h
@@ -2196,10 +2196,10 @@ private:
     friend class UsdSchemaBase;
     friend class UsdAPISchemaBase;
     friend class UsdStage;
-    friend class Usd_StageImplAccess;
     friend class UsdPrimRange;
     friend class Usd_PrimData;
     friend class Usd_PrimFlagsPredicate;
+    friend struct Usd_StageImplAccess;
     friend struct UsdPrim_RelTargetFinder;
     friend struct UsdPrim_AttrConnectionFinder;
 


### PR DESCRIPTION
### Description of Change(s)
This change fixes two areas where something was defined a structure, but was referenced as a class elsewhere. While this is harmless, it does cause some spurious compile time warnings.

I'm trying to reduce the number of warnings I get when building USD (which is a lot) to make it less noisy when developing on the USD codebase. So I'll put up PRs as I have downtime.

This is low priority and low/no impact to the codebase, but the reduced compile time noise is a win.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
