### PR TITLE
Corrected typos in docstrings of wrapRelationshipSpec and wrapAttributeSpec.

### DIFF
--- a/pxr/usd/sdf/wrapAttributeSpec.cpp
+++ b/pxr/usd/sdf/wrapAttributeSpec.cpp
@@ -123,7 +123,7 @@ void wrapAttributeSpec()
         .def("__unused__",
             SdfMakePySpecConstructor(wrapNewPrimAttr,
                 "__init__(ownerPrimSpec, name, typeName, "
-                "variability = Sd.VariabilityVarying, "
+                "variability = Sdf.VariabilityVarying, "
                 "declaresCustom = False)\n"
                 "ownerPrimSpec : PrimSpec\n"
                 "name : string\n"

--- a/pxr/usd/sdf/wrapRelationshipSpec.cpp
+++ b/pxr/usd/sdf/wrapRelationshipSpec.cpp
@@ -32,11 +32,11 @@ void wrapRelationshipSpec()
         .def("__unused__", 
             SdfMakePySpecConstructor(&This::New,
                 "__init__(ownerPrimSpec, name, custom = True, variability = "
-                "Sd.VariabilityUniform)\n"
+                "Sdf.VariabilityUniform)\n"
                 "ownerPrimSpec: PrimSpec\n"
                 "name : string\n"
                 "custom : bool\n"
-                "varibility : Sd.Variability\n"),
+                "variability : Sdf.Variability\n"),
                 (arg("ownerPrimSpec"),
                  arg("name"),
                  arg("custom") = true,


### PR DESCRIPTION
### Description of Change(s)
Corrected a few typos in the docstrings of the AttributeSpec and RelationshipSpec python wrappers.

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3034

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
