### PR TITLE
Open usdview without specifying a file

### DIFF
--- a/pxr/usdImaging/usdviewq/__init__.py
+++ b/pxr/usdImaging/usdviewq/__init__.py
@@ -111,8 +111,9 @@ class Launcher(object):
         register positional arguments on the ArgParser
         '''
         parser.add_argument('usdFile', action='store',
+                            nargs='?',
                             type=str,
-                            help='The file to view')
+                            help='The file to view (Optional)')
 
     def RegisterOptions(self, parser):
         '''
@@ -372,10 +373,15 @@ class Launcher(object):
         context is provided.  For usdview, configuring an asset context by
         default is reasonable, and allows clients that embed usdview to 
         achieve different behavior when needed.
+        
+        If usdFile path is not provided, it returns default context.
         """
         from pxr import Ar
         
         r = Ar.GetResolver()
+        
+        if not usdFile:
+            return r.CreateDefaultContext()
 
         # ConfigureResolverForAsset no longer exists under Ar 2.0; this
         # is here for backwards compatibility with Ar 1.0.

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -403,7 +403,7 @@ class AppController(QtCore.QObject):
             self._ui = Ui_MainWindow()
             self._ui.setupUi(self._mainWindow)
 
-            self._mainWindow.setWindowTitle(parserData.usdFile)
+            self._mainWindow.setWindowTitle(parserData.usdFile or "Empty Stage")
             self._statusBar = QtWidgets.QStatusBar(self._mainWindow)
             self._mainWindow.setStatusBar(self._statusBar)
 
@@ -1203,7 +1203,16 @@ class AppController(QtCore.QObject):
             # layers populated after loading
             _MuteMatchingLayers()
             
-    def _openStage(self, usdFilePath, sessionFilePath,
+    def _getEmptyStage(self):
+
+        with self._makeTimer('create empty stage'):
+            stage = Usd.Stage.CreateInMemory()
+
+        if not stage:
+            sys.stderr.write('Error: Unable to create empty stage\n')
+        return stage
+            
+    def _getStageForFile(self, usdFilePath, sessionFilePath,
                    populationMaskPaths, muteLayersRe):
 
         def _GetFormattedError(reasons=None):
@@ -1274,6 +1283,25 @@ class AppController(QtCore.QObject):
         if not stage:
             sys.stderr.write(_GetFormattedError())
         else:
+            stage.SetEditTarget(stage.GetSessionLayer())
+
+        if self._mallocTags == 'stage':
+            DumpMallocTags(stage, "stage-loading")
+
+        return stage
+
+    def _openStage(self, usdFilePath, sessionFilePath,
+                   populationMaskPaths, muteLayersRe):
+
+        if self._mallocTags != 'none':
+            Tf.MallocTag.Initialize()
+
+        if not usdFilePath:
+            stage = self._getEmptyStage()
+        
+        else:
+            stage = self._getStageForFile(usdFilePath, sessionFilePath,
+                                          populationMaskPaths, muteLayersRe)
             stage.SetEditTarget(stage.GetSessionLayer())
 
         if self._mallocTags == 'stage':
@@ -2795,6 +2823,12 @@ class AppController(QtCore.QObject):
 
         # Start timer to measure Qt shutdown time
         self._startQtShutdownTimer()
+        
+    
+    def _getRecommendedFilenamePrefix(self):
+        return (self._parserData.usdFile.rsplit('.', 1)[0]
+                if self._parserData.usdFile
+                else 'new_file')
 
     def _openFile(self):
         extensions = Sdf.FileFormat.FindAllFileFormatExtensions()
@@ -2836,14 +2870,13 @@ class AppController(QtCore.QObject):
         return saveName
 
     def _saveOverridesAs(self):
-        recommendedFilename = self._parserData.usdFile.rsplit('.', 1)[0]
-        recommendedFilename += '_overrides.usd'
+        recommendedFilename = self._getRecommendedFilenamePrefix() + '_overrides.usd'
 
         saveName = self._getSaveFileName(
             'Save Overrides As', recommendedFilename)
         if len(saveName) == 0:
             return
-        elif (os.path.isfile(saveName) and
+        elif (os.path.isfile(saveName) and self._parserData.usdFile and
             os.path.samefile(saveName, self._parserData.usdFile)):
             msg = QtWidgets.QMessageBox()
             msg.setIcon(QtWidgets.QMessageBox.Critical)
@@ -2857,13 +2890,13 @@ class AppController(QtCore.QObject):
             return
 
         with BusyContext():
-            # In the future, we may allow usdview to be brought up with no file,
-            # in which case it would create an in-memory root layer, to which
-            # all edits will be targeted.  In order to future proof
-            # this, first fetch the root layer, and if it is anonymous, just
-            # export it to the given filename. If it isn't anonmyous (i.e., it
-            # is a regular usd file on disk), export the session layer and add
-            # the stage root file as a sublayer.
+            # usdview can be brought up with no file, in which case it
+            # creates an in-memory root layer, to which all edits are 
+            # targeted. This first fetches the root layer, and if it is 
+            # anonymous, just exports it to the given filename. If it 
+            # isn't anonymous (i.e., it is a regular usd file on disk), 
+            # exports the session layer and add the stage root file 
+            # as a sublayer.
             rootLayer = self._dataModel.stage.GetRootLayer()
             if not rootLayer.anonymous:
                 self._dataModel.stage.GetSessionLayer().Export(
@@ -2889,8 +2922,7 @@ class AppController(QtCore.QObject):
                     saveName, 'Created by UsdView')
 
     def _saveFlattenedAs(self):
-        recommendedFilename = self._parserData.usdFile.rsplit('.', 1)[0]
-        recommendedFilename += '_flattened.usd'
+        recommendedFilename = self._getRecommendedFilenamePrefix() + '_flattened.usd'
 
         saveName = self._getSaveFileName(
             'Save Flattened As', recommendedFilename)
@@ -2905,7 +2937,7 @@ class AppController(QtCore.QObject):
 
     def _saveViewerImage(self):
         recommendedFilename = "{}_{}{:04d}.png".format(
-            self._parserData.usdFile.rsplit('.', 1)[0],
+            self._getRecommendedFilenamePrefix(),
             "" if not self.getActiveCamera()
                 else self.getActiveCamera().GetName() + "_",
             int(self._dataModel.currentFrame.GetValue()))


### PR DESCRIPTION
Running `usdview` without `usdFile` positional argument will now open an empty stage. If `usdFile` is passed, then there will be no behavior change.   

### Description of Change(s)
- Made `usdFile` positional argement Optional
- Updated the `GetResolverContext` method to return a default context when `usdFile` is not passed.
- Updated the `appController` `_openStage` method to create an empty stage when `usdFilePath` is a falsy value.
- Updated the `_saveFlattendedAs`, `_saveOverridesAs` and `_saveViewerImage` methods to use "new_scene" prefix for recommended file name when `usdFile` is a falsy value.

**Note:** Prior to this change, running `usdview` without `usdFile` argument would print `error: the following arguments are required: usdFile`.

### Fixes Issue(s)
#3093

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement