### PR TITLE
Autodesk: Added TF_VERIFY_VK_RESULT for Vulkan

### DIFF
--- a/pxr/imaging/hgiVulkan/buffer.cpp
+++ b/pxr/imaging/hgiVulkan/buffer.cpp
@@ -40,7 +40,7 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     VkBufferCreateInfo bi = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
     bi.size = desc.byteSize;
     bi.usage = HgiVulkanConversions::GetBufferUsage(desc.usage);
-    bi.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT | 
+    bi.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
                 VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE; // gfx queue only
 
@@ -52,9 +52,7 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     VmaAllocationCreateInfo ai = {};
     ai.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT; // GPU efficient
 
-    TF_VERIFY(
-        vmaCreateBuffer(vma,&bi,&ai,&_vkBuffer,&_vmaAllocation,0) == VK_SUCCESS
-    );
+    TF_VERIFY_VK_RESULT(vmaCreateBuffer(vma,&bi,&ai,&_vkBuffer,&_vmaAllocation,0));
 
     // Debug label
     if (!_descriptor.debugName.empty()) {
@@ -150,11 +148,11 @@ HgiVulkanBuffer::GetCPUStagingAddress()
     }
 
     if (!_cpuStagingAddress) {
-        TF_VERIFY(
+        TF_VERIFY_VK_RESULT(
             vmaMapMemory(
-                _device->GetVulkanMemoryAllocator(), 
-                _stagingBuffer->GetVulkanMemoryAllocation(), 
-                &_cpuStagingAddress) == VK_SUCCESS
+                _device->GetVulkanMemoryAllocator(),
+                _stagingBuffer->GetVulkanMemoryAllocation(),
+                &_cpuStagingAddress)
         );
     }
 
@@ -210,7 +208,7 @@ HgiVulkanBuffer::CreateStagingBuffer(
     VkBufferCreateInfo bi = {VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
     bi.size = desc.byteSize;
     bi.usage = HgiVulkanConversions::GetBufferUsage(desc.usage);
-    bi.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT | 
+    bi.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
                 VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE; // gfx queue only
 
@@ -221,14 +219,12 @@ HgiVulkanBuffer::CreateStagingBuffer(
 
     VkBuffer buffer = 0;
     VmaAllocation alloc = 0;
-    TF_VERIFY(
-        vmaCreateBuffer(vma, &bi, &ai, &buffer, &alloc, 0) == VK_SUCCESS
-    );
+    TF_VERIFY_VK_RESULT(vmaCreateBuffer(vma, &bi, &ai, &buffer, &alloc, 0));
 
     // Map the (HOST_VISIBLE) buffer and upload data
     if (desc.initialData) {
         void* map;
-        TF_VERIFY(vmaMapMemory(vma, alloc, &map) == VK_SUCCESS);
+        TF_VERIFY_VK_RESULT(vmaMapMemory(vma, alloc, &map));
         memcpy(map, desc.initialData, desc.byteSize);
         vmaUnmapMemory(vma, alloc);
     }

--- a/pxr/imaging/hgiVulkan/computePipeline.cpp
+++ b/pxr/imaging/hgiVulkan/computePipeline.cpp
@@ -72,12 +72,12 @@ HgiVulkanComputePipeline::HgiVulkanComputePipeline(
     pipeLayCreateInfo.setLayoutCount = (uint32_t)_vkDescriptorSetLayouts.size();
     pipeLayCreateInfo.pSetLayouts = _vkDescriptorSetLayouts.data();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreatePipelineLayout(
             _device->GetVulkanDevice(),
             &pipeLayCreateInfo,
             HgiVulkanAllocator(),
-            &_vkPipelineLayout) == VK_SUCCESS
+            &_vkPipelineLayout)
     );
 
     // Debug label
@@ -97,14 +97,14 @@ HgiVulkanComputePipeline::HgiVulkanComputePipeline(
     //
     HgiVulkanPipelineCache* pCache = device->GetPipelineCache();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateComputePipelines(
             _device->GetVulkanDevice(),
             pCache->GetVulkanPipelineCache(),
             1,
             &pipeCreateInfo,
             HgiVulkanAllocator(),
-            &_vkPipeline) == VK_SUCCESS
+            &_vkPipeline)
     );
 
     // Debug label

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -77,11 +77,11 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     const uint32_t maxDevices = 64;
     VkPhysicalDevice physicalDevices[maxDevices];
     uint32_t physicalDeviceCount = maxDevices;
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkEnumeratePhysicalDevices(
             instance->GetVulkanInstance(),
             &physicalDeviceCount,
-            physicalDevices) == VK_SUCCESS
+            physicalDevices)
     );
 
     for (uint32_t i = 0; i < physicalDeviceCount; i++) {
@@ -123,22 +123,22 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     //
 
     uint32_t extensionCount = 0;
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkEnumerateDeviceExtensionProperties(
             _vkPhysicalDevice,
             nullptr,
             &extensionCount,
-            nullptr) == VK_SUCCESS
+            nullptr)
     );
 
     _vkExtensions.resize(extensionCount);
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkEnumerateDeviceExtensionProperties(
             _vkPhysicalDevice,
             nullptr,
             &extensionCount,
-            _vkExtensions.data()) == VK_SUCCESS
+            _vkExtensions.data())
     );
 
     //
@@ -282,12 +282,8 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     createInfo.enabledExtensionCount = (uint32_t) extensions.size();
     createInfo.pNext = &features;
 
-    TF_VERIFY(
-        vkCreateDevice(
-            _vkPhysicalDevice,
-            &createInfo,
-            HgiVulkanAllocator(),
-            &_vkDevice) == VK_SUCCESS
+    TF_VERIFY_VK_RESULT(
+        vkCreateDevice(_vkPhysicalDevice, &createInfo, HgiVulkanAllocator(), &_vkDevice)
     );
 
     HgiVulkanSetupDeviceDebug(instance, this);
@@ -315,9 +311,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
     }
 
-    TF_VERIFY(
-        vmaCreateAllocator(&allocatorInfo, &_vmaAllocator) == VK_SUCCESS
-    );
+    TF_VERIFY_VK_RESULT(vmaCreateAllocator(&allocatorInfo, &_vmaAllocator));
 
     //
     // Command Queue
@@ -335,7 +329,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
 HgiVulkanDevice::~HgiVulkanDevice()
 {
     // Make sure device is idle before destroying objects.
-    TF_VERIFY(vkDeviceWaitIdle(_vkDevice) == VK_SUCCESS);
+    TF_VERIFY_VK_RESULT(vkDeviceWaitIdle(_vkDevice));
 
     delete _pipelineCache;
     delete _commandQueue;
@@ -389,9 +383,7 @@ HgiVulkanDevice::GetPipelineCache() const
 void
 HgiVulkanDevice::WaitForIdle()
 {
-    TF_VERIFY(
-        vkDeviceWaitIdle(_vkDevice) == VK_SUCCESS
-    );
+    TF_VERIFY_VK_RESULT(vkDeviceWaitIdle(_vkDevice));
 }
 
 bool

--- a/pxr/imaging/hgiVulkan/diagnostic.cpp
+++ b/pxr/imaging/hgiVulkan/diagnostic.cpp
@@ -14,6 +14,8 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/envSetting.h"
 
+#include <vulkan/vk_enum_string_helper.h>
+
 #include <cstring>
 
 
@@ -21,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 TF_DEFINE_ENV_SETTING(HGIVULKAN_DEBUG, 0, "Enable debugging for HgiVulkan");
-TF_DEFINE_ENV_SETTING(HGIVULKAN_DEBUG_VERBOSE, 0, 
+TF_DEFINE_ENV_SETTING(HGIVULKAN_DEBUG_VERBOSE, 0,
     "Enable verbose debugging for HgiVulkan");
 
 bool
@@ -108,12 +110,12 @@ HgiVulkanCreateDebug(HgiVulkanInstance* instance)
     dbgMsgCreateInfo.pfnUserCallback = _VulkanDebugCallback;
     dbgMsgCreateInfo.pUserData = nullptr;
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         instance->vkCreateDebugUtilsMessengerEXT(
             vkInstance,
             &dbgMsgCreateInfo,
             HgiVulkanAllocator(),
-            &instance->vkDebugMessenger) == VK_SUCCESS
+            &instance->vkDebugMessenger)
     );
 }
 
@@ -248,6 +250,20 @@ HgiVulkanEndQueueLabel(HgiVulkanDevice* device)
 
     VkQueue gfxQueue = device->GetCommandQueue()->GetVulkanGraphicsQueue();
     device->vkQueueEndDebugUtilsLabelEXT(gfxQueue);
+}
+
+const char*
+HgiVulkanResultString(VkResult result)
+{
+    return string_VkResult(result);
+}
+
+const char*
+HgiVulkanCommandResultString(const char* cmd, VkResult result)
+{
+    static thread_local std::string buffer;
+    buffer = std::string(cmd) + ": " + string_VkResult(result);
+    return buffer.c_str();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/diagnostic.h
+++ b/pxr/imaging/hgiVulkan/diagnostic.h
@@ -66,6 +66,24 @@ void HgiVulkanBeginQueueLabel(
 HGIVULKAN_API
 void HgiVulkanEndQueueLabel(HgiVulkanDevice* device);
 
+/// Returns a string representation of VkResult
+HGIVULKAN_API
+const char* HgiVulkanResultString(VkResult result);
+
+/// Returns a string representation of the vulkan command and its result
+HGIVULKAN_API
+const char* HgiVulkanCommandResultString(const char* cmd, VkResult result);
+
+#define TF_VERIFY_VK_RESULT(cmd)                                        \
+  do {                                                                  \
+    const auto result = cmd;                                            \
+    if (ARCH_UNLIKELY(result != VK_SUCCESS)) {                          \
+      Tf_PostErrorHelper(TF_CALL_CONTEXT,                               \
+        TF_DIAGNOSTIC_CODING_ERROR_TYPE,                                \
+        std::string{HgiVulkanCommandResultString(#cmd, result)});       \
+    }                                                                   \
+  } while(0)
+
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif

--- a/pxr/imaging/hgiVulkan/graphicsPipeline.cpp
+++ b/pxr/imaging/hgiVulkan/graphicsPipeline.cpp
@@ -330,12 +330,12 @@ HgiVulkanGraphicsPipeline::HgiVulkanGraphicsPipeline(
     pipeLayCreateInfo.setLayoutCount= (uint32_t) _vkDescriptorSetLayouts.size();
     pipeLayCreateInfo.pSetLayouts = _vkDescriptorSetLayouts.data();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreatePipelineLayout(
             _device->GetVulkanDevice(),
             &pipeLayCreateInfo,
             HgiVulkanAllocator(),
-            &_vkPipelineLayout) == VK_SUCCESS
+            &_vkPipelineLayout)
     );
 
     // Debug label
@@ -362,14 +362,14 @@ HgiVulkanGraphicsPipeline::HgiVulkanGraphicsPipeline(
     //
     HgiVulkanPipelineCache* pCache = device->GetPipelineCache();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateGraphicsPipelines(
             _device->GetVulkanDevice(),
             pCache->GetVulkanPipelineCache(),
             1,
             &pipeCreateInfo,
             HgiVulkanAllocator(),
-            &_vkPipeline) == VK_SUCCESS
+            &_vkPipeline)
     );
 
     // Debug label
@@ -503,12 +503,12 @@ HgiVulkanGraphicsPipeline::AcquireVulkanFramebuffer(
     fbCreateInfo.height = framebuffer.dimensions[1];
     fbCreateInfo.layers = 1;
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateFramebuffer(
             _device->GetVulkanDevice(),
             &fbCreateInfo,
             HgiVulkanAllocator(),
-            &framebuffer.vkFramebuffer) == VK_SUCCESS
+            &framebuffer.vkFramebuffer)
     );
 
     // Debug label
@@ -766,12 +766,12 @@ HgiVulkanGraphicsPipeline::_CreateRenderPass()
     vkCreateRenderPass2KHR = (PFN_vkCreateRenderPass2KHR) vkGetDeviceProcAddr(
         _device->GetVulkanDevice(), "vkCreateRenderPass2KHR");
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateRenderPass2KHR(
             _device->GetVulkanDevice(),
             &renderPassInfo,
             HgiVulkanAllocator(),
-            &_vkRenderPass) == VK_SUCCESS
+            &_vkRenderPass)
     );
 
     // Debug label

--- a/pxr/imaging/hgiVulkan/instance.cpp
+++ b/pxr/imaging/hgiVulkan/instance.cpp
@@ -19,20 +19,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 static
 bool
 _CheckInstanceValidationLayerSupport(const char * layerName)
-{  
-    uint32_t layerCount;  
-    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);  
+{
+    uint32_t layerCount;
+    vkEnumerateInstanceLayerProperties(&layerCount, nullptr);
     std::vector<VkLayerProperties> availableLayers(layerCount);
-  
+
     vkEnumerateInstanceLayerProperties(&layerCount, availableLayers.data());
 
-    for (const auto& layerProperties : availableLayers) {  
-        if (strcmp(layerName, layerProperties.layerName) == 0) {  
+    for (const auto& layerProperties : availableLayers) {
+        if (strcmp(layerName, layerProperties.layerName) == 0) {
             return true;
-        }  
-    }  
+        }
+    }
 
-    return false;  
+    return false;
 }
 
 static
@@ -133,12 +133,7 @@ HgiVulkanInstance::HgiVulkanInstance()
         }
     #endif
 
-    TF_VERIFY(
-        vkCreateInstance(
-            &createInfo,
-            HgiVulkanAllocator(),
-            &_vkInstance) == VK_SUCCESS
-    );
+    TF_VERIFY_VK_RESULT(vkCreateInstance(&createInfo, HgiVulkanAllocator(), &_vkInstance));
 
     HgiVulkanCreateDebug(this);
 }

--- a/pxr/imaging/hgiVulkan/resourceBindings.cpp
+++ b/pxr/imaging/hgiVulkan/resourceBindings.cpp
@@ -35,12 +35,12 @@ _CreateDescriptorSetLayout(
     setCreateInfo.pNext = nullptr;
 
     VkDescriptorSetLayout layout = nullptr;
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateDescriptorSetLayout(
             device->GetVulkanDevice(),
             &setCreateInfo,
             HgiVulkanAllocator(),
-            &layout) == VK_SUCCESS
+            &layout)
     );
 
     // Debug label
@@ -170,12 +170,12 @@ HgiVulkanResourceBindings::HgiVulkanResourceBindings(
     pool_info.poolSizeCount = (uint32_t) poolSizes.size();
     pool_info.pPoolSizes = poolSizes.data();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateDescriptorPool(
             _device->GetVulkanDevice(),
             &pool_info,
             HgiVulkanAllocator(),
-            &_vkDescriptorPool) == VK_SUCCESS
+            &_vkDescriptorPool)
     );
 
     // Debug label
@@ -198,11 +198,11 @@ HgiVulkanResourceBindings::HgiVulkanResourceBindings(
     allocateInfo.descriptorSetCount = _descriptorSetCnt;
     allocateInfo.pSetLayouts = &_vkDescriptorSetLayout;
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkAllocateDescriptorSets(
             _device->GetVulkanDevice(),
             &allocateInfo,
-            &_vkDescriptorSet) == VK_SUCCESS
+            &_vkDescriptorSet)
     );
 
     // Debug label

--- a/pxr/imaging/hgiVulkan/sampler.cpp
+++ b/pxr/imaging/hgiVulkan/sampler.cpp
@@ -10,6 +10,7 @@
 #include "pxr/imaging/hgiVulkan/conversions.h"
 #include "pxr/imaging/hgiVulkan/device.h"
 #include "pxr/imaging/hgiVulkan/sampler.h"
+#include "pxr/imaging/hgiVulkan/diagnostic.h"
 
 #include <float.h>
 
@@ -58,12 +59,12 @@ HgiVulkanSampler::HgiVulkanSampler(
                 static_cast<float>(TfGetEnvSetting(HGI_MAX_ANISOTROPY))}) : 1.0f;
     }
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateSampler(
             device->GetVulkanDevice(),
             &sampler,
             HgiVulkanAllocator(),
-            &_vkSampler) == VK_SUCCESS
+            &_vkSampler)
     );
 }
 

--- a/pxr/imaging/hgiVulkan/shaderCompiler.cpp
+++ b/pxr/imaging/hgiVulkan/shaderCompiler.cpp
@@ -102,12 +102,12 @@ _CreateDescriptorSetLayout(
     std::string const& debugName)
 {
     VkDescriptorSetLayout layout = nullptr;
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateDescriptorSetLayout(
             device->GetVulkanDevice(),
             &createInfo,
             HgiVulkanAllocator(),
-            &layout) == VK_SUCCESS
+            &layout)
     );
 
     // Debug label

--- a/pxr/imaging/hgiVulkan/shaderFunction.cpp
+++ b/pxr/imaging/hgiVulkan/shaderFunction.cpp
@@ -57,12 +57,12 @@ HgiVulkanShaderFunction::HgiVulkanShaderFunction(
         shaderCreateInfo.codeSize = _spirvByteSize;
         shaderCreateInfo.pCode = (uint32_t*) spirv.data();
 
-        TF_VERIFY(
+        TF_VERIFY_VK_RESULT(
             vkCreateShaderModule(
                 device->GetVulkanDevice(),
                 &shaderCreateInfo,
                 HgiVulkanAllocator(),
-                &_vkShaderModule) == VK_SUCCESS
+                &_vkShaderModule)
         );
 
         // Debug label

--- a/pxr/imaging/hgiVulkan/texture.cpp
+++ b/pxr/imaging/hgiVulkan/texture.cpp
@@ -107,14 +107,14 @@ HgiVulkanTexture::HgiVulkanTexture(
     // Equivalent to: vkCreateImage, vkAllocateMemory, vkBindImageMemory
     VmaAllocationCreateInfo allocInfo = {};
     allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vmaCreateImage(
             device->GetVulkanMemoryAllocator(),
             &imageCreateInfo,
             &allocInfo,
             &_vkImage,
             &_vmaImageAllocation,
-            nullptr) == VK_SUCCESS
+            nullptr)
     );
 
     TF_VERIFY(_vkImage, "Failed to create image");
@@ -164,12 +164,12 @@ HgiVulkanTexture::HgiVulkanTexture(
     view.subresourceRange.levelCount = desc.mipLevels;
     view.image = _vkImage;
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateImageView(
             device->GetVulkanDevice(),
             &view,
             HgiVulkanAllocator(),
-            &_vkImageView) == VK_SUCCESS
+            &_vkImageView)
     );
 
     // Debug label
@@ -286,12 +286,12 @@ HgiVulkanTexture::HgiVulkanTexture(
     view.subresourceRange.levelCount = desc.mipLevels;
     view.image = srcTexture->GetImage();
 
-    TF_VERIFY(
+    TF_VERIFY_VK_RESULT(
         vkCreateImageView(
             device->GetVulkanDevice(),
             &view,
             HgiVulkanAllocator(),
-            &_vkImageView) == VK_SUCCESS
+            &_vkImageView)
     );
 
     // Debug label
@@ -358,11 +358,11 @@ HgiVulkanTexture::GetCPUStagingAddress()
     }
 
     if (!_cpuStagingAddress) {
-        TF_VERIFY(
+        TF_VERIFY_VK_RESULT(
             vmaMapMemory(
                 _device->GetVulkanMemoryAllocator(), 
                 _stagingBuffer->GetVulkanMemoryAllocation(), 
-                &_cpuStagingAddress) == VK_SUCCESS
+                &_cpuStagingAddress)
         );
     }
 


### PR DESCRIPTION
### Description of Change(s)

Added TF_VERIFY_VK_RESULT to verify the result of the Vulkan call and print the result string if it fails.

### Fixes Issue(s)
- N/A

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
