### PR TITLE
Fixed temporary reference binding in hioOiio loops

### DIFF
--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -805,7 +805,7 @@ HioOIIO_Image::Write(StorageSpec const & storage,
     TypeDesc format = _GetOIIOBaseType(storage.format);
     ImageSpec spec(storage.width, storage.height, nchannels, format);
 
-    for (const std::pair<std::string, VtValue>& m : metadata) {
+    for (const auto& m : metadata) {
         _SetAttribute(&spec, m.first, m.second);
     }
 


### PR DESCRIPTION
### Description of Change(s)
- Fixed an issue in `hioOiio` where temporary references were being bound incorrectly, causing potential errors with Clang. Changed the loop to avoid binding to temporaries by copying the values or using a safer reference type.
### Fixes Issue(s)
- Fixes issue #3340: Temporary reference binding issue in `hioOiio` loops.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
