### PR TITLE
Use Render Delegate's material binding pupose

### DIFF
--- a/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
+++ b/pxr/imaging/hd/sceneIndexAdapterSceneDelegate.cpp
@@ -843,7 +843,8 @@ HdSceneIndexAdapterSceneDelegate::GetBasisCurvesTopology(SdfPath const &id)
         curveVertexCountsDataSource->GetTypedValue(0.0f),
         curveIndices);
 
-    _GatherGeomSubsets(id, _inputSceneIndex, &result);
+    TfToken materialBindingPurpose = GetRenderIndex().GetRenderDelegate()->GetMaterialBindingPurpose();
+    _GatherGeomSubsets(id, _inputSceneIndex, &result, materialBindingPurpose);
 
     return result;
 }


### PR DESCRIPTION
### Description of Change(s)
Changing the SceneIndexAdapterSceneDelegate to query the render delegate's material binding purpose so that the correct material binding is retrieved. This (largely) addresses a regression mentioned below, though there could still be issues with hdPrman and/or Storm which still exercise the old code path.

### Fixes Issue(s)
- Largely fixes #3320 

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
