### PR TITLE
Move all the Windows dll path logic into the WindowsImportWrapper

### DIFF
--- a/build_scripts/pypi/package_files/setup.py
+++ b/build_scripts/pypi/package_files/setup.py
@@ -59,28 +59,6 @@ if windows():
     for f in dll_files:
         shutil.move(f, os.path.join(BUILD_DIR, "lib/python/pxr"))
 
-    # Because there are no RPATHS, patch __init__.py
-    # See this thread and related conversations
-    # https://mail.python.org/pipermail/distutils-sig/2014-September/024962.html
-    with open(os.path.join(BUILD_DIR, 'lib/python/pxr/__init__.py'), 'a+') as init_file:
-        init_file.write('''
-
-# appended to this file for the windows PyPI package
-import os, sys
-dllPath = os.path.split(os.path.realpath(__file__))[0]
-if sys.version_info >= (3, 8, 0):
-    os.environ['PXR_USD_WINDOWS_DLL_PATH'] = dllPath
-# Note that we ALWAYS modify the PATH, even for python-3.8+. This is because:
-#    - Anaconda python interpreters are modified to use the old, pre-3.8, PATH-
-#      based method of loading dlls
-#    - extra calls to os.add_dll_directory won't hurt these anaconda
-#      interpreters
-#    - similarly, adding the extra PATH entry shouldn't hurt standard python
-#      interpreters
-#    - there's no canonical/bulletproof way to check for an anaconda interpreter
-os.environ['PATH'] = dllPath + os.pathsep + os.environ['PATH']
-''')
-
 # Get the readme text
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/pxr/base/tf/__init__.py
+++ b/pxr/base/tf/__init__.py
@@ -75,7 +75,7 @@ if platform.system() == "Windows":
                 dll_dir.close()
 
             if _WINDOWS_IMPORT_WRAPPER_DEPTH == 0 and path_updated:
-                os.environ['PATH'] = os.environ['PATH'][:len(import_paths) + 1]
+                os.environ['PATH'] = os.environ['PATH'][len(import_paths) + 1:]
 
         del os, sys
     del contextlib


### PR DESCRIPTION
### Description of Change(s)
There's already a python context in `pxr/tf/__init__.py` that handles adding and removing dll paths for windows, so I moved the Windows specific import path logic out of the `pxr/__init__.py` to there.  This way, we don't have to permanently change the `PATH`

I couldn't get the tests to pass locally from the dev build, even *without* my changes.
And I couldn't get the release branch to build because boost breaks.
Any suggestions how to deal with this?

However, I was able to test that my changes load the correct DLL's on python 3.7, python 3.11, and anaconda 3.12 both with and without the `PXR_USD_WINDOWS_DLL_PATH` variable set. (I just copied my changes directly into different pip installs)

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3114

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
