### PR TITLE
Compiler Warnings: Overrides a member function but is not marked override

### DIFF
--- a/pxr/usd/usdUtils/assetLocalizationDelegate.h
+++ b/pxr/usd/usdUtils/assetLocalizationDelegate.h
@@ -273,7 +273,7 @@ public:
 
     virtual std::vector<std::string> ProcessPayloads(
         const SdfLayerRefPtr &layer,
-        const SdfPrimSpecHandle &primSpec);
+        const SdfPrimSpecHandle &primSpec) override;
 
     virtual std::vector<std::string> ProcessReferences(
         const SdfLayerRefPtr &layer,

--- a/pxr/usdImaging/usdImaging/cylinderLightAdapter.h
+++ b/pxr/usdImaging/usdImaging/cylinderLightAdapter.h
@@ -49,10 +49,10 @@ public:
     USDIMAGING_API
     virtual SdfPath Populate(UsdPrim const& prim,
                      UsdImagingIndexProxy* index,
-                     UsdImagingInstancerContext const* instancerContext = NULL);
+                     UsdImagingInstancerContext const* instancerContext = NULL) override;
 
     USDIMAGING_API
-    virtual bool IsSupported(UsdImagingIndexProxy const* index) const;
+    virtual bool IsSupported(UsdImagingIndexProxy const* index) const override;
     
 protected:
     virtual void _RemovePrim(SdfPath const& cachePath,

--- a/pxr/usdImaging/usdImaging/portalLightAdapter.h
+++ b/pxr/usdImaging/usdImaging/portalLightAdapter.h
@@ -36,10 +36,10 @@ public:
     USDIMAGING_API
     virtual SdfPath Populate(UsdPrim const& prim,
                      UsdImagingIndexProxy* index,
-                     UsdImagingInstancerContext const* instancerContext = NULL);
+                     UsdImagingInstancerContext const* instancerContext = NULL) override;
 
     USDIMAGING_API
-    virtual bool IsSupported(UsdImagingIndexProxy const* index) const;
+    virtual bool IsSupported(UsdImagingIndexProxy const* index) const override;
 
     // ---------------------------------------------------------------------- //
     /// \name Scene Index Support

--- a/pxr/usdImaging/usdImaging/tetMeshAdapter.h
+++ b/pxr/usdImaging/usdImaging/tetMeshAdapter.h
@@ -81,7 +81,7 @@ public:
                                   SdfPath const& cachePath,
                                   HdDirtyBits* timeVaryingBits,
                                   UsdImagingInstancerContext const* 
-                                      instancerContext = nullptr) const;
+                                      instancerContext = nullptr) const override;
 
     // ---------------------------------------------------------------------- //
     /// \name Change Processing


### PR DESCRIPTION
### Description of Change(s)

Add missing `override` declarations to member methods which override virtual methods of their base classes.

### Fixes Issue(s)
- #3335

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
