### PR TITLE
Compiler Warnings: Static Functions that should be Static Inline

### DIFF
--- a/pxr/base/vt/wrapArray.h
+++ b/pxr/base/vt/wrapArray.h
@@ -303,7 +303,7 @@ static void streamValue(std::ostringstream &stream, T const &value) {
     }
 }
 
-static unsigned int
+static inline unsigned int
 Vt_ComputeEffectiveRankAndLastDimSize(
     Vt_ShapeData const *sd, size_t *lastDimSize)
 {

--- a/pxr/imaging/hdSt/unitTestHelper.h
+++ b/pxr/imaging/hdSt/unitTestHelper.h
@@ -210,7 +210,7 @@ HdSt_TestDriverBase<SceneDelegate>::_Init(HdReprSelector const &reprSelector)
     tracker.AddCollection(_collection.GetName());
 }
 
-static
+static inline
 HdCamera::Projection
 _ToHd(const GfCamera::Projection projection)
 {


### PR DESCRIPTION
### Description of Change(s)

Add `inline` to the static methods the clang compiler thinks should be declared as `static inline`.

### Fixes Issue(s)
- #3324

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
