### PR TITLE
Improve `ArchGetFileName` for windows to return full path

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -532,24 +532,34 @@ ArchGetFileName(FILE *file)
     }
     return result;
 #elif defined (ARCH_OS_WINDOWS)
-    static constexpr DWORD bufSize =
-        sizeof(FILE_NAME_INFO) + sizeof(WCHAR) * 4096;
-    HANDLE hfile = _FileToWinHANDLE(file);
-    auto fileNameInfo = reinterpret_cast<PFILE_NAME_INFO>(malloc(bufSize));
     string result;
-    if (GetFileInformationByHandleEx(
-            hfile, FileNameInfo, static_cast<void *>(fileNameInfo), bufSize)) {
+    WCHAR filePath[MAX_PATH];
+    HANDLE hfile = _FileToWinHANDLE(file);
+    if (GetFinalPathNameByHandleW(hfile, filePath, MAX_PATH, VOLUME_NAME_DOS)) {
         size_t outSize = WideCharToMultiByte(
-            CP_UTF8, 0, fileNameInfo->FileName,
-            fileNameInfo->FileNameLength/sizeof(WCHAR),
+            CP_UTF8, 0, filePath,
+            wcslen(filePath),
             NULL, 0, NULL, NULL);
         result.resize(outSize);
         WideCharToMultiByte(
-            CP_UTF8, 0, fileNameInfo->FileName,
-            fileNameInfo->FileNameLength/sizeof(WCHAR),
+            CP_UTF8, 0, filePath,
+            -1,
             &result.front(), outSize, NULL, NULL);
+
+        if (result.length() > 4)
+        {
+            // It needs to strip the path prefix as
+            // the path returned is DOS device path, and the
+            // syntax is one of:
+            //   \\.\C:\Test\Foo.txt
+            //   \\?\C:\Test\Foo.txt
+            if (result.compare(0, 4, "\\\\?\\") == 0 ||
+                result.compare(0, 4, "\\\\.\\") == 0)
+            {
+                result.erase(0, 4);
+            }
+        }
     }
-    free(fileNameInfo);
     return result;                                        
 #else
 #error Unknown system architecture

--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cerrno>
+#include <filesystem>
 #include <memory>
 #include <utility>
 
@@ -555,21 +556,11 @@ ArchGetFileName(FILE *file)
             -1,
             &result.front(), outSize, NULL, NULL);
 
+        // Strip path prefix if necessary.
         // See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
-        // for format of DOS device paths. For UNC paths, it's returned as untouched.
-        if (result.length() > 4 &&
-            result.compare(0, 8, "\\\\?\\UNC\\") != 0)
-        {
-            // Otherwise, strip prefix from paths returned by GetFinalPathNameByHandleW,
-            // which is one of:
-            //   \\.\C:\Test\Foo.txt
-            //   \\?\C:\Test\Foo.txt
-            if (result.compare(0, 4, "\\\\?\\") == 0 ||
-                result.compare(0, 4, "\\\\.\\") == 0)
-            {
-                result.erase(0, 4);
-            }
-        }
+        // for format of DOS device paths.
+        auto canonicalPath = std::filesystem::canonical(result);
+        result = canonicalPath.string();
     }
     return result;                                        
 #else

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -91,6 +92,12 @@ int main()
     fputs(testContent, firstFile);
     fclose(firstFile);
     ARCH_AXIOM(ArchGetFileLength(firstName.c_str()) == strlen(testContent));
+
+    // Open a file, check that the file path from FILE* handle is matched.
+    ARCH_AXIOM((firstFile = ArchOpenFile(firstName.c_str(), "rb")) != NULL);
+    std::string filePath = ArchGetFileName(firstFile);
+    ARCH_AXIOM(std::filesystem::equivalent(filePath, firstName));
+    fclose(firstFile);
 
     // Map the file and assert the bytes are what we expect they are.
     ARCH_AXIOM((firstFile = ArchOpenFile(firstName.c_str(), "rb")) != NULL);


### PR DESCRIPTION
### Description of Change(s)

In a fix to improve Alembic plugin to read assets with ArResolver to support other sources except local files (https://github.com/PixarAnimationStudios/OpenUSD/pull/3302), Alembic library provides 4 APIs: one of them supports to read from local paths and the other 3 are using istream interfaces which has flaws to support layered ABC files. Therefore, we can only use the API that supports to read from local paths. While it involves to get the mirroed local path from ArAsset, and that's `ArchGetFileName` supposed to work for. 

However, `ArchGetFileName` only returns paths without drive letter, which is relative path related to the current drive the application is running from. This PR is to improve `ArchGetFileName` to return full path from `FILE*`. Here is an example before and after this PR:

Assuming the file path behind the FILE* handle is `C:/path/includes/drive/letter.ext`, and the application is running from `D` drive.
// Before --
ArchGetFileName(file_handle) => "/path/includes/drive/letter.ext"
// After --
ArchGetFileName(file_handle) => "C:/path/includes/drive/letter.ext"

The path returned from old API is `/path/includes/drive/letter.ext`, which is corresponding to `D:/path/includes/drive/letter.ext` in full path, which is wrong.

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
