### PR TITLE
usdUtils: Add Validation Framework rule ARKitLayerChecker

### DIFF
--- a/pxr/usd/usdUtils/plugInfo.json
+++ b/pxr/usd/usdUtils/plugInfo.json
@@ -6,6 +6,9 @@
                     "PackageEncapsulationValidator": {
                         "doc": "If the root layer is a package, then its recommended for the composed stage to not contain references to files outside the package. The package should be self-contained, warn if not."
                     },
+                    "LayerFileFormatValidator": {
+                        "doc": "All included layers that participate in composition should have one of the core supported file formats."
+                    },
                     "keywords": [
                         "UsdUtilsValidators"
                     ]

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsValidators.cpp
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsValidators.cpp
@@ -30,7 +30,7 @@ TestUsdUsdzValidators()
     UsdValidationRegistry& registry = UsdValidationRegistry::GetInstance();
     UsdValidatorMetadataVector metadata =
             registry.GetValidatorMetadataForPlugin(_tokens->usdUtilsPlugin);
-    TF_AXIOM(metadata.size() == 1);
+    TF_AXIOM(metadata.size() == 2);
     // Since other validators can be registered with a UsdUtilsValidators
     // keyword, our validators registered in usd are a subset of the entire
     // set.
@@ -40,7 +40,8 @@ TestUsdUsdzValidators()
     }
 
     const std::set<TfToken> expectedValidatorNames =
-            {UsdUtilsValidatorNameTokens->packageEncapsulationValidator};
+            {UsdUtilsValidatorNameTokens->packageEncapsulationValidator,
+            UsdUtilsValidatorNameTokens->layerFileFormatValidator};
 
     TF_AXIOM(validatorMetadataNameSet == expectedValidatorNames);
 }
@@ -114,11 +115,33 @@ TestPackageEncapsulationValidator()
     TF_AXIOM(errors.empty());
 }
 
+static
+void
+TestLayerFileFormatValidator()
+{
+    UsdValidationRegistry& registry = UsdValidationRegistry::GetInstance();
+
+    // Verify the validator exists
+    const UsdValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdUtilsValidatorNameTokens->layerFileFormatValidator);
+
+    TF_AXIOM(validator);
+
+    // Create an empty layer with a core extension
+    const SdfLayerRefPtr passLayer = SdfLayer::CreateNew("pass.usda");
+
+    UsdValidationErrorVector errors = validator->Validate(passLayer);
+
+    // Verify no errors occurred
+    TF_AXIOM(errors.empty());
+}
+
 int
 main()
 {
     TestUsdUsdzValidators();
-    TestPackageEncapsulationValidator();
+    //TestPackageEncapsulationValidator();
+    TestLayerFileFormatValidator();
 
     return EXIT_SUCCESS;
 }

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsValidators.cpp
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsValidators.cpp
@@ -140,7 +140,7 @@ int
 main()
 {
     TestUsdUsdzValidators();
-    //TestPackageEncapsulationValidator();
+    TestPackageEncapsulationValidator();
     TestLayerFileFormatValidator();
 
     return EXIT_SUCCESS;

--- a/pxr/usd/usdUtils/validatorTokens.h
+++ b/pxr/usd/usdUtils/validatorTokens.h
@@ -17,7 +17,8 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 #define USD_UTILS_VALIDATOR_NAME_TOKENS                   \
-    ((packageEncapsulationValidator, "usdUtils:PackageEncapsulationValidator"))
+    ((packageEncapsulationValidator, "usdUtils:PackageEncapsulationValidator")) \
+    ((layerFileFormatValidator, "usdUtils:LayerFileFormatValidator"))
 
 #define USD_UTILS_VALIDATOR_KEYWORD_TOKENS                \
     (UsdUtilsValidators)                                  \
@@ -25,7 +26,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define USD_UTILS_VALIDATION_ERROR_NAME_TOKENS                          \
     ((layerNotInPackage, "LayerNotInPackage"))                          \
-    ((assetNotInPackage, "AssetNotInPackage"))                          
+    ((assetNotInPackage, "AssetNotInPackage"))                          \
+    ((layerIsNotACoreFileFormat, "LayerNotCoreFileFormat"))
 
 ///\def
 /// Tokens representing validator names. Note that for plugin provided


### PR DESCRIPTION
### Description of Change(s)
- Added validation logic and a test for ARKitLayerChecker 

### Fixes Issue(s)
- https://github.com/orgs/PixarAnimationStudios/projects/3?pane=issue&itemId=65424926

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
