### PR TITLE
Support OpenImageIO 3.x inside the `hioOiio` plugin

### DIFF
--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -289,7 +289,7 @@ _FindAttribute(ImageSpec const & spec, std::string const & metadataKey)
     bool convertMatrixTypes = false;
     std::string key = _TranslateMetadataKey(metadataKey, &convertMatrixTypes);
 
-    ImageIOParameter const * param = spec.find_attribute(key);
+    ParamValue const * param = spec.find_attribute(key);
     if (!param) {
         return VtValue();
     }
@@ -713,13 +713,21 @@ HioOIIO_Image::ReadCropped(int const cropTop,
     // If needed, convert double precision images to float
     bool res = false;
     if (imageInput->spec().format == TypeDesc::DOUBLE) {
-        res = imageInput->read_image(TypeDesc::FLOAT,
+        res = imageInput->read_image(_subimage,
+            _miplevel,
+            0,
+            -1,
+            TypeDesc::FLOAT,
             start,
             AutoStride,
             readStride,
             AutoStride);
     } else{
-        res = imageInput->read_image(imageInput->spec().format,
+        res = imageInput->read_image(_subimage,
+            _miplevel,
+            0,
+            -1,
+            imageInput->spec().format,
             start,
             AutoStride,
             readStride,


### PR DESCRIPTION
### Description of Change(s)
The soon to be released OpenImageIO 3.x series drops a variety of old, deprecated, methods and types.

In the context of the imaging `hioOiio` plugin, this simply means to adjust the following [1]:
- The `ImageIOParameter` type alias is removed and just `ParamValue` should be used
- The `read_image` method must take in subimage, miplevel, and channel values explicitly

These changes are compatible with the OpenImageIO 2.x series and shouldn't present a problem for those not updating just yet.

[1] https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/docs/Deprecations-3.0.md#imageioh

### Fixes Issue(s)
- Building against OIIO 3

- [ ] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
