### PR TITLE
Ensure HdDependenciesSchema::GetEntries is linkable

### DIFF
--- a/pxr/imaging/hd/dependenciesSchema.h
+++ b/pxr/imaging/hd/dependenciesSchema.h
@@ -67,6 +67,7 @@ public:
     using EntryPair = std::pair<TfToken, HdDependencySchema>;
     using EntryVector = TfSmallVector<EntryPair, 8>;
 
+    HD_API
     EntryVector GetEntries();
 
 // --(END CUSTOM CODE: Schema Methods)--


### PR DESCRIPTION
Adding `HD_API` to `HdDependenciesSchema::GetEntries` so that the symbol will be found on Windows.

### Description of Change(s)

Without this change, Windows-based users of `HdDependenciesSchema` are unable to use the `GetEntries` method as the symbol isn't "exposed" (I don't know the strictly proper terminology)

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [X] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
