### PR TITLE
[hdEmbree] ensure we respect PXR_WORK_THREAD_LIMIT (standalone)

### DIFF
--- a/pxr/base/work/threadLimits.cpp
+++ b/pxr/base/work/threadLimits.cpp
@@ -71,14 +71,14 @@ WorkGetPhysicalConcurrencyLimit()
 #endif
 }
 
-// This function always returns an actual thread count >= 1.
+// This function always returns either 0 (meaning "no change") or >= 1
 static unsigned
 Work_NormalizeThreadCount(const int n)
 {
     // Zero means "no change", and n >= 1 means exactly n threads, so simply
     // pass those values through unchanged.
     // For negative integers, subtract the absolute value from the total number
-    // of available cores (denoting all but n cores). If n == number of cores,
+    // of available cores (denoting all but n cores). If |n| >= number of cores,
     // clamp to 1 to set single-threaded mode.
     return n >= 0 ? n : std::max<int>(1, n + WorkGetPhysicalConcurrencyLimit());
 }


### PR DESCRIPTION
> [!IMPORTANT] 
> This is a duplicate of this PR:
>
> - https://github.com/PixarAnimationStudios/OpenUSD/pull/3198
>
> ...except pulled out of the UsdLux-HdEmbree PR "chain", to make for easier standalone integration, as it has no other PR dependencies, and is a simple/small change.
>
> I will close this PR if the other is merged first, and vice-versa.


### Description of Change(s)

Fixes an issue where pre-oneTBB, threads spawned from the non-root thread (such as the render thread) would not respect PXR_WORK_THREAD_LIMIT

### Fixes Issue(s)
- renderThread-spawned processes don't respect PXR_WORK_THREAD_LIMIT


<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
