### PR TITLE
hio: Add CMake options to handled image file formats by plugins

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -240,3 +240,12 @@ if (${PXR_BUILD_PYTHON_DOCUMENTATION})
         set(PXR_BUILD_PYTHON_DOCUMENTATION "OFF" CACHE BOOL "" FORCE)
     endif()
 endif()
+
+set(PXR_IMAGING_HIO_STB_PRECEDENCE "30" CACHE STRING "Hio plugin precedence for Hio_StbImage.")
+set(PXR_IMAGING_HIO_STB_FORMATS "bmp;jpg;jpeg;png;tga;hdr" CACHE STRING "Image file formats handled by Hio_StbImage Hio plugin.")
+
+set(PXR_IMAGING_HIO_OPENEXR_PRECEDENCE "30" CACHE STRING "Hio plugin precedence for Hio_OpenEXRImage.")
+set(PXR_IMAGING_HIO_OPENEXR_FORMATS "exr" CACHE STRING "Image file formats handled by Hio_OpenEXRImage Hio plugin.")
+
+set(PXR_IMAGING_HIO_OIIO_PRECEDENCE "10" CACHE STRING "Hio plugin precedence for HioOIIO_Image.")
+set(PXR_IMAGING_HIO_OIIO_FORMATS "tif;tiff;zfile;tx" CACHE STRING "Image file formats handled by HioOIIO_Image Hio plugin.")

--- a/pxr/imaging/hio/CMakeLists.txt
+++ b/pxr/imaging/hio/CMakeLists.txt
@@ -1,6 +1,43 @@
 set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hio)
 
+set (optionalCppFiles)
+set (optionalPrivateHeaders)
+if (PXR_IMAGING_HIO_STB_FORMATS)
+    list(APPEND optionalCppFiles
+        stbImage.cpp
+    )
+    list(APPEND optionalPrivateHeaders
+        stb/stb_image.h
+        stb/stb_image_resize2.h
+        stb/stb_image_write.h
+    )
+endif()
+if (PXR_IMAGING_HIO_OPENEXR_FORMATS)
+    list(APPEND optionalCppFiles
+        OpenEXRImage.cpp
+        OpenEXR/openexr-c.c
+    )
+    list(APPEND optionalPrivateHeaders
+        OpenEXR/openexr-c.h
+    )
+endif()
+
+set(JSON_HIO_STB_FORMATS ${PXR_IMAGING_HIO_STB_FORMATS})
+list(TRANSFORM JSON_HIO_STB_FORMATS REPLACE "[a-zA-Z0-9]+" "\"\\0\"")
+list(JOIN JSON_HIO_STB_FORMATS ", " JSON_HIO_STB_FORMATS)
+
+set(JSON_HIO_OPENEXR_FORMATS ${PXR_IMAGING_HIO_OPENEXR_FORMATS})
+list(TRANSFORM JSON_HIO_OPENEXR_FORMATS REPLACE "[a-zA-Z0-9]+" "\"\\0\"")
+list(JOIN JSON_HIO_OPENEXR_FORMATS ", " JSON_HIO_OPENEXR_FORMATS)
+
+file(READ "${CMAKE_CURRENT_LIST_DIR}/plugInfo.json.in" content)
+string(REPLACE "<JSON_HIO_OPENEXR_FORMATS>" "${JSON_HIO_OPENEXR_FORMATS}" content "${content}")
+string(REPLACE "<PXR_IMAGING_HIO_OPENEXR_PRECEDENCE>" "${PXR_IMAGING_HIO_OPENEXR_PRECEDENCE}" content "${content}")
+string(REPLACE "<JSON_HIO_STB_FORMATS>" "${JSON_HIO_STB_FORMATS}" content "${content}")
+string(REPLACE "<PXR_IMAGING_HIO_STB_PRECEDENCE>" "${PXR_IMAGING_HIO_STB_PRECEDENCE}" content "${content}")
+file(WRITE "${CMAKE_CURRENT_LIST_DIR}/plugInfo.json" "${content}")
+
 pxr_library(hio
     LIBRARIES
         arch
@@ -29,16 +66,11 @@ pxr_library(hio
         api.h
 
     PRIVATE_HEADERS
-        OpenEXR/openexr-c.h
         rankedTypeMap.h
-        stb/stb_image.h
-        stb/stb_image_resize2.h
-        stb/stb_image_write.h
+        ${optionalPrivateHeaders}
 
     CPPFILES
-        OpenEXRImage.cpp
-        OpenEXR/openexr-c.c
-        stbImage.cpp
+        ${optionalCppFiles}
 
     RESOURCE_FILES
         plugInfo.json

--- a/pxr/imaging/hio/plugInfo.json.in
+++ b/pxr/imaging/hio/plugInfo.json.in
@@ -5,13 +5,12 @@
                 "Types": {
                    "Hio_OpenEXRImage" : {
                         "bases": ["HioImage"],
-                        "imageTypes": ["exr"],
-                        "precedence": 30
+                        "imageTypes": [<JSON_HIO_OPENEXR_FORMATS>],
+                        "precedence": <PXR_IMAGING_HIO_OPENEXR_PRECEDENCE>
                     },
                     "Hio_StbImage" : {
-                        "bases": ["HioImage"],
-                        "imageTypes": ["bmp", "jpg", "jpeg", "png", "tga", "hdr"],
-                        "precedence": 30
+                        "imageTypes": [<JSON_HIO_STB_FORMATS>],
+                        "precedence": <PXR_IMAGING_HIO_STB_PRECEDENCE>
                     }
                 }
             },

--- a/pxr/imaging/plugin/hioOiio/CMakeLists.txt
+++ b/pxr/imaging/plugin/hioOiio/CMakeLists.txt
@@ -7,6 +7,12 @@ if (NOT ${PXR_BUILD_GPU_SUPPORT})
     return()
 endif()
 
+if (NOT PXR_IMAGING_HIO_OIIO_FORMATS)
+    message(STATUS
+            "Skipping ${PXR_PACKAGE} because PXR_IMAGING_HIO_OIIO_FORMATS is empty")
+    return()
+endif()
+
 # Use the import targets set by Imath's package config
 if (Imath_FOUND)
     set(__OIIO_IMATH_LIBS "Imath::Imath")
@@ -14,6 +20,15 @@ else()
     set(__OIIO_IMATH_INCLUDE ${OPENEXR_INCLUDE_DIRS})
     set(__OIIO_IMATH_LIBS ${OPENEXR_LIBRARIES})
 endif()
+
+set(JSON_HIO_OIIO_FORMATS ${PXR_IMAGING_HIO_OIIO_FORMATS})
+list(TRANSFORM JSON_HIO_OIIO_FORMATS REPLACE "[a-zA-Z0-9]+" "\"\\0\"")
+list(JOIN JSON_HIO_OIIO_FORMATS ", " JSON_HIO_OIIO_FORMATS)
+
+file(READ "${CMAKE_CURRENT_LIST_DIR}/plugInfo.json.in" content)
+string(REPLACE "<JSON_HIO_OIIO_FORMATS>" "${JSON_HIO_OIIO_FORMATS}" content "${content}")
+string(REPLACE "<PXR_IMAGING_HIO_OIIO_PRECEDENCE>" "${PXR_IMAGING_HIO_OIIO_PRECEDENCE}" content "${content}")
+file(WRITE "${CMAKE_CURRENT_LIST_DIR}/plugInfo.json" "${content}")
 
 pxr_plugin(hioOiio
     LIBRARIES

--- a/pxr/imaging/plugin/hioOiio/plugInfo.json.in
+++ b/pxr/imaging/plugin/hioOiio/plugInfo.json.in
@@ -5,8 +5,8 @@
         "Types": {
           "HioOIIO_Image" : {
             "bases": ["HioImage"],
-            "imageTypes": ["tif", "tiff", "zfile", "tx"],
-            "precedence": 10
+            "imageTypes": [<JSON_HIO_OIIO_FORMATS>],
+            "precedence": <PXR_IMAGING_HIO_OIIO_PRECEDENCE>
           }
         }
       },


### PR DESCRIPTION
### Description of Change(s)

This PR introduces CMake options to determine which image file formats are handled by each HioImage plugins.
Options defaults to the same behavior as before this PR for backward compatibility.

Those new options allow for an integration to control which plugins should handled which file formats.
For example it is possible to disable `Hio_StbImage` and let `Hio_Oiio` handle all image formats.

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [ ] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement
