### PR TITLE
[hdSt, hgi] Fix unitTestHelper for incorrect byteSize

### DIFF
--- a/pxr/imaging/hdSt/unitTestHelper.cpp
+++ b/pxr/imaging/hdSt/unitTestHelper.cpp
@@ -565,13 +565,13 @@ HdSt_TextureTestDriver::_CreateBufferResources()
     vboDesc.vertexStride = elementsPerVertex * sizeof(vertData[0]);
     _vertexBuffer = _hgi->CreateBuffer(vboDesc);
 
-    static const int32_t indices[3] = { 0, 1, 2 };
+    constexpr int32_t indices[3] = { 0, 1, 2 };
 
     HgiBufferDesc iboDesc;
     iboDesc.debugName = "HdSt_TextureTestDriver IndexBuffer";
     iboDesc.usage = HgiBufferUsageIndex32;
     iboDesc.initialData = indices;
-    iboDesc.byteSize = sizeof(indices) * sizeof(indices[0]);
+    iboDesc.byteSize = sizeof(indices);
     _indexBuffer = _hgi->CreateBuffer(iboDesc);
 }
 

--- a/pxr/imaging/hgi/unitTestHelper.cpp
+++ b/pxr/imaging/hgi/unitTestHelper.cpp
@@ -358,13 +358,13 @@ HgiGfxCmdBfrExecutionTestDriver::_CreateResourceBuffers()
         return false;
     }
 
-    static const int32_t indices[3] = { 0, 1, 2 };
+    constexpr int32_t indices[3] = { 0, 1, 2 };
 
     HgiBufferDesc iboDesc;
     iboDesc.debugName = "IndexBuffer";
     iboDesc.usage = HgiBufferUsageIndex32;
     iboDesc.initialData = indices;
-    iboDesc.byteSize = sizeof(indices) * sizeof(indices[0]);
+    iboDesc.byteSize = sizeof(indices);
     _indexBuffer = _hgi->CreateBuffer(iboDesc);
     if (!_indexBuffer) {
         return false;


### PR DESCRIPTION
### Description of Change(s)

ASan identified a stack-buffer-overflow for `byteSize` in `unitTestHelper`. `byteSize` has been set to the correct size 

### Fixes Issue(s)
-

<!--
Please follow the Contributing and Building guidelines to run tests against your
change. Place an X in the box if tests are run and are all tests passing.
-->
- [x] I have verified that all unit tests pass with the proposed changes
<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [x] I have submitted a signed Contributor License Agreement
