### PR TITLE
Apple: Add support for reading UV data on curves in the Alembic reader.

### DIFF
--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -3484,6 +3484,9 @@ _ReadCurves(_PrimReaderContext* context)
         SdfValueTypeNames->FloatArray,
         _CopyGeneric<IFloatGeomParam, float>(
             context->ExtractSchema("width")));
+
+    // Read texture coordinates
+    _ReadProperty<IV2fGeomParam, GfVec2f>(context, "uv", _GetUVPropertyName(), _GetUVTypeName());
 }
 
 static


### PR DESCRIPTION
### Description of Change(s)
The Alembic importer plugin did not handle UVs on Curve primitive, like it did for PolyMesh and Subdivs. This adds the same function call to _ReadCurves which is used in _ReadPolyMesh. This has been tested on Alembic files written from Maya.

### Fixes Issue(s)

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
