### PR TITLE
Autodesk: Vulkan Bugfix - HgiVulkanBlitCmds offset

### DIFF
--- a/pxr/imaging/hgiVulkan/blitCmds.cpp
+++ b/pxr/imaging/hgiVulkan/blitCmds.cpp
@@ -283,15 +283,15 @@ void HgiVulkanBlitCmds::CopyBufferCpuToGpu(
     if (!buffer->IsCPUStagingAddress(copyOp.cpuSourceBuffer) ||
         copyOp.sourceByteOffset != copyOp.destinationByteOffset) {
 
-        uint8_t* dst = static_cast<uint8_t*>(buffer->GetCPUStagingAddress());
-        size_t dstOffset = copyOp.destinationByteOffset;
-
         // Offset into the src buffer
-        uint8_t* src = ((uint8_t*) copyOp.cpuSourceBuffer) +
+        const uint8_t* src = static_cast<const uint8_t*>(copyOp.cpuSourceBuffer) +
             copyOp.sourceByteOffset;
 
-        // Offset into the dst buffer
-        memcpy(dst + dstOffset, src, copyOp.byteSize);
+        // Offset into the dst buffer.
+        uint8_t* dst = static_cast<uint8_t*>(buffer->GetCPUStagingAddress()) +
+            copyOp.destinationByteOffset;
+
+        memcpy(dst, src, copyOp.byteSize);
     }
 
     // Schedule copy data from staging buffer to device-local buffer.
@@ -299,7 +299,9 @@ void HgiVulkanBlitCmds::CopyBufferCpuToGpu(
 
     if (TF_VERIFY(stagingBuffer)) {
         VkBufferCopy copyRegion = {};
-        copyRegion.srcOffset = copyOp.sourceByteOffset;
+        // Note we use the destinationByteOffset as the srcOffset here. The staging buffer
+        // should be prepared with the same data layout of the destination buffer.
+        copyRegion.srcOffset = copyOp.destinationByteOffset;
         copyRegion.dstOffset = copyOp.destinationByteOffset;
         copyRegion.size = copyOp.byteSize;
 


### PR DESCRIPTION
### Description of Change(s)

⚠️ Branched off `feature-hgi-vulkan`.

The staged copy of HgiVulkanBlitCmds has incorrect source and destination offset,

Source offset of a cpu-to-gpu-copy defines the offset of the source cpu memory, and the destination offset of a cpu-to-gpu-copy defines the offset of the destination gpu buffer.

The `memcpy` from the cpu memory to the staging buffer should use the source offset and the destination offset respectively. But the copy from the staging buffer to the gpu buffer should use the destination offset to define `VkBufferCopy.srcOffset`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A

### Fixes Issue(s)

N/A

### Checklist

[ ] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
