### PR TITLE
Autodesk: Expose dome light textures max resolution

### DIFF
--- a/pxr/imaging/hdSt/domeLightComputations.cpp
+++ b/pxr/imaging/hdSt/domeLightComputations.cpp
@@ -32,11 +32,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 HdSt_DomeLightComputationGPU::HdSt_DomeLightComputationGPU(
     const TfToken &shaderToken,
     HdStSimpleLightingShaderPtr const &lightingShader,
+    const unsigned int outputWidth,
+    const unsigned int outputHeight,
     const unsigned int numLevels,
     const unsigned int level, 
     const float roughness) 
   : _shaderToken(shaderToken), 
     _lightingShader(lightingShader),
+    _outputWidth(outputWidth),
+    _outputHeight(outputHeight),
     _numLevels(numLevels), 
     _level(level), 
     _roughness(roughness)
@@ -167,10 +171,10 @@ HdSt_DomeLightComputationGPU::Execute(
 
     // Size of texture to be created.
     // Downsize larger textures
-    bool downsize = (srcDim[0] > 256 && srcDim[1] > 256);
-    int width  = downsize ? srcDim[0] / 2 : srcDim[0];
-    int height = downsize ? srcDim[1] / 2 : srcDim[1];
-    
+    bool downsize = (_outputWidth > 256 && _outputHeight > 256);
+    int width = downsize ? _outputWidth / 2 : _outputWidth;
+    int height = downsize ? _outputHeight / 2 : _outputHeight;
+
     // Make sure dimensions align with the local size used in the Compute Shader
     width = _MakeMultipleOf(width, localSize);
     height = _MakeMultipleOf(height, localSize);

--- a/pxr/imaging/hdSt/domeLightComputations.h
+++ b/pxr/imaging/hdSt/domeLightComputations.h
@@ -46,6 +46,10 @@ public:
         const TfToken & shaderToken, 
         // Lighting shader that remembers the GL texture names
         HdStSimpleLightingShaderPtr const &lightingShader,
+        // Width of output textures.
+        unsigned int outputWidth,
+        // Height of output textures.
+        unsigned int outputHeight,
         // Number of mip levels.
         unsigned int numLevels = 1,
         // Level to be filled (0 means also to allocate texture)
@@ -67,6 +71,8 @@ public:
 private:
     const TfToken _shaderToken;
     HdStSimpleLightingShaderPtr const _lightingShader;
+    const unsigned int _outputWidth;
+    const unsigned int _outputHeight;
     const unsigned int _numLevels;
     const unsigned int _level;
     const float _roughness;

--- a/pxr/imaging/hdSt/renderDelegate.cpp
+++ b/pxr/imaging/hdSt/renderDelegate.cpp
@@ -54,6 +54,9 @@ TF_DEFINE_ENV_SETTING(HD_ENABLE_GPU_TINY_PRIM_CULLING, false,
 TF_DEFINE_ENV_SETTING(HDST_MAX_LIGHTS, 16,
                       "Maximum number of lights to render with");
 
+TF_DEFINE_ENV_SETTING(HDST_DOME_LIGHT_TEXTURES_MAX_RES, 8192,
+                      "Maximum resolution of processed textures for dome light");
+
 const TfTokenVector HdStRenderDelegate::SUPPORTED_RPRIM_TYPES =
 {
     HdPrimTypeTokens->mesh,
@@ -192,6 +195,10 @@ HdStRenderDelegate::HdStRenderDelegate(HdRenderSettingsMap const& settingsMap)
             "Maximum number of lights",
             HdStRenderSettingsTokens->maxLights,
             VtValue(int(TfGetEnvSetting(HDST_MAX_LIGHTS))) },
+        HdRenderSettingDescriptor{
+            "Maximum resolution of processed textures for dome light",
+            HdStRenderSettingsTokens->domeLightTexturesMaxResolution,
+            VtValue(static_cast<int>(TfGetEnvSetting(HDST_DOME_LIGHT_TEXTURES_MAX_RES))) },
     };
 
     _PopulateDefaultSettings(_settingDescriptors);

--- a/pxr/imaging/hdSt/simpleLightingShader.cpp
+++ b/pxr/imaging/hdSt/simpleLightingShader.cpp
@@ -49,6 +49,7 @@ HdStSimpleLightingShader::HdStSimpleLightingShader()
     : _lightingContext(GlfSimpleLightingContext::New())
     , _useLighting(true)
     , _glslfx(std::make_unique<HioGlslfx>(HdStPackageSimpleLightingShader()))
+    , _domeLightTexturesMaxResolution(8192)
     , _renderParam(nullptr)
 {
 }
@@ -593,14 +594,6 @@ HdStSimpleLightingShader::AddResourcesFromTextures(ResourceContext &ctx) const
             std::const_pointer_cast<HdStShaderCode, const HdStShaderCode>(
                 shared_from_this()));
 
-    // Irriadiance map computations.
-    ctx.AddComputation(
-        nullptr,
-        std::make_shared<HdSt_DomeLightComputationGPU>(
-            _tokens->domeLightIrradiance,
-            thisShader),
-        HdStComputeQueueZero);
-    
     // Calculate the number of mips for the prefilter texture
     // Note that the size of the prefilter texture is half the size of the 
     // original Environment Map (srcTextureObject)
@@ -619,8 +612,36 @@ HdStSimpleLightingShader::AddResourcesFromTextures(ResourceContext &ctx) const
     }
     const GfVec3i srcDim = srcTexture->GetDescriptor().dimensions;
 
-    const unsigned int numPrefilterLevels = 
-        std::max((unsigned int)(std::log2(std::max(srcDim[0], srcDim[1]))), 1u);
+    // Size of texture to be created.
+    unsigned int outputWidth = srcDim[0];
+    unsigned int outputHeight = srcDim[1];
+
+    // Check max resolution.
+    unsigned int maxDim = std::max(outputWidth, outputHeight);
+    if (maxDim > _domeLightTexturesMaxResolution) {
+        float ratio = outputWidth / outputHeight;
+        if (outputWidth >= outputHeight) {
+            outputWidth = _domeLightTexturesMaxResolution;
+            outputHeight = outputWidth / ratio;
+        }
+        else {
+            outputHeight = _domeLightTexturesMaxResolution;
+            outputWidth = outputHeight * ratio;
+        }
+    }
+
+    // Irriadiance map computations.
+    ctx.AddComputation(
+        nullptr,
+        std::make_shared<HdSt_DomeLightComputationGPU>(
+            _tokens->domeLightIrradiance,
+            thisShader,
+            outputWidth,
+            outputHeight),
+        HdStComputeQueueZero);
+
+    const unsigned int numPrefilterLevels =
+        std::max(static_cast<unsigned int>(std::log2(std::max(outputWidth, outputHeight))), 1u);
 
     // Prefilter map computations. mipLevel = 0 allocates texture.
     for (unsigned int mipLevel = 0; mipLevel < numPrefilterLevels; ++mipLevel) {
@@ -632,6 +653,8 @@ HdStSimpleLightingShader::AddResourcesFromTextures(ResourceContext &ctx) const
             std::make_shared<HdSt_DomeLightComputationGPU>(
                 _tokens->domeLightPrefilter, 
                 thisShader,
+                outputWidth,
+                outputHeight,
                 numPrefilterLevels,
                 mipLevel,
                 roughness),
@@ -643,7 +666,9 @@ HdStSimpleLightingShader::AddResourcesFromTextures(ResourceContext &ctx) const
         nullptr,
         std::make_shared<HdSt_DomeLightComputationGPU>(
             _tokens->domeLightBRDF,
-            thisShader),
+            thisShader,
+            outputWidth,
+            outputHeight),
         HdStComputeQueueZero);
 }
 
@@ -651,6 +676,16 @@ HdStShaderCode::NamedTextureHandleVector const &
 HdStSimpleLightingShader::GetNamedTextureHandles() const
 {
     return _namedTextureHandles;
+}
+
+void 
+HdStSimpleLightingShader::SetDomeLightTexturesMaxResolution(unsigned int maxRes)
+{
+    if (_domeLightTexturesMaxResolution != maxRes) {
+        _domeLightTexturesMaxResolution = maxRes;
+        _domeLightEnvironmentTextureHandle = nullptr;
+        _domeLightTextureHandles.clear();
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/simpleLightingShader.h
+++ b/pxr/imaging/hdSt/simpleLightingShader.h
@@ -121,6 +121,9 @@ public:
         return _shadowAovBindings;
     }
 
+    HDST_API
+    void SetDomeLightTexturesMaxResolution(unsigned int maxRes);
+
 private:
     SdfPath _GetAovPath(TfToken const &aov, size_t shadowIndex) const;
     void _ResizeOrCreateBufferForAov(size_t shadowIndex) const;
@@ -143,6 +146,9 @@ private:
     NamedTextureHandleVector _namedTextureHandles;
 
     NamedTextureHandleVector _domeLightTextureHandles;
+    // Maximum resolution of processed textures for dome light
+    unsigned int _domeLightTexturesMaxResolution;
+
     NamedTextureHandleVector _shadowTextureHandles;
     
     HdSt_MaterialParamVector _lightTextureParams;

--- a/pxr/imaging/hdSt/tokens.h
+++ b/pxr/imaging/hdSt/tokens.h
@@ -87,7 +87,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     (volumeRaymarchingStepSize)                 \
     (volumeRaymarchingStepSizeLighting)         \
     (volumeMaxTextureMemoryPerField)            \
-    (maxLights)
+    (maxLights)                                 \
+    (domeLightTexturesMaxResolution)
 
 // Material tags help bucket prims into different queues for draw submission.
 // The tags supported by Storm are:

--- a/pxr/imaging/hdx/simpleLightTask.cpp
+++ b/pxr/imaging/hdx/simpleLightTask.cpp
@@ -155,6 +155,12 @@ HdxSimpleLightTask::Sync(HdSceneDelegate* delegate,
         _maxLights = size_t(
             renderIndex.GetRenderDelegate()->GetRenderSetting<int>(
                 HdStRenderSettingsTokens->maxLights, 16));
+
+        // Update dome light textures max resolution.
+        _lightingShader->SetDomeLightTexturesMaxResolution(static_cast<unsigned int>(
+            renderIndex.GetRenderDelegate()->GetRenderSetting<unsigned int>(
+                HdStRenderSettingsTokens->domeLightTexturesMaxResolution, 8192)));
+
         _settingsVersion = renderDelegate->GetRenderSettingsVersion();
         verifyNumLights = true;
     }


### PR DESCRIPTION
### Description of Change(s)

To improve the loading time of dome light in Storm, add a new render setting ("domeLightTexturesMaxResolution") for adjustment of the size of pre-processed textures of dome light.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

* N/A

### Fixes Issue(s)

* https://github.com/PixarAnimationStudios/OpenUSD/issues/3342

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
