### PR TITLE
Disambiguate semantic labels from model hierarchy

### DIFF
--- a/pxr/usd/usdSemantics/overview.md
+++ b/pxr/usd/usdSemantics/overview.md
@@ -1,6 +1,6 @@
-# UsdSemantics : Semantic Labeling for Model Hierarchy {#usd_semantics_overview}
+# UsdSemantics : Semantic Labeling of Scenes {#usd_semantics_overview}
 \if ( PIXAR_MFB_BUILD )
-\mainpage UsdSemantics : Semantic Labeling for Model Hierarchy
+\mainpage UsdSemantics : Semantic Labeling of Scenes
 \endif
 
 While prims have a unique name and hierarchical identifier, it is sometimes


### PR DESCRIPTION
### Description of Change(s)

The header for the `UsdSemantics` domain docs may suggest that it's related to `kind`-based model hierarchy, but it's a distinct concept. Revising the header to remove this association.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
