### PR TITLE
Autodesk: Enable experimental Vulkan testing on macOS

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1410,10 +1410,6 @@ def InstallOpenSubdiv(context, force, buildArgs):
             '-DNO_TBB=ON',
         ]
 
-        # Use Metal for macOS and all Apple embedded systems.
-        if MacOS():
-            extraArgs.append('-DNO_OPENGL=ON')
-
         # Add on any user-specified extra arguments.
         extraArgs += buildArgs
 

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -35,8 +35,10 @@ option(PXR_BUILD_MAYAPY_TESTS "Build mayapy spline tests" OFF)
 option(PXR_BUILD_ANIMX_TESTS "Build AnimX spline tests" OFF)
 option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
 option(PXR_PREFER_SAFETY_OVER_SPEED
-       "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
-        ON)
+        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.\
+         These checks may negatively impact performance." ON)
+option(PXR_ENABLE_EXPERIMENTAL_TESTS "Enable experimental tests on macOS.\
+         These aren't guaranteed to pass." OFF)
 
 if(APPLE)
     # Cross Compilation detection as defined in CMake docs
@@ -68,16 +70,17 @@ if(APPLE)
     endif ()
 endif()
 
-
-# Determine GFX api
-# Metal only valid on Apple platforms
-set(pxr_enable_metal "OFF")
-if(APPLE)
-    set(pxr_enable_metal "ON")
-endif()
-option(PXR_ENABLE_METAL_SUPPORT "Enable Metal based components" "${pxr_enable_metal}")
-option(PXR_ENABLE_VULKAN_SUPPORT "Enable Vulkan based components" OFF)
+# Determine graphics API
+# In the current state of USD, OpenGL support is always required to build.
+include(CMakeDependentOption)
 option(PXR_ENABLE_GL_SUPPORT "Enable OpenGL based components" ON)
+# Metal only valid on Apple platforms
+if(APPLE)
+    cmake_dependent_option(PXR_ENABLE_METAL_SUPPORT "Enable Metal based components" ON "PXR_ENABLE_GL_SUPPORT" OFF)
+else()
+    set(PXR_ENABLE_METAL_SUPPORT OFF CACHE BOOL "Enable Metal based components" FORCE)
+endif()
+cmake_dependent_option(PXR_ENABLE_VULKAN_SUPPORT "Enable Vulkan based components" OFF "PXR_ENABLE_GL_SUPPORT" OFF)
 
 # Precompiled headers are a win on Windows, not on gcc.
 set(pxr_enable_pch "OFF")

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -266,6 +266,7 @@ if (PXR_BUILD_IMAGING)
     # --X11
     if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
         find_package(X11)
+        add_definitions(-DPXR_X11_SUPPORT_ENABLED)
     endif()
     # --Embree
     if (PXR_BUILD_EMBREE_PLUGIN)

--- a/extras/imaging/examples/hdTiny/CMakeLists.txt
+++ b/extras/imaging/examples/hdTiny/CMakeLists.txt
@@ -18,46 +18,47 @@ pxr_plugin(${PXR_PACKAGE}
     DISABLE_PRECOMPILED_HEADERS
 )
 
-pxr_build_test(testHdTiny
-    LIBRARIES
-        hdx
-    
-    CPPFILES
-        testenv/testHdTiny.cpp
-)
+if (PXR_ENABLE_GL_SUPPORT)
+    pxr_build_test(testHdTiny
+        LIBRARIES
+            hdx
 
-pxr_install_test_dir(
-    SRC testenv/testHdTiny
-    DEST testHdTiny
-)
+        CPPFILES
+            testenv/testHdTiny.cpp
+    )
 
-# This test only runs on MacOS and Linux for now.
-if (APPLE)
-    pxr_register_test(testHdTiny
-        ENV
-            DYLD_INSERT_LIBRARIES=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.dylib
-            ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
-        STDOUT_REDIRECT output.txt
-        DIFF_COMPARE output.txt
+    pxr_install_test_dir(
+        SRC testenv/testHdTiny
+        DEST testHdTiny
     )
-elseif (UNIX)
-    pxr_register_test(testHdTiny
-        ENV
-            LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.so
-            ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
-        STDOUT_REDIRECT output.txt
-        DIFF_COMPARE output.txt
-    )
-elseif (WIN32)
-    pxr_register_test(testHdTiny
-        ENV
-            ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
-        PRE_PATH
-            ${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny" 
-        STDOUT_REDIRECT output.txt
-        DIFF_COMPARE output.txt
-    )
+
+    if (APPLE)
+        pxr_register_test(testHdTiny
+            ENV
+                DYLD_INSERT_LIBRARIES=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.dylib
+                ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
+            COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny"
+            STDOUT_REDIRECT output.txt
+            DIFF_COMPARE output.txt
+        )
+    elseif (UNIX)
+        pxr_register_test(testHdTiny
+            ENV
+                LD_PRELOAD=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny.so
+                ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
+            COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny"
+            STDOUT_REDIRECT output.txt
+            DIFF_COMPARE output.txt
+        )
+    elseif (WIN32)
+        pxr_register_test(testHdTiny
+            ENV
+                ${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny/resources
+            PRE_PATH
+                ${CMAKE_INSTALL_PREFIX}/share/usd/examples/plugin/hdTiny
+            COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdTiny"
+            STDOUT_REDIRECT output.txt
+            DIFF_COMPARE output.txt
+        )
+    endif()
 endif()

--- a/pxr/imaging/glf/CMakeLists.txt
+++ b/pxr/imaging/glf/CMakeLists.txt
@@ -9,7 +9,9 @@ endif()
 
 set(optionalPublicClasses "")
 if (X11_FOUND)
-    list(APPEND optionalPublicClasses testGLContext)
+    list(APPEND optionalPublicClasses testGLXContext)
+else()
+    list(APPEND optionalPublicClasses testGLNullContext)
 endif()
 
 pxr_library(glf
@@ -37,6 +39,7 @@ pxr_library(glf
         simpleLightingContext
         simpleMaterial
         simpleShadowArray
+        testGLContext
         texture
         uniformBlock
         utils

--- a/pxr/imaging/glf/testGLContext.cpp
+++ b/pxr/imaging/glf/testGLContext.cpp
@@ -8,111 +8,15 @@
 
 #include "pxr/base/tf/diagnostic.h"
 
-#include <GL/glx.h>
+#ifdef PXR_X11_SUPPORT_ENABLED
+#include "pxr/imaging/glf/testGLXContext.h"
+#else
+#include "pxr/imaging/glf/testGLNullContext.h"
+#endif
 
-#include <stdio.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-class Glf_TestGLContextPrivate {
-public:
-    Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const * other=NULL );
-
-    void  makeCurrent( ) const;
-    
-    bool isValid();
-
-    bool operator==(const Glf_TestGLContextPrivate& rhs) const
-    {
-        return _dpy == rhs._dpy && _context == rhs._context;
-    }
-
-    static const Glf_TestGLContextPrivate * currentContext();
-
-    static bool areSharing( const Glf_TestGLContextPrivate * context1, 
-        const Glf_TestGLContextPrivate * context2 );
-
-private:
-    Display * _dpy;
-    
-    GLXContext _context;
-    
-    Glf_TestGLContextPrivate const * _sharedContext;
-
-    static GLXWindow _win;
-
-    static Glf_TestGLContextPrivate const * _currenGLContext;
-};
-
-Glf_TestGLContextPrivate const * Glf_TestGLContextPrivate::_currenGLContext=NULL;
-GLXWindow Glf_TestGLContextPrivate::_win=0;
-
-Glf_TestGLContextPrivate::Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const * other ) 
-    : _dpy(NULL), _context(NULL)
-{ 
-    static int attribs[] = { GLX_DOUBLEBUFFER, GLX_RGBA_BIT, 
-            GLX_RED_SIZE, 8, GLX_GREEN_SIZE, 8, GLX_BLUE_SIZE, 8,
-            GLX_SAMPLE_BUFFERS, 1, GLX_SAMPLES, 4, None };
-
-    _dpy = XOpenDisplay(0);
-
-    int n;
-    GLXFBConfig * fbConfigs = glXChooseFBConfig( _dpy, 
-        DefaultScreen(_dpy), attribs, &n );
-
-    GLXContext share = other ? other->_context : 0;
-
-    _context = glXCreateNewContext( _dpy,
-        fbConfigs[0], GLX_RGBA_TYPE, share, true);
-	
-    _sharedContext=other ? other : this;
-
-    if (!_win) {
-        XVisualInfo * vi = glXGetVisualFromFBConfig( _dpy, fbConfigs[0] );
-
-	XSetWindowAttributes  swa;
-	swa.colormap = XCreateColormap(_dpy, RootWindow(_dpy, vi->screen),
-             vi->visual, AllocNone);
-	swa.border_pixel = 0;
-	swa.event_mask = StructureNotifyMask;
-
-	Window xwin = XCreateWindow( _dpy, RootWindow(_dpy, vi->screen), 
-            0, 0, 256, 256, 0, vi->depth, InputOutput, vi->visual, 
-	    CWBorderPixel|CWColormap|CWEventMask, &swa );
-
-	_win = glXCreateWindow( _dpy, fbConfigs[0], xwin, NULL );
-    }
-}
-
-void 
-Glf_TestGLContextPrivate::makeCurrent( ) const
-{
-    glXMakeContextCurrent(_dpy, _win, _win, _context);
-
-    _currenGLContext=this;
-}
-
-bool
-Glf_TestGLContextPrivate::isValid()
-{   
-    return _context!=NULL; 
-}
-
-const Glf_TestGLContextPrivate * 
-Glf_TestGLContextPrivate::currentContext()
-{
-    return _currenGLContext;
-}
-
-bool 
-Glf_TestGLContextPrivate::areSharing( const Glf_TestGLContextPrivate * context1, const Glf_TestGLContextPrivate * context2 )
-{
-    if (!context1 || !context2)
-        return false;
-
-    return context1->_sharedContext==context2->_sharedContext;
-}
 
 Glf_TestGLContextPrivate *
 _GetSharedContext()
@@ -217,4 +121,3 @@ GlfTestGLContext::_IsEqual(GlfGLContextSharedPtr const &rhs) const
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/imaging/glf/testGLNullContext.cpp
+++ b/pxr/imaging/glf/testGLNullContext.cpp
@@ -1,0 +1,52 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "testGLNullContext.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+Glf_TestGLContextPrivate const * Glf_TestGLContextPrivate::_currenGLContext=nullptr;
+
+Glf_TestGLContextPrivate::Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const *)
+{
+}
+
+void
+Glf_TestGLContextPrivate::makeCurrent( ) const
+{
+    _currenGLContext=this;
+}
+
+bool
+Glf_TestGLContextPrivate::isValid()
+{
+    return true;
+}
+
+bool
+Glf_TestGLContextPrivate::operator==(const Glf_TestGLContextPrivate& rhs) const
+{
+    return true;
+}
+
+const Glf_TestGLContextPrivate *
+Glf_TestGLContextPrivate::currentContext()
+{
+    return _currenGLContext;
+}
+
+bool
+Glf_TestGLContextPrivate::areSharing(
+    const Glf_TestGLContextPrivate * context1,
+    const Glf_TestGLContextPrivate * context2)
+{
+    if (!context1 || !context2)
+        return false;
+
+    return context1->_sharedContext==context2->_sharedContext;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/glf/testGLNullContext.h
+++ b/pxr/imaging/glf/testGLNullContext.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_GLF_TEST_GLNULLCONTEXT_H
+#define PXR_IMAGING_GLF_TEST_GLNULLCONTEXT_H
+
+/// \file glf/testGLNull/Context.h
+
+#include "pxr/pxr.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class Glf_TestGLContextPrivate {
+public:
+    Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const * other=nullptr );
+
+    void  makeCurrent( ) const;
+
+    bool isValid();
+
+    bool operator==(const Glf_TestGLContextPrivate& rhs) const;
+
+    static const Glf_TestGLContextPrivate * currentContext();
+
+    static bool areSharing( const Glf_TestGLContextPrivate * context1,
+        const Glf_TestGLContextPrivate * context2 );
+
+private:
+    Glf_TestGLContextPrivate const * _sharedContext;
+
+    static Glf_TestGLContextPrivate const * _currenGLContext;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif //PXR_IMAGING_GLF_TEST_GLNULLCONTEXT_H

--- a/pxr/imaging/glf/testGLXContext.cpp
+++ b/pxr/imaging/glf/testGLXContext.cpp
@@ -1,0 +1,86 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "testGLXContext.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+Glf_TestGLContextPrivate const * Glf_TestGLContextPrivate::_currenGLContext=nullptr;
+GLXWindow Glf_TestGLContextPrivate::_win=0;
+
+Glf_TestGLContextPrivate::Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const * other )
+{
+    static int attribs[] = { GLX_DOUBLEBUFFER, GLX_RGBA_BIT,
+            GLX_RED_SIZE, 8, GLX_GREEN_SIZE, 8, GLX_BLUE_SIZE, 8,
+            GLX_SAMPLE_BUFFERS, 1, GLX_SAMPLES, 4, None };
+
+    _dpy = XOpenDisplay(0);
+
+    int n;
+    GLXFBConfig * fbConfigs = glXChooseFBConfig( _dpy,
+        DefaultScreen(_dpy), attribs, &n );
+
+    GLXContext share = other ? other->_context : 0;
+
+    _context = glXCreateNewContext( _dpy,
+        fbConfigs[0], GLX_RGBA_TYPE, share, true);
+
+    _sharedContext=other ? other : this;
+
+    if (!_win) {
+        XVisualInfo * vi = glXGetVisualFromFBConfig( _dpy, fbConfigs[0] );
+
+        XSetWindowAttributes  swa;
+        swa.colormap = XCreateColormap(_dpy, RootWindow(_dpy, vi->screen),
+                 vi->visual, AllocNone);
+        swa.border_pixel = 0;
+        swa.event_mask = StructureNotifyMask;
+
+        Window xwin = XCreateWindow( _dpy, RootWindow(_dpy, vi->screen),
+                0, 0, 256, 256, 0, vi->depth, InputOutput, vi->visual,
+	        CWBorderPixel|CWColormap|CWEventMask, &swa );
+
+        _win = glXCreateWindow( _dpy, fbConfigs[0], xwin, NULL );
+    }
+}
+
+void
+Glf_TestGLContextPrivate::makeCurrent( ) const
+{
+    glXMakeContextCurrent(_dpy, _win, _win, _context);
+    _currenGLContext=this;
+}
+
+bool
+Glf_TestGLContextPrivate::isValid()
+{
+    return _context!=nullptr;
+}
+
+bool
+Glf_TestGLContextPrivate::operator==(const Glf_TestGLContextPrivate& rhs) const
+{
+    return _dpy == rhs._dpy && _context == rhs._context;
+}
+
+const Glf_TestGLContextPrivate *
+Glf_TestGLContextPrivate::currentContext()
+{
+    return _currenGLContext;
+}
+
+bool
+Glf_TestGLContextPrivate::areSharing(
+    const Glf_TestGLContextPrivate * context1,
+    const Glf_TestGLContextPrivate * context2)
+{
+    if (!context1 || !context2)
+        return false;
+
+    return context1->_sharedContext==context2->_sharedContext;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/glf/testGLXContext.h
+++ b/pxr/imaging/glf/testGLXContext.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_GLF_TEST_GLXCONTEXT_H
+#define PXR_IMAGING_GLF_TEST_GLXCONTEXT_H
+
+/// \file glf/testGLXContext.h
+
+#include "pxr/pxr.h"
+
+#include <GL/glx.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class Glf_TestGLContextPrivate {
+public:
+    Glf_TestGLContextPrivate( Glf_TestGLContextPrivate const * other=nullptr );
+
+    void  makeCurrent( ) const;
+
+    bool isValid();
+
+    bool operator==(const Glf_TestGLContextPrivate& rhs) const;
+
+    static const Glf_TestGLContextPrivate * currentContext();
+
+    static bool areSharing( const Glf_TestGLContextPrivate * context1,
+        const Glf_TestGLContextPrivate * context2 );
+
+private:
+    Display * _dpy = nullptr;
+
+    GLXContext _context = nullptr;
+
+    Glf_TestGLContextPrivate const * _sharedContext;
+
+    static GLXWindow _win;
+
+    static Glf_TestGLContextPrivate const * _currenGLContext;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif //PXR_IMAGING_GLF_TEST_GLXCONTEXT_H

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -3,9 +3,9 @@ set(PXR_PACKAGE hdSt)
 
 # XXX We check for PXR_ENABLE_GL_SUPPORT since Storm currently still uses
 # GL via GarchGLApi. Once Storm uses only Hgi, remove GL_SUPPORT check.
-if (NOT ${PXR_BUILD_GPU_SUPPORT} OR NOT ${PXR_ENABLE_GL_SUPPORT})
+if (NOT PXR_ENABLE_GL_SUPPORT)
     message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT is OFF")
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
     return()
 endif()
 
@@ -13,7 +13,7 @@ set(optionalLibs "")
 set(optionalIncludeDirs "")
 set(optionalPublicClasses "")
 set(optionalPrivateClasses "")
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
+if (PXR_ENABLE_MATERIALX_SUPPORT)
     list(APPEND optionalLibs
         MaterialXGenShader
         MaterialXRender
@@ -96,7 +96,7 @@ pxr_library(hdSt
         nurbsApproximatingSceneIndexPlugin
         instancer
         interleavedMemoryManager
-        light      
+        light
         lightingShader
         material
         materialNetwork
@@ -164,7 +164,7 @@ pxr_library(hdSt
         materialPrimvarTransferSceneIndexPlugin
         materialParam
         meshShaderKey
-        meshTopology 
+        meshTopology
         nodeIdentifierResolvingSceneIndex
         nodeIdentifierResolvingSceneIndexPlugin
         pipelineDrawBatch
@@ -225,7 +225,7 @@ pxr_build_test(testHdStQualifiers
         testenv/testHdStQualifiers.cpp
 )
 
-if (X11_FOUND OR APPLE)
+if (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
 pxr_build_test(testHdStBasicDrawing
     LIBRARIES
         hdSt
@@ -235,9 +235,7 @@ pxr_build_test(testHdStBasicDrawing
     CPPFILES
         testenv/testHdStBasicDrawing.cpp
 )
-endif()
 
-if (X11_FOUND)
 pxr_build_test(testHdStBarAllocationLimit
     LIBRARIES
         hdSt
@@ -459,7 +457,7 @@ pxr_build_test(testHdStInstancingUnbalanced
     CPPFILES
         testenv/testHdStInstancingUnbalanced.cpp
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
+if (PXR_ENABLE_MATERIALX_SUPPORT)
 pxr_build_test(testHdStMaterialXShaderGen
     LIBRARIES
         hdSt
@@ -592,11 +590,7 @@ pxr_build_test(testHdStSubResourceRegistry
     CPPFILES
         testenv/testHdStSubResourceRegistry.cpp
 )
-endif()
 
-if (X11_FOUND)
-# Most HdSt tests require setup of a GL context and window. This is the 
-# exception.
 pxr_register_test(testHdStBufferSource
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStBufferSource"
     EXPECTED_RETURN_CODE 0
@@ -606,7 +600,7 @@ pxr_register_test(testHdStBufferSource
 )
 endif()
 
-if (${PXR_HEADLESS_TEST_MODE})
+if (PXR_HEADLESS_TEST_MODE)
     message(STATUS "Skipping ${PXR_PACKAGE} tests because PXR_HEADLESS_TEST_MODE is ON")
     return()
 endif()
@@ -625,7 +619,7 @@ pxr_register_test(testHdStQualifiers
         TF_DEBUG=HD_SAFE_MODE
 )
 
-if (APPLE)
+if (APPLE AND NOT PXR_ENABLE_EXPERIMENTAL_TESTS)
     message(STATUS "Skipping rest of ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
 endif()
@@ -666,14 +660,18 @@ pxr_install_test_dir(
     SRC testenv/testHdStClipPlanes
     DEST testHdStClipPlanes
 )
-pxr_install_test_dir(
-    SRC testenv/testHdStCodeGen_GL
-    DEST testHdStCodeGen_GL
-)
-pxr_install_test_dir(
-    SRC testenv/testHdStCodeGen_Vulkan
-    DEST testHdStCodeGen_Vulkan
-)
+if (PXR_ENABLE_GL_SUPPORT)
+    pxr_install_test_dir(
+        SRC testenv/testHdStCodeGen_GL
+        DEST testHdStCodeGen_GL
+    )
+endif()
+if (PXR_ENABLE_VULKAN_SUPPORT)
+    pxr_install_test_dir(
+        SRC testenv/testHdStCodeGen_Vulkan
+        DEST testHdStCodeGen_Vulkan
+    )
+endif()
 pxr_install_test_dir(
     SRC testenv/testHdStCurveDrawing
     DEST testHdStCurveDrawing
@@ -722,7 +720,7 @@ pxr_install_test_dir(
     SRC testenv/testHdStInstancingUnbalancedNoBindless
     DEST testHdStInstancingUnbalancedNoBindless
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
+if (PXR_ENABLE_MATERIALX_SUPPORT)
 pxr_install_test_dir(
     SRC testenv/testHdStMaterialXShaderGen
     DEST testHdStMaterialXShaderGen
@@ -2567,19 +2565,21 @@ pxr_register_test(testHdStDisplayStyle_refined
     ENV
         TF_DEBUG=HD_SAFE_MODE
 )
-pxr_register_test(testHdStDrawBatching
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStDrawBatching"
-    EXPECTED_RETURN_CODE 0
-    STDOUT_REDIRECT testHdStDrawBatching-Run1-stdout.txt
-    POST_COMMAND "diff -I computeShader -I drawingShader -I gpuMemoryUsed testHdStDrawBatching-Run1-stdout.txt ${CMAKE_INSTALL_PREFIX}/tests/ctest/testHdStDrawBatching/baseline/testHdStDrawBatching-Run1-stdout.txt"
-    TESTENV testHdStDrawBatching
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-        HD_ENABLE_DOUBLE_MATRIX=1
-        HD_ENABLE_GPU_COUNT_VISIBLE_INSTANCES=1
-        HD_ENABLE_PACKED_NORMALS=0
-        HGI_ENABLE_VULKAN=0
-)
+if (PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
+    pxr_register_test(testHdStDrawBatching
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStDrawBatching"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT testHdStDrawBatching-Run1-stdout.txt
+        POST_COMMAND "diff -I computeShader -I drawingShader -I gpuMemoryUsed testHdStDrawBatching-Run1-stdout.txt ${CMAKE_INSTALL_PREFIX}/tests/ctest/testHdStDrawBatching/baseline/testHdStDrawBatching-Run1-stdout.txt"
+        TESTENV testHdStDrawBatching
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HD_ENABLE_DOUBLE_MATRIX=1
+            HD_ENABLE_GPU_COUNT_VISIBLE_INSTANCES=1
+            HD_ENABLE_PACKED_NORMALS=0
+            HGI_ENABLE_VULKAN=0
+    )
+endif()
 pxr_register_test(testHdStDrawItemIntegrity
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStDrawItemIntegrity --offscreen"
     EXPECTED_RETURN_CODE 0
@@ -2691,47 +2691,55 @@ pxr_register_test(testHdStFrustumCullingInstanceGPU
         HD_ENABLE_GPU_COUNT_VISIBLE_INSTANCES=1
         HD_ENABLE_GPU_FRUSTUM_CULLING=1
 )
-pxr_register_test(testHdStGL
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGL"
-    EXPECTED_RETURN_CODE 0
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
-pxr_register_test(testHdStGLSL_instanceTransform0
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform0"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testHdStGLSL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
-pxr_register_test(testHdStGLSL_instanceTransform1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform1"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testHdStGLSL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
-pxr_register_test(testHdStGLSL_instanceTransform2
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform2"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testHdStGLSL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
-pxr_register_test(testHdStGLSL_instanceTransform3
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform3"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testHdStGLSL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
-pxr_register_test(testHdStGLSL_determinant
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx determinant"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testHdStGLSL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
+if (PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
+    pxr_register_test(testHdStGL
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGL"
+        EXPECTED_RETURN_CODE 0
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+    pxr_register_test(testHdStGLSL_instanceTransform0
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform0"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testHdStGLSL
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+    pxr_register_test(testHdStGLSL_instanceTransform1
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform1"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testHdStGLSL
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+    pxr_register_test(testHdStGLSL_instanceTransform2
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform2"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testHdStGLSL
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+    pxr_register_test(testHdStGLSL_instanceTransform3
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx instanceTransform3"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testHdStGLSL
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+    pxr_register_test(testHdStGLSL_determinant
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStGLSL testHarness.glslfx determinant"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testHdStGLSL
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            HGI_ENABLE_VULKAN=0
+    )
+endif()
 pxr_register_test(testHdStHWFaceCulling
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStHWFaceCulling"
     EXPECTED_RETURN_CODE 0
@@ -2739,13 +2747,15 @@ pxr_register_test(testHdStHWFaceCulling
     POST_COMMAND "diff -I computeShader -I drawingShader -I gpuMemoryUsed -I uboSize -I ssboSize testHdStHWFaceCulling-Run1-stdout.txt ${CMAKE_INSTALL_PREFIX}/tests/ctest/testHdStHWFaceCulling/baseline/testHdStHWFaceCulling-Run1-stdout.txt"
     TESTENV testHdStHWFaceCulling
 )
-pxr_register_test(testHdStIndirectDrawBatchCodeGen
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStIndirectDrawBatchCodeGen"
-    EXPECTED_RETURN_CODE 0
-    ENV
-        HD_ENABLE_GPU_FRUSTUM_CULLING=false
-        HGI_ENABLE_VULKAN=0
-)
+if (PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
+    pxr_register_test(testHdStIndirectDrawBatchCodeGen
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStIndirectDrawBatchCodeGen"
+        EXPECTED_RETURN_CODE 0
+        ENV
+            HD_ENABLE_GPU_FRUSTUM_CULLING=false
+            HGI_ENABLE_VULKAN=0
+    )
+endif()
 pxr_register_test(testHdStIndirectDrawBatchCulling
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStIndirectDrawBatchCulling"
     EXPECTED_RETURN_CODE 0
@@ -2877,7 +2887,7 @@ pxr_register_test(testHdStInstancingUnbalancedNoBindless
         HGIGL_ENABLE_BINDLESS_BUFFER=0
         TF_DEBUG=HD_SAFE_MODE
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
+if (PXR_ENABLE_MATERIALX_SUPPORT)
 pxr_register_test(testHdStMaterialXShaderGen_SSdefault
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStMaterialXShaderGen --filename standard_surface_default.mtlx"
     STDOUT_REDIRECT shadergen_SSdefault.out

--- a/pxr/imaging/hdSt/codeGen.cpp
+++ b/pxr/imaging/hdSt/codeGen.cpp
@@ -39,9 +39,8 @@
 
 #if defined(__APPLE__)
 #include <opensubdiv/osd/mtlPatchShaderSource.h>
-#else
-#include <opensubdiv/osd/glslPatchShaderSource.h>
 #endif
+#include <opensubdiv/osd/glslPatchShaderSource.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -1763,7 +1762,7 @@ HdSt_CodeGen::_PlumbInterstageElements()
 
 static
 std::string
-_GetOSDCommonShaderSource()
+_GetOSDCommonShaderSource(TfToken const &apiName)
 {
     // Prepare OpenSubdiv common shader source for use in the shader
     // code declarations section and define some accessor methods and
@@ -1771,52 +1770,61 @@ _GetOSDCommonShaderSource()
     std::stringstream ss;
 
 #if OPENSUBDIV_VERSION_NUMBER >= 30600
-#if defined(__APPLE__)
-    ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetPatchDrawingShaderSource();
-#else
-    ss << "FORWARD_DECL(MAT4 GetProjectionMatrix());\n"
-          "FORWARD_DECL(float GetTessLevel());\n"
-          "mat4 OsdModelViewMatrix() { return mat4(1); }\n"
-          "mat4 OsdProjectionMatrix() { return mat4(GetProjectionMatrix()); }\n"
-          "float OsdTessLevel() { return GetTessLevel(); }\n"
-          "\n";
 
-    ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetPatchDrawingShaderSource();
+    if (apiName == HgiTokens->Metal) {
+#if defined(__APPLE__)
+        ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetPatchDrawingShaderSource();
+#else
+        TF_FATAL_ERROR("Cannot use Metal on a non-Apple platform");
 #endif
+    } else {
+        ss << "FORWARD_DECL(MAT4 GetProjectionMatrix());\n"
+              "FORWARD_DECL(float GetTessLevel());\n"
+              "mat4 OsdModelViewMatrix() { return mat4(1); }\n"
+              "mat4 OsdProjectionMatrix() { return mat4(GetProjectionMatrix()); }\n"
+              "float OsdTessLevel() { return GetTessLevel(); }\n"
+              "\n";
+
+        ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetPatchDrawingShaderSource();
+    }
 
 #else // OPENSUBDIV_VERSION_NUMBER
     // Additional declarations are needed for older OpenSubdiv versions.
 
+    if (apiName == HgiTokens->Metal) {
 #if defined(__APPLE__)
-    ss << "#define CONTROL_INDICES_BUFFER_INDEX 0\n"
-       << "#define OSD_PATCHPARAM_BUFFER_INDEX 0\n"
-       << "#define OSD_PERPATCHVERTEX_BUFFER_INDEX 0\n"
-       << "#define OSD_PERPATCHTESSFACTORS_BUFFER_INDEX 0\n"
-       << "#define OSD_KERNELLIMIT_BUFFER_INDEX 0\n"
-       << "#define OSD_PATCHPARAM_BUFFER_INDEX 0\n"
-       << "#define VERTEX_BUFFER_INDEX 0\n"
+        ss << "#define CONTROL_INDICES_BUFFER_INDEX 0\n"
+           << "#define OSD_PATCHPARAM_BUFFER_INDEX 0\n"
+           << "#define OSD_PERPATCHVERTEX_BUFFER_INDEX 0\n"
+           << "#define OSD_PERPATCHTESSFACTORS_BUFFER_INDEX 0\n"
+           << "#define OSD_KERNELLIMIT_BUFFER_INDEX 0\n"
+           << "#define OSD_PATCHPARAM_BUFFER_INDEX 0\n"
+           << "#define VERTEX_BUFFER_INDEX 0\n"
 
-       // The ifdef for this in OSD is AFTER the first usage.
-       << "#define OSD_MAX_VALENCE 4\n"
+           // The ifdef for this in OSD is AFTER the first usage.
+           << "#define OSD_MAX_VALENCE 4\n"
 
-       << "\n"
-       << "struct OsdInputVertexType {\n"
-       << "    vec3 position;\n"
-       << "};\n"
-       << "\n";
+           << "\n"
+           << "struct OsdInputVertexType {\n"
+           << "    vec3 position;\n"
+           << "};\n"
+           << "\n";
 
-    ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetCommonShaderSource();
+        ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetCommonShaderSource();
 #else
-    ss << "FORWARD_DECL(MAT4 GetProjectionMatrix());\n"
-       << "FORWARD_DECL(float GetTessLevel());\n"
-       << "mat4 OsdModelViewMatrix() { return mat4(1); }\n"
-       << "mat4 OsdProjectionMatrix() { return mat4(GetProjectionMatrix()); }\n"
-       << "int OsdPrimitiveIdBase() { return 0; }\n"
-       << "float OsdTessLevel() { return GetTessLevel(); }\n"
-       << "\n";
-
-    ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetCommonShaderSource();
+        TF_FATAL_ERROR("Cannot use Metal on a non-Apple platform");
 #endif
+    } else {
+        ss << "FORWARD_DECL(MAT4 GetProjectionMatrix());\n"
+           << "FORWARD_DECL(float GetTessLevel());\n"
+           << "mat4 OsdModelViewMatrix() { return mat4(1); }\n"
+           << "mat4 OsdProjectionMatrix() { return mat4(GetProjectionMatrix()); }\n"
+           << "int OsdPrimitiveIdBase() { return 0; }\n"
+           << "float OsdTessLevel() { return GetTessLevel(); }\n"
+           << "\n";
+
+        ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetCommonShaderSource();
+    }
 #endif // OPENSUBDIV_VERSION_NUMBER
 
     return ss.str();
@@ -1824,16 +1832,21 @@ _GetOSDCommonShaderSource()
 
 static
 std::string
-_GetOSDPatchBasisShaderSource()
+_GetOSDPatchBasisShaderSource(TfToken const &apiName)
 {
     std::stringstream ss;
+    if (apiName == HgiTokens->Metal) {
 #if defined(__APPLE__)
-    ss << "#define OSD_PATCH_BASIS_METAL\n";
-    ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetPatchBasisShaderSource();
+        ss << "#define OSD_PATCH_BASIS_METAL\n";
+        ss << OpenSubdiv::Osd::MTLPatchShaderSource::GetPatchBasisShaderSource();
 #else
-    ss << "#define OSD_PATCH_BASIS_GLSL\n";
-    ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetPatchBasisShaderSource();
+        TF_FATAL_ERROR("Cannot use Metal on a non-Apple platform");
 #endif
+    } else {
+        ss << "#define OSD_PATCH_BASIS_GLSL\n";
+        ss << OpenSubdiv::Osd::GLSLPatchShaderSource::GetPatchBasisShaderSource();
+    }
+
     return ss.str();
 }
 
@@ -2137,10 +2150,12 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
     if (_geometricShader->IsPrimTypeMesh() &&
         _geometricShader->IsPrimTypePatches()) {
         if (_hasPTCS) {
-            _genPTCS << _GetOSDPatchBasisShaderSource();
+            _genPTCS << _GetOSDPatchBasisShaderSource(
+                registry->GetHgi()->GetAPIName());
         }
         if (_hasPTVS) {
-            _genPTVS << _GetOSDPatchBasisShaderSource();
+            _genPTVS << _GetOSDPatchBasisShaderSource(
+                registry->GetHgi()->GetAPIName());
         }
     }
 
@@ -2150,9 +2165,11 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
         _geometricShader->GetFvarPatchType() == 
         HdSt_GeometricShader::FvarPatchType::PATCH_BOXSPLINETRIANGLE) {
         if (_hasGS) {
-            _genGS << _GetOSDPatchBasisShaderSource();
+            _genGS << _GetOSDPatchBasisShaderSource(
+                registry->GetHgi()->GetAPIName());
         } else {
-            _genFS << _GetOSDPatchBasisShaderSource();
+            _genFS << _GetOSDPatchBasisShaderSource(
+                registry->GetHgi()->GetAPIName());
         }
     }
 
@@ -2398,7 +2415,7 @@ HdSt_CodeGen::Compile(HdStResourceRegistry*const registry)
     // method of patch coord interpolation.
     if (_geometricShader->IsPrimTypeRefinedMesh()) {
         // Include OpenSubdiv shader source and use full patch interpolation.
-        _osd << _GetOSDCommonShaderSource();
+        _osd << _GetOSDCommonShaderSource(registry->GetHgi()->GetAPIName());
         _osd <<
             "vec4 InterpolatePatchCoord(vec2 uv, ivec3 patchParam)\n"
             "{\n"
@@ -6931,4 +6948,3 @@ HdSt_CodeGen::_GetFallbackScalarSwizzleString(TfToken const &returnType,
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen.cpp
@@ -74,10 +74,10 @@ CodeGenTest(HdSt_ShaderKey const &key, bool instance, bool smoothNormals)
     sharedData.instancerLevels = 0;
     HdStDrawItem drawItem(&sharedData);
 
-    static HgiUniquePtr hgi = Hgi::CreatePlatformDefaultHgi();
-    static HdDriver driver{HgiTokens->renderDriver, VtValue(hgi.get())};
-    static HdStRenderDelegate renderDelegate;
-    static std::unique_ptr<HdRenderIndex> index(
+    HgiUniquePtr hgi = Hgi::CreatePlatformDefaultHgi();
+    HdDriver driver{HgiTokens->renderDriver, VtValue(hgi.get())};
+    HdStRenderDelegate renderDelegate;
+    std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
     HdStResourceRegistrySharedPtr const & registry =
         std::static_pointer_cast<HdStResourceRegistry>(

--- a/pxr/imaging/hdSt/testenv/testHdStDrawItemsCache.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStDrawItemsCache.cpp
@@ -498,4 +498,3 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 }
-

--- a/pxr/imaging/hdSt/testenv/testHdStQuadrangulation.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStQuadrangulation.cpp
@@ -78,10 +78,10 @@ _CompareQuadPoints(std::string const & name,
 {
     std::cout << "GPU quadrangulate = " << gpu << "\n";
 
-    static HgiUniquePtr _hgi = Hgi::CreatePlatformDefaultHgi();
-    static HdDriver driver{HgiTokens->renderDriver, VtValue(_hgi.get())};
-    static HdStRenderDelegate renderDelegate;
-    static std::unique_ptr<HdRenderIndex> index(
+    HgiUniquePtr _hgi = Hgi::CreatePlatformDefaultHgi();
+    HdDriver driver{HgiTokens->renderDriver, VtValue(_hgi.get())};
+    HdStRenderDelegate renderDelegate;
+    std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
     HdStResourceRegistrySharedPtr const& registry = 
         std::static_pointer_cast<HdStResourceRegistry>(

--- a/pxr/imaging/hdx/CMakeLists.txt
+++ b/pxr/imaging/hdx/CMakeLists.txt
@@ -3,9 +3,9 @@ set(PXR_PACKAGE hdx)
 
 # XXX We check for PXR_ENABLE_GL_SUPPORT since Hdx currently still uses
 # GL via GarchGLApi. Once Hdx uses only Hgi, remove GL_SUPPORT check.
-if (NOT ${PXR_BUILD_GPU_SUPPORT} OR NOT ${PXR_ENABLE_GL_SUPPORT})
+if (NOT ${PXR_ENABLE_GL_SUPPORT})
     message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT is OFF")
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
     return()
 endif()
 

--- a/pxr/imaging/hgi/CMakeLists.txt
+++ b/pxr/imaging/hgi/CMakeLists.txt
@@ -47,7 +47,7 @@ if (${PXR_HEADLESS_TEST_MODE})
     return()
 endif()
 
-if (APPLE)
+if (APPLE AND NOT PXR_ENABLE_EXPERIMENTAL_TESTS)
     message(STATUS "Skipping ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
 endif()

--- a/pxr/imaging/hgiInterop/opengl.cpp
+++ b/pxr/imaging/hgiInterop/opengl.cpp
@@ -14,7 +14,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-static const char* _vertexFullscreen =
+static const char* _vertexFullscreen120 =
     "#version 120\n"
     "attribute vec4 position;\n"
     "attribute vec2 uvIn;\n"
@@ -25,7 +25,7 @@ static const char* _vertexFullscreen =
     "    uv = uvIn;\n"
     "}\n";
 
-static const char* _fragmentNoDepthFullscreen =
+static const char* _fragmentNoDepthFullscreen120 =
     "#version 120\n"
     "varying vec2 uv;\n"
     "uniform sampler2D colorIn;\n"
@@ -34,7 +34,7 @@ static const char* _fragmentNoDepthFullscreen =
     "    gl_FragColor = texture2D(colorIn, uv);\n"
     "}\n";
 
-static const char* _fragmentDepthFullscreen =
+static const char* _fragmentDepthFullscreen120 =
     "#version 120\n"
     "varying vec2 uv;\n"
     "uniform sampler2D colorIn;\n"
@@ -95,9 +95,9 @@ HgiInteropOpenGL::HgiInteropOpenGL()
     , _prgDepth(0)
     , _vertexBuffer(0)
 {
-    _vs = _CompileShader(_vertexFullscreen, GL_VERTEX_SHADER);
-    _fsNoDepth = _CompileShader(_fragmentNoDepthFullscreen, GL_FRAGMENT_SHADER);
-    _fsDepth = _CompileShader(_fragmentDepthFullscreen, GL_FRAGMENT_SHADER);
+    _vs = _CompileShader(_vertexFullscreen120, GL_VERTEX_SHADER);
+    _fsNoDepth = _CompileShader(_fragmentNoDepthFullscreen120, GL_FRAGMENT_SHADER);
+    _fsDepth = _CompileShader(_fragmentDepthFullscreen120, GL_FRAGMENT_SHADER);
     _prgNoDepth = _LinkProgram(_vs, _fsNoDepth);
     _prgDepth = _LinkProgram(_vs, _fsDepth);
     _vertexBuffer = _CreateVertexBuffer();

--- a/pxr/imaging/hgiInterop/vulkan.cpp
+++ b/pxr/imaging/hgiInterop/vulkan.cpp
@@ -14,7 +14,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-static const char* _vertexFullscreen =
+static const char* _vertexFullscreen120 =
     "#version 120\n"
     "attribute vec4 position;\n"
     "attribute vec2 uvIn;\n"
@@ -25,7 +25,18 @@ static const char* _vertexFullscreen =
     "    uv = uvIn;\n"
     "}\n";
 
-static const char* _fragmentNoDepthFullscreen =
+static const char* _vertexFullscreen140 =
+    "#version 140\n"
+    "in vec4 position;\n"
+    "in vec2 uvIn;\n"
+    "out vec2 uv;\n"
+    "void main(void)\n"
+    "{\n"
+    "    gl_Position = position;\n"
+    "    uv = uvIn;\n"
+    "}\n";
+
+static const char* _fragmentNoDepthFullscreen120 =
     "#version 120\n"
     "varying vec2 uv;\n"
     "uniform sampler2D colorIn;\n"
@@ -34,7 +45,17 @@ static const char* _fragmentNoDepthFullscreen =
     "    gl_FragColor = texture2D(colorIn, uv);\n"
     "}\n";
 
-static const char* _fragmentDepthFullscreen =
+static const char* _fragmentNoDepthFullscreen140 =
+    "#version 140\n"
+    "in vec2 uv;\n"
+    "out vec4 colorOut;\n"
+    "uniform sampler2D colorIn;\n"
+    "void main(void)\n"
+    "{\n"
+    "    colorOut = texture(colorIn, uv);\n"
+    "}\n";
+
+static const char* _fragmentDepthFullscreen120 =
     "#version 120\n"
     "varying vec2 uv;\n"
     "uniform sampler2D colorIn;\n"
@@ -46,6 +67,18 @@ static const char* _fragmentDepthFullscreen =
     "    gl_FragDepth = depth;\n"
     "}\n";
 
+static const char* _fragmentDepthFullscreen140 =
+    "#version 140\n"
+    "in vec2 uv;\n"
+    "out vec4 colorOut;\n"
+    "uniform sampler2D colorIn;\n"
+    "uniform sampler2D depthIn;\n"
+    "void main(void)\n"
+    "{\n"
+    "    colorOut = texture(colorIn, uv);\n"
+    "    gl_FragDepth = texture(depthIn, uv).r;\n"
+    "}\n";
+
 static uint32_t
 _CompileShader(const char* src, GLenum stage)
 {
@@ -54,7 +87,15 @@ _CompileShader(const char* src, GLenum stage)
     glCompileShader(shaderId);
     GLint status;
     glGetShaderiv(shaderId, GL_COMPILE_STATUS, &status);
-    TF_VERIFY(status == GL_TRUE);
+    if (status != GL_TRUE) {
+        int logSize = 0;
+        glGetShaderiv(shaderId, GL_INFO_LOG_LENGTH, &logSize);
+        std::string errors;
+        errors.resize(logSize + 1);
+        glGetShaderInfoLog(shaderId, logSize, nullptr, errors.data());
+        TF_VERIFY(false, "Failed to compile shader: %s", errors.c_str());
+    }
+
     return shaderId;
 }
 
@@ -85,6 +126,14 @@ _CreateVertexBuffer()
     glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     return vertexBuffer;
+}
+
+static uint32_t
+_CreateVertexArray()
+{
+    uint32_t vertexArray = 0;
+    glGenVertexArrays(1, &vertexArray);
+    return vertexArray;
 }
 
 static void
@@ -155,17 +204,28 @@ HgiInteropVulkan::HgiInteropVulkan(Hgi* hgiVulkan)
     , _prgNoDepth(0)
     , _prgDepth(0)
     , _vertexBuffer(0)
+    , _vertexArray(0)
     , _glColorTex(0)
     , _glDepthTex(0)
 {
     GarchGLApiLoad();
-    _vs = _CompileShader(_vertexFullscreen, GL_VERTEX_SHADER);
-    _fsNoDepth = _CompileShader(_fragmentNoDepthFullscreen, GL_FRAGMENT_SHADER);
-    _fsDepth = _CompileShader(_fragmentDepthFullscreen, GL_FRAGMENT_SHADER);
+    _vs = _CompileShader(GARCH_GL_VERSION_3_1 ? _vertexFullscreen140 :
+        _vertexFullscreen120, GL_VERTEX_SHADER);
+    _fsNoDepth = _CompileShader(GARCH_GL_VERSION_3_1 ?
+        _fragmentNoDepthFullscreen140 : _fragmentNoDepthFullscreen120,
+        GL_FRAGMENT_SHADER);
+    _fsDepth = _CompileShader(GARCH_GL_VERSION_3_1 ?
+        _fragmentDepthFullscreen140 : _fragmentDepthFullscreen120,
+        GL_FRAGMENT_SHADER);
     _prgNoDepth = _LinkProgram(_vs, _fsNoDepth);
     _prgDepth = _LinkProgram(_vs, _fsDepth);
     _vertexBuffer = _CreateVertexBuffer();
-    TF_VERIFY(glGetError() == GL_NO_ERROR);
+    if (GARCH_GL_VERSION_3_0) {
+        _vertexArray = _CreateVertexArray();
+    }
+
+    const GLenum error = glGetError();
+    TF_VERIFY(error == GL_NO_ERROR, "OpenGL error: 0x%04x", error);
 }
 
 HgiInteropVulkan::~HgiInteropVulkan()
@@ -176,13 +236,18 @@ HgiInteropVulkan::~HgiInteropVulkan()
     glDeleteProgram(_prgNoDepth);
     glDeleteProgram(_prgDepth);
     glDeleteBuffers(1, &_vertexBuffer);
+    if (_vertexArray) {
+        glDeleteVertexArrays(1, &_vertexArray);
+    }
     if (_glColorTex) {
         glDeleteTextures(1, &_glColorTex);
     }
     if (_glDepthTex) {
         glDeleteTextures(1, &_glDepthTex);
     }
-    TF_VERIFY(glGetError() == GL_NO_ERROR);
+
+    const GLenum error = glGetError();
+    TF_VERIFY(error == GL_NO_ERROR, "OpenGL error: 0x%04x", error);
 }
 
 void
@@ -198,7 +263,10 @@ HgiInteropVulkan::CompositeToInterop(
     }
 
     // Verify there were no gl errors coming in.
-    TF_VERIFY(glGetError() == GL_NO_ERROR);
+    {
+        const GLenum error = glGetError();
+        TF_VERIFY(error == GL_NO_ERROR, "OpenGL error: 0x%04x", error);
+    }
 
     GLint restoreDrawFramebuffer = 0;
     bool doRestoreDrawFramebuffer = false;
@@ -259,6 +327,10 @@ HgiInteropVulkan::CompositeToInterop(
     // Get the current array buffer binding state
     GLint restoreArrayBuffer = 0;
     glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &restoreArrayBuffer);
+
+    if (_vertexArray) {
+        glBindVertexArray(_vertexArray);
+    }
 
     // Vertex attributes
     const GLint locPosition = glGetAttribLocation(prg, "position");
@@ -325,6 +397,10 @@ HgiInteropVulkan::CompositeToInterop(
     // Restore state and verify gl errors
     glDisableVertexAttribArray(locPosition);
     glDisableVertexAttribArray(locUv);
+    if (_vertexArray) {
+        glBindVertexArray(0);
+    }
+
     glBindBuffer(GL_ARRAY_BUFFER, restoreArrayBuffer);
     
     if (!blendEnabled) {
@@ -367,7 +443,10 @@ HgiInteropVulkan::CompositeToInterop(
                           restoreDrawFramebuffer);
     }
 
-    TF_VERIFY(glGetError() == GL_NO_ERROR);
+    {
+        const GLenum error = glGetError();
+        TF_VERIFY(error == GL_NO_ERROR, "OpenGL error: 0x%04x", error);
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiInterop/vulkan.h
+++ b/pxr/imaging/hgiInterop/vulkan.h
@@ -50,6 +50,7 @@ private:
     uint32_t _prgNoDepth;
     uint32_t _prgDepth;
     uint32_t _vertexBuffer;
+    uint32_t _vertexArray;
 
     // XXX We tmp copy Vulkan's GPU texture to CPU and then to GL texture
     // Once we share GPU memory between Vulkan and GL we can remove this.

--- a/pxr/imaging/hgiMetal/CMakeLists.txt
+++ b/pxr/imaging/hgiMetal/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hgiMetal)
 
-if (NOT ${PXR_BUILD_GPU_SUPPORT} OR NOT ${PXR_ENABLE_METAL_SUPPORT})
+if (NOT ${PXR_ENABLE_METAL_SUPPORT})
     message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT or PXR_ENABLE_METAL_SUPPORT is OFF")
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_METAL_SUPPORT is OFF")
     return()
 endif()
 

--- a/pxr/imaging/hgiVulkan/CMakeLists.txt
+++ b/pxr/imaging/hgiVulkan/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(PXR_PREFIX pxr/imaging)
 set(PXR_PACKAGE hgiVulkan)
 
-if (NOT ${PXR_BUILD_GPU_SUPPORT} OR NOT ${PXR_ENABLE_VULKAN_SUPPORT})
+if (NOT ${PXR_ENABLE_VULKAN_SUPPORT})
     message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT or PXR_ENABLE_VULKAN_SUPPORT is OFF")
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_VULKAN_SUPPORT is OFF")
     return()
 endif()
 
@@ -59,7 +59,7 @@ if (${PXR_HEADLESS_TEST_MODE})
     return()
 endif()
 
-if (APPLE)
+if (APPLE AND NOT PXR_ENABLE_EXPERIMENTAL_TESTS)
     message(STATUS "Skipping ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
 endif()

--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -207,20 +207,22 @@ pxr_build_test(testUsdImagingExcluded
     CPPFILES
         testenv/testUsdImagingExcluded.cpp
 )
-pxr_build_test(testUsdImagingMaterialBinding
-    LIBRARIES
-        usdImaging
-        usdShade
-        usd
-        hd
-        glf
-        garch
-        tf
-        gf
-        vt
-    CPPFILES
-        testenv/testUsdImagingMaterialBinding.cpp
-)
+if(PXR_ENABLE_GL_SUPPORT)
+    pxr_build_test(testUsdImagingMaterialBinding
+        LIBRARIES
+            usdImaging
+            usdShade
+            usd
+            hd
+            glf
+            garch
+            tf
+            gf
+            vt
+        CPPFILES
+            testenv/testUsdImagingMaterialBinding.cpp
+    )
+endif()
 pxr_build_test(testUsdImagingNestedInstancingCategories
     LIBRARIES
         usdImaging

--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdImagingGL)
 
-if (NOT ${PXR_BUILD_GPU_SUPPORT})
+if (NOT ${PXR_ENABLE_GL_SUPPORT})
     message(STATUS
-        "Skipping ${PXR_PACKAGE} because PXR_BUILD_GPU_SUPPORT is OFF")
+        "Skipping ${PXR_PACKAGE} because PXR_ENABLE_GL_SUPPORT is OFF")
     return()
 endif()
 
@@ -157,7 +157,7 @@ if (${PXR_HEADLESS_TEST_MODE})
     return()
 endif()
 
-if (APPLE)
+if (APPLE AND NOT PXR_ENABLE_EXPERIMENTAL_TESTS)
     message(STATUS "Skipping ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
 endif()
@@ -3778,49 +3778,58 @@ pxr_register_test(testUsdImagingGLUsdSkelExtCompGPU_twoBends
         USDSKELIMAGING_FORCE_CPU_COMPUTE=0
 )
 
-pxr_register_test(testUsdImagingGLPopOut
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test test.usda"
-    IMAGE_DIFF_COMPARE
-        test_0.png
-        test_1.png
-        test_2.png
-        test_3.png
-        test_4.png
-        test_5.png
-        test_6.png
-        test_7.png
-        test_8.png
-    FAIL .05
-    FAIL_PERCENT .03
-    PERCEPTUAL
-    EXPECTED_RETURN_CODE 0
-    TESTENV testUsdImagingGLPopOut
-)
+if(NOT APPLE)
+    # OpenGL specific tests
+    pxr_register_test(testUsdImagingGLPopOut
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test test.usda"
+        IMAGE_DIFF_COMPARE
+            test_0.png
+            test_1.png
+            test_2.png
+            test_3.png
+            test_4.png
+            test_5.png
+            test_6.png
+            test_7.png
+            test_8.png
+        FAIL .05
+        FAIL_PERCENT .03
+        PERCEPTUAL
+        EXPECTED_RETURN_CODE 0
+        TESTENV testUsdImagingGLPopOut
+        ENV
+            HGI_ENABLE_VULKAN=0
+    )
 
-pxr_register_test(testUsdImagingGLPopOut_instance
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance test_instance.usda"
-    IMAGE_DIFF_COMPARE
-        test_instance_0.png
-        test_instance_1.png
-        test_instance_2.png
-        test_instance_3.png
-        test_instance_4.png
-        test_instance_5.png
-        test_instance_6.png
-        test_instance_7.png
-        test_instance_8.png
-    FAIL .05
-    FAIL_PERCENT .03
-    PERCEPTUAL
-    EXPECTED_RETURN_CODE 0
-    TESTENV testUsdImagingGLPopOut
-)
+    pxr_register_test(testUsdImagingGLPopOut_instance
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance test_instance.usda"
+        IMAGE_DIFF_COMPARE
+            test_instance_0.png
+            test_instance_1.png
+            test_instance_2.png
+            test_instance_3.png
+            test_instance_4.png
+            test_instance_5.png
+            test_instance_6.png
+            test_instance_7.png
+            test_instance_8.png
+        FAIL .05
+        FAIL_PERCENT .03
+        PERCEPTUAL
+        EXPECTED_RETURN_CODE 0
+        TESTENV testUsdImagingGLPopOut
+        ENV
+            HGI_ENABLE_VULKAN=0
+    )
 
-pxr_register_test(testUsdImagingGLPopOut_instance_empty
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance_empty test_instance_empty.usda"
-    EXPECTED_RETURN_CODE 0
-    TESTENV testUsdImagingGLPopOut
-)
+    pxr_register_test(testUsdImagingGLPopOut_instance_empty
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLPopOut --output test_instance_empty test_instance_empty.usda"
+        EXPECTED_RETURN_CODE 0
+        TESTENV testUsdImagingGLPopOut
+        ENV
+            HGI_ENABLE_VULKAN=0
+    )
+endif()
 
 pxr_register_test(testUsdImagingGLMaterialTag
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -cullStyle back -offscreen -frameAll -stage materialTag.usda -write testUsdImagingGLMaterialTag.png"


### PR DESCRIPTION
### Description of Change(s)

- Add `PXR_ENABLE_EXPERIMENTAL_TESTS` (off by default) to enable more graphics tests.
  - Building with it enabled, you now have access to way more tests.
  - Currently only used on macOS. I'll have Windows support ready a bit later.
- Cleanup use of `PXR_ENABLE_GL_SUPPORT` and `PXR_BUILD_GPU_SUPPORT`.
  - `PXR_BUILD_GPU_SUPPORT` is only true if `PXR_ENABLE_GL_SUPPORT` is true: cleanup redundant checks.
  - Add or correct various `PXR_ENABLE_GL_SUPPORT` checks.
- Remove X11 requirement.
  - Create a null GL context when X11 isn't available, so tests can still run (but without HgiGL support).
- Various changes to make HgiVulkan work on macOS. Using Lavapipe you can run the full test suite.
  - Enable GLSL support on macOS. This will also be needed by HgiWebGPU.
  - Add OpenGL 1.4 support to HgiInterop and use a VertexArray, as required by Apple OpenGL.
  - The vast majority of tests are passing. Most are failing because tiny differences compared to the baseline, minor issues with Lavapipe, or unreliable tests (mostly dependency on the order of unordered collection).
  - This PR focuses on getting the tests to run, not to pass.
- Fix `testHdStCodeGen` and `testHdStQuadrangulation` crashing due to undefined static destruction order.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

* N/A

### Fixes Issue(s)

* N/A

### Checklist

[ ] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[X] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
