### PR TITLE
work: account for task_group_base interface change in oneTBB 2022.0.0

### DIFF
--- a/pxr/base/work/dispatcher.cpp
+++ b/pxr/base/work/dispatcher.cpp
@@ -33,7 +33,11 @@ WorkDispatcher::WorkDispatcher()
 #if TBB_INTERFACE_VERSION_MAJOR >= 12
 inline tbb::detail::d1::wait_context& 
 WorkDispatcher::_TaskGroup::_GetInternalWaitContext() {
+#if TBB_INTERFACE_VERSION_MINOR >= 14
+    return m_wait_vertex.get_context();
+#else
     return m_wait_ctx;
+#endif
 }
 #endif
 


### PR DESCRIPTION
The `m_wait_ctx` member being used in a narrow band of oneTBB versions was removed in a refactor that went into version [v2022.0.0](https://github.com/oneapi-src/oneTBB/releases/tag/v2022.0.0) which was released yesterday:
https://github.com/oneapi-src/oneTBB/commit/1f52f5093ec7ce23829fe64ab82ac5541fea42ee

This change accounts for the update in the new version of oneTBB and uses the newly added `m_wait_vertex` member to access the same context as before.


I am far from an expert in the TBB API or the intricacies of this area of libwork, but wanted to offer this up as it allowed me to successfully build OpenUSD against the latest version of oneTBB. I have *not* done any performance profiling with the new oneTBB version.

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
