### PR TITLE
Update to schema examples documentation

### DIFF
--- a/docs/tut_generating_new_schema.rst
+++ b/docs/tut_generating_new_schema.rst
@@ -378,7 +378,7 @@ Using the Schema Classes
       :filename:`usdSchemaExamples.dll` and :filename:`.lib`) and the 
       :filename:`usdSchemaExamples` directory to :filename`<prefix>/plugin/usd`
 
-    * You may encounter an :filename:`ImportError DLL load failed` when running from
+    * You may encounter :filename:`ImportError DLL load failed` when running from
       Python 3.8+ on Windows. This is due to the DLL directory not being added to
       trusted locations and can be resolved by manually adding the :filename:`resources`
       directory before import via :filename:`os.add_dll_directory`.

--- a/docs/tut_generating_new_schema.rst
+++ b/docs/tut_generating_new_schema.rst
@@ -377,6 +377,11 @@ Using the Schema Classes
     * Copying :filename:`usdSchemaExamples.so` (on Windows, 
       :filename:`usdSchemaExamples.dll` and :filename:`.lib`) and the 
       :filename:`usdSchemaExamples` directory to :filename`<prefix>/plugin/usd`
+
+    * You may encounter an :filename:`ImportError DLL load failed` when running from
+      Python 3.8+ on Windows. This is due to the DLL directory not being added to
+      trusted locations and can be resolved by manually adding the :filename:`resources`
+      directory before import via :filename:`os.add_dll_directory`.
    
 Create a usd file named Test.usda with the following content:
 


### PR DESCRIPTION
### Description of Change(s)

Adds a note to the schema examples tutorial that warns about an issue with Python 3.8+ on Windows where the `resources` or DLL directories need to be manually added to trusted locations in order to import.

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3376

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[X] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
