### PR TITLE
usdGeom: y up axis validator

### DIFF
--- a/pxr/usd/usdGeom/plugInfo.json
+++ b/pxr/usd/usdGeom/plugInfo.json
@@ -443,7 +443,10 @@
                         "schemaTypes": [
                             "UsdGeomSubset"
                         ]
-                    }, 
+                    },
+                    "YUpAxisValidator": {
+                        "doc": "UsdStage metadata of upAxis must be Y."
+                    },
                     "keywords": [
                         "UsdGeomValidators"
                     ]

--- a/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
@@ -367,7 +367,6 @@ void TestUsdGeomStageMetadata()
 static
 void TestUsdGeomYUpAxisValidator()
 {
-    // Get stageMetadataChecker
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
     const UsdValidator *validator = registry.GetOrLoadValidatorByName(
             UsdGeomValidatorNameTokens->yUpAxisValidator);

--- a/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomValidators.cpp
@@ -29,6 +29,7 @@ TestUsdGeomValidators()
         UsdGeomValidatorNameTokens->subsetFamilies,
         UsdGeomValidatorNameTokens->subsetParentIsImageable,
         UsdGeomValidatorNameTokens->stageMetadataChecker,
+        UsdGeomValidatorNameTokens->yUpAxisValidator
     };
 
     const UsdValidationRegistry& registry =
@@ -41,7 +42,7 @@ TestUsdGeomValidators()
 
     UsdValidatorMetadataVector metadata =
         registry.GetValidatorMetadataForPlugin(_tokens->usdGeomPlugin);
-    TF_AXIOM(metadata.size() == 3);
+    TF_AXIOM(metadata.size() == 4);
     for (const UsdValidatorMetadata& metadata : metadata) {
         validatorMetadataNameSet.insert(metadata.name);
     }
@@ -315,7 +316,7 @@ TestUsdGeomSubsetParentIsImageable()
 }
 
 static
-void TestUsdStageMetadata()
+void TestUsdGeomStageMetadata()
 {
     // Get stageMetadataChecker
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
@@ -333,10 +334,10 @@ void TestUsdStageMetadata()
     TF_AXIOM(errors.size() == 2);
     auto rootLayerIdentifier = rootLayer->GetIdentifier().c_str();
     const std::vector<std::string> expectedErrorMessages = {
-        TfStringPrintf("Stage with root layer <%s> does not specify its linear "
-                       "scale in metersPerUnit.", rootLayerIdentifier),
-        TfStringPrintf("Stage with root layer <%s> does not specify an upAxis.", 
-                       rootLayerIdentifier)
+        TfStringPrintf("Stage with root layer <%s> does not specify its "
+                       "linear scale in metersPerUnit.", rootLayerIdentifier),
+        TfStringPrintf("Stage with root layer <%s> does not specify an "
+                       "upAxis.", rootLayerIdentifier)
     };
 
     const std::vector<TfToken> expectedErrorIdentifiers = {
@@ -363,14 +364,52 @@ void TestUsdStageMetadata()
     TF_AXIOM(errors.empty());
 }
 
+static
+void TestUsdGeomYUpAxisValidator()
+{
+    // Get stageMetadataChecker
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    const UsdValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdGeomValidatorNameTokens->yUpAxisValidator);
+    TF_AXIOM(validator);
+
+    // Create an empty stage with a Z up axis
+    SdfLayerRefPtr rootLayer = SdfLayer::CreateAnonymous();
+    UsdStageRefPtr usdStage = UsdStage::Open(rootLayer);
+
+    UsdGeomSetStageUpAxis(usdStage, UsdGeomTokens->z);
+
+    UsdValidationErrorVector errors = validator->Validate(usdStage);
+
+    // Verify the error is present
+    const TfToken expectedIdentifier =
+        TfToken("usdGeom:YUpAxisValidator.nonYUpAxis");
+    const std::string expectedErrorMsg =
+        "Stage specifies upAxis 'Z'. upAxis should be 'Y'.";
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetIdentifier() == expectedIdentifier);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // Change the up axis to Y
+    UsdGeomSetStageUpAxis(usdStage, UsdGeomTokens->y);
+
+    errors = validator->Validate(usdStage);
+
+    // Verify the errors are fixed
+    TF_AXIOM(errors.empty());
+}
+
 int
 main()
 {
     TestUsdGeomValidators();
     TestUsdGeomSubsetFamilies();
     TestUsdGeomSubsetParentIsImageable();
-    TestUsdStageMetadata();
+    TestUsdGeomStageMetadata();
+    TestUsdGeomYUpAxisValidator();
 
-    std::cout << "OK\n";
     return EXIT_SUCCESS;
 }

--- a/pxr/usd/usdGeom/validatorTokens.h
+++ b/pxr/usd/usdGeom/validatorTokens.h
@@ -19,7 +19,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define USD_GEOM_VALIDATOR_NAME_TOKENS                              \
     ((stageMetadataChecker, "usdGeom:StageMetadataChecker"))        \
     ((subsetFamilies, "usdGeom:SubsetFamilies"))                    \
-    ((subsetParentIsImageable, "usdGeom:SubsetParentIsImageable"))
+    ((subsetParentIsImageable, "usdGeom:SubsetParentIsImageable"))  \
+    ((yUpAxisValidator, "usdGeom:YUpAxisValidator"))
 
 #define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                           \
     (UsdGeomSubset)                                                 \
@@ -29,7 +30,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((missingMetersPerUnitMetadata, "MissingMetersPerUnitMetadata"))    \
     ((missingUpAxisMetadata, "MissingUpAxisMetadata"))                  \
     ((invalidSubsetFamily,  "InvalidSubsetFamily"))                     \
-    ((notImageableSubsetParent, "NotImageableSubsetParent"))
+    ((notImageableSubsetParent, "NotImageableSubsetParent"))            \
+    ((nonYUpAxis, "nonYUpAxis"))
 
 /// \def USD_GEOM_VALIDATOR_NAME_TOKENS
 /// Tokens representing validator names. Note that for plugin provided

--- a/pxr/usd/usdGeom/validators.cpp
+++ b/pxr/usd/usdGeom/validators.cpp
@@ -155,6 +155,33 @@ _SubsetParentIsImageable(const UsdPrim& usdPrim)
     };
 }
 
+static
+UsdValidationErrorVector
+_YUpAxisValidator(const UsdStagePtr &usdStage)
+{
+    if (usdStage->HasAuthoredMetadata(UsdGeomTokens->upAxis)) {
+        TfToken axis;
+        usdStage->GetMetadata(UsdGeomTokens->upAxis, &axis);
+
+        if (axis != UsdGeomTokens->y)
+        {
+            return {
+                UsdValidationError(
+                    UsdGeomValidationErrorNameTokens->nonYUpAxis,
+                    UsdValidationErrorType::Error,
+                    UsdValidationErrorSites{UsdValidationErrorSite(usdStage,
+                                                           SdfPath("/"))},
+                    TfStringPrintf(
+                    "Stage specifies upAxis '%s'. upAxis should"
+                                 " be 'Y'.", axis.GetText())
+                )
+            };
+        }
+    }
+
+    return {};
+}
+
 TF_REGISTRY_FUNCTION(UsdValidationRegistry)
 {
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
@@ -170,6 +197,10 @@ TF_REGISTRY_FUNCTION(UsdValidationRegistry)
     registry.RegisterPluginValidator(
         UsdGeomValidatorNameTokens->subsetParentIsImageable,
         _SubsetParentIsImageable);
+
+    registry.RegisterPluginValidator(
+        UsdGeomValidatorNameTokens->yUpAxisValidator,
+        _YUpAxisValidator);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
- Moving the existing portion of the StageMetadataChecker from complianceChecker.py that verifies the upAxis is Y
- Added implementation code, a test, and necessary tokens & plugInfo entries

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
- https://github.com/orgs/PixarAnimationStudios/projects/3/views/1?pane=issue&itemId=65424791

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[X] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
