### PR TITLE
Fix fallthrough on failed lookup of pythonLibPath (Linux)

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -234,6 +234,10 @@ def GetPythonInfo(context):
     else:
         raise RuntimeError("Platform not supported")
 
+    assert os.path.exists(pythonExecPath), f"Could not find {pythonExecPath}"
+    assert os.path.exists(pythonLibPath), f"Could not find {pythonLibPath}"
+    assert os.path.exists(pythonIncludeDir), f"Could not find {pythonIncludeDir}"
+
     return (pythonExecPath, pythonLibPath, pythonIncludeDir, pythonVersion)
 
 def GetCPUCount():

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -210,6 +210,7 @@ def GetPythonInfo(context):
                                      _GetPythonLibraryFilename(context))
     elif Linux():
         pythonMultiarchSubdir = sysconfig.get_config_var("multiarchsubdir")
+        searched = set()
         # Try multiple ways to get the python lib dir
         for pythonLibDir in (sysconfig.get_config_var("LIBDIR"),
                              os.path.join(pythonBaseDir, "lib")):
@@ -217,12 +218,16 @@ def GetPythonInfo(context):
                 pythonLibPath = \
                     os.path.join(pythonLibDir + pythonMultiarchSubdir,
                                  _GetPythonLibraryFilename(context))
+                searched.add(pythonLibPath)
                 if os.path.isfile(pythonLibPath):
                     break
             pythonLibPath = os.path.join(pythonLibDir,
                                          _GetPythonLibraryFilename(context))
+            searched.add(pythonLibPath)
             if os.path.isfile(pythonLibPath):
                 break
+        else:
+            raise RuntimeError(f"Could not find the Python library path at: {searched}")
     elif MacOS():
         pythonLibPath = os.path.join(pythonBaseDir, "lib",
                                      _GetPythonLibraryFilename(context))


### PR DESCRIPTION
### Description of Change(s)

The Python library name lookup here uses a heuristic that is potentially fallible.
However it currently falls through if the path doesn't exist at all.

Additionally none of the paths are verified before returning, so I added some asserts for that.

I don't think this will fix https://github.com/PixarAnimationStudios/OpenUSD/issues/3401 but it will likely help reduce some of the debugging burden in the future by failing earlier in a clearer way.


### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
