### PR TITLE
Fix infinite recursion writing to removable drives mounted to NTFS folders

### DIFF
--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -80,13 +80,22 @@ Tf_HasAttribute(
 
     // Ignore reparse points on network volumes. They can't be resolved
     // properly, so simply remove the reparse point attribute and treat
-    // it like a regular file/directory.
+    // it like a regular file/directory. Also ignore reparse points where
+    // TfReadLink returns the passed in path. As described in ArchReadLink,
+    // this will happen in cases where the reparse points are NT Object
+    // Manager paths, which cannot be used as file paths. Or if TfReadLink
+    // returns an empty string, that means we could not resolve the link
+    // at all, so treat it as if it is not a link.
+    std::string linkPath;
     if ((attribs & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
         // Calling PathIsNetworkPath sometimes sets the "last error" to an
         // error code indicating an incomplete overlapped I/O function. We
         // want to ignore this error.
         DWORD olderr = GetLastError();
-        if (PathIsNetworkPathW(pathW.c_str())) {
+        linkPath = TfReadLink(path.c_str());
+        if (PathIsNetworkPathW(pathW.c_str()) ||
+            linkPath.empty() ||
+            path == linkPath) {
             attribs &= ~FILE_ATTRIBUTE_REPARSE_POINT;
         }
         SetLastError(olderr);
@@ -106,8 +115,7 @@ Tf_HasAttribute(
     }
 
     // Read symlinks until we find the real file.
-    return Tf_HasAttribute(TfReadLink(path.c_str()), resolveSymlinks,
-                           attribute, expected);
+    return Tf_HasAttribute(linkPath, resolveSymlinks, attribute, expected);
 }
 
 // Same as above but the bits in attribute must all be set.

--- a/pxr/base/tf/fileUtils.cpp
+++ b/pxr/base/tf/fileUtils.cpp
@@ -114,6 +114,12 @@ Tf_HasAttribute(
         return attribute == 0 || (attribs & attribute) == expected;
     }
 
+    // At this point we know (attribs & FILE_ATTRIBUTE_REPARSE_POINT) != 0
+    // or we would have returned in the if block above. This means linkPath
+    // will be holding the result of calling TfReadLink(path.c_str()). The
+    // code is separated in this way to avoid calling TfReadLink twice. This
+    // is why we can simply pass linkPath to the Tf_HasAttribute call below.
+
     // Read symlinks until we find the real file.
     return Tf_HasAttribute(linkPath, resolveSymlinks, attribute, expected);
 }

--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -58,12 +58,8 @@ _ExpandSymlinks(const std::string& path)
             prefix.push_back('\\');
         }
         if (TfIsLink(prefix)) {
-            // Expand the link and repeat with the new path if the path changed.
-            // The path may remain unchanged or be empty if the link type is
-            // unsupported or the mount destination is not available.
-            auto newPrefix = TfReadLink(prefix);
-            if (!newPrefix.empty() && newPrefix != prefix)
-                return _ExpandSymlinks(newPrefix + path.substr(i));
+            // Expand the link and repeat with the new path.
+            return _ExpandSymlinks(TfReadLink(prefix) + path.substr(i));
         }
         i = path.find_first_of("/\\", i + 1);
     }


### PR DESCRIPTION
Fix another issue with unresolvable reparse points on Windows. ArchReadLink
can return the passed in path if it refers to an "NT Object Manager" path, and we need to handle this as if it isn't a reparse point, because we can't follow the link.

This generalizes the fix by @seando-adsk in f6c2e82, by handling mounted volumes on Windows and avoiding infinitely recursive calls to TfReadLink by having TfIsLink return false in cases where this bad behavior could arise.

### Description of Change(s)
Changed Tf_HasAttribute to remove the reparse point attribute on a directory if TfReadLink returns the original path or an empty string (i.e. we couldn't follow the link). This means TfIsLink returns false in these cases, preventing recursive calls to TfReadLink because we always call TfIsLink before calling TfReadLink.

### Fixes Issue(s)
#3414

### Checklist

[ X ] I have created this PR based on the dev branch

[ X ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality
Unit testing this is basically impossible given the complex steps required to set up the USB drive appropriately.

[ X ] I have verified that all unit tests pass with the proposed changes

[ X ] I have submitted a signed Contributor License Agreement (Reference: 
