### PR TITLE
build: remove distutils dependency

### DIFF
--- a/pxr/usd/bin/usdedit/usdedit.py
+++ b/pxr/usd/bin/usdedit/usdedit.py
@@ -20,12 +20,12 @@ def _findEditorTools(usdFileName, readOnly):
         sys.exit("Error: Couldn't find 'usdcat'. Expected it to be in PATH.")
 
     # Ensure we have a suitable editor available
-    from distutils.spawn import find_executable
+    import shutil
     editorCmd = (os.getenv("USD_EDITOR") or
                  os.getenv("EDITOR") or 
-                 find_executable("emacs") or
-                 find_executable("vim") or
-                 find_executable("notepad"))
+                 shutil.which("emacs") or
+                 shutil.which("vim") or
+                 shutil.which("notepad"))
     
     if not editorCmd:
         sys.exit("Error: Couldn't find a suitable text editor to use. Expected " 

--- a/pxr/usd/usdUtils/toolPaths.py
+++ b/pxr/usd/usdUtils/toolPaths.py
@@ -7,7 +7,7 @@
 import os
 import platform
 import sys
-from distutils.spawn import find_executable
+import shutil
 
 def FindUsdBinary(name):
     """Returns the full path to the named executable if it can be found, or
@@ -20,18 +20,18 @@ def FindUsdBinary(name):
     """
 
     # First search PATH
-    binpath = find_executable(name)
+    binpath = shutil.which(name)
     if binpath:
         return binpath
 
     # Then look relative to the current executable
-    binpath = find_executable(name,
+    binpath = shutil.which(name,
         path=os.path.abspath(os.path.dirname(sys.argv[0])))
     if binpath:
         return binpath
 
     if platform.system() == 'Windows':
-        # find_executable under Windows only returns *.EXE files so we need to
+        # shutil.which under Windows only returns *.EXE files so we need to
         # traverse the tool path.
         path = os.environ.get('PATH', '').split(os.pathsep)
         for base in [os.path.join(p, name) for p in path]:

--- a/pxr/usd/usdUtils/updateSchemaWithSdrNode.py
+++ b/pxr/usd/usdUtils/updateSchemaWithSdrNode.py
@@ -182,6 +182,23 @@ def _SetSchemaUserDocFields(spec, doc):
     # (example: https://openusd.org/release/user_guides/schemas/index.html)
     spec.customData[UserDocConstants.USERDOC_FULL] = doc
 
+
+def StringToBool(val):
+    """Convert a string representation of truth to True or False.
+    
+    True values are 'y', 'yes', 't', 'true', 'on', and '1';
+    False values are 'n', 'no', 'f', 'false', 'off', and '0'.
+    
+    Raises ValueError if `val` is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError(f"Invalid truth value: {val}")
+
 def UpdateSchemaWithSdrNode(schemaLayer, sdrNode, renderContext="",
         overrideIdentifier=""):
     """
@@ -271,7 +288,6 @@ def UpdateSchemaWithSdrNode(schemaLayer, sdrNode, renderContext="",
           SdfPropertySpec's CONNECTABILITY.
     """
 
-    import distutils.util
     import os
 
     # Early exit on invalid parameters
@@ -350,7 +366,7 @@ def UpdateSchemaWithSdrNode(schemaLayer, sdrNode, renderContext="",
     if SchemaDefiningKeys.PROVIDES_USD_SHADE_CONNECTABLE_API_BEHAVIOR in \
             sdrNodeMetadata:
         providesUsdShadeConnectableAPIBehavior = \
-            distutils.util.strtobool(sdrNodeMetadata[SchemaDefiningKeys. \
+            StringToBool(sdrNodeMetadata[SchemaDefiningKeys. \
                 PROVIDES_USD_SHADE_CONNECTABLE_API_BEHAVIOR])
 
     apiSchemasForAttrPruning = None
@@ -460,7 +476,7 @@ def UpdateSchemaWithSdrNode(schemaLayer, sdrNode, renderContext="",
                 # Since we want to assign the types for these to bool and
                 # because in python boolean type is a subset of int, we need to
                 # do following instead of assign the propValue directly.
-                propValue = distutils.util.strtobool(sdrNodeMetadata[propKey])
+                propValue = StringToBool(sdrNodeMetadata[propKey])
                 extraPlugInfo[propKey] = bool(propValue)
 
         primSpecCustomData['extraPlugInfo'] = extraPlugInfo


### PR DESCRIPTION
### Description of Change(s)
- swap out usages of `find_executable` with `shutil.which`
- replace strtobool with an equivalent function (https://docs.python.org/3.9/distutils/apiref.html#distutils.util.strtobool)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
- https://github.com/PixarAnimationStudios/OpenUSD/issues/3389

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
