### PR TITLE
hioOiio: remove use of deprecated API to support OpenImageIO v3.0.0.3

### DIFF
--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -289,7 +289,7 @@ _FindAttribute(ImageSpec const & spec, std::string const & metadataKey)
     bool convertMatrixTypes = false;
     std::string key = _TranslateMetadataKey(metadataKey, &convertMatrixTypes);
 
-    ImageIOParameter const * param = spec.find_attribute(key);
+    ParamValue const * param = spec.find_attribute(key);
     if (!param) {
         return VtValue();
     }

--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -711,21 +711,21 @@ HioOIIO_Image::ReadCropped(int const cropTop,
     // Read Image into pixels, flipping upon load so that
     // origin is at lower left corner
     // If needed, convert double precision images to float
-    bool res = false;
-    if (imageInput->spec().format == TypeDesc::DOUBLE) {
-        res = imageInput->read_image(TypeDesc::FLOAT,
-            start,
-            AutoStride,
-            readStride,
-            AutoStride);
-    } else{
-        res = imageInput->read_image(imageInput->spec().format,
-            start,
-            AutoStride,
-            readStride,
-            AutoStride);
+    TypeDesc format = imageInput->spec().format;
+    if (format == TypeDesc::DOUBLE) {
+        format = TypeDesc::FLOAT;
     }
 
+    bool res = imageInput->read_image(
+        imageInput->current_subimage(),
+        imageInput->current_miplevel(),
+        0,
+        -1,
+        format,
+        start,
+        AutoStride,
+        readStride,
+        AutoStride);
     if (!res)
     {
         TF_RUNTIME_ERROR("Failed to read image pixel from \"%s\", error = %s",


### PR DESCRIPTION
This fixes up a few usages of long-deprecated OpenImageIO API to allow building against OpenImageIO v3.0.0.3, where those bits of API were finally removed.

This OpenImageIO commit in particular is where the deprecated API was removed:
https://github.com/AcademySoftwareFoundation/OpenImageIO/commit/a4a759f8755929c9cd12ec0da8beed152c37ed09

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
