### PR TITLE
hdx: Fixes for 1d luts in HdxColorCorrectionTask

### DIFF
--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -444,6 +444,7 @@ HdxColorCorrectionTask::_CreateOpenColorIOResourcesImpl(
 
         // Sampler description
         HgiSamplerDesc sampDesc;
+        sampDesc.debugName = samplerName;
         sampDesc.magFilter =
             interpolation == OCIO::Interpolation::INTERP_NEAREST ?
                 HgiSamplerFilterNearest : HgiSamplerFilterLinear;

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -454,9 +454,14 @@ HdxColorCorrectionTask::_CreateOpenColorIOResourcesImpl(
         sampDesc.addressModeU = HgiSamplerAddressModeClampToEdge;
         sampDesc.addressModeV = HgiSamplerAddressModeClampToEdge;
 
+        std::vector<float> lutVector = std::vector<float>(
+            lutValues,
+            lutValues + (valueCount * sizeof(float))
+        );
+
         result->luts.emplace_back(
             _TextureSamplerDesc{
-                texDesc, sampDesc, float4AdaptedLutValues});
+                texDesc, sampDesc, lutVector});
     }
 
     //

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -456,7 +456,7 @@ HdxColorCorrectionTask::_CreateOpenColorIOResourcesImpl(
 
         std::vector<float> lutVector = std::vector<float>(
             lutValues,
-            lutValues + (valueCount * sizeof(float))
+            lutValues + valueCount
         );
 
         result->luts.emplace_back(


### PR DESCRIPTION
### Description of Change(s)

This fixes a couple of issues in HdxColorCorrectionTask for users of 1d luts. We started to notice a `TF_VERIFY()` failure and a mostly-black/uninitialized viewport in usdview when we upgraded to OCIO 2.2 (VFX CY2023).

```
ERROR: Usdview encountered an error while rendering.
Error in '<PXR_NS>::HdxColorCorrectionTask::_CreateOpenColorIOShaderCode' at line 562 in file /.../pxr/imaging/hdx/colorCorrectionTask.cpp :
'Failed verification: ' !texInfo.texName.empty() && !texInfo.samplerName.empty() ''
```

* 2d106a1138faa66d935fae2df89f0c9ba8a37ef9 fixes the `TF_VERIFY()` check.
* ec769ab42fe1dd427d40c1a3184db761348128a0 initializes the lut values passed to the ` _TextureSamplerDesc`. I was finding `float4AdaptedLutValues` was only conditionally initialized based on the active `HgiFormat fmt`.

I realize I've left some of the checklist undone but mostly just checking on interest.

### Fixes Issue(s)

* Similar: #3274 

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [ ] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
