### PR TITLE
Autodesk: Fix Vulkan crashes for missing extensions and layers

### DIFF
--- a/pxr/imaging/hgi/hgi.cpp
+++ b/pxr/imaging/hgi/hgi.cpp
@@ -102,6 +102,12 @@ _MakeNewPlatformDefaultHgi()
         return nullptr;
     }
 
+    if (!instance->IsBackendSupported()) {
+        TF_DEBUG(HGI_DEBUG_INSTANCE_CREATION).Msg("Hgi %s is not supported\n",
+            hgiType);
+        return nullptr;
+    }
+
     TF_DEBUG(HGI_DEBUG_INSTANCE_CREATION).Msg("Successfully created platform "
         "default Hgi %s\n", hgiType);
 
@@ -168,6 +174,12 @@ _MakeNamedHgi(const TfToken& hgiToken)
     if (!instance) {
         TF_CODING_ERROR("[PluginLoad] Cannot construct instance of type '%s'\n",
             plugType.GetTypeName().c_str());
+        return nullptr;
+    }
+
+    if (!instance->IsBackendSupported()) {
+        TF_DEBUG(HGI_DEBUG_INSTANCE_CREATION).Msg("Hgi %s is not supported\n",
+            hgiType.c_str());
         return nullptr;
     }
 

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -87,6 +87,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     , _vmaAllocator(nullptr)
     , _commandQueue(nullptr)
     , _capabilities(nullptr)
+    , _pipelineCache(nullptr)
 {
     //
     // Determine physical device
@@ -112,7 +113,8 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         if (familyIndex == VK_QUEUE_FAMILY_IGNORED) continue;
 
         // Assume we always want a presentation capable device for now.
-        if (!_SupportsPresentation(instance, physicalDevices[i], familyIndex)) {
+        if (instance->HasPresentation() &&
+            !_SupportsPresentation(instance, physicalDevices[i], familyIndex)) {
             continue;
         }
 
@@ -383,10 +385,12 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
 
 HgiVulkanDevice::~HgiVulkanDevice()
 {
-    // Make sure device is idle before destroying objects.
-    HGIVULKAN_VERIFY_VK_RESULT(
-        vkDeviceWaitIdle(_vkDevice)
-    );
+    if (_vkDevice) {
+        // Make sure device is idle before destroying objects.
+        HGIVULKAN_VERIFY_VK_RESULT(
+            vkDeviceWaitIdle(_vkDevice)
+        );
+    }
 
     delete _pipelineCache;
     delete _commandQueue;

--- a/pxr/imaging/hgiVulkan/diagnostic.cpp
+++ b/pxr/imaging/hgiVulkan/diagnostic.cpp
@@ -207,6 +207,10 @@ HgiVulkanBeginLabel(
         return;
     }
 
+    if (!TF_VERIFY(device && device->vkCmdBeginDebugUtilsLabelEXT)) {
+        return;
+    }
+
     VkCommandBuffer vkCmbuf = cb->GetVulkanCommandBuffer();
     VkDebugUtilsLabelEXT labelInfo = {VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT};
     labelInfo.pLabelName = label;
@@ -219,6 +223,10 @@ HgiVulkanEndLabel(
     HgiVulkanCommandBuffer* cb)
 {
     if (!HgiVulkanIsDebugEnabled()) {
+        return;
+    }
+
+    if (!TF_VERIFY(device && device->vkCmdEndDebugUtilsLabelEXT)) {
         return;
     }
 
@@ -235,6 +243,10 @@ HgiVulkanBeginQueueLabel(
         return;
     }
 
+    if (!TF_VERIFY(device && device->vkQueueBeginDebugUtilsLabelEXT)) {
+        return;
+    }
+
     VkQueue gfxQueue = device->GetCommandQueue()->GetVulkanGraphicsQueue();
     VkDebugUtilsLabelEXT labelInfo = {VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT};
     labelInfo.pLabelName = label;
@@ -245,6 +257,10 @@ void
 HgiVulkanEndQueueLabel(HgiVulkanDevice* device)
 {
     if (!HgiVulkanIsDebugEnabled()) {
+        return;
+    }
+
+    if (!TF_VERIFY(device && device->vkQueueEndDebugUtilsLabelEXT)) {
         return;
     }
 

--- a/pxr/imaging/hgiVulkan/instance.h
+++ b/pxr/imaging/hgiVulkan/instance.h
@@ -40,8 +40,12 @@ public:
     HGIVULKAN_API
     PFN_vkGetInstanceProcAddr GetPFNInstancProcAddr();
 
+    /// Does the instance support presentation?
+    bool HasPresentation() { return _hasPresentation; }
+
 private:
     VkInstance _vkInstance;
+    bool _hasPresentation;
 };
 
 


### PR DESCRIPTION
### Description of Change(s)

⚠ Branched off feature-hgi-vulkan

Skip unavailable Vulkan layers to prevent crashing on device creation. Report missing layers and extensions.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [ ] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
