### PR TITLE
NVIDIA: Fix binding of `UsdGeomPrimvar::CreateIndicesAttr` function

### DIFF
--- a/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
@@ -200,6 +200,14 @@ class TestUsdGeomPrimvarsAPI(unittest.TestCase):
         self.assertEqual(u1.GetTimeSamplesInInterval(Gf.Interval(0.5, 1.5)), [1.0])
         self.assertTrue(u1.ValueMightBeTimeVarying())
 
+	self.assertFalse(v1.IsIndexed())
+        self.assertTrue(v1.CreateIndicesAttr())
+        self.assertTrue(v1.GetIndicesAttr())
+        self.assertFalse(v1.IsIndexed())
+        self.assertTrue(v1.GetIndicesAttr().Set(Vt.IntArray([0, 1, 2, 2, 1, 0])))
+        self.assertTrue(v1.IsIndexed())
+        self.assertTrue(v1.GetIndicesAttr())
+
         # Add more time-samples to u1
         indicesAt0 = Vt.IntArray([])
         uValAt3 = Vt.FloatArray([4.1,5.1,6.1])

--- a/pxr/usd/usdGeom/wrapPrimvar.cpp
+++ b/pxr/usd/usdGeom/wrapPrimvar.cpp
@@ -196,7 +196,7 @@ void wrapUsdGeomPrimvar()
         .def("GetIndices", _GetIndices, 
             (arg("time")=UsdTimeCode::Default()))
         .def("GetIndicesAttr", &Primvar::GetIndicesAttr)
-        .def("CreateIndicesAttr", &Primvar::GetIndicesAttr)
+        .def("CreateIndicesAttr", &Primvar::CreateIndicesAttr)
         .def("IsIndexed", &Primvar::IsIndexed)
 
         .def("GetUnauthoredValuesIndex", &Primvar::GetUnauthoredValuesIndex)


### PR DESCRIPTION
### Description of Change(s)

Binding of `UsdGeomPrimvar::CreateIndicesAttr` is incorrectly pointed to `UsdGeomPrimvar::GetIndicesAttr`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[x] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
