### PR TITLE
Apple: Mention that USDZ files are Zip32 only

### DIFF
--- a/docs/spec_usdz.rst
+++ b/docs/spec_usdz.rst
@@ -113,6 +113,9 @@ the ability to relax this constraint in the future, but consider it unlikely.
     aggregate an arbitrary composition's worth of usd files into a single file,
     without removing any composition features from the scene.
 
+Additionally, USDZ files must be Zip32 documents. OpenUSD does not support Zip64.
+As such, the total file size of a USDZ must be under 4GB.
+
 Layout
 ------
 


### PR DESCRIPTION

### Description of Change(s)

It is a common point of confusion that USDZ files are Zip64 compliant.

In the AOUSD specification, I'll be mentioning that we only support Zip32 and I'd like to do the same for the USDZ spec doc as well.

### Fixes Issue(s)

See https://github.com/PixarAnimationStudios/OpenUSD/issues/3424 for more information


### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
