### PR TITLE
Autodesk: Make visible some methods from HdSingleInputFilteringSceneIndexBase

### DIFF
--- a/pxr/imaging/hd/filteringSceneIndex.h
+++ b/pxr/imaging/hd/filteringSceneIndex.h
@@ -167,18 +167,22 @@ private:
         _Observer(HdSingleInputFilteringSceneIndexBase *owner)
         : _owner(owner) {}
 
+        HD_API
         void PrimsAdded(
                 const HdSceneIndexBase &sender,
                 const AddedPrimEntries &entries) override;
 
+        HD_API
         void PrimsRemoved(
                 const HdSceneIndexBase &sender,
                 const RemovedPrimEntries &entries) override;
 
+        HD_API
         void PrimsDirtied(
                 const HdSceneIndexBase &sender,
                 const DirtiedPrimEntries &entries) override;
 
+        HD_API
         void PrimsRenamed(
                 const HdSceneIndexBase &sender,
                 const RenamedPrimEntries &entries) override;


### PR DESCRIPTION
### Description of Change(s)

This pull request fixes a visibility bug by making visible some methods from HdSingleInputFilteringSceneIndexBase.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
