### PR TITLE
Apple: Fixes for stricter compiler parsing

### DIFF
--- a/pxr/usd/sdf/children.cpp
+++ b/pxr/usd/sdf/children.cpp
@@ -190,7 +190,7 @@ Sdf_Children<ChildPolicy>::_UpdateChildNames() const
     _childNamesValid = true;
 
     if (_layer) {
-        _childNames = _layer->GetFieldAs<std::vector<FieldType> >(
+        _childNames = _layer->template GetFieldAs<std::vector<FieldType>>(
             _parentPath, _childrenKey);
     } else {
         _childNames.clear();

--- a/pxr/usd/sdf/childrenProxy.h
+++ b/pxr/usd/sdf/childrenProxy.h
@@ -52,13 +52,6 @@ private:
             return *_pos;
         }
 
-        template <class U>
-        _ValueProxy& operator=(const U& x)
-        {
-            _owner->_Set(*_pos, x);
-            return *this;
-        }
-
         bool operator==(const mapped_type& other) const
         {
             return *_pos == other;


### PR DESCRIPTION
### Description of Change(s)

An upcoming Clang/LLVM version has stricter mandatory template checking that causes OpenUSD to fail to compile.
These are technically issues in the OpenUSD codebase that go against the C++ standard, but compilers have ignored them thus far. Therefore I am submitting them as fixes here.

We request that these please be part of the 25.2 release to prevent compilation issues for other developers.

The two issues:

1. Clang will check for template uses along uninitialized paths as well during compilation. `SdfChildrenProxy` had one such path, which had to be removed to allow compilation as it referenced a non existent method.
See the [changelog](https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics:~:text=Clang%20now%20looks%20up%20members%20of%20the%20current%20instantiation%20in%20the%20template%20definition%20context%20if%20the%20current%20instantiation%20has%20no%20dependent%20base%20classes.) and [PR](https://github.com/llvm/llvm-project/pull/84050)
2. Clang is being stricter about templated function calls in its parser. `Sdf_Children<ChildPolicy>::_UpdateChildNames()` used a method call that was in violation of the following ISO spec:

   ISO C++03 14.2/4:

   > When the name of a member template specialization appears after . or -> in a postfix-expression, or after nested-name-specifier in a qualified-id, and the postfix-expression or qualified-id explicitly depends on a template-parameter (14.6.2), the member template name must be prefixed by the keyword template. Otherwise the name is assumed to name a non-template.

    Explicitly adding the template keyword resolves this. Unfortunately this also gets tagged as unnecessary by older LLVM versions or other compilers. However, a warning felt better than a compile failure.

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
