### PR TITLE
usdValidation: usdGeom: YUpAxisValidator

### DIFF
--- a/pxr/usdValidation/usdGeomValidators/plugInfo.json
+++ b/pxr/usdValidation/usdGeomValidators/plugInfo.json
@@ -23,7 +23,10 @@
                         "schemaTypes": [
                             "UsdGeomSubset"
                         ]
-                    }, 
+                    },
+                    "YUpAxisValidator": {
+                        "doc": "UsdStage metadata of upAxis must be Y."
+                    },
                     "keywords": [
                         "UsdGeomValidators"
                     ]

--- a/pxr/usdValidation/usdGeomValidators/testenv/testUsdGeomValidators.cpp
+++ b/pxr/usdValidation/usdGeomValidators/testenv/testUsdGeomValidators.cpp
@@ -29,6 +29,7 @@ TestUsdGeomValidators()
         UsdGeomValidatorNameTokens->subsetFamilies,
         UsdGeomValidatorNameTokens->subsetParentIsImageable,
         UsdGeomValidatorNameTokens->stageMetadataChecker,
+        UsdGeomValidatorNameTokens->yUpAxisValidator
     };
 
     const UsdValidationRegistry &registry
@@ -42,7 +43,7 @@ TestUsdGeomValidators()
     UsdValidationValidatorMetadataVector metadata
         = registry.GetValidatorMetadataForPlugin(
             _tokens->usdGeomValidatorsPlugin);
-    TF_AXIOM(metadata.size() == 3);
+    TF_AXIOM(metadata.size() == 4);
     for (const UsdValidationValidatorMetadata &metadata : metadata) {
         validatorMetadataNameSet.insert(metadata.name);
     }
@@ -315,7 +316,7 @@ TestUsdGeomSubsetParentIsImageable()
 }
 
 static void
-TestUsdStageMetadata()
+TestUsdGeomStageMetadata()
 {
     // Get stageMetadataChecker
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
@@ -333,16 +334,17 @@ TestUsdStageMetadata()
     TF_AXIOM(errors.size() == 2);
     auto rootLayerIdentifier = rootLayer->GetIdentifier().c_str();
     const std::vector<std::string> expectedErrorMessages = {
-        TfStringPrintf("Stage with root layer <%s> does not specify its linear "
-                       "scale in metersPerUnit.",
+        TfStringPrintf("Stage with root layer <%s> does not specify its "
+            "linear scale in metersPerUnit.",
                        rootLayerIdentifier),
-        TfStringPrintf("Stage with root layer <%s> does not specify an upAxis.",
+        TfStringPrintf("Stage with root layer <%s> does not specify an "
+            "upAxis.",
                        rootLayerIdentifier)
     };
 
     const std::vector<TfToken> expectedErrorIdentifiers = {
         TfToken(
-            "usdGeomValidators:StageMetadataChecker.MissingMetersPerUnitMetadata"),
+        "usdGeomValidators:StageMetadataChecker.MissingMetersPerUnitMetadata"),
         TfToken("usdGeomValidators:StageMetadataChecker.MissingUpAxisMetadata")
     };
 
@@ -364,14 +366,51 @@ TestUsdStageMetadata()
     TF_AXIOM(errors.empty());
 }
 
+static void
+TestUsdGeomYUpAxisValidator()
+{
+    UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
+    const UsdValidationValidator *validator = registry.GetOrLoadValidatorByName(
+            UsdGeomValidatorNameTokens->yUpAxisValidator);
+    TF_AXIOM(validator);
+
+    // Create an empty stage with a Z up axis
+    SdfLayerRefPtr rootLayer = SdfLayer::CreateAnonymous();
+    UsdStageRefPtr usdStage = UsdStage::Open(rootLayer);
+
+    UsdGeomSetStageUpAxis(usdStage, UsdGeomTokens->z);
+
+    UsdValidationErrorVector errors = validator->Validate(usdStage);
+
+    // Verify the error is present
+    const TfToken expectedIdentifier =
+        TfToken("usdGeomValidators:YUpAxisValidator.nonYUpAxis");
+    const std::string expectedErrorMsg =
+        "Stage specifies upAxis 'Z'. upAxis should be 'Y'.";
+    TF_AXIOM(errors.size() == 1);
+    TF_AXIOM(errors[0].GetType() == UsdValidationErrorType::Error);
+    TF_AXIOM(errors[0].GetIdentifier() == expectedIdentifier);
+    TF_AXIOM(errors[0].GetSites().size() == 1);
+    TF_AXIOM(errors[0].GetSites()[0].IsValid());
+    TF_AXIOM(errors[0].GetMessage() == expectedErrorMsg);
+
+    // Change the up axis to Y
+    UsdGeomSetStageUpAxis(usdStage, UsdGeomTokens->y);
+
+    errors = validator->Validate(usdStage);
+
+    // Verify the errors are fixed
+    TF_AXIOM(errors.empty());
+}
+
 int
 main()
 {
     TestUsdGeomValidators();
     TestUsdGeomSubsetFamilies();
     TestUsdGeomSubsetParentIsImageable();
-    TestUsdStageMetadata();
+    TestUsdGeomStageMetadata();
+    TestUsdGeomYUpAxisValidator();
 
-    std::cout << "OK\n";
     return EXIT_SUCCESS;
 }

--- a/pxr/usdValidation/usdGeomValidators/validatorTokens.h
+++ b/pxr/usdValidation/usdGeomValidators/validatorTokens.h
@@ -19,7 +19,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define USD_GEOM_VALIDATOR_NAME_TOKENS                                         \
     ((stageMetadataChecker, "usdGeomValidators:StageMetadataChecker"))         \
     ((subsetFamilies, "usdGeomValidators:SubsetFamilies"))                     \
-    ((subsetParentIsImageable, "usdGeomValidators:SubsetParentIsImageable"))
+    ((subsetParentIsImageable, "usdGeomValidators:SubsetParentIsImageable"))   \
+    ((yUpAxisValidator, "usdGeomValidators:YUpAxisValidator"))
 
 #define USD_GEOM_VALIDATOR_KEYWORD_TOKENS                                      \
     (UsdGeomSubset)                                                            \
@@ -29,7 +30,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((missingMetersPerUnitMetadata, "MissingMetersPerUnitMetadata"))           \
     ((missingUpAxisMetadata, "MissingUpAxisMetadata"))                         \
     ((invalidSubsetFamily, "InvalidSubsetFamily"))                             \
-    ((notImageableSubsetParent, "NotImageableSubsetParent"))
+    ((notImageableSubsetParent, "NotImageableSubsetParent"))                   \
+    ((nonYUpAxis, "nonYUpAxis"))
 
 /// \def USD_GEOM_VALIDATOR_NAME_TOKENS
 /// Tokens representing validator names. Note that for plugin provided

--- a/pxr/usdValidation/usdGeomValidators/validators.cpp
+++ b/pxr/usdValidation/usdGeomValidators/validators.cpp
@@ -142,6 +142,34 @@ _SubsetParentIsImageable(const UsdPrim &usdPrim)
             usdPrim.GetPath().GetText(), parentPrim.GetPath().GetText())) };
 }
 
+static UsdValidationErrorVector
+_YUpAxisValidator(const UsdStagePtr &usdStage)
+{
+    if (usdStage->HasAuthoredMetadata(UsdGeomTokens->upAxis)) {
+        TfToken axis;
+        usdStage->GetMetadata(UsdGeomTokens->upAxis, &axis);
+
+        if (axis != UsdGeomTokens->y)
+        {
+            return {
+                UsdValidationError(
+                    UsdGeomValidationErrorNameTokens->nonYUpAxis,
+                    UsdValidationErrorType::Error,
+                    UsdValidationErrorSites{UsdValidationErrorSite(usdStage,
+                                                           SdfPath("/"))},
+                    TfStringPrintf(
+                    "Stage specifies upAxis '%s'. upAxis should"
+                                 " be 'Y'.", axis.GetText())
+                )
+            };
+        }
+    }
+
+    return {};
+}
+
+
+
 TF_REGISTRY_FUNCTION(UsdValidationRegistry)
 {
     UsdValidationRegistry &registry = UsdValidationRegistry::GetInstance();
@@ -156,6 +184,10 @@ TF_REGISTRY_FUNCTION(UsdValidationRegistry)
     registry.RegisterPluginValidator(
         UsdGeomValidatorNameTokens->subsetParentIsImageable,
         _SubsetParentIsImageable);
+
+    registry.RegisterPluginValidator(
+        UsdGeomValidatorNameTokens->yUpAxisValidator,
+        _YUpAxisValidator);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)
- Moving the existing portion of the StageMetadataChecker from complianceChecker.py that verifies the upAxis is Y
- Added implementation code, a test, and necessary tokens & plugInfo entries

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
- https://github.com/orgs/PixarAnimationStudios/projects/3/views/1?pane=issue&itemId=65424791

Note: This PR is a replacement for https://github.com/PixarAnimationStudios/OpenUSD/pull/3399

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[X] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
