### PR TITLE
Autodesk: Fix primId visualization issues on HgiVulkan

### DIFF
--- a/pxr/imaging/hdx/visualizeAovTask.h
+++ b/pxr/imaging/hdx/visualizeAovTask.h
@@ -100,7 +100,7 @@ private:
     bool _CreatePipeline(HgiTextureDesc const& outputTextureDesc);
 
     // Utility to create a texture sampler
-    bool _CreateSampler();
+    bool _CreateSampler(HgiTextureDesc const& inputAovTextureDesc);
 
     // Create texture to write the colorized results into.
     bool _CreateOutputTexture(GfVec3i const &dimensions);

--- a/pxr/imaging/hgi/types.cpp
+++ b/pxr/imaging/hgi/types.cpp
@@ -237,6 +237,33 @@ HgiGetComponentBaseFormat(
     return HgiFormatInvalid;
 }
 
+bool
+HgiIsFloatFormat(
+    const HgiFormat f)
+{
+    switch (HgiGetComponentBaseFormat(f)) {
+    case HgiFormatUNorm8:
+    case HgiFormatSNorm8:
+    case HgiFormatFloat16:
+    case HgiFormatFloat32:
+    case HgiFormatFloat32UInt8: // Unclear
+    case HgiFormatBC6FloatVec3:
+    case HgiFormatBC6UFloatVec3:
+    case HgiFormatPackedInt1010102:
+        return true;
+    case HgiFormatInt16:
+    case HgiFormatUInt16:
+    case HgiFormatInt32:
+        return false;
+    case HgiFormatInvalid:
+        TF_CODING_ERROR("Invalid Format");
+        return false;
+    default:
+        TF_CODING_ERROR("Missing Format");
+        return false;
+    }
+}
+
 uint16_t
 _ComputeNumMipLevels(const GfVec3i &dimensions)
 {

--- a/pxr/imaging/hgi/types.h
+++ b/pxr/imaging/hgi/types.h
@@ -162,6 +162,11 @@ HGI_API
 HgiFormat HgiGetComponentBaseFormat(
     HgiFormat f);
 
+/// Returns true if the scalar type of the format is a floating point type.
+HGI_API
+bool HgiIsFloatFormat(
+    HgiFormat f);
+
 /// Returns mip infos.
 ///
 /// If dataByteSize is specified, the levels stops when the total memory


### PR DESCRIPTION
### Description of Change(s)

Fixes testUsdImagingGLBasicDrawing_id
- Handle integer AOVs correctly
- Transition the AOV for shader read as required by Vulkan (same solution as for `colorCorrectionTask`).

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
