### PR TITLE
Autodesk: Enable -fvisibility=hidden and -fvisibility-inlines-hidden to hide symbols on Linux and macOS

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -37,6 +37,11 @@ from shutil import which
 # Helpers for printing output
 verbosity = 1
 
+# Hide symbols
+HIDDEN_SYMBOLS = ['-DCMAKE_CXX_VISIBILITY_PRESET=hidden',
+                  '-DCMAKE_C_VISIBILITY_PRESET=hidden',
+                  '-DCMAKE_VISIBILITY_INLINES_HIDDEN=ON']
+
 def Print(msg):
     if verbosity > 0:
         print(msg)
@@ -1801,6 +1806,8 @@ def InstallUSD(context, force, buildArgs):
         # system installed boost
         extraArgs.append('-DBoost_NO_BOOST_CMAKE=On')
         extraArgs.append('-DBoost_NO_SYSTEM_PATHS=True')
+
+        extraArgs += HIDDEN_SYMBOLS
         extraArgs += buildArgs
 
         RunCMake(context, force, extraArgs)

--- a/extras/imaging/examples/hdui/dataSourceTreeWidget.h
+++ b/extras/imaging/examples/hdui/dataSourceTreeWidget.h
@@ -17,7 +17,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HDUI_API_CLASS HduiDataSourceTreeWidget : public QTreeWidget
+class ARCH_EXPORT_TYPE HduiDataSourceTreeWidget : public QTreeWidget
 {
     Q_OBJECT;
 

--- a/extras/imaging/examples/hdui/dataSourceValueTreeView.h
+++ b/extras/imaging/examples/hdui/dataSourceValueTreeView.h
@@ -17,7 +17,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HDUI_API_CLASS HduiDataSourceValueTreeView : public QTreeView
+class ARCH_EXPORT_TYPE HduiDataSourceValueTreeView : public QTreeView
 {
     Q_OBJECT;
 public:

--- a/extras/imaging/examples/hdui/registeredSceneIndexChooser.h
+++ b/extras/imaging/examples/hdui/registeredSceneIndexChooser.h
@@ -18,7 +18,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HDUI_API_CLASS HduiRegisteredSceneIndexChooser : public QPushButton
+class ARCH_EXPORT_TYPE HduiRegisteredSceneIndexChooser : public QPushButton
 {
     Q_OBJECT;
 public:

--- a/extras/imaging/examples/hdui/sceneIndexDebuggerWidget.h
+++ b/extras/imaging/examples/hdui/sceneIndexDebuggerWidget.h
@@ -26,7 +26,7 @@ class HduiDataSourceTreeWidget;
 class HduiDataSourceValueTreeView;
 class HduiRegisteredSceneIndexChooser;
 
-class HDUI_API_CLASS HduiSceneIndexDebuggerWidget
+class ARCH_EXPORT_TYPE HduiSceneIndexDebuggerWidget
     : public QWidget, public TfWeakBase
 {
     Q_OBJECT;

--- a/extras/imaging/examples/hdui/sceneIndexObserverLoggingTreeView.h
+++ b/extras/imaging/examples/hdui/sceneIndexObserverLoggingTreeView.h
@@ -17,7 +17,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HDUI_API_CLASS HduiSceneIndexObserverLoggingTreeView : public QTreeView
+class ARCH_EXPORT_TYPE HduiSceneIndexObserverLoggingTreeView : public QTreeView
 {
     Q_OBJECT;
 public:
@@ -37,7 +37,7 @@ public Q_SLOTS:
 
 private:
 
-    class HDUI_API_CLASS _ObserverModel :
+    class ARCH_EXPORT_TYPE _ObserverModel :
         public HdSceneIndexObserver, public QAbstractItemModel
     {
     public:

--- a/extras/imaging/examples/hdui/sceneIndexObserverLoggingWidget.h
+++ b/extras/imaging/examples/hdui/sceneIndexObserverLoggingWidget.h
@@ -18,7 +18,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HduiSceneIndexObserverLoggingTreeView;
 
-class HDUI_API_CLASS HduiSceneIndexObserverLoggingWidget : public QWidget
+class ARCH_EXPORT_TYPE HduiSceneIndexObserverLoggingWidget : public QWidget
 {
     Q_OBJECT;
 public:

--- a/extras/imaging/examples/hdui/sceneIndexTreeWidget.h
+++ b/extras/imaging/examples/hdui/sceneIndexTreeWidget.h
@@ -22,7 +22,7 @@ class Hdui_SceneIndexPrimTreeWidgetItem;
 
 //-----------------------------------------------------------------------------
 
-class HDUI_API_CLASS HduiSceneIndexTreeWidget
+class ARCH_EXPORT_TYPE HduiSceneIndexTreeWidget
     : public QTreeWidget, public HdSceneIndexObserver
 {
     Q_OBJECT;

--- a/extras/usd/examples/usdResolverExample/resolverContext.h
+++ b/extras/usd/examples/usdResolverExample/resolverContext.h
@@ -19,7 +19,7 @@
 /// allows the client to specify a version mapping file to use for
 /// {$VERSION} substitutions during asset resolution. See overview
 /// for more details.
-class UsdResolverExampleResolverContext
+class ARCH_EXPORT_TYPE UsdResolverExampleResolverContext
 {
 public:
     /// Create a context that specifies that the version mappings in

--- a/extras/usd/examples/usdSchemaExamples/complex.h
+++ b/extras/usd/examples/usdSchemaExamples/complex.h
@@ -37,7 +37,7 @@ class SdfAssetPath;
 ///
 /// An example of a untyped IsA schema prim
 ///
-class UsdSchemaExamplesComplex : public UsdSchemaExamplesSimple
+class ARCH_EXPORT_TYPE UsdSchemaExamplesComplex : public UsdSchemaExamplesSimple
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/extras/usd/examples/usdSchemaExamples/paramsAPI.h
+++ b/extras/usd/examples/usdSchemaExamples/paramsAPI.h
@@ -36,7 +36,7 @@ class SdfAssetPath;
 /// \class UsdSchemaExamplesParamsAPI
 ///
 ///
-class UsdSchemaExamplesParamsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdSchemaExamplesParamsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/extras/usd/examples/usdSchemaExamples/simple.h
+++ b/extras/usd/examples/usdSchemaExamples/simple.h
@@ -38,7 +38,7 @@ class SdfAssetPath;
 /// An example of an untyped schema prim. Note that it does not 
 /// specify a typeName
 ///
-class UsdSchemaExamplesSimple : public UsdTyped
+class ARCH_EXPORT_TYPE UsdSchemaExamplesSimple : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/base/arch/export.h
+++ b/pxr/base/arch/export.h
@@ -58,7 +58,7 @@
 /// A class is added to the API like this:
 ///
 /// \code
-///  class FOO_API FooClass ...
+///  class ARCH_EXPORT_TYPE FooClass ...
 /// \endcode
 ///
 /// This will add every member to the API, including implicitly created
@@ -74,7 +74,7 @@
 /// Instead they are added when explicitly instantiated like so:
 ///
 /// \code
-///  template class FOO_API FooTemplateClass<FooArgType>;
+///  template class ARCH_EXPORT_TYPE FooTemplateClass<FooArgType>;
 /// \endcode
 ///
 /// It's also sometimes necessary to indicate that an instantiation exists
@@ -128,7 +128,7 @@
 /// FOO_LOCAL:
 ///
 /// \code
-///  struct FOO_API FooSemiAPI {
+///  struct ARCH_EXPORT_TYPE FooSemiAPI {
 ///      void DoSomethingPublic();
 ///      FOO_LOCAL void _DoSomethingPrivate();
 ///  };
@@ -153,20 +153,16 @@
 #   endif
 #elif defined(ARCH_COMPILER_GCC) && ARCH_COMPILER_GCC_MAJOR >= 4 || defined(ARCH_COMPILER_CLANG)
 #   define ARCH_EXPORT __attribute__((visibility("default")))
-#   define ARCH_IMPORT
+#   define ARCH_IMPORT __attribute__((visibility("default")))
 #   define ARCH_HIDDEN __attribute__((visibility("hidden")))
-#   if defined(ARCH_COMPILER_CLANG)
-#       define ARCH_EXPORT_TYPE __attribute__((type_visibility("default")))
-#   else
-#       define ARCH_EXPORT_TYPE __attribute__((visibility("default")))
-#   endif
+#   define ARCH_EXPORT_TYPE __attribute__((visibility("default")))
 #else
 #   define ARCH_EXPORT
 #   define ARCH_IMPORT
 #   define ARCH_HIDDEN
 #   define ARCH_EXPORT_TYPE
 #endif
-#define ARCH_EXPORT_TEMPLATE(type, ...)
+#define ARCH_EXPORT_TEMPLATE(type, ...) extern template type ARCH_EXPORT __VA_ARGS__
 #define ARCH_IMPORT_TEMPLATE(type, ...) extern template type ARCH_IMPORT __VA_ARGS__
 
 #endif // PXR_BASE_ARCH_EXPORT_H

--- a/pxr/base/arch/testArchAbi.h
+++ b/pxr/base/arch/testArchAbi.h
@@ -20,7 +20,7 @@ struct ArchAbiBase2 {
 };
 
 template <class T>
-struct ArchAbiDerived : public ArchAbiBase1, public ArchAbiBase2 {
+struct ARCH_EXPORT_TYPE ArchAbiDerived : public ArchAbiBase1, public ArchAbiBase2 {
     virtual ~ArchAbiDerived() { }
     virtual const char* name() const { return "ArchAbiDerived"; }
 };

--- a/pxr/base/gf/camera.h
+++ b/pxr/base/gf/camera.h
@@ -29,7 +29,7 @@ class GfFrustum;
 /// This class provides a thin wrapper on the camera data model,
 /// with a small number of computations.
 ///
-class GfCamera
+class ARCH_EXPORT_TYPE GfCamera
 {
 public:
     /// Projection type.

--- a/pxr/base/gf/dualQuatd.h
+++ b/pxr/base/gf/dualQuatd.h
@@ -46,7 +46,7 @@ double GfDot(const GfDualQuatd& dq1, const GfDualQuatd& dq2);
 ///    https://www.cs.utah.edu/~ladislav/kavan06dual/kavan06dual.pdf
 ///    https://faculty.sites.iastate.edu/jia/files/inline-files/dual-quaternion.pdf
 ///
-class GfDualQuatd final
+class ARCH_EXPORT_TYPE GfDualQuatd final
 {
   public:
     typedef double ScalarType;

--- a/pxr/base/gf/dualQuatf.h
+++ b/pxr/base/gf/dualQuatf.h
@@ -46,7 +46,7 @@ float GfDot(const GfDualQuatf& dq1, const GfDualQuatf& dq2);
 ///    https://www.cs.utah.edu/~ladislav/kavan06dual/kavan06dual.pdf
 ///    https://faculty.sites.iastate.edu/jia/files/inline-files/dual-quaternion.pdf
 ///
-class GfDualQuatf final
+class ARCH_EXPORT_TYPE GfDualQuatf final
 {
   public:
     typedef float ScalarType;

--- a/pxr/base/gf/dualQuath.h
+++ b/pxr/base/gf/dualQuath.h
@@ -47,7 +47,7 @@ GfHalf GfDot(const GfDualQuath& dq1, const GfDualQuath& dq2);
 ///    https://www.cs.utah.edu/~ladislav/kavan06dual/kavan06dual.pdf
 ///    https://faculty.sites.iastate.edu/jia/files/inline-files/dual-quaternion.pdf
 ///
-class GfDualQuath final
+class ARCH_EXPORT_TYPE GfDualQuath final
 {
   public:
     typedef GfHalf ScalarType;

--- a/pxr/base/gf/ilmbase_half.h
+++ b/pxr/base/gf/ilmbase_half.h
@@ -94,7 +94,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace pxr_half {
 
-class half
+class ARCH_EXPORT_TYPE half
 {
   public:
 

--- a/pxr/base/gf/interval.h
+++ b/pxr/base/gf/interval.h
@@ -29,7 +29,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Can represent intervals with either open or closed boundary
 /// conditions.
 ///
-class GfInterval
+class ARCH_EXPORT_TYPE GfInterval
 {
 public:
     /// \name Constructors

--- a/pxr/base/gf/matrix2d.h
+++ b/pxr/base/gf/matrix2d.h
@@ -41,7 +41,7 @@ class GfMatrix2f;
 /// Matrices are defined to be in row-major order, so <c>matrix[i][j]</c>
 /// indexes the element in the \e i th row and the \e j th column.
 ///
-class GfMatrix2d
+class ARCH_EXPORT_TYPE GfMatrix2d
 {
 public:
     typedef double ScalarType;

--- a/pxr/base/gf/matrix2f.h
+++ b/pxr/base/gf/matrix2f.h
@@ -41,7 +41,7 @@ class GfMatrix2f;
 /// Matrices are defined to be in row-major order, so <c>matrix[i][j]</c>
 /// indexes the element in the \e i th row and the \e j th column.
 ///
-class GfMatrix2f
+class ARCH_EXPORT_TYPE GfMatrix2f
 {
 public:
     typedef float ScalarType;

--- a/pxr/base/gf/matrix3d.h
+++ b/pxr/base/gf/matrix3d.h
@@ -61,7 +61,7 @@ class GfQuatd;
 ///        matrix and S represents a scale matrix, the
 ///        product R*S  will rotate a row vector, then scale
 ///        it.
-class GfMatrix3d
+class ARCH_EXPORT_TYPE GfMatrix3d
 {
 public:
     typedef double ScalarType;

--- a/pxr/base/gf/matrix3f.h
+++ b/pxr/base/gf/matrix3f.h
@@ -61,7 +61,7 @@ class GfQuatf;
 ///        matrix and S represents a scale matrix, the
 ///        product R*S  will rotate a row vector, then scale
 ///        it.
-class GfMatrix3f
+class ARCH_EXPORT_TYPE GfMatrix3f
 {
 public:
     typedef float ScalarType;

--- a/pxr/base/gf/matrix4d.h
+++ b/pxr/base/gf/matrix4d.h
@@ -67,7 +67,7 @@ class GfMatrix3d;
 ///        matrix and T represents a translation matrix, the
 ///        product R*T will rotate a row vector, then translate
 ///        it.
-class GfMatrix4d
+class ARCH_EXPORT_TYPE GfMatrix4d
 {
 public:
     typedef double ScalarType;

--- a/pxr/base/gf/matrix4f.h
+++ b/pxr/base/gf/matrix4f.h
@@ -67,7 +67,7 @@ class GfMatrix3f;
 ///        matrix and T represents a translation matrix, the
 ///        product R*T will rotate a row vector, then translate
 ///        it.
-class GfMatrix4f
+class ARCH_EXPORT_TYPE GfMatrix4f
 {
 public:
     typedef float ScalarType;

--- a/pxr/base/gf/quatd.h
+++ b/pxr/base/gf/quatd.h
@@ -39,7 +39,7 @@ double GfDot(const GfQuatd& q1, const GfQuatd& q2);
 /// Basic type: a quaternion, a complex number with a real coefficient and
 /// three imaginary coefficients, stored as a 3-vector.
 ///
-class GfQuatd
+class ARCH_EXPORT_TYPE GfQuatd
 {
   public:
     typedef double ScalarType;

--- a/pxr/base/gf/quaternion.h
+++ b/pxr/base/gf/quaternion.h
@@ -29,7 +29,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// part and a vector of three imaginary values. Quaternions are used by the
 /// \c GfRotation class to represent arbitrary-axis rotations.
 ///
-class GfQuaternion
+class ARCH_EXPORT_TYPE GfQuaternion
 {
   public:
 

--- a/pxr/base/gf/quatf.h
+++ b/pxr/base/gf/quatf.h
@@ -39,7 +39,7 @@ float GfDot(const GfQuatf& q1, const GfQuatf& q2);
 /// Basic type: a quaternion, a complex number with a real coefficient and
 /// three imaginary coefficients, stored as a 3-vector.
 ///
-class GfQuatf
+class ARCH_EXPORT_TYPE GfQuatf
 {
   public:
     typedef float ScalarType;

--- a/pxr/base/gf/quath.h
+++ b/pxr/base/gf/quath.h
@@ -40,7 +40,7 @@ GfHalf GfDot(const GfQuath& q1, const GfQuath& q2);
 /// Basic type: a quaternion, a complex number with a real coefficient and
 /// three imaginary coefficients, stored as a 3-vector.
 ///
-class GfQuath
+class ARCH_EXPORT_TYPE GfQuath
 {
   public:
     typedef GfHalf ScalarType;

--- a/pxr/base/gf/range1d.h
+++ b/pxr/base/gf/range1d.h
@@ -41,7 +41,7 @@ struct GfIsGfRange<class GfRange1d> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange1d
+class ARCH_EXPORT_TYPE GfRange1d
 {
 public:
 

--- a/pxr/base/gf/range1f.h
+++ b/pxr/base/gf/range1f.h
@@ -41,7 +41,7 @@ struct GfIsGfRange<class GfRange1f> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange1f
+class ARCH_EXPORT_TYPE GfRange1f
 {
 public:
 

--- a/pxr/base/gf/range2d.h
+++ b/pxr/base/gf/range2d.h
@@ -43,7 +43,7 @@ struct GfIsGfRange<class GfRange2d> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange2d
+class ARCH_EXPORT_TYPE GfRange2d
 {
 public:
 

--- a/pxr/base/gf/range2f.h
+++ b/pxr/base/gf/range2f.h
@@ -43,7 +43,7 @@ struct GfIsGfRange<class GfRange2f> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange2f
+class ARCH_EXPORT_TYPE GfRange2f
 {
 public:
 

--- a/pxr/base/gf/range3d.h
+++ b/pxr/base/gf/range3d.h
@@ -43,7 +43,7 @@ struct GfIsGfRange<class GfRange3d> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange3d
+class ARCH_EXPORT_TYPE GfRange3d
 {
 public:
 

--- a/pxr/base/gf/range3f.h
+++ b/pxr/base/gf/range3f.h
@@ -43,7 +43,7 @@ struct GfIsGfRange<class GfRange3f> { static const bool value = true; };
 /// operations are component-wise and conform to interval mathematics. An
 /// empty range is one where max < min.
 /// The default empty is [FLT_MAX,-FLT_MAX]
-class GfRange3f
+class ARCH_EXPORT_TYPE GfRange3f
 {
 public:
 

--- a/pxr/base/gf/rect2i.h
+++ b/pxr/base/gf/rect2i.h
@@ -40,7 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Specifically, <em> width = maxX - minX + 1</em> and
 /// <em>height = maxY - minY + 1.</em> 
 ///
-class GfRect2i {
+class ARCH_EXPORT_TYPE GfRect2i {
 public:
     /// Constructs an empty rectangle.
     GfRect2i(): _min(0,0), _max(-1,-1)

--- a/pxr/base/gf/vec2d.h
+++ b/pxr/base/gf/vec2d.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec2d> { static const bool value = true; };
 /// Represents a vector of 2 components of type \c double.
 /// It is intended to be fast and simple.
 ///
-class GfVec2d
+class ARCH_EXPORT_TYPE GfVec2d
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec2f.h
+++ b/pxr/base/gf/vec2f.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec2f> { static const bool value = true; };
 /// Represents a vector of 2 components of type \c float.
 /// It is intended to be fast and simple.
 ///
-class GfVec2f
+class ARCH_EXPORT_TYPE GfVec2f
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec2h.h
+++ b/pxr/base/gf/vec2h.h
@@ -43,7 +43,7 @@ struct GfIsGfVec<class GfVec2h> { static const bool value = true; };
 /// Represents a vector of 2 components of type \c GfHalf.
 /// It is intended to be fast and simple.
 ///
-class GfVec2h
+class ARCH_EXPORT_TYPE GfVec2h
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec2i.h
+++ b/pxr/base/gf/vec2i.h
@@ -40,7 +40,7 @@ struct GfIsGfVec<class GfVec2i> { static const bool value = true; };
 /// Represents a vector of 2 components of type \c int.
 /// It is intended to be fast and simple.
 ///
-class GfVec2i
+class ARCH_EXPORT_TYPE GfVec2i
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec3d.h
+++ b/pxr/base/gf/vec3d.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec3d> { static const bool value = true; };
 /// Represents a vector of 3 components of type \c double.
 /// It is intended to be fast and simple.
 ///
-class GfVec3d
+class ARCH_EXPORT_TYPE GfVec3d
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec3f.h
+++ b/pxr/base/gf/vec3f.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec3f> { static const bool value = true; };
 /// Represents a vector of 3 components of type \c float.
 /// It is intended to be fast and simple.
 ///
-class GfVec3f
+class ARCH_EXPORT_TYPE GfVec3f
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec3h.h
+++ b/pxr/base/gf/vec3h.h
@@ -43,7 +43,7 @@ struct GfIsGfVec<class GfVec3h> { static const bool value = true; };
 /// Represents a vector of 3 components of type \c GfHalf.
 /// It is intended to be fast and simple.
 ///
-class GfVec3h
+class ARCH_EXPORT_TYPE GfVec3h
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec3i.h
+++ b/pxr/base/gf/vec3i.h
@@ -40,7 +40,7 @@ struct GfIsGfVec<class GfVec3i> { static const bool value = true; };
 /// Represents a vector of 3 components of type \c int.
 /// It is intended to be fast and simple.
 ///
-class GfVec3i
+class ARCH_EXPORT_TYPE GfVec3i
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec4d.h
+++ b/pxr/base/gf/vec4d.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec4d> { static const bool value = true; };
 /// Represents a vector of 4 components of type \c double.
 /// It is intended to be fast and simple.
 ///
-class GfVec4d
+class ARCH_EXPORT_TYPE GfVec4d
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec4f.h
+++ b/pxr/base/gf/vec4f.h
@@ -42,7 +42,7 @@ struct GfIsGfVec<class GfVec4f> { static const bool value = true; };
 /// Represents a vector of 4 components of type \c float.
 /// It is intended to be fast and simple.
 ///
-class GfVec4f
+class ARCH_EXPORT_TYPE GfVec4f
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec4h.h
+++ b/pxr/base/gf/vec4h.h
@@ -43,7 +43,7 @@ struct GfIsGfVec<class GfVec4h> { static const bool value = true; };
 /// Represents a vector of 4 components of type \c GfHalf.
 /// It is intended to be fast and simple.
 ///
-class GfVec4h
+class ARCH_EXPORT_TYPE GfVec4h
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/gf/vec4i.h
+++ b/pxr/base/gf/vec4i.h
@@ -40,7 +40,7 @@ struct GfIsGfVec<class GfVec4i> { static const bool value = true; };
 /// Represents a vector of 4 components of type \c int.
 /// It is intended to be fast and simple.
 ///
-class GfVec4i
+class ARCH_EXPORT_TYPE GfVec4i
 {
 public:
     /// Scalar element type and dimension.

--- a/pxr/base/plug/interfaceFactory.h
+++ b/pxr/base/plug/interfaceFactory.h
@@ -15,7 +15,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 // For use by \c PLUG_REGISTER_INTERFACE_SINGLETON_TYPE.
-class Plug_InterfaceFactory {
+class ARCH_EXPORT_TYPE Plug_InterfaceFactory {
 public:
     struct Base : public TfType::FactoryBase {
     public:

--- a/pxr/base/plug/notice.h
+++ b/pxr/base/plug/notice.h
@@ -22,7 +22,7 @@ class PlugNotice
 {
 public:
     /// Base class for all Plug notices.
-    class Base : public TfNotice
+    class ARCH_EXPORT_TYPE Base : public TfNotice
     {
     public:
         PLUG_API virtual ~Base();
@@ -30,7 +30,7 @@ public:
 
     /// Notice sent after new plugins have been registered with the Plug
     /// registry.
-    class DidRegisterPlugins : public Base
+    class ARCH_EXPORT_TYPE DidRegisterPlugins : public Base
     {
     public:
         explicit DidRegisterPlugins(const PlugPluginPtrVector& newPlugins);

--- a/pxr/base/plug/testPlugBase.h
+++ b/pxr/base/plug/testPlugBase.h
@@ -20,7 +20,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 template <int M>
-class _TestPlugBase : public TfRefBase, public TfWeakBase {
+class ARCH_EXPORT_TYPE _TestPlugBase : public TfRefBase, public TfWeakBase {
   public:
     typedef _TestPlugBase This;
     typedef TfRefPtr<This> RefPtr;
@@ -49,13 +49,13 @@ class _TestPlugBase : public TfRefBase, public TfWeakBase {
 };
 
 template <int N>
-class _TestPlugFactoryBase : public TfType::FactoryBase {
+class ARCH_EXPORT_TYPE _TestPlugFactoryBase : public TfType::FactoryBase {
 public:
     virtual TfRefPtr<_TestPlugBase<N> > New() const = 0;
 };
 
 template <typename T>
-class _TestPlugFactory : public _TestPlugFactoryBase<T::N> {
+class ARCH_EXPORT_TYPE _TestPlugFactory : public _TestPlugFactoryBase<T::N> {
 public:
     virtual TfRefPtr<_TestPlugBase<T::N> > New() const
     {

--- a/pxr/base/tf/anyWeakPtr.h
+++ b/pxr/base/tf/anyWeakPtr.h
@@ -151,7 +151,7 @@ public:
     friend WeakPtr TfAnyWeakPtrDynamicCast(const TfAnyWeakPtr &anyWeak, WeakPtr*);
 
     // This is using the standard type-erasure pattern.
-    struct _PointerHolderBase {
+    struct ARCH_EXPORT_TYPE _PointerHolderBase {
         TF_API virtual ~_PointerHolderBase();
         virtual void Clone(_Data *target) const = 0; 
         virtual bool IsInvalid() const = 0;
@@ -166,7 +166,7 @@ public:
         virtual bool _IsPolymorphic() const = 0;
     };
 
-    struct _EmptyHolder : _PointerHolderBase {
+    struct ARCH_EXPORT_TYPE _EmptyHolder : _PointerHolderBase {
         TF_API virtual ~_EmptyHolder();
         TF_API virtual void Clone(_Data *target) const; 
         TF_API virtual bool IsInvalid() const;

--- a/pxr/base/tf/diagnosticMgr.cpp
+++ b/pxr/base/tf/diagnosticMgr.cpp
@@ -139,6 +139,12 @@ TfDiagnosticMgr::~TfDiagnosticMgr()
 {
 }
 
+TfDiagnosticMgr&
+TfDiagnosticMgr::GetInstance() 
+{
+    return TfSingleton<TfDiagnosticMgr>::GetInstance();
+}
+
 void
 TfDiagnosticMgr::AddDelegate(Delegate* delegate)
 {

--- a/pxr/base/tf/diagnosticMgr.h
+++ b/pxr/base/tf/diagnosticMgr.h
@@ -136,9 +136,7 @@ public:
     };
 
     /// Return the singleton instance.
-    TF_API static This &GetInstance() {
-        return TfSingleton<This>::GetInstance();
-    }
+    TF_API static TfDiagnosticMgr &GetInstance();
 
     /// Add the delegate \p delegate to the list of current delegates.
     ///

--- a/pxr/base/tf/exception.h
+++ b/pxr/base/tf/exception.h
@@ -43,7 +43,7 @@ struct TfSkipCallerFrames
 /// boost.python to raise a Python exeption wrapping the thrown exception
 /// object.  Similarly utilties that call Python via Tf will re-throw the
 /// embedded C++ exception if the Python exception unwinds back into C++.
-class TfBaseException : public std::exception
+class ARCH_EXPORT_TYPE TfBaseException : public std::exception
 {
 public:
     TF_API

--- a/pxr/base/tf/notice.h
+++ b/pxr/base/tf/notice.h
@@ -73,7 +73,7 @@ class Tf_NoticeRegistry;
 /// 
 /// For more on using notices in Python, see the Editor With Notices tutorial.
 /// 
-class TfNotice {
+class ARCH_EXPORT_TYPE TfNotice {
 private:
     class _DelivererBase;
     typedef TfWeakPtr<_DelivererBase> _DelivererWeakPtr;
@@ -442,7 +442,7 @@ public:
 private:
     // Abstract base class for calling listeners.
     // A typed-version derives (via templating) off this class.
-    class _DelivererBase : public TfWeakBase {
+    class ARCH_EXPORT_TYPE _DelivererBase : public TfWeakBase {
     public:
         _DelivererBase()
             : _list(0), _active(true), _markedForRemoval(false)

--- a/pxr/base/tf/pyModuleNotice.h
+++ b/pxr/base/tf/pyModuleNotice.h
@@ -23,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// triggered by this notice to the end of an application iteration.  This, of
 /// course, is good practice in general.
 ///
-class TfPyModuleWasLoaded : public TfNotice {
+class ARCH_EXPORT_TYPE TfPyModuleWasLoaded : public TfNotice {
 public:
     explicit TfPyModuleWasLoaded(std::string const &name) : _name(name) {}
 

--- a/pxr/base/tf/pyNoticeWrapper.h
+++ b/pxr/base/tf/pyNoticeWrapper.h
@@ -55,8 +55,8 @@ private:
 
 };
 
-struct TfPyNoticeWrapperBase : public TfType::PyPolymorphicBase {
-    TF_API virtual ~TfPyNoticeWrapperBase();
+struct ARCH_EXPORT_TYPE TfPyNoticeWrapperBase : public TfType::PyPolymorphicBase {
+    virtual ~TfPyNoticeWrapperBase();
     virtual pxr_boost::python::handle<> GetNoticePythonObject() const = 0;
 };
 

--- a/pxr/base/tf/pyObjWrapper.h
+++ b/pxr/base/tf/pyObjWrapper.h
@@ -74,7 +74,7 @@ private:
 /// However it is important to note that callers must ensure the GIL is held
 /// before using these operators!
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
-class TfPyObjWrapper
+class ARCH_EXPORT_TYPE TfPyObjWrapper
     : public pxr_boost::python::api::object_operators<TfPyObjWrapper>
 {
     typedef pxr_boost::python::object object;

--- a/pxr/base/tf/pyObjectFinder.h
+++ b/pxr/base/tf/pyObjectFinder.h
@@ -19,7 +19,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-struct Tf_PyObjectFinderBase {
+struct ARCH_EXPORT_TYPE Tf_PyObjectFinderBase {
     TF_API virtual ~Tf_PyObjectFinderBase();
     virtual pxr_boost::python::object Find(void const *objPtr) const = 0;
 };

--- a/pxr/base/tf/refBase.h
+++ b/pxr/base/tf/refBase.h
@@ -53,7 +53,7 @@ template <class T> class TfWeakPtr;
 /// To disable the cost of the "unique changed" system, derive
 /// from TfSimpleRefBase instead.
 ///
-class TfRefBase {
+class ARCH_EXPORT_TYPE TfRefBase {
 public:
 
     typedef void (*UniqueChangedFuncPtr)(TfRefBase const *, bool);
@@ -136,7 +136,7 @@ private:
 /// Derive from this class if you don't plan on wrapping your
 /// reference-counted object via pxr_boost::python.
 ///
-class TfSimpleRefBase : public TfRefBase {
+class ARCH_EXPORT_TYPE TfSimpleRefBase : public TfRefBase {
 public:
     TF_API virtual ~TfSimpleRefBase();
 };

--- a/pxr/base/tf/scriptModuleLoader.h
+++ b/pxr/base/tf/scriptModuleLoader.h
@@ -38,7 +38,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Generally, user code will not make use of this.
 ///
-class TfScriptModuleLoader : public TfWeakBase {
+class ARCH_EXPORT_TYPE TfScriptModuleLoader : public TfWeakBase {
 
   public:
 

--- a/pxr/base/tf/singleton.h
+++ b/pxr/base/tf/singleton.h
@@ -88,6 +88,7 @@
 /// to the sole instance of the registry.
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/export.h"
 #include "pxr/base/arch/pragmas.h"
 
 #include <atomic>
@@ -102,7 +103,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \ref TfSingleton_typicalUse "Typical Use" for a canonical example).
 ///
 template <class T>
-class TfSingleton {
+class ARCH_EXPORT_TYPE TfSingleton {
 public:
     /// Return a reference to an object of type \c T, creating it if
     /// necessary.

--- a/pxr/base/tf/token.h
+++ b/pxr/base/tf/token.h
@@ -67,7 +67,7 @@ struct TfTokenFastArbitraryLessThan;
 /// constructors).  However, auto conversion from \c TfToken to \c string and
 /// \c char* is provided.
 ///
-class TfToken
+class ARCH_EXPORT_TYPE TfToken
 {
 public:
     enum _ImmortalTag { Immortal };

--- a/pxr/base/tf/type.h
+++ b/pxr/base/tf/type.h
@@ -53,7 +53,7 @@ public:
     using DefinitionCallback = void (*)(TfType);
 
     /// Base class of all factory types.
-    class FactoryBase {
+    class ARCH_EXPORT_TYPE FactoryBase {
     public:
         TF_API virtual ~FactoryBase();
     };
@@ -69,7 +69,7 @@ public:
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
     // This is a non-templated base class for the templated
     // polymorphic-to-Python infrastructure.
-    struct PyPolymorphicBase
+    struct ARCH_EXPORT_TYPE PyPolymorphicBase
     {
     protected:
         TF_API virtual ~PyPolymorphicBase();

--- a/pxr/base/tf/typeNotice.h
+++ b/pxr/base/tf/typeNotice.h
@@ -17,7 +17,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \class TfTypeWasDeclaredNotice
 ///
 /// TfNotice sent after a TfType is declared.
-class TfTypeWasDeclaredNotice : public TfNotice
+class ARCH_EXPORT_TYPE TfTypeWasDeclaredNotice : public TfNotice
 {
 public:
     TfTypeWasDeclaredNotice( TfType t );

--- a/pxr/base/tf/weakBase.h
+++ b/pxr/base/tf/weakBase.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // object is destroyed when both the original whose address it was
 // initialized with, and there are no weak pointers left pointing to that
 // remnant.
-class Tf_Remnant : public TfSimpleRefBase
+class ARCH_EXPORT_TYPE Tf_Remnant : public TfSimpleRefBase
 {
 public:
 

--- a/pxr/base/trace/collection.h
+++ b/pxr/base/trace/collection.h
@@ -63,7 +63,7 @@ public:
     ///
     /// This interface provides a way to access data a TraceCollection.
     ///
-    class Visitor {
+    class ARCH_EXPORT_TYPE Visitor {
     public:
         /// Destructor
         TRACE_API virtual ~Visitor();

--- a/pxr/base/trace/collectionNotice.h
+++ b/pxr/base/trace/collectionNotice.h
@@ -22,7 +22,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// A TfNotice that is sent when the TraceCollector creates a TraceCollection.
 /// This can potentially be sent from multiple threads. Listeners must be 
 /// thread safe.
-class TraceCollectionAvailable : public TfNotice
+class ARCH_EXPORT_TYPE TraceCollectionAvailable : public TfNotice
 {
 public:
     /// Constructor.

--- a/pxr/base/trace/collector.cpp
+++ b/pxr/base/trace/collector.cpp
@@ -93,6 +93,11 @@ TraceCollector::TraceCollector()
     }
 }
 
+TraceCollector& 
+TraceCollector::GetInstance()
+{
+    return TfSingleton<TraceCollector>::GetInstance();
+}
 
 TraceCollector::~TraceCollector()
 {

--- a/pxr/base/trace/collector.h
+++ b/pxr/base/trace/collector.h
@@ -64,9 +64,7 @@ public:
     using Key = TraceDynamicKey;
 
     /// Returns the singleton instance.
-    TRACE_API static TraceCollector& GetInstance() {
-         return TfSingleton<TraceCollector>::GetInstance();
-    }
+    TRACE_API static TraceCollector& GetInstance();
     
     TRACE_API ~TraceCollector();
 

--- a/pxr/base/trace/reporter.h
+++ b/pxr/base/trace/reporter.h
@@ -44,7 +44,7 @@ class TraceCollectionAvailable;
 /// This class converts streams of TraceEvent objects into call trees which
 /// can then be used as a data source to a GUI or written out to a file.
 ///
-class TraceReporter : 
+class ARCH_EXPORT_TYPE TraceReporter : 
     public TraceReporterBase {
 public:
 

--- a/pxr/base/ts/knot.h
+++ b/pxr/base/ts/knot.h
@@ -34,7 +34,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// \sa TsTypedKnot
 ///
-class TsKnot
+class ARCH_EXPORT_TYPE TsKnot
 {
 public:
     /// \name Construction and value semantics

--- a/pxr/base/ts/spline.h
+++ b/pxr/base/ts/spline.h
@@ -55,7 +55,7 @@ class VtDictionary;
 /// copies, will incur the cost of duplicating the data, including all the
 /// knots.
 ///
-class TsSpline
+class ARCH_EXPORT_TYPE TsSpline
 {
 public:
     /// \name Construction and value semantics

--- a/pxr/base/ts/tsTest_Museum.h
+++ b/pxr/base/ts/tsTest_Museum.h
@@ -21,7 +21,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // A collection of museum exhibits.  These are spline cases that can be used by
 // tests to exercise various behaviors.
 //
-class TsTest_Museum
+class ARCH_EXPORT_TYPE TsTest_Museum
 {
 public:
     enum DataId

--- a/pxr/base/ts/tsTest_SplineData.h
+++ b/pxr/base/ts/tsTest_SplineData.h
@@ -19,7 +19,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // A generic way of encoding spline control parameters.  Allows us to pass the
 // same data to different backends (Ts, mayapy, etc) for evaluation.
 //
-class TsTest_SplineData
+class ARCH_EXPORT_TYPE TsTest_SplineData
 {
 public:
     // Interpolation method for a spline segment.

--- a/pxr/base/ts/types.h
+++ b/pxr/base/ts/types.h
@@ -28,7 +28,7 @@ using TsTime = double;
 
 /// Interpolation mode for a spline segment (region between two knots).
 ///
-enum TsInterpMode
+enum ARCH_EXPORT_TYPE TsInterpMode
 {
     TsInterpValueBlock  = 0,  //< No value in this segment.
     TsInterpHeld        = 1,  //< Constant value in this segment.
@@ -38,7 +38,7 @@ enum TsInterpMode
 
 /// Type of interpolation for a spline's \c Curve segments.
 ///
-enum TsCurveType
+enum ARCH_EXPORT_TYPE TsCurveType
 {
     TsCurveTypeBezier  = 0,  //< Bezier curve, free tangent widths.
     TsCurveTypeHermite = 1   //< Hermite curve, like Bezier but fixed tan width.
@@ -47,7 +47,7 @@ enum TsCurveType
 /// Curve-shaping mode for one of a spline's extrapolation regions (before all
 /// knots and after all knots).
 ///
-enum TsExtrapMode
+enum ARCH_EXPORT_TYPE TsExtrapMode
 {
     TsExtrapValueBlock    = 0, //< No value in this region.
     TsExtrapHeld          = 1, //< Constant value in this region.
@@ -146,7 +146,7 @@ public:
 /// See \ref page_ts_regression for a general introduction to regression and
 /// anti-regression.
 ///
-enum TsAntiRegressionMode
+enum ARCH_EXPORT_TYPE TsAntiRegressionMode
 {
     /// Do not enforce.  If there is regression, runtime evaluation will use
     /// KeepRatio.

--- a/pxr/base/vt/array.cpp
+++ b/pxr/base/vt/array.cpp
@@ -31,7 +31,7 @@ Vt_ArrayBase::_DetachCopyHook(char const *funcName) const
 
 // Instantiate basic array templates.
 #define VT_ARRAY_EXPLICIT_INST(unused, elem) \
-    template class VT_API VtArray< VT_TYPE(elem) >;
+    template class ARCH_EXPORT_TYPE VtArray< VT_TYPE(elem) >;
 TF_PP_SEQ_FOR_EACH(VT_ARRAY_EXPLICIT_INST, ~, VT_SCALAR_VALUE_TYPES)
 
 

--- a/pxr/base/vt/array.h
+++ b/pxr/base/vt/array.h
@@ -208,7 +208,7 @@ protected:
 /// VtArray will log a stack trace for every copy-on-write detach that occurs.
 ///
 template<typename ELEM>
-class VtArray : public Vt_ArrayBase {
+class ARCH_EXPORT_TYPE VtArray : public Vt_ArrayBase {
   public:
 
     /// Type this array holds.

--- a/pxr/base/vt/dictionary.h
+++ b/pxr/base/vt/dictionary.h
@@ -40,7 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// For a list of functions that can manipulate VtDictionary objects, see the  
 /// \link group_vtdict_functions VtDictionary Functions \endlink group page .
 ///
-class VtDictionary {
+class ARCH_EXPORT_TYPE VtDictionary {
     typedef std::map<std::string, VtValue, std::less<>> _Map;
     std::unique_ptr<_Map> _dictMap;
 

--- a/pxr/base/vt/types.h
+++ b/pxr/base/vt/types.h
@@ -150,7 +150,7 @@ VT_SCALAR_CLASS_VALUE_TYPES VT_BUILTIN_VALUE_TYPES
 //
 // typedef VtArray<int> VtIntArray;
 // typedef VtArray<double> VtDoubleArray;
-template<typename T> class VtArray;
+template<typename T> class ARCH_EXPORT_TYPE VtArray;
 #define VT_ARRAY_TYPEDEF(unused, elem) \
 typedef VtArray< VT_TYPE(elem) > \
 TF_PP_CAT(Vt, TF_PP_CAT(VT_TYPE_NAME(elem), Array)) ;

--- a/pxr/base/vt/value.h
+++ b/pxr/base/vt/value.h
@@ -143,7 +143,7 @@ struct Vt_ValueGetStored
 /// or less safety or checking than the conversion constructors of the types
 /// themselves.  This includes VtArray, even VtArray<T> for T in scalar types
 /// that are range-checked when held singly.
-class VtValue
+class ARCH_EXPORT_TYPE VtValue
 {
     static const unsigned int _LocalFlag       = 1 << 0;
     static const unsigned int _TrivialCopyFlag = 1 << 1;

--- a/pxr/imaging/cameraUtil/conformWindow.h
+++ b/pxr/imaging/cameraUtil/conformWindow.h
@@ -24,7 +24,7 @@ class GfFrustum;
 /// Policy of how to conform a window to the given aspect ratio.
 /// An ASCII-art explanation is given in the corresponding .cpp file.
 /// 
-enum CameraUtilConformWindowPolicy {
+enum ARCH_EXPORT_TYPE CameraUtilConformWindowPolicy {
     /// Modify width
     CameraUtilMatchVertically,
     /// Modify height

--- a/pxr/imaging/garch/glDebugWindow.h
+++ b/pxr/imaging/garch/glDebugWindow.h
@@ -20,7 +20,7 @@ class Garch_GLPlatformDebugWindow;
 ///
 /// Platform specific minimum GL widget for unit tests.
 ///
-class GarchGLDebugWindow {
+class ARCH_EXPORT_TYPE GarchGLDebugWindow {
 public:
     GARCH_API
     GarchGLDebugWindow(const char *title, int width, int height);

--- a/pxr/imaging/garch/glPlatformContextDarwin.h
+++ b/pxr/imaging/garch/glPlatformContextDarwin.h
@@ -8,12 +8,13 @@
 #define PXR_IMAGING_GARCH_GL_PLATFORM_CONTEXT_DARWIN_H
 
 #include "pxr/pxr.h"
+#include "pxr/imaging/garch/api.h"
 #include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-class GarchNSGLContextState {
+class ARCH_EXPORT_TYPE GarchNSGLContextState {
 public:
     /// Construct with the current state.
     GarchNSGLContextState();

--- a/pxr/imaging/garch/glPlatformContextDarwin.mm
+++ b/pxr/imaging/garch/glPlatformContextDarwin.mm
@@ -91,7 +91,7 @@ GarchNSGLContextState::DoneCurrent()
 #endif
 }
 
-GarchGLPlatformContextState
+GARCH_API GarchGLPlatformContextState
 GarchGetNullGLPlatformContextState()
 {
     return GarchNSGLContextState(GarchNSGLContextState::NullState::nullstate);

--- a/pxr/imaging/garch/glPlatformContextGLX.h
+++ b/pxr/imaging/garch/glPlatformContextGLX.h
@@ -13,7 +13,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-class GarchGLXContextState {
+class ARCH_EXPORT_TYPE GarchGLXContextState {
 public:
     /// Construct with the current state.
     GarchGLXContextState();

--- a/pxr/imaging/garch/glPlatformDebugContext.h
+++ b/pxr/imaging/garch/glPlatformDebugContext.h
@@ -25,7 +25,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(GarchGLPlatformDebugContext);
 ///
 /// Platform specific context (e.g. X11/GLX) which supports debug output.
 ///
-class GarchGLPlatformDebugContext : public TfRefBase, public TfWeakBase {
+class ARCH_EXPORT_TYPE GarchGLPlatformDebugContext : public TfRefBase, public TfWeakBase {
 public:
     
     static GarchGLPlatformDebugContextRefPtr

--- a/pxr/imaging/glf/drawTarget.h
+++ b/pxr/imaging/glf/drawTarget.h
@@ -47,7 +47,7 @@ typedef std::shared_ptr<class GlfGLContext> GlfGLContextSharedPtr;
 /// are also available (by setting the format to GL_DEPTH_STENCIL and
 /// the internalFormat to GL_DEPTH24_STENCIL8)
 ///
-class GlfDrawTarget : public TfRefBase, public TfWeakBase {
+class ARCH_EXPORT_TYPE GlfDrawTarget : public TfRefBase, public TfWeakBase {
 public:
     typedef GlfDrawTarget This;
 

--- a/pxr/imaging/glf/simpleLight.h
+++ b/pxr/imaging/glf/simpleLight.h
@@ -26,7 +26,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-class GlfSimpleLight final {
+class ARCH_EXPORT_TYPE GlfSimpleLight final {
 public:
     GLF_API
     GlfSimpleLight(GfVec4f const & position = GfVec4f(0.0, 0.0, 0.0, 1.0));

--- a/pxr/imaging/glf/texture.h
+++ b/pxr/imaging/glf/texture.h
@@ -42,7 +42,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(GlfTexture);
 /// A texture is typically defined by reading texture image data from an image
 /// file but a texture might also represent an attachment of a draw target.
 ///
-class GlfTexture : public TfRefBase, public TfWeakBase
+class ARCH_EXPORT_TYPE GlfTexture : public TfRefBase, public TfWeakBase
 {
 public:
     /// \class Binding

--- a/pxr/imaging/hd/basisCurves.h
+++ b/pxr/imaging/hd/basisCurves.h
@@ -48,7 +48,7 @@ struct HdBasisCurvesReprDesc
 
 /// Hydra Schema for a collection of curves using a particular basis.
 ///
-class HdBasisCurves : public HdRprim
+class ARCH_EXPORT_TYPE HdBasisCurves : public HdRprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/basisCurvesTopology.h
+++ b/pxr/imaging/hd/basisCurvesTopology.h
@@ -56,7 +56,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///  optional index buffer to map the generated indices to actual indices in
 ///  the vertex buffer.
 ///
-class HdBasisCurvesTopology : public HdTopology {
+class ARCH_EXPORT_TYPE HdBasisCurvesTopology : public HdTopology {
 public:
 
     HD_API

--- a/pxr/imaging/hd/bprim.h
+++ b/pxr/imaging/hd/bprim.h
@@ -36,7 +36,7 @@ class HdRenderParam;
 /// Dependent on the state of any other prim.
 ///
 /// The most typical use of a Bprim would be a Texture.
-class HdBprim
+class ARCH_EXPORT_TYPE HdBprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/bufferArray.h
+++ b/pxr/imaging/hd/bufferArray.h
@@ -65,7 +65,7 @@ using HdBufferArrayUsageHint = uint32_t;
 /// can be shared across multiple HdRprims, in the context of buffer
 /// aggregation.
 ///
-class HdBufferArray : public std::enable_shared_from_this<HdBufferArray> 
+class ARCH_EXPORT_TYPE HdBufferArray : public std::enable_shared_from_this<HdBufferArray> 
 {
 public:
     HD_API

--- a/pxr/imaging/hd/bufferArrayRange.h
+++ b/pxr/imaging/hd/bufferArrayRange.h
@@ -31,7 +31,7 @@ using HdBufferSourceSharedPtr = std::shared_ptr<class HdBufferSource>;
 /// inherited of this interface so that client (drawItem) can be agnostic about
 /// the implementation detail of aggregation.
 ///
-class HdBufferArrayRange 
+class ARCH_EXPORT_TYPE HdBufferArrayRange 
 {
 public:
 

--- a/pxr/imaging/hd/bufferSource.h
+++ b/pxr/imaging/hd/bufferSource.h
@@ -35,7 +35,7 @@ using HdBufferSourceWeakPtr = std::weak_ptr<HdBufferSource>;
 /// resource registry with the buffer array range that specifies the
 /// destination resource.
 ///
-class HdBufferSource 
+class ARCH_EXPORT_TYPE HdBufferSource 
 {
 public:
     HdBufferSource() : _state(UNRESOLVED) { }
@@ -193,7 +193,7 @@ private:
 ///   virtual void Resolve();
 /// and set the result via _SetResult().
 ///
-class HdComputedBufferSource : public HdBufferSource {
+class ARCH_EXPORT_TYPE HdComputedBufferSource : public HdBufferSource {
 public:
     HD_API
     virtual TfToken const &GetName() const override;
@@ -218,7 +218,7 @@ private:
 /// A abstract base class for pure cpu computation.
 /// the result won't be scheduled for GPU transfer.
 ///
-class HdNullBufferSource : public HdBufferSource {
+class ARCH_EXPORT_TYPE HdNullBufferSource : public HdBufferSource {
 public:
     HD_API
     virtual TfToken const &GetName() const override;

--- a/pxr/imaging/hd/camera.h
+++ b/pxr/imaging/hd/camera.h
@@ -83,7 +83,7 @@ TF_DECLARE_PUBLIC_TOKENS(HdCameraTokens, HD_API, HD_CAMERA_TOKENS);
 /// Backends that use additional camera parameters can inherit from HdCamera and
 /// pull on them.
 ///
-class HdCamera : public HdSprim
+class ARCH_EXPORT_TYPE HdCamera : public HdSprim
 {
 public:
     using ClipPlanesVector = std::vector<GfVec4d>;

--- a/pxr/imaging/hd/coordSys.h
+++ b/pxr/imaging/hd/coordSys.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// of the transform from its local space to world space.  In other
 /// words, it has the same interpretation as the transform for rprims.
 ///
-class HdCoordSys : public HdSprim
+class ARCH_EXPORT_TYPE HdCoordSys : public HdSprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/dataSource.h
+++ b/pxr/imaging/hd/dataSource.h
@@ -77,7 +77,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// should use HD_DECLARE_DATASOURCE_ABSTRACT, which omits the 
 /// definition of ::New().
 ///
-class HdDataSourceBase
+class ARCH_EXPORT_TYPE HdDataSourceBase
 {
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdDataSourceBase)
@@ -95,7 +95,7 @@ HD_DECLARE_DATASOURCE_HANDLES(HdDataSourceBase);
 /// Note that implementations are responsible for providing cache invalidation,
 /// if necessary.
 ///
-class HdContainerDataSource : public HdDataSourceBase
+class ARCH_EXPORT_TYPE HdContainerDataSource : public HdDataSourceBase
 {
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdContainerDataSource);
@@ -127,7 +127,7 @@ HD_DECLARE_DATASOURCE_HANDLES(HdContainerDataSource);
 /// \p HdSampledDataSource can be used instead. Note that implementations are
 /// responsible for providing cache invalidation, if necessary.
 ///
-class HdVectorDataSource : public HdDataSourceBase
+class ARCH_EXPORT_TYPE HdVectorDataSource : public HdDataSourceBase
 { 
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdVectorDataSource);
@@ -149,7 +149,7 @@ HD_DECLARE_DATASOURCE_HANDLES(HdVectorDataSource);
 /// A datasource representing time-sampled values. Note that implementations
 /// are responsible for providing cache invalidation, if necessary.
 ///
-class HdSampledDataSource : public HdDataSourceBase
+class ARCH_EXPORT_TYPE HdSampledDataSource : public HdDataSourceBase
 {
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdSampledDataSource);
@@ -189,7 +189,7 @@ HD_DECLARE_DATASOURCE_HANDLES(HdSampledDataSource);
 /// A datasource representing a concretely-typed sampled value.
 ///
 template <typename T>
-class HdTypedSampledDataSource : public HdSampledDataSource
+class ARCH_EXPORT_TYPE HdTypedSampledDataSource : public HdSampledDataSource
 {
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdTypedSampledDataSource<T>);
@@ -208,7 +208,7 @@ public:
 /// child being null. This type is useful when composing containers, where a
 /// block might shadow sampled data, and sampled data might shadow nullptr.
 ///
-class HdBlockDataSource : public HdDataSourceBase
+class ARCH_EXPORT_TYPE HdBlockDataSource : public HdDataSourceBase
 {
 public:
     HD_DECLARE_DATASOURCE(HdBlockDataSource);

--- a/pxr/imaging/hd/dataSourceLocator.h
+++ b/pxr/imaging/hd/dataSourceLocator.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Data Source Locators are meant to be short lists of tokens that, taken
 /// together, can represent the location of a given data source.
 ///
-class HdDataSourceLocator
+class ARCH_EXPORT_TYPE HdDataSourceLocator
 {
 public:
 

--- a/pxr/imaging/hd/drawItem.h
+++ b/pxr/imaging/hd/drawItem.h
@@ -44,7 +44,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \note
 /// Rendering backends may choose to specialize this class.
 ///
-class HdDrawItem
+class ARCH_EXPORT_TYPE HdDrawItem
 {
 public:
     HF_MALLOC_TAG_NEW("new HdDrawItem");

--- a/pxr/imaging/hd/driver.h
+++ b/pxr/imaging/hd/driver.h
@@ -20,7 +20,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// the render delegate and rendering tasks.
 /// The application manages the lifetime (destruction) of HdDriver and must 
 /// ensure it remains valid while Hydra is running.
-class HdDriver {
+class ARCH_EXPORT_TYPE HdDriver {
 public:
     TfToken name;
     VtValue driver;

--- a/pxr/imaging/hd/extComputation.h
+++ b/pxr/imaging/hd/extComputation.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// ExtComputations use a pull model, so processing is only triggered if
 /// a downstream computation or prim pulls on one the computations outputs.
 ///
-class HdExtComputation : public HdSprim
+class ARCH_EXPORT_TYPE HdExtComputation : public HdSprim
 {
 public:
     /// Construct a new ExtComputation identified by id.

--- a/pxr/imaging/hd/field.h
+++ b/pxr/imaging/hd/field.h
@@ -30,7 +30,7 @@ using HdFieldPtrConstVector = std::vector<class HdField const *>;
 /// Hydra schema for a USD field primitive. Acts like a texture, combined
 /// with other fields to make up a renderable volume.
 ///
-class HdField : public HdBprim
+class ARCH_EXPORT_TYPE HdField : public HdBprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/filteringSceneIndex.h
+++ b/pxr/imaging/hd/filteringSceneIndex.h
@@ -118,7 +118,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(HdSingleInputFilteringSceneIndexBase);
 /// An abstract base class for a filtering scene index that observes a single 
 /// input scene index.
 ///
-class HdSingleInputFilteringSceneIndexBase : public HdFilteringSceneIndexBase
+class ARCH_EXPORT_TYPE HdSingleInputFilteringSceneIndexBase : public HdFilteringSceneIndexBase
 {
 public:
     HD_API

--- a/pxr/imaging/hd/flattenedDataSourceProvider.h
+++ b/pxr/imaging/hd/flattenedDataSourceProvider.h
@@ -25,7 +25,7 @@ using HdFlattenedDataSourceProviderSharedPtr =
 /// flattened data source which is in the prim container data
 /// source.
 ///
-class HdFlattenedDataSourceProvider
+class ARCH_EXPORT_TYPE HdFlattenedDataSourceProvider
 {
 public:
     class Context

--- a/pxr/imaging/hd/flattenedOverlayDataSourceProvider.h
+++ b/pxr/imaging/hd/flattenedOverlayDataSourceProvider.h
@@ -17,7 +17,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Flattens a data source by using HdOverlayContainerDataSource.
 ///
-class HdFlattenedOverlayDataSourceProvider : public HdFlattenedDataSourceProvider
+class ARCH_EXPORT_TYPE HdFlattenedOverlayDataSourceProvider : public HdFlattenedDataSourceProvider
 {
 public:
     HD_API

--- a/pxr/imaging/hd/instancer.h
+++ b/pxr/imaging/hd/instancer.h
@@ -105,7 +105,7 @@ class HdRenderParam;
 /// All data access (aside from local caches) is routed to the HdSceneDelegate.
 ///
 
-class HdInstancer {
+class ARCH_EXPORT_TYPE HdInstancer {
 public:
     /// Constructor.
     HD_API

--- a/pxr/imaging/hd/light.h
+++ b/pxr/imaging/hd/light.h
@@ -63,7 +63,7 @@ using HdLightPtrConstVector = std::vector<class HdLight const *>;
 ///
 /// A light model, used in conjunction with HdRenderPass.
 ///
-class HdLight : public HdSprim
+class ARCH_EXPORT_TYPE HdLight : public HdSprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/material.h
+++ b/pxr/imaging/hd/material.h
@@ -18,7 +18,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Hydra Schema for a material object.
 ///
-class HdMaterial : public HdSprim
+class ARCH_EXPORT_TYPE HdMaterial : public HdSprim
 {
 public:
     // change tracking for HdMaterial prim

--- a/pxr/imaging/hd/materialFilteringSceneIndexBase.h
+++ b/pxr/imaging/hd/materialFilteringSceneIndexBase.h
@@ -23,7 +23,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(HdMaterialFilteringSceneIndexBase);
 /// only material network data sources. Subclasses implement only 
 /// _GetFilteringFunction to provide a callback to run when a material network
 /// is first queried.
-class HdMaterialFilteringSceneIndexBase :
+class ARCH_EXPORT_TYPE HdMaterialFilteringSceneIndexBase :
     public HdSingleInputFilteringSceneIndexBase
 {
 public:

--- a/pxr/imaging/hd/materialNetwork2Interface.h
+++ b/pxr/imaging/hd/materialNetwork2Interface.h
@@ -19,7 +19,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Implements HdMaterialNetworkInterface interface backed by an
 /// HdMaterialNetwork2 -- which is useful for implementing material
 /// filtering functions without being tied to the legacy data model
-class HdMaterialNetwork2Interface
+class ARCH_EXPORT_TYPE HdMaterialNetwork2Interface
     : public HdMaterialNetworkInterface
 {
 public:

--- a/pxr/imaging/hd/mesh.h
+++ b/pxr/imaging/hd/mesh.h
@@ -98,7 +98,7 @@ struct HdMeshReprDesc
 
 /// Hydra Schema for a subdivision surface or poly-mesh object.
 ///
-class HdMesh : public HdRprim
+class ARCH_EXPORT_TYPE HdMesh : public HdRprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/meshTopology.h
+++ b/pxr/imaging/hd/meshTopology.h
@@ -35,7 +35,7 @@ using HdMeshTopologySharedPtr = std::shared_ptr<class HdMeshTopology>;
 /// of computing derivative topological data (such as indices or subdivision
 /// stencil tables and patch tables).
 ///
-class HdMeshTopology : public HdTopology {
+class ARCH_EXPORT_TYPE HdMeshTopology : public HdTopology {
 public:
     HD_API
     HdMeshTopology();

--- a/pxr/imaging/hd/meshUtil.h
+++ b/pxr/imaging/hd/meshUtil.h
@@ -297,7 +297,7 @@ private:
 /// drawing order and requires minimal additional GPU data.
 ///
 ///
-class HdMeshEdgeIndexTable
+class ARCH_EXPORT_TYPE HdMeshEdgeIndexTable
 {
 public:
     HD_API

--- a/pxr/imaging/hd/perfLog.h
+++ b/pxr/imaging/hd/perfLog.h
@@ -76,7 +76,7 @@ class HdResourceRegistry;
 ///
 /// Performance counter monitoring.
 ///
-class HdPerfLog
+class ARCH_EXPORT_TYPE HdPerfLog
 {
 public:
     HD_API

--- a/pxr/imaging/hd/points.h
+++ b/pxr/imaging/hd/points.h
@@ -34,7 +34,7 @@ struct HdPointsReprDesc
 
 /// Hydra Schema for a point cloud.
 ///
-class HdPoints: public HdRprim
+class ARCH_EXPORT_TYPE HdPoints: public HdRprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/renderBuffer.h
+++ b/pxr/imaging/hd/renderBuffer.h
@@ -29,7 +29,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Render buffers can be targeted by render passes.  They also contain
 /// mapping functionality for reading and writing buffer data.
-class HdRenderBuffer : public HdBprim
+class ARCH_EXPORT_TYPE HdRenderBuffer : public HdBprim
 {
 public:
     // change tracking for HdRenderBuffer

--- a/pxr/imaging/hd/renderDelegate.h
+++ b/pxr/imaging/hd/renderDelegate.h
@@ -42,7 +42,7 @@ using HdDriverVector = std::vector<HdDriver*>;
 /// that is obtained from the render delegate and passed to each prim
 /// during Sync processing.
 ///
-class HdRenderParam 
+class ARCH_EXPORT_TYPE HdRenderParam 
 {
 public:
     HdRenderParam() {}
@@ -75,7 +75,7 @@ typedef std::vector<HdRenderSettingDescriptor> HdRenderSettingDescriptorList;
 
 /// \class HdRenderDelegate
 ///
-class HdRenderDelegate
+class ARCH_EXPORT_TYPE HdRenderDelegate
 {
 public:
     HD_API

--- a/pxr/imaging/hd/renderPass.h
+++ b/pxr/imaging/hd/renderPass.h
@@ -49,7 +49,7 @@ using HdRenderPassStateSharedPtr = std::shared_ptr<class HdRenderPassState>;
 /// Rendering backends are expected to specialize this abstract class, and
 /// return the specialized object via HdRenderDelegate::CreateRenderPass
 ///
-class HdRenderPass 
+class ARCH_EXPORT_TYPE HdRenderPass 
 {
 public:
     HD_API

--- a/pxr/imaging/hd/renderPassState.h
+++ b/pxr/imaging/hd/renderPassState.h
@@ -42,7 +42,7 @@ class HdCamera;
 ///
 /// Parameters are expressed as GL states, uniforms or shaders.
 ///
-class HdRenderPassState
+class ARCH_EXPORT_TYPE HdRenderPassState
 {
 public:
     HD_API

--- a/pxr/imaging/hd/rendererPlugin.h
+++ b/pxr/imaging/hd/rendererPlugin.h
@@ -29,7 +29,7 @@ class HdPluginRenderDelegateUniqueHandle;
 /// The class is used to factory objects that provide delegate support
 /// to other parts of the Hydra Ecosystem.
 ///
-class HdRendererPlugin : public HfPluginBase {
+class ARCH_EXPORT_TYPE HdRendererPlugin : public HfPluginBase {
 public:
 
     ///

--- a/pxr/imaging/hd/resourceRegistry.h
+++ b/pxr/imaging/hd/resourceRegistry.h
@@ -30,7 +30,7 @@ using HdResourceRegistrySharedPtr = std::shared_ptr<class HdResourceRegistry>;
 ///
 /// A central registry for resources.
 ///
-class HdResourceRegistry  {
+class ARCH_EXPORT_TYPE HdResourceRegistry  {
 public:
     HF_MALLOC_TAG_NEW("new HdResourceRegistry");
 

--- a/pxr/imaging/hd/retainedDataSource.cpp
+++ b/pxr/imaging/hd/retainedDataSource.cpp
@@ -23,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 namespace
 {
 
-class Hd_EmptyContainerDataSource : public HdRetainedContainerDataSource
+class ARCH_EXPORT_TYPE Hd_EmptyContainerDataSource : public HdRetainedContainerDataSource
 {
 public:
     TfTokenVector GetNames() override 
@@ -41,7 +41,7 @@ public:
 
 // Linear storage/search for containers with small numbers of children.
 template <size_t T>
-class Hd_SmallRetainedContainerDataSource
+class ARCH_EXPORT_TYPE Hd_SmallRetainedContainerDataSource
     : public HdRetainedContainerDataSource
 {
 public:
@@ -104,7 +104,7 @@ private:
 
 // Fallback any-sized container.
 template <size_t T>
-class Hd_MappedRetainedContainerDataSource
+class ARCH_EXPORT_TYPE Hd_MappedRetainedContainerDataSource
     : public HdRetainedContainerDataSource
 {
 public:

--- a/pxr/imaging/hd/retainedDataSource.h
+++ b/pxr/imaging/hd/retainedDataSource.h
@@ -27,7 +27,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// break away from the more live data sources (e.g., those that query a
 /// backing scene).
 ///
-class HdRetainedContainerDataSource : public HdContainerDataSource
+class ARCH_EXPORT_TYPE HdRetainedContainerDataSource : public HdContainerDataSource
 {
 public:
     HD_DECLARE_DATASOURCE_ABSTRACT(HdRetainedContainerDataSource);
@@ -146,7 +146,7 @@ HD_DECLARE_DATASOURCE_HANDLES(HdRetainedSampledDataSource);
 /// semantics.
 ///
 template <typename T>
-class HdRetainedTypedSampledDataSource : public HdTypedSampledDataSource<T>
+class ARCH_EXPORT_TYPE HdRetainedTypedSampledDataSource : public HdTypedSampledDataSource<T>
 {
 public:
     //abstract to implement New outside in service of specialization
@@ -201,7 +201,7 @@ HdRetainedTypedSampledDataSource<bool>::New(const bool &value);
 /// multiple samples at once.
 ///
 template <typename T>
-class HdRetainedTypedMultisampledDataSource : public HdTypedSampledDataSource<T>
+class ARCH_EXPORT_TYPE HdRetainedTypedMultisampledDataSource : public HdTypedSampledDataSource<T>
 {
 public:
     HD_DECLARE_DATASOURCE(HdRetainedTypedMultisampledDataSource<T>);
@@ -331,7 +331,7 @@ HdRetainedTypedMultisampledDataSource<T>::GetTypedValue(
 /// Internally it uses a TfSmallVector with up to 32 locally stored entries
 /// for storage.
 ///
-class HdRetainedSmallVectorDataSource : public HdVectorDataSource
+class ARCH_EXPORT_TYPE HdRetainedSmallVectorDataSource : public HdVectorDataSource
 {
 public:
     HD_DECLARE_DATASOURCE(HdRetainedSmallVectorDataSource);

--- a/pxr/imaging/hd/retainedSceneIndex.h
+++ b/pxr/imaging/hd/retainedSceneIndex.h
@@ -23,7 +23,7 @@ TF_DECLARE_REF_PTRS(HdRetainedSceneIndex);
 ///
 /// Concrete scene container which can be externally populated and dirtied.
 ///
-class HdRetainedSceneIndex : public HdSceneIndexBase
+class ARCH_EXPORT_TYPE HdRetainedSceneIndex : public HdSceneIndexBase
 {
 public:
 

--- a/pxr/imaging/hd/rprim.h
+++ b/pxr/imaging/hd/rprim.h
@@ -34,7 +34,7 @@ using HdReprSharedPtr = std::shared_ptr<HdRepr>;
 /// The render engine state for a given rprim from the scene graph. All data
 /// access (aside from local caches) is delegated to the HdSceneDelegate.
 ///
-class HdRprim
+class ARCH_EXPORT_TYPE HdRprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/rprimCollection.h
+++ b/pxr/imaging/hd/rprimCollection.h
@@ -34,7 +34,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// HdRenderPass
 /// HdDirtyList
 ///
-class HdRprimCollection {
+class ARCH_EXPORT_TYPE HdRprimCollection {
 public:
     HD_API
     HdRprimCollection();

--- a/pxr/imaging/hd/sceneDelegate.h
+++ b/pxr/imaging/hd/sceneDelegate.h
@@ -388,7 +388,7 @@ typedef std::vector<HdVolumeFieldDescriptor>
 ///
 /// Adapter class providing data exchange with the client scene graph.
 ///
-class HdSceneDelegate {
+class ARCH_EXPORT_TYPE HdSceneDelegate {
 public:
     /// Constructor used for nested delegate objects which share a RenderIndex.
     HD_API

--- a/pxr/imaging/hd/sceneIndex.h
+++ b/pxr/imaging/hd/sceneIndex.h
@@ -44,7 +44,7 @@ struct HdSceneIndexPrim
 /// data directly, and it can also register observers to be notified about
 /// scene changes (see HdSceneIndexObserver).
 ///
-class HdSceneIndexBase : public TfRefBase, public TfWeakBase
+class ARCH_EXPORT_TYPE HdSceneIndexBase : public TfRefBase, public TfWeakBase
 {
 public:
     HD_API
@@ -246,7 +246,7 @@ private:
 /// are not automatically registered here, and must be manually added
 /// (generally by the application).
 ///
-class HdSceneIndexNameRegistry
+class ARCH_EXPORT_TYPE HdSceneIndexNameRegistry
     : public TfSingleton<HdSceneIndexNameRegistry> 
 {
     friend class TfSingleton<HdSceneIndexNameRegistry>;
@@ -285,6 +285,8 @@ private:
 
     _NamedInstanceMap _namedInstances;
 };
+
+HD_API_TEMPLATE_CLASS(TfSingleton<HdSceneIndexNameRegistry>);
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/imaging/hd/sceneIndexObserver.h
+++ b/pxr/imaging/hd/sceneIndexObserver.h
@@ -28,7 +28,7 @@ TF_DECLARE_WEAK_PTRS(HdSceneIndexObserver);
 /// Observer of scene data. From the time an observer is registered with
 /// a scene index, the scene index will send it diffs as the scene changes.
 ///
-class HdSceneIndexObserver : public TfWeakBase
+class ARCH_EXPORT_TYPE HdSceneIndexObserver : public TfWeakBase
 {
 public:
 

--- a/pxr/imaging/hd/sceneIndexPlugin.h
+++ b/pxr/imaging/hd/sceneIndexPlugin.h
@@ -14,7 +14,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class HdSceneIndexPlugin : public HfPluginBase
+class ARCH_EXPORT_TYPE HdSceneIndexPlugin : public HfPluginBase
 {
 public:
 

--- a/pxr/imaging/hd/selection.h
+++ b/pxr/imaging/hd/selection.h
@@ -32,7 +32,7 @@ using HdSelectionSharedPtr = std::shared_ptr<class HdSelection>;
 /// It current supports active and rollover selection modes, and may be
 /// inherited for customization.
 ///
-class HdSelection
+class ARCH_EXPORT_TYPE HdSelection
 {
 public:
     /// Selection modes allow differentiation in selection highlight behavior.

--- a/pxr/imaging/hd/sortedIds.h
+++ b/pxr/imaging/hd/sortedIds.h
@@ -72,7 +72,7 @@ public:
     void Clear();
 
 private:
-    class _UpdateImpl;
+    struct _UpdateImpl;
 
     enum _EditMode { _NoMode, _InsertMode, _RemoveMode, _UpdateMode };
     

--- a/pxr/imaging/hd/sprim.h
+++ b/pxr/imaging/hd/sprim.h
@@ -31,7 +31,7 @@ class HdRenderParam;
 ///
 /// The lifetime of HdSprim is owned by HdRenderIndex.
 ///
-class HdSprim
+class ARCH_EXPORT_TYPE HdSprim
 {
 public:
     HD_API

--- a/pxr/imaging/hd/task.h
+++ b/pxr/imaging/hd/task.h
@@ -40,7 +40,7 @@ using HdTaskContext =
 /// Developers can subclass HdTask to prepare resources, run 3d renderpasses, 
 /// run 2d renderpasses such as compositing or color correction, or coordinate 
 /// integration with the application or other renderers.
-class HdTask {
+class ARCH_EXPORT_TYPE HdTask {
 public:
     /// Construct a new task.
     /// If the task is going to be added to the render index, id

--- a/pxr/imaging/hd/unitTestDelegate.h
+++ b/pxr/imaging/hd/unitTestDelegate.h
@@ -32,7 +32,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// A simple delegate class for unit test driver.
 ///
-class HdUnitTestDelegate : public HdSceneDelegate
+class ARCH_EXPORT_TYPE HdUnitTestDelegate : public HdSceneDelegate
 {
 public:
     HD_API

--- a/pxr/imaging/hd/unitTestNullRenderDelegate.h
+++ b/pxr/imaging/hd/unitTestNullRenderDelegate.h
@@ -13,7 +13,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class Hd_UnitTestNullRenderDelegate final : public HdRenderDelegate
+class ARCH_EXPORT_TYPE Hd_UnitTestNullRenderDelegate final : public HdRenderDelegate
 {
 public:
     Hd_UnitTestNullRenderDelegate() = default;

--- a/pxr/imaging/hd/volume.h
+++ b/pxr/imaging/hd/volume.h
@@ -22,7 +22,7 @@ using HdVolumePtrConstVector = std::vector<class HdVolume const *>;
 ///
 /// Hd schema for a renderable volume primitive.
 ///
-class HdVolume : public HdRprim
+class ARCH_EXPORT_TYPE HdVolume : public HdRprim
 {
 public:
     HD_API

--- a/pxr/imaging/hdSt/basisCurvesShaderKey.h
+++ b/pxr/imaging/hdSt/basisCurvesShaderKey.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// example ORIENTED only makes sense with RIBBON. In the future, we hope to 
 /// eliminate NormalStyle, perhaps by merging the (RIBBON, ROUND) mode into a 
 /// more automatic HALFTUBE and by relying more on materials for HAIR.
-struct HdSt_BasisCurvesShaderKey : public HdSt_ShaderKey
+struct ARCH_EXPORT_TYPE HdSt_BasisCurvesShaderKey : public HdSt_ShaderKey
 {
     enum DrawStyle{
         POINTS,       // Draws only the control vertices.

--- a/pxr/imaging/hdSt/basisCurvesTopology.h
+++ b/pxr/imaging/hdSt/basisCurvesTopology.h
@@ -25,7 +25,7 @@ using HdBufferSourceSharedPtr = std::shared_ptr<class HdBufferSource>;
 //
 // Storm implementation for basisCurves topology.
 //
-class HdSt_BasisCurvesTopology final : public HdBasisCurvesTopology {
+class ARCH_EXPORT_TYPE HdSt_BasisCurvesTopology final : public HdBasisCurvesTopology {
 public:
     HDST_API
     static HdSt_BasisCurvesTopologySharedPtr New(const HdBasisCurvesTopology &src);

--- a/pxr/imaging/hdSt/bufferArrayRange.h
+++ b/pxr/imaging/hdSt/bufferArrayRange.h
@@ -39,7 +39,7 @@ using HdStBufferResourceNamedList =
 /// inherited of this interface so that client (drawItem) can be agnostic about
 /// the implementation detail of aggregation.
 ///
-class HdStBufferArrayRange : public HdBufferArrayRange 
+class ARCH_EXPORT_TYPE HdStBufferArrayRange : public HdBufferArrayRange 
 {
 public:
     HdStBufferArrayRange(HdStResourceRegistry* resourceRegistry);

--- a/pxr/imaging/hdSt/computation.h
+++ b/pxr/imaging/hdSt/computation.h
@@ -32,7 +32,7 @@ using HdStComputationSharedPtrVector = std::vector<HdStComputationSharedPtr>;
 /// using buffer specs determined by GetBufferSpecs, and registered as a pair
 /// of computation and range.
 ///
-class HdStComputation
+class ARCH_EXPORT_TYPE HdStComputation
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/drawItem.h
+++ b/pxr/imaging/hdSt/drawItem.h
@@ -20,7 +20,7 @@ using HdSt_GeometricShaderSharedPtr =
 using HdSt_MaterialNetworkShaderSharedPtr =
         std::shared_ptr<class HdSt_MaterialNetworkShader>;
 
-class HdStDrawItem : public HdDrawItem
+class ARCH_EXPORT_TYPE HdStDrawItem : public HdDrawItem
 {
 public:
     HF_MALLOC_TAG_NEW("new HdStDrawItem");

--- a/pxr/imaging/hdSt/extCompGpuComputation.h
+++ b/pxr/imaging/hdSt/extCompGpuComputation.h
@@ -65,7 +65,7 @@ using HdStExtCompGpuComputationSharedPtr =
 /// \see HdResourceRegistry
 /// \see HdExtComputation
 /// \see HdBufferArrayRange
-class HdStExtCompGpuComputation final : public HdStComputation
+class ARCH_EXPORT_TYPE HdStExtCompGpuComputation final : public HdStComputation
 {
 public:
     /// Constructs a new GPU ExtComputation computation.

--- a/pxr/imaging/hdSt/geometricShader.h
+++ b/pxr/imaging/hdSt/geometricShader.h
@@ -40,7 +40,7 @@ class HioGlslfx;
 /// stages and uses geometry opinions (such as cullstyle, double sided, etc)
 /// to generate shader code variants via mixins.
 ///
-class HdSt_GeometricShader : public HdStShaderCode {
+class ARCH_EXPORT_TYPE HdSt_GeometricShader : public HdStShaderCode {
 public:
     /// Used in HdSt_CodeGen to generate the appropriate shader source 
     enum class PrimitiveType {

--- a/pxr/imaging/hdSt/lightingShader.h
+++ b/pxr/imaging/hdSt/lightingShader.h
@@ -20,7 +20,7 @@ using HdStLightingShaderSharedPtr = std::shared_ptr<class HdStLightingShader>;
 ///
 /// A lighting shader base class.
 ///
-class HdStLightingShader : public HdStShaderCode {
+class ARCH_EXPORT_TYPE HdStLightingShader : public HdStShaderCode {
 public:
     HDST_API
     HdStLightingShader();

--- a/pxr/imaging/hdSt/meshShaderKey.h
+++ b/pxr/imaging/hdSt/meshShaderKey.h
@@ -17,7 +17,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 
-struct HdSt_MeshShaderKey : public HdSt_ShaderKey
+struct ARCH_EXPORT_TYPE HdSt_MeshShaderKey : public HdSt_ShaderKey
 {
     enum NormalSource
     {

--- a/pxr/imaging/hdSt/meshTopology.h
+++ b/pxr/imaging/hdSt/meshTopology.h
@@ -50,7 +50,7 @@ using HdSt_MeshTopologySharedPtr = std::shared_ptr<class HdSt_MeshTopology>;
 ///
 /// Storm implementation for mesh topology.
 ///
-class HdSt_MeshTopology final : public HdMeshTopology {
+class ARCH_EXPORT_TYPE HdSt_MeshTopology final : public HdMeshTopology {
 public:
     /// Specifies how subdivision mesh topology is refined.
     enum RefineMode {

--- a/pxr/imaging/hdSt/renderDelegate.h
+++ b/pxr/imaging/hdSt/renderDelegate.h
@@ -31,7 +31,7 @@ using HdStResourceRegistrySharedPtr =
 /// While it currently has some ties to GL, the goal is to use Hgi to allow
 /// it to be graphics API agnostic.
 ///
-class HdStRenderDelegate final : public HdRenderDelegate
+class ARCH_EXPORT_TYPE HdStRenderDelegate final : public HdRenderDelegate
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/renderPass.h
+++ b/pxr/imaging/hdSt/renderPass.h
@@ -20,7 +20,7 @@ class Hgi;
 ///
 /// A single draw pass to a render target/buffer. Stream implementation.
 ///
-class HdSt_RenderPass : public HdRenderPass {
+class ARCH_EXPORT_TYPE HdSt_RenderPass : public HdRenderPass {
 public:
     HDST_API
     HdSt_RenderPass(HdRenderIndex *index, HdRprimCollection const &collection);

--- a/pxr/imaging/hdSt/renderPassState.h
+++ b/pxr/imaging/hdSt/renderPassState.h
@@ -45,7 +45,7 @@ class HdSt_ResourceBinder;
 ///
 /// Parameters are expressed as GL states, uniforms or shaders.
 ///
-class HdStRenderPassState : public HdRenderPassState
+class ARCH_EXPORT_TYPE HdStRenderPassState : public HdRenderPassState
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -103,7 +103,7 @@ using HdStComputationComputeQueuePairVector =
 ///
 /// A central registry of all GPU resources.
 ///
-class HdStResourceRegistry final : public HdResourceRegistry 
+class ARCH_EXPORT_TYPE HdStResourceRegistry final : public HdResourceRegistry 
 {
 public:
     HF_MALLOC_TAG_NEW("new HdStResourceRegistry");

--- a/pxr/imaging/hdSt/samplerObject.h
+++ b/pxr/imaging/hdSt/samplerObject.h
@@ -62,8 +62,8 @@ protected:
 ///
 /// A sampler suitable for HdStUvTextureObject.
 ///
-class HdStUvSamplerObject final : public HdStSamplerObject {
-public:
+class ARCH_EXPORT_TYPE HdStUvSamplerObject final : public HdStSamplerObject {
+public: 
     HDST_API 
     HdStUvSamplerObject(
         HdStUvTextureObject const &uvTexture,

--- a/pxr/imaging/hdSt/shaderCode.h
+++ b/pxr/imaging/hdSt/shaderCode.h
@@ -55,7 +55,7 @@ class HdStResourceRegistry;
 ///
 /// This interface provides a simple way for clients to affect the
 /// composition of shading programs used for a render pass.
-class HdStShaderCode : public std::enable_shared_from_this<HdStShaderCode>
+class ARCH_EXPORT_TYPE HdStShaderCode : public std::enable_shared_from_this<HdStShaderCode>
 {
 public:
     typedef size_t ID;

--- a/pxr/imaging/hdSt/simpleLightingShader.h
+++ b/pxr/imaging/hdSt/simpleLightingShader.h
@@ -37,7 +37,7 @@ TF_DECLARE_REF_PTRS(GlfBindingMap);
 ///
 /// A shader that supports simple lighting functionality.
 ///
-class HdStSimpleLightingShader : public HdStLightingShader 
+class ARCH_EXPORT_TYPE HdStSimpleLightingShader : public HdStLightingShader 
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/subtextureIdentifier.h
+++ b/pxr/imaging/hdSt/subtextureIdentifier.h
@@ -25,7 +25,7 @@ class HdStDynamicUvTextureImplementation;
 /// file that can contain several textures (e.g., frames in a movie or
 /// grids in an OpenVDB file).
 /// 
-class HdStSubtextureIdentifier
+class ARCH_EXPORT_TYPE HdStSubtextureIdentifier
 {
 public:
     using ID = size_t;
@@ -38,7 +38,7 @@ public:
 
 protected:
     HDST_API
-    friend size_t hash_value(const HdStSubtextureIdentifier &subId);
+    friend HDST_API size_t hash_value(const HdStSubtextureIdentifier &subId);
 
     virtual ID _Hash() const = 0;
 };
@@ -52,7 +52,7 @@ size_t hash_value(const HdStSubtextureIdentifier &subId);
 /// Base class for information identifying a grid in a volume field
 /// file. Parallels FieldBase in usdVol.
 ///
-class HdStFieldBaseSubtextureIdentifier : public HdStSubtextureIdentifier
+class ARCH_EXPORT_TYPE HdStFieldBaseSubtextureIdentifier : public HdStSubtextureIdentifier
 {
 public:
     /// Get field name.
@@ -92,7 +92,7 @@ private:
 /// (flipVertically = false) which have opposite conventions for the
 /// vertical orientation.
 ///
-class HdStAssetUvSubtextureIdentifier final
+class ARCH_EXPORT_TYPE HdStAssetUvSubtextureIdentifier final
                                 : public HdStSubtextureIdentifier
 {
 public:
@@ -151,7 +151,7 @@ private:
 /// HdStRenderBuffer::Sync/Allocate and the texture is filled by using
 /// it as render target in various render passes.
 ///
-class HdStDynamicUvSubtextureIdentifier : public HdStSubtextureIdentifier
+class ARCH_EXPORT_TYPE HdStDynamicUvSubtextureIdentifier : public HdStSubtextureIdentifier
 {
 public:
     HDST_API
@@ -179,7 +179,7 @@ protected:
 /// Specifies whether a Ptex texture should be loaded with pre-multiplied alpha
 /// values.
 ///
-class HdStPtexSubtextureIdentifier final
+class ARCH_EXPORT_TYPE HdStPtexSubtextureIdentifier final
                                 : public HdStSubtextureIdentifier
 {
 public:
@@ -210,7 +210,7 @@ private:
 /// Specifies whether a Udim texture should be loaded with pre-multiplied alpha
 /// values and the color space in which the texture is encoded.
 ///
-class HdStUdimSubtextureIdentifier final
+class ARCH_EXPORT_TYPE HdStUdimSubtextureIdentifier final
                                 : public HdStSubtextureIdentifier
 {
 public:

--- a/pxr/imaging/hdSt/textureCpuData.h
+++ b/pxr/imaging/hdSt/textureCpuData.h
@@ -19,7 +19,7 @@ struct HgiTextureDesc;
 /// Represents CPU data that can be stored in a HdStUvTextureObject, mostly,
 /// likely during the load phase to be committed to the GPU.
 ///
-class HdStTextureCpuData {
+class ARCH_EXPORT_TYPE HdStTextureCpuData {
 public:
     HDST_API
     virtual ~HdStTextureCpuData();

--- a/pxr/imaging/hdSt/textureObject.h
+++ b/pxr/imaging/hdSt/textureObject.h
@@ -38,7 +38,7 @@ using HdStTextureObjectSharedPtr = std::shared_ptr<class HdStTextureObject>;
 /// Base class for a texture object. The actual GPU resources will be
 /// allocated during the commit phase.
 ///
-class HdStTextureObject :
+class ARCH_EXPORT_TYPE HdStTextureObject :
             public std::enable_shared_from_this<HdStTextureObject>
 {
 public:
@@ -135,7 +135,7 @@ private:
 ///
 /// A base class for uv textures.
 ///
-class HdStUvTextureObject : public HdStTextureObject
+class ARCH_EXPORT_TYPE HdStUvTextureObject : public HdStTextureObject
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/textureObjectRegistry.h
+++ b/pxr/imaging/hdSt/textureObjectRegistry.h
@@ -32,7 +32,7 @@ class HdStTextureIdentifier;
 ///
 /// A central registry for texture GPU resources.
 ///
-class HdSt_TextureObjectRegistry final
+class ARCH_EXPORT_TYPE HdSt_TextureObjectRegistry final
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/unitTestGLDrawing.h
+++ b/pxr/imaging/hdSt/unitTestGLDrawing.h
@@ -24,7 +24,7 @@ class HdSt_UnitTestWindow;
 ///
 /// A helper class for unit tests which need to perform GL drawing.
 ///
-class HdSt_UnitTestGLDrawing {
+class ARCH_EXPORT_TYPE HdSt_UnitTestGLDrawing {
 public:
     HDST_API
     HdSt_UnitTestGLDrawing();

--- a/pxr/imaging/hdSt/unitTestHelper.h
+++ b/pxr/imaging/hdSt/unitTestHelper.h
@@ -483,7 +483,7 @@ HdSt_TestDriverBase<SceneDelegate>::Present(
 ///
 /// A simple task to execute a render pass.
 ///
-class HdSt_DrawTask final : public HdTask
+class ARCH_EXPORT_TYPE HdSt_DrawTask final : public HdTask
 {
 public:
     HDST_API
@@ -525,7 +525,7 @@ private:
 ///
 /// A unit test driver that exercises the core engine.
 ///
-class HdSt_TestDriver final : public HdSt_TestDriverBase<HdUnitTestDelegate>
+class ARCH_EXPORT_TYPE HdSt_TestDriver final : public HdSt_TestDriverBase<HdUnitTestDelegate>
 {
 public:
     HDST_API
@@ -571,7 +571,7 @@ using HdSt_TestDriverUniquePtr = std::unique_ptr<HdSt_TestDriver>;
 using HdSt_TestLightingShaderSharedPtr =
     std::shared_ptr<class HdSt_TestLightingShader>;
 
-class HdSt_TestLightingShader : public HdStLightingShader
+class ARCH_EXPORT_TYPE HdSt_TestLightingShader : public HdStLightingShader
 {
 public:
     HDST_API
@@ -622,7 +622,7 @@ private:
 
 // --------------------------------------------------------------------------
 
-class HdSt_TextureTestDriver
+class ARCH_EXPORT_TYPE HdSt_TextureTestDriver
 {
 public:
     HDST_API

--- a/pxr/imaging/hdSt/vboSimpleMemoryManager.h
+++ b/pxr/imaging/hdSt/vboSimpleMemoryManager.h
@@ -27,7 +27,7 @@ class HdStResourceRegistry;
 ///
 /// This class doesn't perform any aggregation.
 ///
-class HdStVBOSimpleMemoryManager : public HdStAggregationStrategy
+class ARCH_EXPORT_TYPE HdStVBOSimpleMemoryManager : public HdStAggregationStrategy
 {
 public:
     HdStVBOSimpleMemoryManager(HdStResourceRegistry* resourceRegistry)

--- a/pxr/imaging/hdx/pickTask.h
+++ b/pxr/imaging/hdx/pickTask.h
@@ -230,7 +230,7 @@ struct HdxPrimOriginInfo
 ///         influences this operation. For e.g., the subprim indices are ignored
 ///         when the pickTarget is pickPrimsAndInstances.
 ///
-struct HdxPickTaskContextParams
+struct ARCH_EXPORT_TYPE HdxPickTaskContextParams
 {
     using DepthMaskCallback = std::function<void(void)>;
 

--- a/pxr/imaging/hdx/renderSetupTask.h
+++ b/pxr/imaging/hdx/renderSetupTask.h
@@ -117,7 +117,7 @@ private:
 ///
 /// RenderTask parameters (renderpass state).
 ///
-struct HdxRenderTaskParams
+struct ARCH_EXPORT_TYPE HdxRenderTaskParams
 {
     HdxRenderTaskParams()
         // Global Params

--- a/pxr/imaging/hdx/selectionTracker.h
+++ b/pxr/imaging/hdx/selectionTracker.h
@@ -89,7 +89,7 @@ using HdxSelectionTrackerSharedPtr =
 /// HdxSelectionTask takes HdxSelectionTracker as a task parameter, and uploads
 /// the selection buffer encoding to the GPU.
 ///
-class HdxSelectionTracker
+class ARCH_EXPORT_TYPE HdxSelectionTracker
 {
 public:
     HDX_API

--- a/pxr/imaging/hdx/unitTestDelegate.h
+++ b/pxr/imaging/hdx/unitTestDelegate.h
@@ -8,6 +8,7 @@
 #define PXR_IMAGING_HDX_UNIT_TEST_DELEGATE_H
 
 #include "pxr/pxr.h"
+#include "pxr/imaging/hdx/api.h"
 #include "pxr/imaging/hd/sceneDelegate.h"
 #include "pxr/imaging/hd/tokens.h"
 #include "pxr/imaging/glf/simpleLight.h"
@@ -32,7 +33,7 @@ _BuildArray(T values[], int numValues)
     return result;
 }
 
-class Hdx_UnitTestDelegate : public HdSceneDelegate
+class ARCH_EXPORT_TYPE Hdx_UnitTestDelegate : public HdSceneDelegate
 {
 public:
     Hdx_UnitTestDelegate(HdRenderIndex *renderIndex, 

--- a/pxr/imaging/hf/pluginBase.h
+++ b/pxr/imaging/hf/pluginBase.h
@@ -19,7 +19,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// functionality other than to serve as a polymorphic type for the
 /// plugin registry.
 ///
-class HfPluginBase
+class ARCH_EXPORT_TYPE HfPluginBase
 {
 public:
     HF_API

--- a/pxr/imaging/hf/pluginRegistry.h
+++ b/pxr/imaging/hf/pluginRegistry.h
@@ -51,7 +51,7 @@ class Hf_PluginEntry;
 ///    }
 ///}
 ///
-class HfPluginRegistry
+class ARCH_EXPORT_TYPE HfPluginRegistry
 {
 
 public:

--- a/pxr/imaging/hgi/blitCmds.h
+++ b/pxr/imaging/hgi/blitCmds.h
@@ -34,7 +34,7 @@ using HgiBlitCmdsUniquePtr = std::unique_ptr<class HgiBlitCmds>;
 /// HgiBlitCmds is a lightweight object that cannot be re-used after it has
 /// been submitted. A new cmds object should be acquired for each frame.
 ///
-class HgiBlitCmds : public HgiCmds
+class ARCH_EXPORT_TYPE HgiBlitCmds : public HgiCmds
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/buffer.h
+++ b/pxr/imaging/hgi/buffer.h
@@ -78,7 +78,7 @@ inline bool operator!=(
 /// The fill the buffer with data you supply `initialData` in the descriptor.
 /// To update the data inside the buffer later on, use blitCmds.
 ///
-class HgiBuffer
+class ARCH_EXPORT_TYPE HgiBuffer
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/computeCmds.h
+++ b/pxr/imaging/hgi/computeCmds.h
@@ -25,7 +25,7 @@ using HgiComputeCmdsUniquePtr = std::unique_ptr<class HgiComputeCmds>;
 /// HgiComputeCmds is a lightweight object that cannot be re-used after it has
 /// been submitted. A new cmds object should be acquired for each frame.
 ///
-class HgiComputeCmds : public HgiCmds
+class ARCH_EXPORT_TYPE HgiComputeCmds : public HgiCmds
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/computePipeline.h
+++ b/pxr/imaging/hgi/computePipeline.h
@@ -89,7 +89,7 @@ bool operator!=(
 /// To the client (HdSt) compute pipeline resources are referred to via
 /// opaque, stateless handles (HgiComputePipelineHandle).
 ///
-class HgiComputePipeline
+class ARCH_EXPORT_TYPE HgiComputePipeline
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -27,7 +27,7 @@ using HgiGraphicsCmdsUniquePtr = std::unique_ptr<class HgiGraphicsCmds>;
 /// HgiGraphicsCmds is a lightweight object that cannot be re-used after it has
 /// been submitted. A new cmds object should be acquired for each frame.
 ///
-class HgiGraphicsCmds : public HgiCmds
+class ARCH_EXPORT_TYPE HgiGraphicsCmds : public HgiCmds
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/graphicsPipeline.h
+++ b/pxr/imaging/hgi/graphicsPipeline.h
@@ -439,7 +439,7 @@ bool operator!=(
 /// To the client (HdSt) pipeline resources are referred to via
 /// opaque, stateless handles (HgiPipelineHandle).
 ///
-class HgiGraphicsPipeline
+class ARCH_EXPORT_TYPE HgiGraphicsPipeline
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/handle.h
+++ b/pxr/imaging/hgi/handle.h
@@ -29,7 +29,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// can wrap the returned handle in a shared_ptr.
 ///
 template<class T>
-class HgiHandle
+class ARCH_EXPORT_TYPE HgiHandle
 {
 public:
     HgiHandle() : _ptr(nullptr), _id(0) {}

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -90,7 +90,7 @@ using HgiUniquePtr = std::unique_ptr<class Hgi>;
 ///     for i to num_threads
 ///         hgi->SubmitCmds( cmds[i] )
 ///
-class Hgi
+class ARCH_EXPORT_TYPE Hgi
 {
 public:
     HGI_API
@@ -348,7 +348,7 @@ private:
 ///
 /// Hgi factory for plugin system
 ///
-class HgiFactoryBase : public TfType::FactoryBase {
+class ARCH_EXPORT_TYPE HgiFactoryBase : public TfType::FactoryBase {
 public:
     virtual Hgi* New() const = 0;
 };

--- a/pxr/imaging/hgi/indirectCommandEncoder.h
+++ b/pxr/imaging/hgi/indirectCommandEncoder.h
@@ -53,7 +53,7 @@ using HgiIndirectCommandsUniquePtr = std::unique_ptr<HgiIndirectCommands>;
 /// Execute draw takes the HgiIndirectCommands structure and replays it on the
 /// device.  Currently this is only implemented on the Metal HGI device.
 ///
-class HgiIndirectCommandEncoder : public HgiCmds
+class ARCH_EXPORT_TYPE HgiIndirectCommandEncoder : public HgiCmds
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/resourceBindings.h
+++ b/pxr/imaging/hgi/resourceBindings.h
@@ -170,7 +170,7 @@ bool operator!=(
 /// Represents a collection of buffers, texture and vertex attributes that will
 /// be used by an cmds object (and pipeline).
 ///
-class HgiResourceBindings
+class ARCH_EXPORT_TYPE HgiResourceBindings
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/sampler.h
+++ b/pxr/imaging/hgi/sampler.h
@@ -104,7 +104,7 @@ bool operator!=(
 /// perform texture sampling operations.
 /// Samplers should be created via Hgi::CreateSampler.
 ///
-class HgiSampler
+class ARCH_EXPORT_TYPE HgiSampler
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/shaderFunction.h
+++ b/pxr/imaging/hgi/shaderFunction.h
@@ -27,7 +27,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// apply to other graphics backends, such as Vulkan, where the shader functions
 /// are used during rendering.
 ///
-class HgiShaderFunction
+class ARCH_EXPORT_TYPE HgiShaderFunction
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/shaderGenerator.h
+++ b/pxr/imaging/hgi/shaderGenerator.h
@@ -27,7 +27,7 @@ struct HgiShaderFunctionDesc;
 /// for different APIs. It's main role is to make GLSLFX a write once language,
 /// no matter the API
 ///
-class HgiShaderGenerator
+class ARCH_EXPORT_TYPE HgiShaderGenerator
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/shaderProgram.h
+++ b/pxr/imaging/hgi/shaderProgram.h
@@ -60,7 +60,7 @@ inline bool operator!=(
 /// when the program is detroyed, because only the client knows if the shader
 /// functions are used by other shader programs.
 ///
-class HgiShaderProgram
+class ARCH_EXPORT_TYPE HgiShaderProgram
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/shaderSection.h
+++ b/pxr/imaging/hgi/shaderSection.h
@@ -35,7 +35,7 @@ using HgiShaderSectionAttributeVector =
 /// Can be subclassed to add more behaviour for complex cases
 /// and to hook into the visitor tree.
 ///
-class HgiShaderSection
+class ARCH_EXPORT_TYPE HgiShaderSection
 {
 public:
     HGI_API

--- a/pxr/imaging/hgi/texture.h
+++ b/pxr/imaging/hgi/texture.h
@@ -140,7 +140,7 @@ bool operator!=(
 /// To the client (HdSt) texture resources are referred to via
 /// opaque, stateless handles (HgTextureHandle).
 ///
-class HgiTexture
+class ARCH_EXPORT_TYPE HgiTexture
 {
 public:
     HGI_API

--- a/pxr/imaging/hgiGL/device.h
+++ b/pxr/imaging/hgiGL/device.h
@@ -61,7 +61,7 @@ private:
     HgiGLDevice & operator=(const HgiGLDevice&) = delete;
     HgiGLDevice(const HgiGLDevice&) = delete;
 
-    friend std::ofstream& operator<<(
+    friend HGIGL_API std::ofstream& operator<<(
         std::ofstream& out,
         const HgiGLDevice& dev);
 

--- a/pxr/imaging/hgiGL/graphicsCmds.h
+++ b/pxr/imaging/hgiGL/graphicsCmds.h
@@ -23,7 +23,7 @@ class HgiGLDevice;
 ///
 /// OpenGL implementation of HgiGraphicsCmds.
 ///
-class HgiGLGraphicsCmds final : public HgiGraphicsCmds
+class ARCH_EXPORT_TYPE HgiGLGraphicsCmds final : public HgiGraphicsCmds
 {
 public:
     HGIGL_API

--- a/pxr/imaging/hgiGL/sampler.h
+++ b/pxr/imaging/hgiGL/sampler.h
@@ -22,7 +22,7 @@ using HgiTextureHandle = HgiHandle<class HgiTexture>;
 ///
 /// OpenGL implementation of HgiSampler
 ///
-class HgiGLSampler final : public HgiSampler
+class ARCH_EXPORT_TYPE HgiGLSampler final : public HgiSampler
 {
 public:
     HGIGL_API

--- a/pxr/imaging/hgiGL/texture.h
+++ b/pxr/imaging/hgiGL/texture.h
@@ -27,7 +27,7 @@ TF_DECLARE_WEAK_PTRS(HgiGLTexture);
 /// This is useful to invalidate container objects such as framebuffer objects
 /// that reference a deleted texture resource as an attachment.
 ///
-class HgiGLTexture final : public HgiTexture, public TfWeakBase
+class ARCH_EXPORT_TYPE HgiGLTexture final : public HgiTexture, public TfWeakBase
 {
 public:
     HGIGL_API

--- a/pxr/imaging/hio/fieldTextureData.h
+++ b/pxr/imaging/hio/fieldTextureData.h
@@ -29,7 +29,7 @@ using HioFieldTextureDataSharedPtr = std::shared_ptr<class HioFieldTextureData>;
 /// An interface class for reading volume files having a
 /// transformation.
 ///
-class HioFieldTextureData
+class ARCH_EXPORT_TYPE HioFieldTextureData
 {
 public:
     HIO_API
@@ -86,7 +86,7 @@ private:
 ///
 /// A base class to make HioFieldTextureData objects, implemented by plugins.
 ///
-class HIO_API HioFieldTextureDataFactoryBase : public TfType::FactoryBase
+class ARCH_EXPORT_TYPE HioFieldTextureDataFactoryBase : public TfType::FactoryBase
 {
 protected:
     friend class HioFieldTextureData;

--- a/pxr/imaging/hio/image.h
+++ b/pxr/imaging/hio/image.h
@@ -34,7 +34,7 @@ using HioImageSharedPtr = std::shared_ptr<class HioImage>;
 ///
 /// Texture paths are UTF-8 strings, resolvable by AR. Texture system dispatch
 /// is driven by extension, with [A-Z] (and no other characters) case folded.
-class HioImage
+class ARCH_EXPORT_TYPE HioImage
 {
 public:
 
@@ -184,7 +184,7 @@ HioImage::GetMetadata(TfToken const & key, T * value) const
     return true;
 }
 
-class HIO_API HioImageFactoryBase : public TfType::FactoryBase {
+class ARCH_EXPORT_TYPE HioImageFactoryBase : public TfType::FactoryBase {
 public:
     virtual HioImageSharedPtr New() const = 0;
 };

--- a/pxr/imaging/plugin/hioAvif/AVIFImage.cpp
+++ b/pxr/imaging/plugin/hioAvif/AVIFImage.cpp
@@ -49,7 +49,7 @@ ARCH_PRAGMA_UNUSED_FUNCTION
 PXR_NAMESPACE_OPEN_SCOPE
 
 // It's necessary to export the class so it's typeinfo is visible for registration
-class HIOAVIF_API Hio_AVIFImage final : public HioImage
+class ARCH_EXPORT_TYPE Hio_AVIFImage final : public HioImage
 {
     std::shared_ptr<ArAsset> _asset;
     std::string              _filename;

--- a/pxr/usd/ar/asset.h
+++ b/pxr/usd/ar/asset.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Interface for accessing the contents of an asset.
 ///
 /// \see ArResolver::OpenAsset for how to retrieve instances of this object.
-class ArAsset {
+class ARCH_EXPORT_TYPE ArAsset {
 public:
     AR_API
     virtual ~ArAsset();

--- a/pxr/usd/ar/defaultResolver.h
+++ b/pxr/usd/ar/defaultResolver.h
@@ -47,7 +47,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// ArDefaultResolver supports creating an ArDefaultResolverContext via
 /// ArResolver::CreateContextFromString by passing a list of directories
 /// delimited by the platform's standard path separator.
-class ArDefaultResolver
+class ARCH_EXPORT_TYPE ArDefaultResolver
     : public ArResolver
 {
 public:

--- a/pxr/usd/ar/defaultResolverContext.h
+++ b/pxr/usd/ar/defaultResolverContext.h
@@ -43,7 +43,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// // resolution.
 /// \endcode
 ///
-class ArDefaultResolverContext
+class ARCH_EXPORT_TYPE ArDefaultResolverContext
 {
 public:
     /// Default construct a context with no search path.

--- a/pxr/usd/ar/definePackageResolver.h
+++ b/pxr/usd/ar/definePackageResolver.h
@@ -38,7 +38,7 @@ TF_REGISTRY_FUNCTION(TfType) {                  \
     Ar_DefinePackageResolver<__VA_ARGS__>();    \
 }
 
-class Ar_PackageResolverFactoryBase 
+class ARCH_EXPORT_TYPE Ar_PackageResolverFactoryBase 
     : public TfType::FactoryBase 
 {
 public:

--- a/pxr/usd/ar/defineResolver.h
+++ b/pxr/usd/ar/defineResolver.h
@@ -38,7 +38,7 @@ TF_REGISTRY_FUNCTION(TfType) {        \
 }
 #endif // doxygen
 
-class Ar_ResolverFactoryBase 
+class ARCH_EXPORT_TYPE Ar_ResolverFactoryBase 
     : public TfType::FactoryBase 
 {
 public:

--- a/pxr/usd/ar/filesystemAsset.h
+++ b/pxr/usd/ar/filesystemAsset.h
@@ -24,7 +24,7 @@ class ArResolvedPath;
 /// \class ArFilesystemAsset
 ///
 /// ArAsset implementation for asset represented by a file on a filesystem.
-class ArFilesystemAsset
+class ARCH_EXPORT_TYPE ArFilesystemAsset
     : public ArAsset
 {
 public:

--- a/pxr/usd/ar/notice.h
+++ b/pxr/usd/ar/notice.h
@@ -33,7 +33,7 @@ class ArNotice
 public:
     /// \class ResolverNotice
     /// Base class for all ArResolver-related notices.
-    class ResolverNotice
+    class ARCH_EXPORT_TYPE ResolverNotice
         : public TfNotice
     {
     public:
@@ -45,7 +45,7 @@ public:
     /// \class ResolverChanged
     /// Notice sent when asset paths may resolve to a different path than
     /// before due to a change in the resolver.
-    class ResolverChanged 
+    class ARCH_EXPORT_TYPE ResolverChanged 
         : public ResolverNotice
     {
     public:

--- a/pxr/usd/ar/packageResolver.h
+++ b/pxr/usd/ar/packageResolver.h
@@ -75,7 +75,7 @@ class VtValue;
 /// }
 /// \endcode
 ///
-class ArPackageResolver
+class ARCH_EXPORT_TYPE ArPackageResolver
 {
 public:
     ArPackageResolver(const ArPackageResolver&) = delete;

--- a/pxr/usd/ar/resolver.h
+++ b/pxr/usd/ar/resolver.h
@@ -39,7 +39,7 @@ class VtValue;
 /// asset resolution behavior by implementing a subclass of ArResolver.
 /// Clients may use #ArGetResolver to access the configured asset resolver.
 ///
-class ArResolver 
+class ARCH_EXPORT_TYPE ArResolver 
 {
 public:
     AR_API

--- a/pxr/usd/ar/resolverContext.h
+++ b/pxr/usd/ar/resolverContext.h
@@ -228,7 +228,7 @@ private:
         return static_cast<const _Typed<Context>&>(untyped);
     }
 
-    struct _Untyped 
+    struct ARCH_EXPORT_TYPE _Untyped 
     {
         AR_API
         virtual ~_Untyped();

--- a/pxr/usd/ar/testenv/TestArURIResolver_plugin.h
+++ b/pxr/usd/ar/testenv/TestArURIResolver_plugin.h
@@ -5,6 +5,7 @@
 // https://openusd.org/license.
 //
 #include "pxr/pxr.h"
+#include "pxr/usd/ar/api.h"
 
 #include "pxr/usd/ar/defineResolverContext.h"
 #include "pxr/base/tf/hash.h"
@@ -12,7 +13,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class _TestURIResolverContext
+class ARCH_EXPORT_TYPE _TestURIResolverContext
 {
 public:
     _TestURIResolverContext() = default;

--- a/pxr/usd/ar/writableAsset.h
+++ b/pxr/usd/ar/writableAsset.h
@@ -23,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// \see ArResolver::OpenAssetForWrite for how to retrieve instances of
 /// this object.
-class ArWritableAsset
+class ARCH_EXPORT_TYPE ArWritableAsset
 {
 public:
     AR_API

--- a/pxr/usd/kind/registry.h
+++ b/pxr/usd/kind/registry.h
@@ -50,7 +50,7 @@ TF_DECLARE_PUBLIC_TOKENS(KindTokens, KIND_API, KIND_TOKENS);
 /// To make this robust, KindRegistry exposes no means to mutate the registry.
 /// All extensions must be accomplished via plugInfo.json files, which are
 /// consumed once during the registry initialization (See \ref kind_extensions )
-class KindRegistry : public TfWeakBase
+class ARCH_EXPORT_TYPE KindRegistry : public TfWeakBase
 {
     KindRegistry(const KindRegistry&) = delete;
     KindRegistry& operator=(const KindRegistry&) = delete;

--- a/pxr/usd/ndr/declare.h
+++ b/pxr/usd/ndr/declare.h
@@ -182,7 +182,7 @@ private:
 };
 
 /// Enumeration used to select nodes by version.
-enum NdrVersionFilter {
+enum ARCH_EXPORT_TYPE NdrVersionFilter {
     NdrVersionFilterDefaultOnly,
     NdrVersionFilterAllVersions,
     NdrNumVersionFilters

--- a/pxr/usd/ndr/discoveryPlugin.h
+++ b/pxr/usd/ndr/discoveryPlugin.h
@@ -123,7 +123,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(NdrDiscoveryPlugin);
 ///     </li>
 /// </ul>
 ///
-class NdrDiscoveryPlugin : public TfRefBase, public TfWeakBase
+class ARCH_EXPORT_TYPE NdrDiscoveryPlugin : public TfRefBase, public TfWeakBase
 {
 public:
     using Context = NdrDiscoveryPluginContext;
@@ -147,7 +147,7 @@ public:
 /// \cond
 /// Factory classes should be hidden from the documentation.
 
-class NdrDiscoveryPluginFactoryBase : public TfType::FactoryBase
+class ARCH_EXPORT_TYPE NdrDiscoveryPluginFactoryBase : public TfType::FactoryBase
 {
 public:
     NDR_API

--- a/pxr/usd/ndr/filesystemDiscovery.h
+++ b/pxr/usd/ndr/filesystemDiscovery.h
@@ -41,7 +41,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(_NdrFilesystemDiscoveryPlugin);
 /// while walking the search paths. Set to "true" (case sensitive) if they
 /// should be followed.
 ///
-class _NdrFilesystemDiscoveryPlugin final : public NdrDiscoveryPlugin
+class ARCH_EXPORT_TYPE _NdrFilesystemDiscoveryPlugin final : public NdrDiscoveryPlugin
 {
 public:
     /// A filter for discovered nodes.  If the function returns false

--- a/pxr/usd/ndr/node.h
+++ b/pxr/usd/ndr/node.h
@@ -28,7 +28,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// nodes can be created that derive from `NdrNode`; those specialized nodes can
 /// add their own domain-specific data and methods.
 ///
-class NdrNode
+class ARCH_EXPORT_TYPE NdrNode
 {
 public:
     /// Constructor.

--- a/pxr/usd/ndr/parserPlugin.h
+++ b/pxr/usd/ndr/parserPlugin.h
@@ -105,7 +105,7 @@ TF_REGISTRY_FUNCTION(TfType)                                            \
 ///         the documentation for the `plug` library (in pxr/base).
 ///     </li>
 /// </ul>
-class NdrParserPlugin : public TfWeakBase
+class ARCH_EXPORT_TYPE NdrParserPlugin : public TfWeakBase
 {
 public:
     NDR_API
@@ -150,7 +150,7 @@ public:
 /// \cond
 /// Factory classes should be hidden from the documentation.
 
-class NdrParserPluginFactoryBase : public TfType::FactoryBase
+class ARCH_EXPORT_TYPE NdrParserPluginFactoryBase : public TfType::FactoryBase
 {
 public:
     virtual NdrParserPlugin* New() const = 0;

--- a/pxr/usd/ndr/property.h
+++ b/pxr/usd/ndr/property.h
@@ -31,7 +31,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// In almost all cases, this class will not be used directly. More specialized
 /// properties can be created that derive from `NdrProperty`; those specialized
 /// properties can add their own domain-specific data and methods.
-class NdrProperty
+class ARCH_EXPORT_TYPE NdrProperty
 {
 public:
     /// Constructor.

--- a/pxr/usd/pcp/dependency.h
+++ b/pxr/usd/pcp/dependency.h
@@ -28,7 +28,7 @@ class PcpNodeRef;
 /// A classification of PcpPrimIndex->PcpSite dependencies
 /// by composition structure.
 ///
-enum PcpDependencyType {
+enum ARCH_EXPORT_TYPE PcpDependencyType {
     /// No type of dependency.
     PcpDependencyTypeNone = 0,
 

--- a/pxr/usd/pcp/dynamicFileFormatInterface.h
+++ b/pxr/usd/pcp/dynamicFileFormatInterface.h
@@ -27,7 +27,7 @@ class VtValue;
 /// format is on the hook for using the provided context to compute any prim
 /// field values it needs and generate the relevant file format arguments for
 /// its content.
-class PcpDynamicFileFormatInterface
+class ARCH_EXPORT_TYPE PcpDynamicFileFormatInterface
 {
 public:
     /// Empty virtual destructor to prevent build errors with some compilers.

--- a/pxr/usd/pcp/errors.h
+++ b/pxr/usd/pcp/errors.h
@@ -25,7 +25,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Enum to indicate the type represented by a Pcp error.
 ///
-enum PcpErrorType {
+enum ARCH_EXPORT_TYPE PcpErrorType {
     PcpErrorType_ArcCycle,
     PcpErrorType_ArcPermissionDenied,
     PcpErrorType_ArcToProhibitedChild,
@@ -68,7 +68,7 @@ typedef std::vector<PcpErrorBasePtr> PcpErrorVector;
 ///
 /// Base class for all error types.
 ///
-class PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorBase {
 public:
     /// Destructor.
     PCP_API virtual ~PcpErrorBase();
@@ -99,7 +99,7 @@ typedef std::shared_ptr<PcpErrorArcCycle> PcpErrorArcCyclePtr;
 ///
 /// Arcs between PcpNodes that form a cycle.
 ///
-class PcpErrorArcCycle : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorArcCycle : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorArcCyclePtr New();
@@ -127,7 +127,7 @@ typedef std::shared_ptr<PcpErrorArcPermissionDenied>
 /// Arcs that were not made between PcpNodes because of permission
 /// restrictions.
 ///
-class PcpErrorArcPermissionDenied : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorArcPermissionDenied : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorArcPermissionDeniedPtr New();
@@ -160,7 +160,7 @@ typedef std::shared_ptr<PcpErrorArcToProhibitedChild>
 /// Arcs that were not made between PcpNodes because the target is a prohibited
 /// child prim of its parent due to relocations.
 ///
-class PcpErrorArcToProhibitedChild : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorArcToProhibitedChild : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorArcToProhibitedChildPtr New();
@@ -194,7 +194,7 @@ typedef std::shared_ptr<PcpErrorCapacityExceeded> PcpErrorCapacityExceededPtr;
 ///
 /// Exceeded the capacity for composition arcs at a single site.
 ///
-class PcpErrorCapacityExceeded : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorCapacityExceeded : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorCapacityExceededPtr New(PcpErrorType errorType);
@@ -210,7 +210,7 @@ private:
 
 ///////////////////////////////////////////////////////////////////////////////
 
-class PcpErrorInconsistentPropertyBase : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInconsistentPropertyBase : public PcpErrorBase {
 public:
     /// Destructor.
     PCP_API ~PcpErrorInconsistentPropertyBase() override;
@@ -241,7 +241,7 @@ typedef std::shared_ptr<PcpErrorInconsistentPropertyType>
 ///
 /// Properties that have specs with conflicting definitions.
 ///
-class PcpErrorInconsistentPropertyType : 
+class ARCH_EXPORT_TYPE PcpErrorInconsistentPropertyType : 
     public PcpErrorInconsistentPropertyBase {
 public:
     /// Returns a new error object.
@@ -272,7 +272,7 @@ typedef std::shared_ptr<PcpErrorInconsistentAttributeType>
 ///
 /// Attributes that have specs with conflicting definitions.
 ///
-class PcpErrorInconsistentAttributeType : 
+class ARCH_EXPORT_TYPE PcpErrorInconsistentAttributeType : 
     public PcpErrorInconsistentPropertyBase {
 public:
     /// Returns a new error object.
@@ -303,7 +303,7 @@ typedef std::shared_ptr<PcpErrorInconsistentAttributeVariability>
 ///
 /// Attributes that have specs with conflicting variability.
 ///
-class PcpErrorInconsistentAttributeVariability : 
+class ARCH_EXPORT_TYPE PcpErrorInconsistentAttributeVariability : 
     public PcpErrorInconsistentPropertyBase {
 public:
     /// Returns a new error object.
@@ -334,7 +334,7 @@ typedef std::shared_ptr<PcpErrorInvalidPrimPath>
 ///
 /// Invalid prim paths used by references or payloads.
 ///
-class PcpErrorInvalidPrimPath : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidPrimPath : public PcpErrorBase {
 public:        
     /// Returns a new error object.
     static PcpErrorInvalidPrimPathPtr New();
@@ -367,7 +367,7 @@ class PcpErrorInvalidAssetPathBase;
 typedef std::shared_ptr<PcpErrorInvalidAssetPathBase>
     PcpErrorInvalidAssetPathBasePtr;
 
-class PcpErrorInvalidAssetPathBase : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidAssetPathBase : public PcpErrorBase {
 public:
     /// Destructor.
     PCP_API ~PcpErrorInvalidAssetPathBase() override;
@@ -409,7 +409,7 @@ typedef std::shared_ptr<PcpErrorInvalidAssetPath>
 ///
 /// Invalid asset paths used by references or payloads.
 ///
-class PcpErrorInvalidAssetPath : public PcpErrorInvalidAssetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidAssetPath : public PcpErrorInvalidAssetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidAssetPathPtr New();
@@ -434,7 +434,7 @@ typedef std::shared_ptr<PcpErrorMutedAssetPath>
 ///
 /// Muted asset paths used by references or payloads.
 ///
-class PcpErrorMutedAssetPath : public PcpErrorInvalidAssetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorMutedAssetPath : public PcpErrorInvalidAssetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorMutedAssetPathPtr New();
@@ -459,7 +459,7 @@ typedef std::shared_ptr<PcpErrorTargetPathBase>
 ///
 /// Base class for composition errors related to target or connection paths.
 ///
-class PcpErrorTargetPathBase : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorTargetPathBase : public PcpErrorBase {
 public:
     /// Destructor.
     PCP_API ~PcpErrorTargetPathBase() override;
@@ -495,7 +495,7 @@ typedef std::shared_ptr<PcpErrorInvalidInstanceTargetPath>
 /// Invalid target or connection path authored in an inherited
 /// class that points to an instance of that class.
 ///
-class PcpErrorInvalidInstanceTargetPath : public PcpErrorTargetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidInstanceTargetPath : public PcpErrorTargetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidInstanceTargetPathPtr New();
@@ -521,7 +521,7 @@ typedef std::shared_ptr<PcpErrorInvalidExternalTargetPath>
 /// Invalid target or connection path in some scope that points to
 /// an object outside of that scope.
 ///
-class PcpErrorInvalidExternalTargetPath : public PcpErrorTargetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidExternalTargetPath : public PcpErrorTargetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidExternalTargetPathPtr New();
@@ -549,7 +549,7 @@ typedef std::shared_ptr<PcpErrorInvalidTargetPath>
 /// 
 /// Invalid target or connection path.
 ///
-class PcpErrorInvalidTargetPath : public PcpErrorTargetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidTargetPath : public PcpErrorTargetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidTargetPathPtr New();
@@ -574,7 +574,7 @@ typedef std::shared_ptr<PcpErrorInvalidSublayerOffset>
 ///
 /// Sublayers that use invalid layer offsets.
 ///
-class PcpErrorInvalidSublayerOffset : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidSublayerOffset : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidSublayerOffsetPtr New();
@@ -603,7 +603,7 @@ typedef std::shared_ptr<PcpErrorInvalidReferenceOffset>
 ///
 /// References or payloads that use invalid layer offsets.
 ///
-class PcpErrorInvalidReferenceOffset : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidReferenceOffset : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidReferenceOffsetPtr New();
@@ -645,7 +645,7 @@ typedef std::shared_ptr<PcpErrorInvalidSublayerOwnership>
 ///
 /// Sibling layers that have the same owner.
 ///
-class PcpErrorInvalidSublayerOwnership : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidSublayerOwnership : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidSublayerOwnershipPtr New();
@@ -674,7 +674,7 @@ typedef std::shared_ptr<PcpErrorInvalidSublayerPath>
 ///
 /// Asset paths that could not be both resolved and loaded.
 ///
-class PcpErrorInvalidSublayerPath : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidSublayerPath : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidSublayerPathPtr New();
@@ -703,7 +703,7 @@ typedef std::shared_ptr<PcpErrorRelocationBase>
 ///
 /// Base class for composition errors related to relocates.
 ///
-class PcpErrorRelocationBase : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorRelocationBase : public PcpErrorBase {
 public:
     /// Destructor.
     PCP_API ~PcpErrorRelocationBase() override;
@@ -723,7 +723,7 @@ typedef std::shared_ptr<PcpErrorInvalidAuthoredRelocation>
 ///
 /// Invalid authored relocation found in a relocates field.
 ///
-class PcpErrorInvalidAuthoredRelocation : public PcpErrorRelocationBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidAuthoredRelocation : public PcpErrorRelocationBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidAuthoredRelocationPtr New();
@@ -759,7 +759,7 @@ typedef std::shared_ptr<PcpErrorInvalidConflictingRelocation>
 ///
 /// Relocation conflicts with another relocation in the layer stack.
 ///
-class PcpErrorInvalidConflictingRelocation : public PcpErrorRelocationBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidConflictingRelocation : public PcpErrorRelocationBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidConflictingRelocationPtr New();
@@ -813,7 +813,7 @@ typedef std::shared_ptr<PcpErrorInvalidSameTargetRelocations>
 ///
 /// Multiple relocations in the layer stack have the same target.
 ///
-class PcpErrorInvalidSameTargetRelocations : public PcpErrorRelocationBase {
+class ARCH_EXPORT_TYPE PcpErrorInvalidSameTargetRelocations : public PcpErrorRelocationBase {
 public:
     /// Returns a new error object.
     static PcpErrorInvalidSameTargetRelocationsPtr New();
@@ -853,7 +853,7 @@ typedef std::shared_ptr<PcpErrorOpinionAtRelocationSource>
 ///
 /// Opinions were found at a relocation source path.
 ///
-class PcpErrorOpinionAtRelocationSource : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorOpinionAtRelocationSource : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorOpinionAtRelocationSourcePtr New();
@@ -881,7 +881,7 @@ typedef std::shared_ptr<PcpErrorPrimPermissionDenied>
 ///
 /// Layers with illegal opinions about private prims.
 ///
-class PcpErrorPrimPermissionDenied : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorPrimPermissionDenied : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorPrimPermissionDeniedPtr New();
@@ -911,7 +911,7 @@ typedef std::shared_ptr<PcpErrorPropertyPermissionDenied>
 ///
 /// Layers with illegal opinions about private properties.
 ///
-class PcpErrorPropertyPermissionDenied : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorPropertyPermissionDenied : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorPropertyPermissionDeniedPtr New();
@@ -939,7 +939,7 @@ typedef std::shared_ptr<PcpErrorSublayerCycle> PcpErrorSublayerCyclePtr;
 ///
 /// Layers that recursively sublayer themselves.
 ///
-class PcpErrorSublayerCycle : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorSublayerCycle : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorSublayerCyclePtr New();
@@ -967,7 +967,7 @@ typedef std::shared_ptr<PcpErrorTargetPermissionDenied>
 ///
 /// Paths with illegal opinions about private targets.
 ///
-class PcpErrorTargetPermissionDenied : public PcpErrorTargetPathBase {
+class ARCH_EXPORT_TYPE PcpErrorTargetPermissionDenied : public PcpErrorTargetPathBase {
 public:
     /// Returns a new error object.
     static PcpErrorTargetPermissionDeniedPtr New();
@@ -992,7 +992,7 @@ typedef std::shared_ptr<PcpErrorUnresolvedPrimPath>
 ///
 /// Asset paths that could not be both resolved and loaded.
 ///
-class PcpErrorUnresolvedPrimPath : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorUnresolvedPrimPath : public PcpErrorBase {
 public:
     /// Returns a new error object.
     static PcpErrorUnresolvedPrimPathPtr New();
@@ -1032,7 +1032,7 @@ typedef std::shared_ptr<PcpErrorVariableExpressionError>
 ///
 /// Error when evaluating a variable expression.
 ///
-class PcpErrorVariableExpressionError : public PcpErrorBase {
+class ARCH_EXPORT_TYPE PcpErrorVariableExpressionError : public PcpErrorBase {
 public:
     static PcpErrorVariableExpressionErrorPtr New();
 

--- a/pxr/usd/pcp/layerStack.h
+++ b/pxr/usd/pcp/layerStack.h
@@ -47,7 +47,7 @@ class PcpLifeboat;
 ///
 /// PcpLayerStacks are constructed and managed by a Pcp_LayerStackRegistry.
 ///
-class PcpLayerStack : public TfRefBase, public TfWeakBase {
+class ARCH_EXPORT_TYPE PcpLayerStack : public TfRefBase, public TfWeakBase {
     PcpLayerStack(const PcpLayerStack&) = delete;
     PcpLayerStack& operator=(const PcpLayerStack&) = delete;
 

--- a/pxr/usd/pcp/types.h
+++ b/pxr/usd/pcp/types.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Describes the type of arc connecting two nodes in the prim index.
 ///
-enum PcpArcType {
+enum ARCH_EXPORT_TYPE PcpArcType {
     // The root arc is a special value used for the root node of 
     // the prim index. Unlike the following arcs, it has no parent node.
     PcpArcTypeRoot,
@@ -41,7 +41,7 @@ enum PcpArcType {
 };
 
 /// \enum PcpRangeType
-enum PcpRangeType {
+enum ARCH_EXPORT_TYPE PcpRangeType {
     // Range including just the root node.
     PcpRangeTypeRoot,
 

--- a/pxr/usd/sdf/abstractData.h
+++ b/pxr/usd/sdf/abstractData.h
@@ -53,7 +53,7 @@ TF_DECLARE_PUBLIC_TOKENS(SdfDataTokens, SDF_API, SDF_DATA_TOKENS);
 /// consistency guarantees about the scene description it contains.
 /// Instead, it is a basis for building those things.
 ///
-class SdfAbstractData : public TfRefBase, public TfWeakBase
+class ARCH_EXPORT_TYPE SdfAbstractData : public TfRefBase, public TfWeakBase
 {
 public:
     SdfAbstractData() {}

--- a/pxr/usd/sdf/assetPath.h
+++ b/pxr/usd/sdf/assetPath.h
@@ -26,7 +26,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// disallowed.  Attempts to construct asset paths with such characters will
 /// issue a TfError and produce the default-constructed empty asset path.
 ///
-class SdfAssetPath
+class ARCH_EXPORT_TYPE SdfAssetPath
 {
 public:
     /// \name Constructors

--- a/pxr/usd/sdf/changeManager.h
+++ b/pxr/usd/sdf/changeManager.h
@@ -36,7 +36,7 @@ class SdfSpec;
 ///
 /// For now this class uses TfNotices to represent invalidations.
 ///
-class Sdf_ChangeManager {
+class ARCH_EXPORT_TYPE Sdf_ChangeManager {
     Sdf_ChangeManager(const Sdf_ChangeManager&) = delete;
     Sdf_ChangeManager& operator=(const Sdf_ChangeManager&) = delete;
 public:

--- a/pxr/usd/sdf/childrenPolicies.h
+++ b/pxr/usd/sdf/childrenPolicies.h
@@ -58,7 +58,7 @@ public:
 
 };
 
-class Sdf_PrimChildPolicy :
+class ARCH_EXPORT_TYPE Sdf_PrimChildPolicy :
     public Sdf_TokenChildPolicy<SdfPrimSpecHandle>
 {
 public:
@@ -72,7 +72,7 @@ public:
     }
 };
 
-class Sdf_PropertyChildPolicy :
+class ARCH_EXPORT_TYPE Sdf_PropertyChildPolicy :
     public Sdf_TokenChildPolicy<SdfPropertySpecHandle>
 {
 public:
@@ -94,7 +94,7 @@ public:
     }
 };
 
-class Sdf_AttributeChildPolicy :
+class ARCH_EXPORT_TYPE Sdf_AttributeChildPolicy :
     public Sdf_TokenChildPolicy<SdfAttributeSpecHandle>
 {
 public:
@@ -116,7 +116,7 @@ public:
     }
 };
 
-class Sdf_RelationshipChildPolicy : 
+class ARCH_EXPORT_TYPE Sdf_RelationshipChildPolicy : 
     public Sdf_TokenChildPolicy<SdfRelationshipSpecHandle>
 {
 public:
@@ -161,7 +161,7 @@ public:
     }
 };
 
-class Sdf_VariantChildPolicy :
+class ARCH_EXPORT_TYPE Sdf_VariantChildPolicy :
     public Sdf_TokenChildPolicy<SdfVariantSpecHandle>
 {
 public:
@@ -183,7 +183,7 @@ public:
     }
 };
 
-class Sdf_VariantSetChildPolicy :
+class ARCH_EXPORT_TYPE Sdf_VariantSetChildPolicy :
     public Sdf_TokenChildPolicy<SdfVariantSetSpecHandle>
 {
 public:

--- a/pxr/usd/sdf/copyUtils.h
+++ b/pxr/usd/sdf/copyUtils.h
@@ -102,7 +102,7 @@ using SdfShouldCopyValueFn = std::function<
 /// To accommodate this, consumers may provide a callback that applies a
 /// scene description edit in \p valueToCopy via an SdfCopySpecsValueEdit 
 /// object. 
-class SdfCopySpecsValueEdit
+class ARCH_EXPORT_TYPE SdfCopySpecsValueEdit
 {
 public:
     /// Callback to apply a scene description edit to the specified layer and

--- a/pxr/usd/sdf/data.h
+++ b/pxr/usd/sdf/data.h
@@ -29,7 +29,7 @@ TF_DECLARE_WEAK_AND_REF_PTRS(SdfData);
 /// An SdfData is an implementation of SdfAbstractData that simply
 /// stores specs and fields in a map keyed by path.
 ///
-class SdfData : public SdfAbstractData
+class ARCH_EXPORT_TYPE SdfData : public SdfAbstractData
 {
 public:
     SdfData() {}

--- a/pxr/usd/sdf/fileFormat.h
+++ b/pxr/usd/sdf/fileFormat.h
@@ -44,7 +44,7 @@ TF_DECLARE_PUBLIC_TOKENS(SdfFileFormatTokens, SDF_API, SDF_FILE_FORMAT_TOKENS);
 ///
 /// Base class for file format implementations.
 ///
-class SdfFileFormat
+class ARCH_EXPORT_TYPE SdfFileFormat
     : public TfRefBase
     , public TfWeakBase
 {
@@ -522,7 +522,7 @@ private:
 };
 
 // Base file format factory.
-class Sdf_FileFormatFactoryBase : public TfType::FactoryBase {
+class ARCH_EXPORT_TYPE Sdf_FileFormatFactoryBase : public TfType::FactoryBase {
 public:
     SDF_API virtual ~Sdf_FileFormatFactoryBase();
     virtual SdfFileFormatRefPtr New() const = 0;

--- a/pxr/usd/sdf/layer.h
+++ b/pxr/usd/sdf/layer.h
@@ -78,7 +78,7 @@ struct Sdf_AssetInfo;
 /// is 24, then a sample at time ordinate 24 should be viewed exactly one second
 /// after the sample at time ordinate 0.
 /// 
-class SdfLayer 
+class ARCH_EXPORT_TYPE SdfLayer 
     : public TfRefBase
     , public TfWeakBase
 {

--- a/pxr/usd/sdf/layerOffset.h
+++ b/pxr/usd/sdf/layerOffset.h
@@ -40,7 +40,7 @@ class SdfTimeCode;
 /// GetReferenceLayerOffset() methods (the latter is the referenceLayerOffset 
 /// property in Python) of the SdfPrimSpec class.
 ///
-class SdfLayerOffset
+class ARCH_EXPORT_TYPE SdfLayerOffset
 {
 public:
     /// \name Constructors

--- a/pxr/usd/sdf/listOp.h
+++ b/pxr/usd/sdf/listOp.h
@@ -66,7 +66,7 @@ struct Sdf_ListOpTraits
 /// to be encountered, while appending items will preserve the last.
 
 template <typename T>
-class SdfListOp {
+class ARCH_EXPORT_TYPE SdfListOp {
 public:
     typedef T ItemType;
     typedef std::vector<ItemType> ItemVector;

--- a/pxr/usd/sdf/namespaceEdit.h
+++ b/pxr/usd/sdf/namespaceEdit.h
@@ -112,7 +112,7 @@ SDF_API std::ostream& operator<<(std::ostream&, const SdfNamespaceEditVector&);
 ///
 /// Detailed information about a namespace edit.
 ///
-struct SdfNamespaceEditDetail {
+struct ARCH_EXPORT_TYPE SdfNamespaceEditDetail {
 public:
     /// Validity of an edit.
     enum Result {

--- a/pxr/usd/sdf/notice.h
+++ b/pxr/usd/sdf/notice.h
@@ -29,7 +29,7 @@ public:
     /// Base notification class for scene.  Only useful for type hierarchy
     /// purposes.
     ///
-    class Base : public TfNotice {
+    class ARCH_EXPORT_TYPE Base : public TfNotice {
     public:
         SDF_API ~Base();
     };
@@ -90,7 +90,7 @@ public:
     /// can listen to notices from only the set of layers they care about rather
     /// than listening to the global LayersDidChange notice.
     ///
-    class LayersDidChangeSentPerLayer 
+    class ARCH_EXPORT_TYPE LayersDidChangeSentPerLayer 
         : public Base, public BaseLayersDidChange {
     public:
         LayersDidChangeSentPerLayer(const SdfLayerChangeListVec &changeVec,
@@ -103,7 +103,7 @@ public:
     ///
     /// Global notice sent to indicate that layer contents have changed.
     ///
-    class LayersDidChange
+    class ARCH_EXPORT_TYPE LayersDidChange
         : public Base, public BaseLayersDidChange {
     public:
         LayersDidChange(const SdfLayerChangeListVec &changeVec,
@@ -116,7 +116,7 @@ public:
     ///
     /// Sent when the (scene spec) info of a layer have changed.
     ///
-    class LayerInfoDidChange : public Base {
+    class ARCH_EXPORT_TYPE LayerInfoDidChange : public Base {
     public:
         LayerInfoDidChange( const TfToken &key ) :
             _key(key) {}
@@ -132,7 +132,7 @@ public:
     ///
     /// Sent when the identifier of a layer has changed.
     ///
-    class LayerIdentifierDidChange : public Base {
+    class ARCH_EXPORT_TYPE LayerIdentifierDidChange : public Base {
     public:
         SDF_API
         LayerIdentifierDidChange(const std::string& oldIdentifier,
@@ -155,14 +155,14 @@ public:
     ///
     /// Sent after a layer has been loaded from a file.
     ///
-    class LayerDidReplaceContent : public Base {
+    class ARCH_EXPORT_TYPE LayerDidReplaceContent : public Base {
     public:
         SDF_API ~LayerDidReplaceContent();
     };
 
     /// \class LayerDidReloadContent
     /// Sent after a layer is reloaded.
-    class LayerDidReloadContent : public LayerDidReplaceContent {
+    class ARCH_EXPORT_TYPE LayerDidReloadContent : public LayerDidReplaceContent {
     public:
         SDF_API virtual ~LayerDidReloadContent();
     };
@@ -181,7 +181,7 @@ public:
     /// Similar behavior to LayersDidChange, but only gets sent if a change
     /// in the dirty status of a layer occurs.
     ///
-    class LayerDirtinessChanged : public Base {
+    class ARCH_EXPORT_TYPE LayerDirtinessChanged : public Base {
     public:
         SDF_API ~LayerDirtinessChanged();
     };
@@ -192,7 +192,7 @@ public:
     /// muted layers. Note this does not necessarily mean the specified
     /// layer is currently loaded.
     ///
-    class LayerMutenessChanged : public Base {
+    class ARCH_EXPORT_TYPE LayerMutenessChanged : public Base {
     public:
         LayerMutenessChanged(const std::string& layerPath, bool wasMuted)
             : _layerPath(layerPath)

--- a/pxr/usd/sdf/opaqueValue.h
+++ b/pxr/usd/sdf/opaqueValue.h
@@ -28,7 +28,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// attribute is an opaque attribute that represents a group of other 
 /// properties.
 ///
-class SdfOpaqueValue final {};
+class ARCH_EXPORT_TYPE SdfOpaqueValue final {};
 
 inline bool
 operator==(SdfOpaqueValue const &, SdfOpaqueValue const &)

--- a/pxr/usd/sdf/path.h
+++ b/pxr/usd/sdf/path.h
@@ -42,7 +42,7 @@ void TfDelegatedCountIncrement(Sdf_PathNode const *) noexcept;
 void TfDelegatedCountDecrement(Sdf_PathNode const *) noexcept;
 
 // Tags used for the pools of path nodes.
-struct Sdf_PathPrimTag;
+struct ARCH_EXPORT_TYPE Sdf_PathPrimTag;
 struct Sdf_PathPropTag;
 
 // These are validated below.
@@ -270,7 +270,7 @@ VT_TYPE_IS_CHEAP_TO_COPY(class SdfPath);
 /// the number of values created (since it requires synchronized access to
 /// this table) or copied (since it requires atomic ref-counting operations).
 ///
-class SdfPath
+class ARCH_EXPORT_TYPE SdfPath
 {
 public:
     /// The empty path value, equivalent to SdfPath().

--- a/pxr/usd/sdf/pathExpression.h
+++ b/pxr/usd/sdf/pathExpression.h
@@ -51,7 +51,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// These building blocks may be joined as mentioned above, with `+`, `-`, `&`,
 /// or whitespace, and may be complemented with `~`, and grouped with `(` and
 /// `)`.
-class SdfPathExpression
+class ARCH_EXPORT_TYPE SdfPathExpression
 {
 public:
     using PathPattern = SdfPathPattern;

--- a/pxr/usd/sdf/pathNode.h
+++ b/pxr/usd/sdf/pathNode.h
@@ -38,7 +38,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // '/Foo/Bar.attr' would store a prim-part handle to the '/Foo/Bar' node, and a
 // property-part handle to 'attr'.
 //
-class Sdf_PathNode {
+class ARCH_EXPORT_TYPE Sdf_PathNode {
     Sdf_PathNode(Sdf_PathNode const &) = delete;
     Sdf_PathNode &operator=(Sdf_PathNode const &) = delete;
 public:

--- a/pxr/usd/sdf/payload.h
+++ b/pxr/usd/sdf/payload.h
@@ -38,7 +38,7 @@ typedef std::vector<SdfPayload> SdfPayloadVector;
 /// system behaviors will not traverse across, providing a user-visible
 /// way to manage the working set of the scene.
 ///
-class SdfPayload {
+class ARCH_EXPORT_TYPE SdfPayload {
 public:
     /// Create a payload. See SdfAssetPath for what characters are valid in \p
     /// assetPath.  If \p assetPath contains invalid characters, issue an error

--- a/pxr/usd/sdf/reference.h
+++ b/pxr/usd/sdf/reference.h
@@ -55,7 +55,7 @@ typedef std::vector<SdfReference> SdfReferenceVector;
 /// Custom data is for use by plugins or other non-tools supplied extensions
 /// that need to be able to store data associated with references.
 ///
-class SdfReference {
+class ARCH_EXPORT_TYPE SdfReference {
 public:
     /// Creates a reference with all its meta data.  The default reference is an
     /// internal reference to the default prim.  See SdfAssetPath for what

--- a/pxr/usd/sdf/schema.h
+++ b/pxr/usd/sdf/schema.h
@@ -563,7 +563,7 @@ private:
 /// Class that provides information about the various scene description 
 /// fields.
 ///
-class SdfSchema : public SdfSchemaBase {
+class ARCH_EXPORT_TYPE SdfSchema : public SdfSchemaBase {
 public:
     SDF_API
     static const SdfSchema& GetInstance()

--- a/pxr/usd/sdf/textFileFormat.h
+++ b/pxr/usd/sdf/textFileFormat.h
@@ -38,7 +38,7 @@ class ArAsset;
 ///
 /// Sdf text file format
 ///
-class SdfTextFileFormat : public SdfFileFormat
+class ARCH_EXPORT_TYPE SdfTextFileFormat : public SdfFileFormat
 {
 public:
     // SdfFileFormat overrides.

--- a/pxr/usd/sdf/timeCode.h
+++ b/pxr/usd/sdf/timeCode.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// value but is used to indicate that this value should be resolved by any
 /// time based value resolution.
 ///
-class SdfTimeCode
+class ARCH_EXPORT_TYPE SdfTimeCode
 {
 public:
     /// \name Constructors

--- a/pxr/usd/sdf/types.h
+++ b/pxr/usd/sdf/types.h
@@ -65,7 +65,7 @@ class SdfPath;
 
 /// An enum that specifies the type of an object. Objects
 /// are entities that have fields and are addressable by path.
-enum SdfSpecType {
+enum ARCH_EXPORT_TYPE SdfSpecType {
     // The unknown type has a value of 0 so that SdfSpecType() is unknown.
     SdfSpecTypeUnknown = 0,
 
@@ -97,7 +97,7 @@ enum SdfSpecType {
 /// <li><b>SdfNumSpecifiers.</b> The number of specifiers.
 /// </ul>
 ///
-enum SdfSpecifier {
+enum ARCH_EXPORT_TYPE SdfSpecifier {
     SdfSpecifierDef,
     SdfSpecifierOver,
     SdfSpecifierClass,
@@ -129,7 +129,7 @@ SdfIsDefiningSpecifier(SdfSpecifier spec)
 /// <li><b>SdfNumPermission.</b> Internal sentinel value.
 /// </ul>
 ///
-enum SdfPermission {
+enum ARCH_EXPORT_TYPE SdfPermission {
     SdfPermissionPublic,         
     SdfPermissionPrivate,        
 
@@ -153,7 +153,7 @@ enum SdfPermission {
 ///     <li><b>SdNumVariabilities.</b> Internal sentinel value.
 /// </ul>
 ///
-enum SdfVariability {
+enum ARCH_EXPORT_TYPE SdfVariability {
     SdfVariabilityVarying,
     SdfVariabilityUniform,
 
@@ -472,7 +472,7 @@ std::ostream &VtStreamOut(const SdfVariantSelectionMap &, std::ostream &);
 /// well as limited inspection and editing capabilities (e.g., moving
 /// this data to a different spec or field) even when the data type
 /// of the value isn't known.
-class SdfUnregisteredValue
+class ARCH_EXPORT_TYPE SdfUnregisteredValue
 {
 public:
     /// Wraps an empty VtValue
@@ -588,7 +588,7 @@ extern SDF_API TfStaticData<const Sdf_ValueTypeNamesType,
 /// layer->SetTimeSample(attribute->GetPath(), 101, VtValue(SdfValueBlock()));
 /// \endcode
 ///
-struct SdfValueBlock { 
+struct ARCH_EXPORT_TYPE SdfValueBlock {
     bool operator==(const SdfValueBlock& block) const { return true; }
     bool operator!=(const SdfValueBlock& block) const { return false; }
 

--- a/pxr/usd/sdf/variableExpression.h
+++ b/pxr/usd/sdf/variableExpression.h
@@ -119,7 +119,7 @@ public:
 
     /// \class EmptyList
     /// A result value representing an empty list.
-    class EmptyList { };
+    class ARCH_EXPORT_TYPE EmptyList { };
 
     /// \class Result
     class Result

--- a/pxr/usd/sdr/shaderNode.h
+++ b/pxr/usd/sdr/shaderNode.h
@@ -66,7 +66,7 @@ TF_DECLARE_PUBLIC_TOKENS(SdrNodeRole, SDR_API, SDR_NODE_ROLE_TOKENS);
 ///
 /// A specialized version of `NdrNode` which holds shading information.
 ///
-class SdrShaderNode : public NdrNode
+class ARCH_EXPORT_TYPE SdrShaderNode : public NdrNode
 {
 public:
     /// Constructor.

--- a/pxr/usd/sdr/shaderProperty.h
+++ b/pxr/usd/sdr/shaderProperty.h
@@ -84,7 +84,7 @@ TF_DECLARE_PUBLIC_TOKENS(SdrPropertyTokens, SDR_API, SDR_PROPERTY_TOKENS);
 ///
 /// A specialized version of `NdrProperty` which holds shading information.
 ///
-class SdrShaderProperty : public NdrProperty
+class ARCH_EXPORT_TYPE SdrShaderProperty : public NdrProperty
 {
 public:
     // Constructor.

--- a/pxr/usd/usd/apiSchemaBase.h
+++ b/pxr/usd/usd/apiSchemaBase.h
@@ -95,7 +95,7 @@ class SdfAssetPath;
 /// 
 /// 
 ///
-class UsdAPISchemaBase : public UsdSchemaBase
+class ARCH_EXPORT_TYPE UsdAPISchemaBase : public UsdSchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usd/clipsAPI.h
+++ b/pxr/usd/usd/clipsAPI.h
@@ -85,7 +85,7 @@ class SdfAssetPath;
 /// For further information, see \ref Usd_Page_ValueClips
 /// 
 ///
-class UsdClipsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdClipsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usd/collectionAPI.h
+++ b/pxr/usd/usd/collectionAPI.h
@@ -181,7 +181,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdTokens->rightHanded
 /// as the value.
 ///
-class UsdCollectionAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdCollectionAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usd/common.h
+++ b/pxr/usd/usd/common.h
@@ -68,7 +68,7 @@ typedef std::map<class TfToken, VtValue,
 /// Specifies a position to add items to lists.  Used by some Add()
 /// methods in the USD API that manipulate lists, such as AddReference().
 ///
-enum UsdListPosition {
+enum ARCH_EXPORT_TYPE UsdListPosition {
     /// The position at the front of the prepend list.
     /// An item added at this position will, after composition is applied,
     /// be stronger than other items prepended in this layer, and stronger
@@ -96,7 +96,7 @@ enum UsdListPosition {
 /// Controls UsdStage::Load() and UsdPrim::Load() behavior regarding whether or
 /// not descendant prims are loaded.
 ///
-enum UsdLoadPolicy {
+enum ARCH_EXPORT_TYPE UsdLoadPolicy {
     /// Load a prim plus all its descendants.
     UsdLoadWithDescendants,
     /// Load a prim by itself with no descendants.

--- a/pxr/usd/usd/interpolation.h
+++ b/pxr/usd/usd/interpolation.h
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// See \ref Usd_AttributeInterpolation for more details.
 ///
-enum UsdInterpolationType
+enum ARCH_EXPORT_TYPE UsdInterpolationType
 {
     UsdInterpolationTypeHeld,  ///< Held interpolation
     UsdInterpolationTypeLinear ///< Linear interpolation

--- a/pxr/usd/usd/modelAPI.h
+++ b/pxr/usd/usd/modelAPI.h
@@ -52,7 +52,7 @@ class SdfAssetPath;
 /// \todo GetModelInstanceName()
 /// 
 ///
-class UsdModelAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdModelAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usd/notice.h
+++ b/pxr/usd/usd/notice.h
@@ -27,7 +27,7 @@ class UsdNotice {
 public:
 
     /// Base class for UsdStage notices.
-    class StageNotice : public TfNotice {
+    class ARCH_EXPORT_TYPE StageNotice : public TfNotice {
     public:
         USD_API
         StageNotice(const UsdStageWeakPtr &stage);
@@ -53,7 +53,7 @@ public:
     /// values for properties or metadata.  It does not \em necessarily imply
     /// invalidation of UsdPrim s.
     ///
-    class StageContentsChanged : public StageNotice {
+    class ARCH_EXPORT_TYPE StageContentsChanged : public StageNotice {
     public:
         explicit StageContentsChanged(const UsdStageWeakPtr& stage)
             : StageNotice(stage) {}
@@ -108,7 +108,7 @@ public:
     /// wish to reason about all changes as a whole should use the methods that
     /// return a PathRange, like GetResyncedPaths().
     /// 
-    class ObjectsChanged : public StageNotice {
+    class ARCH_EXPORT_TYPE ObjectsChanged : public StageNotice {
         using _PathsToChangesMap = 
             std::map<SdfPath, std::vector<const SdfChangeList::Entry*>>;
 
@@ -373,7 +373,7 @@ public:
     /// Notice sent when a stage's EditTarget has changed.  Sent in the
     /// thread that changed the target.
     ///
-    class StageEditTargetChanged : public StageNotice {
+    class ARCH_EXPORT_TYPE StageEditTargetChanged : public StageNotice {
     public:
         explicit StageEditTargetChanged(const UsdStageWeakPtr &stage)
             : StageNotice(stage) {}
@@ -394,7 +394,7 @@ public:
     /// muting/unmuting layer does not belong to the current stage, or is a 
     /// layer that does belong to the current stage but is not yet loaded 
     /// because it is behind an unloaded payload or unselected variant.
-    class LayerMutingChanged : public StageNotice {
+    class ARCH_EXPORT_TYPE LayerMutingChanged : public StageNotice {
     public:
         explicit LayerMutingChanged(const UsdStageWeakPtr &stage, 
                 const std::vector<std::string>& mutedLayers, 

--- a/pxr/usd/usd/resolveInfo.h
+++ b/pxr/usd/usd/resolveInfo.h
@@ -31,7 +31,7 @@ TF_DECLARE_WEAK_PTRS(PcpLayerStack);
 ///
 /// For more details, see \ref Usd_ValueResolution.
 ///
-enum UsdResolveInfoSource
+enum ARCH_EXPORT_TYPE UsdResolveInfoSource
 {
     UsdResolveInfoSourceNone,            ///< No value
 

--- a/pxr/usd/usd/schemaBase.h
+++ b/pxr/usd/usd/schemaBase.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// arguments take them by <tt>const &</tt> if const access is sufficient,
 /// otherwise by non-const pointer.
 ///
-class UsdSchemaBase {
+class ARCH_EXPORT_TYPE UsdSchemaBase {
 public:
     /// Compile time constant representing what kind of schema this class is.
     ///

--- a/pxr/usd/usd/schemaRegistry.h
+++ b/pxr/usd/usd/schemaRegistry.h
@@ -50,7 +50,7 @@ using UsdSchemaVersion = unsigned int;
 /// classes, to enumerate all properties for a given schema class, and finally 
 /// to provide fallback values for unauthored built-in properties.
 ///
-class UsdSchemaRegistry : public TfWeakBase {
+class ARCH_EXPORT_TYPE UsdSchemaRegistry : public TfWeakBase {
     UsdSchemaRegistry(const UsdSchemaRegistry&) = delete;
     UsdSchemaRegistry& operator=(const UsdSchemaRegistry&) = delete;
 public:

--- a/pxr/usd/usd/stage.h
+++ b/pxr/usd/usd/stage.h
@@ -133,7 +133,7 @@ SDF_DECLARE_HANDLES(SdfLayer);
 /// stage->GetEditTargetForLocalLayer(stage->GetSessionLayer()) and set that
 /// target in the stage by calling SetEditTarget() or creating a UsdEditContext.
 ///
-class UsdStage : public TfRefBase, public TfWeakBase {
+class ARCH_EXPORT_TYPE UsdStage : public TfRefBase, public TfWeakBase {
 public:
 
     // --------------------------------------------------------------------- //

--- a/pxr/usd/usd/stageCacheContext.h
+++ b/pxr/usd/usd/stageCacheContext.h
@@ -39,7 +39,7 @@ UsdUseButDoNotPopulateCache(StageCache &cache) {
     return Usd_NonPopulatingStageCacheWrapper(cache);
 }
 
-enum UsdStageCacheContextBlockType
+enum ARCH_EXPORT_TYPE UsdStageCacheContextBlockType
 {
     /// Indicate that a UsdStageCacheContext should ignore all currently bound
     /// UsdStageCacheContexts, preventing reading from or writing to their

--- a/pxr/usd/usd/stageLoadRules.h
+++ b/pxr/usd/usd/stageLoadRules.h
@@ -36,7 +36,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// Remove redundant rules that do not change the effective load state with
 /// UsdStageLoadRules::Minimize().
-class UsdStageLoadRules
+class ARCH_EXPORT_TYPE UsdStageLoadRules
 {
 public:
     /// \enum Rule

--- a/pxr/usd/usd/testenv/TestUsdResolverChangedResolver.h
+++ b/pxr/usd/usd/testenv/TestUsdResolverChangedResolver.h
@@ -8,6 +8,7 @@
 #define PXR_USD_USD_TEST_USD_RESOLVER_CHANGED_RESOLVER_H
 
 #include "pxr/pxr.h"
+#include "pxr/usd/ar/api.h"
 
 #include "pxr/usd/ar/defineResolverContext.h"
 #include "pxr/usd/ar/resolver.h"
@@ -22,7 +23,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class _TestResolverContext
 ///
-class _TestResolverContext
+class ARCH_EXPORT_TYPE _TestResolverContext
 {
 public:
     _TestResolverContext(const std::string& configName_)
@@ -46,7 +47,7 @@ AR_DECLARE_RESOLVER_CONTEXT(_TestResolverContext);
 
 /// \class _TestResolverPluginInterface
 ///
-class _TestResolverPluginInterface
+class ARCH_EXPORT_TYPE _TestResolverPluginInterface
 {
 public:
     virtual ~_TestResolverPluginInterface() { }

--- a/pxr/usd/usd/typed.h
+++ b/pxr/usd/usd/typed.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// UsdTyped implements a typeName-based query for its override of
 /// UsdSchemaBase::_IsCompatible().  It provides no other behavior.
 ///
-class UsdTyped : public UsdSchemaBase
+class ARCH_EXPORT_TYPE UsdTyped : public UsdSchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usd/usdFileFormat.h
+++ b/pxr/usd/usd/usdFileFormat.h
@@ -39,7 +39,7 @@ TF_DECLARE_PUBLIC_TOKENS(UsdUsdFileFormatTokens, USD_API, USD_USD_FILE_FORMAT_TO
 /// If no UsdUsdFileFormatTokens->FormatArg is supplied, the default is
 /// UsdUsdcFileFormatTokens->Id.
 ///
-class UsdUsdFileFormat : public SdfFileFormat
+class ARCH_EXPORT_TYPE UsdUsdFileFormat : public SdfFileFormat
 {
 public:
     using SdfFileFormat::FileFormatArguments;

--- a/pxr/usd/usdGeom/basisCurves.h
+++ b/pxr/usd/usdGeom/basisCurves.h
@@ -243,7 +243,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomBasisCurves : public UsdGeomCurves
+class ARCH_EXPORT_TYPE UsdGeomBasisCurves : public UsdGeomCurves
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/boundable.h
+++ b/pxr/usd/usdGeom/boundable.h
@@ -62,7 +62,7 @@ class SdfAssetPath;
 /// will be pruned from BBox computation; the authored extent is expected to
 /// incorporate all child bounds.
 ///
-class UsdGeomBoundable : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdGeomBoundable : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/camera.h
+++ b/pxr/usd/usdGeom/camera.h
@@ -90,7 +90,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCamera : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdGeomCamera : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/capsule.h
+++ b/pxr/usd/usdGeom/capsule.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCapsule : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCapsule : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/capsule_1.h
+++ b/pxr/usd/usdGeom/capsule_1.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCapsule_1 : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCapsule_1 : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/cone.h
+++ b/pxr/usd/usdGeom/cone.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCone : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCone : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/cube.h
+++ b/pxr/usd/usdGeom/cube.h
@@ -40,7 +40,7 @@ class SdfAssetPath;
 /// The fallback values for Cube, Sphere, Cone, and Cylinder are set so that
 /// they all pack into the same volume/bounds.
 ///
-class UsdGeomCube : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCube : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/curves.h
+++ b/pxr/usd/usdGeom/curves.h
@@ -55,7 +55,7 @@ class SdfAssetPath;
 /// abstract type.
 /// 
 ///
-class UsdGeomCurves : public UsdGeomPointBased
+class ARCH_EXPORT_TYPE UsdGeomCurves : public UsdGeomPointBased
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/cylinder.h
+++ b/pxr/usd/usdGeom/cylinder.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCylinder : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCylinder : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/cylinder_1.h
+++ b/pxr/usd/usdGeom/cylinder_1.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomCylinder_1 : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomCylinder_1 : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/gprim.h
+++ b/pxr/usd/usdGeom/gprim.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomGprim : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdGeomGprim : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/hermiteCurves.h
+++ b/pxr/usd/usdGeom/hermiteCurves.h
@@ -66,7 +66,7 @@ class SdfAssetPath;
 /// varying (linear), uniform (per curve element), or constant (per prim).
 /// 
 ///
-class UsdGeomHermiteCurves : public UsdGeomCurves
+class ARCH_EXPORT_TYPE UsdGeomHermiteCurves : public UsdGeomCurves
 {
 public:
     /// Compile time constant representing what kind of schema this class is.
@@ -198,7 +198,7 @@ public:
     /// Represents points and tangents of the same size. 
     /// 
     /// Utility to interleave point and tangent data. This class is immutable.
-    class PointAndTangentArrays {
+    class ARCH_EXPORT_TYPE PointAndTangentArrays {
         VtArray<GfVec3f> _points;
         VtArray<GfVec3f> _tangents;
 

--- a/pxr/usd/usdGeom/imageable.h
+++ b/pxr/usd/usdGeom/imageable.h
@@ -54,7 +54,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomImageable : public UsdTyped
+class ARCH_EXPORT_TYPE UsdGeomImageable : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/mesh.h
+++ b/pxr/usd/usdGeom/mesh.h
@@ -113,7 +113,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomMesh : public UsdGeomPointBased
+class ARCH_EXPORT_TYPE UsdGeomMesh : public UsdGeomPointBased
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/modelAPI.h
+++ b/pxr/usd/usdGeom/modelAPI.h
@@ -133,7 +133,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomModelAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdGeomModelAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/motionAPI.h
+++ b/pxr/usd/usdGeom/motionAPI.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// 
 /// 
 ///
-class UsdGeomMotionAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdGeomMotionAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/nurbsCurves.h
+++ b/pxr/usd/usdGeom/nurbsCurves.h
@@ -57,7 +57,7 @@ class SdfAssetPath;
 /// authored one value per curve.  \em knots should be the concatentation of
 /// all batched curves.
 ///
-class UsdGeomNurbsCurves : public UsdGeomCurves
+class ARCH_EXPORT_TYPE UsdGeomNurbsCurves : public UsdGeomCurves
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/nurbsPatch.h
+++ b/pxr/usd/usdGeom/nurbsPatch.h
@@ -89,7 +89,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomNurbsPatch : public UsdGeomPointBased
+class ARCH_EXPORT_TYPE UsdGeomNurbsPatch : public UsdGeomPointBased
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/plane.h
+++ b/pxr/usd/usdGeom/plane.h
@@ -53,7 +53,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomPlane : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomPlane : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/pointBased.h
+++ b/pxr/usd/usdGeom/pointBased.h
@@ -38,7 +38,7 @@ class SdfAssetPath;
 /// Base class for all UsdGeomGprims that possess points,
 /// providing common attributes such as normals and velocities.
 ///
-class UsdGeomPointBased : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomPointBased : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/pointInstancer.h
+++ b/pxr/usd/usdGeom/pointInstancer.h
@@ -258,7 +258,7 @@ class SdfAssetPath;
 /// \endcode
 /// 
 ///
-class UsdGeomPointInstancer : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdGeomPointInstancer : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/points.h
+++ b/pxr/usd/usdGeom/points.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// have interpolation metadata.  It's common for authored widths and normals
 /// to have constant or varying interpolation.
 ///
-class UsdGeomPoints : public UsdGeomPointBased
+class ARCH_EXPORT_TYPE UsdGeomPoints : public UsdGeomPointBased
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/primvarsAPI.h
+++ b/pxr/usd/usdGeom/primvarsAPI.h
@@ -62,7 +62,7 @@ class SdfAssetPath;
 /// must first cache the results of FindIncrementallyInheritablePrimvars() for
 /// each non-leaf prim on the stage. 
 ///
-class UsdGeomPrimvarsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdGeomPrimvarsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/scope.h
+++ b/pxr/usd/usdGeom/scope.h
@@ -39,7 +39,7 @@ class SdfAssetPath;
 /// through a Scope successfully - it is just a guaranteed no-op from a
 /// transformability perspective.
 ///
-class UsdGeomScope : public UsdGeomImageable
+class ARCH_EXPORT_TYPE UsdGeomScope : public UsdGeomImageable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/sphere.h
+++ b/pxr/usd/usdGeom/sphere.h
@@ -40,7 +40,7 @@ class SdfAssetPath;
 /// The fallback values for Cube, Sphere, Cone, and Cylinder are set so that
 /// they all pack into the same volume/bounds.
 ///
-class UsdGeomSphere : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdGeomSphere : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/subset.h
+++ b/pxr/usd/usdGeom/subset.h
@@ -67,7 +67,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomSubset : public UsdTyped
+class ARCH_EXPORT_TYPE UsdGeomSubset : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/tetMesh.h
+++ b/pxr/usd/usdGeom/tetMesh.h
@@ -47,7 +47,7 @@ class SdfAssetPath;
 /// indices into the TetMesh's <b>points</b> attribute, inherited from 
 /// UsdGeomPointBased.
 ///
-class UsdGeomTetMesh : public UsdGeomPointBased
+class ARCH_EXPORT_TYPE UsdGeomTetMesh : public UsdGeomPointBased
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/visibilityAPI.h
+++ b/pxr/usd/usdGeom/visibilityAPI.h
@@ -73,7 +73,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdGeomTokens->rightHanded
 /// as the value.
 ///
-class UsdGeomVisibilityAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdGeomVisibilityAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/xform.h
+++ b/pxr/usd/usdGeom/xform.h
@@ -36,7 +36,7 @@ class SdfAssetPath;
 ///
 /// Concrete prim schema for a transform, which implements Xformable 
 ///
-class UsdGeomXform : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdGeomXform : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/xformCommonAPI.h
+++ b/pxr/usd/usdGeom/xformCommonAPI.h
@@ -69,7 +69,7 @@ class SdfAssetPath;
 /// SetRotate(), SetScale() and SetPivot() methods are provided by this API 
 /// to allow such sparse authoring.
 ///
-class UsdGeomXformCommonAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdGeomXformCommonAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdGeom/xformOp.h
+++ b/pxr/usd/usdGeom/xformOp.h
@@ -90,7 +90,7 @@ TF_DECLARE_PUBLIC_TOKENS(UsdGeomXformOpTypes, USDGEOM_API, USDGEOM_XFORM_OP_TYPE
 /// the order in which their corresponding elements are consumed by the 
 /// rotation, not how they are laid out.
 ///
-class UsdGeomXformOp
+class ARCH_EXPORT_TYPE UsdGeomXformOp
 {
 public:
   

--- a/pxr/usd/usdGeom/xformable.h
+++ b/pxr/usd/usdGeom/xformable.h
@@ -232,7 +232,7 @@ class SdfAssetPath;
 /// 
 /// 
 ///
-class UsdGeomXformable : public UsdGeomImageable
+class ARCH_EXPORT_TYPE UsdGeomXformable : public UsdGeomImageable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdHydra/generativeProceduralAPI.h
+++ b/pxr/usd/usdHydra/generativeProceduralAPI.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdHydraTokens->rightHanded
 /// as the value.
 ///
-class UsdHydraGenerativeProceduralAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdHydraGenerativeProceduralAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/boundableLightBase.h
+++ b/pxr/usd/usdLux/boundableLightBase.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// functions provided by LightAPI for concrete derived light types.
 /// 
 ///
-class UsdLuxBoundableLightBase : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdLuxBoundableLightBase : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/cylinderLight.h
+++ b/pxr/usd/usdLux/cylinderLight.h
@@ -40,7 +40,7 @@ class SdfAssetPath;
 /// The cylinder does not emit light from the flat end-caps.
 /// 
 ///
-class UsdLuxCylinderLight : public UsdLuxBoundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxCylinderLight : public UsdLuxBoundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/diskLight.h
+++ b/pxr/usd/usdLux/diskLight.h
@@ -38,7 +38,7 @@ class SdfAssetPath;
 /// Light emitted from one side of a circular disk.
 /// The disk is centered in the XY plane and emits light along the -Z axis.
 ///
-class UsdLuxDiskLight : public UsdLuxBoundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxDiskLight : public UsdLuxBoundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/distantLight.h
+++ b/pxr/usd/usdLux/distantLight.h
@@ -38,7 +38,7 @@ class SdfAssetPath;
 /// Light emitted from a distant source along the -Z axis.
 /// Also known as a directional light.
 ///
-class UsdLuxDistantLight : public UsdLuxNonboundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxDistantLight : public UsdLuxNonboundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/domeLight.h
+++ b/pxr/usd/usdLux/domeLight.h
@@ -68,7 +68,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxDomeLight : public UsdLuxNonboundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxDomeLight : public UsdLuxNonboundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/domeLight_1.h
+++ b/pxr/usd/usdLux/domeLight_1.h
@@ -80,7 +80,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxDomeLight_1 : public UsdLuxNonboundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxDomeLight_1 : public UsdLuxNonboundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/geometryLight.h
+++ b/pxr/usd/usdLux/geometryLight.h
@@ -39,7 +39,7 @@ class SdfAssetPath;
 /// Light emitted outward from a geometric prim (UsdGeomGprim),
 /// which is typically a mesh.
 ///
-class UsdLuxGeometryLight : public UsdLuxNonboundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxGeometryLight : public UsdLuxNonboundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/lightAPI.h
+++ b/pxr/usd/usdLux/lightAPI.h
@@ -69,7 +69,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxLightAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxLightAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/lightFilter.h
+++ b/pxr/usd/usdLux/lightFilter.h
@@ -58,7 +58,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxLightFilter : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdLuxLightFilter : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/lightListAPI.h
+++ b/pxr/usd/usdLux/lightListAPI.h
@@ -160,7 +160,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxLightListAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxLightListAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/listAPI.h
+++ b/pxr/usd/usdLux/listAPI.h
@@ -45,7 +45,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdLuxTokens->rightHanded
 /// as the value.
 ///
-class UsdLuxListAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxListAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/meshLightAPI.h
+++ b/pxr/usd/usdLux/meshLightAPI.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// \see \ref Usd_AutoAppliedAPISchemas
 /// 
 ///
-class UsdLuxMeshLightAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxMeshLightAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/nonboundableLightBase.h
+++ b/pxr/usd/usdLux/nonboundableLightBase.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// functions provided by LightAPI for concrete derived light types.
 /// 
 ///
-class UsdLuxNonboundableLightBase : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdLuxNonboundableLightBase : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/pluginLight.h
+++ b/pxr/usd/usdLux/pluginLight.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// \see \ref usdLux_PluginSchemas
 /// 
 ///
-class UsdLuxPluginLight : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdLuxPluginLight : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/pluginLightFilter.h
+++ b/pxr/usd/usdLux/pluginLightFilter.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// \see \ref usdLux_PluginSchemas
 /// 
 ///
-class UsdLuxPluginLightFilter : public UsdLuxLightFilter
+class ARCH_EXPORT_TYPE UsdLuxPluginLightFilter : public UsdLuxLightFilter
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/portalLight.h
+++ b/pxr/usd/usdLux/portalLight.h
@@ -39,7 +39,7 @@ class SdfAssetPath;
 /// of a dome light.  Transmits light in the -Z direction.
 /// The rectangle is 1 unit in length.
 ///
-class UsdLuxPortalLight : public UsdLuxBoundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxPortalLight : public UsdLuxBoundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/rectLight.h
+++ b/pxr/usd/usdLux/rectLight.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// position, a texture file's min coordinates should be at (+X, +Y) and 
 /// max coordinates at (-X, -Y).
 ///
-class UsdLuxRectLight : public UsdLuxBoundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxRectLight : public UsdLuxBoundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/shadowAPI.h
+++ b/pxr/usd/usdLux/shadowAPI.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// Controls to refine a light's shadow behavior.  These are
 /// non-physical controls that are valuable for visual lighting work.
 ///
-class UsdLuxShadowAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxShadowAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/shapingAPI.h
+++ b/pxr/usd/usdLux/shapingAPI.h
@@ -40,7 +40,7 @@ class SdfAssetPath;
 ///
 /// Controls for shaping a light's emission.
 ///
-class UsdLuxShapingAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxShapingAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/sphereLight.h
+++ b/pxr/usd/usdLux/sphereLight.h
@@ -37,7 +37,7 @@ class SdfAssetPath;
 ///
 /// Light emitted outward from a sphere.
 ///
-class UsdLuxSphereLight : public UsdLuxBoundableLightBase
+class ARCH_EXPORT_TYPE UsdLuxSphereLight : public UsdLuxBoundableLightBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdLux/volumeLightAPI.h
+++ b/pxr/usd/usdLux/volumeLightAPI.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// \see \ref Usd_AutoAppliedAPISchemas
 /// 
 ///
-class UsdLuxVolumeLightAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdLuxVolumeLightAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdMedia/assetPreviewsAPI.h
+++ b/pxr/usd/usdMedia/assetPreviewsAPI.h
@@ -74,7 +74,7 @@ class SdfAssetPath;
 /// 
 /// 
 ///
-class UsdMediaAssetPreviewsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdMediaAssetPreviewsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdMedia/spatialAudio.h
+++ b/pxr/usd/usdMedia/spatialAudio.h
@@ -88,7 +88,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdMediaTokens->rightHanded
 /// as the value.
 ///
-class UsdMediaSpatialAudio : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdMediaSpatialAudio : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdMtlx/backdoor.cpp
+++ b/pxr/usd/usdMtlx/backdoor.cpp
@@ -49,6 +49,10 @@ _MtlxTest(R&& reader, bool nodeGraphs)
         TF_RUNTIME_ERROR("MaterialX read failed: %s", x.what());
         return TfNullPtr;
     }
+    catch (std::exception& x) {
+        TF_RUNTIME_ERROR("MaterialX read failed: %s", x.what());
+        return TfNullPtr;
+    }
 }
 
 } // anonymous namespace

--- a/pxr/usd/usdPhysics/articulationRootAPI.h
+++ b/pxr/usd/usdPhysics/articulationRootAPI.h
@@ -42,7 +42,7 @@ class SdfAssetPath;
 /// or indirect parent of the root joint which is connected to the world, or 
 /// on the joint itself..
 ///
-class UsdPhysicsArticulationRootAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsArticulationRootAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/collisionAPI.h
+++ b/pxr/usd/usdPhysics/collisionAPI.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// RigidBodyAPI applied, this collider is a part of that body. If there is 
 /// no body in the parent hierarchy, this collider is considered to be static.
 ///
-class UsdPhysicsCollisionAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsCollisionAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/collisionGroup.h
+++ b/pxr/usd/usdPhysics/collisionGroup.h
@@ -46,7 +46,7 @@ class SdfAssetPath;
 /// defines the members of this Collisiongroup.
 /// 
 ///
-class UsdPhysicsCollisionGroup : public UsdTyped
+class ARCH_EXPORT_TYPE UsdPhysicsCollisionGroup : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/distanceJoint.h
+++ b/pxr/usd/usdPhysics/distanceJoint.h
@@ -38,7 +38,7 @@ class SdfAssetPath;
 /// Predefined distance joint type (Distance between rigid bodies
 /// may be limited to given minimum or maximum distance.)
 ///
-class UsdPhysicsDistanceJoint : public UsdPhysicsJoint
+class ARCH_EXPORT_TYPE UsdPhysicsDistanceJoint : public UsdPhysicsJoint
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/driveAPI.h
+++ b/pxr/usd/usdPhysics/driveAPI.h
@@ -50,7 +50,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdPhysicsTokens->rightHanded
 /// as the value.
 ///
-class UsdPhysicsDriveAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsDriveAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/filteredPairsAPI.h
+++ b/pxr/usd/usdPhysics/filteredPairsAPI.h
@@ -42,7 +42,7 @@ class SdfAssetPath;
 /// not collide against. Note that FilteredPairsAPI filtering has precedence 
 /// over CollisionGroup filtering.
 ///
-class UsdPhysicsFilteredPairsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsFilteredPairsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/fixedJoint.h
+++ b/pxr/usd/usdPhysics/fixedJoint.h
@@ -37,7 +37,7 @@ class SdfAssetPath;
 /// Predefined fixed joint type (All degrees of freedom are 
 /// removed.)
 ///
-class UsdPhysicsFixedJoint : public UsdPhysicsJoint
+class ARCH_EXPORT_TYPE UsdPhysicsFixedJoint : public UsdPhysicsJoint
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/joint.h
+++ b/pxr/usd/usdPhysics/joint.h
@@ -42,7 +42,7 @@ class SdfAssetPath;
 /// Note that default behavior is to disable collision between jointed bodies.
 /// 
 ///
-class UsdPhysicsJoint : public UsdGeomImageable
+class ARCH_EXPORT_TYPE UsdPhysicsJoint : public UsdGeomImageable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/limitAPI.h
+++ b/pxr/usd/usdPhysics/limitAPI.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// PhysicsLimitAPI is applied to. Note that if the low limit is higher than 
 /// the high limit, motion along this axis is considered locked.
 ///
-class UsdPhysicsLimitAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsLimitAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/massAPI.h
+++ b/pxr/usd/usdPhysics/massAPI.h
@@ -39,7 +39,7 @@ class SdfAssetPath;
 /// MassAPI can be applied to any object that has a PhysicsCollisionAPI or
 /// a PhysicsRigidBodyAPI.
 ///
-class UsdPhysicsMassAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsMassAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/materialAPI.h
+++ b/pxr/usd/usdPhysics/materialAPI.h
@@ -39,7 +39,7 @@ class SdfAssetPath;
 /// that have a relationship to this material will have their collision response 
 /// defined through this material.
 ///
-class UsdPhysicsMaterialAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsMaterialAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/meshCollisionAPI.h
+++ b/pxr/usd/usdPhysics/meshCollisionAPI.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdPhysicsTokens->rightHanded
 /// as the value.
 ///
-class UsdPhysicsMeshCollisionAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsMeshCollisionAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/prismaticJoint.h
+++ b/pxr/usd/usdPhysics/prismaticJoint.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdPhysicsTokens->rightHanded
 /// as the value.
 ///
-class UsdPhysicsPrismaticJoint : public UsdPhysicsJoint
+class ARCH_EXPORT_TYPE UsdPhysicsPrismaticJoint : public UsdPhysicsJoint
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/revoluteJoint.h
+++ b/pxr/usd/usdPhysics/revoluteJoint.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdPhysicsTokens->rightHanded
 /// as the value.
 ///
-class UsdPhysicsRevoluteJoint : public UsdPhysicsJoint
+class ARCH_EXPORT_TYPE UsdPhysicsRevoluteJoint : public UsdPhysicsJoint
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/rigidBodyAPI.h
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// it will update this prim's pose. All prims in the hierarchy below this 
 /// prim should move accordingly.
 ///
-class UsdPhysicsRigidBodyAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdPhysicsRigidBodyAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/scene.h
+++ b/pxr/usd/usdPhysics/scene.h
@@ -37,7 +37,7 @@ class SdfAssetPath;
 ///
 /// General physics simulation properties, required for simulation.
 ///
-class UsdPhysicsScene : public UsdTyped
+class ARCH_EXPORT_TYPE UsdPhysicsScene : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdPhysics/sphericalJoint.h
+++ b/pxr/usd/usdPhysics/sphericalJoint.h
@@ -45,7 +45,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdPhysicsTokens->rightHanded
 /// as the value.
 ///
-class UsdPhysicsSphericalJoint : public UsdPhysicsJoint
+class ARCH_EXPORT_TYPE UsdPhysicsSphericalJoint : public UsdPhysicsJoint
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdProc/generativeProcedural.h
+++ b/pxr/usd/usdProc/generativeProcedural.h
@@ -54,7 +54,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdProcTokens->rightHanded
 /// as the value.
 ///
-class UsdProcGenerativeProcedural : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdProcGenerativeProcedural : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRender/pass.h
+++ b/pxr/usd/usdRender/pass.h
@@ -107,7 +107,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRenderTokens->rightHanded
 /// as the value.
 ///
-class UsdRenderPass : public UsdTyped
+class ARCH_EXPORT_TYPE UsdRenderPass : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRender/product.h
+++ b/pxr/usd/usdRender/product.h
@@ -53,7 +53,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRenderTokens->rightHanded
 /// as the value.
 ///
-class UsdRenderProduct : public UsdRenderSettingsBase
+class ARCH_EXPORT_TYPE UsdRenderProduct : public UsdRenderSettingsBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRender/settings.h
+++ b/pxr/usd/usdRender/settings.h
@@ -45,7 +45,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRenderTokens->rightHanded
 /// as the value.
 ///
-class UsdRenderSettings : public UsdRenderSettingsBase
+class ARCH_EXPORT_TYPE UsdRenderSettings : public UsdRenderSettingsBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRender/settingsBase.h
+++ b/pxr/usd/usdRender/settingsBase.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRenderTokens->rightHanded
 /// as the value.
 ///
-class UsdRenderSettingsBase : public UsdTyped
+class ARCH_EXPORT_TYPE UsdRenderSettingsBase : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRender/var.h
+++ b/pxr/usd/usdRender/var.h
@@ -54,7 +54,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRenderTokens->rightHanded
 /// as the value.
 ///
-class UsdRenderVar : public UsdTyped
+class ARCH_EXPORT_TYPE UsdRenderVar : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRi/materialAPI.h
+++ b/pxr/usd/usdRi/materialAPI.h
@@ -52,7 +52,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdRiTokens->rightHanded
 /// as the value.
 ///
-class UsdRiMaterialAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdRiMaterialAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRi/renderPassAPI.h
+++ b/pxr/usd/usdRi/renderPassAPI.h
@@ -57,7 +57,7 @@ class SdfAssetPath;
 /// normally, so this collection sets includeRoot to 0.
 /// 
 ///
-class UsdRiRenderPassAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdRiRenderPassAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRi/splineAPI.h
+++ b/pxr/usd/usdRi/splineAPI.h
@@ -54,7 +54,7 @@ class SdfAssetPath;
 /// - Catmull-Rom (UsdRiTokens->catmullRom)
 /// 
 ///
-class UsdRiSplineAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdRiSplineAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdRi/statementsAPI.h
+++ b/pxr/usd/usdRi/statementsAPI.h
@@ -49,7 +49,7 @@ class SdfAssetPath;
 /// namespace.
 /// 
 ///
-class UsdRiStatementsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdRiStatementsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdSemantics/labelsAPI.h
+++ b/pxr/usd/usdSemantics/labelsAPI.h
@@ -41,7 +41,7 @@ class SdfAssetPath;
 /// See `UsdSemanticsLabelsQuery` for more information about computations and
 /// inheritance of semantics.
 ///
-class UsdSemanticsLabelsAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdSemanticsLabelsAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/connectableAPI.h
+++ b/pxr/usd/usdShade/connectableAPI.h
@@ -61,7 +61,7 @@ class SdfAssetPath;
 /// UsdShadeInput and UsdShadeOutput.
 /// 
 ///
-class UsdShadeConnectableAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdShadeConnectableAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/connectableAPIBehavior.h
+++ b/pxr/usd/usdShade/connectableAPIBehavior.h
@@ -28,7 +28,7 @@ class UsdShadeOutput;
 ///
 /// This enables schema libraries to enable UsdShadeConnectableAPI for
 /// their prim types and define its behavior.
-class UsdShadeConnectableAPIBehavior
+class ARCH_EXPORT_TYPE UsdShadeConnectableAPIBehavior
 {
 public:
 

--- a/pxr/usd/usdShade/coordSysAPI.h
+++ b/pxr/usd/usdShade/coordSysAPI.h
@@ -62,7 +62,7 @@ class SdfAssetPath;
 /// a single shared paint coordinate system.
 /// 
 ///
-class UsdShadeCoordSysAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdShadeCoordSysAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/material.h
+++ b/pxr/usd/usdShade/material.h
@@ -92,7 +92,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdShadeTokens->rightHanded
 /// as the value.
 ///
-class UsdShadeMaterial : public UsdShadeNodeGraph
+class ARCH_EXPORT_TYPE UsdShadeMaterial : public UsdShadeNodeGraph
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/materialBindingAPI.h
+++ b/pxr/usd/usdShade/materialBindingAPI.h
@@ -131,7 +131,7 @@ class SdfAssetPath;
 /// <i>authored</i> properties.
 /// 
 ///
-class UsdShadeMaterialBindingAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdShadeMaterialBindingAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/nodeDefAPI.h
+++ b/pxr/usd/usdShade/nodeDefAPI.h
@@ -64,7 +64,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdShadeTokens->rightHanded
 /// as the value.
 ///
-class UsdShadeNodeDefAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdShadeNodeDefAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/nodeGraph.h
+++ b/pxr/usd/usdShade/nodeGraph.h
@@ -60,7 +60,7 @@ class SdfAssetPath;
 /// output on a shader inside the node-graph.
 /// 
 ///
-class UsdShadeNodeGraph : public UsdTyped
+class ARCH_EXPORT_TYPE UsdShadeNodeGraph : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/shader.h
+++ b/pxr/usd/usdShade/shader.h
@@ -65,7 +65,7 @@ class SdfAssetPath;
 /// input parameters are encapsulated in the property schema UsdShadeInput.
 /// 
 ///
-class UsdShadeShader : public UsdTyped
+class ARCH_EXPORT_TYPE UsdShadeShader : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdShade/shaderDefParser.h
+++ b/pxr/usd/usdShade/shaderDefParser.h
@@ -22,7 +22,7 @@ class UsdStageCache;
 /// Parses shader definitions represented using USD scene description using the 
 /// schemas provided by UsdShade.
 /// 
-class UsdShadeShaderDefParserPlugin : public NdrParserPlugin 
+class ARCH_EXPORT_TYPE UsdShadeShaderDefParserPlugin : public NdrParserPlugin 
 {
 public: 
     USDSHADE_API

--- a/pxr/usd/usdSkel/animation.h
+++ b/pxr/usd/usdSkel/animation.h
@@ -42,7 +42,7 @@ class SdfAssetPath;
 /// documentation for more information.
 /// 
 ///
-class UsdSkelAnimation : public UsdTyped
+class ARCH_EXPORT_TYPE UsdSkelAnimation : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdSkel/bindingAPI.h
+++ b/pxr/usd/usdSkel/bindingAPI.h
@@ -52,7 +52,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdSkelTokens->rightHanded
 /// as the value.
 ///
-class UsdSkelBindingAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdSkelBindingAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdSkel/blendShape.h
+++ b/pxr/usd/usdSkel/blendShape.h
@@ -45,7 +45,7 @@ class SdfAssetPath;
 /// documentation for information.
 /// 
 ///
-class UsdSkelBlendShape : public UsdTyped
+class ARCH_EXPORT_TYPE UsdSkelBlendShape : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdSkel/root.h
+++ b/pxr/usd/usdSkel/root.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// See the extended \ref UsdSkel_SkelRoot "Skel Root Schema" documentation for
 /// more information.
 ///
-class UsdSkelRoot : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdSkelRoot : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdSkel/skeleton.h
+++ b/pxr/usd/usdSkel/skeleton.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// more information.
 /// 
 ///
-class UsdSkelSkeleton : public UsdGeomBoundable
+class ARCH_EXPORT_TYPE UsdSkelSkeleton : public UsdGeomBoundable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdUI/backdrop.h
+++ b/pxr/usd/usdUI/backdrop.h
@@ -61,7 +61,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdUITokens->rightHanded
 /// as the value.
 ///
-class UsdUIBackdrop : public UsdTyped
+class ARCH_EXPORT_TYPE UsdUIBackdrop : public UsdTyped
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdUI/nodeGraphNodeAPI.h
+++ b/pxr/usd/usdUI/nodeGraphNodeAPI.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdUITokens->rightHanded
 /// as the value.
 ///
-class UsdUINodeGraphNodeAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdUINodeGraphNodeAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdUI/sceneGraphPrimAPI.h
+++ b/pxr/usd/usdUI/sceneGraphPrimAPI.h
@@ -44,7 +44,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdUITokens->rightHanded
 /// as the value.
 ///
-class UsdUISceneGraphPrimAPI : public UsdAPISchemaBase
+class ARCH_EXPORT_TYPE UsdUISceneGraphPrimAPI : public UsdAPISchemaBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdUtils/coalescingDiagnosticDelegate.h
+++ b/pxr/usd/usdUtils/coalescingDiagnosticDelegate.h
@@ -64,7 +64,7 @@ typedef std::vector<UsdUtilsCoalescingDiagnosticDelegateItem>
 /// results, as well as a compressed view which deduplicates
 /// diagnostic events by their source line number, function and file 
 /// from which they occurred.
-class UsdUtilsCoalescingDiagnosticDelegate : public TfDiagnosticMgr::Delegate {
+class ARCH_EXPORT_TYPE UsdUtilsCoalescingDiagnosticDelegate : public TfDiagnosticMgr::Delegate {
 public:
     USDUTILS_API
     UsdUtilsCoalescingDiagnosticDelegate();

--- a/pxr/usd/usdUtils/conditionalAbortDiagnosticDelegate.h
+++ b/pxr/usd/usdUtils/conditionalAbortDiagnosticDelegate.h
@@ -76,7 +76,7 @@ private:
 ///         excludeFilters);
 /// \endcode
 ///
-class UsdUtilsConditionalAbortDiagnosticDelegate : 
+class ARCH_EXPORT_TYPE UsdUtilsConditionalAbortDiagnosticDelegate : 
     public TfDiagnosticMgr::Delegate 
 {
 public:

--- a/pxr/usd/usdVol/field3DAsset.h
+++ b/pxr/usd/usdVol/field3DAsset.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdVolTokens->rightHanded
 /// as the value.
 ///
-class UsdVolField3DAsset : public UsdVolFieldAsset
+class ARCH_EXPORT_TYPE UsdVolField3DAsset : public UsdVolFieldAsset
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdVol/fieldAsset.h
+++ b/pxr/usd/usdVol/fieldAsset.h
@@ -42,7 +42,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdVolTokens->rightHanded
 /// as the value.
 ///
-class UsdVolFieldAsset : public UsdVolFieldBase
+class ARCH_EXPORT_TYPE UsdVolFieldAsset : public UsdVolFieldBase
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdVol/fieldBase.h
+++ b/pxr/usd/usdVol/fieldBase.h
@@ -36,7 +36,7 @@ class SdfAssetPath;
 ///
 /// Base class for field primitives.
 ///
-class UsdVolFieldBase : public UsdGeomXformable
+class ARCH_EXPORT_TYPE UsdVolFieldBase : public UsdGeomXformable
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdVol/openVDBAsset.h
+++ b/pxr/usd/usdVol/openVDBAsset.h
@@ -43,7 +43,7 @@ class SdfAssetPath;
 /// So to set an attribute to the value "rightHanded", use UsdVolTokens->rightHanded
 /// as the value.
 ///
-class UsdVolOpenVDBAsset : public UsdVolFieldAsset
+class ARCH_EXPORT_TYPE UsdVolOpenVDBAsset : public UsdVolFieldAsset
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usd/usdVol/volume.h
+++ b/pxr/usd/usdVol/volume.h
@@ -53,7 +53,7 @@ class SdfAssetPath;
 /// by multiple Volumes, a Volume's Field prims should be located
 /// under the Volume in namespace, for enhanced organization.
 ///
-class UsdVolVolume : public UsdGeomGprim
+class ARCH_EXPORT_TYPE UsdVolVolume : public UsdGeomGprim
 {
 public:
     /// Compile time constant representing what kind of schema this class is.

--- a/pxr/usdImaging/usdImaging/apiSchemaAdapter.h
+++ b/pxr/usdImaging/usdImaging/apiSchemaAdapter.h
@@ -36,7 +36,7 @@ using UsdImagingAPISchemaAdapterSharedPtr =
 ///
 /// These map behavior of applied API schemas to contributions the hydra prims
 /// and data sources generated for a given USD prim.
-class UsdImagingAPISchemaAdapter 
+class ARCH_EXPORT_TYPE UsdImagingAPISchemaAdapter 
             : public std::enable_shared_from_this<UsdImagingAPISchemaAdapter>
 {
 public:

--- a/pxr/usdImaging/usdImaging/dataSourcePrim.h
+++ b/pxr/usdImaging/usdImaging/dataSourcePrim.h
@@ -426,7 +426,7 @@ HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourcePrimOrigin);
 /// drop inherited attributes on subprims (/prim.a), letting them inherit from
 /// /prim instead.  This way we don't (e.g.) double-apply transforms.
 ///
-class UsdImagingDataSourcePrim : public HdContainerDataSource
+class ARCH_EXPORT_TYPE UsdImagingDataSourcePrim : public HdContainerDataSource
 {
 public:
     HD_DECLARE_DATASOURCE(UsdImagingDataSourcePrim);

--- a/pxr/usdImaging/usdImaging/dataSourceStageGlobals.h
+++ b/pxr/usdImaging/usdImaging/dataSourceStageGlobals.h
@@ -27,7 +27,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// certain behaviors (like getting the time coordinate, or whether we support
 /// time-varying tracking).
 /// 
-class UsdImagingDataSourceStageGlobals
+class ARCH_EXPORT_TYPE UsdImagingDataSourceStageGlobals
 {
 public:
     USDIMAGING_API

--- a/pxr/usdImaging/usdImaging/fieldAdapter.h
+++ b/pxr/usdImaging/usdImaging/fieldAdapter.h
@@ -22,7 +22,7 @@ class UsdPrim;
 ///
 /// Base class for all USD fields.
 ///
-class UsdImagingFieldAdapter : public UsdImagingPrimAdapter {
+class ARCH_EXPORT_TYPE UsdImagingFieldAdapter : public UsdImagingPrimAdapter {
 public:
     using BaseAdapter = UsdImagingPrimAdapter;
 

--- a/pxr/usdImaging/usdImaging/gprimAdapter.h
+++ b/pxr/usdImaging/usdImaging/gprimAdapter.h
@@ -28,7 +28,7 @@ class UsdGeomGprim;
 /// Gprim data support, such as visibility, doubleSided, extent, displayColor,
 /// displayOpacity, purpose, and transform.
 ///
-class UsdImagingGprimAdapter : public UsdImagingInstanceablePrimAdapter
+class ARCH_EXPORT_TYPE UsdImagingGprimAdapter : public UsdImagingInstanceablePrimAdapter
 {
 public:
     using BaseAdapter = UsdImagingInstanceablePrimAdapter;

--- a/pxr/usdImaging/usdImaging/instanceablePrimAdapter.h
+++ b/pxr/usdImaging/usdImaging/instanceablePrimAdapter.h
@@ -19,7 +19,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// An abstract adapter class for prims that are instanceable. Adapters for
 /// instanceable prims should derive from this class instead of
 /// UsdImaginggPrimAdapter.
-class UsdImagingInstanceablePrimAdapter : public UsdImagingPrimAdapter
+class ARCH_EXPORT_TYPE UsdImagingInstanceablePrimAdapter : public UsdImagingPrimAdapter
 {
 public:
     using BaseAdapter = UsdImagingPrimAdapter;

--- a/pxr/usdImaging/usdImaging/lightAdapter.h
+++ b/pxr/usdImaging/usdImaging/lightAdapter.h
@@ -23,7 +23,7 @@ class UsdPrim;
 ///
 /// Base class for all lights.
 ///
-class UsdImagingLightAdapter : public UsdImagingInstanceablePrimAdapter {
+class ARCH_EXPORT_TYPE UsdImagingLightAdapter : public UsdImagingInstanceablePrimAdapter {
 public:
     using BaseAdapter = UsdImagingInstanceablePrimAdapter;
 

--- a/pxr/usdImaging/usdImaging/primAdapter.h
+++ b/pxr/usdImaging/usdImaging/primAdapter.h
@@ -49,7 +49,7 @@ using UsdImagingPrimAdapterSharedPtr =
 ///
 /// Base class for all PrimAdapters.
 ///
-class UsdImagingPrimAdapter 
+class ARCH_EXPORT_TYPE UsdImagingPrimAdapter 
   : public std::enable_shared_from_this<UsdImagingPrimAdapter>
 {
 public:

--- a/pxr/usdImaging/usdviewq/hydraObserver.h
+++ b/pxr/usdImaging/usdviewq/hydraObserver.h
@@ -129,7 +129,7 @@ private:
 
     bool _Target(const HdSceneIndexBaseRefPtr &sceneIndex);
 
-    class _Observer : public HdSceneIndexObserver
+    class ARCH_EXPORT_TYPE _Observer : public HdSceneIndexObserver
     {
     public:
         USDVIEWQ_API

--- a/pxr/usdValidation/usdValidation/error.h
+++ b/pxr/usdValidation/usdValidation/error.h
@@ -33,8 +33,7 @@ class UsdValidationValidator;
 ///       hence reported as warning by the validation task.
 /// Info: Associates the UsdValidationErrorType with information which needs to
 ///       be reported to the users by the validation task.
-enum class UsdValidationErrorType
-{
+enum class ARCH_EXPORT_TYPE UsdValidationErrorType {
     None = 0,
     Error,
     Warn,

--- a/pxr/usdValidation/usdValidation/registry.h
+++ b/pxr/usdValidation/usdValidation/registry.h
@@ -146,7 +146,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// \sa UsdValidationValidator
 /// \sa UsdValidationValidatorSuite
-class UsdValidationRegistry
+class ARCH_EXPORT_TYPE UsdValidationRegistry
 {
     UsdValidationRegistry(const UsdValidationRegistry &) = delete;
     UsdValidationRegistry &operator=(const UsdValidationRegistry &) = delete;


### PR DESCRIPTION
### Description of Change(s)

This change intends to enable building with `-fvisibility=hidden` to hide the symbols. for these benefits:
1. It allows compiler and linker to do more optimizations, makes startup faster and binaries smaller
2. Minimization of the set of exported symbols in order to track ABI changes
3. Compliance with some specification or standard

Post on AOUSD: [Support building with -fvisibility=hidden](https://forum.aousd.org/t/support-building-with-fvisibility-hidden/1965)

### General technical comment
 
We have added ARCH_EXPORT_TYPE to classes, structs, enums, and some instantiated templates that require visible symbols, to instruct the compiler to generate visible symbols.

On windows, the macro ARCH_EXPORT_TYPE is expanded to empty in MSVC because the current symbol export works fine and does not need to be modified. The reason for not replacing the member function export with a class-level export in this PR is to reduce the workload and to avoid cumbersome and complex technical constraints, which would require a lot of non-patterned modifications. 

It's worth noting that visible and export are not equivalent terms, even though we may not be aware of the difference in our day-to-day work. It helps to understand some seemingly strange problems. For example, Clang can optimize and not to generate code and symbols for inline functions marked as visible, which can lead to symbol lookups failure when linking across modules.

Further cleanup can be done by following up with smaller PRs, which do not have to be as large as this one, so the effort and risk is more manageable.

In Clang, the visibility of an instantiated type of a template depends on both the template and template arguments. 
```C++
template<typename T> class __attribute__((visibility("default"))) Foo{};
class __attribute__((visibility("hidden"))) Bar{};
```
the visibility of `Foo<Bar>` would be hidden other than default, even Foo is marked as default. That is why this PR added "default" to some enums and lots of simple struct types.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

Related issues:
- https://github.com/PixarAnimationStudios/OpenUSD/issues/1475
- https://github.com/PixarAnimationStudios/OpenUSD/issues/665

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
