### PR TITLE
build_usd.py: add required libraries in dependency order

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2412,22 +2412,22 @@ if context.buildMaterialX:
 
 if context.buildImaging:
     if context.enablePtex:
-        requiredDependencies += [PTEX, ZLIB]
+        requiredDependencies += [ZLIB, PTEX]
 
     requiredDependencies += [OPENSUBDIV]
 
     if context.enableOpenVDB:
-        requiredDependencies += [BLOSC, BOOST, OPENEXR, OPENVDB, TBB, ZLIB]
-    
+        requiredDependencies += [ZLIB, BOOST, TBB, OPENEXR, BLOSC, OPENVDB]
+
     if context.buildOIIO:
-        requiredDependencies += [BOOST, JPEG, TIFF, PNG, OPENEXR, OPENIMAGEIO, ZLIB]
+        requiredDependencies += [ZLIB, BOOST, JPEG, TIFF, PNG, OPENEXR, OPENIMAGEIO]
 
     if context.buildOCIO:
-        requiredDependencies += [OPENCOLORIO, ZLIB]
+        requiredDependencies += [ZLIB, OPENCOLORIO]
 
     if context.buildEmbree:
         requiredDependencies += [TBB, EMBREE]
-                             
+
 if context.buildUsdview:
     requiredDependencies += [PYOPENGL, PYSIDE]
 


### PR DESCRIPTION
This is a quick follow-up to 5dfaca0acbc09e6077f8bfc6fec95465bc8200d5.

When libraries are added to `requiredDependencies`, they will be built in the order in which they are appended to the list. This means that any intermediary dependencies should be appended **before** the "primary" library. For example, if Ptex is enabled (which requires zlib), zlib must be built first, so ZLIB must be appended to requiredDependencies before PTEX.

I ran into this building for Windows where building zlib is required. The build script determined that the dependencies were "..., Ptex, zlib, ...", and the Ptex build complained about zlib being missing when it attempted to build Ptex before building zlib.

### Checklist

[ x ] I have created this PR based on the dev branch

[ x ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ x ] I have verified that all unit tests pass with the proposed changes

[ x ] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
