### PR TITLE
UsdView: Display resolved labels in prim rollover window

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -21,7 +21,7 @@ from collections import deque, OrderedDict
 from functools import cmp_to_key
 
 # Usd Library Components
-from pxr import Usd, UsdGeom, UsdShade, UsdUtils, UsdImagingGL, Glf, Sdf, Tf, Ar
+from pxr import Usd, UsdGeom, UsdShade, UsdUtils, UsdImagingGL, Glf, Sdf, Tf, Ar, UsdSemantics
 from pxr import UsdAppUtils
 from pxr.UsdAppUtils.complexityArgs import RefinementComplexities
 from pxr.UsdUtils.constantsGroup import ConstantsGroup
@@ -36,7 +36,7 @@ from .layerStackContextMenu import LayerStackContextMenu
 from .attributeViewContextMenu import AttributeViewContextMenu
 from .customAttributes import (_GetCustomAttributes, CustomAttribute,
                                BoundingBoxAttribute, LocalToWorldXformAttribute,
-                               ResolvedBoundMaterial)
+                               ResolvedBoundMaterial, ResolvedLabelsAttribute)
 from .primTreeWidget import PrimTreeWidget, PrimViewColumnIndex
 from .primViewItem import PrimViewItem
 from .variantComboBox import VariantComboBox
@@ -57,7 +57,7 @@ from .common import (UIBaseColors, UIPropertyValueSourceColors, UIFonts,
                      PropTreeWidgetTypeIsRel, PrimNotFoundException,
                      GetRootLayerStackInfo, HasSessionVis, GetEnclosingModelPrim,
                      GetPrimsLoadability, ClearColors,
-                     HighlightColors, KeyboardShortcuts, PrintWarning)
+                     HighlightColors, KeyboardShortcuts, PrintWarning, TruncateMiddle)
 
 from .settings import StateSource, ConfigManager
 from .usdviewApi import UsdviewApi
@@ -5165,6 +5165,16 @@ class AppController(QtCore.QObject):
                         if currProtoPath.HasPrefix(path):
                             currProtoPath = currProtoPath.MakeRelativePath(path)
                         propertyStr += "<br> -- <em>instance of prototype &lt;%s&gt;</em>" % str(currProtoPath)
+            
+            # Semantic information
+            primResolvedLabelsProp = ResolvedLabelsAttribute(currentPrim=prim, rootDataModel=None)
+            primResolvedLabels = primResolvedLabelsProp.Get(self._dataModel.currentFrame)
+            if primResolvedLabels:
+                propertyStr += "<br> -- <em>%s</em> = %s" %\
+                    (
+                        primResolvedLabelsProp.GetName().lower(), 
+                        TruncateMiddle(str(primResolvedLabels), max_length=round(1.5*self._maxToolTipWidth()))
+                    )
 
             # Material info - this IS expected
             materialStr = "<hr><b>Material assignment:</b>"
@@ -5201,6 +5211,17 @@ class AppController(QtCore.QObject):
                         bindingRel.GetPath(), model)
                 materialStr += "<br><small><em>Material binding "\
                     "relationship: %s</em></small>" % str(bindingRelPath)
+
+                # Semantic information
+                mtlResolvedLabelsProp = ResolvedLabelsAttribute(currentPrim=material.GetPrim(), rootDataModel=None)
+                mtlResolvedLabels = mtlResolvedLabelsProp.Get(self._dataModel.currentFrame)
+                if mtlResolvedLabels:
+                    materialStr += "<br><small><em>%s: %s</em></small>" %\
+                        (
+                            mtlResolvedLabelsProp.GetName(), 
+                            TruncateMiddle(str(mtlResolvedLabels), max_length=round(1.5*self._maxToolTipWidth()))
+                        )
+
 
             if not gotValidMaterial:
                 materialStr += "<small><em>No assigned Material!</em></small>"

--- a/pxr/usdImaging/usdviewq/common.py
+++ b/pxr/usdImaging/usdviewq/common.py
@@ -284,6 +284,28 @@ def GetShortStringForValue(prop, val):
 
     return result[:500]
 
+def TruncateMiddle(text, max_length=125, ellipsis='...'):
+    """Truncate a string to a maximum length, replacing the middle with an
+    ellipsis if necessary.  If the string is already shorter than the maximum
+    length, it is returned unchanged.
+    
+    Args:
+        text (str): The string to truncate.
+        max_length (int): The maximum length of the returned string.
+        ellipsis (str): The string to insert in the middle of the truncated
+            string.  Defaults to '...'.
+    Returns:
+        str: The truncated string.
+    """
+    if len(text) <= max_length:
+        return text
+    
+    # Calculate the number of characters to keep on each side
+    side_length = (max_length - len(ellipsis)) // 2
+    
+    # Truncate the string and add ellipsis
+    return text[:side_length] + ellipsis + text[-side_length:]
+
 # Return a string that reports size in metric units (units of 1000, not 1024).
 def ReportMetricSize(sizeInBytes):
     if sizeInBytes == 0:


### PR DESCRIPTION
### Description of Change(s)
This PR uses the usdSemantics schema and API to compute the taxonomies and the associated labels and display them in UsdView's prim rollover window.

The resolved labels for a *prim* under the cursor and for its bound *materials* are computed as follows:
- The taxonomies and their labels on the prim and all its ancestors (inherited labels).  
- For each taxonomy, the unique set of labels is computed and sorted lexicographically by the 'UsdSemantics.LabelsQuery.ComputeUniqueInheritedLabels()` API.

Note that the list of taxonomies and resolved labels is truncated to fit in the rollover window, using the new `TruncateMiddle()` utility function, by omitting the middle part of the list and displaying its start and end. This provides a user experience similar to that provided by the Qt widgets used in the attribute editor.

![image](https://github.com/user-attachments/assets/5e9f8eae-2509-40ef-aa25-5db525a3d6d2)


### Link to proposal 
N/A

### Fixes Issue(s)
N/A

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
