### PR TITLE
Autodesk: testUsdImagingGL image diff threshold adjustments

### DIFF
--- a/pxr/usdImaging/usdImagingGL/CMakeLists.txt
+++ b/pxr/usdImaging/usdImagingGL/CMakeLists.txt
@@ -787,7 +787,7 @@ pxr_register_test(testUsdImagingGLBasicDrawingNonBindless_batch
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasicDrawingNonBindless_batch.png
     FAIL 1
-    FAIL_PERCENT 1.1
+    FAIL_PERCENT 1.4
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLBasicDrawingNonBindless
@@ -1189,7 +1189,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesWithColor
         testUsdImagingGLBasisCurvesWithColor_1.2.png
         testUsdImagingGLBasisCurvesWithColor_1.3.png
     FAIL .05
-    FAIL_PERCENT .03
+    FAIL_PERCENT .04
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLBasisCurvesWithColor
@@ -1200,7 +1200,7 @@ pxr_register_test(testUsdImagingGLBasisCurvesWithScale
     IMAGE_DIFF_COMPARE
         testUsdImagingGLBasisCurvesWithScale_1.1.png
     FAIL .05
-    FAIL_PERCENT .03
+    FAIL_PERCENT .08
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLBasisCurvesWithScale
@@ -2496,8 +2496,8 @@ pxr_register_test(testUsdImagingGLColorOpacityPrimvar
     IMAGE_DIFF_COMPARE
         color_opacity_primvar_000.png
         color_opacity_primvar_001.png
-    FAIL .05
-    FAIL_PERCENT .03
+    FAIL 0.1
+    FAIL_PERCENT 0.15
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLColorOpacityPrimvar
@@ -2530,7 +2530,7 @@ pxr_register_test(testUsdImagingGLCards
     IMAGE_DIFF_COMPARE
         testCards.png
     FAIL 0.01
-    FAIL_PERCENT 0.1
+    FAIL_PERCENT 0.2
     WARN 0.02
     WARN_PERCENT 0.05
     EXPECTED_RETURN_CODE 0
@@ -2542,9 +2542,9 @@ pxr_register_test(testUsdImagingGLCards_anim
     IMAGE_DIFF_COMPARE
         testAnim_001.png
         testAnim_002.png
-    FAIL 0.01
-    FAIL_PERCENT 0.1
-    WARN 0.02
+    FAIL 0.02
+    FAIL_PERCENT 0.2
+    WARN 0.03
     WARN_PERCENT 0.05
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLCards
@@ -2703,9 +2703,9 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Texture
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTexture.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -2734,7 +2734,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Displacement
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 0.04
-    FAIL_PERCENT 0.02
+    FAIL_PERCENT 0.5
     WARN 0.02
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
@@ -2748,7 +2748,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureOpacity
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureOpacity.png
-    FAIL 0.05
+    FAIL 0.15
     FAIL_PERCENT 0.1
     WARN 0.025
     WARN_PERCENT 0.05
@@ -2764,7 +2764,7 @@ pxr_register_test(testUsdImagingGLPreviewSurface_TextureScaleAndBias
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureScaleAndBias.png
     FAIL 0.04
-    FAIL_PERCENT 0.02
+    FAIL_PERCENT 0.03
     WARN 0.02
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
@@ -2778,9 +2778,9 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Transform2d
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTransform2d.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -2793,8 +2793,8 @@ pxr_register_test(testUsdImagingGLPreviewSurface_SourceColorSpace
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSourceColorSpace.png
-    FAIL 0.02
-    FAIL_PERCENT 0.01
+    FAIL 0.05
+    FAIL_PERCENT 0.025
     WARN 0.01
     WARN_PERCENT 0.005
     EXPECTED_RETURN_CODE 0
@@ -2808,8 +2808,8 @@ pxr_register_test(testUsdImagingGLPreviewSurface_NormalMap
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceNormalMap.png
-    FAIL 0.04
-    FAIL_PERCENT 0.1
+    FAIL 0.05
+    FAIL_PERCENT 0.12
     WARN 0.02
     WARN_PERCENT 0.05
     EXPECTED_RETURN_CODE 0
@@ -2840,9 +2840,9 @@ pxr_register_test(testUsdImagingGLPreviewSurface_Animated
         testPreviewSurfaceAnimated_002.png
         testPreviewSurfaceAnimated_003.png
         testPreviewSurfaceAnimated_004.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -2998,9 +2998,9 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Texture
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTexture.usda -write testPreviewSurfaceTexture.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTexture.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -3029,7 +3029,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Displacement
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceDisplacement.png
     FAIL 0.04
-    FAIL_PERCENT 0.02
+    FAIL_PERCENT 0.5
     WARN 0.02
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
@@ -3043,7 +3043,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureOpacity
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTextureOpacity.usda -write testPreviewSurfaceTextureOpacity.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureOpacity.png
-    FAIL 0.05
+    FAIL 0.15
     FAIL_PERCENT 0.1
     WARN 0.025
     WARN_PERCENT 0.05
@@ -3059,7 +3059,7 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_TextureScaleAndBias
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTextureScaleAndBias.png
     FAIL 0.04
-    FAIL_PERCENT 0.02
+    FAIL_PERCENT 0.03
     WARN 0.02
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
@@ -3073,9 +3073,9 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Transform2d
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceTransform2d.usda -write testPreviewSurfaceTransform2d.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceTransform2d.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -3088,8 +3088,8 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_SourceColorSpace
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceSourceColorSpace.usda -write testPreviewSurfaceSourceColorSpace.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceSourceColorSpace.png
-    FAIL 0.02
-    FAIL_PERCENT 0.01
+    FAIL 0.05
+    FAIL_PERCENT 0.025
     WARN 0.01
     WARN_PERCENT 0.005
     EXPECTED_RETURN_CODE 0
@@ -3103,8 +3103,8 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_NormalMap
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -lighting -shading smooth -frameAll -stage testPreviewSurfaceNormalMap.usda -write testPreviewSurfaceNormalMap.png"
     IMAGE_DIFF_COMPARE
         testPreviewSurfaceNormalMap.png
-    FAIL 0.04
-    FAIL_PERCENT 0.1
+    FAIL 0.05
+    FAIL_PERCENT 0.12
     WARN 0.02
     WARN_PERCENT 0.05
     EXPECTED_RETURN_CODE 0
@@ -3136,9 +3136,9 @@ pxr_register_test(testUsdImagingGLPreviewSurfaceNonBindless_Animated
         testPreviewSurfaceAnimated_002.png
         testPreviewSurfaceAnimated_003.png
         testPreviewSurfaceAnimated_004.png
-    FAIL 0.04
+    FAIL 0.1
     FAIL_PERCENT 0.02
-    WARN 0.02
+    WARN 0.05
     WARN_PERCENT 0.01
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLPreviewSurface
@@ -3415,7 +3415,7 @@ pxr_register_test(testUsdImagingGLFaceVarying_Uniform_Low
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVarying_Uniform_Low.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLFaceVarying
@@ -3439,7 +3439,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Uniform_Low.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLFaceVarying
@@ -3451,7 +3451,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLinearInterp_Uniform_Medium.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLFaceVarying
@@ -3542,7 +3542,7 @@ pxr_register_test(testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low
     IMAGE_DIFF_COMPARE
         testUsdImagingGLFaceVaryingLeftHanded_Adaptive_Low.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLFaceVarying
@@ -3647,7 +3647,7 @@ pxr_register_test(testUsdImagingGLUsdUdims_ScaleAndBias
     IMAGE_DIFF_COMPARE
         usdUdimsScaleAndBias.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdUdims
@@ -3699,7 +3699,7 @@ pxr_register_test(testUsdImagingGLUsdUdimsNonBindless_ScaleAndBias
     IMAGE_DIFF_COMPARE
         usdUdimsScaleAndBias.png
     FAIL 1
-    FAIL_PERCENT 1
+    FAIL_PERCENT 1.5
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
     TESTENV testUsdImagingGLUsdUdims
@@ -4631,8 +4631,8 @@ pxr_register_test(testUsdImagingGLAovVisualization_Storm_primId
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -offscreen -stage viz_aov.usda -rendererAov primId -clear 0 0 0 1 -lighting -camera /main_cam -write testUsdImagingGLAovVisualization_Storm_primId.png"
     IMAGE_DIFF_COMPARE
         testUsdImagingGLAovVisualization_Storm_primId.png
-    FAIL 0.05
-    FAIL_PERCENT 0.02
+    FAIL 0.001
+    FAIL_PERCENT 0.6
     WARN 0.025
     WARN_PERCENT 0.002
     EXPECTED_RETURN_CODE 0
@@ -4845,8 +4845,8 @@ if (MaterialX_FOUND AND ${PXR_ENABLE_MATERIALX_SUPPORT})
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdImagingGLBasicDrawing -lighting -sceneLights -shading smooth -complexity 1.3 -offscreen -frameAll -stage mxNormalMap.usda -write mxNormalMap.png"
         IMAGE_DIFF_COMPARE
             mxNormalMap.png
-        FAIL 0.1
-        FAIL_PERCENT 0.005
+        FAIL 0.15
+        FAIL_PERCENT 0.1
         WARN 0.05
         WARN_PERCENT 0.03
         EXPECTED_RETURN_CODE 0


### PR DESCRIPTION
### Description of Change(s)

Slightly increase `testUsdImagingGL` image diff thresholds to allow them to pass with Metal and Vulkan (Lavapipe).

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
