### PR TITLE
Add storm support for camera exposure controls

### DIFF
--- a/pxr/imaging/hdx/CMakeLists.txt
+++ b/pxr/imaging/hdx/CMakeLists.txt
@@ -48,6 +48,7 @@ pxr_library(hdx
         freeCameraPrimDataSource
         fullscreenShader
         hgiConversions
+        linearExposureScaleTask
         oitBufferAccessor
         oitRenderTask
         oitResolveTask
@@ -88,6 +89,7 @@ pxr_library(hdx
         shaders/colorChannel.glslfx
         shaders/colorCorrection.glslfx
         shaders/fullscreen.glslfx
+        shaders/linearExposureScale.glslfx
         shaders/oitResolveImageShader.glslfx
         shaders/outline.glslfx
         shaders/renderPass.glslfx

--- a/pxr/imaging/hdx/linearExposureScaleTask.cpp
+++ b/pxr/imaging/hdx/linearExposureScaleTask.cpp
@@ -1,0 +1,184 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/imaging/hdx/linearExposureScaleTask.h"
+#include "pxr/imaging/hdx/fullscreenShader.h"
+#include "pxr/imaging/hdx/package.h"
+
+#include "pxr/imaging/hd/camera.h"
+#include "pxr/imaging/hd/perfLog.h"
+#include "pxr/imaging/hd/tokens.h"
+
+#include "pxr/imaging/hf/perfLog.h"
+#include "pxr/imaging/hio/glslfx.h"
+
+#include "pxr/imaging/hgi/blitCmds.h"
+#include "pxr/imaging/hgi/blitCmdsOps.h"
+#include "pxr/imaging/hgi/hgi.h"
+#include "pxr/imaging/hgi/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+    ((linearExposureScaleFrag, "LinearExposureScaleFragment"))
+);
+
+HdxLinearExposureScaleTask::HdxLinearExposureScaleTask(
+    HdSceneDelegate* delegate,
+    SdfPath const& id)
+  : HdxTask(id)
+{
+}
+
+HdxLinearExposureScaleTask::~HdxLinearExposureScaleTask() = default;
+
+void
+HdxLinearExposureScaleTask::_Sync(HdSceneDelegate* delegate,
+                           HdTaskContext* ctx,
+                           HdDirtyBits* dirtyBits)
+{
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
+    if (!_compositor) {
+        _compositor = std::make_unique<HdxFullscreenShader>(
+            _GetHgi(), "LinearExposureScale");
+    }
+
+    if ((*dirtyBits) & HdChangeTracker::DirtyParams) {
+        HdxLinearExposureScaleTaskParams params;
+
+        if (_GetTaskParams(delegate, &params)) {
+            _cameraPath = params.cameraPath;
+        }
+    }
+
+    // Currently, we're querying GetLinearExposureScale() every frame -
+    // if we wanted to be more selective:
+    //
+    // - target camera should get a HdCamera::DirtyParams update whenever
+    //   any input attrs to linearExposureScale change
+    // - we could store a version counter on the HdCamera
+    // - ...and a `_lastCamVersion` on this task, and then only update
+    //   our _linearExposureScale if it didn't == cam's version
+    //
+    // However, this shouldn't be a problem unless
+    // _compositor->SetShaderConstants is expensive, so not going to
+    // optimize unless we have evidence of that.
+    if (_cameraPath.IsEmpty()) {
+        _linearExposureScale = 1.0f;
+    } else {
+        HdRenderIndex &renderIndex = delegate->GetRenderIndex();
+        const HdCamera *camera = static_cast<const HdCamera *>(
+            renderIndex.GetSprim(HdPrimTypeTokens->camera, _cameraPath));
+        if (!TF_VERIFY(camera)) {
+            return;
+        }
+
+        _linearExposureScale = camera->GetLinearExposureScale();
+    }
+
+    *dirtyBits = HdChangeTracker::Clean;
+}
+
+void
+HdxLinearExposureScaleTask::Prepare(HdTaskContext* ctx,
+                             HdRenderIndex* renderIndex)
+{
+}
+
+void
+HdxLinearExposureScaleTask::Execute(HdTaskContext* ctx)
+{
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
+    HgiTextureHandle aovTexture;
+    _GetTaskContextData(ctx, HdAovTokens->color, &aovTexture);
+
+    HgiShaderFunctionDesc fragDesc;
+    fragDesc.debugName = _tokens->linearExposureScaleFrag.GetString();
+    fragDesc.shaderStage = HgiShaderStageFragment;
+    HgiShaderFunctionAddStageInput(
+        &fragDesc, "uvOut", "vec2");
+    HgiShaderFunctionAddTexture(
+        &fragDesc, "colorIn");
+    HgiShaderFunctionAddStageOutput(
+        &fragDesc, "hd_FragColor", "vec4", "color");
+
+    // The order of the constant parameters has to match the order in the
+    // _ParameterBuffer struct
+    HgiShaderFunctionAddConstantParam(
+        &fragDesc, "screenSize", "vec2");
+    HgiShaderFunctionAddConstantParam(
+        &fragDesc, "linearExposureScale", "float");
+
+    _compositor->SetProgram(
+        HdxPackageLinearExposureScaleShader(),
+        _tokens->linearExposureScaleFrag,
+        fragDesc);
+    const auto &aovDesc = aovTexture->GetDescriptor();
+    if (_UpdateParameterBuffer(
+            static_cast<float>(aovDesc.dimensions[0]),
+            static_cast<float>(aovDesc.dimensions[1]))) {
+        size_t byteSize = sizeof(_ParameterBuffer);
+        _compositor->SetShaderConstants(byteSize, &_parameterData);
+    }
+
+    _compositor->BindTextures({aovTexture});
+
+    _compositor->Draw(aovTexture, /*no depth*/HgiTextureHandle());
+}
+
+bool
+HdxLinearExposureScaleTask::_UpdateParameterBuffer(
+    float screenSizeX, float screenSizeY)
+{
+    _ParameterBuffer pb;
+
+    pb.linearExposureScale = _linearExposureScale;
+    pb.screenSize[0] = screenSizeX;
+    pb.screenSize[1] = screenSizeY;
+
+    // All data is still the same, no need to update the storage buffer
+    if (pb == _parameterData) {
+        return false;
+    }
+
+    _parameterData = pb;
+
+    return true;
+}
+
+
+// -------------------------------------------------------------------------- //
+// VtValue Requirements
+// -------------------------------------------------------------------------- //
+
+std::ostream& operator<<(
+    std::ostream& out,
+    const HdxLinearExposureScaleTaskParams& pv)
+{
+    out << "LinearExposureScaleTask Params: (...) "
+        << pv.cameraPath << " "
+    ;
+    return out;
+}
+
+bool operator==(const HdxLinearExposureScaleTaskParams& lhs,
+                const HdxLinearExposureScaleTaskParams& rhs)
+{
+    return lhs.cameraPath == rhs.cameraPath;
+}
+
+bool operator!=(const HdxLinearExposureScaleTaskParams& lhs,
+                const HdxLinearExposureScaleTaskParams& rhs)
+{
+    return !(lhs == rhs);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdx/linearExposureScaleTask.h
+++ b/pxr/imaging/hdx/linearExposureScaleTask.h
@@ -1,0 +1,102 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef HDX_LINEAREXPOSURESCALE_TASK_H
+#define HDX_LINEAREXPOSURESCALE_TASK_H
+
+#include "pxr/pxr.h"
+#include "pxr/usd/sdf/path.h"
+#include "pxr/imaging/hdx/api.h"
+#include "pxr/imaging/hdx/task.h"
+#include "pxr/imaging/hdx/tokens.h"
+#include "pxr/imaging/hgi/graphicsCmds.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// \class HdxLinearExposureScaleTask
+///
+/// A task for applying an exposure scale for display.
+///
+class HdxLinearExposureScaleTask : public HdxTask
+{
+public:
+    HDX_API
+    HdxLinearExposureScaleTask(HdSceneDelegate* delegate, SdfPath const& id);
+
+    HDX_API
+    ~HdxLinearExposureScaleTask() override;
+
+    /// Prepare the tasks resources
+    HDX_API
+    void Prepare(HdTaskContext* ctx,
+                 HdRenderIndex* renderIndex) override;
+
+    /// Execute the exposure scale task
+    HDX_API
+    void Execute(HdTaskContext* ctx) override;
+
+protected:
+    /// Sync the render pass resources
+    HDX_API
+    void _Sync(HdSceneDelegate* delegate,
+               HdTaskContext* ctx,
+               HdDirtyBits* dirtyBits) override;
+
+private:
+    HdxLinearExposureScaleTask() = delete;
+    HdxLinearExposureScaleTask(const HdxLinearExposureScaleTask &) = delete;
+    HdxLinearExposureScaleTask &operator =(const HdxLinearExposureScaleTask &) = delete;
+
+    // Utility function to update the shader uniform parameters.
+    // Returns true if the values were updated. False if unchanged.
+    bool _UpdateParameterBuffer(float screenSizeX, float screenSizeY);
+
+    // This struct must match ParameterBuffer in linearExposureScale.glslfx.
+    // Be careful to remember the std430 rules.
+    struct _ParameterBuffer
+    {
+        float screenSize[2];
+        float linearExposureScale;
+        bool operator==(const _ParameterBuffer& other) const {
+            return linearExposureScale == other.linearExposureScale &&
+                   screenSize[0] == other.screenSize[0] &&
+                   screenSize[1] == other.screenSize[1];
+        }
+    };
+
+    std::unique_ptr<class HdxFullscreenShader> _compositor;
+    _ParameterBuffer _parameterData;
+
+    SdfPath _cameraPath;
+
+    // The multiplier to be applied to the displayed pixels
+    float _linearExposureScale = 1.0f;
+};
+
+
+/// \class HdxLinearExposureScaleTaskParams
+///
+/// LinearExposureScaleTask parameters.
+///
+struct HdxLinearExposureScaleTaskParams
+{
+    SdfPath cameraPath;
+};
+
+// VtValue requirements
+HDX_API
+std::ostream& operator<<(std::ostream& out, const HdxLinearExposureScaleTaskParams& pv);
+HDX_API
+bool operator==(const HdxLinearExposureScaleTaskParams& lhs,
+                const HdxLinearExposureScaleTaskParams& rhs);
+HDX_API
+bool operator!=(const HdxLinearExposureScaleTaskParams& lhs,
+                const HdxLinearExposureScaleTaskParams& rhs);
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hdx/package.cpp
+++ b/pxr/imaging/hdx/package.cpp
@@ -84,6 +84,13 @@ HdxPackageRenderPassShadowShader()
 }
 
 TfToken
+HdxPackageLinearExposureScaleShader()
+{
+    static TfToken shader = _GetShaderPath("linearExposureScale.glslfx");
+    return shader;
+}
+
+TfToken
 HdxPackageColorChannelShader()
 {
     static TfToken shader = _GetShaderPath("colorChannel.glslfx");

--- a/pxr/imaging/hdx/package.h
+++ b/pxr/imaging/hdx/package.h
@@ -20,6 +20,7 @@ TfToken HdxPackageRenderPassColorAndSelectionShader();
 TfToken HdxPackageRenderPassColorWithOccludedSelectionShader();
 TfToken HdxPackageRenderPassPickingShader();
 TfToken HdxPackageRenderPassShadowShader();
+TfToken HdxPackageLinearExposureScaleShader();
 TfToken HdxPackageColorChannelShader();
 TfToken HdxPackageColorCorrectionShader();
 TfToken HdxPackageVisualizeAovShader();

--- a/pxr/imaging/hdx/shaders/linearExposureScale.glslfx
+++ b/pxr/imaging/hdx/shaders/linearExposureScale.glslfx
@@ -1,0 +1,34 @@
+-- glslfx version 0.1
+
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+-- configuration
+{
+    "techniques": {
+        "default": {
+            "LinearExposureScaleFragment": {
+                "source": [ "LinearExposureScale.Fragment" ]
+            }
+        }
+    }
+}
+
+
+-- glsl LinearExposureScale.Fragment
+
+
+void main(void)
+{
+    vec2 fragCoord = uvOut * screenSize;
+    vec4 color = HgiTexelFetch_colorIn(ivec2(fragCoord));
+
+    // Only color, not alpha is exposure scaled!
+    color.rgb *= linearExposureScale;
+
+    hd_FragColor = color;
+}

--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -15,6 +15,7 @@
 #include "pxr/imaging/hdx/colorizeSelectionTask.h"
 #include "pxr/imaging/hdx/colorCorrectionTask.h"
 #include "pxr/imaging/hdx/freeCameraSceneDelegate.h"
+#include "pxr/imaging/hdx/linearExposureScaleTask.h"
 #include "pxr/imaging/hdx/oitRenderTask.h"
 #include "pxr/imaging/hdx/oitResolveTask.h"
 #include "pxr/imaging/hdx/oitVolumeRenderTask.h"
@@ -47,6 +48,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (shadowTask)
     (aovInputTask)
     (selectionTask)
+    (linearExposureScaleTask)
     (colorizeSelectionTask)
     (oitResolveTask)
     (colorCorrectionTask)
@@ -204,6 +206,7 @@ HdxTaskController::~HdxTaskController()
         _selectionTaskId,
         _simpleLightTaskId,
         _shadowTaskId,
+        _linearExposureScaleTaskId,
         _colorizeSelectionTaskId,
         _colorCorrectionTaskId,
         _pickTaskId,
@@ -261,10 +264,12 @@ HdxTaskController::_CreateRenderGraph()
         _renderTaskIds.push_back(_CreateRenderTask(
             HdStMaterialTagTokens->volume));
 
+
         if (_AovsSupported()) {
             _CreateAovInputTask();
             _CreateOitResolveTask();
             _CreateSelectionTask();
+            _CreateLinearExposureScaleTask();
             _CreateColorCorrectionTask();
             _CreateVisualizeAovTask();
             _CreatePresentTask();
@@ -285,6 +290,7 @@ HdxTaskController::_CreateRenderGraph()
         if (_AovsSupported()) {
             if (_gpuEnabled) {
                 _CreateAovInputTask();
+                _CreateLinearExposureScaleTask();
                 _CreateColorizeSelectionTask();
                 _CreateColorCorrectionTask();
                 _CreateVisualizeAovTask();
@@ -445,6 +451,23 @@ HdxTaskController::_CreateSelectionTask()
     _delegate.SetParameter(_selectionTaskId, HdTokens->params,
         selectionParams);
 }
+
+void
+HdxTaskController::_CreateLinearExposureScaleTask()
+{
+    // Create a post-process exposure scaling task.
+    _linearExposureScaleTaskId = GetControllerId().AppendChild(
+        _tokens->linearExposureScaleTask);
+
+    HdxLinearExposureScaleTaskParams linearExposureScaleParams;
+
+    GetRenderIndex()->InsertTask<HdxLinearExposureScaleTask>(&_delegate,
+        _linearExposureScaleTaskId);
+
+    _delegate.SetParameter(_linearExposureScaleTaskId, HdTokens->params,
+        linearExposureScaleParams);
+}
+
 
 void
 HdxTaskController::_CreateColorizeSelectionTask()
@@ -642,6 +665,12 @@ HdxTaskController::_SelectionEnabled() const
 }
 
 bool
+HdxTaskController::_LinearExposureScaleEnabled() const
+{
+    return _viewportAov == HdAovTokens->color;
+}
+
+bool
 HdxTaskController::_ColorizeSelectionEnabled() const
 {
     if (_viewportAov == HdAovTokens->color) {
@@ -708,6 +737,7 @@ HdxTaskController::GetRenderingTaskPaths() const
      * - aovInputTaskId
      * - boundingBoxTaskId
      * - selectionTaskId
+     * - linearExposureScaleTaskId
      * - colorizeSelectionTaskId
      * - colorCorrectionTaskId
      * - visualizeAovTaskId
@@ -762,6 +792,10 @@ HdxTaskController::GetRenderingTaskPaths() const
 
     if (!_selectionTaskId.IsEmpty() && _SelectionEnabled()) {
         paths.push_back(_selectionTaskId);
+    }
+
+    if (!_linearExposureScaleTaskId.IsEmpty() && _LinearExposureScaleEnabled()) {
+        paths.push_back(_linearExposureScaleTaskId);
     }
 
     if (!_colorizeSelectionTaskId.IsEmpty() && _ColorizeSelectionEnabled()) {
@@ -2061,6 +2095,18 @@ HdxTaskController::_SetCameraParamForTasks(SdfPath const& id)
             GetRenderIndex()->GetChangeTracker().MarkTaskDirty(
                 _pickFromRenderBufferTaskId, HdChangeTracker::DirtyParams);
         }
+
+        if (!_linearExposureScaleTaskId.IsEmpty()) {
+            HdxLinearExposureScaleTaskParams params =
+                _delegate.GetParameter<HdxLinearExposureScaleTaskParams>(
+                    _linearExposureScaleTaskId, HdTokens->params);
+            params.cameraPath = _activeCameraId;
+            _delegate.SetParameter(_linearExposureScaleTaskId, HdTokens->params,
+                                   params);
+            GetRenderIndex()->GetChangeTracker().MarkTaskDirty(
+                _linearExposureScaleTaskId, HdChangeTracker::DirtyParams);
+        }
+
     }
 }
 

--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -292,6 +292,7 @@ private:
     SdfPath _CreateRenderTask(TfToken const& materialTag);
     void _CreateOitResolveTask();
     void _CreateSelectionTask();
+    void _CreateLinearExposureScaleTask();
     void _CreateColorizeSelectionTask();
     void _CreateColorCorrectionTask();
     void _CreateVisualizeAovTask();
@@ -312,6 +313,7 @@ private:
     bool _ShadowsEnabled() const;
     bool _SelectionEnabled() const;
     bool _ColorizeSelectionEnabled() const;
+    bool _LinearExposureScaleEnabled() const;
     bool _ColorCorrectionEnabled() const;
     bool _VisualizeAovEnabled() const;
     bool _ColorizeQuantizationEnabled() const;
@@ -406,6 +408,7 @@ private:
     SdfPath _aovInputTaskId;
     SdfPath _oitResolveTaskId;
     SdfPath _selectionTaskId;
+    SdfPath _linearExposureScaleTaskId;
     SdfPath _colorizeSelectionTaskId;
     SdfPath _colorCorrectionTaskId;
     SdfPath _visualizeAovTaskId;

--- a/pxr/imaging/hdx/tokens.h
+++ b/pxr/imaging/hdx/tokens.h
@@ -63,6 +63,7 @@ TF_DECLARE_PUBLIC_TOKENS(HdxTokens, HDX_API, HDX_TOKENS);
     (colorizeSelectionTask)     \
     (drawTargetTask)            \
     (drawTargetResolveTask)     \
+    (linearExposureScaleTask)   \
     (oitRenderTask)             \
     (oitResolveTask)            \
     (oitVolumeRenderTask)       \


### PR DESCRIPTION
### Description of Change(s)

This is a follow-up / add-on to the PR which adds camera exposure controls:

- #3085

It adds `HdxExposureScaleTask` to allow visualization of the camera exposure controls in Storm.

See here to just see the additional changes, vs #3085:
- https://github.com/anderslanglands/USD/pull/2/files

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
