### PR TITLE
fix typo

### DIFF
--- a/pxr/imaging/hdx/taskController.h
+++ b/pxr/imaging/hdx/taskController.h
@@ -137,7 +137,7 @@ public:
     /// -------------------------------------------------------
     /// Camera and Framing API
     
-    /// Set the size of the render buffers baking the AOVs.
+    /// Set the size of the render buffers backing the AOVs.
     /// GUI applications should set this to the size of the window.
     ///
     HDX_API


### PR DESCRIPTION
### Description of Change(s)

Fixed typo. Baking should be backing (I believe). Can be confusing as baking is used when talking about pre-rendered shadows.

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[typo fix] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[typo fix] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
