### PR TITLE
[gf] Update TF_FOR_ALL to C++11 iterator

### DIFF
--- a/pxr/base/gf/multiInterval.cpp
+++ b/pxr/base/gf/multiInterval.cpp
@@ -28,8 +28,8 @@ GfMultiInterval::GfMultiInterval(const GfInterval &i)
 
 GfMultiInterval::GfMultiInterval(const std::vector<GfInterval> &intervals)
 {
-    TF_FOR_ALL(i, intervals)
-        Add(*i);
+    for(const auto& i: intervals)
+        Add(i);
 }
 
 size_t
@@ -94,8 +94,8 @@ GfMultiInterval::Contains(const GfMultiInterval & s) const
     if (s.IsEmpty()) {
         return false;
     }
-    TF_FOR_ALL(i, s) {
-        if (!Contains(*i)) {
+    for(const auto& i: s) {
+        if (!Contains(i)) {
             return false;
         }
     }
@@ -178,8 +178,8 @@ GfMultiInterval::GetContainingInterval( double x ) const
 void
 GfMultiInterval::Add( const GfMultiInterval &intervals )
 {
-    TF_FOR_ALL(i, intervals)
-        Add(*i);
+    for(const auto& i: intervals)
+        Add(i);
 }
 
 void
@@ -231,8 +231,8 @@ GfMultiInterval::Add( const GfInterval & interval )
 void
 GfMultiInterval::Remove( const GfMultiInterval &intervals )
 {
-    TF_FOR_ALL(i, intervals)
-        Remove(*i);
+    for(const auto& i: intervals)
+        Remove(i);
 }
 
 // Remove interval j from interval at iterator i, inserting new intervals
@@ -284,16 +284,16 @@ GfMultiInterval::GetComplement() const
 {
     GfMultiInterval r;
     GfInterval workingInterval = GfInterval::GetFullInterval();
-    TF_FOR_ALL(i, _set) {
+    for(const auto& i: _set) {
         // Insert interval prior to *i.
-        workingInterval.SetMax( i->GetMin(), !i->IsMinClosed() );
+        workingInterval.SetMax( i.GetMin(), !i.IsMinClosed() );
         if (!workingInterval.IsEmpty()) {
             r._set.insert(/* hint */ r._set.end(), workingInterval);
         }
 
         // Set up next interval.
         workingInterval = GfInterval::GetFullInterval();
-        workingInterval.SetMin( i->GetMax(), !i->IsMaxClosed() );
+        workingInterval.SetMin( i.GetMax(), !i.IsMaxClosed() );
     }
     if (!workingInterval.IsEmpty()) {
         r._set.insert(/* hint */ r._set.end(), workingInterval);
@@ -337,8 +337,8 @@ void
 GfMultiInterval::ArithmeticAdd( const GfInterval &i )
 {
     GfMultiInterval result;
-    TF_FOR_ALL(it, *this) {
-        result.Add(*it + i);
+    for(const auto& it: *this) {
+        result.Add(it + i);
     }
 
     swap(result);
@@ -349,10 +349,10 @@ operator<<(std::ostream &out, const GfMultiInterval &s)
 {
     out << "[";
     bool first = true;
-    TF_FOR_ALL(interval, s) {
+    for(const auto& interval: s) {
         if (!first)
             out << ", ";
-        out << Gf_OstreamHelperP(*interval);
+        out << Gf_OstreamHelperP(interval);
         first = false;
     }
     out << "]";

--- a/pxr/base/gf/wrapMultiInterval.cpp
+++ b/pxr/base/gf/wrapMultiInterval.cpp
@@ -32,10 +32,10 @@ _Repr(GfMultiInterval const &self)
     if (!self.IsEmpty()) {
         r += "[";
         int count = 0;
-        TF_FOR_ALL(i, self) {
+        for(const auto& i : self) {
             if (count)
                 r += ", ";
-            r += TfPyRepr(*i);
+            r += TfPyRepr(i);
             count++;
         }
         r += "]";


### PR DESCRIPTION
### Description of Change(s)

Update files under `pxr/base/gf` by replacing `TF_FOR_ALL` with C++11-style range-based for each loop.
Additionally, updated pointer usage to align with the new iterator approach, since we now handle references directly rather than raw pointers.

### Ongoing Issue(s)

This PR addresses issue #80, though many more instances still need to be resolved. Given the age of this issue (approximately 6–7 years), I wanted to reopen the discussion to evaluate its relevance. Specifically, is the header iterator.h still necessary?

Previous attempts to address this issue (e.g., https://github.com/PixarAnimationStudios/OpenUSD/pull/398) have been closed without further updates to the thread. I look forward to hearing thoughts on whether we should proceed with this.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
