### PR TITLE
Autodesk: Expose additional header files in pxr/imaging/hdSt in the USD package

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -69,6 +69,7 @@ pxr_library(hdSt
         dependencySceneIndexPlugin
         dispatchBuffer
         domeLightComputations
+        drawBatch
         drawItem
         drawItemInstance
         drawTarget
@@ -93,6 +94,7 @@ pxr_library(hdSt
         hioConversions
         imageShaderRenderPass
         implicitSurfaceSceneIndexPlugin
+        indirectDrawBatch
         nurbsApproximatingSceneIndexPlugin
         instancer
         interleavedMemoryManager
@@ -100,8 +102,10 @@ pxr_library(hdSt
         lightingShader
         material
         materialNetwork
+        materialNetworkShader
         mesh
         package
+        pipelineDrawBatch
         points
         primUtils
         ptexTextureObject
@@ -111,10 +115,12 @@ pxr_library(hdSt
         renderPass
         renderPassShader
         renderPassState
+        resourceBinder
         resourceRegistry
         samplerObject
         samplerObjectRegistry
         shaderCode
+        shaderKey
         simpleLightingShader
         smoothNormals
         stagingBuffer
@@ -150,7 +156,6 @@ pxr_library(hdSt
         basisCurvesTopology
         codeGen
         cullingShaderKey
-        drawBatch
         drawItemsCache
         extCompComputeShader
         extCompComputedInputSource
@@ -158,8 +163,6 @@ pxr_library(hdSt
         extCompSceneInputSource
         fieldTextureCpuData
         imageShaderShaderKey
-        indirectDrawBatch
-        materialNetworkShader
         materialBindingResolvingSceneIndexPlugin
         materialPrimvarTransferSceneIndexPlugin
         materialParam
@@ -167,12 +170,9 @@ pxr_library(hdSt
         meshTopology 
         nodeIdentifierResolvingSceneIndex
         nodeIdentifierResolvingSceneIndexPlugin
-        pipelineDrawBatch
         pointsShaderKey
         quadrangulate
         renderPassShaderKey
-        resourceBinder
-        shaderKey
         subdivision
         triangulate
         unitTestHelper


### PR DESCRIPTION
### Description of Change(s)

There are lots of files missing in the pxr/imaging/hdSt folder in the final package compared to the original source. Many of them are indispensable if we would like to use raw DrawItem. In additional, the classes in those missing files are all DLL exported. There are good reasons to expose them.  

- shaderKey.h
- drawBatch.h
- pipelineDrawBatch.h
- indirectDrawBatch.h
- materialNetworkShader.h
- resourceBinder.h

Also verified that making them public doesn't introduce symbol changes.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
