### PR TITLE
[sdf] Fix Sdf_Children<ChildPolicy>::Find to return correct value

### DIFF
--- a/pxr/usd/sdf/children.cpp
+++ b/pxr/usd/sdf/children.cpp
@@ -86,19 +86,18 @@ size_t
 Sdf_Children<ChildPolicy>::Find(const KeyType &key) const
 {
     if (!TF_VERIFY(IsValid())) {
-        return 0;
+        return _childNames.size();
     }
 
     _UpdateChildNames();
 
     const FieldType expectedKey(_keyPolicy.Canonicalize(key));
-    size_t i = 0;
-    for (i=0; i < _childNames.size(); i++) {
+    for (size_t i=0; i < _childNames.size(); i++) {
         if (_childNames[i] == expectedKey) {
-            break;
+            return i;
         }
     }
-    return i;
+    return _childNames.size();
 }
 
 template<class ChildPolicy>

--- a/pxr/usd/sdf/testenv/testSdfPrim.py
+++ b/pxr/usd/sdf/testenv/testSdfPrim.py
@@ -79,6 +79,31 @@ class TestSdfPrim(unittest.TestCase):
                 print("     previous list {0}".format(prevGroundTruthList))
                 self.fail("Prim insertion test failed")
 
+    def test_NameChildrenFind(self):
+        layer = Sdf.Layer.CreateAnonymous("test")
+        rootPrim = Sdf.PrimSpec(layer, 'Root', Sdf.SpecifierDef, 'Scope')
+
+        # find the index of a non-existent prim with no children
+        index = rootPrim.nameChildren.index('nonexistent')
+        self.assertEqual(index, -1)
+
+        # insert some child prims to find
+        for i in range(10):
+            primName = 'geom{0}'.format(i)
+            primSpec = Sdf.PrimSpec(layer, primName, Sdf.SpecifierDef, 'Scope')
+
+            rootPrim.nameChildren.insert(i, primSpec)
+
+        # find the index of the prims
+        for i in range(10):
+            primName = 'geom{0}'.format(i)
+            index = rootPrim.nameChildren.index(primName)
+            self.assertEqual(index, i)
+        
+        # find the index of a non-existent prim
+        index = rootPrim.nameChildren.index('nonexistent')
+        self.assertEqual(index, -1)
+
     def test_InertSpecRemoval(self):
         layer = Sdf.Layer.CreateAnonymous()
 


### PR DESCRIPTION
In most cases, Sdf_Children<ChildPolicy>::Find would return the incorrect value of 0 instead the size of _childNames. This would incorrectly index into the first element when a match was not found

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[x] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
