### PR TITLE
Add missing #include <cstdint>

### DIFF
--- a/pxr/usd/usd/zipFile.h
+++ b/pxr/usd/usd/zipFile.h
@@ -10,6 +10,7 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/usd/api.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>


### PR DESCRIPTION
Fixes failure to compile with GCC 15

### Description of Change(s)

Adds `#include <cstdint>` in `pxr/usd/usd/zipFile.h` for `uint16_t`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A; this is a trivial change.

### Fixes Issue(s)

No issue filed, but this fixes failure to build with GCC 15 (pre-release).

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

*N/A*

[ ] I have verified that all unit tests pass with the proposed changes

*N/A* – I cannot easily run the unit tests, but this cannot affect them

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
