### PR TITLE
Fix UDIM path resolution for scene index plugins

### DIFF
--- a/pxr/usdImaging/usdImaging/dataSourceAttribute.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceAttribute.cpp
@@ -8,9 +8,77 @@
 
 #include "pxr/imaging/hd/dataSourceLocator.h"
 
+#include "pxr/usd/usdShade/udimUtils.h"
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
+
+// We need to find the first layer that changes the value
+// of the parameter so that we anchor relative paths to that.
+static
+SdfLayerHandle
+_FindLayerHandle(const UsdAttribute& attr, const UsdTimeCode& time) {
+    for (const auto& spec: attr.GetPropertyStack(time)) {
+        if (spec->HasDefaultValue() ||
+            spec->GetLayer()->GetNumTimeSamplesForPath(
+                spec->GetPath()) > 0) {
+            return spec->GetLayer();
+        }
+    }
+    return TfNullPtr;
+}
+
+class UsdImagingDataSourceAssetPathAttribute :
+    public UsdImagingDataSourceAttribute<SdfAssetPath>
+{
+public:
+    HD_DECLARE_DATASOURCE(UsdImagingDataSourceAssetPathAttribute);
+
+    /// Returns the extracted SdfAssetPath value of the attribute at
+    /// \p shutterOffset, with proper handling for UDIM paths.
+    SdfAssetPath
+    GetTypedValue(HdSampledDataSource::Time shutterOffset) override
+    {
+        // Zero-initialization for numerical types.
+        SdfAssetPath result{};
+        UsdTimeCode time = _stageGlobals.GetTime();
+        if (time.IsNumeric()) {
+            time = UsdTimeCode(time.GetValue() + shutterOffset);
+        }
+        _usdAttrQuery.Get<SdfAssetPath>(&result, time);
+        if (UsdShadeUdimUtils::IsUdimIdentifier(result.GetAssetPath())) {
+            const std::string resolvedPath =
+                UsdShadeUdimUtils::ResolveUdimPath(result.GetAssetPath(),
+                    _FindLayerHandle(_usdAttrQuery.GetAttribute(), time));
+            if (!resolvedPath.empty()) {
+                result = SdfAssetPath(result.GetAssetPath(), resolvedPath);
+            }
+        }
+        return result;
+    }
+
+protected:
+    UsdImagingDataSourceAssetPathAttribute(
+            const UsdAttribute &usdAttr,
+            const UsdImagingDataSourceStageGlobals &stageGlobals,
+            const SdfPath &sceneIndexPath = SdfPath::EmptyPath(),
+            const HdDataSourceLocator &timeVaryingFlagLocator =
+                    HdDataSourceLocator::EmptyLocator())
+        : UsdImagingDataSourceAttribute<SdfAssetPath>(usdAttr,
+            stageGlobals, sceneIndexPath, timeVaryingFlagLocator)
+    { }
+
+    UsdImagingDataSourceAssetPathAttribute(
+            const UsdAttributeQuery &usdAttrQuery,
+            const UsdImagingDataSourceStageGlobals &stageGlobals,
+            const SdfPath &sceneIndexPath = SdfPath::EmptyPath(),
+            const HdDataSourceLocator &timeVaryingFlagLocator =
+                    HdDataSourceLocator::EmptyLocator())
+        : UsdImagingDataSourceAttribute<SdfAssetPath>(usdAttrQuery,
+            stageGlobals, sceneIndexPath, timeVaryingFlagLocator)
+    { }
+};
 
 typedef HdSampledDataSourceHandle (*_DataSourceFactory)(
         const UsdAttributeQuery &usdAttrQuery,
@@ -29,6 +97,17 @@ HdSampledDataSourceHandle _FactoryImpl(
         const HdDataSourceLocator &timeVaryingFlagLocator)
 {
     return UsdImagingDataSourceAttribute<T>::New(
+            usdAttrQuery, stageGlobals, sceneIndexPath, timeVaryingFlagLocator);
+}
+
+template <>
+HdSampledDataSourceHandle _FactoryImpl<SdfAssetPath>(
+        const UsdAttributeQuery &usdAttrQuery,
+        const UsdImagingDataSourceStageGlobals &stageGlobals,
+        const SdfPath &sceneIndexPath,
+        const HdDataSourceLocator &timeVaryingFlagLocator)
+{
+    return UsdImagingDataSourceAssetPathAttribute::New(
             usdAttrQuery, stageGlobals, sceneIndexPath, timeVaryingFlagLocator);
 }
 

--- a/pxr/usdImaging/usdImaging/dataSourceAttribute.h
+++ b/pxr/usdImaging/usdImaging/dataSourceAttribute.h
@@ -106,7 +106,10 @@ public:
         return outSampleTimes->size() > 1;
     }
 
-private:
+protected:
+    /// Constructors and member data are protected instead of private
+    /// for use by a specialized subclass for accessing SdfAssetPath
+    /// attributes which need special handling for UDIMs.
 
     /// Constructs a new UsdImagingDataSourceAttribute for the given \p usdAttr
     ///
@@ -137,7 +140,6 @@ private:
             const HdDataSourceLocator &timeVaryingFlagLocator =
                     HdDataSourceLocator::EmptyLocator());
 
-private:
     UsdAttributeQuery _usdAttrQuery;
     const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };


### PR DESCRIPTION
### Description of Change(s)

Implement a specialization of UsdImagingDataSourceAttribute<SdfAssetPath>
that properly resolves UDIM relative paths.

Note that I have not created a unit test, or run the unit tests yet. I'm posting this PR early because there is an obvious issue that I want to discuss, namely the correct "location" for this code change. This change, as is, will affect _all_ SdfAssetPath attributes read from USD and accessed by hydra. It is not clear to me if this is a good thing or a bad thing.

If it's a bad thing, I can take this UsdImagingDataSourceAttribute<SdfAssetPath> sepcialization and move it to dataSourceMaterial.cpp instead. Then in _UsdImagingDataSourceShadingNodeParameters::Get, I can conditionally create this data source for SdfAssetPath attributes instead of calling UsdImagingDataSourceAttributeNew to get the "standard" SdfAssetPath handler.

Alternatively, UsdImagingDataSourceAssetPathAttribute could be defined and implemented in dataSourceAttribute.h/cpp, but the standard factory would still return a vanilla UsdImagingDataSourceAttribute<SdfAssetPath>. But in dataSourceMaterial.cpp I could introduce the condition to use UsdImagingDataSourceAssetPathAttribute  for SdfAssetPath attributes. This has the nice feature that if any other scene index code wants to support UDIM translation, the specialized subclass can be shared.

I personally think the universality might be a good thing as if some renderer supports UDIMs on a procedural or other custom prim type, they won't have to jump through hoops or create a custom data source to handle that case. The downside is every time hydra accesses an SdfAssetPath attribute, we will scan that string looking for "<UDIM>". To me this seems like a small price, but happy to accept Pixar's judgement on this and alter this PR as needed.

### Fixes Issue(s)
#3492 

### Checklist

[ X ] I have created this PR based on the dev branch

[ X ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[ X ] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
