### PR TITLE
Adding better Int16 support to HdFormat helpers

### DIFF
--- a/pxr/imaging/hd/types.cpp
+++ b/pxr/imaging/hd/types.cpp
@@ -424,13 +424,23 @@ HdFormat HdGetComponentFormat(HdFormat f)
     case HdFormatFloat32Vec3:
     case HdFormatFloat32Vec4:
         return HdFormatFloat32;
-    case HdFormatFloat32UInt8:
-        return HdFormatFloat32UInt8; // treat as a single component
+    case HdFormatInt16:
+    case HdFormatInt16Vec2:
+    case HdFormatInt16Vec3:
+    case HdFormatInt16Vec4:
+        return HdFormatInt16;
+    case HdFormatUInt16:
+    case HdFormatUInt16Vec2:
+    case HdFormatUInt16Vec3:
+    case HdFormatUInt16Vec4:
+        return HdFormatUInt16;
     case HdFormatInt32:
     case HdFormatInt32Vec2:
     case HdFormatInt32Vec3:
     case HdFormatInt32Vec4:
         return HdFormatInt32;
+    case HdFormatFloat32UInt8:
+        return HdFormatFloat32UInt8; // treat as a single component
     default:
         return HdFormatInvalid;
     }
@@ -443,18 +453,24 @@ size_t HdGetComponentCount(HdFormat f)
     case HdFormatSNorm8Vec2:
     case HdFormatFloat16Vec2:
     case HdFormatFloat32Vec2:
+    case HdFormatInt16Vec2:
+    case HdFormatUInt16Vec2:
     case HdFormatInt32Vec2:
         return 2;
     case HdFormatUNorm8Vec3:
     case HdFormatSNorm8Vec3:
     case HdFormatFloat16Vec3:
     case HdFormatFloat32Vec3:
+    case HdFormatInt16Vec3:
+    case HdFormatUInt16Vec3:
     case HdFormatInt32Vec3:
         return 3;
     case HdFormatUNorm8Vec4:
     case HdFormatSNorm8Vec4:
     case HdFormatFloat16Vec4:
     case HdFormatFloat32Vec4:
+    case HdFormatInt16Vec4:
+    case HdFormatUInt16Vec4:
     case HdFormatInt32Vec4:
         return 4;
     default:
@@ -478,12 +494,20 @@ size_t HdDataSizeOfFormat(HdFormat f)
     case HdFormatSNorm8Vec4:
         return 4;
     case HdFormatFloat16:
+    case HdFormatInt16:
+    case HdFormatUInt16:
         return 2;
     case HdFormatFloat16Vec2:
+    case HdFormatInt16Vec2:
+    case HdFormatUInt16Vec2:
         return 4;
     case HdFormatFloat16Vec3:
+    case HdFormatInt16Vec3:
+    case HdFormatUInt16Vec3:
         return 6;
     case HdFormatFloat16Vec4:
+    case HdFormatInt16Vec4:
+    case HdFormatUInt16Vec4:
         return 8;
     case HdFormatFloat32:
     case HdFormatInt32:


### PR DESCRIPTION
### Description of Change(s)

Adding better support for UInt16, Int16 and Vec2,3,4 versions of these to the Hd helper functions.

This provides full HdFormat coverage to these functions now (i.e., it was only the Int16 formats missing)

### Fixes Issue(s)

#3496

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
