### PR TITLE
hdPrman: MaterialX compile fix for version 1.39.x

### DIFF
--- a/third_party/renderman-26/plugin/hdPrman/matfiltMaterialX.cpp
+++ b/third_party/renderman-26/plugin/hdPrman/matfiltMaterialX.cpp
@@ -820,7 +820,11 @@ _NodeHasTextureCoordPrimvar(
         // for texture coordinates. 
         auto geompropvalueNodes = nodegraph->getNodes(_tokens->geompropvalue);
         for (const mx::NodePtr& mxGeomPropNode : geompropvalueNodes) {
+#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
             if (mxGeomPropNode->getType() == mx::Type::VECTOR2->getName()) {
+#else
+            if (mxGeomPropNode->getType() == mx::Type::VECTOR2.getName()) {
+#endif
                 return true;
             }
         }


### PR DESCRIPTION
### Description of Change(s)

Recently MaterialX 1.39.x+ has had an API change where it was mostly addressed in https://github.com/PixarAnimationStudios/OpenUSD/pull/3159 however the hdPrman hydra delegate has a small bit of code which needed updating for it to compile.

### Fixes Issue(s)

- Compile fix for hdPrman when building against MaterialX 1.39.x+

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[x] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
