### PR TITLE
Autodesk: Fix testHdStTextureHandleRegistry image copy

### DIFF
--- a/pxr/imaging/hdSt/testenv/testHdStTextureHandleRegistry.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStTextureHandleRegistry.cpp
@@ -349,8 +349,9 @@ My_TestGLDrawing::OffscreenTest()
                 
         {
             TfDeleteFile("reloadingTexture.png");
-            std::ifstream src("reloadingTexture2.png");
-            std::ofstream dst("reloadingTexture.png");
+            constexpr auto mode = std::ios_base::binary;
+            std::ifstream src{"reloadingTexture2.png", mode};
+            std::ofstream dst{"reloadingTexture.png", mode};
             
             dst << src.rdbuf();
         }


### PR DESCRIPTION
### Description of Change(s)

Copying binary data in text mode can cause problems on some locales.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
