### PR TITLE
Add ZLIB to requiredDependencies if HDF5 is enabled

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2464,7 +2464,7 @@ if context.buildBoostPython:
 
 if context.buildAlembic:
     if context.enableHDF5:
-        requiredDependencies += [HDF5]
+        requiredDependencies += [ZLIB, HDF5]
     requiredDependencies += [OPENEXR, ALEMBIC]
 
 if context.buildDraco:


### PR DESCRIPTION
### Description of Change(s)

Alembic requires ZLIB, but only in the case that HDF5 support is enabled. Since we are selectively adding zlib as a dependency, we need to append zlib to `requiredDependencies` if HDF5 is enabled in the build context. This fixes alembic build failures on Windows.

### Fixes Issue(s)

This is an extension of #2988 which was selectively adding zlib as a dependency based on other active dependencies.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have submitted a signed Contributor License Agreement
