### PR TITLE
Autodesk: Reduce GPU memory usage of testHdStBarAllocationLimit and testHdStBufferAggregation

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -779,6 +779,7 @@ pxr_register_test(testHdStBarAllocationLimit
     TESTENV testHdStBarAllocationLimit
     ENV
         TF_DEBUG=HD_SAFE_MODE
+        HD_MAX_VBO_SIZE=268435456 # 2^28
 )
 pxr_register_test(testHdStBasicDrawing_Adaptive_lighting_lv1_hull
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStBasicDrawing --offscreen --lighting --repr hull --refineLevel 1 --write testHdStBasicDrawing_adaptive_lighting_lv1_hull.png"
@@ -2320,6 +2321,7 @@ pxr_register_test(testHdStBufferAggregation
     TESTENV testHdStBufferAggregation
     ENV
         TF_DEBUG=HD_SAFE_MODE
+        HD_MAX_VBO_SIZE=268435456 # 2^28
 )
 pxr_register_test(testHdStBufferArray
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStBufferArray"

--- a/pxr/imaging/hdSt/testenv/testHdStBarAllocationLimit.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStBarAllocationLimit.cpp
@@ -8,6 +8,7 @@
 #include "pxr/imaging/hd/tokens.h"
 #include "pxr/imaging/hdSt/unitTestGLDrawing.h"
 #include "pxr/imaging/hdSt/unitTestHelper.h"
+#include "pxr/imaging/hdSt/vboMemoryManager.h"
 
 #include "pxr/imaging/hgi/capabilities.h"
 
@@ -15,7 +16,6 @@
 #include "pxr/base/gf/rotation.h"
 #include "pxr/base/gf/vec3d.h"
 #include "pxr/base/tf/errorMark.h"
-#include "pxr/base/tf/diagnostic.h"
 
 #include <iostream>
 #include <vector>
@@ -120,8 +120,8 @@ My_TestGLDrawing::AddLargeCurve(HdUnitTestDelegate *delegate)
 {
     HdInterpolation colorInterp, widthInterp, opacityInterp;
     colorInterp = widthInterp = opacityInterp = HdInterpolationConstant;
-    
-    static constexpr size_t vboMaxSize = 1 << 30; // default for HD_MAX_VBO_SIZE
+
+    static size_t vboMaxSize = TfGetEnvSetting(HD_MAX_VBO_SIZE);
     const size_t storageMaxSize = _driver->GetHgi()->GetCapabilities()->
         GetMaxShaderStorageBlockSize();
     const size_t maxPointsInVBO = std::min(storageMaxSize, vboMaxSize) / sizeof(GfVec3f);

--- a/pxr/imaging/hdSt/vboMemoryManager.cpp
+++ b/pxr/imaging/hdSt/vboMemoryManager.cpp
@@ -24,7 +24,6 @@
 
 #include "pxr/base/arch/hash.h"
 #include "pxr/base/tf/diagnostic.h"
-#include "pxr/base/tf/envSetting.h"
 #include "pxr/base/tf/iterator.h"
 #include "pxr/base/tf/enum.h"
 

--- a/pxr/imaging/hdSt/vboMemoryManager.h
+++ b/pxr/imaging/hdSt/vboMemoryManager.h
@@ -8,23 +8,26 @@
 #define PXR_IMAGING_HD_ST_VBO_MEMORY_MANAGER_H
 
 #include "pxr/pxr.h"
+
+#include "pxr/base/tf/envSetting.h"
+
 #include "pxr/imaging/hdSt/api.h"
 #include "pxr/imaging/hdSt/strategyBase.h"
+#include "pxr/imaging/hdSt/bufferArrayRange.h"
 
 #include "pxr/imaging/hgi/enums.h"
 
 #include "pxr/imaging/hd/bufferArray.h"
-#include "pxr/imaging/hdSt/bufferArrayRange.h"
 #include "pxr/imaging/hd/bufferSpec.h"
 #include "pxr/imaging/hd/bufferSource.h"
-
-#include "pxr/base/tf/mallocTag.h"
-#include "pxr/base/tf/token.h"
 
 #include <list>
 #include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+HDST_API
+extern TfEnvSetting<int> HD_MAX_VBO_SIZE;
 
 class HdStResourceRegistry;
 

--- a/pxr/imaging/hdSt/vboSimpleMemoryManager.cpp
+++ b/pxr/imaging/hdSt/vboSimpleMemoryManager.cpp
@@ -11,6 +11,7 @@
 #include "pxr/imaging/hdSt/bufferResource.h"
 #include "pxr/imaging/hdSt/bufferUtils.h"
 #include "pxr/imaging/hdSt/tokens.h"
+#include "pxr/imaging/hdSt/vboMemoryManager.h"
 #include "pxr/imaging/hdSt/vboSimpleMemoryManager.h"
 
 #include "pxr/imaging/hd/bufferArrayRange.h"
@@ -30,8 +31,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
-extern TfEnvSetting<int> HD_MAX_VBO_SIZE;
 
 // ---------------------------------------------------------------------------
 //  HdStVBOSimpleMemoryManager

--- a/pxr/imaging/hgiVulkan/CMakeLists.txt
+++ b/pxr/imaging/hgiVulkan/CMakeLists.txt
@@ -47,6 +47,7 @@ pxr_library(hgiVulkan
         vulkan.h
 
     PRIVATE_CLASSES
+        debugCodes
         spirv_reflect
 
     RESOURCE_FILES

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -5,12 +5,15 @@
 // https://openusd.org/license.
 //
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/envSetting.h"
 
 #include "pxr/imaging/hgiVulkan/capabilities.h"
+
 #include "pxr/imaging/hgiVulkan/device.h"
 #include "pxr/imaging/hgiVulkan/diagnostic.h"
+#include "pxr/imaging/hgiVulkan/debugCodes.h"
 
-#include "pxr/base/tf/envSetting.h"
+#include <iostream>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -18,6 +21,63 @@ TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_MULTI_DRAW_INDIRECT, true,
                       "Use Vulkan multi draw indirect");
 TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_BUILTIN_BARYCENTRICS, false,
                       "Use Vulkan built in barycentric coordinates");
+
+static void _DumpDeviceDeviceMemoryProperties(
+    const VkPhysicalDeviceMemoryProperties& vkMemoryProperties)
+{
+    std::cout << "Vulkan memory info:\n";
+    for (uint32_t heapIndex = 0;
+            heapIndex < vkMemoryProperties.memoryHeapCount; heapIndex++) {
+        std::cout << "Heap " << heapIndex << ":\n";
+        const auto& heap = vkMemoryProperties.memoryHeaps[heapIndex];
+        std::cout << "    Size: " << heap.size << "\n";
+        std::cout << "    Flags:";
+        if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+            std::cout << " DEVICE_LOCAL";
+        }
+        if (heap.flags & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT) {
+            std::cout << " MULTI_INSTANCE";
+        }
+        std::cout << "\n";
+
+        for (uint32_t typeIndex = 0;
+                typeIndex < vkMemoryProperties.memoryTypeCount; typeIndex++) {
+            const auto& memoryType = vkMemoryProperties.memoryTypes[typeIndex];
+            if (memoryType.heapIndex != heapIndex) {
+                continue;
+            }
+
+            std::cout << "    Memory type " << typeIndex << ":\n";
+            std::cout << "        Flags:";
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) {
+                std::cout << " DEVICE_LOCAL";
+            }
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+                std::cout << " HOST_VISIBLE";
+            }
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) {
+                std::cout << " HOST_COHERENT";
+            }
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_HOST_CACHED_BIT) {
+                std::cout << " HOST_CACHED";
+            }
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
+                std::cout << " LAZILY_ALLOCATED";
+            }
+            if (memoryType.propertyFlags &
+                    VK_MEMORY_PROPERTY_PROTECTED_BIT) {
+                std::cout << " PROTECTED";
+            }
+            std::cout << "\n";
+        }
+    }
+    std::cout << std::flush;
+}
 
 HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     : supportsTimeStamps(false)
@@ -45,6 +105,10 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     vkGetPhysicalDeviceProperties(physicalDevice, &vkDeviceProperties);
     vkGetPhysicalDeviceFeatures(physicalDevice, &vkDeviceFeatures);
     vkGetPhysicalDeviceMemoryProperties(physicalDevice, &vkMemoryProperties);
+
+    if (TfDebug::IsEnabled(HGIVULKAN_DUMP_DEVICE_MEMORY_PROPERTIES)) {
+        _DumpDeviceDeviceMemoryProperties(vkMemoryProperties);
+    }
 
     // Vertex attribute divisor properties ext
     vkVertexAttributeDivisorProperties.sType =
@@ -147,7 +211,7 @@ HgiVulkanCapabilities::~HgiVulkanCapabilities() = default;
 int
 HgiVulkanCapabilities::GetAPIVersion() const
 {
-    return vkDeviceProperties.apiVersion;
+    return static_cast<int>(vkDeviceProperties.apiVersion);
 }
 
 int

--- a/pxr/imaging/hgiVulkan/debugCodes.cpp
+++ b/pxr/imaging/hgiVulkan/debugCodes.cpp
@@ -1,0 +1,22 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/imaging/hgiVulkan/debugCodes.h"
+
+#include "pxr/base/tf/debug.h"
+#include "pxr/base/tf/registryManager.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_REGISTRY_FUNCTION(TfDebug)
+{
+     TF_DEBUG_ENVIRONMENT_SYMBOL(HGIVULKAN_DUMP_DEVICE_MEMORY_PROPERTIES,
+        "Dump the output of vkGetPhysicalDeviceMemoryProperties");
+}
+
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/debugCodes.h
+++ b/pxr/imaging/hgiVulkan/debugCodes.h
@@ -1,0 +1,23 @@
+
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HGIVULKAN_DEBUGCODES_H
+#define PXR_IMAGING_HGIVULKAN_DEBUGCODES_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/debug.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+TF_DEBUG_CODES(
+    HGIVULKAN_DUMP_DEVICE_MEMORY_PROPERTIES
+);
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_IMAGING_HGIVULKAN_DEBUGCODES_H


### PR DESCRIPTION
### Description of Change(s)

- Scale the memory usage off `testHdStBarAllocationLimit` and `testHdStBufferAggregation` according to `HD_MAX_VBO_SIZE`, and reduce its value during tests so they pass on a 4GB GPU
- Add some debug code to dump the Vulkan device memory properties. Useful for debugging memory issues when you don't have access to the device.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
