### PR TITLE
APPLE: Fix iOS not clearing background buffer when animating/navigating.

### DIFF
--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -112,15 +112,9 @@ HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
             hasClear = true;
         }
         
-        if (@available(macos 100.100, ios 8.0, *)) {
-            metalColorAttachment.loadAction = MTLLoadActionLoad;
-        }
-        else {
-            metalColorAttachment.loadAction =
+        metalColorAttachment.loadAction =
                 HgiMetalConversions::GetAttachmentLoadOp(
                     hgiColorAttachment.loadOp);
-        }
-
         metalColorAttachment.storeAction =
             HgiMetalConversions::GetAttachmentStoreOp(
                 hgiColorAttachment.storeOp);


### PR DESCRIPTION
### Description of Change(s)

There was an errant availability macro that was causing the path to be taken on only non-macOS platforms. This caused issues where the background would retain the previous background, causing a Solitaire win like effect.

This patch makes the color pass use the same pattern as the depth pass, and adequately clear the background.
I believe this resolves to the same LoadAction, but something about the availability macro was causing an issue here.

Either way, at least it cleans it up.

Tested on iOS 18.3

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[X] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
