### PR TITLE
Do not reject 'velocities' or 'accelerations' as primvars for the renderer

### DIFF
--- a/pxr/usdImaging/usdImaging/dataSourcePrimvars.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourcePrimvars.cpp
@@ -40,18 +40,11 @@ _GetInterpolation(const UsdAttribute &attr)
 
 // Reject primvars:points since we always want to get the value from
 // the points attribute.
-// Similar for velocities and accelerations.
 static
 bool
 _RejectPrimvar(const TfToken &name)
 {
     if (name == UsdGeomTokens->points) {
-        return true;
-    }
-    if (name == UsdGeomTokens->velocities) {
-        return true;
-    }
-    if (name == UsdGeomTokens->accelerations) {
         return true;
     }
 


### PR DESCRIPTION
### Description of Change(s)

Selectively undoing part of https://github.com/PixarAnimationStudios/OpenUSD/commit/c55f1384b37ffd74fac58b6a18ec33b2699b4687#diff-4058391680f6b738982c851862d178868840850626cbaa3ad17c597b6c21014f to restore `velocities` and `accelerations` as valid primvars for the renderer.

### Fixes Issue(s)

#3508 

### Checklist

[X] I have created this PR based on the dev branch

[X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[X] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
