### PR TITLE
[Plug] Update TF_FOR_ALL to C++11 iterator

### DIFF
--- a/pxr/base/plug/plugin.cpp
+++ b/pxr/base/plug/plugin.cpp
@@ -271,7 +271,7 @@ PlugPlugin::_LoadWithDependents(_SeenPlugins *seenPlugins)
 
         // Load any dependencies.
         JsObject dependencies = GetDependencies();
-        for(auto& i : dependencies) {
+        for(const auto& i : dependencies) {
             string baseTypeName = i.first;
             TfType baseType = TfType::FindByName(baseTypeName);
 
@@ -428,7 +428,7 @@ PlugPlugin::_GetAllPlugins()
     std::lock_guard<std::mutex> lock(_allPluginsMutex);
     PlugPluginPtrVector plugins;
     plugins.reserve(_allPlugins->size());
-    for(auto& it: *_allPlugins) {
+    for(const auto& it: *_allPlugins) {
         plugins.push_back(TfCreateWeakPtr(it.second.get()));
     }
     return plugins;
@@ -473,7 +473,7 @@ PlugPlugin::DeclaresType(const TfType& type, bool includeSubclasses) const
     if (const JsValue* typesEntry = TfMapLookupPtr(_dict, "Types")) {
         if (typesEntry->IsObject()) {
             const JsObject& typesDict = typesEntry->GetJsObject();
-            for(auto& it: typesDict) {
+            for(const auto& it: typesDict) {
                 const TfType typeFromPlugin = TfType::FindByName(it.first);
                 const bool match = 
                     (includeSubclasses ? 
@@ -518,7 +518,7 @@ PlugPlugin::_DeclareAliases( TfType t, const JsObject & metadata )
 
     const JsObject& aliasDict = i->second.GetJsObject();
 
-    for(auto& aliasIt: aliasDict) {
+    for(const auto& aliasIt: aliasDict) {
 
         if (!aliasIt.second.IsString()) {
             TF_WARN("Expected string for alias name, but found %s",
@@ -542,7 +542,7 @@ PlugPlugin::_DeclareTypes()
         const JsObject& types = typesValue.GetJsObject();
 
         // Declare TfTypes for all the types found in the plugin.
-        for(auto& i: types) {
+        for(const auto& i: types) {
             if (i.second.IsObject()) {
                 _DeclareType(i.first, i.second.GetJsObject());
             }
@@ -589,13 +589,13 @@ PlugPlugin::_DeclareType(
     } else {
         // Make sure that the bases mentioned in the plugin
         // metadata are among them.
-        for(TfType& base: basesVec) {
+        for(const TfType& base: basesVec) {
             std::string const &baseName = base.GetTypeName();
             if (std::find(existingBases.begin(), existingBases.end(),
                           base) == existingBases.end()) {
                 // Our expected base was not found.
                 std::string basesStr;
-                for(TfType& j: existingBases)
+                for(const TfType& j: existingBases)
                     basesStr += j.GetTypeName() + " ";
                 TF_CODING_ERROR(
                     "The metadata for plugin '%s' defined in %s declares "

--- a/pxr/base/plug/wrapPlugin.cpp
+++ b/pxr/base/plug/wrapPlugin.cpp
@@ -29,7 +29,7 @@ static dict
 _ConvertDict( const JsObject & dictionary )
 {
     dict result;
-    for(auto& i : dictionary) {
+    for(const auto& i : dictionary) {
         const string & key = i.first;
         const JsValue & val = i.second;
 

--- a/pxr/base/plug/wrapPlugin.cpp
+++ b/pxr/base/plug/wrapPlugin.cpp
@@ -29,9 +29,9 @@ static dict
 _ConvertDict( const JsObject & dictionary )
 {
     dict result;
-    TF_FOR_ALL(i, dictionary) {
-        const string & key = i->first;
-        const JsValue & val = i->second;
+    for(auto& i : dictionary) {
+        const string & key = i.first;
+        const JsValue & val = i.second;
 
         result[key] = JsConvertToContainerType<object, dict>(val);
     }


### PR DESCRIPTION
### Description of Change(s)

Update files under `pxr/base/plug` by replacing TF_FOR_ALL with C++11-style range-based for each loop.
Additionally, updated pointer usage to align with the new iterator approach, since we now handle references directly rather than raw pointers.

There is C++17 possibility to be used in some cases but this is left for another discussion.

### Obgoing Issue(s)

This PR addresses issue https://github.com/PixarAnimationStudios/OpenUSD/issues/80, though many more instances still need to be resolved. Given the age of this issue (approximately 6–7 years), I wanted to reopen the discussion to evaluate its relevance. Specifically, is the header iterator.h still necessary?

Previous attempts to address this issue (e.g., https://github.com/PixarAnimationStudios/OpenUSD/pull/396) have been closed without further updates to the thread. I look forward to hearing thoughts on whether we should proceed with this.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
