### PR TITLE
Autodesk: HdxOitResolveTask - fix screen size computation

### DIFF
--- a/pxr/imaging/hdx/oitResolveTask.cpp
+++ b/pxr/imaging/hdx/oitResolveTask.cpp
@@ -173,6 +173,8 @@ HdxOitResolveTask::Sync(
             params.useAovMultiSample);
         _renderPassState->SetResolveAovMultiSample(
             params.resolveAovMultiSample);
+
+        _newScreenSize = params.screenSize;
     }
 
     *dirtyBits = HdChangeTracker::Clean;
@@ -243,6 +245,11 @@ HdxOitResolveTask::_ComputeScreenSize(
 {
     const HdRenderPassAovBindingVector& aovBindings = _GetAovBindings(ctx);
     if (aovBindings.empty()) {
+        // For legacy purpose check if the new size is valid.
+        if (_newScreenSize[0]!=0 && _newScreenSize[1]!=0) {
+            return _newScreenSize;
+        }
+
         return _GetScreenSize();
     }
 
@@ -250,6 +257,11 @@ HdxOitResolveTask::_ComputeScreenSize(
     HdRenderBuffer * const buffer = static_cast<HdRenderBuffer*>(
         renderIndex->GetBprim(HdPrimTypeTokens->renderBuffer, bufferId));
     if (!buffer) {
+        // For legacy purpose check if the new size is valid.
+        if (_newScreenSize[0]!=0 && _newScreenSize[1]!=0) {
+            return _newScreenSize;
+        }
+
         TF_CODING_ERROR("No render buffer at path %s specified in AOV bindings",
                         bufferId.GetText());
         return _GetScreenSize();
@@ -440,7 +452,8 @@ operator==(HdxOitResolveTaskParams const& lhs,
            HdxOitResolveTaskParams const& rhs)
 {
     return lhs.useAovMultiSample == rhs.useAovMultiSample
-        && lhs.resolveAovMultiSample == rhs.resolveAovMultiSample;
+        && lhs.resolveAovMultiSample == rhs.resolveAovMultiSample
+        && lhs.screenSize == rhs.screenSize;
 }
 
 bool
@@ -455,7 +468,8 @@ operator<<(std::ostream& out, HdxOitResolveTaskParams const& p)
 {
     out << "OitResolveTask Params: (...) "
         << p.useAovMultiSample << " "
-        << p.resolveAovMultiSample;
+        << p.resolveAovMultiSample << " "
+        << p.screenSize;
     return out;
 }
 

--- a/pxr/imaging/hdx/oitResolveTask.h
+++ b/pxr/imaging/hdx/oitResolveTask.h
@@ -47,13 +47,12 @@ using HdStRenderPassShaderSharedPtr =
 /// OIT resolve task params.
 struct HdxOitResolveTaskParams
 {
-    HdxOitResolveTaskParams()
-        : useAovMultiSample(true)
-        , resolveAovMultiSample(true)
-    {}
+    HdxOitResolveTaskParams() = default;
 
-    bool useAovMultiSample;
-    bool resolveAovMultiSample;
+    bool useAovMultiSample { true };
+    bool resolveAovMultiSample { true };
+
+    pxr::GfVec2i screenSize { 0 };
 };
 
 /// \class HdxOitResolveTask
@@ -123,7 +122,11 @@ private:
     HdStRenderPassStateSharedPtr _renderPassState;
     HdStRenderPassShaderSharedPtr _renderPassShader;
 
+    /// Current screen size.
     GfVec2i _screenSize;
+    /// New screen size (from params).
+    GfVec2i _newScreenSize;
+
     HdBufferArrayRangeSharedPtr _counterBar;
     HdBufferArrayRangeSharedPtr _dataBar;
     HdBufferArrayRangeSharedPtr _depthBar;

--- a/pxr/imaging/hdx/taskController.cpp
+++ b/pxr/imaging/hdx/taskController.cpp
@@ -2149,6 +2149,23 @@ HdxTaskController::_UpdateAovDimensions(GfVec2i const& dimensions)
                 HdRenderBuffer::DirtyDescription);
         }
     }
+
+    // Update the OIT Resolve Task.
+
+    if (!_oitResolveTaskId.IsEmpty()) {
+        HdxOitResolveTaskParams params =
+            _delegate.GetParameter<HdxOitResolveTaskParams>(_oitResolveTaskId,
+                HdTokens->params);
+
+        if (params.screenSize != dimensions) {
+            params.screenSize = dimensions;
+
+            _delegate.SetParameter(_oitResolveTaskId, HdTokens->params,
+                params);
+            changeTracker.MarkTaskDirty(_oitResolveTaskId,
+                HdChangeTracker::DirtyParams);
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Description of Change(s)

Bug fix: Have a generic way to get the screen size but keeps OpenGL code for backward compatibility with legacy code.

The screen size computation in the `HdxOitResolveTask` is based on some OpenGL code when the aovs are not accessible. That's problematic for cases not running with OpenGL (e.g., macOs with Metal). The change consists to add the screen size to the `HdxOitResolveTaskParams` structure so, the computation is not anymore needed.

Note: The original design flaw remains as it computes the render buffer size and not the screen size. In some cases it could be different. For backward compatibility the computation still returns the render buffer size and uses it as screen size.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
