### PR TITLE
Autodesk: testUsdView shots must be UI scale independent

### DIFF
--- a/pxr/usdImaging/bin/testusdview/testusdview.py
+++ b/pxr/usdImaging/bin/testusdview/testusdview.py
@@ -49,7 +49,7 @@ class TestUsdView(Usdviewq.Launcher):
         # Set a fixed size on the stage view so that any image tests get a
         # consistent resolution - but only if we've created a viewer
         if appController._stageView:
-            appController._stageView.setFixedSize(597,540)
+            appController._stageView.SetPhysicalWindowSize(597, 540)
 
         # Process initial loading events
         app.processEvents()

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -2717,8 +2717,18 @@ class AppController(QtCore.QObject):
     def GrabViewportShot(self, cropToAspectRatio=False):
         '''Returns a QImage of the current stage view in usdview.'''
         if self._stageView:
-            return self._stageView.grabFrameBuffer(
+            shot = self._stageView.grabFrameBuffer(
                 cropToAspectRatio=cropToAspectRatio)
+            # The framebuffer might be a pixel larger in either dimension
+            # because its size was rounded up when applying the device
+            # pixel ratio, so crop the extra down to the original physical size.
+            width, height = self._stageView.GetPhysicalWindowSize()
+            width = min(width, shot.width())
+            height = min(height, shot.height())
+            if shot.width() == width and shot.height() == height:
+                return shot
+            else:
+                return shot.copy(0, 0, width, height)
         else:
             return None
 


### PR DESCRIPTION
### Description of Change(s)

- Compensate for the device scaling ratio when setting the original window size of the tests.
- Use the original window size in `StageView` so we avoid problems with integer rounding in the scaling round trip (`widgetSize` is `round(round(originalSize / scale) * scale)` so it's not necessarily the same).
- Round up the widget window size so we can truncate it to the original window size when taking a screenshot.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
