### PR TITLE
[Tf] Update TF_FOR_ALL to C++11 iterator 

### DIFF
--- a/pxr/base/tf/errorMark.cpp
+++ b/pxr/base/tf/errorMark.cpp
@@ -109,11 +109,11 @@ TfReportActiveErrorMarks()
         localStacks = TfErrorMark_GetActiveMarkStacks();
     }
 
-    TF_FOR_ALL(i, localStacks) {
+    for(const auto& i: localStacks) {
         printf("== TfErrorMark @ %p created from ===========================\n",
-               i->first);
+               i.first);
         std::stringstream ss;
-        ArchPrintStackFrames(ss, i->second);
+        ArchPrintStackFrames(ss, i.second);
         printf("%s\n", ss.str().c_str());
     }
 }

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -190,8 +190,8 @@ Tf_MallocTagStringMatchTable::SetMatchList(const std::string& matchList)
 {
     _matchStrings.clear();
     std::vector<std::string> items = TfStringTokenize(matchList, ",\t\n");
-    TF_FOR_ALL(i, items) {
-        _matchStrings.push_back(_MatchString(TfStringTrim(*i, " ")));
+    for(std::string i: items) {
+        _matchStrings.push_back(_MatchString(TfStringTrim(i, " ")));
     }
 }
 
@@ -681,12 +681,12 @@ Tf_MallocGlobalData::_SetTraceNames(const std::string& matchList)
     _traceMatchTable.SetMatchList(matchList);
 
     // Update trace flag on every existing call site.
-    TF_FOR_ALL(i, _callSiteTable) {
-        if (_traceMatchTable.Match(i->second->_name.get())) {
-            i->second->_flags |= Tf_MallocCallSite::_TraceFlag;
+    for(const auto& i: _callSiteTable) {
+        if (_traceMatchTable.Match(i.second->_name.get())) {
+            i.second->_flags |= Tf_MallocCallSite::_TraceFlag;
         }
         else {
-            i->second->_flags &= ~Tf_MallocCallSite::_TraceFlag;
+            i.second->_flags &= ~Tf_MallocCallSite::_TraceFlag;
         }
     }
 }
@@ -757,12 +757,12 @@ Tf_MallocGlobalData::_SetDebugNames(const std::string& matchList)
     _debugMatchTable.SetMatchList(matchList);
 
     // Update debug flag on every existing call site.
-    TF_FOR_ALL(i, _callSiteTable) {
-        if (_debugMatchTable.Match(i->second->_name.get())) {
-            i->second->_flags |= Tf_MallocCallSite::_DebugFlag;
+    for(const auto& i: _callSiteTable) {
+        if (_debugMatchTable.Match(i.second->_name.get())) {
+            i.second->_flags |= Tf_MallocCallSite::_DebugFlag;
         }
         else {
-            i->second->_flags &= ~Tf_MallocCallSite::_DebugFlag;
+            i.second->_flags &= ~Tf_MallocCallSite::_DebugFlag;
         }
     }
 }
@@ -824,10 +824,10 @@ Tf_MallocGlobalData::_BuildUniqueMallocStacks(TfMallocTag::CallTree* tree)
             vector<uintptr_t>, _MallocStackData, _HashMallocStack> _Map;
         _Map map;
 
-        TF_FOR_ALL(it, _callStackTable) {
+        for(const auto& it: _callStackTable) {
             // Since _callStackTable does not change at this point it is
             // ok to store the address of the malloc stack in the data.
-            const TfMallocTag::CallStackInfo &stackInfo = it->second;
+            const TfMallocTag::CallStackInfo &stackInfo = it.second;
             _MallocStackData data = { &stackInfo.stack, 0, 0 };
 
             pair<_Map::iterator, bool> insertResult = map.insert(
@@ -841,8 +841,8 @@ Tf_MallocGlobalData::_BuildUniqueMallocStacks(TfMallocTag::CallTree* tree)
         // Sort the malloc stack data by allocation size.
         std::vector<const _MallocStackData *> sortedStackData;
         sortedStackData.reserve(map.size());
-        TF_FOR_ALL(it, map) {
-            sortedStackData.push_back(&it->second);
+        for(const auto& it: map) {
+            sortedStackData.push_back(&it.second);
         }
 
         std::sort(
@@ -958,8 +958,8 @@ TfMallocTag::GetCapturedMallocStacks()
         traces.swap(_mallocGlobalData->_callStackTable);
     }
 
-    TF_FOR_ALL(i, traces) {
-        result.push_back(i->second.stack);
+    for(const auto& i: traces) {
+        result.push_back(i.second.stack);
     }
 
     return result;
@@ -1088,8 +1088,8 @@ _GetCallSites(TfMallocTag::CallTree::PathNode* node,
         Tf_GetOrCreateCallSite(table, node->siteName.c_str());
     site->_totalBytes += node->nBytesDirect;
 
-    TF_FOR_ALL(pi, node->children) {
-        _GetCallSites(&(*pi), table);
+    for(auto& pi: node->children) {
+        _GetCallSites(&pi, table);
     }
 }
 
@@ -1118,13 +1118,13 @@ TfMallocTag::GetCallTree(CallTree* tree, bool skipRepeated)
 
         // Copy the callsites into the calltree
         tree->callSites.reserve(callSiteTable.size());
-        TF_FOR_ALL(csi, callSiteTable) {
+        for(const auto& csi: callSiteTable) {
             CallTree::CallSite cs = {
-                csi->second->_name.get(),
-                static_cast<size_t>(csi->second->_totalBytes)
+                csi.second->_name.get(),
+                static_cast<size_t>(csi.second->_totalBytes)
             };
             tree->callSites.push_back(cs);
-            delete csi->second;
+            delete csi.second;
         }
 
         gd->_BuildUniqueMallocStacks(tree);
@@ -1228,11 +1228,11 @@ _GetAsCommaSeparatedString(size_t number)
     string str = TfStringPrintf("%ld", number);
     size_t n = str.size();
 
-    TF_FOR_ALL(it, str) {
+    for(char it: str) {
         if (n < str.size() && n%3 == 0) {
             result.push_back(',');
         }
-        result.push_back(*it);
+        result.push_back(it);
         n--;
     }
     return result;
@@ -1345,8 +1345,8 @@ _PrintMallocCallSites(
 
     // Use a map to sort by allocation size.
     map<size_t, const string *> map;
-    TF_FOR_ALL(csi, callSites) {
-        map.insert(make_pair(csi->nBytes, &csi->name));
+    for(const auto& csi: callSites) {
+        map.insert(make_pair(csi.nBytes, &csi.name));
     }
 
     // XXX:cleanup We should pass in maxNameWidth.
@@ -1403,8 +1403,8 @@ _GetNumAllocationInSubTree(
     const TfMallocTag::CallTree::PathNode &node)
 {
     int64_t nAllocations = node.nAllocations;
-    TF_FOR_ALL(it, node.children) {
-        nAllocations += _GetNumAllocationInSubTree(*it);
+    for(const auto& it: node.children) {
+        nAllocations += _GetNumAllocationInSubTree(it);
     }
     return nAllocations;
 }
@@ -1451,15 +1451,15 @@ _ReportMallocNode(
     // (i.e. that sorting is a view into the unaltered source data).
     std::vector<const TfMallocTag::CallTree::PathNode *> sortedChildren;
     sortedChildren.reserve(node.children.size());
-    TF_FOR_ALL(it, node.children) {
-        sortedChildren.push_back(&(*it));
+    for(const auto& it: node.children) {
+        sortedChildren.push_back(&it);
     }
 
     std::sort(
         sortedChildren.begin(), sortedChildren.end(), _MallocPathNodeLessThan);
 
-    TF_FOR_ALL(it, sortedChildren) {
-        _ReportMallocNode(out, **it, level+1);
+    for(const auto& it: sortedChildren) {
+        _ReportMallocNode(out, *it, level+1);
     }
 }
 

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -1088,8 +1088,8 @@ _GetCallSites(TfMallocTag::CallTree::PathNode* node,
         Tf_GetOrCreateCallSite(table, node->siteName.c_str());
     site->_totalBytes += node->nBytesDirect;
 
-    for(auto& pi: node->children) {
-        _GetCallSites(&pi, table);
+    for(TfMallocTag::CallTree::PathNode& child: node->children) {
+        _GetCallSites(&child, table);
     }
 }
 
@@ -1403,8 +1403,8 @@ _GetNumAllocationInSubTree(
     const TfMallocTag::CallTree::PathNode &node)
 {
     int64_t nAllocations = node.nAllocations;
-    for(const auto& it: node.children) {
-        nAllocations += _GetNumAllocationInSubTree(it);
+    for(const TfMallocTag::CallTree::PathNode& child: node.children) {
+        nAllocations += _GetNumAllocationInSubTree(child);
     }
     return nAllocations;
 }
@@ -1451,15 +1451,15 @@ _ReportMallocNode(
     // (i.e. that sorting is a view into the unaltered source data).
     std::vector<const TfMallocTag::CallTree::PathNode *> sortedChildren;
     sortedChildren.reserve(node.children.size());
-    for(const auto& it: node.children) {
-        sortedChildren.push_back(&it);
+    for(const TfMallocTag::CallTree::PathNode& child: node.children) {
+        sortedChildren.push_back(&child);
     }
 
     std::sort(
         sortedChildren.begin(), sortedChildren.end(), _MallocPathNodeLessThan);
 
-    for(const auto& it: sortedChildren) {
-        _ReportMallocNode(out, *it, level+1);
+    for(const TfMallocTag::CallTree::PathNode& child: sortedChildren) {
+        _ReportMallocNode(out, *child, level+1);
     }
 }
 

--- a/pxr/base/tf/notice.cpp
+++ b/pxr/base/tf/notice.cpp
@@ -137,8 +137,8 @@ TfNotice::Revoke(Key& key)
 void
 TfNotice::Revoke(Keys* keys)
 {
-    TF_FOR_ALL(i, *keys) {
-        Revoke(*i);
+    for(auto& i: *keys) {
+        Revoke(i);
     }
     keys->clear();
 }
@@ -158,8 +158,8 @@ TfNotice::RevokeAndWait(Key& key)
 void
 TfNotice::RevokeAndWait(Keys* keys)
 {
-    TF_FOR_ALL(i, *keys) {
-        RevokeAndWait(*i);
+    for(auto& i: *keys) {
+        RevokeAndWait(i);
     }
     keys->clear();
 }

--- a/pxr/base/tf/notice.cpp
+++ b/pxr/base/tf/notice.cpp
@@ -135,12 +135,12 @@ TfNotice::Revoke(Key& key)
 }
 
 void
-TfNotice::Revoke(Keys* keys)
+TfNotice::Revoke(Keys& keys)
 {
-    for(auto& i: *keys) {
+    for(Key& i: keys) {
         Revoke(i);
     }
-    keys->clear();
+    keys.clear();
 }
 
 bool
@@ -156,12 +156,12 @@ TfNotice::RevokeAndWait(Key& key)
 }
 
 void
-TfNotice::RevokeAndWait(Keys* keys)
+TfNotice::RevokeAndWait(Keys& keys)
 {
-    for(auto& i: *keys) {
+    for(Key& i: keys) {
         RevokeAndWait(i);
     }
-    keys->clear();
+    keys.clear();
 }
 
 void

--- a/pxr/base/tf/notice.h
+++ b/pxr/base/tf/notice.h
@@ -376,7 +376,7 @@ public:
     /// notice types and call-back methods for which the keys were
     /// created.  It then clears the keys container.
     TF_API
-    static void Revoke(TfNotice::Keys* keys);
+    static void Revoke(TfNotice::Keys& keys);
 
     /// Revoke interest by a listener.
     ///
@@ -397,7 +397,7 @@ public:
     /// created.  It then clears the keys container.  This will not return
     /// while any threads are invoking any handlers.
     TF_API
-    static void RevokeAndWait(TfNotice::Keys* keys);
+    static void RevokeAndWait(TfNotice::Keys& keys);
 
     /// Deliver the notice to interested listeners, returning the number
     /// of interested listeners.  

--- a/pxr/base/tf/noticeRegistry.cpp
+++ b/pxr/base/tf/noticeRegistry.cpp
@@ -116,7 +116,7 @@ _BeginSend(const TfNotice &notice,
             const std::type_info &senderType,
             const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    for(const auto& i: probes)
+    for(const TfNotice::WeakProbePtr& i: probes)
         if (i)
             i->BeginSend(notice, sender, senderType);
 }
@@ -124,7 +124,7 @@ _BeginSend(const TfNotice &notice,
 void
 Tf_NoticeRegistry::_EndSend(const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    for(const auto& i: probes)
+    for(const TfNotice::WeakProbePtr& i: probes)
         if (i)
             i->EndSend();
 }
@@ -229,7 +229,7 @@ Tf_NoticeRegistry::_Send(const TfNotice &n, const TfType & noticeType,
         // Copy off a list of the probes.
         _Lock lock(_probeMutex);
         probeList.reserve(_probes.size());
-        for(const auto& i: _probes) {
+        for(const TfNotice::WeakProbePtr& i: _probes) {
             if (i) {
                 probeList.push_back(i);
             }

--- a/pxr/base/tf/noticeRegistry.cpp
+++ b/pxr/base/tf/noticeRegistry.cpp
@@ -138,7 +138,7 @@ _BeginDelivery(const TfNotice &notice,
                const std::type_info &listenerType,
                const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    for(const auto& i: probes)
+    for(const TfNotice::WeakProbePtr& i: probes)
         if (i)
             i->BeginDelivery(notice, sender,
                                 senderType, listener, listenerType);
@@ -148,7 +148,7 @@ void
 Tf_NoticeRegistry::
 _EndDelivery(const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    for(const auto& i: probes)
+    for(const TfNotice::WeakProbePtr& i: probes)
         if (i)
             i->EndDelivery();
 }

--- a/pxr/base/tf/noticeRegistry.cpp
+++ b/pxr/base/tf/noticeRegistry.cpp
@@ -116,17 +116,17 @@ _BeginSend(const TfNotice &notice,
             const std::type_info &senderType,
             const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    TF_FOR_ALL(i, probes)
-        if (*i)
-            (*i)->BeginSend(notice, sender, senderType);
+    for(const auto& i: probes)
+        if (i)
+            i->BeginSend(notice, sender, senderType);
 }
 
 void
 Tf_NoticeRegistry::_EndSend(const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    TF_FOR_ALL(i, probes)
-        if (*i)
-            (*i)->EndSend();
+    for(const auto& i: probes)
+        if (i)
+            i->EndSend();
 }
 
 void
@@ -138,9 +138,9 @@ _BeginDelivery(const TfNotice &notice,
                const std::type_info &listenerType,
                const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    TF_FOR_ALL(i, probes)
-        if (*i)
-            (*i)->BeginDelivery(notice, sender,
+    for(const auto& i: probes)
+        if (i)
+            i->BeginDelivery(notice, sender,
                                 senderType, listener, listenerType);
 }
 
@@ -148,9 +148,9 @@ void
 Tf_NoticeRegistry::
 _EndDelivery(const std::vector<TfNotice::WeakProbePtr> &probes)
 {
-    TF_FOR_ALL(i, probes)
-        if (*i)
-            (*i)->EndDelivery();
+    for(const auto& i: probes)
+        if (i)
+            i->EndDelivery();
 }
 
 TfNotice::Key
@@ -229,9 +229,9 @@ Tf_NoticeRegistry::_Send(const TfNotice &n, const TfType & noticeType,
         // Copy off a list of the probes.
         _Lock lock(_probeMutex);
         probeList.reserve(_probes.size());
-        TF_FOR_ALL(i, _probes) {
-            if (*i) {
-                probeList.push_back(*i);
+        for(const auto& i: _probes) {
+            if (i) {
+                probeList.push_back(i);
             }
         }
         doProbing = !probeList.empty();

--- a/pxr/base/tf/pyContainerConversions.h
+++ b/pxr/base/tf/pyContainerConversions.h
@@ -47,8 +47,8 @@ struct TfPySequenceToPython
     static PyObject* convert(ContainerType const &c)
     {
         pxr_boost::python::list result;
-        TF_FOR_ALL(i, c) {
-            result.append(*i);
+        for(const auto& i: c) {
+            result.append(i);
         }
         return pxr_boost::python::incref(result.ptr());
     }

--- a/pxr/base/tf/pyEnum.cpp
+++ b/pxr/base/tf/pyEnum.cpp
@@ -37,8 +37,8 @@ Tf_PyEnumRegistry::Tf_PyEnumRegistry()
 Tf_PyEnumRegistry::~Tf_PyEnumRegistry()
 {
     // release our references on all the objects we own.
-    TF_FOR_ALL(i, _objectsToEnums)
-        decref(i->first);
+    for(const auto& i: _objectsToEnums)
+        decref(i.first);
 }
 // CODE_COVERAGE_ON
 

--- a/pxr/base/tf/pyError.cpp
+++ b/pxr/base/tf/pyError.cpp
@@ -91,8 +91,8 @@ TfPyConvertPythonExceptionToTfErrors()
             extract<vector<TfError> > extractor(args);
             if (extractor.check()) {
                 vector<TfError> errs = extractor();
-                TF_FOR_ALL(e, errs)
-                    TfDiagnosticMgr::GetInstance().AppendError(*e);
+                for(const auto& e: errs)
+                    TfDiagnosticMgr::GetInstance().AppendError(e);
             }
         } else {
             TF_ERROR(exc, TF_PYTHON_EXCEPTION, "Tf Python Exception");

--- a/pxr/base/tf/pyError.cpp
+++ b/pxr/base/tf/pyError.cpp
@@ -91,7 +91,7 @@ TfPyConvertPythonExceptionToTfErrors()
             extract<vector<TfError> > extractor(args);
             if (extractor.check()) {
                 vector<TfError> errs = extractor();
-                for(const auto& e: errs)
+                for(const TfError& e: errs)
                     TfDiagnosticMgr::GetInstance().AppendError(e);
             }
         } else {

--- a/pxr/base/tf/refPtrTracker.cpp
+++ b/pxr/base/tf/refPtrTracker.cpp
@@ -152,9 +152,9 @@ void
 TfRefPtrTracker::ReportAllWatchedCounts(std::ostream& stream) const
 {
     stream << "TfRefPtrTracker watched counts:" << std::endl;
-    TF_FOR_ALL(i, _watched) {
-        stream << "  " << i->first << ": " << i->second
-               << " (type " << _GetDemangled(i->first) << ")"
+    for(const auto& i: _watched) {
+        stream << "  " << i.first << ": " << i.second
+               << " (type " << _GetDemangled(i.first) << ")"
                << std::endl;
     }
 }
@@ -164,9 +164,9 @@ TfRefPtrTracker::ReportAllTraces(std::ostream& stream) const
 {
     stream << "TfRefPtrTracker traces:" << std::endl;
     _Lock lock(_mutex);
-    TF_FOR_ALL(i, _traces) {
-        const Trace& trace = i->second;
-        stream << "  Owner: " << i->first
+    for(const auto& i: _traces) {
+        const Trace& trace = i.second;
+        stream << "  Owner: " << i.first
                << " " << _type[trace.type] << " " << trace.obj << ":"
                << std::endl;
         stream << "=============================================================="
@@ -195,10 +195,10 @@ TfRefPtrTracker::ReportTracesForWatched(
            << " (type " << _GetDemangled(watched) << ")" << std::endl;
 
     // Loop over all traces and report the ones that are watching watched.
-    TF_FOR_ALL(i, _traces) {
-        const Trace& trace = i->second;
+    for(const auto& i: _traces) {
+        const Trace& trace = i.second;
         if (trace.obj == watched) {
-            stream << "  Owner: " << i->first
+            stream << "  Owner: " << i.first
                    << " " << _type[trace.type] << ":"
                    << std::endl;
             stream << "=============================================================="

--- a/pxr/base/tf/templateString.cpp
+++ b/pxr/base/tf/templateString.cpp
@@ -51,7 +51,7 @@ TfTemplateString::Substitute(const Mapping& mapping) const
     vector<string> evalErrors;
     string result = _Evaluate(mapping, &evalErrors);
 
-    for(const auto& it: evalErrors)
+    for(const string& it: evalErrors)
         TF_CODING_ERROR("%s", it.c_str());
 
     return result;
@@ -69,7 +69,7 @@ void
 TfTemplateString::_EmitParseErrors() const
 {
     tbb::spin_mutex::scoped_lock lock(_data->mutex);
-    for(const auto& it: _data->parseErrors)
+    for(const string& it: _data->parseErrors)
         TF_CODING_ERROR("%s", it.c_str());
 }
 

--- a/pxr/base/tf/templateString.cpp
+++ b/pxr/base/tf/templateString.cpp
@@ -51,8 +51,8 @@ TfTemplateString::Substitute(const Mapping& mapping) const
     vector<string> evalErrors;
     string result = _Evaluate(mapping, &evalErrors);
 
-    TF_FOR_ALL(it, evalErrors)
-        TF_CODING_ERROR("%s", it->c_str());
+    for(const auto& it: evalErrors)
+        TF_CODING_ERROR("%s", it.c_str());
 
     return result;
 }
@@ -69,8 +69,8 @@ void
 TfTemplateString::_EmitParseErrors() const
 {
     tbb::spin_mutex::scoped_lock lock(_data->mutex);
-    TF_FOR_ALL(it, _data->parseErrors)
-        TF_CODING_ERROR("%s", it->c_str());
+    for(const auto& it: _data->parseErrors)
+        TF_CODING_ERROR("%s", it.c_str());
 }
 
 TfTemplateString::Mapping
@@ -79,8 +79,8 @@ TfTemplateString::GetEmptyMapping() const
     Mapping mapping;
     if (IsValid()) {
         tbb::spin_mutex::scoped_lock lock(_data->mutex);
-        TF_FOR_ALL(it, _data->placeholders)
-            mapping.insert(make_pair(it->name, std::string()));
+        for(const auto& it: _data->placeholders)
+            mapping.insert(make_pair(it.name, std::string()));
     }
     return mapping;
 }
@@ -188,17 +188,17 @@ _Evaluate(const Mapping& mapping, vector<string>* errors) const
 
     tbb::spin_mutex::scoped_lock lock(_data->mutex);
 
-    TF_FOR_ALL(it, _data->placeholders) {
+    for(const auto& it: _data->placeholders) {
         // Add template content between the end of the last placeholder (or
         // the start of the template) and the start of the next placeholder.
         result.insert(result.end(),
-            _data->template_.begin() + pos, _data->template_.begin() + it->pos);
+            _data->template_.begin() + pos, _data->template_.begin() + it.pos);
 
-        if (it->name[0] == _Sigil) {
+        if (it.name[0] == _Sigil) {
             result.insert(result.end(), _Sigil);
         }
         else {
-            Mapping::const_iterator mit = mapping.find(it->name);
+            Mapping::const_iterator mit = mapping.find(it.name);
             if (mit != mapping.end()) {
                 result.insert(result.end(),
                     mit->second.begin(),
@@ -206,14 +206,14 @@ _Evaluate(const Mapping& mapping, vector<string>* errors) const
             } else {
                 // Insert the placeholder into the result.
                 result.insert(result.end(),
-                    _data->template_.begin() + it->pos,
-                    _data->template_.begin() + it->pos + it->len);
+                    _data->template_.begin() + it.pos,
+                    _data->template_.begin() + it.pos + it.len);
                 _ERROR(errors, "No mapping found for placeholder '%s'",
-                    it->name.c_str());
+                    it.name.c_str());
             }
         }
 
-        pos = it->pos + it->len;
+        pos = it.pos + it.len;
     }
 
     // Add the remainder of the template string.

--- a/pxr/base/tf/testenv/bits.cpp
+++ b/pxr/base/tf/testenv/bits.cpp
@@ -139,18 +139,18 @@ Test_TfBits()
         TF_AXIOM(b.GetAsStringLeftToRight() == "0101");
     
         size_t c=0;
-        TF_FOR_ALL(i, b.GetAllView())
-            c += *i;
+        for(const auto& i: b.GetAllView())
+            c += i;
         TF_AXIOM(c == 6);
     
         c=0;
-        TF_FOR_ALL(i, b.GetAllSetView())
-            c += *i;
+        for(const auto& i: b.GetAllSetView())
+            c += i;
         TF_AXIOM(c == 4);
     
         c=0;
-        TF_FOR_ALL(i, b.GetAllUnsetView())
-            c += *i;
+        for(const auto& i: b.GetAllUnsetView())
+            c += i;
         TF_AXIOM(c == 2);
     }
 

--- a/pxr/base/tf/token.cpp
+++ b/pxr/base/tf/token.cpp
@@ -123,8 +123,8 @@ struct Tf_TokenRegistry
         }
         std::sort(sizesWithSet.begin(), sizesWithSet.end());
         printf("Set # -- Size\n");
-        TF_FOR_ALL(i, sizesWithSet) {
-            printf("%zu -- %zu\n", i->second, i->first);
+        for(const auto& i: sizesWithSet) {
+            printf("%zu -- %zu\n", i.second, i.first);
         }
 
         // Uncomment to dump every token & refcount.

--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -638,7 +638,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
 
         // Try the first element of each non-empty sequence, in order.
         bool anyLeft = false;
-        for(const auto& candSeq: *seqs)
+        for(const TypeVector& candSeq: *seqs)
         {
             if (candSeq.empty())
                 continue;
@@ -648,7 +648,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
 
             // Check that the candidate does not occur in the tail
             // ("cdr", in lisp terms) of any of the sequences.
-            for(const auto& checkSeq: *seqs)
+            for(const TypeVector& checkSeq: *seqs)
             {
                 if (checkSeq.size() <= 1)
                     continue;
@@ -679,7 +679,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
         result->push_back(cand);
 
         // Remove candidate from input sequences.
-        for(auto& seqIt: *seqs) {
+        for(TypeVector& seqIt: *seqs) {
             if (!seqIt.empty() && seqIt.front() == cand)
                 seqIt.erase( seqIt.begin() );
         }

--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -629,7 +629,7 @@ TfType::GetAllDerivedTypes(std::set<TfType> *result) const
 
 // Helper for resolving ancestor order in the case of multiple inheritance.
 static bool
-_MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
+_MergeAncestors(vector<TypeVector> &seqs, TypeVector * result)
 {
     while(true)
     {
@@ -638,7 +638,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
 
         // Try the first element of each non-empty sequence, in order.
         bool anyLeft = false;
-        for(const TypeVector& candSeq: *seqs)
+        for(const TypeVector& candSeq: seqs)
         {
             if (candSeq.empty())
                 continue;
@@ -648,7 +648,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
 
             // Check that the candidate does not occur in the tail
             // ("cdr", in lisp terms) of any of the sequences.
-            for(const TypeVector& checkSeq: *seqs)
+            for(const TypeVector& checkSeq: seqs)
             {
                 if (checkSeq.size() <= 1)
                     continue;
@@ -679,7 +679,7 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
         result->push_back(cand);
 
         // Remove candidate from input sequences.
-        for(TypeVector& seqIt: *seqs) {
+        for(TypeVector& seqIt: seqs) {
             if (!seqIt.empty() && seqIt.front() == cand)
                 seqIt.erase( seqIt.begin() );
         }
@@ -729,7 +729,7 @@ TfType::GetAllAncestorTypes(vector<TfType> *result) const
     }
 
     // Merge the input sequences to resolve final inheritance order.
-    bool ok = _MergeAncestors( &seqs, result );
+    bool ok = _MergeAncestors(seqs, result );
 
     if (!ok) {
         TF_CODING_ERROR("Cannot resolve ancestor classes for '%s' "

--- a/pxr/base/tf/type.cpp
+++ b/pxr/base/tf/type.cpp
@@ -638,23 +638,23 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
 
         // Try the first element of each non-empty sequence, in order.
         bool anyLeft = false;
-        TF_FOR_ALL(candSeq, *seqs)
+        for(const auto& candSeq: *seqs)
         {
-            if (candSeq->empty())
+            if (candSeq.empty())
                 continue;
                 
             anyLeft = true;
-            cand = candSeq->front();
+            cand = candSeq.front();
 
             // Check that the candidate does not occur in the tail
             // ("cdr", in lisp terms) of any of the sequences.
-            TF_FOR_ALL(checkSeq, *seqs)
+            for(const auto& checkSeq: *seqs)
             {
-                if (checkSeq->size() <= 1)
+                if (checkSeq.size() <= 1)
                     continue;
 
-                if (std::find( ++(checkSeq->begin()), checkSeq->end(), cand )
-                    != checkSeq->end())
+                if (std::find( ++(checkSeq.begin()), checkSeq.end(), cand )
+                    != checkSeq.end())
                 {
                     // Reject this candidate.
                     cand = TfType();
@@ -679,9 +679,9 @@ _MergeAncestors(vector<TypeVector> *seqs, TypeVector *result)
         result->push_back(cand);
 
         // Remove candidate from input sequences.
-        TF_FOR_ALL(seqIt, *seqs) {
-            if (!seqIt->empty() && seqIt->front() == cand)
-                seqIt->erase( seqIt->begin() );
+        for(auto& seqIt: *seqs) {
+            if (!seqIt.empty() && seqIt.front() == cand)
+                seqIt.erase( seqIt.begin() );
         }
     }
 }
@@ -720,12 +720,12 @@ TfType::GetAllAncestorTypes(vector<TfType> *result) const
     seqs.push_back( baseTypes );
 
     // Remaining sequences: Inherited types for each direct base.
-    TF_FOR_ALL(it, baseTypes) {
+    for(const auto& it: baseTypes) {
         // Populate the base's ancestor types directly into a new vector on
         // the back of seqs.
         seqs.push_back( TypeVector() );
         TypeVector &baseSeq = seqs.back();
-        it->GetAllAncestorTypes(&baseSeq);
+        it.GetAllAncestorTypes(&baseSeq);
     }
 
     // Merge the input sequences to resolve final inheritance order.
@@ -1096,9 +1096,9 @@ TfType::CastFromAncestor(TfType ancestor, void* addr) const
         return addr;
 
     ScopedLock regLock(GetRegistryMutex(), /*write=*/false);
-    TF_FOR_ALL(it, _info->baseTypes) { 
-        if (void* tmp = it->CastFromAncestor(ancestor, addr)) {
-            if (_CastFunction *castFunc = _info->GetCastFunc(it->GetTypeid()))
+    for(const auto& it: _info->baseTypes) { 
+        if (void* tmp = it.CastFromAncestor(ancestor, addr)) {
+            if (_CastFunction *castFunc = _info->GetCastFunc(it.GetTypeid()))
                 return (*castFunc)(tmp, false);
         }
     }

--- a/pxr/base/tf/wrapError.cpp
+++ b/pxr/base/tf/wrapError.cpp
@@ -128,8 +128,8 @@ _RepostErrors(pxr_boost::python::object exc)
                     printf("Tf.RepostErrors: exception contains no errors\n");
                 return false;
             }
-            TF_FOR_ALL(i, errs)
-                TfDiagnosticMgr::GetInstance().AppendError(*i);
+            for(const auto& i: errs)
+                TfDiagnosticMgr::GetInstance().AppendError(i);
             return true;
         } else {
             if (TF_ERROR_MARK_TRACKING)

--- a/pxr/base/tf/wrapError.cpp
+++ b/pxr/base/tf/wrapError.cpp
@@ -128,8 +128,8 @@ _RepostErrors(pxr_boost::python::object exc)
                     printf("Tf.RepostErrors: exception contains no errors\n");
                 return false;
             }
-            for(const auto& i: errs)
-                TfDiagnosticMgr::GetInstance().AppendError(i);
+            for(const TfError& e: errs)
+                TfDiagnosticMgr::GetInstance().AppendError(e);
             return true;
         } else {
             if (TF_ERROR_MARK_TRACKING)

--- a/pxr/base/tf/wrapMallocTag.cpp
+++ b/pxr/base/tf/wrapMallocTag.cpp
@@ -69,11 +69,11 @@ _GetCallStacks()
 
     // Cache address to function name map, one lookup per address.
     std::map<uintptr_t, std::string> functionNames;
-    TF_FOR_ALL(stack, stacks) {
-        TF_FOR_ALL(func, *stack) {
-            std::string& name = functionNames[*func];
+    for(const auto& stack: stacks) {
+        for(const auto& func: stack) {
+            std::string& name = functionNames[func];
             if (name.empty()) {
-                ArchGetAddressInfo(reinterpret_cast<void*>(*func),
+                ArchGetAddressInfo(reinterpret_cast<void*>(func),
                                    NULL, NULL, &name, NULL);
                 if (name.empty()) {
                     name = "<unknown>";
@@ -83,10 +83,10 @@ _GetCallStacks()
     }
 
     std::vector<std::string> result;
-    TF_FOR_ALL(stack, stacks) {
+    for(const auto& stack: stacks) {
         result.push_back(std::string());
         std::string& trace = result.back();
-        TF_FOR_ALL(func, *stack) {
+        for(const auto& func: stack) {
             trace += TfStringPrintf("  0x%016lx: %s\n",
                                     (unsigned long)*func,
                                     functionNames[*func].c_str());

--- a/pxr/base/tf/wrapMallocTag.cpp
+++ b/pxr/base/tf/wrapMallocTag.cpp
@@ -88,8 +88,8 @@ _GetCallStacks()
         std::string& trace = result.back();
         for(const auto& func: stack) {
             trace += TfStringPrintf("  0x%016lx: %s\n",
-                                    (unsigned long)*func,
-                                    functionNames[*func].c_str());
+                                    (unsigned long)func,
+                                    functionNames[func].c_str());
         }
         trace += '\n';
     }

--- a/pxr/base/tf/wrapPyContainerConversions.cpp
+++ b/pxr/base/tf/wrapPyContainerConversions.cpp
@@ -23,8 +23,8 @@ struct Set_ToPython
     static PyObject* convert(CONTAINER_TYPE const &c)
     {
         PyObject* set = PySet_New(NULL);
-        TF_FOR_ALL(i, c) {
-            PySet_Add(set, pxr_boost::python::object(*i).ptr());
+        for(const auto& i: c) {
+            PySet_Add(set, pxr_boost::python::object(i).ptr());
         }
         return set;
     }

--- a/pxr/base/tf/wrapType.cpp
+++ b/pxr/base/tf/wrapType.cpp
@@ -222,8 +222,8 @@ _DumpTypeHierarchyRecursive( TfType t, int depth=0 )
 
     printf("%s%s\n", indent.c_str(), t.GetTypeName().c_str());
     std::vector<TfType> derived = t.GetDirectlyDerivedTypes();
-    TF_FOR_ALL(it, derived) {
-        _DumpTypeHierarchyRecursive( *it, depth+1 );
+    for(const auto& it: derived) {
+        _DumpTypeHierarchyRecursive( it, depth+1 );
     }
 }
 

--- a/pxr/base/tf/wrapType.cpp
+++ b/pxr/base/tf/wrapType.cpp
@@ -222,7 +222,7 @@ _DumpTypeHierarchyRecursive( TfType t, int depth=0 )
 
     printf("%s%s\n", indent.c_str(), t.GetTypeName().c_str());
     std::vector<TfType> derived = t.GetDirectlyDerivedTypes();
-    for(const auto& it: derived) {
+    for(const TfType& it: derived) {
         _DumpTypeHierarchyRecursive( it, depth+1 );
     }
 }


### PR DESCRIPTION
### Description of Change(s)

Update files under pxr/base/tf by replacing TF_FOR_ALL with C++11-style range-based for each loop.
Additionally, updated pointer usage to align with the new iterator approach, since we now handle references directly rather than raw pointers.

No modification to `iterator.h` was done nether to the part of `bits.h` and `compressedBits.h` that provide support for `TF_FOR_ALL` as it break the compilation and because the modification of the iterators regarding `bits` and `compressedBits` is out of scope of this PR.

File in sub folder have not been touch yet except `testenv/bits`.

### Ongoing Issue(s)

This PR addresses issue https://github.com/PixarAnimationStudios/OpenUSD/issues/80, though many more instances still need to be resolved. 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
