### PR TITLE
Autodesk: Add more strict check when using texture prim path as hash

### DIFF
--- a/pxr/imaging/hdSt/material.cpp
+++ b/pxr/imaging/hdSt/material.cpp
@@ -115,6 +115,7 @@ HdStMaterial::_ProcessTextureDescriptors(
     HdSceneDelegate * const sceneDelegate,
     HdStResourceRegistrySharedPtr const& resourceRegistry,
     std::weak_ptr<HdStShaderCode> const &shaderCode,
+    HdStMaterialNetwork::TextureDescriptorVector const& oldDescs,
     HdStMaterialNetwork::TextureDescriptorVector const &descs,
     HdStShaderCode::NamedTextureHandleVector * const texturesFromStorm,
     HdBufferSpecVector * const specs,
@@ -150,12 +151,25 @@ HdStMaterial::_ProcessTextureDescriptors(
         // Better batch invalidation (i.e., not global) would really help
         // us here, as would hints from the scene about how likely the
         // textures are to change.  Maybe in the future...
-        
+
+        bool useTexturePrimHash = _isInitialized;
+        // On our 2nd+ sync, if the texture prim path is changed (i.e., disconnect and reconnect texture input node),
+        // the hash can't be re-used as it might be collide with others.
+        if (useTexturePrimHash) {
+            const auto it = std::find_if(oldDescs.begin(), oldDescs.end(),
+                [&desc](const HdStMaterialNetwork::TextureDescriptor& oldDesc) {
+                    return oldDesc.name == desc.name && oldDesc.texturePrim == desc.texturePrim;
+                });
+            if (it == oldDescs.end()) {
+                useTexturePrimHash = false;
+            }
+        }
+
         texturesFromStorm->push_back(
             { desc.name,
               desc.type,
               textureHandle,
-              _isInitialized
+              useTexturePrimHash
                   ? hash_value(desc.texturePrim)
                   : _GetTextureHandleHash(textureHandle) });
     }
@@ -197,6 +211,8 @@ HdStMaterial::Sync(HdSceneDelegate *sceneDelegate,
     TfToken materialTag = _materialTag;
     HdSt_MaterialParamVector params;
     HdStMaterialNetwork::TextureDescriptorVector textureDescriptors;
+    // Cache the old descriptors before they are reset
+    HdStMaterialNetwork::TextureDescriptorVector oldTextureDescriptors = _networkProcessor.GetTextureDescriptors();
 
     VtValue vtMat = sceneDelegate->GetMaterialResource(GetId());
     if (vtMat.IsHolding<HdMaterialNetworkMap>()) {
@@ -313,6 +329,7 @@ HdStMaterial::Sync(HdSceneDelegate *sceneDelegate,
         sceneDelegate,
         resourceRegistry,
         _materialNetworkShader,
+        oldTextureDescriptors,
         textureDescriptors,
         &textures,
         &specs,

--- a/pxr/imaging/hdSt/material.h
+++ b/pxr/imaging/hdSt/material.h
@@ -100,6 +100,7 @@ private:
         HdSceneDelegate * sceneDelegate,
         HdStResourceRegistrySharedPtr const& resourceRegistry,
         std::weak_ptr<HdStShaderCode> const &shaderCode,
+        HdStMaterialNetwork::TextureDescriptorVector const& oldDescs,
         HdStMaterialNetwork::TextureDescriptorVector const &descs,
         HdStShaderCode::NamedTextureHandleVector * texturesFromStorm,
         HdBufferSpecVector * specs,


### PR DESCRIPTION
### Description of Change(s)

If a scene have multiple texture prims with same names, e.g., there're lots of texture prim named as /full_color_texture in the ALab scene ([link](https://animallogic.com/alab/)), when different USD prims with materials refer to its own /full_color_texture are put together into the scene, and the problem happens when we do "texture off" and "texture on" mode switch on the scene:

When switch to "texture off" mode, we dirty the scene by disconnect texture inputs nodes of all materials via `HdDataSourceMaterialNetworkInterface::DeleteNodeInputConnection()`, then some prims might be drawn in a batch now as the texture inputs are disconnected.
When we switch to "texture on" mode by reconnect texture inputs nodes of all materials, then in `HdStMaterial::Sync(...)`, the previous batched draw prims are still not broken as now the texture prim path are all /full_color_texture, which produces same hash code due to that perf optimization code, and the drawing result is incorrect as those prims are actually referring to different texture files.

To fix is, when _isInitialized is true, adding another check on that TextureDescriptor to see if the texture's prim path is changed or not, if yes, do not use texture prim path as hash.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/3416

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
