### PR TITLE
Dev fix implicit conversion

### DIFF
--- a/pxr/imaging/hd/testenv/testHdSortedIds.cpp
+++ b/pxr/imaging/hd/testenv/testHdSortedIds.cpp
@@ -46,8 +46,8 @@ _InitPaths()
     }
 
     // Shuffle paths randomly.
-    const size_t seed =
-        std::chrono::system_clock::now().time_since_epoch().count();
+    const std::mt19937::result_type seed =
+        static_cast<std::mt19937::result_type>(std::chrono::system_clock::now().time_since_epoch().count());
     std::cout << "Random seed: " << seed << "\n";
     std::mt19937 randomGen(seed);
 
@@ -371,7 +371,7 @@ bool
 InsertRemoveDupesTest()
 {
     std::cout << "\n\nInsertRemoveDupesTest():\n";
-    
+
     using P = SdfPath;
     Hd_SortedIds sortedIds;
     SdfPathVector expected;
@@ -381,7 +381,7 @@ InsertRemoveDupesTest()
 
     expected = {P("/A"),P("/B")};
     TF_AXIOM(sortedIds.GetIds() == expected);
-    
+
     sortedIds.Insert(P("/B"));
     sortedIds.Insert(P("/A"));
     sortedIds.Insert(P("/B"));

--- a/pxr/imaging/hd/testenv/testHdSortedIdsPerf.cpp
+++ b/pxr/imaging/hd/testenv/testHdSortedIdsPerf.cpp
@@ -27,9 +27,9 @@ _GetInitPaths()
 {
     static SdfPathVector theInitPaths = []() {
         SdfPathVector paths;
-        
+
         char primName[] = "/_/_/_/_";
-        
+
         for (size_t firstLevel = 0; firstLevel < numFirstLevel; ++firstLevel) {
             primName[1] = firstLevelChar[firstLevel];
             for (char secondLevel = 'A'; secondLevel <= 'Z'; ++secondLevel) {
@@ -44,12 +44,12 @@ _GetInitPaths()
             }
         }
         // Shuffle paths randomly.
-        const size_t seed = 5109223000;
+        const std::mt19937::result_type seed = static_cast<std::mt19937::result_type>(5109223000);
         std::mt19937 randomGen(seed);
         std::shuffle(paths.begin(), paths.end(), randomGen);
 
         printf("Using %zu initial paths\n", paths.size());
-        
+
         return paths;
     }();
 
@@ -146,7 +146,7 @@ MultiRemoveInsertTest(Metrics &metrics)
         }
         ids.GetIds(); // force sort.
     });
-    
+
     metrics.emplace_back("add_del_multiple", ArchTicksToNanoseconds(ticks));
 }
 
@@ -180,7 +180,7 @@ SubtreeRemoveInsertTest(Metrics &metrics)
     Hd_SortedIds ids = _GetPopulatedIds();
 
     std::vector<int64_t> timings;
-    
+
     for (SdfPathVector const &subtreePaths: subtreePathVecs) {
         timings.push_back(
             ArchMeasureExecutionTime([&ids, &subtreePaths]() {
@@ -232,7 +232,7 @@ PartialSubtreeRemoveInsertTest(Metrics &metrics)
     Hd_SortedIds ids = _GetPopulatedIds();
 
     std::vector<int64_t> timings;
-    
+
     for (SdfPathVector const &subtreePaths: subtreePathVecs) {
         timings.push_back(
             ArchMeasureExecutionTime([&ids, &subtreePaths]() {
@@ -300,7 +300,7 @@ SpreadRemoveInsertTest(Metrics &metrics, size_t numElts)
         size_t idx = (ids.GetIds().size() * (x+1)) / (numElts+1);
         paths.push_back(ids.GetIds()[idx]);
     }
-        
+
     int64_t ticks = ArchMeasureExecutionTime([&ids, &paths]() {
         for (SdfPath const &path: paths) {
             ids.Remove(path);
@@ -357,7 +357,7 @@ SubtreeRenameTest(Metrics &metrics,
 int main()
 {
     Metrics metrics;
-    
+
     PopulateTest(metrics);
     SingleRemoveInsertTest(metrics);
     MultiRemoveInsertTest(metrics);
@@ -380,7 +380,7 @@ int main()
     SubtreeRenameTest(metrics, SdfPath("/A/B/C"), SdfPath("/A/B/_C"));
     SubtreeRenameTest(metrics, SdfPath("/A/B"), SdfPath("/A/_B"));
     SubtreeRenameTest(metrics, SdfPath("/Z/Z"), SdfPath("/A/B/_Z"));
-    
+
     FILE *statsFile = fopen("perfstats.raw", "w");
     for (const auto &[metricName, ns]: metrics) {
         fprintf(statsFile,
@@ -389,6 +389,6 @@ int main()
         printf("%s : %zd ns\n", metricName.c_str(), ns);
     }
     fclose(statsFile);
-    
+
     printf("OK\n");
 }


### PR DESCRIPTION
### Description of Change(s)

Added explicit static_cast when converting to mt19937::result_type (uint_fast32_t) from:
- system_clock time count (64-bit integer)
- Large integer, 5109223000

Even though we're going from larger integers 
to 32-bits, this is fine for random number generation seeding. The explicit cast makes this clearer in the code and removes the compiler warnings for implicit conversion. 

The changes are in the test files: testHdSortedIds.cpp and testHdSortedIdsPerf.cpp, both of which still pass with the changes. I looked at the contribution and coding guidelines, if I overlooked something or there is a preferred way of implementing these changes, please let me know.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
#3339

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[x] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
