### PR TITLE
Add test to reproduce multi-threading issue of computing extent and relationship

### DIFF
--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -116,6 +116,20 @@ pxr_build_test(testUsdGeomHasAPI
         testenv/testUsdGeomHasAPI.cpp
 )
 
+pxr_build_test(testUsdGeomExtentThreading
+    LIBRARIES
+        usd
+        usdGeom
+        usdShade
+    CPPFILES
+        testenv/testUsdGeomExtentThreading.cpp
+)
+
+pxr_install_test_dir(
+    SRC testenv/testUsdGeomExtentThreading
+    DEST testUsdGeomExtentThreading
+)
+
 pxr_install_test_dir(
     SRC testenv/testUsdGeomBasisCurves
     DEST testUsdGeomBasisCurves
@@ -331,6 +345,11 @@ pxr_register_test(testUsdGeomComputeAtTime
 pxr_register_test(testUsdGeomImageable
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomImageable"
+    EXPECTED_RETURN_CODE 0
+)
+
+pxr_register_test(testUsdGeomExtentThreading
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomExtentThreading"
     EXPECTED_RETURN_CODE 0
 )
 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomExtentThreading.cpp
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomExtentThreading.cpp
@@ -1,0 +1,100 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/base/work/loops.h"
+#include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usd/prim.h"
+#include "pxr/usd/usd/relationship.h"
+#include "pxr/usd/usdGeom/mesh.h"
+#include "pxr/usd/usdGeom/boundable.h"
+#include "pxr/usd/usdShade/material.h"
+#include "pxr/usd/usdGeom/subset.h"
+
+#include <iostream>
+#include <mutex>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+
+const SdfPathSet listOfPathsWithMaterials = {
+    SdfPath("/World/Plane"),
+};
+
+void ComputeMaterialBindings(PXR_NS::UsdPrim prim)
+{
+    for (auto p = prim; !p.IsPseudoRoot(); p = p.GetParent())
+    {
+        PXR_NS::UsdRelationship relationship = p.GetRelationship(PXR_NS::UsdShadeTokens->materialBinding);
+        if(relationship)
+        {
+            PXR_NS::SdfPathVector targetPaths;
+            relationship.GetForwardedTargets(&targetPaths);
+            if (targetPaths.empty() && listOfPathsWithMaterials.count(prim.GetPrimPath()) > 0)
+            {
+                static std::mutex mtx;
+                std::scoped_lock lock(mtx);
+                std::cerr << "Buggy relationship: " << relationship.GetPath() << "\n";
+                std::cerr << "Relationship returned empty forwarded targets on " << p.GetPrimPath() << "\n";
+                std::cerr << "Relationship is " << (relationship.IsValid() ? "valid" : "not valid") << "\n";
+                std::exit(1);
+            }
+        }
+    }
+}
+
+void TraverseNode(PXR_NS::UsdPrim prim)
+{
+    if (prim.IsA<PXR_NS::UsdGeomMesh>())
+    {
+        ComputeMaterialBindings(prim);
+    }
+
+    if (prim.IsA<PXR_NS::UsdGeomBoundable>())
+    {
+        PXR_NS::UsdGeomBoundable points(prim);
+        PXR_NS::VtVec3fArray extent;
+        points.ComputeExtent(PXR_NS::UsdTimeCode::Default(), &extent);
+    }
+
+    std::vector<PXR_NS::UsdPrim> filteredChildren;
+    auto children = prim.GetChildren();
+    for (const auto& childPrim : children)
+    {
+        // Cull materials and their child shaders.
+        if (!childPrim.IsA<PXR_NS::UsdShadeMaterial>() && !childPrim.IsA<PXR_NS::UsdGeomSubset>())
+        {
+            filteredChildren.push_back(childPrim);
+        }
+    }
+
+    PXR_NS::WorkParallelForN(filteredChildren.size(), [&](size_t start, size_t end) {
+        for (size_t i = start; i < end; ++i)
+        {
+            TraverseNode(filteredChildren[i]);
+        }
+    });
+}
+
+void BuildTreeFrom(PXR_NS::UsdStageRefPtr stage)
+{
+    TraverseNode(stage->GetPseudoRoot());
+}
+
+void TestThreading()
+{
+    PXR_NS::UsdStageRefPtr stage = PXR_NS::UsdStage::Open("mesh.usda");
+    BuildTreeFrom(stage);
+}
+
+int main()
+{
+    TestThreading();
+}

--- a/pxr/usd/usdGeom/testenv/testUsdGeomExtentThreading/mesh.usda
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomExtentThreading/mesh.usda
@@ -1,0 +1,39 @@
+#usda 1.0
+(
+    defaultPrim = "World"
+)
+
+def Xform "World"
+{
+    def Mesh "Plane" (
+        prepend apiSchemas = ["MaterialBindingAPI"]
+    )
+    {
+        rel material:binding = </World/Looks/OmniPBR> (
+            bindMaterialAs = "weakerThanDescendants"
+        )
+    }
+
+    def Plane "Plane_01" (
+    )
+    {
+    }
+
+    def Plane "Plane_02" (
+    )
+    {
+    }
+
+    def Plane "Plane_03" (
+    )
+    {
+    }
+
+    def Scope "Looks"
+    {
+        def Material "OmniPBR"
+        {
+        }
+    }
+}
+


### PR DESCRIPTION
### Description of Change(s)
We found a very strange behavior that `ComputeExtent` along with `GetForwardedTargets` in a multi-threading way would influence the behavior of getting material binding with API `UsdRelationship::GetForwardedTargets`. See the changes of this PR about the test to reproduce this. In this test, it's trying to traverse the whole stage with multi-threads. All operations are supposed to be read-only to the stage, and the test should be successful. However, it fails unexpectedly sometimes. Adding `TfRegistryManager::GetInstance().SubscribeTo<UsdGeomBoundable>();` to the first line of `main()` will pass the test, which we still have no idea why.

You need to run the test with `--repeat until-fail:1000` to increase the possibility of failure.  

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3529

### Checklist

[x] I have created this PR based on the dev branch

[x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

[ ] I have added unit tests that exercise this functionality (Reference: 
[testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

[ ] I have verified that all unit tests pass with the proposed changes

[x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
