### PR TITLE
APPLE: Fix Missing cstdef

### DIFF
--- a/pxr/base/gf/half.h
+++ b/pxr/base/gf/half.h
@@ -18,6 +18,8 @@
 #include "pxr/base/gf/ilmbase_halfLimits.h"
 #include "pxr/base/gf/traits.h"
 
+#include <cstddef>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// A 16-bit floating point data type.
@@ -25,9 +27,9 @@ using GfHalf = pxr_half::half;
 
 namespace pxr_half {
     /// Overload hash_value for half.
-    inline size_t hash_value(const half h) { return h.bits(); }
+    inline std::size_t hash_value(const half h) { return h.bits(); }
     // Explicitly delete hashing via implicit conversion of half to float
-    size_t hash_value(float) = delete;
+    std::size_t hash_value(float) = delete;
 }
 
 template <>


### PR DESCRIPTION
### Description of Change(s)

An upstream change to Clang will require that size_t be explicitly brought in from a header, rather than implicitly used, as it allows delineation between different declarations of size_t.

The compiler versions are free to move around and/or remove unnecessary implicit includes internally to improve build times regularly and breaks folks accidentally relying on transitive includes quite often. libc++ 20.0.0 removed some transitive includes which causes breakages in code that was accidentally relying on those, violating the "include-what-you-use" principle

This change brings them in from cstddef and prefixes them with the std namespace

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
