### PR TITLE
Make sure to find vulkan if vulkan support is enabled in pxrConfig.cmake

### DIFF
--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -74,6 +74,14 @@ if(@Imath_FOUND@)
     find_package(Imath REQUIRED)
 endif()
 
+# If Vulkan support was enabled for the USD build, make sure to locate it using
+# the VULKAN_SDK environment variable.
+if(@PXR_ENABLE_VULKAN_SUPPORT@)
+    if (EXISTS $ENV{VULKAN_SDK})
+        find_package(Vulkan REQUIRED)
+    endif()
+endif()
+
 include("${PXR_CMAKE_DIR}/cmake/pxrTargets.cmake")
 if (TARGET usd_ms)
     set(libs "usd_ms")


### PR DESCRIPTION
### Description of Change(s)

Make sure to locate the Vulkan SDK if Vulkan support was enabled.

When building against OpenUSD, if hgiVulkan was built we need to locate where the vulkan SDK is as `Vulkan::Vulkan` is a target dependency in `pxrTargets.cmake`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
