### PR TITLE
hd: add include of <chrono> in testHdSortedIds.cpp

### DIFF
--- a/pxr/imaging/hd/testenv/testHdSortedIds.cpp
+++ b/pxr/imaging/hd/testenv/testHdSortedIds.cpp
@@ -8,6 +8,7 @@
 #include "pxr/imaging/hd/sortedIds.h"
 #include "pxr/usd/sdf/path.h"
 #include "pxr/base/tf/errorMark.h"
+#include <chrono>
 #include <random>
 #include <algorithm>
 #include <iterator>


### PR DESCRIPTION
### Description of Change(s)

The code makes use of `std::chrono::system_clock`, so this adds an include of the header in which that class is declared.

### Fixes Issue(s)

This addresses a compilation failure on Windows when using Visual Studio 2022 17.13.1 (MSVC 14.43.34808):

```
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.19045.
-- The C compiler identification is MSVC 19.43.34808.0
-- The CXX compiler identification is MSVC 19.43.34808.0
...
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped
...
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/MSVC/14.43.34808/bin/Hostx64/x64/cl.exe - skipped

...

C:\Users\MattJohnson\Developer\OpenUSD\pxr\imaging\hd\testenv\testHdSortedIds.cpp(50,22): error C2039: 'system_clock': is not a member of 'std::chrono' [D:\OpenUSD_inst\build\OpenUSD\pxr\imaging\hd\testHdSortedIds.vcxproj]
      C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286,11):
      see declaration of 'std::chrono'
  
C:\Users\MattJohnson\Developer\OpenUSD\pxr\imaging\hd\testenv\testHdSortedIds.cpp(50,22): error C3083: 'system_clock': the symbol to the left of a '::' must be a type [D:\OpenUSD_inst\build\OpenUSD\pxr\imaging\hd\testHdSortedIds.vcxproj]
C:\Users\MattJohnson\Developer\OpenUSD\pxr\imaging\hd\testenv\testHdSortedIds.cpp(50,36): error C2039: 'now': is not a member of 'std::chrono' [D:\OpenUSD_inst\build\OpenUSD\pxr\imaging\hd\testHdSortedIds.vcxproj]
      C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.43.34808\include\__msvc_chrono.hpp(286,11):
      see declaration of 'std::chrono'
  
C:\Users\MattJohnson\Developer\OpenUSD\pxr\imaging\hd\testenv\testHdSortedIds.cpp(50,36): error C3861: 'now': identifier not found [D:\OpenUSD_inst\build\OpenUSD\pxr\imaging\hd\testHdSortedIds.vcxproj]
C:\Users\MattJohnson\Developer\OpenUSD\pxr\imaging\hd\testenv\testHdSortedIds.cpp(49,18): error C2737: 'seed': const object must be initialized [D:\OpenUSD_inst\build\OpenUSD\pxr\imaging\hd\testHdSortedIds.vcxproj]
```

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
