### PR TITLE
Support uic -g python

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2671,9 +2671,9 @@ if PYSIDE in requiredDependencies:
     # The USD build will skip building usdview if pyside6-uic or pyside2-uic is
     # not found, so check for it here to avoid confusing users. This list of 
     # PySide executable names comes from cmake/modules/FindPySide.cmake
-    pyside6Uic = ["pyside6-uic"]
+    pyside6Uic = ["pyside6-uic", "uic"]
     found_pyside6Uic = any([which(p) for p in pyside6Uic])
-    pyside2Uic = ["pyside2-uic"]
+    pyside2Uic = ["pyside2-uic", "uic"]
     found_pyside2Uic = any([which(p) for p in pyside2Uic])
     if not given_pysideUic and not found_pyside2Uic and not found_pyside6Uic:
         PrintError("PySide's user interface compiler was not found -- please"

--- a/cmake/modules/FindPySide.cmake
+++ b/cmake/modules/FindPySide.cmake
@@ -32,11 +32,13 @@ if (pySideImportResult EQUAL 1 OR PYSIDE_USE_PYSIDE2)
 endif()
 
 # If nothing is found, the result will be <VAR>-NOTFOUND.
-find_program(PYSIDEUICBINARY NAMES ${pySideUIC} HINTS ${PYSIDE_BIN_DIR})
-
+find_program(PYSIDEUICBINARY NAMES ${pySideUIC} uic HINTS ${PYSIDE_BIN_DIR})
 if (pySideImportResult)
     # False if the constant ends in the suffix -NOTFOUND.
     if (PYSIDEUICBINARY)
+        if (PYSIDEUICBINARY STREQUAL uic)
+            set(PYSIDEUICBINARY "uic -g python")
+        endif()
         message(STATUS "Found ${pySideImportResult}: with ${PYTHON_EXECUTABLE}, will use ${PYSIDEUICBINARY} for pyside-uic binary")
         set(PYSIDE_AVAILABLE True)
     else()


### PR DESCRIPTION
### Description of Change(s)

This PR adds support for generating PySide's UI code with `uic --generator python` if available, alongside `pyside-uic` and `pyside6-uic`.

Some Linux distributions like the current debian stable do not ship with `pyside-uic` but rely on `uic -g python` instead. The next debian versions will ship PySide6 (with `pyside6-uic`). With this pathch, USD can be built on debian (with a manually compiled recent version of cmake) with the distributions packages:

```
# apt install python3-pyside2.qtwidgets python3-pyside2.qtopengl libpython3.11-dev python3-opengl python3-jinja2 qtbase5-dev-tools
```
### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
