### PR TITLE
NVIDIA: Fix issue of switching material bindings for skeletal mesh

### DIFF
--- a/pxr/usdImaging/usdImaging/indexProxy.cpp
+++ b/pxr/usdImaging/usdImaging/indexProxy.cpp
@@ -127,6 +127,7 @@ UsdImagingIndexProxy::RemovePrimInfoDependency(SdfPath const& cachePath)
             TF_DEBUG(USDIMAGING_CHANGES).
                 Msg("[Revert dependency] <%s> -> <%s>\n",
                     it->first.GetText(), it->second.GetText());
+            primInfo->extraDependencies.erase(it->first);
             _delegate->_dependencyInfo.erase(it);
             break;
         }

--- a/pxr/usdImaging/usdSkelImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdSkelImaging/CMakeLists.txt
@@ -47,3 +47,32 @@ pxr_library(usdSkelImaging
         plugInfo.json
         shaders/skinning.glslfx
 )
+
+# Build tests
+pxr_build_test(testUsdSkelImagingChanges
+    LIBRARIES
+        usdImaging
+        usdShade
+        usdGeom
+        usdSkel
+        usd
+        sdf
+        hd
+        tf
+        gf
+        arch
+    CPPFILES
+        testenv/testUsdSkelImagingChanges.cpp
+)
+
+# Install (copy test assets and baselines)
+pxr_install_test_dir(
+    SRC testenv/testUsdSkelImagingChanges
+    DEST testUsdSkelImagingChanges
+)
+
+# Register tests
+pxr_register_test(testUsdSkelImagingChanges
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelImagingChanges"
+    EXPECTED_RETURN_CODE 0
+)

--- a/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingChanges.cpp
+++ b/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingChanges.cpp
@@ -1,0 +1,86 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usdImaging/usdImaging/unitTestHelper.h"
+
+#include "pxr/imaging/hd/material.h"
+#include "pxr/imaging/hd/renderIndex.h"
+#include "pxr/imaging/hd/unitTestNullRenderDelegate.h"
+
+#include "pxr/usd/usd/stage.h"
+
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static void
+SwitchBoundMaterialTest()
+{
+    std::cout << "-------------------------------------------------------\n";
+    std::cout << "SwitchBoundMaterialTest\n";
+    std::cout << "-------------------------------------------------------\n";
+
+    const std::string usdPath = "switchBoundMaterial/model.usda";
+    UsdStageRefPtr stage = UsdStage::Open(usdPath);
+    TF_AXIOM(stage);
+    
+    // Bring up Hydra
+    Hd_UnitTestNullRenderDelegate renderDelegate;
+    std::unique_ptr<HdRenderIndex>
+        renderIndex(HdRenderIndex::New(&renderDelegate, HdDriverVector()));
+    auto delegate = std::make_unique<UsdImagingDelegate>(renderIndex.get(),
+                               SdfPath::AbsoluteRootPath());
+    delegate->Populate(stage->GetPseudoRoot());
+    delegate->ApplyPendingUpdates();
+    delegate->SyncAll(true);
+    
+    // Clean the dirty bits
+    HdChangeTracker& tracker = renderIndex->GetChangeTracker();
+    tracker.MarkRprimClean(SdfPath("/Root/Geometry/box1"));
+    tracker.MarkRprimClean(SdfPath("/Root/Geometry/box2"));
+
+    // Switch the material for box1
+    auto box1Prim = stage->GetPrimAtPath(SdfPath("/Root/Geometry/box1"));
+    TF_AXIOM(box1Prim);
+    auto materialBinding = box1Prim.GetRelationship(UsdShadeTokens->materialBinding);
+    TF_AXIOM(materialBinding);
+    materialBinding.SetTargets({SdfPath("/Root/Looks/green")});
+
+    delegate->ApplyPendingUpdates();
+    delegate->SyncAll(true);
+    
+    // Check that the dirty bits are clean for box2
+    auto dirtyBits = tracker.GetRprimDirtyBits(SdfPath("/Root/Geometry/box2"));
+    TF_AXIOM(dirtyBits == HdChangeTracker::Clean);
+
+    // Switch the material on the neck
+    auto box2Prim = stage->GetPrimAtPath(SdfPath("/Root/Geometry/box2"));
+    TF_AXIOM(box2Prim);
+    materialBinding = box2Prim.GetRelationship(UsdShadeTokens->materialBinding);
+    TF_AXIOM(materialBinding);
+    materialBinding.SetTargets({SdfPath("/Root/Looks/green")});
+    delegate->ApplyPendingUpdates();
+
+    // Check that the dirty bits are set for box2
+    // Note: There was a bug that switching the material on a skinned mesh
+    // the second time would not cause the dirty bits to be set.
+    dirtyBits = tracker.GetRprimDirtyBits(SdfPath("/Root/Geometry/box2"));
+    TF_AXIOM(dirtyBits != HdChangeTracker::Clean);
+}
+
+int main()
+{
+    TfErrorMark mark;
+
+    SwitchBoundMaterialTest();
+
+    if (TF_AXIOM(mark.IsClean()))
+        std::cout << "OK" << std::endl;
+    else
+        std::cout << "FAILED" << std::endl;
+}
+

--- a/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingChanges/switchBoundMaterial/model.usda
+++ b/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingChanges/switchBoundMaterial/model.usda
@@ -1,0 +1,103 @@
+#usda 1.0
+(
+    metersPerUnit = 1.0
+    upAxis = "Z"
+    defaultPrim = "Root"
+)
+
+def SkelRoot "Root" (
+    prepend apiSchemas = ["SkelBindingAPI"]
+)
+{
+    def Skeleton "Skeleton"
+    {
+        uniform token[] joints = ["Root"]
+        uniform matrix4d[] bindTransforms = [
+            ((1., 0., 0., 0.), (0., 1., 0., 0.), (0., 0., 1., 0.), (0.0, 0.0, 0.0, 1.)),    # Root
+        ]
+        uniform matrix4d[] restTransforms = [
+            ((1., 0., 0., 0.), (0., 1., 0., 0.), (0., 0., 1., 0.), (0., 0., 0., 1.)),    # Root
+        ]
+    }
+    
+    def Scope "Geometry"
+    {
+        def Mesh "box1" (
+            prepend apiSchemas = ["MaterialBindingAPI", "SkelBindingAPI"]
+        )
+        {
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 4, 5, 6, 7, 1, 2, 5, 6, 0, 4, 7, 3, 0, 1, 5, 4, 3, 7, 6, 2]
+            token orientation = "rightHanded"
+            point3f[] points = [(-0.6, -0.6, 0), (-0.6, 0.6, 0), (0.6, 0.6, 0), (0.6, -0.6, 0), (-0.6, -0.6, 0.14), (-0.6, 0.6, 0.14), (0.6, 0.6, 0.14), (0.6, -0.6, 0.14)]
+
+            rel material:binding = </Root/Looks/red> (
+                bindMaterialAs = "weakerThanDescendants"
+            )
+            
+            int[] primvars:skel:jointIndices = [0, 0, 0, 0] (interpolation = "vertex") # Neck
+            float[] primvars:skel:jointWeights = [1., 1., 1., 1.] (interpolation = "vertex")
+            prepend rel skel:skeleton = </Root/Skeleton>
+            bool doubleSided = 1
+        }
+
+        def Mesh "box2" (
+            prepend apiSchemas = ["MaterialBindingAPI", "SkelBindingAPI"]
+        )
+        {
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 4, 5, 6, 7, 1, 2, 5, 6, 0, 4, 7, 3, 0, 1, 5, 4, 3, 7, 6, 2]
+            token orientation = "rightHanded"
+            point3f[] points = [(-0.6, -0.6, 1), (-0.6, 0.6, 1), (0.6, 0.6, 1), (0.6, -0.6, 1), (-0.6, -0.6, 1.14), (-0.6, 0.6, 1.14), (0.6, 0.6, 1.14), (0.6, -0.6, 1.14)]
+            token scheme = "none"
+
+            rel material:binding = </Root/Looks/red> (
+                bindMaterialAs = "weakerThanDescendants"
+            )
+            
+            int[] primvars:skel:jointIndices = [0, 0, 0, 0] (interpolation = "vertex") # Head
+            float[] primvars:skel:jointWeights = [1., 1., 1., 1.] (interpolation = "vertex")
+            prepend rel skel:skeleton = </Root/Skeleton>
+            bool doubleSided = 1
+        }
+    }
+
+    def Scope "Looks"
+    {
+        def Material "red"
+        {
+            token outputs:displacement.connect = </Root/Looks/red/Shader.outputs:displacement>
+            token outputs:surface.connect = </Root/Looks/red/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "UsdPreviewSurface"
+                color3f inputs:diffuseColor = (1, 0, 0)
+                token outputs:displacement (
+                    renderType = "material"
+                )
+                token outputs:surface (
+                    renderType = "material"
+                )
+            }
+        }
+
+        def Material "green"
+        {
+            token outputs:displacement.connect = </Root/Looks/green/Shader.outputs:displacement>
+            token outputs:surface.connect = </Root/Looks/green/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "UsdPreviewSurface"
+                color3f inputs:diffuseColor = (0, 1, 0)
+                token outputs:displacement (
+                    renderType = "material"
+                )
+                token outputs:surface (
+                    renderType = "material"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change(s)

Switching material bindings for skeletal meshes may cause out of sync issue. 

See https://github.com/PixarAnimationStudios/OpenUSD/issues/1747 for more details.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/1747

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
