### PR TITLE
Fix ArchGetFileName on windows for file paths with special characters

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -546,21 +546,13 @@ ArchGetFileName(FILE *file)
     }
 
     if (dwSize != 0) {
-        size_t outSize = WideCharToMultiByte(
-            CP_UTF8, 0, filePath.data(),
-            dwSize,
-            NULL, 0, NULL, NULL);
-        result.resize(outSize);
-        WideCharToMultiByte(
-            CP_UTF8, 0, filePath.data(),
-            -1,
-            &result.front(), outSize, NULL, NULL);
-
         // Strip path prefix if necessary.
         // See https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
         // for format of DOS device paths.
-        auto canonicalPath = std::filesystem::canonical(result);
-        result = canonicalPath.string();
+        
+        auto canonicalPath = std::filesystem::canonical(
+            std::filesystem::path(filePath.begin(), filePath.begin() + dwSize));
+        result = ArchWindowsUtf16ToUtf8(canonicalPath.wstring());
     }
     return result;                                        
 #else

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -96,7 +96,12 @@ int main()
     // Open a file, check that the file path from FILE* handle is matched.
     ARCH_AXIOM((firstFile = ArchOpenFile(firstName.c_str(), "rb")) != NULL);
     std::string filePath = ArchGetFileName(firstFile);
+#if defined(ARCH_OS_WINDOWS)
+    ARCH_AXIOM(std::filesystem::equivalent(ArchWindowsUtf8ToUtf16(filePath),
+                   ArchWindowsUtf8ToUtf16(firstName)));
+#else
     ARCH_AXIOM(std::filesystem::equivalent(filePath, firstName));
+#endif
     fclose(firstFile);
 
     // Map the file and assert the bytes are what we expect they are.


### PR DESCRIPTION
### Description of Change(s)

ArchGetFileName called std::filesystem::canonical() with an utf8-encoded std::string, but on windows std::filesystem::path expects std::string with system encoding. To fix this issue the std::filesystem::path is now created from the utf16-encoded string, which is returned by GetFinalPathNameByHandleW().

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
