### PR TITLE
APPLE: Remove multiple instances of ZLIB

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2514,7 +2514,7 @@ if context.buildAnimXTests:
 # itself does not require it. The --no-zlib flag can be passed to the build
 # script to allow the dependency to find zlib in the build environment.
 if (Linux() or not context.buildZlib) and ZLIB in requiredDependencies:
-    requiredDependencies.remove(ZLIB)
+    requiredDependencies = [r for r in requiredDependencies if r != ZLIB]
 
 # Error out if user is building monolithic library on windows with draco plugin
 # enabled. This currently results in missing symbols.


### PR DESCRIPTION
### Description of Change(s)

Due to a prior change in OpenUSD, ZLIB was moved to a conditional dependency, and then removed from the list if run on Linux or macOS

Unfortunately, the removal only removes the first found instance of ZLib, so doesn't remove it if multiple dependencies ask for it.

A future clang version also has issues with the ZLib version used here so this would be needed to pass builds soon. However, since clang is used primarily on Linux and Mac, it is preferred to just use the OS provided version of Zlib.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
