### PR TITLE
APPLE: Update LibPNG to 1.6.47

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1253,7 +1253,7 @@ TIFF = Dependency("TIFF", InstallTIFF, "include/tiff.h")
 ############################################################
 # PNG
 
-PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.38.zip"
+PNG_URL = "https://github.com/glennrp/libpng/archive/refs/tags/v1.6.47.zip"
 
 def InstallPNG(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(PNG_URL, context, force)):


### PR DESCRIPTION
### Description of Change(s)

An upcoming compiler change for Clang is causing issues with the version of LibPNG as used by build_usd.py

This change causes some of the LibPNG ifdefs to fail, causing it to try and bring in fp.h instead of math.h (https://github.com/pnggroup/libpng/blob/v1.6.38/pngpriv.h#L524)

This was fixed in 1.6.41 with this commit (https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24)

Since we have to update the libPng version anyway, I just opted to use the most recent version.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
