### PR TITLE
APPLE: Make vtDictionary erase match std::map/unordered_map

### DIFF
--- a/pxr/base/vt/dictionary.cpp
+++ b/pxr/base/vt/dictionary.cpp
@@ -66,15 +66,17 @@ VtDictionary::size_type VtDictionary::erase(const string& key) {
     return _dictMap ? _dictMap->erase(key) : 0;
 }
 
-void VtDictionary::erase(iterator it) {
-    _dictMap->erase(it.GetUnderlyingIterator(_dictMap.get()));
+VtDictionary::iterator VtDictionary::erase(iterator it) {
+    return iterator(_dictMap.get(),
+                    _dictMap->erase(it.GetUnderlyingIterator(_dictMap.get())));
 }
 
-void VtDictionary::erase(iterator f, iterator l) {
+VtDictionary::iterator VtDictionary::erase(iterator f, iterator l) {
     if (!_dictMap)
-        return;
-    _dictMap->erase(f.GetUnderlyingIterator(_dictMap.get()),
-        l.GetUnderlyingIterator(_dictMap.get()));
+        return iterator();
+    return iterator(_dictMap.get(),
+                    _dictMap->erase(f.GetUnderlyingIterator(_dictMap.get()),
+                                    l.GetUnderlyingIterator(_dictMap.get())));
 }
 
 void VtDictionary::clear() {

--- a/pxr/base/vt/dictionary.h
+++ b/pxr/base/vt/dictionary.h
@@ -232,11 +232,11 @@ public:
 
     /// Erases the element pointed to by \p it. 
     VT_API
-    void erase(iterator it);
+    iterator erase(iterator it);
 
     /// Erases all elements in a range.
     VT_API
-    void erase(iterator f, iterator l);
+    iterator erase(iterator f, iterator l);
 
     /// Erases all of the elements. 
     VT_API

--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -889,6 +889,23 @@ testDictionaryIterators()
                 "have equal values.");
         }
     }
+
+
+    // Check a dictionaries erase method allows iterator incrementing
+    {
+        VtDictionary a = {key1, key2, key3};
+        for (auto it = a.begin(); it != a.end();) {
+            it = a.erase(it);
+            if (it != a.end()) {
+                it = it++;
+            }
+        }
+
+        if (!a.empty()) {
+            die("VtDictionary::erase iterator did not remove all items");
+        }
+    }
+
 }
 
 static void


### PR DESCRIPTION
### Description of Change(s)

VtDictionary's erase method didn't return the iterator when it was done. This PR (thanks to Maddy Adams) makes it conform to the same methods as the standard library dictionary, which allows them to be treated more similarly in codebases.

This is required for some of our internal work with the compiler, and it would be great if the mainline repo could also include it.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
