### PR TITLE
🐛 Fix support for multiple mtlx shaders

### DIFF
--- a/pxr/usd/usdMtlx/reader.cpp
+++ b/pxr/usd/usdMtlx/reader.cpp
@@ -699,6 +699,9 @@ private:
     void _ConnectNodes();
     void _ConnectTerminals(const mx::ConstElementPtr& iface,
                            const UsdShadeConnectableAPI& connectable);
+    bool _IsNodeConnectedToMaterial(const mx::NodePtr& mtlxNode, 
+                                    const mx::NodePtr& mtlxMaterial,
+                                    const std::string& mtlxShaderType);
 
 private:
     mx::ConstNodeDefPtr _mtlxNodeDef;
@@ -736,6 +739,22 @@ _NodeGraphBuilder::SetTarget(
     const mx::ConstElementPtr& childName)
 {
     SetTarget(stage, parentPath.AppendChild(_MakeName(childName)));
+}
+
+bool
+_NodeGraphBuilder::_IsNodeConnectedToMaterial(
+    const mx::NodePtr& mtlxNode,
+    const mx::NodePtr& mtlxMaterial,
+    const std::string & mtlxShaderType)
+{
+    // Check a direct shader of a certain type.
+    // mx::getShaderNodes only checks directly connected input shaders.
+    for (auto mtlxShaderNode: mx::getShaderNodes(mtlxMaterial, mtlxShaderType)) {
+        if (mtlxShaderNode == mtlxNode) {
+            return true;
+        }
+    }
+    return false;
 }
 
 UsdPrim
@@ -780,14 +799,44 @@ _NodeGraphBuilder::Build(ShaderNamesByOutputName* outputs)
         usdPrim = _usdStage->DefinePrim(_usdPath);
     }
 
+    // Collect all materials to check if surfaceshaders have been already made.
+    std::vector<mx::NodePtr> materials;
+    for (mx::NodePtr& mtlxNode : _mtlxContainer->getChildrenOfType<mx::Node>()) {
+        const std::string &nodeType = _Attr(mtlxNode, names.type);
+        if (nodeType == "material")
+            materials.push_back(mtlxNode);
+    }
+
     // Build the graph of nodes.
     for (mx::NodePtr& mtlxNode : _mtlxContainer->getChildrenOfType<mx::Node>()) {
         // If the _mtlxContainer is the document (there is no nodegraph) the 
-        // nodes gathered here will include the material and surfaceshader 
-        // nodes which are not part of the implicit nodegraph. Ignore them.
+        // nodes gathered here will include the material and directly connected
+        // surfaceshader nodes which are not part of the implicit nodegraph. Ignore them.
         const std::string &nodeType = _Attr(mtlxNode, names.type);
-        if (nodeType == "material" || nodeType == "surfaceshader")
+        if (nodeType == "material")
             continue;
+        // Make sure shaders that are part of the implicit nodegraph
+        // are included here. Shaders directly connected to a material
+        // Should already have been setup.
+        // Create the shader if it doesn't exist and copy node def values.
+        bool connectedToMaterial = false;
+        for(auto mtlxMaterial: materials){
+            connectedToMaterial = (
+                _IsNodeConnectedToMaterial(mtlxNode, mtlxMaterial,  mx::SURFACE_SHADER_TYPE_STRING) ||
+                _IsNodeConnectedToMaterial(mtlxNode, mtlxMaterial,  mx::DISPLACEMENT_SHADER_TYPE_STRING) ||
+                _IsNodeConnectedToMaterial(mtlxNode, mtlxMaterial,  mx::VOLUME_SHADER_TYPE_STRING)
+            );
+            if (connectedToMaterial)
+                break;
+        }
+        if (connectedToMaterial){
+            // Ignore connected shaders to material 
+            // as they have been setup prior to this.
+            continue;
+        }
+        TF_DEBUG(USDMTLX_READER).Msg("Adding missing surface shader (%s)\n",
+        mtlxNode->getName().c_str());
+
         _AddNode(mtlxNode, usdPrim);
     }
     _ConnectNodes();


### PR DESCRIPTION
### Description of Change(s)
* Make sure multiple shaders are found within a network and are added to USD. Previously only the shaders to the material is found and used. A case here is to use two shaders into a mix node, which are not found.

shadergraph:
![mix-of-shaders_smudged](https://github.com/user-attachments/assets/92d1c527-87ec-4ed1-91dc-6ef9055ff42d)

The translation of the shader graph misses to add in the standar surface shaders, see before and after image below.

Before fix:
![mix_current_smudged](https://github.com/user-attachments/assets/ea43683f-c309-4fcd-ad6b-5eb22272b333)

after fix:
![mix_fix_smudged](https://github.com/user-attachments/assets/2d617138-397a-4d24-ba69-d984626de591)



### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
