### PR TITLE
Turn on MSVC conformant preprocessor by default when available.

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -39,6 +39,15 @@ if (${PXR_STRICT_BUILD_MODE})
     set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /WX")
 endif()
 
+# Conformant preprocessor is available for Visual Studio 2019 16.5 and above.
+# This translates to MSVC version 1925. For more details, see:
+# https://learn.microsoft.com/en-us/cpp/overview/compiler-versions?view=msvc-170#version-macros
+# If compatibility with legacy rules for macro expansion are needed, see:
+# https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview?view=msvc-170#rescanning-replacement-list-for-macros
+if (MSVC_VERSION GREATER_EQUAL 1925)
+    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:preprocessor")
+else()
+
 # The Visual Studio preprocessor does not conform to the C++ standard,
 # resulting in warnings like:
 #
@@ -48,12 +57,9 @@ endif()
 # code sites that tricky to guard with individual pragmas, so we opt to
 # disable them throughout the build here.
 #
-# Note that these issues are apparently fixed with the "new" preprocessor
-# present in Visual Studio 2019 version 16.5. If/when we enable that option,
-# we should revisit this.
-#
 # https://developercommunity.visualstudio.com/t/standard-conforming-preprocessor-invalid-warning-c/364698
 _disable_warning("4003")
+endif()
 
 # truncation from 'double' to 'float' due to matrix and vector classes in `Gf`
 _disable_warning("4244")


### PR DESCRIPTION
### Description of Change(s)

This enables the MSVC flag for the conformant preprocessor (/Zc:preprocessor) by default. 
Any projects/targets working with headers from this library and compiling with MSVC are encouraged to enable this flag as well. IntelliSense in Visual Studio and VS Code can run into memory issues when using the legacy preprocessor and parsing certain macros used in [preprocessorUtilsLite.h](https://github.com/PixarAnimationStudios/OpenUSD/blob/dev/pxr/base/tf/preprocessorUtilsLite.h).

I've added supporting links in the comments for additional context, let me know if you have any questions!

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
