### PR TITLE
"Block" prim in Stage Scene Index while it's being removed

### DIFF
--- a/pxr/usdImaging/usdImaging/stageSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/stageSceneIndex.cpp
@@ -227,7 +227,7 @@ UsdImagingStageSceneIndex::GetPrim(const SdfPath &path) const
 
     static const HdSceneIndexPrim s_emptyPrim = {TfToken(), nullptr};
 
-    if (!_stage) {
+    if (!_stage || path == _usdPrimBeingRemoved) {
         return s_emptyPrim;
     }
 
@@ -278,7 +278,7 @@ UsdImagingStageSceneIndex::GetChildPrimPaths(
     }
 
     UsdPrim prim = _stage->GetPrimAtPath(path);
-    if (!prim) {
+    if (!prim || prim.GetPath() == _usdPrimBeingRemoved) {
         return {};
     }
 
@@ -645,7 +645,9 @@ UsdImagingStageSceneIndex::_ApplyPendingResyncs()
 
         TF_DEBUG(USDIMAGING_CHANGES).Msg("[Population] Repopulating <%s>\n",
                                          primPath.GetText());
+        _usdPrimBeingRemoved = primPath;
         _SendPrimsRemoved({primPath});
+        _usdPrimBeingRemoved = SdfPath::EmptyPath();
         _PopulateSubtree(prim);
 
         // Prune property updates of resynced prims, which are redundant.

--- a/pxr/usdImaging/usdImaging/stageSceneIndex.h
+++ b/pxr/usdImaging/usdImaging/stageSceneIndex.h
@@ -157,6 +157,7 @@ private:
 
     // Note: resync paths mean we remove the whole subtree and repopulate.
     SdfPathVector _usdPrimsToResync;
+    SdfPath _usdPrimBeingRemoved;
     // Property changes get converted into PrimsDirtied messages.
     std::map<SdfPath, TfTokenVector> _usdPropertiesToUpdate;
     std::map<SdfPath, TfTokenVector> _usdPropertiesToResync;


### PR DESCRIPTION
### Description of Change(s)

Flag the `primPath` of the prim currently being removed (via `_SendPrimsRemoved`) so that any calls back to this Scene Index about `primPath` should indicate a non-existent prim.

This is a food-for-thought proposal to address https://github.com/PixarAnimationStudios/OpenUSD/issues/3563

### Fixes Issue(s)

Fixes #3563 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
