### PR TITLE
Fix build of usd executables when PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is enabled

### DIFF
--- a/pxr/external/boost/python/CMakeLists.txt
+++ b/pxr/external/boost/python/CMakeLists.txt
@@ -338,6 +338,23 @@ target_compile_definitions(python
     PRIVATE $<$<NOT:$<CONFIG:Debug>>:NDEBUG>
 )
 
+# Even if PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is defined (to avoid that the usd python extensions
+# links to the python library, to avoid problems with statically linked python interpreters) 
+# we want that executables that link usd_python to link with the Python library, 
+# as otherwise they would fail due to missing symbols, see
+# https://github.com/PixarAnimationStudios/OpenUSD/issues/2371
+# and https://github.com/PixarAnimationStudios/OpenUSD/issues/2568
+# This can be done by adding to INTERFACE_LINK_LIBRARIES the appropriate generator expression,
+# that will evalute to empty when usd_python is linked to a library, but it will evaluate to
+# Python3::Python when linked to an executable
+if (PXR_PY_UNDEFINED_DYNAMIC_LOOKUP)
+    # This should equivalent to target_link_libraries(python INTERFACE ...), that we can't
+    # use as pxr_library already use the target_link_libraries plain signature, and the two can't be mixed
+    set_property(TARGET python APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:Python3::Python>"
+    )
+endif()
+
 # Since we're not going through the normal pxr_build_test macros
 # we need to elide tests here if requested.
 if (NOT PXR_BUILD_TESTS)


### PR DESCRIPTION
### Description of Change(s)

Even if PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is defined (to avoid that the usd python extensions links to the python library, to avoid problems with statically linked python interpreters) we want that executables that link usd_python to link with the Python library,  as otherwise they would fail due to missing symbols, see https://github.com/PixarAnimationStudios/OpenUSD/issues/2371 and https://github.com/PixarAnimationStudios/OpenUSD/issues/2568. 

This can be done by adding to INTERFACE_LINK_LIBRARIES the appropriate generator expression, that will evalute to empty when usd_python is linked to a library, but it will evaluate to Python3::Python when linked to an executable.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

This needs to be verified by the specific persons that open the issues, but probably this will fix the following issues:

* https://github.com/PixarAnimationStudios/OpenUSD/issues/2371
* https://github.com/PixarAnimationStudios/OpenUSD/issues/2568
* https://github.com/PixarAnimationStudios/OpenUSD/issues/3031

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
