### PR TITLE
Add Conda environment check in GetPythonInfo for Linux

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -78,6 +78,9 @@ if MacOS():
 def MacOSTargetEmbedded(context):
     return MacOS() and apple_utils.TargetEmbeddedOS(context)
 
+def CondaEnvQ():
+    return "CONDA_PREFIX" in os.environ
+
 def GetLocale():
     if Windows():
         # Windows handles encoding a little differently then Linux / Mac
@@ -187,7 +190,14 @@ def GetPythonInfo(context):
                 suffix=('_d' if context.buildDebug and context.debugPython
                         else ''))
         elif Linux():
-            return sysconfig.get_config_var("LDLIBRARY")
+            if CondaEnvQ():
+                return "libpython{version}.so".format(
+                    version=(sysconfig.get_config_var('LDVERSION') or
+                             sysconfig.get_config_var('VERSION') or
+                            pythonVersion))
+            else:
+                return sysconfig.get_config_var("LDLIBRARY")
+
         elif MacOS():
             return "libpython{version}.dylib".format(
                 version=(sysconfig.get_config_var('LDVERSION') or


### PR DESCRIPTION
### Description of Change(s)

There are several anaconda-related build issues, reported (see #3577, #2371). At leas on Linux builds, some of the problems are due to the conda python reporting that it is built with a static libpython. In the macOS section of the `build_usd` the test is more 'liberal' than simply testing for `LDLIBRARY`. 

This change adds a CondaQ predicate to the build script, and, if true, uses the macOS logic in the build section. Otherwise it remains the 'old way' using `LDLIBRARY`.

### Fixes Issue(s)

Possibly #3577, #2371 on Linux

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [-] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html)) NB - this is in a build script and there are no tests published. 

- [-] I have verified that all unit tests pass with the proposed changes NB - I have tested this in multiple environments

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
