### PR TITLE
[Vt] Update TF_FOR_ALL to C++11 iterator

### DIFF
--- a/pxr/base/vt/dictionary.cpp
+++ b/pxr/base/vt/dictionary.cpp
@@ -312,10 +312,10 @@ VtDictionaryOver(VtDictionary *strong, const VtDictionary &weak,
     strong->insert(weak.begin(), weak.end());
 
     if (coerceToWeakerOpinionType) {
-        TF_FOR_ALL(i, *strong) {
-            VtDictionary::const_iterator j = weak.find(i->first);
+        for(auto &i: *strong) {
+            VtDictionary::const_iterator j = weak.find(i.first);
             if (j != weak.end()) {
-                i->second.CastToTypeOf(j->second);
+                i.second.CastToTypeOf(j->second);
             }
         }
     }
@@ -330,21 +330,21 @@ VtDictionaryOver(const VtDictionary &strong, VtDictionary *weak,
         return;
     }
     if (coerceToWeakerOpinionType) {
-        TF_FOR_ALL(it, strong) {
-            VtDictionary::iterator j = weak->find(it->first);
+        for(const auto &i: strong) {
+            VtDictionary::iterator j = weak->find(i.first);
             if (j == weak->end()) {
-                weak->insert(*it);
+                weak->insert(i);
             }
             else {
-                j->second = VtValue::CastToTypeOf(it->second, j->second);
+                j->second = VtValue::CastToTypeOf(i.second, j->second);
             }
         }
     }
     else {
         // Can't use map::insert here, because that doesn't overwrite
         // values for keys in strong that are already in weak.
-        TF_FOR_ALL(it, strong) {
-            (*weak)[it->first] = it->second;
+        for(auto &it: strong) {
+            (*weak)[it.first] = it.second;
         }
     }
 }
@@ -367,19 +367,19 @@ VtDictionaryOverRecursive(VtDictionary *strong, const VtDictionary &weak,
         return;
     }
 
-    TF_FOR_ALL(it, weak) {
+    for(const auto &it: weak) {
         // If both dictionaries have values that are in turn dictionaries, 
         // recurse:
-        if (VtDictionaryIsHolding<VtDictionary>(*strong, it->first) &&
-            VtDictionaryIsHolding<VtDictionary>(weak, it->first)) {
+        if (VtDictionaryIsHolding<VtDictionary>(*strong, it.first) &&
+            VtDictionaryIsHolding<VtDictionary>(weak, it.first)) {
 
             const VtDictionary &weakSubDict =
-                VtDictionaryGet<VtDictionary>(weak, it->first);
+                VtDictionaryGet<VtDictionary>(weak, it.first);
 
             // Swap out the stored dictionary, mutate it, then swap it back in
             // place.  This avoids expensive copying.  There may still be a copy
             // if the VtValue storage is shared.
-            VtDictionary::iterator i = strong->find(it->first);
+            VtDictionary::iterator i = strong->find(it.first);
             VtDictionary strongSubDict;
             i->second.Swap(strongSubDict);
             // Modify the extracted dict.
@@ -390,9 +390,9 @@ VtDictionaryOverRecursive(VtDictionary *strong, const VtDictionary &weak,
         } else {
             // Insert will set strong with value from weak only if 
             // strong does not already have a value for that key.
-            std::pair<VtDictionary::iterator, bool> result =strong->insert(*it);
+            std::pair<VtDictionary::iterator, bool> result =strong->insert(it);
             if (!result.second && coerceToWeakerOpinionType) {
-                result.first->second.CastToTypeOf(it->second);
+                result.first->second.CastToTypeOf(it.second);
             }
         }
     }
@@ -407,19 +407,19 @@ VtDictionaryOverRecursive(const VtDictionary &strong, VtDictionary *weak,
         return;
     }
 
-    TF_FOR_ALL(it, strong) {
+    for(const auto &it: strong) {
         // If both dictionaries have values that are in turn dictionaries, 
         // recurse:
-        if (VtDictionaryIsHolding<VtDictionary>(strong, it->first) &&
-            VtDictionaryIsHolding<VtDictionary>(*weak, it->first)) {
+        if (VtDictionaryIsHolding<VtDictionary>(strong, it.first) &&
+            VtDictionaryIsHolding<VtDictionary>(*weak, it.first)) {
 
             VtDictionary const &strongSubDict =
-                VtDictionaryGet<VtDictionary>(strong, it->first);
+                VtDictionaryGet<VtDictionary>(strong, it.first);
 
             // Swap out the stored dictionary, mutate it, then swap it back in
             // place.  This avoids expensive copying.  There may still be a copy
             // if the VtValue storage is shared.
-            VtDictionary::iterator i = weak->find(it->first);
+            VtDictionary::iterator i = weak->find(it.first);
             VtDictionary weakSubDict;
             i->second.Swap(weakSubDict);
             // Modify the extracted dict.
@@ -429,15 +429,15 @@ VtDictionaryOverRecursive(const VtDictionary &strong, VtDictionary *weak,
 
         } else if (coerceToWeakerOpinionType) {
             // Else stomp over weak with strong but with type coersion.
-            VtDictionary::iterator j = weak->find(it->first);
+            VtDictionary::iterator j = weak->find(it.first);
             if (j == weak->end()) {
-                weak->insert(*it);
+                weak->insert(it);
             } else {
-                j->second = VtValue::CastToTypeOf(it->second, j->second);
+                j->second = VtValue::CastToTypeOf(it.second, j->second);
             }
         } else {
             // Else stomp over weak with strong
-            (*weak)[it->first] = it->second;
+            (*weak)[it.first] = it.second;
         }
     }
 }
@@ -452,12 +452,12 @@ bool operator==(VtDictionary const &lhs, VtDictionary const &rhs)
     // Iterate over all key-value pairs in the left-hand side dictionary
     // and check if they match up with the content of the right-hand
     // side dictionary.
-    TF_FOR_ALL(it, lhs){
-        VtDictionary::const_iterator it2 = rhs.find(it->first);
+    for(const auto &it: lhs){
+        VtDictionary::const_iterator it2 = rhs.find(it.first);
         if (it2 == rhs.end()) {
             return false;
         }
-        if (it->second != it2->second) {
+        if (it.second != it2->second) {
             return false;
         }
     }
@@ -474,12 +474,12 @@ operator<<(std::ostream &stream, VtDictionary const &dict)
 {
     bool first = true;
     stream << '{';
-    TF_FOR_ALL(i, dict) {
+    for(const auto &i: dict) {
         if (first)
             first = false;
         else
             stream << ", ";
-        stream << '\'' << i->first << "': " << i->second;
+        stream << '\'' << i.first << "': " << i.second;
     }
     stream << '}';
     return stream;

--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -81,8 +81,8 @@ static void testArray() {
     VtDoubleArray da(60);
 
     double val = 1;
-    TF_FOR_ALL(elem, da)
-        *elem = val++;
+    for(auto& elem: da)
+        elem = val++;
 
     val = 1;
     for (VtDoubleArray::const_iterator i = da.begin(); i != da.end(); ++i)

--- a/pxr/base/vt/value.cpp
+++ b/pxr/base/vt/value.cpp
@@ -515,12 +515,12 @@ std::ostream &
 VtStreamOut(vector<VtValue> const &val, std::ostream &stream) {
     bool first = true;
     stream << '[';
-    TF_FOR_ALL(i, val) {
+    for(const VtValue &i: val) {
         if (first)
             first = false;
         else
             stream << ", ";
-        stream << *i;
+        stream << i;
     }
     stream << ']';
     return stream;

--- a/pxr/base/vt/wrapDictionary.cpp
+++ b/pxr/base/vt/wrapDictionary.cpp
@@ -40,8 +40,8 @@ struct VtValueArrayToPython
     {
         // TODO Use result converter. TfPySequenceToList.
         list result;
-        TF_FOR_ALL(i, v) {
-            object o = TfPyObject(*i);
+        for(const VtValue &i: v) {
+            object o = TfPyObject(i);
             result.append(o);
         }
         return incref(result.ptr());
@@ -55,8 +55,8 @@ struct VtDictionaryArrayToPython
     {
         // TODO Use result converter. TfPySequenceToList.
         list result;
-        TF_FOR_ALL(i, v) {
-            object o = TfPyObject(*i);
+        for(const VtDictionary &i: v) {
+            object o = TfPyObject(i);
             result.append(o);
         }
         return incref(result.ptr());
@@ -72,9 +72,9 @@ struct VtDictionaryToPython
 
         // TODO Use result converter TfPyMapToDictionary??
         dict result;
-        TF_FOR_ALL(i, v) {
-            object o = TfPyObject(i->second);
-            result.setdefault(i->first, o);
+        for(const auto &i: v) {
+            object o = TfPyObject(i.second);
+            result.setdefault(i.first, o);
         }
         return incref(result.ptr());
     }


### PR DESCRIPTION
### Description of Change(s)

Update files under pxr/base/vt by replacing TF_FOR_ALL with C++11-style range-based for each loop.

### Important notes

There is an example the might be worth looking into since some of the code that not use TF_FOR_ALL could be using also C++11 iterator, specifically :
https://github.com/PixarAnimationStudios/OpenUSD/blob/184178320608f3b05090bfa8ec030911a72c0a2c/pxr/base/vt/testenv/testVtCpp.cpp#L88-L90

could just be :
```cpp
for (const auto& element : da) {
    if (element != val++)
        die("iterator");
}
```
### Open Issue(s)

This PR addresses issue https://github.com/PixarAnimationStudios/OpenUSD/issues/80, though many more instances still need to be resolved.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
