### PR TITLE
Autodesk: Add the drawingCoordBufferBinding in the Hash computing of ResourceBinder metadata

### DIFF
--- a/pxr/imaging/hdSt/resourceBinder.cpp
+++ b/pxr/imaging/hdSt/resourceBinder.cpp
@@ -1630,6 +1630,8 @@ HdSt_ResourceBinder::MetaData::ComputeHash() const
     
     hash = TfHash::Combine(
         hash,
+        drawingCoordBufferBinding.offset,
+        drawingCoordBufferBinding.stride,
         drawingCoord0Binding.binding.GetValue(),
         drawingCoord0Binding.dataType,
         drawingCoord1Binding.binding.GetValue(),


### PR DESCRIPTION
### Description of Change(s)

The DrawingCoordBufferBinding is not included in the hash of `HdStResourceBinder::MetaData`. So two drawitems with the same geometric shader and different DrawingCoordBufferBinding will get the same culling program, but they should use different culling program. 

In this PR we add `DrawingCoordBufferBinding` to the hash of `HdStResourceBinder::MetaData`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
