### PR TITLE
Fix invalid escape sequence in Python 3.12

### DIFF
--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -131,7 +131,7 @@ def _stripPath(f, pathPattern):
             return m.group(1).replace('\\', '/')
         pathPattern = pathPattern.replace('\\', '/')
         pathPattern = pathPattern.replace('/', '[/\\\\]')
-        pathPattern = pathPattern + '(\S*)'
+        pathPattern = pathPattern + r'(\S*)'
         repl = _windowsReplacement
 
     # Read entire file and perform substitution.


### PR DESCRIPTION
### Description of Change(s)
Fixes an invalid escape sequence that is a syntax error in Python 3.12.

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
