### PR TITLE
Autodesk: Vulkan validation errors

### DIFF
--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -1057,6 +1057,9 @@ _BindingState::GetBindingsForViewTransformation(
     binder.GetInterleavedBufferArrayBindingDesc(
         bindingsDesc, constantBar, _tokens->constantPrimvars);
 
+    binder.GetInterleavedBufferArrayBindingDesc(
+        bindingsDesc, topVisBar, HdTokens->topologyVisibility);
+
     // Bind the instance buffers to support instance transformations.
     if (instanceIndexBar) {
         for (size_t level = 0; level < instancePrimvarBars.size(); ++level) {
@@ -1076,9 +1079,6 @@ _BindingState::GetBindingsForDrawing(
     GetBindingsForViewTransformation(bindingsDesc);
 
     bindingsDesc->debugName = "PipelineDrawBatch.Drawing";
-
-    binder.GetInterleavedBufferArrayBindingDesc(
-        bindingsDesc, topVisBar, HdTokens->topologyVisibility);
 
     binder.GetBufferArrayBindingDesc(bindingsDesc, indexBar);
     if (!geometricShader->IsPrimTypePoints()) {

--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -1027,10 +1027,12 @@ HdStRenderPassState::MakeGraphicsCmdsDesc(
 
         if (HdAovHasDepthSemantic(aov.aovName) ||
             HdAovHasDepthStencilSemantic(aov.aovName)) {
-            desc.depthAttachmentDesc = std::move(attachmentDesc);
-            desc.depthTexture = hgiTexHandle;
-            if (hgiResolveHandle) {
-                desc.depthResolveTexture = hgiResolveHandle;
+            if (_depthTestEnabled || _depthMaskEnabled) {
+                desc.depthAttachmentDesc = std::move(attachmentDesc);
+                desc.depthTexture = hgiTexHandle;
+                if (hgiResolveHandle) {
+                    desc.depthResolveTexture = hgiResolveHandle;
+                }
             }
         } else if (TF_VERIFY(desc.colorAttachmentDescs.size() < maxColorTex,
                    "Too many aov bindings for color attachments"))
@@ -1129,7 +1131,9 @@ HdStRenderPassState::_InitAttachmentState(
 
         if (HdAovHasDepthSemantic(binding.aovName) ||
             HdAovHasDepthStencilSemantic(binding.aovName)) {
-            pipeDesc->depthAttachmentDesc = attachment;
+            if (_depthTestEnabled || _depthMaskEnabled) {
+                pipeDesc->depthAttachmentDesc = attachment;
+            }
         } else {
             pipeDesc->colorAttachmentDescs.push_back(attachment);
         }

--- a/pxr/imaging/hdx/colorCorrectionTask.cpp
+++ b/pxr/imaging/hdx/colorCorrectionTask.cpp
@@ -1151,7 +1151,8 @@ HdxColorCorrectionTask::Execute(HdTaskContext* ctx)
     // However, the intermediate color-corrected buffer is in the correct layout
     // ie: Color Attachment Optimal.
     // So, no layout transition there.
-    aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
+    const auto oldLayout =
+        aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
 
     if (!TF_VERIFY(_CreateBufferResources())) {
         return;
@@ -1175,7 +1176,7 @@ HdxColorCorrectionTask::Execute(HdTaskContext* ctx)
     // is converted to a Color Attachment Optimal layout.
     // Hence, preserving the state atomicity of this pass.
     // Otherwise, it's business as usual.
-    aovTexture->SubmitLayoutChange(HgiTextureUsageBitsColorTarget);
+    aovTexture->SubmitLayoutChange(oldLayout);
 
     // Toggle color and colorIntermediate
     _ToggleRenderTarget(ctx);

--- a/pxr/imaging/hdx/oitVolumeRenderTask.cpp
+++ b/pxr/imaging/hdx/oitVolumeRenderTask.cpp
@@ -110,7 +110,7 @@ HdxOitVolumeRenderTask::Execute(HdTaskContext* ctx)
     }
 
     extendedState->SetUseSceneMaterials(true);
-    renderPassState->SetDepthFunc(HdCmpFuncAlways);
+    renderPassState->SetEnableDepthTest(false);
     // Setting cull style for consistency even though it is hard-coded in
     // shaders/volume.glslfx.
     renderPassState->SetCullStyle(HdCullStyleBack);
@@ -135,7 +135,13 @@ HdxOitVolumeRenderTask::Execute(HdTaskContext* ctx)
     extendedState->SetRenderPassShader(_oitVolumeRenderPassShader);
     renderPassState->SetEnableDepthMask(false);
     renderPassState->SetColorMasks({HdRenderPassState::ColorMaskNone});
+
+    HgiTextureHandle depthTexture;
+    _GetTaskContextData(ctx, HdAovTokens->depth, &depthTexture);
+
+    depthTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
     HdxRenderTask::Execute(ctx);
+    depthTexture->SubmitLayoutChange(HgiTextureUsageBitsDepthTarget);
 }
 
 

--- a/pxr/imaging/hdx/oitVolumeRenderTask.cpp
+++ b/pxr/imaging/hdx/oitVolumeRenderTask.cpp
@@ -139,9 +139,10 @@ HdxOitVolumeRenderTask::Execute(HdTaskContext* ctx)
     HgiTextureHandle depthTexture;
     _GetTaskContextData(ctx, HdAovTokens->depth, &depthTexture);
 
-    depthTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
+    const auto oldLayout =
+        depthTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
     HdxRenderTask::Execute(ctx);
-    depthTexture->SubmitLayoutChange(HgiTextureUsageBitsDepthTarget);
+    depthTexture->SubmitLayoutChange(oldLayout);
 }
 
 

--- a/pxr/imaging/hdx/visualizeAovTask.cpp
+++ b/pxr/imaging/hdx/visualizeAovTask.cpp
@@ -597,7 +597,8 @@ HdxVisualizeAovTask::Execute(HdTaskContext* ctx)
     HgiTextureDesc const& aovTexDesc = aovTexture->GetDescriptor();
 
     // Transition from color target layout to shader read layout
-    aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
+    const auto oldLayout =
+        aovTexture->SubmitLayoutChange(HgiTextureUsageBitsShaderRead);
 
     if (!TF_VERIFY(_CreateBufferResources())) {
         return;
@@ -639,7 +640,7 @@ HdxVisualizeAovTask::Execute(HdTaskContext* ctx)
     _ApplyVisualizationKernel(outputTexture);
 
     // Restore the original color target layout
-    aovTexture->SubmitLayoutChange(HgiTextureUsageBitsColorTarget);
+    aovTexture->SubmitLayoutChange(oldLayout);
 
     if (canUseIntermediateAovTexture) {
         // Swap the handles on the task context so that future downstream tasks

--- a/pxr/imaging/hgi/texture.h
+++ b/pxr/imaging/hgi/texture.h
@@ -171,9 +171,10 @@ public:
 
     /// This function initiates a layout change process on this texture 
     /// resource. This feature is at the moment required explicitly by explicit 
-    /// APIs like Vulkan.
+    /// APIs like Vulkan. Returns the previous layout to make it easier to
+    /// restore it correctly.
     HGI_API
-    virtual void SubmitLayoutChange(HgiTextureUsage newLayout) = 0;
+    virtual HgiTextureUsage SubmitLayoutChange(HgiTextureUsage newLayout) = 0;
 
 protected:
     HGI_API

--- a/pxr/imaging/hgiGL/texture.cpp
+++ b/pxr/imaging/hgiGL/texture.cpp
@@ -440,10 +440,10 @@ HgiGLTexture::GetBindlessHandle()
     return _bindlessHandle;
 }
 
-void 
+HgiTextureUsage
 HgiGLTexture::SubmitLayoutChange(HgiTextureUsage newLayout)
 {
-    return;
+    return 0;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiGL/texture.h
+++ b/pxr/imaging/hgiGL/texture.h
@@ -48,9 +48,9 @@ public:
 
     /// This function does not do anything. There is no support for explicit 
     /// layout transition in non-explicit APIs like OpenGL. Hence this function
-    /// simply returns void.
+    /// simply returns 0 (none).
     HGIGL_API
-    void SubmitLayoutChange(HgiTextureUsage newLayout) override;
+    HgiTextureUsage SubmitLayoutChange(HgiTextureUsage newLayout) override;
 
 protected:
     friend class HgiGL;

--- a/pxr/imaging/hgiMetal/texture.h
+++ b/pxr/imaging/hgiMetal/texture.h
@@ -41,9 +41,9 @@ public:
     
     /// This function does not do anything. At the moment there is no need for 
     /// explicit layout transitions for the Metal backend. Hence this function 
-    /// simply returns void. 
+    /// simply returns 0 (none).
     HGIMETAL_API
-    void SubmitLayoutChange(HgiTextureUsage newLayout) override;
+    HgiTextureUsage SubmitLayoutChange(HgiTextureUsage newLayout) override;
 
 protected:
     friend class HgiMetal;

--- a/pxr/imaging/hgiMetal/texture.mm
+++ b/pxr/imaging/hgiMetal/texture.mm
@@ -281,10 +281,10 @@ HgiMetalTexture::GetTextureId() const
     return _textureId;
 }
 
-void 
+HgiTextureUsage
 HgiMetalTexture::SubmitLayoutChange(HgiTextureUsage newLayout)
 {
-    return;
+    return 0;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/texture.h
+++ b/pxr/imaging/hgiVulkan/texture.h
@@ -87,7 +87,7 @@ public:
     /// transition isn't immediately executed. The command buffer simply 
     /// records the request and executes when in the next submission cycle.
     HGIVULKAN_API
-    void SubmitLayoutChange(HgiTextureUsage newLayout) override;
+    HgiTextureUsage SubmitLayoutChange(HgiTextureUsage newLayout) override;
 
     /// Transition image from oldLayout to newLayout.
     /// `producerAccess` of 0 means:


### PR DESCRIPTION
### Description of Change(s)

* Fix Vulkan validation errors related to volume rendering.
* A cull compute shader sometime has a `topologyVisibility` binding. The `pipelineDrawBatch` doesn't bind this buffer for culling. It's not actually used, so not binding the buffer doesn't break anything, but Vulkan mandates that any buffer in a descriptor set layout (created by reflection) must be bound, regardless of its use. This caused a validation error. I moved the binding call so it now executes for both cull and draw.
* `SubmitLayoutChange` should return the old layout so restoring it isn't as error prone
* Sometimes old layout can be depth instead of color.
* Don't enable alpha-to-coverage if there's no color attachment

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
