### PR TITLE
Fix for Namespace edits causing overlapping moves

### DIFF
--- a/pxr/usd/sdf/childrenUtils.cpp
+++ b/pxr/usd/sdf/childrenUtils.cpp
@@ -348,8 +348,11 @@ bool Sdf_ChildrenUtils<ChildPolicy>::InsertChild(
         layer->SetField(oldParentPath, oldChildrenKey, oldSiblingNames);
     }
 
-    // Move the actual spec data
-    layer->_MoveSpec(value->GetPath(), newPath);
+    // Move the actual spec data only if necessary, to avoid triggering a coding error
+    // when we don't want to and actually cannot move the spec for a reorder
+    if (value->GetPath() != newPath) {
+        layer->_MoveSpec(value->GetPath(), newPath);
+    }
 
     // Update and set the _childNames vector.
     childNames.insert(childNames.begin()+index, key);


### PR DESCRIPTION
### Description of Change(s)

This fixes the scenario where name space edits may cause overlapping moves, resulting errors.
Thanks to Damien for the suggested fix.

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3592

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
