### PR TITLE
Autodesk: Fix sizing issue with MacOS windows

### DIFF
--- a/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
+++ b/pxr/imaging/garch/glPlatformDebugWindowDarwin.mm
@@ -190,8 +190,11 @@ Garch_GLPlatformDebugWindow::Init(const char *title,
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
     id applicationName = [[NSProcessInfo processInfo] processName];
 
-    NSRect frame = NSMakeRect(0, 0, width, height);
-    NSRect viewBounds = NSMakeRect(0, 0, width, height);
+    NSScreen *mainScreen = [NSScreen mainScreen];
+    CGFloat scaleFactor = [mainScreen backingScaleFactor];
+    NSRect screenFrame = [mainScreen frame];
+    NSRect frame = NSMakeRect(screenFrame.origin.x, screenFrame.origin.y, width / scaleFactor, height / scaleFactor);
+    NSRect viewBounds = NSMakeRect(screenFrame.origin.x, screenFrame.origin.y, width / scaleFactor, height / scaleFactor);
 
     Garch_GLPlatformView *view =
         [[Garch_GLPlatformView alloc] initGL:viewBounds callback:_callback];
@@ -204,7 +207,7 @@ Garch_GLPlatformDebugWindow::Init(const char *title,
                                  |NSResizableWindowMask
                         backing:NSBackingStoreBuffered
                         defer:NO];
-    [window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
+    [window cascadeTopLeftFromPoint:NSMakePoint(screenFrame.origin.x + 20, screenFrame.origin.y + 20)];
     [window setTitle: applicationName];
     [window makeKeyAndOrderFront:nil];
 


### PR DESCRIPTION
### Description of Change(s)

Fixes rendering this in retina display:

![image](https://github.com/user-attachments/assets/3029d32e-2ce6-4523-b628-a46d6e5cd475)


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
