### PR TITLE
Autodesk: Set Default Path of TBB and OpenSubdiv in pxrConfig.cmake.in

### DIFF
--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -53,6 +53,13 @@ if (NOT DEFINED PXR_FIND_TBB_IN_CONFIG)
     set(PXR_FIND_TBB_IN_CONFIG "@PXR_FIND_TBB_IN_CONFIG@")
 endif()
 if (PXR_FIND_TBB_IN_CONFIG)
+    # Set TBB_DIR to where the TBBConfig.cmake file was located.
+    # This can be overridden by specifying a different TBB_DIR when running cmake.
+    if (NOT DEFINED TBB_DIR)
+        if (NOT [[@TBB_DIR@]] STREQUAL "")
+            set(TBB_DIR [[@TBB_DIR@]])
+        endif()
+    endif()
     find_dependency(TBB @TBB_VERSION@ CONFIG)
 endif()
 
@@ -60,6 +67,13 @@ if (NOT DEFINED PXR_FIND_OPENSUBDIV_IN_CONFIG)
     set(PXR_FIND_OPENSUBDIV_IN_CONFIG "@PXR_FIND_OPENSUBDIV_IN_CONFIG@")
 endif()
 if (PXR_FIND_OPENSUBDIV_IN_CONFIG)
+    # Set OpenSubdiv_DIR to where the OpenSubdivConfig.cmake file was located.
+    # This can be overridden by specifying a different OpenSubdiv_DIR when running cmake.
+    if (NOT DEFINED OpenSubdiv_DIR)
+        if (NOT [[@OpenSubdiv_DIR@]] STREQUAL "")
+            set(OpenSubdiv_DIR [[@OpenSubdiv_DIR@]])
+        endif()
+    endif()
     find_dependency(OpenSubdiv @OpenSubdiv_VERSION@ CONFIG)
 endif()
 


### PR DESCRIPTION
### Description of Change(s)

Similar to MaterialX exported targets, adding these default paths makes pxrConfig.cmake easy to use, especially when TBB and OpenSubdiv are passed to USD cmake step. And user doesn't need to specify TBB_DIR and OpenSubdiv_DIR when using pxr exported targets.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
