### PR TITLE
Provide quiet status specialization for python

### DIFF
--- a/pxr/base/tf/__init__.py
+++ b/pxr/base/tf/__init__.py
@@ -190,7 +190,7 @@ def Status(msg, verbose=True):
         codeInfo = GetCodeLocation(framesUp=1)
         _Status(msg, codeInfo[0], codeInfo[1], codeInfo[2], codeInfo[3])
     else:
-        _Status(msg, "", "", "", 0)
+        _Status(msg)
 
 def RaiseCodingError(msg):
     """Raise a coding error to the Tf Diagnostic system."""

--- a/pxr/base/tf/wrapStatus.cpp
+++ b/pxr/base/tf/wrapStatus.cpp
@@ -54,6 +54,15 @@ _Status(string const &msg, string const& moduleName, string const& functionName,
         Post(msg);
 }
 
+static void
+_QuietStatus(string const& msg)
+{
+    TfDiagnosticMgr::StatusHelper(
+        TfCallContext{},
+        TF_DIAGNOSTIC_STATUS_TYPE,
+        TfEnum::GetName(TfEnum(TF_DIAGNOSTIC_STATUS_TYPE)).c_str()).Post(msg);
+}
+
 static string
 TfStatus__repr__(TfStatus const &self)
 {
@@ -70,6 +79,7 @@ TfStatus__repr__(TfStatus const &self)
 
 void wrapStatus() {
     def("_Status", &_Status);
+    def("_Status", &_QuietStatus);
 
     typedef TfStatus This;
 


### PR DESCRIPTION
### Description of Change(s)
`Tf_PythonCallContext` assumes that a valid `moduleName` and `functionName` are available and joins them with `.`.  However, when `Tf.Status` is called with `verbose=False`, `moduleName` and `functionName` are both empty.

This yields a non-empty `fullName` of `.` when consumed by downstream diagnostic delegates that could be confusing.

This PR introduces a "quiet" version of `_Status` which bypasses `Tf_PyCallContext` and provides an explicitly empty `TfCallContext`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
#3311 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
