### PR TITLE
Add tests for ArchGetFileName with utf8 path

### DIFF
--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -98,7 +98,15 @@ int main()
     std::string filePath = ArchGetFileName(firstFile);
     ARCH_AXIOM(std::filesystem::equivalent(filePath, firstName));
     fclose(firstFile);
-
+    
+    // Test utf-8 path
+    std::string secondName = ArchMakeTmpFileName("测试");
+    ARCH_AXIOM((firstFile = ArchOpenFile(secondName.c_str(), "w")) != NULL);
+    filePath = ArchGetFileName(firstFile);
+    ARCH_AXIOM(std::filesystem::equivalent(std::filesystem::u8path(filePath),
+               std::filesystem::u8path(secondName)));
+    fclose(firstFile);
+    
     // Map the file and assert the bytes are what we expect they are.
     ARCH_AXIOM((firstFile = ArchOpenFile(firstName.c_str(), "rb")) != NULL);
     ArchConstFileMapping cfm = ArchMapFileReadOnly(firstFile);


### PR DESCRIPTION
### Description of Change(s)

ArchGetFileName was modified for returning full path, but it was not tested with utf8 path, and may cause crash when it's called with utf8 path. This MR is to add tests to cover that The fix is in PR https://github.com/PixarAnimationStudios/OpenUSD/pull/3545.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
