### PR TITLE
Fix for usdview not creating a context prior to opening stage

### DIFF
--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1223,13 +1223,15 @@ class AppController(QtCore.QObject):
             popMask = (None if populationMaskPaths is None else
                        Usd.StagePopulationMask())
 
-            # Open as a layer first to make sure its a valid file format
-            try:
-                layer = Sdf.Layer.FindOrOpen(usdFilePath)
-            except Tf.ErrorException as e:
-                sys.stderr.write(_GetFormattedError(
-                    [err.commentary.strip() for err in e.args]))
-                sys.exit(1)
+            ctx = self._resolverContextFn(usdFilePath)
+            with Ar.ResolverContextBinder(ctx):
+                # Open as a layer first to make sure its a valid file format
+                try:
+                    layer = Sdf.Layer.FindOrOpen(usdFilePath)
+                except Tf.ErrorException as e:
+                    sys.stderr.write(_GetFormattedError(
+                        [err.commentary.strip() for err in e.args]))
+                    sys.exit(1)
 
             if sessionFilePath:
                 try:
@@ -1250,12 +1252,12 @@ class AppController(QtCore.QObject):
                     popMask.Add(p)
                 stage = Usd.Stage.OpenMasked(layer,
                                              sessionLayer,
-                                             self._resolverContextFn(usdFilePath),
+                                             ctx,
                                              popMask, loadSet)
             else:
                 stage = Usd.Stage.Open(layer,
                                        sessionLayer,
-                                       self._resolverContextFn(usdFilePath), 
+                                       ctx, 
                                        loadSet)
 
             self._applyStageOpenLayerMutes(stage, muteLayersRe)

--- a/pxr/usdImaging/usdviewq/appController.py
+++ b/pxr/usdImaging/usdviewq/appController.py
@@ -1209,11 +1209,7 @@ class AppController(QtCore.QObject):
             if reasons:
                 err += "\n".join(reasons) + "\n"
             return err
-
-        if not Ar.GetResolver().Resolve(usdFilePath):
-            sys.stderr.write(_GetFormattedError(["File not found"]))
-            sys.exit(1)
-
+        
         if self._mallocTags != 'none':
             Tf.MallocTag.Initialize()
 
@@ -1232,6 +1228,11 @@ class AppController(QtCore.QObject):
                     sys.stderr.write(_GetFormattedError(
                         [err.commentary.strip() for err in e.args]))
                     sys.exit(1)
+
+                if not layer:
+                    if not Ar.GetResolver().Resolve(usdFilePath):
+                        sys.stderr.write(_GetFormattedError(["File not found"]))
+                        sys.exit(1)
 
             if sessionFilePath:
                 try:


### PR DESCRIPTION
### Description of Change(s)
This fixes the issue of usdview not creating it's context prior to reading the initial layer.
Prior to this fix the stage rootlayer would not respect the given context.

This issue is discussed here - https://forum.aousd.org/t/best-practices-opening-usdstage-versus-usdview/2367

I will submit another PR (shortly) for the usdcat/usdedit fix



### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
