### PR TITLE
Apple: Make Zipfile.cpp validate content length for zip32

### DIFF
--- a/pxr/usd/sdf/zipFile.cpp
+++ b/pxr/usd/sdf/zipFile.cpp
@@ -957,6 +957,12 @@ SdfZipFileWriter::AddFile(
     }
 
     _OutputStream outStream(_impl->outputFile.Get());
+    if (outStream.Tell() > UINT32_MAX) {
+        TF_RUNTIME_ERROR(
+            "Cannot add %s because zipfile is larger than allowed by Zip32 (%d)", filePath.c_str(), UINT32_MAX
+        );
+         return {};
+    }
 
     std::string err;
     ArchConstFileMapping mapping = ArchMapFileReadOnly(filePath, &err);
@@ -964,6 +970,14 @@ SdfZipFileWriter::AddFile(
         TF_RUNTIME_ERROR(
             "Failed to map '%s': %s", filePath.c_str(), err.c_str());
         return std::string();
+    }
+
+    auto fileSize = ArchGetFileMappingLength(mapping);
+    if (fileSize > UINT32_MAX) {
+        TF_RUNTIME_ERROR(
+            "Cannot add %s because it is larger than allowed by Zip32  (%d)", filePath.c_str(), UINT32_MAX
+        );
+        return {};
     }
 
     // Set up local file header
@@ -974,8 +988,8 @@ SdfZipFileWriter::AddFile(
     h.f.compressionMethod = 0; // No compression
     std::tie(h.f.lastModTime, h.f.lastModDate) = _ModTimeAndDate(filePath);
     h.f.crc32 = _Crc32(mapping);
-    h.f.compressedSize = ArchGetFileMappingLength(mapping);
-    h.f.uncompressedSize = ArchGetFileMappingLength(mapping);
+    h.f.compressedSize = fileSize;
+    h.f.uncompressedSize = fileSize;
     h.f.filenameLength = zipFilePath.length();
     
     const uint32_t offset = outStream.Tell();
@@ -1060,6 +1074,13 @@ SdfZipFileWriter::Save()
         r.commentStart = nullptr;
 
         _WriteEndOfCentralDirectoryRecord(outStream, r);
+    }
+
+    if (outStream.Tell() > UINT32_MAX) {
+        TF_RUNTIME_ERROR(
+            "Zipfile is larger than allowed by Zip32 (%d)", UINT32_MAX
+        );
+        return false;
     }
 
     _impl->outputFile.Close();


### PR DESCRIPTION
### Description of Change(s)

This PR adds validations to zipFIle write out so that we can make sure we're only writing valid Zip32 files.
This prevents several forms of data corruption, and allows for early exits.

I haven't added unit tests since I don't know of a good way to add a test here for such large data without wrecking CI setups (nobody wants unnecessary 4GB files in there).

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3424 (partially since this also includes other suggestions)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3098

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
