### PR TITLE
 Fix for usdcat not using a context

### DIFF
--- a/pxr/usd/bin/usdcat/usdcat.cpp
+++ b/pxr/usd/bin/usdcat/usdcat.cpp
@@ -7,6 +7,8 @@
 
 #include "pxr/pxr.h"
 
+#include "pxr/usd/ar/resolver.h"
+#include "pxr/usd/ar/resolverContextBinder.h"
 #include "pxr/base/tf/fileUtils.h"
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/pxrCLI11/CLI11.h"
@@ -184,21 +186,35 @@ static int UsdCat(const Args &args) {
         // Capture errors that are emitted so we can do error handling below.
         TfErrorMark errMark;
 
+        // create and bind a context for opening layers
+        ArResolver &resolver = ArGetResolver();
+        const ArResolverContext context =
+            resolver.CreateDefaultContextForAsset(input);
+        const ArResolverContextBinder binder(context);
+
         // Either open a layer or compose a stage, depending on whether or not
         // --flatten was specified.
         if (args.flatten) {
+            // create context layer for stage opening
+            SdfLayerRefPtr ctxLayer;
+            ctxLayer = SdfLayer::FindOrOpen(input);
+
             if (args.mask.empty()) {
-                stage = UsdStage::Open(input);
+                stage = UsdStage::Open(ctxLayer, context);
             } else {
                 // Mask can be provided as a comma or space delimited string
                 auto mask = UsdStagePopulationMask();
                 for (const auto &path : TfStringTokenize(args.mask, ", ")) {
                     mask.Add(SdfPath(path));
                 }
-                stage = UsdStage::OpenMasked(input, mask);
+                stage = UsdStage::OpenMasked(ctxLayer, context, mask);
             }
         } else if (args.flattenLayerStack) {
-            stage = UsdStage::Open(input, UsdStage::LoadNone);
+            // create context layer for stage opening
+            SdfLayerRefPtr ctxLayer;
+            ctxLayer = SdfLayer::FindOrOpen(input);
+
+            stage = UsdStage::Open(ctxLayer, context, UsdStage::LoadNone);
             if (stage) {
                 layer = UsdUtilsFlattenLayerStack(stage);
             }


### PR DESCRIPTION
### Description of Change(s)
This fixes the issue of usdcat not creating it's context prior to reading the initial layer and loading a stage.

This helps to bring usdcat and usdedit inline with the recent fix to usdview - https://github.com/PixarAnimationStudios/OpenUSD/pull/3616



### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
