### PR TITLE
Fixed crash in ArchReadLink on Windows.

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -1219,8 +1219,9 @@ std::string ArchReadLink(const char* path)
                                unsigned char[MAX_REPARSE_DATA_SIZE]);
     REPARSE_DATA_BUFFER* reparse = (REPARSE_DATA_BUFFER*)buffer.get();
 
+    DWORD bytesReturned = 0;
     if (!DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0, reparse,
-                         MAX_REPARSE_DATA_SIZE, NULL, NULL)) {
+                         MAX_REPARSE_DATA_SIZE, &bytesReturned, NULL)) {
         CloseHandle(handle);
         return std::string();
     }


### PR DESCRIPTION
Fixed a crash that was caused by passing in a null pointer that returns the size of returned buffer. The win32 documentation for DeviceIoControl says that this parameter can't be null when the `lpOverlapped` parameter is null. https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-deviceiocontrol

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
