### PR TITLE
[usdImaging] Fix crash upon deleting or deactivating all skinning targets

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdSkelImaging/CMakeLists.txt
@@ -47,3 +47,32 @@ pxr_library(usdSkelImaging
         plugInfo.json
         shaders/skinning.glslfx
 )
+
+# Build tests
+pxr_build_test(testUsdSkelImagingSkeletonAdapter
+    LIBRARIES
+        usdImaging
+        usdShade
+        usdGeom
+        usdSkel
+        usd
+        sdf
+        hd
+        tf
+        gf
+        arch
+    CPPFILES
+        testenv/testUsdSkelImagingSkeletonAdapter.cpp
+)
+
+# Install (copy test assets and baselines)
+pxr_install_test_dir(
+    SRC testenv/testUsdSkelImagingSkeletonAdapter
+    DEST testUsdSkelImagingSkeletonAdapter
+)
+
+# Register tests
+pxr_register_test(testUsdSkelImagingSkeletonAdapter
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSkelImagingSkeletonAdapter"
+    EXPECTED_RETURN_CODE 0
+)

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -151,6 +151,10 @@ UsdSkelImagingSkeletonAdapter::Populate(
             
             // Insert two computations ...
             UsdPrim const& skinnedPrim = query.GetPrim();
+            if (!skinnedPrim) {
+                continue;
+            }
+
             SdfPath skinnedPrimPath = ResolveCachePath(
                 skinnedPrim.GetPath(), instancerContext);
 

--- a/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingSkeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingSkeletonAdapter.cpp
@@ -1,0 +1,61 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/usdImaging/usdImaging/unitTestHelper.h"
+
+#include "pxr/imaging/hd/material.h"
+#include "pxr/imaging/hd/renderIndex.h"
+#include "pxr/imaging/hd/unitTestNullRenderDelegate.h"
+
+#include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usd/editContext.h"
+#include "pxr/usd/usdSkel/animation.h"
+#include "pxr/usd/usdSkel/bindingAPI.h"
+#include "pxr/usd/usdSkel/root.h"
+
+#include <iostream>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static void
+TestSkinnedMeshInvalidation()
+{
+    std::cout << "-------------------------------------------------------\n";
+    std::cout << "TestSkinnedMeshInvalidation\n";
+    std::cout << "-------------------------------------------------------\n";
+
+    const std::string usdPath = "model.usda";
+    UsdStageRefPtr stage = UsdStage::Open(usdPath);
+    TF_AXIOM(stage);
+    
+    // Bring up Hydra
+    Hd_UnitTestNullRenderDelegate renderDelegate;
+    std::unique_ptr<HdRenderIndex>
+        renderIndex(HdRenderIndex::New(&renderDelegate, HdDriverVector()));
+    auto delegate = std::make_unique<UsdImagingDelegate>(renderIndex.get(),
+                               SdfPath::AbsoluteRootPath());
+    delegate->Populate(stage->GetPseudoRoot());
+    delegate->ApplyPendingUpdates();
+    delegate->SyncAll(true);
+    
+    UsdPrim box_prim = stage->GetPrimAtPath(SdfPath("/Root/Skinning"));
+    TF_AXIOM(box_prim);
+    box_prim.SetActive(false);
+    // Test crash due to access invalidated skinning mesh.
+    // NOTE: This is a test for a crash that happened in the
+    //       UsdSkelImagingSkeletonAdapter::Populate() method.
+    delegate->ApplyPendingUpdates();
+    delegate->SyncAll(true);
+    box_prim.SetActive(true);
+    delegate->ApplyPendingUpdates();
+    delegate->SyncAll(true);
+}
+
+int main()
+{
+    TestSkinnedMeshInvalidation();
+}

--- a/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingSkeletonAdapter/model.usda
+++ b/pxr/usdImaging/usdSkelImaging/testenv/testUsdSkelImagingSkeletonAdapter/model.usda
@@ -1,0 +1,41 @@
+#usda 1.0
+(
+    defaultPrim = "Root"
+)
+
+def SkelRoot "Root" (
+    prepend apiSchemas = ["SkelBindingAPI"]
+)
+{
+    rel skel:skeleton = </Root/Skeleton>
+    def Xform "Skinning"
+    {
+        def Mesh "Box" (
+            apiSchemas = ["SkelBindingAPI"]
+        )
+        {
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 4, 5, 6, 7, 1, 2, 5, 6, 0, 4, 7, 3, 0, 1, 5, 4, 3, 7, 6, 2]
+            token orientation = "rightHanded"
+            point3f[] points = [(-0.6, -0.6, 0), (-0.6, 0.6, 0), (0.6, 0.6, 0), (0.6, -0.6, 0), (-0.6, -0.6, 0.14), (-0.6, 0.6, 0.14), (0.6, 0.6, 0.14), (0.6, -0.6, 0.14)]
+            
+            int[] primvars:skel:jointIndices = [0, 0, 0, 0] (interpolation = "vertex")
+            float[] primvars:skel:jointWeights = [1., 1., 1., 1.] (interpolation = "vertex")
+            bool doubleSided = 1
+        }
+    }
+
+    def Skeleton "Skeleton" (
+        prepend apiSchemas = ["SkelBindingAPI"]
+    )
+    {
+        uniform token[] joints = ["Root"]
+        uniform matrix4d[] bindTransforms = [
+            ((1., 0., 0., 0.), (0., 1., 0., 0.), (0., 0., 1., 0.), (0.0, 0.0, 0.0, 1.)),    # Root
+        ]
+        uniform matrix4d[] restTransforms = [
+            ((1., 0., 0., 0.), (0., 1., 0., 0.), (0., 0., 1., 0.), (0., 0., 0., 1.)),    # Root
+        ]
+    }
+}
+


### PR DESCRIPTION
### Description of Change(s)

 Fix crash upon deleting or deactivating all skinning targets. This is only crashed when all skinning targets are removed or deactivated. 

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
