### PR TITLE
Reference `arch_{c,d}tor`'s address to prevent inline removal

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -9,7 +9,7 @@
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /EHsc")
 
 # Standards compliant.
-set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings")
+set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings /Zc:inline")
 
 # Visual Studio sets the value of __cplusplus to 199711L regardless of
 # the C++ standard actually being used, unless /Zc:__cplusplus is enabled.
@@ -17,19 +17,6 @@ set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:rvalueCast /Zc:strictStrings")
 # For more details, see:
 # https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:__cplusplus")
-
-# The /Zc:inline option strips out the "arch_ctor_<name>" symbols used for
-# library initialization by ARCH_CONSTRUCTOR starting in Visual Studio 2019, 
-# causing release builds to fail. Disable the option for this and later 
-# versions.
-# 
-# For more details, see:
-# https://developercommunity.visualstudio.com/content/problem/914943/zcinline-removes-extern-symbols-inside-anonymous-n.html
-if (MSVC_VERSION GREATER_EQUAL 1920)
-    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline-")
-else()
-    set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /Zc:inline")
-endif()
 
 # Turn on all but informational warnings.
 set(_PXR_CXX_FLAGS "${_PXR_CXX_FLAGS} /W3")

--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -16,6 +16,8 @@
 #include "pxr/pxr.h"
 #include "pxr/base/arch/export.h"
 
+#include <memory>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 #if defined(doxygen)
@@ -277,20 +279,24 @@ struct Arch_ConstructorInit {
     ARCH_API ~Arch_ConstructorInit();
 };
 
-// Emit a Arch_ConstructorEntry in the .pxrctor section.  The namespace and
-// extern are to convince the compiler and linker to leave the object in the
-// final library/executable instead of stripping it out.  In clang/gcc we use
+// Emit a Arch_ConstructorEntry in the .pxrctor section.  The
+// arch_{c,d}tor_unused assignment is a workaround to ensure arch_{c,d}tor
+// isn't removed when /Zc:inline is enabled. In clang/gcc we use
 // __attribute__((used)) to do that.
 #   define ARCH_CONSTRUCTOR(_name, _priority)                                  \
     static void _name();                                                       \
     namespace {                                                                \
     __declspec(allocate(".pxrctor"))                                           \
-    extern const Arch_ConstructorEntry                                         \
+    static const Arch_ConstructorEntry                                         \
     _ARCH_CAT_NOEXPAND(arch_ctor_, _name) = {                                  \
         reinterpret_cast<Arch_ConstructorEntry::Type>(&_name),                 \
         static_cast<unsigned>(PXR_VERSION),                                    \
         _priority                                                              \
     };                                                                         \
+    void _ARCH_CAT_NOEXPAND(arch_ctor_unused, _name)() {                       \
+        static const auto unused =                                             \
+             std::addressof(_ARCH_CAT_NOEXPAND(arch_ctor_, _name));            \
+    }                                                                          \
     }                                                                          \
     _ARCH_ENSURE_PER_LIB_INIT(Arch_ConstructorInit, _archCtorInit);            \
     static void _name()
@@ -300,12 +306,16 @@ struct Arch_ConstructorInit {
     static void _name();                                                       \
     namespace {                                                                \
     __declspec(allocate(".pxrdtor"))                                           \
-    extern const Arch_ConstructorEntry                                         \
+    static const Arch_ConstructorEntry                                         \
     _ARCH_CAT_NOEXPAND(arch_dtor_, _name) = {                                  \
         reinterpret_cast<Arch_ConstructorEntry::Type>(&_name),                 \
         static_cast<unsigned>(PXR_VERSION),                                    \
         _priority                                                              \
     };                                                                         \
+    void _ARCH_CAT_NOEXPAND(arch_dtor_unused, _name)() {                       \
+        static const auto unused =                                             \
+             std::addressof(_ARCH_CAT_NOEXPAND(arch_dtor_, _name));            \
+    }                                                                          \
     }                                                                          \
     _ARCH_ENSURE_PER_LIB_INIT(Arch_ConstructorInit, _archCtorInit);            \
     static void _name()


### PR DESCRIPTION
### Description of Change(s)
In Visual Studio 2019, `/Zc:inline` started pruning out code managed by the `ARCH_{CONSTRUCTOR,DESTRUCTOR}` pattern, primarily affecting code in `TfRegistry` code blocks. The temporary solution was to disable `/Zc:inline` which yields larger binaries (acf7c132affd6489b2f96c8b94d689e7508a90e6).

The post tracking this issue was recently closed. It was suggested that taking the address of the discarded `Arch_ConstructorEntry` could hint that the symbol is being used: [/Zc:inline removes extern symbols inside anonymous namespaces in VS2019 - Developer Community](https://developercommunity.visualstudio.com/t/zcinline-removes-extern-symbols-inside-anonymous-n/914943).

This implements the suggestion.  A quick test suggests it reduces the size of the DLL directory by about 10%. The `/Zc:inline` documentation suggests there should be faster link times, but that was not profiled.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#1279

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
