### PR TITLE
[hdMtlx] fix CMakeList.txt to build tests

### DIFF
--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -360,7 +360,7 @@ pxr_register_test(testUsdImagingStageSceneIndexContents
 # This test requires MaterialX support and is not currently supported on static 
 # builds as it uses a plugin mechanism which is not supported for static build 
 # configurations. 
-if (BUILD_SHARED_LIBS AND $PXR_ENABLE_MATERIALX_SUPPORT)
+if (BUILD_SHARED_LIBS AND ${PXR_ENABLE_MATERIALX_SUPPORT})
 
 pxr_build_test(testUsdImagingHdMtlx
     LIBRARIES


### PR DESCRIPTION
### Description of Change(s)

Fix a typo that made it so the hdMtlx tests weren't buildable.


### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
