### PR TITLE
Apple: Handle NaN and Inf timesample situations

### DIFF
--- a/pxr/usd/pcp/errors.cpp
+++ b/pxr/usd/pcp/errors.cpp
@@ -640,6 +640,31 @@ PcpErrorInvalidSublayerOffset::ToString() const
 
 ///////////////////////////////////////////////////////////////////////////////
 
+PcpErrorInvalidSublayerTimeCodesPerSecondPtr
+PcpErrorInvalidSublayerTimeCodesPerSecond::New()
+{
+    return PcpErrorInvalidSublayerTimeCodesPerSecondPtr(new PcpErrorInvalidSublayerTimeCodesPerSecond);
+}
+
+PcpErrorInvalidSublayerTimeCodesPerSecond::PcpErrorInvalidSublayerTimeCodesPerSecond() :
+    PcpErrorBase(PcpErrorType_InvalidSublayerTimeCodesPerSecond)
+{
+}
+
+PcpErrorInvalidSublayerTimeCodesPerSecond::~PcpErrorInvalidSublayerTimeCodesPerSecond()
+{
+}
+
+// virtual
+std::string
+PcpErrorInvalidSublayerTimeCodesPerSecond::ToString() const
+{
+    return TfStringPrintf("Invalid timeCodesPerScond %f in layer @%s . Using default of 24.0.",
+        timeCodesPerSecond , layer->GetIdentifier().c_str());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 PcpErrorInvalidReferenceOffsetPtr
 PcpErrorInvalidReferenceOffset::New()
 {

--- a/pxr/usd/pcp/errors.h
+++ b/pxr/usd/pcp/errors.h
@@ -43,6 +43,7 @@ enum PcpErrorType {
     PcpErrorType_InvalidTargetPath,
     PcpErrorType_InvalidReferenceOffset,
     PcpErrorType_InvalidSublayerOffset,
+    PcpErrorType_InvalidSublayerTimeCodesPerSecond,
     PcpErrorType_InvalidSublayerOwnership,
     PcpErrorType_InvalidSublayerPath,
     PcpErrorType_InvalidVariantSelection,
@@ -590,6 +591,35 @@ public:
 private:
     /// Constructor is private. Use New() instead.
     PcpErrorInvalidSublayerOffset();
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Forward declarations:
+class PcpErrorInvalidSublayerTimeCodesPerSecond;
+typedef std::shared_ptr<PcpErrorInvalidSublayerTimeCodesPerSecond>
+    PcpErrorInvalidSublayerTimeCodesPerSecondPtr;
+
+/// \class PcpErrorInvalidSublayerTimeCodesPerSecond
+///
+/// Sublayers that have an invalid Timecodes Per Second
+///
+class PcpErrorInvalidSublayerTimeCodesPerSecond : public PcpErrorBase {
+public:
+    /// Returns a new error object.
+    static PcpErrorInvalidSublayerTimeCodesPerSecondPtr New();
+    /// Destructor.
+    PCP_API ~PcpErrorInvalidSublayerTimeCodesPerSecond() override;
+    /// Converts error to string message.
+    PCP_API std::string ToString() const override;
+
+    SdfLayerHandle layer;
+    double timeCodesPerSecond;
+
+private:
+    /// Constructor is private. Use New() instead.
+    PcpErrorInvalidSublayerTimeCodesPerSecond();
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pxr/usd/pcp/layerStack.cpp
+++ b/pxr/usd/pcp/layerStack.cpp
@@ -30,7 +30,7 @@
 
 using std::string;
 using std::vector;
-
+#include <iostream>
 PXR_NAMESPACE_OPEN_SCOPE
 
 ////////////////////////////////////////////////////////////////////////
@@ -1551,7 +1551,7 @@ PcpLayerStack::_Compute(const std::string &fileFormatTarget,
 
     // The layer stack's time codes per second initially comes from the root 
     // layer. An opinion in the session layer may override it below.
-    _timeCodesPerSecond = rootTcps;
+    _timeCodesPerSecond = _validatedTimeCodesPerSecond(_identifier.rootLayer, rootTcps, &errors);
 
     // Add the layer stack due to the session layer.  We *don't* apply
     // the sessionOwner to this stack.  We also skip this if the session
@@ -1583,7 +1583,7 @@ PcpLayerStack::_Compute(const std::string &fileFormatTarget,
             // layer stack TCPS to the layer.
             if (_ShouldUseSessionTcps(_identifier.sessionLayer, 
                                       _identifier.rootLayer)) {
-                _timeCodesPerSecond = sessionTcps;
+                _timeCodesPerSecond = _validatedTimeCodesPerSecond(_identifier.sessionLayer, sessionTcps, &errors);
                 rootLayerOffset.SetScale(_timeCodesPerSecond / rootTcps);
             } else {
                 sessionLayerOffset.SetScale(_timeCodesPerSecond / sessionTcps);
@@ -1805,7 +1805,8 @@ PcpLayerStack::_BuildLayerStack(
 
         // Apply the scale from computed layer TCPS to sublayer TCPS to sublayer
         // layer offset.
-        const double sublayerTcps = sublayerRefPtrs[i]->GetTimeCodesPerSecond();
+        double sublayerTcps = sublayerRefPtrs[i]->GetTimeCodesPerSecond();
+        sublayerTcps = _validatedTimeCodesPerSecond(sublayerRefPtrs[i], sublayerTcps, errors);
         if (layerTcps != sublayerTcps) {
             sublayerOffset.SetScale(sublayerOffset.GetScale() * 
                                     layerTcps / sublayerTcps);
@@ -1859,6 +1860,21 @@ PcpLayerStack::_BuildLayerStack(
     seenLayers->erase(layer);
 
     return SdfLayerTree::New(layer, subtrees, offset);
+}
+
+double PcpLayerStack::_validatedTimeCodesPerSecond(const SdfLayerHandle & layer, double tcps, PcpErrorVector *errors) {
+    if (tcps <= 0) {
+        // Report error, but continue with the default timeCodesPerSecond value
+        PcpErrorInvalidSublayerTimeCodesPerSecondPtr err =
+            PcpErrorInvalidSublayerTimeCodesPerSecond::New();
+        err->rootSite = PcpSite(_identifier, SdfPath::AbsoluteRootPath());
+        err->layer       = layer;
+        err->timeCodesPerSecond    = tcps;
+        errors->push_back(err);
+        return 24.0;
+    }
+
+    return tcps;
 }
 
 std::ostream&

--- a/pxr/usd/pcp/layerStack.h
+++ b/pxr/usd/pcp/layerStack.h
@@ -241,6 +241,8 @@ private:
         SdfLayerHandleSet *seenLayers,
         PcpErrorVector *errors);
 
+    double _validatedTimeCodesPerSecond(const SdfLayerHandle & layer, double tcps, PcpErrorVector *errors);
+
 private:
     /// The identifier that uniquely identifies this layer stack.
     const PcpLayerStackIdentifier _identifier;

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -9439,10 +9439,10 @@ UsdStage::_GetTimeSamplesInIntervalFromResolveInfo(
                 // Map the interval (expressed in stage time) to layer time.
                 const SdfLayerOffset stageToLayer =
                     info._layerToStageOffset.GetInverse();
-                const GfInterval layerInterval =
-                    interval * stageToLayer.GetScale()
-                    + stageToLayer.GetOffset();
-                if (std::isfinite(interval.GetMin()) && std::isfinite(interval.GetMax())) {
+                if (std::isfinite(stageToLayer.GetScale()) && std::isfinite(stageToLayer.GetOffset())) {
+                    const GfInterval layerInterval =
+                        interval * stageToLayer.GetScale()
+                        + stageToLayer.GetOffset();
                     Usd_CopyTimeSamplesInInterval(samples, layerInterval, times);
                     // Map the layer sample times to stage times.
                     for (auto &time : *times) {

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -9439,15 +9439,19 @@ UsdStage::_GetTimeSamplesInIntervalFromResolveInfo(
                 // Map the interval (expressed in stage time) to layer time.
                 const SdfLayerOffset stageToLayer =
                     info._layerToStageOffset.GetInverse();
-                if (std::isfinite(stageToLayer.GetScale()) && std::isfinite(stageToLayer.GetOffset())) {
-                    const GfInterval layerInterval =
-                        interval * stageToLayer.GetScale()
-                        + stageToLayer.GetOffset();
-                    Usd_CopyTimeSamplesInInterval(samples, layerInterval, times);
-                    // Map the layer sample times to stage times.
-                    for (auto &time : *times) {
-                        time = info._layerToStageOffset * time;
-                    }
+                // If we encounter an invalid offset, we issue a warning but don't stop processing.
+                // This effectively makes the stage static on failure but still allows it to process.
+                if (!stageToLayer.IsValid()) {
+                    TF_WARN("SdfLayerOffset has unsupported values. Stage will be treated as static.");
+                    return true;
+                }
+                const GfInterval layerInterval =
+                    interval * stageToLayer.GetScale()
+                    + stageToLayer.GetOffset();
+                Usd_CopyTimeSamplesInInterval(samples, layerInterval, times);
+                // Map the layer sample times to stage times.
+                for (auto &time : *times) {
+                    time = info._layerToStageOffset * time;
                 }
             }
         }

--- a/pxr/usd/usd/stage.cpp
+++ b/pxr/usd/usd/stage.cpp
@@ -90,6 +90,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -8088,7 +8089,7 @@ _HasTimeSamples(const SdfLayerRefPtr& source,
                 const double* time = nullptr, 
                 double* lower = nullptr, double* upper = nullptr)
 {
-    if (time) {
+    if (time && std::isfinite(*time)) {
         // If caller wants bracketing time samples as well, we can just use
         // GetBracketingTimeSamplesForPath. If no samples exist, this should
         // return false.
@@ -9441,10 +9442,12 @@ UsdStage::_GetTimeSamplesInIntervalFromResolveInfo(
                 const GfInterval layerInterval =
                     interval * stageToLayer.GetScale()
                     + stageToLayer.GetOffset();
-                Usd_CopyTimeSamplesInInterval(samples, layerInterval, times);
-                // Map the layer sample times to stage times.
-                for (auto &time : *times) {
-                    time = info._layerToStageOffset * time;
+                if (std::isfinite(interval.GetMin()) && std::isfinite(interval.GetMax())) {
+                    Usd_CopyTimeSamplesInInterval(samples, layerInterval, times);
+                    // Map the layer sample times to stage times.
+                    for (auto &time : *times) {
+                        time = info._layerToStageOffset * time;
+                    }
                 }
             }
         }

--- a/pxr/usd/usd/testenv/testUsdNanTimesamples/_animation.usda
+++ b/pxr/usd/usd/testenv/testUsdNanTimesamples/_animation.usda
@@ -1,0 +1,33 @@
+#usda 1.0
+(
+    defaultPrim = "mesh"
+    endTimeCode = 100
+    startTimeCode = 0
+)
+
+def Mesh "mesh"
+{
+    double3 xformOp:translate = (0, 0, 0)
+    double3 xformOp:translate.timeSamples = {
+        0: (0, 0, 0),
+        100: (100, 0, 0),
+    }
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 4, 6, 2, 0, 1, 5, 4, 4, 5, 7, 6, 3, 7, 5, 1, 6, 7, 3, 2, 2, 3, 1, 0]
+    point3f[] points = [(-0.5, -0.5, -0.5), (0.5, -0.5, -0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5)]
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+    uniform token subdivisionScheme = "none"
+}
+
+def Camera "camera" {
+    float2 clippingRange = (1.0, 2000000.0)
+    float focalLength = 218.12925720214844
+    float focusDistance = 1129.03515625
+    float fStop = 5.6
+    float horizontalAperture = 24.0519962310791
+    float verticalAperture = 20.954999923706055
+    custom Matrix4d xformOp:transform = ((1.0, 0.0, 0.0, 0.0),(0.0, 1.0, 0.0, 0.0),(0.0, 0.0, 1.0, 0.0),(50.0, 0.0, 1129.0351765518724, 1.0))
+    uniform token[] xformOpOrder = ["xformOp:transform"]
+}

--- a/pxr/usd/usd/testenv/testUsdNanTimesamples/entry_point.usda
+++ b/pxr/usd/usd/testenv/testUsdNanTimesamples/entry_point.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    timeCodesPerSecond = 0
+    endTimeCode = 100
+    startTimeCode = 0
+    subLayers = [
+        @_animation.usda@
+    ]
+)

--- a/pxr/usd/usd/testenv/testUsdTimeSamples.py
+++ b/pxr/usd/usd/testenv/testUsdTimeSamples.py
@@ -656,5 +656,9 @@ def "Foo" {
         self.assertEqual(x.Get(Usd.TimeCode.PreTime(17)), 
                          Vt.DoubleArray(2, (6, 7)))
 
+    def testUsdNanTimesamples(self):
+        stage = Usd.Stage.Open("testUsdNanTimesamples/entry_point.usda")
+        self.assertTrue(stage.GetPrimAtPath("/Mesh").IsValid())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)

There are certain situations where USD encounters a NaN or Inf time or time interval when populating the scene values, causing a crash.

This PR simply checks for the values being finite before proceeding.

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
