### PR TITLE
Upgrade to Embree 4

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1599,12 +1599,8 @@ MATERIALX = Dependency("MaterialX", InstallMaterialX, "include/MaterialXCore/Lib
 
 ############################################################
 # Embree
-# For MacOS we use version 3.13.3 to include a fix from Intel
-# to build on Apple Silicon.
-if MacOS():
-    EMBREE_URL = "https://github.com/embree/embree/archive/v3.13.3.zip"
-else:
-    EMBREE_URL = "https://github.com/embree/embree/archive/v3.2.2.zip"
+
+EMBREE_URL = "https://github.com/embree/embree/archive/v4.4.0.zip"
 
 def InstallEmbree(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(EMBREE_URL, context, force)):

--- a/cmake/modules/FindEmbree.cmake
+++ b/cmake/modules/FindEmbree.cmake
@@ -20,11 +20,11 @@
 #=============================================================================
 
 if (APPLE)
-    set (EMBREE_LIB_NAME libembree3.dylib)
+    set (EMBREE_LIB_NAME libembree4.dylib)
 elseif (UNIX)
-    set (EMBREE_LIB_NAME libembree3.so)
+    set (EMBREE_LIB_NAME libembree4.so)
 elseif (WIN32)
-    set (EMBREE_LIB_NAME embree3.lib)
+    set (EMBREE_LIB_NAME embree4.lib)
 endif()
 
 find_library(EMBREE_LIBRARY
@@ -39,7 +39,7 @@ find_library(EMBREE_LIBRARY
 )
 
 find_path(EMBREE_INCLUDE_DIR
-    embree3/rtcore.h
+    embree4/rtcore.h
 HINTS
     "${EMBREE_LOCATION}/include"
     "$ENV{EMBREE_LOCATION}/include"
@@ -47,12 +47,12 @@ DOC
     "Embree headers path"
 )
 
-if (EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" )
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MAJOR.*$")
+if (EMBREE_INCLUDE_DIR AND EXISTS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h" )
+    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MAJOR.*$")
     string(REGEX MATCHALL "[0-9]+" MAJOR ${TMP})
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MINOR.*$")
+    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_MINOR.*$")
     string(REGEX MATCHALL "[0-9]+" MINOR ${TMP})
-    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree3/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_PATCH.*$")
+    file(STRINGS "${EMBREE_INCLUDE_DIR}/embree4/rtcore_version.h" TMP REGEX "^#define RTC_VERSION_PATCH.*$")
     string(REGEX MATCHALL "[0-9]+" PATCH ${TMP})
 
     set (EMBREE_VERSION ${MAJOR}.${MINOR}.${PATCH})

--- a/pxr/imaging/plugin/hdEmbree/context.h
+++ b/pxr/imaging/plugin/hdEmbree/context.h
@@ -14,7 +14,7 @@
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/vt/array.h"
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/mesh.h
+++ b/pxr/imaging/plugin/hdEmbree/mesh.h
@@ -15,8 +15,8 @@
 
 #include "pxr/imaging/plugin/hdEmbree/meshSamplers.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/meshSamplers.h
+++ b/pxr/imaging/plugin/hdEmbree/meshSamplers.h
@@ -12,8 +12,8 @@
 #include "pxr/imaging/hd/meshUtil.h"
 #include "pxr/base/vt/types.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_geometry.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_geometry.h>
 
 #include <bitset>
 

--- a/pxr/imaging/plugin/hdEmbree/pch.h
+++ b/pxr/imaging/plugin/hdEmbree/pch.h
@@ -76,9 +76,9 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_geometry.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_geometry.h>
+#include <embree4/rtcore_ray.h>
 #include <tbb/blocked_range.h>
 #include <tbb/cache_aligned_allocator.h>
 #include <tbb/concurrent_hash_map.h>

--- a/pxr/imaging/plugin/hdEmbree/renderDelegate.h
+++ b/pxr/imaging/plugin/hdEmbree/renderDelegate.h
@@ -14,7 +14,7 @@
 #include "pxr/base/tf/staticTokens.h"
 
 #include <mutex>
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/renderParam.h
+++ b/pxr/imaging/plugin/hdEmbree/renderParam.h
@@ -11,7 +11,7 @@
 #include "pxr/imaging/hd/renderDelegate.h"
 #include "pxr/imaging/hd/renderThread.h"
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/plugin/hdEmbree/renderer.cpp
+++ b/pxr/imaging/plugin/hdEmbree/renderer.cpp
@@ -667,9 +667,9 @@ HdEmbreeRenderer::_TraceRay(unsigned int x, unsigned int y,
     rayHit.ray.flags = 0;
     _PopulateRayHit(&rayHit, origin, dir, 0.0f);
     {
-      RTCIntersectContext context;
-      rtcInitIntersectContext(&context);
-      rtcIntersect1(_scene, &context, &rayHit);
+      RTCIntersectArguments arguments;
+      rtcInitIntersectArguments(&arguments);
+      rtcIntersect1(_scene, &rayHit, &arguments);
       //
       // there is something odd about how this is used in Embree. Is it reversed
       // here and then when it it used in
@@ -1005,9 +1005,9 @@ HdEmbreeRenderer::_ComputeAmbientOcclusion(GfVec3f const& position,
         shadow.flags = 0;
         _PopulateRay(&shadow, position, shadowDir, 0.001f);
         {
-          RTCIntersectContext context;
-          rtcInitIntersectContext(&context);
-          rtcOccluded1(_scene,&context,&shadow);
+          RTCOccludedArguments arguments;
+          rtcInitOccludedArguments(&arguments);
+          rtcOccluded1(_scene,&shadow,&arguments);
         }
 
         // Record this AO ray's contribution to the occlusion factor: a

--- a/pxr/imaging/plugin/hdEmbree/renderer.h
+++ b/pxr/imaging/plugin/hdEmbree/renderer.h
@@ -15,8 +15,8 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/rect2i.h"
 
-#include <embree3/rtcore.h>
-#include <embree3/rtcore_ray.h>
+#include <embree4/rtcore.h>
+#include <embree4/rtcore_ray.h>
 
 #include <random>
 #include <atomic>

--- a/pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
+++ b/pxr/imaging/plugin/hdEmbree/testenv/testHdEmbree.cpp
@@ -23,7 +23,7 @@
 
 #include "pxr/base/tf/errorMark.h"
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 #include <iostream>
 
 PXR_NAMESPACE_USING_DIRECTIVE


### PR DESCRIPTION
### Description of Change(s)

Embree 3 has compiler issues with the latest versions of Clang. While we could opt to add patches in the build_usd.py to make it pass, it feels like there's better incentive to just move to newer Embree since it's not production critical, but is useful for validations.

I did consider keeping support for Embree 3 in addition to Embree 4, but for the same reason, it felt like it would just overcomplicate things given the limitations of the current Embree backend.

Posting this PR on behalf of Maddy Adams

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
