### PR TITLE
Fix unsigned underflow in HdStMesh loop when instance levels are zero (Fixes #3239)

### DIFF
--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -362,9 +362,8 @@ HdStMesh::_UpdateDrawItemsForGeomSubsets(HdSceneDelegate *sceneDelegate,
                         &changeTracker);
                 }
             } else {
-                // more geom subsets than before
-                // move instance primvar levels toward end
-                for (size_t i = numInstanceLevels - 1; i >= 0; --i) {
+                if (numInstanceLevels > 0) {
+                    for (size_t i = numInstanceLevels; i-- > 0;) {
                     HdBufferArrayRangeSharedPtr instancePvRange = 
                         drawItem->GetInstancePrimvarRange(i);
                     HdStUpdateDrawItemBAR(


### PR DESCRIPTION
### Description of Change(s)

This change fixes an unsigned integer underflow in HdStMesh::_UpdateDrawItemsForGeomSubsets where numInstanceLevels was used in a reverse loop without checking for zero. When numInstanceLevels == 0, the loop previously wrapped around due to the use of size_t, causing usdview and HdStorm to hang or enter an extremely long loop. This is now resolved by adding a guard check and using a safe reverse loop form:

`for (size_t i = numInstanceLevels; i-- > 0;)
`
### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
