### PR TITLE
Apple: Handle a possible nullptr when checking layer dependencies

### DIFF
--- a/pxr/usd/usdUtils/assetLocalization.cpp
+++ b/pxr/usd/usdUtils/assetLocalization.cpp
@@ -122,6 +122,10 @@ UsdUtils_LocalizationContext::_ProcessLayer(
         SdfPrimSpecHandle curr = dfs.top();
         dfs.pop();
 
+        if (!curr) {
+            continue;
+        }
+
         // Metadata is processed even on the pseudoroot, which ensures
         // we process layer metadata properly.
         _ProcessMetadata(layer, curr);


### PR DESCRIPTION
### Description of Change(s)

When trying to package this asset, we experience a nullptr dereference while traversing the dependencies.
It's a simple check in the DFS to avoid the crash. Note that the localization will still faile, but it won't crash anymore.

[palmtree.usdc.zip](https://github.com/user-attachments/files/20258336/palmtree.usdc.zip)

I don't have a great asset to share that can be added to the unit tests, so I haven't written one unfortunately. If folks had a suggestion for something that would similarly trigger it, that would be great.

Thanks to Damien Courtois for discovering this and suggesting the workaround here.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
