### PR TITLE
Autodesk: Make tracked render tags subtractive to avoid syncing unnecessary rprims

### DIFF
--- a/pxr/imaging/hd/dirtyList.cpp
+++ b/pxr/imaging/hd/dirtyList.cpp
@@ -131,21 +131,20 @@ HdDirtyList::UpdateRenderTagsAndReprSelectors(
 {
     bool trackedRenderTagsChanged = false;
 
-    // Grow the tracked render tags set if necessary.
-    // XXX The additive only nature of this policy can result in more Rprims
-    // being sync'd than necessary.
+    // Update the tracked render tags set if necessary.
     {
         // See comment in_DirtyRprimIdsFilterPredicate re: empty render tags.
-        TRACE_SCOPE("Render tag combine");
-        TfTokenVector combinedRenderTags;
-        std::set_union(_trackedRenderTags.cbegin(),
-                       _trackedRenderTags.cend(),
-                       tags.cbegin(),
-                       tags.cend(),
-                       std::back_inserter(combinedRenderTags));
+        TRACE_SCOPE("Render tag update");
 
-        if (_trackedRenderTags != combinedRenderTags) {
-            _trackedRenderTags.swap(combinedRenderTags);
+        // Sort and remove duplicates to avoid unnecessary changes.
+        TfTokenVector sortedRenderTags(tags);
+        std::sort(sortedRenderTags.begin(), sortedRenderTags.end());
+        sortedRenderTags.erase(
+            std::unique(sortedRenderTags.begin(), sortedRenderTags.end()),
+            sortedRenderTags.end());
+
+        if (_trackedRenderTags != sortedRenderTags) {
+            _trackedRenderTags.swap(sortedRenderTags);
             trackedRenderTagsChanged = true;
         }
     }

--- a/pxr/imaging/hd/testenv/testHdDirtyList.cpp
+++ b/pxr/imaging/hd/testenv/testHdDirtyList.cpp
@@ -119,23 +119,23 @@ BasicTest()
             HdReprSelectorVector({surface}));
         _VerifyDirtyListSize(&dl, numGeometryPrims);
 
-        // geometry -> guide : The tracked render tag set is grown since the
-        // no rprims have been added/removed, and the repr opinion of rprims
-        // hasn't changed. The dirty list will be rebuilt to include both
-        // geometry and guide prims.
+        // geometry -> guide : The tracked render tag set changes from
+        // {'geometry'} to {'guide'}, and the repr opinion of rprims hasn't
+        // changed. The dirty list will be rebuilt to include just the guide
+        // prims but ignore geometry prims.
         dl.UpdateRenderTagsAndReprSelectors(
             TfTokenVector({HdRenderTagTokens->guide}),
             HdReprSelectorVector({surface}));
 
-        _VerifyDirtyListSize(&dl, numGeometryPrims + numGuidePrims);
+        _VerifyDirtyListSize(&dl, numGuidePrims);
         _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 2);
 
-        // guide -> geometry : Dirty list will be rebuilt to just the varying
-        // ones (which is none).
+        // guide -> geometry : Dirty list will be rebuilt to include geometry
+        // prims again.
         dl.UpdateRenderTagsAndReprSelectors(
             TfTokenVector({HdRenderTagTokens->geometry}),
             HdReprSelectorVector({surface}));
-        _VerifyDirtyListSize(&dl, 0);
+        _VerifyDirtyListSize(&dl, numGeometryPrims);
         _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 3);
     }
 
@@ -144,6 +144,11 @@ BasicTest()
     {
         std::cout << "4. Add an rprim\n";
         perfLog.ResetCounters();
+
+        // Reset render tag and repr trackers to an all-pass filter.
+        dl.UpdateRenderTagsAndReprSelectors(
+            TfTokenVector({/*empty render tags*/}),
+            HdReprSelectorVector({surface}));
 
         delegate.AddCube(SdfPath("/cube4"), GfMatrix4f());
         numGeometryPrims++;


### PR DESCRIPTION
### Description of Change(s)

`HdDirtyList::UpdateRenderTagsAndReprSelectors` will always append new render tags that will be rendered to the `_trackedRenderTags`. If a render tag in `_trackedRenderTags `is no longer used by the rendering task, it will not be removed from `_trackedRenderTags`. So once a render tag is added into `_trackedRenderTags`, in all the following rendering tasks the rprims with this render tag will always be synced, even if the task will not render these rprims.
The correct behaviour should be that this function will replace the old render tags with the new render tags.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
