### PR TITLE
Autodesk: Start and stop TfStopwatch only when PLUG_INFO_SEARCH is enabled

### DIFF
--- a/pxr/base/plug/info.cpp
+++ b/pxr/base/plug/info.cpp
@@ -692,13 +692,20 @@ Plug_ReadPlugInfo(
     const AddPluginCallback& addPlugin,
     Plug_TaskArena* taskArena)
 {
-    if (TfDebug::IsEnabled(PLUG_INFO_SEARCH)) {
+    const bool usdPlugInfoSearchDebugCodeActive =
+        TfDebug::IsEnabled(PLUG_INFO_SEARCH);
+
+    if (usdPlugInfoSearchDebugCodeActive) {
         TF_DEBUG(PLUG_INFO_SEARCH).Msg(
             "Will check plugin info paths:\n    %s\n",
             TfStringJoin(pathnames, "\n    ").c_str());
     }
+
+    // Debug timing info
     TfStopwatch stopwatch;
-    stopwatch.Start();
+    if (usdPlugInfoSearchDebugCodeActive) {
+        stopwatch.Start();
+    }
 
     _ReadContext context(*taskArena, addVisitedPath, addPlugin);
     for (const auto& pathname : pathnames) {
@@ -730,10 +737,14 @@ Plug_ReadPlugInfo(
     if (!pathsAreOrdered) {
         context.taskArena.Wait();
     }
-    stopwatch.Stop();
-    TF_DEBUG(PLUG_INFO_SEARCH).
-        Msg(" Did check plugin info paths in %f seconds\n", 
-            stopwatch.GetSeconds());
+
+    // Debug timing info
+    if (usdPlugInfoSearchDebugCodeActive) {
+       stopwatch.Stop();
+       TF_DEBUG(PLUG_INFO_SEARCH).
+           Msg(" Did check plugin info paths in %f seconds\n", 
+               stopwatch.GetSeconds());
+    }
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
### Description of Change(s)

Start and stop `TfStopwatch` only when `PLUG_INFO_SEARCH` is enabled to prevent crashes on processors without support for the RDTSCP instruction.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/3613

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
