### PR TITLE
Autodesk: Disable parallel render when the scene is small on Mac

### DIFF
--- a/pxr/imaging/hgi/graphicsCmds.cpp
+++ b/pxr/imaging/hgi/graphicsCmds.cpp
@@ -12,4 +12,7 @@ HgiGraphicsCmds::HgiGraphicsCmds() = default;
 
 HgiGraphicsCmds::~HgiGraphicsCmds() = default;
 
+void HgiGraphicsCmds::EnableParallelEncoder(bool enable) {
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgi/graphicsCmds.h
+++ b/pxr/imaging/hgi/graphicsCmds.h
@@ -186,6 +186,10 @@ public:
     HGI_API
     virtual void InsertMemoryBarrier(HgiMemoryBarrier barrier) = 0;
 
+    /// Enable or disable parallel encoder
+    HGI_API
+    virtual void EnableParallelEncoder(bool enable);
+
 protected:
     HGI_API
     HgiGraphicsCmds();

--- a/pxr/imaging/hgiMetal/graphicsCmds.h
+++ b/pxr/imaging/hgiMetal/graphicsCmds.h
@@ -99,7 +99,7 @@ public:
     void InsertMemoryBarrier(HgiMemoryBarrier barrier) override;
     
     HGIMETAL_API
-    void EnableParallelEncoder(bool enable);
+    void EnableParallelEncoder(bool enable) override;
 
     // Needs to be accessible from the Metal IndirectCommandEncoder
     id<MTLRenderCommandEncoder> GetEncoder(uint32_t encoderIndex = 0);

--- a/pxr/imaging/hgiMetal/graphicsCmds.mm
+++ b/pxr/imaging/hgiMetal/graphicsCmds.mm
@@ -215,14 +215,7 @@ HgiMetalGraphicsCmds::HgiMetalGraphicsCmds(
         }
     }
     
-    _enableParallelEncoder = _hgi->GetCapabilities()->useParallelEncoder;
-    
-    if (_enableParallelEncoder) {
-        _maxNumEncoders = WorkGetPhysicalConcurrencyLimit() / 2;
-    }
-    else {
-        _maxNumEncoders = 1;
-    }
+    EnableParallelEncoder(_hgi->GetCapabilities()->useParallelEncoder);
     
     if (hasClear) {
         GetEncoder();
@@ -244,6 +237,12 @@ void
 HgiMetalGraphicsCmds::EnableParallelEncoder(bool enable)
 {
     _enableParallelEncoder = enable;
+    if (_enableParallelEncoder) {
+        _maxNumEncoders = WorkGetPhysicalConcurrencyLimit() / 2;
+    }
+    else {
+        _maxNumEncoders = 1;
+    }
 }
 
 void


### PR DESCRIPTION
### Description of Change(s)

Put the API EnableParallelEncoder into HgiGraphicsCmds, so that the user could control if parallel encoder is used. Although this API is only valid for Metal currently, we put it in the base class so that the user could use it easier.

It is very common that the draw count is small in a draw process. In that case, parallel encoder is not needed. This API enables that the user could disable parallel encoder.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
