### PR TITLE
Autodesk: Only InsertMemoryBarrier in compute cmds when it's needed

### DIFF
--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -330,16 +330,28 @@ HdStCommandBuffer::PrepareDraw(
     // Once all the prepare work is done, add a memory barrier before the next
     // stage.
     HgiComputeCmds *computeCmds =
-        resourceRegistry->GetGlobalComputeCmds(HgiComputeDispatchConcurrent);
+        resourceRegistry->GetGlobalComputeCmds(HgiComputeDispatchConcurrent, false);
 
-    computeCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
+    // Only insert barrier when there is compute commands.
+    if (computeCmds)
+        computeCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
+
+    bool hasEncodeDraw = false;
 
     for (auto const& batch : _drawBatches) {
-        batch->EncodeDraw(renderPassState, resourceRegistry,
+        hasEncodeDraw |= batch->EncodeDraw(renderPassState, resourceRegistry,
             /*firstDrawBatch*/batch == *_drawBatches.begin());
     }
 
-    computeCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
+    // Only insert barrier when there is compute commands.
+    if (hasEncodeDraw)
+    {
+        if (!computeCmds)
+            computeCmds = resourceRegistry->GetGlobalComputeCmds(HgiComputeDispatchConcurrent, false);
+
+        if (computeCmds)
+            computeCmds->InsertMemoryBarrier(HgiMemoryBarrierAll);
+    }
 
     //
     // Compute work that was set up for indirect command buffers and frustum

--- a/pxr/imaging/hdSt/drawBatch.h
+++ b/pxr/imaging/hdSt/drawBatch.h
@@ -80,7 +80,7 @@ public:
         HdStResourceRegistrySharedPtr const &resourceRegistry) = 0;
 
     /// Encode drawing commands for this batch.
-    virtual void EncodeDraw(
+    virtual bool EncodeDraw(
         HdStRenderPassStateSharedPtr const & renderPassState,
         HdStResourceRegistrySharedPtr const & resourceRegistry,
         bool firstDrawBatch) = 0;

--- a/pxr/imaging/hdSt/indirectDrawBatch.cpp
+++ b/pxr/imaging/hdSt/indirectDrawBatch.cpp
@@ -938,13 +938,14 @@ HdSt_IndirectDrawBatch::PrepareDraw(
     }
 }
 
-void
+bool
 HdSt_IndirectDrawBatch::EncodeDraw(
     HdStRenderPassStateSharedPtr const & renderPassState,
     HdStResourceRegistrySharedPtr const & resourceRegistry,
     bool /*firstDrawBatch*/)
 {
     // No implementation.
+    return false;
 }
 
 ////////////////////////////////////////////////////////////

--- a/pxr/imaging/hdSt/indirectDrawBatch.h
+++ b/pxr/imaging/hdSt/indirectDrawBatch.h
@@ -51,7 +51,7 @@ public:
 
     /// Encode drawing commands for this batch.
     HDST_API
-    void EncodeDraw(
+    bool EncodeDraw(
         HdStRenderPassStateSharedPtr const & renderPassState,
         HdStResourceRegistrySharedPtr const & resourceRegistry,
         bool firstDrawBatch) override;

--- a/pxr/imaging/hdSt/pipelineDrawBatch.cpp
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.cpp
@@ -980,13 +980,13 @@ HdSt_PipelineDrawBatch::PrepareDraw(
     }
 }
 
-void
+bool
 HdSt_PipelineDrawBatch::EncodeDraw(
     HdStRenderPassStateSharedPtr const & renderPassState,
     HdStResourceRegistrySharedPtr const & resourceRegistry,
     bool firstDrawBatch)
 {
-    if (_HasNothingToDraw()) return;
+    if (_HasNothingToDraw()) return false;
 
     Hgi *hgi = resourceRegistry->GetHgi();
     HgiCapabilities const *capabilities = hgi->GetCapabilities();
@@ -1002,7 +1002,10 @@ HdSt_PipelineDrawBatch::EncodeDraw(
     if (drawICB) {
         _PrepareIndirectCommandBuffer(renderPassState, resourceRegistry,
             firstDrawBatch);
+        return true;
     }
+
+    return false;
 }
 
 ////////////////////////////////////////////////////////////

--- a/pxr/imaging/hdSt/pipelineDrawBatch.h
+++ b/pxr/imaging/hdSt/pipelineDrawBatch.h
@@ -53,7 +53,7 @@ public:
 
     /// Encode drawing commands for this batch.
     HDST_API
-    void EncodeDraw(
+    bool EncodeDraw(
         HdStRenderPassStateSharedPtr const & renderPassState,
         HdStResourceRegistrySharedPtr const & resourceRegistry,
         bool firstDrawBatch) override;

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -727,7 +727,7 @@ HdStResourceRegistry::GetGlobalBlitCmds()
 }
 
 HgiComputeCmds*
-HdStResourceRegistry::GetGlobalComputeCmds(HgiComputeDispatch dispatchMethod)
+HdStResourceRegistry::GetGlobalComputeCmds(HgiComputeDispatch dispatchMethod, bool forceCreate)
 {
     // If the HGI device isn't capable of concurrent dispatch then
     // only specify serial.
@@ -743,7 +743,7 @@ HdStResourceRegistry::GetGlobalComputeCmds(HgiComputeDispatch dispatchMethod)
         _computeCmds.reset();
     }
 
-    if (!_computeCmds) {
+    if (!_computeCmds && forceCreate) {
         HgiComputeCmdsDesc desc;
         desc.dispatchMethod = dispatchMethod;
         _computeCmds = _hgi->CreateComputeCmds(desc);

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -466,7 +466,7 @@ public:
     /// only valid until the HgiComputeCmds has been submitted.
     HDST_API
     HgiComputeCmds* GetGlobalComputeCmds(
-        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial);
+        HgiComputeDispatch dispatchMethod = HgiComputeDispatchSerial, bool forceCreate = true);
 
     /// Submits blit work queued in global blit cmds for GPU execution.
     /// We can call this when we want to submit some work to the GPU.


### PR DESCRIPTION
### Description of Change(s)

Only insert memory barrier when there is compute commands recorded.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
