### PR TITLE
[usdUtils] Prevent ComputeAllDependenciesClient from adding invalid layers

### DIFF
--- a/pxr/usd/usdUtils/dependencies.cpp
+++ b/pxr/usd/usdUtils/dependencies.cpp
@@ -17,6 +17,7 @@
 #include "pxr/usd/sdf/fileFormat.h"
 #include "pxr/usd/sdf/layerUtils.h"
 
+#include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/trace/trace.h"
 
 #include <functional>
@@ -126,7 +127,12 @@ struct UsdUtils_ComputeAllDependenciesClient
             }
         }
         else if (UsdStage::IsSupportedFile(anchoredPath)) {
-            layers.insert(SdfLayer::FindOrOpen(anchoredPath));
+            SdfLayerRefPtr dependencyLayer = SdfLayer::FindOrOpen(anchoredPath);
+            if (dependencyLayer) {
+                layers.insert(dependencyLayer);
+            } else {
+                TF_WARN("Failed to open dependency layer: %s (%s)", dependency.c_str(), anchoredPath.c_str());
+            }
         }
         else {
             assets.insert(resolvedPath);

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
@@ -5,7 +5,7 @@
 # Licensed under the terms set forth in the LICENSE.txt file available at
 # https://openusd.org/license.
 
-from pxr import Ar, UsdUtils, Sdf, Usd
+from pxr import Ar, Tf, UsdUtils, Sdf, Usd
 from pathlib import Path
 import os
 import unittest
@@ -294,6 +294,31 @@ class TestUsdUtilsDependencies(unittest.TestCase):
         self.assertEqual(unresolved, ["missing.png",
                                       "missing_in_package.png", 
                                       "missing_in_reference.png"])
+        
+    def test_ComputeAllDependenciesInvalidPayload(self):
+        """Tests that invalid payloads are detected and reported"""
+
+        def TestDirPath(path):
+            return os.path.normcase(
+                os.path.abspath(os.path.join(testDir, path)))
+
+        testDir = "computeAllDependenciesInvalidPayload"
+        stagePath = "root.usda"
+
+        delegate = UsdUtils.CoalescingDiagnosticDelegate()
+
+        layers, references, unresolved = UsdUtils.ComputeAllDependencies(TestDirPath(stagePath))
+        self.assertEqual(len(layers), 1)
+        self.assertEqual(layers[0].identifier, TestDirPath(stagePath))
+        self.assertEqual(len(references), 0)
+        self.assertEqual(len(unresolved), 0)
+
+        unfiltered = delegate.TakeUncoalescedDiagnostics()
+        self.assertEqual(len(unfiltered), 1)
+        self.assertEqual(unfiltered[0].commentary,
+                         "Failed to open dependency layer: ./invalid.usd "
+                         f"({TestDirPath('invalid.usd')})")
+
 
 if __name__=="__main__":
     unittest.main()

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesInvalidPayload/root.usda
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies/computeAllDependenciesInvalidPayload/root.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def "foo"
+{
+    def "invalid" (
+        prepend payload = @./invalid.usd@
+    )
+    {
+
+    }
+}


### PR DESCRIPTION
### Description of Change(s)
`UsdUtils_ComputeAllDependenciesClient` would output invalid layers if a layer fails to open. A check is added to make sure the layer opens correctly. If the layer does not open correctly, it will be added to unresolvedPaths

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
