### PR TITLE
pxrConfig.cmake: request MaterialX RenderGlsl component

### DIFF
--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -294,7 +294,11 @@ if (PXR_BUILD_DRACO_PLUGIN)
 endif()
 
 if (PXR_ENABLE_MATERIALX_SUPPORT)
-    find_package(MaterialX REQUIRED)
+    # MaterialX versions before 1.39.5 do not support package components.
+    find_package(MaterialX QUIET COMPONENTS RenderGlsl)
+    if (NOT MaterialX_FOUND)
+        find_package(MaterialX REQUIRED)
+    endif()
     add_definitions(-DPXR_MATERIALX_SUPPORT_ENABLED)
 endif()
 

--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -87,7 +87,11 @@ if(@PXR_ENABLE_MATERIALX_SUPPORT@)
             set(MaterialX_DIR [[@MaterialX_DIR@]])
         endif()
     endif()
-    find_dependency(MaterialX)
+    # MaterialX versions before 1.39.5 do not support package components.
+    find_package(MaterialX QUIET COMPONENTS RenderGlsl)
+    if (NOT MaterialX_FOUND)
+        find_dependency(MaterialX)
+    endif()
 endif()
 
 # Similar to MaterialX above, we are using Imath's cmake package config, so set


### PR DESCRIPTION
### Description of Change(s)

When MaterialX support is enabled, OpenUSD now first asks MaterialX for the `RenderGlsl` CMake package component:

```cmake
find_package(MaterialX QUIET COMPONENTS RenderGlsl)
```

OpenUSD links MaterialX render targets such as `MaterialXRenderGlsl`, and MaterialX 1.39.5 teaches its package config to propagate the dependencies needed by that component. This lets MaterialX own its OpenGL/X11 dependency propagation instead of OpenUSD spelling those dependencies out directly.

For compatibility with MaterialX versions before 1.39.5, which do not support package components, the lookup falls back to the previous plain MaterialX package lookup. The fallback can be removed later if OpenUSD raises its minimum supported MaterialX version to 1.39.5 or newer.

The generated `pxrConfig.cmake` uses the same lookup pattern so downstream projects that consume OpenUSD also get the MaterialX component dependency handling when available.

Related MaterialX fix: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2752

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))