### PR TITLE
Modernize MaterialX version checks for easy reading and streamlined logic

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -311,7 +311,7 @@ _GetNodeDef(const mx::DocumentPtr& mxDoc, std::string const& prevMxNodeDefName)
     // For nodeDef name changes or node removals between MaterialX v1.38 and 
     // the current version
     std::string mxNodeDefName = prevMxNodeDefName;
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION >= 39
+#if MATERIALX_VERSION_INDEX >= MATERIALX_GENERATE_INDEX(1, 39, 0)
     // The normalmap nodeDef name changed in v1.39
     if (prevMxNodeDefName == "ND_normalmap") {
         mxNodeDefName = "ND_normalmap_float";

--- a/pxr/imaging/hdMtlx/hdMtlx.h
+++ b/pxr/imaging/hdMtlx/hdMtlx.h
@@ -21,6 +21,16 @@ MATERIALX_NAMESPACE_BEGIN
     using DocumentPtr = std::shared_ptr<class Document>;
 MATERIALX_NAMESPACE_END
 
+// The macro and defines MATERIALX_GENERATE_INDEX and MATERIALX_VERSION_INDEX
+// added in MaterialX 1.39.2 and revised in 1.39.4 in MaterialXCore/Library.h,
+// Defined here for versions up to 1.39.4.
+#if (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION < 39) || \
+    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 39 && MATERIALX_BUILD_VERSION < 4)
+#define MATERIALX_GENERATE_INDEX(major, minor, build) (((major) << 22U) | ((minor) << 12U) | (build))
+#define MATERIALX_VERSION_INDEX \
+    MATERIALX_GENERATE_INDEX(MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION, MATERIALX_BUILD_VERSION)
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class SdfPath;

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -637,7 +637,7 @@ _GetGlTFSurfaceMaterialTag(HdMaterialNode2 const& terminal)
 static const mx::TypeDesc
 _GetMxTypeDescription(std::string const& typeName)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     using MxTypeDesc = const mx::TypeDesc*;
 #else
     using MxTypeDesc = const mx::TypeDesc;
@@ -657,14 +657,14 @@ _GetMxTypeDescription(std::string const& typeName)
 
     const auto typeDescIt = _typeLibrary.find(typeName);
     if (typeDescIt != _typeLibrary.end()) {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
       return *typeDescIt->second;
 #else
       return typeDescIt->second;
 #endif
     }
 
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return *mx::Type::NONE;
 #else
     return mx::Type::NONE;

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -254,8 +254,7 @@ HdStMaterialXShaderGen<Base>::_EmitMxSurfaceShader(
             Base::emitFunctionCalls(mxGraph, mxContext, mxStage,
                 mx::ShaderNode::Classification::TEXTURE);
 
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 38 && \
-    MATERIALX_BUILD_VERSION <= 4
+#if MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 38, 4)
             // Emit function calls for all surface shader nodes.
             // These will internally emit their closure function calls.
             Base::emitFunctionCalls(mxGraph, mxContext, mxStage, 
@@ -293,7 +292,7 @@ HdStMaterialXShaderGen<Base>::_EmitMxSurfaceShader(
         if (outputConnection) {
 
             std::string finalOutput = outputConnection->getVariable();
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
             // channels feature removed in MaterialX 1.39
             const std::string& channels = outputSocket->getChannels();
             if (!channels.empty()) {
@@ -828,14 +827,12 @@ HdStMaterialXShaderGen<Base>::_EmitDataStructsAndFunctionDefinitions(
     // Prior to MaterialX 1.38.5 the token substitutions need to
     // include the full path to the .glsl files, so we prepend that
     // here.
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 38
-    #if MATERIALX_BUILD_VERSION < 4
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 38, 4)
         (*tokenSubstitutions)[mx::ShaderGenerator::T_FILE_TRANSFORM_UV].insert(
             0, "stdlib/" + Base::TARGET + "/lib/");
-    #elif MATERIALX_BUILD_VERSION == 4
+#elif MATERIALX_VERSION_INDEX == MATERIALX_GENERATE_INDEX(1, 38, 4)
         (*tokenSubstitutions)[mx::ShaderGenerator::T_FILE_TRANSFORM_UV].insert(
             0, "libraries/stdlib/" + Base::TARGET + "/lib/");
-    #endif
 #endif
 
     // Add light sampling functions
@@ -880,9 +877,7 @@ namespace {
 template<>
 HdStMaterialXShaderGen<mx::GlslShaderGenerator>::HdStMaterialXShaderGen(
     HdSt_MxShaderGenInfo const& mxHdInfo)
-#if (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38) || \
-    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 39 && \
-     MATERIALX_BUILD_VERSION <= 2)
+#if MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 39, 2)
     : mx::GlslShaderGenerator(),
 #else
     : mx::GlslShaderGenerator(mx::TypeSystem::create()),
@@ -1039,9 +1034,7 @@ namespace {
 template<>
 HdStMaterialXShaderGen<mx::VkShaderGenerator>::HdStMaterialXShaderGen(
     HdSt_MxShaderGenInfo const& mxHdInfo)
-#if (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38) || \
-    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 39 && \
-     MATERIALX_BUILD_VERSION <= 2)
+#if MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 39, 2)
     : mx::VkShaderGenerator(),
 #else
     : mx::VkShaderGenerator(mx::TypeSystem::create()),
@@ -1197,9 +1190,7 @@ namespace {
 template<>
 HdStMaterialXShaderGen<mx::MslShaderGenerator>::HdStMaterialXShaderGen(
     HdSt_MxShaderGenInfo const& mxHdInfo)
-#if (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38) || \
-    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 39 && \
-     MATERIALX_BUILD_VERSION <= 2)
+#if MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 39, 2)
     : mx::MslShaderGenerator(),
 #else
     : mx::MslShaderGenerator(mx::TypeSystem::create()),
@@ -1387,7 +1378,7 @@ HdStMaterialXShaderGenMsl::_EmitMxFunctions(
 bool 
 HdStMaterialXHelpers::MxTypeIsNone(mx::TypeDesc typeDesc)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return typeDesc == *mx::Type::NONE;
 #else
     return typeDesc == mx::Type::NONE;
@@ -1397,7 +1388,7 @@ HdStMaterialXHelpers::MxTypeIsNone(mx::TypeDesc typeDesc)
 bool 
 HdStMaterialXHelpers::MxTypeIsSurfaceShader(mx::TypeDesc typeDesc)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return typeDesc == *mx::Type::SURFACESHADER;
 #else
     return typeDesc == mx::Type::SURFACESHADER;
@@ -1407,7 +1398,7 @@ HdStMaterialXHelpers::MxTypeIsSurfaceShader(mx::TypeDesc typeDesc)
 bool 
 HdStMaterialXHelpers::MxTypeDescIsFilename(const mx::TypeDesc typeDesc)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return typeDesc == *mx::Type::FILENAME;
 #else
     return typeDesc == mx::Type::FILENAME;
@@ -1417,7 +1408,7 @@ HdStMaterialXHelpers::MxTypeDescIsFilename(const mx::TypeDesc typeDesc)
 const mx::TypeDesc 
 HdStMaterialXHelpers::GetMxTypeDesc(const mx::ShaderPort* port)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return port->getType() ? *(port->getType()) : *mx::Type::NONE;
 #else
     return port->getType();
@@ -1430,13 +1421,12 @@ HdStMaterialXHelpers::MxGetTypeString(
     const mx::GenContext& mxContext,
     const std::string& typeName)
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     const mx::TypeDesc* mxType = mx::TypeDesc::get(typeName);
     if (!mxType) {
         return mx::Type::NONE->getName();
     }
-#elif MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 39 && \
-    MATERIALX_BUILD_VERSION <=2
+#elif MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 39, 2)
      const mx::TypeDesc mxType = mx::TypeDesc::get(typeName);
 #else
     const mx::TypeDesc mxType = mxContext.getTypeDesc(typeName);
@@ -1447,7 +1437,7 @@ HdStMaterialXHelpers::MxGetTypeString(
 const std::string& 
 HdStMaterialXHelpers::GetVector2Name()
 {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
     return mx::Type::VECTOR2->getName();
 #else
     return mx::Type::VECTOR2.getName();

--- a/pxr/imaging/hdSt/materialXShaderGen.h
+++ b/pxr/imaging/hdSt/materialXShaderGen.h
@@ -8,10 +8,7 @@
 #define PXR_IMAGING_HD_ST_MATERIALX_SHADER_GEN_H
 
 #include "pxr/pxr.h"
-
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-#include <MaterialXGenMsl/MslShaderGenerator.h>
-#include <MaterialXGenGlsl/VkShaderGenerator.h>
+#include <MaterialXCore/Library.h>
 
 // The macro and defines MATERIALX_GENERATE_INDEX and MATERIALX_VERSION_INDEX
 // added in MaterialX 1.39.2 and revised in 1.39.4 in MaterialXCore/Library.h,
@@ -22,6 +19,10 @@
 #define MATERIALX_VERSION_INDEX \
     MATERIALX_GENERATE_INDEX(MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION, MATERIALX_BUILD_VERSION)
 #endif
+
+#include <MaterialXGenGlsl/GlslShaderGenerator.h>
+#include <MaterialXGenGlsl/VkShaderGenerator.h>
+#include <MaterialXGenMsl/MslShaderGenerator.h>
     
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/pxr/imaging/hdSt/materialXShaderGen.h
+++ b/pxr/imaging/hdSt/materialXShaderGen.h
@@ -13,6 +13,16 @@
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 #include <MaterialXGenGlsl/VkShaderGenerator.h>
 
+// The macro and defines MATERIALX_GENERATE_INDEX and MATERIALX_VERSION_INDEX
+// added in MaterialX 1.39.2 and revised in 1.39.4 in MaterialXCore/Library.h,
+// Defined here for versions up to 1.39.4.
+#if (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION < 39) || \
+    (MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION == 39 && MATERIALX_BUILD_VERSION < 4)
+#define MATERIALX_GENERATE_INDEX(major, minor, build) (((major) << 22U) | ((minor) << 12U) | (build))
+#define MATERIALX_VERSION_INDEX \
+    MATERIALX_GENERATE_INDEX(MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION, MATERIALX_BUILD_VERSION)
+#endif
+    
 PXR_NAMESPACE_OPEN_SCOPE
 
 struct HdSt_MxShaderGenInfo;

--- a/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.cpp
+++ b/pxr/usdImaging/bin/usdBakeMtlx/bakeMaterialX.cpp
@@ -20,7 +20,6 @@
 #include "pxr/usd/usdShade/shader.h"
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Generated.h>
 #include <MaterialXCore/Node.h>
 #include <MaterialXFormat/Util.h>
 #include <MaterialXFormat/XmlIo.h>
@@ -128,8 +127,7 @@ void _BakeMtlxDocument(
         : mx::Image::BaseType::UINT8;
 
     // Construct a Texture Baker.
-#if MATERIALX_MAJOR_VERSION <= 1 && MATERIALX_MINOR_VERSION <= 38 && \
-    MATERIALX_BUILD_VERSION <= 6
+#if MATERIALX_VERSION_INDEX <= MATERIALX_GENERATE_INDEX(1, 38, 6)
     mx::TextureBakerPtr baker = mx::TextureBaker::create(
         textureWidth, textureHeight, baseType);
 #else

--- a/third_party/renderman-26/plugin/hdPrman/matfiltMaterialX.cpp
+++ b/third_party/renderman-26/plugin/hdPrman/matfiltMaterialX.cpp
@@ -400,9 +400,7 @@ _CompileOslSource(
     // Include the filepath to the MaterialX OSL directory containing mx_funcs.h
     std::vector<std::string> oslArgs;
     oslArgs.reserve(searchPaths.size());
-#if MATERIALX_MAJOR_VERSION == 1 && \
-    MATERIALX_MINOR_VERSION == 38 && \
-    MATERIALX_BUILD_VERSION == 3
+#if MATERIALX_VERSION_INDEX == MATERIALX_GENERATE_INDEX(1, 38, 3)
     static const mx::FilePath stdlibOslPath = "stdlib/osl";
 #else 
     // MaterialX v1.38.4 restructured the OSL files and moved mx_funcs.h
@@ -414,11 +412,7 @@ _CompileOslSource(
                                             : "-I" + path.asString());
     }
 
-#if MATERIALX_MAJOR_VERSION == 1 && \
-    MATERIALX_MINOR_VERSION == 38 && \
-    MATERIALX_BUILD_VERSION == 3
-    // Nothing
-#else
+#if MATERIALX_VERSION_INDEX > MATERIALX_GENERATE_INDEX(1, 38, 3)
     // MaterialX 1.38.4 removed its copy of stdosl.h and other OSL headers
     // and requires it to be included from the OSL installation itself.
     oslArgs.push_back(std::string("-I") + TfGetenv("RMANTREE") + "lib/osl");
@@ -842,7 +836,7 @@ _NodeHasTextureCoordPrimvar(
         // for texture coordinates. 
         auto geompropvalueNodes = nodegraph->getNodes(_tokens->geompropvalue);
         for (const mx::NodePtr& mxGeomPropNode : geompropvalueNodes) {
-#if MATERIALX_MAJOR_VERSION == 1 && MATERIALX_MINOR_VERSION <= 38
+#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)
             if (mxGeomPropNode->getType() == mx::Type::VECTOR2->getName()) {
 #else
             if (mxGeomPropNode->getType() == mx::Type::VECTOR2.getName()) {


### PR DESCRIPTION
### Description of Change(s)
Use the new MATERIALX_VERSION_INDEX and MATERIALX_GENERATE_INDEX added in MaterialX 1.39.2.  This makes the version check code easier to read and streamlines the logic to avoids potential version check errors when using MATERIALX_MAJOR_VERSION, MATERIALX_MINOR_VERSION, and MATERIALX_BUILD_VERSION comparisons directly.

**Sample usage:**
`#if MATERIALX_VERSION_INDEX < MATERIALX_GENERATE_INDEX(1, 39, 0)`

Note: MATERIALX_VERSION_INDEX and MATERIALX_GENERATE_INDEX were added as of MaterialX 1.39.2 and then revised in 1.39.4.  Defining these macros if MaterialX version < 1.39.4.

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3651

### Testing
Manually tested compilation with MaterialX 1.39.3 and 1.38.10.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
