### PR TITLE
Fix incorrect plugInfo library path matching on macOS

### DIFF
--- a/build_scripts/pypi/updatePluginfos.py
+++ b/build_scripts/pypi/updatePluginfos.py
@@ -39,7 +39,7 @@ def process_plugin_dict(plugin_dict, libname, newname):
     # the way USD is currently setting these paths internally. If either
     # changes this will break.
     if is_mac_platform():
-        if f'libs/{libname}' in newname:
+        if f'libs/{libname}.' in newname:
             # strip off a pxr/ at the front of the newname
             plugin_dict['LibraryPath'] = os.path.join('../../', newname[4:])
             return True


### PR DESCRIPTION
### Description of Change(s)

The `updatePluginfos.py` script previously used a substring match (f'libs/{libname}' in newname) to find relocated libraries, which could result in incorrect matches (e.g., 'libusd_arch.dylib' matching for 'libusd_ar'). Restrict match to full library names by requiring a trailing dot.

### Fixes Issue(s)

This patch tightens the condition to only match full library names by appending a dot ('.') to ensure correct basename detection.

Fixes: https://github.com/PixarAnimationStudios/OpenUSD/issues/3656

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
