### PR TITLE
Autodesk: [hdSt] Persistent run-time-populated MaterialX codegen cache

### DIFF
--- a/pxr/imaging/hd/instanceRegistry.h
+++ b/pxr/imaging/hd/instanceRegistry.h
@@ -20,32 +20,37 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// Forward declarations
+template <typename VALUE>
+class HdInstanceRegistry;
+
+using HdInstanceKey = uint64_t;
+using HdInstanceRegistryMutex = std::mutex;
+using HdInstanceRegistryLock = std::unique_lock<HdInstanceRegistryMutex>;
 
 /// \class HdInstance
 ///
-/// This class is used as an interface to a shared instance in
-/// HdInstanceRegistry.
+/// This class is used as an interface to a shared instance stored in
+/// a REGISTRY object.
 ///
-/// KeyType is a hashable index type and VALUE is shared_ptr. In most use
-/// cases, the client computes a hash key which represents large bulky data
-/// (like topology, primvars) and registers it into HdInstanceRegistry. If the
-/// key has already been registered, the registry returns HdInstance and the
+/// HdInstanceKeyType is a hashable index type and VALUE is shared_ptr. In most
+/// use cases, the client computes a hash key which represents large bulky data
+/// (like topology, primvars) and registers it into REGISTRY. If the
+/// key has already been registered, the registry returns an HdInstance and the
 /// client can use GetValue() without setting/computing actual bulky data. If
 /// it doesn't exist, IsFirstInstance() returns true for the first instance
 /// and the client needs to populate an appropriate data VALUE into the
 /// instance by SetValue().
 ///
-/// In order to support concurrent access to HdInstanceRegistry, this
-/// class holds a lock to a mutex in HdInstanceRegistry. This lock will
+/// In order to support concurrent access to REGISTRY, this
+/// class holds a lock to a mutex in REGISTRY. This lock will
 /// be held until the instance of this interface class is destroyed.
 ///
-template <typename VALUE>
+template <typename VALUE, class REGISTRY = HdInstanceRegistry<VALUE>>
 class HdInstance {
 public:
-    typedef uint64_t KeyType;
     typedef VALUE ValueType;
-
-    typedef KeyType ID;
+    typedef HdInstanceKey ID;
 
     struct ValueHolder {
         ValueHolder(ValueType const & value = ValueType())
@@ -59,46 +64,44 @@ public:
         ValueType value;
         int recycleCounter;
     };
-    typedef tbb::concurrent_unordered_map<KeyType, ValueHolder> Dictionary;
-
-    typedef std::mutex RegistryMutex;
-    typedef std::unique_lock<RegistryMutex> RegistryLock;
 
     HdInstance() = delete;
 
     /// Construct an instance holding a registry lock, representing a value
     /// held in a registry container.
-    explicit HdInstance(KeyType const &key,
-                        ValueType const &value,
-                        RegistryLock &&registryLock,
-                        Dictionary *container)
+    explicit HdInstance(HdInstanceKey           key,
+                        ValueType const         &value,
+                        HdInstanceRegistryLock  &&registryLock,
+                        REGISTRY                *registry)
         : _key(key)
         , _value(value)
         , _registryLock(std::move(registryLock))
-        , _container(container)
+        , _registry(registry)
         , _isFirstInstance(!bool(_value))
     { }
 
     /// Construct an instance with no lock or registry container. This
     /// is used to present a consistent interface to clients in cases
     /// where shared resource registration is disabled.
-    explicit HdInstance(KeyType const &key)
+    explicit HdInstance(HdInstanceKey key)
         : _key(key)
         , _value(ValueType())
         , _registryLock()
-        , _container(nullptr)
+        , _registry(nullptr)
         , _isFirstInstance(!bool(_value))
     { }
 
     /// Returns the key
-    KeyType const &GetKey() const { return _key; }
+    HdInstanceKey GetKey() const { return _key; }
 
     /// Returns the value
     ValueType const &GetValue() const { return _value; }
 
-    /// Update the value in dictionary indexed by the key.
+    /// Update the value in the registry
     void SetValue(ValueType const &value) {
-        if (_container) (*_container)[_key] = ValueHolder(value);
+        if (_registry) {
+            _registry->_SetValue(_key, value);
+        }
         _value = value;
     }
 
@@ -108,45 +111,55 @@ public:
     }
 
 private:
-    KeyType       _key;
-    ValueType     _value;
-    RegistryLock  _registryLock;
-    Dictionary   *_container;
-    bool          _isFirstInstance;
+    HdInstanceKey           _key;
+    ValueType               _value;
+    HdInstanceRegistryLock  _registryLock;
+    REGISTRY                *_registry = nullptr;
+    bool                    _isFirstInstance;
 };
 
-/// \class HdInstanceRegistry
+/// \class HdInstanceRegistryBase
 ///
-/// HdInstanceRegistry is a dictionary container of HdInstance.
-/// This class is almost just a dictionary from key to value.
-/// For cleaning unused entries, it provides GarbageCollect() API.
-/// It sweeps all entries in the dictionary and erase unreferenced entries.
+/// HdInstanceRegistryBase is a dictionary container of HdInstance.
+/// This class is mostly just a dictionary from key to value, ensuring
+/// thread-safe access to the values.
+/// The DERIVED template parameter can be used in a Curiously Recurring
+/// Template Pattern to extend this class with a persistent cache backing the
+/// in-memory dictionary.
+/// For cleaning up unused entries, the GarbageCollect() API is provided.
+/// It sweeps all entries in the dictionary and erases unreferenced entries.
 /// When HdInstance::ValueType is shared_ptr, it is regarded as unreferenced
 /// if the shared_ptr is unique (use_count==1). Note that Key is not
 /// involved to determine the lifetime of entries.
 ///
-template <typename VALUE>
-class HdInstanceRegistry {
+template <typename VALUE, class DERIVED>
+class HdInstanceRegistryBase {
 public:
-    typedef HdInstance<VALUE> InstanceType;
-
-    HdInstanceRegistry() = default;
+    friend class HdInstance<VALUE, DERIVED>;
+    using InstanceType = HdInstance<VALUE, DERIVED>;
     
-    /// Copy constructor.  Need as HdInstanceRegistry is placed in a map
-    /// and mutex is not copy constructable, so can't use default
-    HdInstanceRegistry(const HdInstanceRegistry &other)
+    using Dictionary = tbb::concurrent_unordered_map<
+        HdInstanceKey,
+        typename InstanceType::ValueHolder
+    >;
+
+    HdInstanceRegistryBase() = default;
+
+    /// Copy constructor.  Need as HdInstanceRegistryBase is placed in a map
+    /// and mutex is not copy-constructible, so can't use default
+    HdInstanceRegistryBase(const HdInstanceRegistryBase &other)
         : _dictionary(other._dictionary)
-        , _registryMutex()  // mutex is not copied
+        , _mutex()  // mutex is not copied
     { }
 
-    /// Returns a shared instance for given key.
+    /// Returns a shared instance for a given key.
     InstanceType GetInstance(
-        typename InstanceType::KeyType const &key);
+        HdInstanceKey key);
 
     /// Returns a shared instance for a given key
     /// only if the key exists in the dictionary.
     InstanceType FindInstance(
-        typename InstanceType::KeyType const &key, bool *found);
+        HdInstanceKey key, bool *found);
 
     /// Removes unreferenced entries and returns the count
     /// of remaining entries. When recycleCount is greater than zero,
@@ -166,7 +179,7 @@ public:
 
     /// Returns a const iterator being/end of dictionary. Mainly used for
     /// resource auditing.
-    typedef typename InstanceType::Dictionary::const_iterator const_iterator;
+    typedef typename Dictionary::const_iterator const_iterator;
     const_iterator begin() const { return _dictionary.begin(); }
     const_iterator end() const { return _dictionary.end(); }
 
@@ -180,28 +193,93 @@ private:
         return value.use_count() == 1;
     }
 
-    typename InstanceType::Dictionary _dictionary;
-    typename InstanceType::RegistryMutex _registryMutex;
+    /// Store the value in the in-memory dictionary and write it to the 
+    /// persistent cache if implemented by the derived class.
+    void _SetValue(
+        HdInstanceKey key,
+        VALUE const& value);
 
-    HdInstanceRegistry &operator =(HdInstanceRegistry &) = delete;
+    /// Look a value up by the key in the in-memory dictionary. If the key is
+    /// not found there and the derived class implements a persistent cache,
+    /// try to load the value from there.
+    typename Dictionary::iterator _LookUp(
+        HdInstanceKey key);
+
+    Dictionary              _dictionary;
+    HdInstanceRegistryMutex _mutex;
+
+    HdInstanceRegistryBase &operator =(HdInstanceRegistryBase &) = delete;
+};
+
+/// \class HdInstanceRegistry
+///
+/// The default implementation of HdInstanceRegistryBase without persistent
+/// cache support.
+///
+template <typename VALUE>
+class HdInstanceRegistry
+    : public HdInstanceRegistryBase<VALUE, HdInstanceRegistry<VALUE>>
+{
+public:
+    friend class HdInstanceRegistryBase<VALUE, HdInstanceRegistry<VALUE>>;
+
+    void SaveToDisk(
+        HdInstanceKey key,
+        VALUE const& value)
+    {
+    }
+
+    VALUE LoadFromDisk(HdInstanceKey key)
+    {
+        return nullptr;
+    }
 };
 
 // ---------------------------------------------------------------------------
-// instance registry impl
+// Implementations
 
-template <typename VALUE>
-HdInstance<VALUE>
-HdInstanceRegistry<VALUE>::GetInstance(
-        typename HdInstance<VALUE>::KeyType const &key)
+template <typename VALUE, class DERIVED>
+typename HdInstanceRegistryBase<VALUE, DERIVED>::Dictionary::iterator
+HdInstanceRegistryBase<VALUE, DERIVED>::_LookUp(
+    HdInstanceKey key)
+{
+    typename Dictionary::iterator it = _dictionary.find(key);
+    if (it != _dictionary.end()) {
+        return it;
+    }
+
+    VALUE value = static_cast<DERIVED*>(this)->LoadFromDisk(key);
+    if (value) {
+        it = _dictionary.insert(
+            std::make_pair(key,
+                typename InstanceType::ValueHolder(value))).first;
+    }
+    return it;
+}
+
+template <typename VALUE, class DERIVED>
+void
+HdInstanceRegistryBase<VALUE, DERIVED>::_SetValue(
+    HdInstanceKey key,
+    VALUE const& value)
+{
+    _dictionary[key] = typename InstanceType::ValueHolder(value);
+    static_cast<DERIVED*>(this)->SaveToDisk(key, value);
+}
+
+template <typename VALUE, class DERIVED>
+HdInstance<VALUE, DERIVED>
+HdInstanceRegistryBase<VALUE, DERIVED>::GetInstance(
+    HdInstanceKey key)
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
 
     // Grab Registry lock
     // (and don't release it in this function, return it instead)
-    typename InstanceType::RegistryLock lock(_registryMutex);
+    HdInstanceRegistryLock lock(_mutex);
 
-    typename InstanceType::Dictionary::iterator it = _dictionary.find(key);
+    typename Dictionary::iterator it = _LookUp(key);
     if (it == _dictionary.end()) {
         // not found. create new one
         it = _dictionary.insert(
@@ -209,44 +287,48 @@ HdInstanceRegistry<VALUE>::GetInstance(
     }
 
     it->second.ResetRecycleCounter();
-    return InstanceType(key, it->second.value, std::move(lock), &_dictionary);
+    return InstanceType(
+        key, it->second.value, std::move(lock), static_cast<DERIVED*>(this));
 }
 
-template <typename VALUE>
-HdInstance<VALUE>
-HdInstanceRegistry<VALUE>::FindInstance(
-        typename HdInstance<VALUE>::KeyType const &key, bool *found)
+template <typename VALUE, class DERIVED>
+HdInstance<VALUE, DERIVED>
+HdInstanceRegistryBase<VALUE, DERIVED>::FindInstance(
+    HdInstanceKey key, bool *found)
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
 
     // Grab Registry lock
     // (and don't release it in this function, return it instead)
-    typename InstanceType::RegistryLock lock(_registryMutex);
+    HdInstanceRegistryLock lock(_mutex);
 
-    typename InstanceType::Dictionary::iterator it = _dictionary.find(key);
+    typename Dictionary::iterator it = _LookUp(key);
     if (it == _dictionary.end()) {
         *found = false;
         return InstanceType(key, VALUE(), std::move(lock), nullptr);
     } else {
         *found = true;
         it->second.ResetRecycleCounter();
-        return InstanceType(key, it->second.value,std::move(lock),&_dictionary);
+        return InstanceType(
+            key, it->second.value, std::move(lock),
+            static_cast<DERIVED*>(this));
     }
 }
 
-template <typename VALUE>
+template <typename VALUE, class DERIVED>
 size_t
-HdInstanceRegistry<VALUE>::GarbageCollect(int recycleCount)
+HdInstanceRegistryBase<VALUE, DERIVED>::GarbageCollect(int recycleCount)
 {
     // Call GarbageCollect with empty callback function
     return GarbageCollect([](void*){}, recycleCount);
 }
 
-template <typename VALUE>
+template <typename VALUE, class DERIVED>
 template <typename Callback>
 size_t
-HdInstanceRegistry<VALUE>::GarbageCollect(Callback &&callback, int recycleCount)
+HdInstanceRegistryBase<VALUE, DERIVED>::GarbageCollect(
+    Callback &&callback, int recycleCount)
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();
@@ -257,7 +339,7 @@ HdInstanceRegistry<VALUE>::GarbageCollect(Callback &&callback, int recycleCount)
     }
 
     size_t inUseCount = 0;
-    for (typename InstanceType::Dictionary::iterator it = _dictionary.begin();
+    for (typename Dictionary::iterator it = _dictionary.begin();
          it != _dictionary.end();) {
 
         // erase instance which isn't referred from anyone
@@ -273,9 +355,9 @@ HdInstanceRegistry<VALUE>::GarbageCollect(Callback &&callback, int recycleCount)
     return inUseCount;
 }
 
-template <typename VALUE>
+template <typename VALUE, class DERIVED>
 void
-HdInstanceRegistry<VALUE>::Invalidate()
+HdInstanceRegistryBase<VALUE, DERIVED>::Invalidate()
 {
     HD_TRACE_FUNCTION();
     HF_MALLOC_TAG_FUNCTION();

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -26,6 +26,7 @@ if (${PXR_ENABLE_MATERIALX_SUPPORT})
     list(APPEND optionalPrivateClasses
          materialXFilter
          materialXShaderGen
+         materialXShaderRegistry
     )
 endif()
 if (PXR_ENABLE_PTEX_SUPPORT)
@@ -460,16 +461,6 @@ pxr_build_test(testHdStInstancingUnbalanced
     CPPFILES
         testenv/testHdStInstancingUnbalanced.cpp
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
-pxr_build_test(testHdStMaterialXShaderGen
-    LIBRARIES
-        hdSt
-        hdMtlx
-        tf
-    CPPFILES
-        testenv/testHdStMaterialXShaderGen.cpp
-)
-endif()
 pxr_build_test(testHdStMeshTopology
     LIBRARIES
         hdSt
@@ -626,6 +617,28 @@ pxr_register_test(testHdStQualifiers
         TF_DEBUG=HD_SAFE_MODE
 )
 
+if (${PXR_ENABLE_MATERIALX_SUPPORT})
+pxr_build_test(testHdStMaterialXShaderGen
+    LIBRARIES
+        hdSt
+        hdMtlx
+        tf
+    CPPFILES
+        testenv/testHdStMaterialXShaderGen.cpp
+)
+pxr_install_test_dir(
+    SRC testenv/testHdStMaterialXShaderGen
+    DEST testHdStMaterialXShaderGen
+)
+pxr_register_test(testHdStMaterialXShaderGen_testCacheSerialization
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStMaterialXShaderGen --testCacheSerialization"
+    EXPECTED_RETURN_CODE 0
+    STDOUT_REDIRECT shadergen_testCacheSerialization.out
+    DIFF_COMPARE shadergen_testCacheSerialization.out
+    TESTENV testHdStMaterialXShaderGen
+)
+endif()
+
 if (APPLE)
     message(STATUS "Skipping rest of ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
@@ -723,12 +736,6 @@ pxr_install_test_dir(
     SRC testenv/testHdStInstancingUnbalancedNoBindless
     DEST testHdStInstancingUnbalancedNoBindless
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
-pxr_install_test_dir(
-    SRC testenv/testHdStMaterialXShaderGen
-    DEST testHdStMaterialXShaderGen
-)
-endif()
 pxr_install_test_dir(
     SRC testenv/testHdStMultipleFvarTopologies
     DEST testHdStMultipleFvarTopologies

--- a/pxr/imaging/hdSt/materialNetwork.cpp
+++ b/pxr/imaging/hdSt/materialNetwork.cpp
@@ -1121,7 +1121,7 @@ HdStMaterialNetwork::ProcessMaterialNetwork(
 
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
         if (!isVolume) {
-            _materialXGfx = HdSt_ApplyMaterialXFilter(&surfaceNetwork, materialId,
+            _materialXCodegenResult = HdSt_ApplyMaterialXFilter(&surfaceNetwork, materialId,
                                       *surfTerminal, surfTerminalPath,
                                       &_materialParams, resourceRegistry);
         }

--- a/pxr/imaging/hdSt/materialNetwork.h
+++ b/pxr/imaging/hdSt/materialNetwork.h
@@ -23,6 +23,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 class HdStResourceRegistry;
 using HioGlslfxSharedPtr = std::shared_ptr<class HioGlslfx>;
 using HdSt_MaterialParamVector = std::vector<class HdSt_MaterialParam>;
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+class HdSt_MaterialXCodegenResult;
+using HdSt_MaterialXCodegenResultPtr =
+    std::shared_ptr<class HdSt_MaterialXCodegenResult>;
+#endif
 
 /// \class HdStMaterialNetwork
 ///
@@ -103,7 +108,7 @@ private:
     HioGlslfxSharedPtr _surfaceGfx;
     size_t _surfaceGfxHash;
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
-    MaterialX::ShaderPtr _materialXGfx;
+    HdSt_MaterialXCodegenResultPtr _materialXCodegenResult;
 #endif
 };
 

--- a/pxr/imaging/hdSt/materialParam.h
+++ b/pxr/imaging/hdSt/materialParam.h
@@ -30,7 +30,7 @@ public:
 
     // Indicates the kind of material parameter.
     enum ParamType {
-        // This is a shader specified fallback value that is
+        // This is a shader-specified fallback value that is
         // not connected to either a primvar or texture.
         ParamTypeFallback,
         // This is a parameter that is connected to a texture.

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -7,8 +7,10 @@
 #include "pxr/imaging/hdSt/materialParam.h"
 #include "pxr/imaging/hdSt/materialXFilter.h"
 #include "pxr/imaging/hdSt/materialXShaderGen.h"
+#include "pxr/imaging/hdSt/materialXShaderRegistry.h"
 #include "pxr/imaging/hdSt/package.h"
 #include "pxr/imaging/hdSt/resourceRegistry.h"
+
 #include "pxr/imaging/hdMtlx/hdMtlx.h"
 #include "pxr/imaging/hgi/tokens.h"
 
@@ -1061,16 +1063,13 @@ _ReplaceFilenameInput(
 // Gather the Material Params from the glslfx ShaderPtr
 void
 _AddMaterialXParams(
-    mx::ShaderPtr const& glslfxShader,
+    HdSt_MaterialXCodegenResult const& mxCodegenResult,
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& terminalNodePath,
     HdAnnonNodePathMap const& hdToAnnonNodePathMap,
     HdSt_MaterialParamVector* materialParams)
 {
     TRACE_FUNCTION_SCOPE("Collect Mtlx params from glslfx shader.")
-    if (!glslfxShader) {
-        return;
-    }
 
     // Storm can only find primvar nodes when they are connected to the terminal
     _ConnectPrimvarNodesToTerminalNode(terminalNodePath, hdNetwork);
@@ -1109,126 +1108,56 @@ _AddMaterialXParams(
         }
     }
 
-    const mx::ShaderStage& pxlStage = glslfxShader->getStage(mx::Stage::PIXEL);
-    const auto& paramsBlock = pxlStage.getUniformBlock(mx::HW::PUBLIC_UNIFORMS);
-    for (size_t i = 0; i < paramsBlock.size(); ++i) {
+    HdSt_MaterialParamVector const& fallbackParams =
+        mxCodegenResult.GetFallbackParams();
 
-        // MaterialX parameter Information
-        const auto* variable = paramsBlock[i];
-        const auto varType = HdStMaterialXHelpers::GetMxTypeDesc(variable);
+    for (HdSt_MaterialParam const& fallbackParam : fallbackParams) {
 
-        // Create a corresponding HdSt_MaterialParam
-        HdSt_MaterialParam param;
-        param.paramType = HdSt_MaterialParam::ParamTypeFallback;
-        param.name = TfToken(variable->getVariable());
+        materialParams->push_back(fallbackParam);
 
-        // Get the parameter value from the map created above
-        const auto paramValueIt =
-            mxParamNameToValue.find(variable->getVariable());
+        // Look up the parameter value in the map created above
+        const auto paramValueIt = mxParamNameToValue.find(fallbackParam.name);
         if (paramValueIt != mxParamNameToValue.end()) {
-            if (varType.getBaseType() == mx::TypeDesc::BASETYPE_BOOLEAN ||
-                varType.getBaseType() == mx::TypeDesc::BASETYPE_FLOAT ||
-                varType.getBaseType() == mx::TypeDesc::BASETYPE_INTEGER) {
-                param.fallbackValue = paramValueIt->second;
-            }
+            materialParams->back().fallbackValue = paramValueIt->second;
         }
+
         // If it was not found in the mapping use the value from the MaterialX
         // variable to get the value. 
-        // Note that if the network was upgraded in Hdmtlx, and the node's 
+        // Note that if the network was upgraded in HdMtlx, and the node's 
         // parameter names changed they will not be found through the above 
         // mapping and instead need to be found from the variables in the 
-        // MaterialX glslfxShader. 
-        else {
-            std::string separator;
-            const auto varValue = variable->getValue();
-            std::istringstream valueStream(varValue
-                ? varValue->getValueString() : std::string());
-            if (varType.getBaseType() == mx::TypeDesc::BASETYPE_BOOLEAN) {
-                const bool val = valueStream.str() == "true";
-                param.fallbackValue = VtValue(val);
-            }
-            else if (varType.getBaseType() == mx::TypeDesc::BASETYPE_FLOAT) {
-                if (varType.getSize() == 1) {
-                    float val;
-                    valueStream >> val;
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 2) {
-                    GfVec2f val;
-                    valueStream >> val[0] >> separator >> val[1];
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 3) {
-                    GfVec3f val;
-                    valueStream >> val[0] >> separator >> val[1] >> separator 
-                                >> val[2];
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 4) {
-                    GfVec4f val;
-                    valueStream >> val[0] >> separator >> val[1] >> separator
-                                >> val[2] >> separator >> val[3];
-                    param.fallbackValue = VtValue(val);
-                }
-            }
-            else if (varType.getBaseType() == mx::TypeDesc::BASETYPE_INTEGER) {
-                if (varType.getSize() == 1) {
-                    int val;
-                    valueStream >> val;
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 2) {
-                    GfVec2i val;
-                    valueStream >> val[0] >> separator >> val[1];
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 3) {
-                    GfVec3i val;
-                    valueStream >> val[0] >> separator >> val[1] >> separator 
-                                >> val[2];
-                    param.fallbackValue = VtValue(val);
-                }
-                else if (varType.getSize() == 4) {
-                    GfVec4i val;
-                    valueStream >> val[0] >> separator >> val[1] >> separator
-                        >> val[2] >> separator >> val[3];
-                    param.fallbackValue = VtValue(val);
-                }
-            }
-        }
+        // MaterialX shader.
+    }
 
-        if (!param.fallbackValue.IsEmpty()) {
-            materialParams->push_back(std::move(param));
-        }
+    for (TfToken textureParamName : mxCodegenResult.GetTextureParams()) {
 
         // For filename inputs, manage the associated texture node
-        if (varType.getSemantic() == mx::TypeDesc::SEMANTIC_FILENAME) {
-            // Get the anonymized MaterialX node name from the param name
-            // annonNodeName_paramName -> annonNodeName
-            std::string mxNodeName = variable->getVariable();
-            const auto underscorePos = mxNodeName.find('_');
-            if (underscorePos != std::string_view::npos) {
-                mxNodeName = mxNodeName.substr(0, underscorePos);
-            }
+        
+        // Get the anonymized MaterialX node name from the param name
+        // anonNodeName_paramName -> anonNodeName
+        std::string mxNodeName = textureParamName;
+        const auto underscorePos = mxNodeName.find('_');
+        if (underscorePos != std::string_view::npos) {
+            mxNodeName = mxNodeName.substr(0, underscorePos);
+        }
 
-            // Get the original hdNodeName from the MaterialX node name
-            const auto hdNodePathIt = annonToHdNodePathMap.find(mxNodeName);
-            if (hdNodePathIt != annonToHdNodePathMap.end()) {
-                _UpdateTextureNode(
-                    param.name, hdNetwork, 
-                    terminalNodePath, hdNodePathIt->second);
-            } else {
-                // Storm does not expect textures/filename to be direct inputs 
-                // on materials, replace this filename input with a connection
-                // to an image node
-                _ReplaceFilenameInput(
-                    hdNetwork, terminalNodePath, variable->getVariable());
-            }
+        // Get the original hdNodeName from the MaterialX node name
+        const auto origNodePathIt = annonToHdNodePathMap.find(mxNodeName);
+        if (origNodePathIt != annonToHdNodePathMap.end()) {
+            _UpdateTextureNode(
+                textureParamName, hdNetwork,
+                terminalNodePath, origNodePathIt->second);
+        } else {
+            // Storm does not expect textures/filename to be direct inputs 
+            // on materials, replace this filename input with a connection
+            // to an image node
+            _ReplaceFilenameInput(
+                hdNetwork, terminalNodePath, textureParamName);
         }
     }
 }
 
-static mx::ShaderPtr
+static HdSt_MaterialXCodegenResultPtr
 _GenerateMaterialXShader(
     HdMaterialNetwork2 const& hdNetwork,
     SdfPath const& materialPath,
@@ -1264,8 +1193,10 @@ _GenerateMaterialXShader(
     mxHdInfo.bindlessTexturesEnabled = bindlessTexturesEnabled;
 
     // Generate the glslfx source code from the mtlxDoc
-    return HdSt_GenMaterialXShader(
+    mx::ShaderPtr mxShader = HdSt_GenMaterialXShader(
         mtlxDoc, stdLibraries, searchPaths, mxHdInfo, apiName);
+
+    return std::make_shared<HdSt_MaterialXCodegenResult>(*mxShader);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1296,8 +1227,37 @@ _IsTopologicalShader(TfToken const& nodeId)
     return TfStringStartsWith(nodeId.GetString(), "ND_swizzle_");
 }
 
-// Build the topoNetwork, equivalent to the given hdNetwork but anonymized and 
-// stripped of non-topological parameters to better re-use the generated shader.  
+// Helper functions generating hashes which are stable from one run of the
+// application to another
+namespace
+{
+    // The default implementation
+    template <typename T>
+    void _AppendPersistentHash(Tf_HashState& hashState, T const& value)
+    {
+        TfHashAppend(hashState, value);
+    }
+
+    // TfHashAppend hashes TfTokens not as strings, but as pointers to interned
+    // strings which are not stable from run to run
+    void _AppendPersistentHash(
+        Tf_HashState& hashState, TfToken const& token)
+    {
+        TfHashAppend(hashState, token.GetString());
+    }
+
+    // A VtValue may store a TfToken, in which case we need to convert it to a
+    // string in order to avoid the same pitfall as above
+    void _AppendPersistentHash(Tf_HashState& hashState, VtValue const& vtValue)
+    {
+        if (vtValue.IsHolding<TfToken>()) {
+            TfHashAppend(hashState, vtValue.Get<TfToken>().GetString());
+        } else {
+            TfHashAppend(hashState, vtValue.GetHash());
+        }
+    }
+}
+
 size_t _BuildEquivalentMaterialNetwork(
     HdMaterialNetwork2 const& hdNetwork,
     HdMaterialNetwork2* topoNetwork,
@@ -1409,22 +1369,38 @@ size_t _BuildEquivalentMaterialNetwork(
 
     // Build the topo hash from the topo network
     Tf_HashState topoHash;
-    for (const auto& terminal : topoNetwork->terminals) {
-        TfHashAppend(topoHash, terminal.first);
-        TfHashAppend(topoHash, terminal.second.upstreamNode.GetName());
+
+    TRACE_FUNCTION_SCOPE("Hashing the network")
+
+    for (std::pair<TfToken, HdMaterialConnection2> const& terminal
+        : topoNetwork->terminals) {
+
+        _AppendPersistentHash(topoHash, terminal.first);
+        _AppendPersistentHash(topoHash, terminal.second.upstreamNode.GetName());
     }
-    for (const auto& node : topoNetwork->nodes) {
-        TfHashAppend(topoHash, node.first.GetName());
-        TfHashAppend(topoHash, node.second.nodeTypeId);
-        for (const auto& param : node.second.parameters) {
-            TfHashAppend(topoHash, param.first);
-            TfHashAppend(topoHash, param.second.GetHash());
+    for (std::pair<SdfPath, HdMaterialNode2> const& node
+        : topoNetwork->nodes) {
+
+        _AppendPersistentHash(topoHash, node.first.GetName());
+        _AppendPersistentHash(topoHash, node.second.nodeTypeId);
+
+        for (std::pair<TfToken, VtValue> const& param
+            : node.second.parameters) {
+
+            _AppendPersistentHash(topoHash, param.first);
+            _AppendPersistentHash(topoHash, param.second);
         }
-        for (const auto& connection : node.second.inputConnections) {
-            TfHashAppend(topoHash, connection.first);
-            for (const auto& source : connection.second) {
-                TfHashAppend(topoHash, source.upstreamNode.GetName());
-                TfHashAppend(topoHash, source.upstreamOutputName);
+
+        for (std::pair<
+                TfToken, std::vector<HdMaterialConnection2>
+            > const& connection
+            : node.second.inputConnections) {
+
+            _AppendPersistentHash(topoHash, connection.first);
+
+            for (HdMaterialConnection2 const& source : connection.second) {
+                _AppendPersistentHash(topoHash, source.upstreamNode.GetName());
+                _AppendPersistentHash(topoHash, source.upstreamOutputName);
             }
         }
     }
@@ -1433,7 +1409,7 @@ size_t _BuildEquivalentMaterialNetwork(
 }
 
 
-mx::ShaderPtr
+HdSt_MaterialXCodegenResultPtr
 HdSt_ApplyMaterialXFilter(
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& materialPath,
@@ -1453,6 +1429,13 @@ HdSt_ApplyMaterialXFilter(
 
     TRACE_FUNCTION_SCOPE("ApplyMaterialXFilter: Found Mtlx Node.")
 
+    HdSt_MaterialXShaderRegistry* const materialXShaderRegistry =
+        resourceRegistry->GetMaterialXShaderRegistry();
+
+    if (!TF_VERIFY(materialXShaderRegistry)) {
+        return nullptr;
+    }
+
     // Anonymize the network to make sure shader code does not depend
     // on node names
     HdAnnonNodePathMap annonNodePathMap;
@@ -1461,7 +1444,6 @@ HdSt_ApplyMaterialXFilter(
         *hdNetwork, &annonNetwork, &annonNodePathMap);
     SdfPath anonTerminalNodePath = annonNodePathMap[terminalNodePath];
 
-    mx::ShaderPtr glslfxShader;
     const TfToken materialTag(_GetMaterialTag(*hdNetwork, terminalNode));
     const bool bindlessTexturesEnabled = 
         resourceRegistry->GetHgi()->GetCapabilities()->IsSet(
@@ -1471,16 +1453,19 @@ HdSt_ApplyMaterialXFilter(
     // Use the Resource Registry to cache the generated MaterialX 
     // glslfx Shader
     Tf_HashState shaderHash;
-    TfHashAppend(shaderHash, topoHash);
-    TfHashAppend(shaderHash, materialTag);
-    HdInstance<mx::ShaderPtr> glslfxInstance =
-        resourceRegistry->RegisterMaterialXShader(shaderHash.GetCode());
+    _AppendPersistentHash(shaderHash, topoHash);
+    _AppendPersistentHash(shaderHash, materialTag);
+    
+    HdSt_MaterialXShaderRegistry::InstanceType instance =
+        materialXShaderRegistry->GetInstance(
+            shaderHash.GetCode());
 
-    if (glslfxInstance.IsFirstInstance()) {
+    HdSt_MaterialXCodegenResultPtr codegenResult;
+    if (instance.IsFirstInstance()) {
         try {
-            glslfxShader = _GenerateMaterialXShader(
-                annonNetwork, materialPath, terminalNode, 
-                anonTerminalNodePath, materialTag, apiName, 
+            codegenResult = _GenerateMaterialXShader(
+                annonNetwork, materialPath, terminalNode,
+                anonTerminalNodePath, materialTag, apiName,
                 bindlessTexturesEnabled);
         } catch (mx::Exception& exception) {
             TF_CODING_ERROR("Unable to create the Glslfx Shader.\n"
@@ -1488,11 +1473,10 @@ HdSt_ApplyMaterialXFilter(
         }
 
         // Store the mx::ShaderPtr
-        glslfxInstance.SetValue(glslfxShader);
+        instance.SetValue(codegenResult);
     }
     else {
-        // Get the mx::ShaderPtr from the resource registry
-        glslfxShader = glslfxInstance.GetValue();
+        codegenResult = instance.GetValue();
     }
 
     // Add a Fallback DomeLight texture node to the network
@@ -1500,16 +1484,14 @@ HdSt_ApplyMaterialXFilter(
 
     // Add material parameters from the original network
     _AddMaterialXParams(
-        glslfxShader, hdNetwork, terminalNodePath,
+        *codegenResult, hdNetwork, terminalNodePath,
         annonNodePathMap, materialParams);
 
     // Create a new terminal node with the glslfxShader
-    if (glslfxShader) {
-        const std::string glslfxSourceCode =
-            glslfxShader->getSourceCode(mx::Stage::PIXEL);
+    if (codegenResult) {
         SdrShaderNodeConstPtr sdrNode =
             sdrRegistry.GetShaderNodeFromSourceCode(
-                glslfxSourceCode,
+                codegenResult->GetPixelShaderSource(),
                 HioGlslfxTokens->glslfx,
                 SdrTokenMap()); // metadata
         HdMaterialNode2 newTerminalNode;
@@ -1521,7 +1503,7 @@ HdSt_ApplyMaterialXFilter(
         hdNetwork->nodes[terminalNodePath] = newTerminalNode;
     }
 
-    return glslfxShader;
+    return codegenResult;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/materialXFilter.h
+++ b/pxr/imaging/hdSt/materialXFilter.h
@@ -18,6 +18,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+class HdSt_MaterialXCodegenResult;
+
+using HdSt_MaterialXCodegenResultPtr =
+    std::shared_ptr<class HdSt_MaterialXCodegenResult>;
+
 // Storing MaterialX-Hydra counterparts and other Hydra specific information
 struct HdSt_MxShaderGenInfo {
     HdSt_MxShaderGenInfo() 
@@ -27,6 +32,7 @@ struct HdSt_MxShaderGenInfo {
           defaultTexcoordName("st"),
           materialTag(HdStMaterialTagTokens->defaultMaterialTag.GetString()),
           bindlessTexturesEnabled(false) {}
+
     MaterialX::StringMap textureMap;
     MaterialX::StringMap primvarMap;
     MaterialX::StringMap primvarDefaultValueMap;
@@ -38,7 +44,7 @@ struct HdSt_MxShaderGenInfo {
 /// MaterialX Filter
 /// Converting a MaterialX node to one with a generated MaterialX glslfx file
 HDST_API
-MaterialX::ShaderPtr HdSt_ApplyMaterialXFilter(
+HdSt_MaterialXCodegenResultPtr HdSt_ApplyMaterialXFilter(
     HdMaterialNetwork2* hdNetwork,
     SdfPath const& materialPath,
     HdMaterialNode2 const& terminalNode,

--- a/pxr/imaging/hdSt/materialXShaderRegistry.cpp
+++ b/pxr/imaging/hdSt/materialXShaderRegistry.cpp
@@ -1,0 +1,542 @@
+﻿//
+// Copyright 2020 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/base/tf/envSetting.h"
+#include "pxr/base/js/json.h"
+
+#include "pxr/imaging/hdSt/materialXShaderRegistry.h"
+#include "pxr/imaging/hdSt/materialXShaderGen.h"
+
+#include "pxr/base/gf/vec2f.h"
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/vec4f.h"
+
+#include <MaterialXGenShader/Shader.h>
+
+#include <fstream>
+
+namespace mx = MaterialX;
+namespace fs = std::filesystem;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_ENV_SETTING(HDST_MTLX_CODEGEN_CACHE_DIR_PATH, "",
+    "Path to the directory of the persistent MaterialX codegen cache");
+
+namespace
+{
+    TF_DEFINE_PRIVATE_TOKENS(
+        _tokens,
+
+        // Extensions of cached files
+        (glslfx)
+        (json)
+
+        // JSON fields per material
+        (texture_parameters)
+        (fallback_parameters)
+
+        // JSON fields per material parameter
+        (name)
+        (type)
+        (value)
+    );
+
+    // Construct a valid filesystem path from the setting string and create
+    // the directory if necessary. If anything goes wrong, we print an error
+    // message and return an empty path, which disables disk caching.
+    //
+    fs::path _ValidateCacheDirPath(const char* cacheDirPath)
+    {
+        HD_TRACE_FUNCTION();
+
+        if (!cacheDirPath) {
+            return {};
+        }
+
+        fs::path path = cacheDirPath;
+        if (path.empty()) {
+            return path;
+        }
+
+        if (fs::exists(path)) {
+            if ( TF_VERIFY(fs::is_directory(path),
+                "%s exists but is not a directory",
+                path.string().c_str()) ) {
+
+                return path;
+            }
+            else {
+                return {};
+            }
+        }
+        else {
+            std::error_code ec;
+            if (TF_VERIFY(fs::create_directory(path, ec),
+                "Failed to create directory %s",
+                path.string().c_str())) {
+
+                return path;
+            }
+            else {
+                return {};
+            }
+        }
+    }
+
+    std::string _GenerateCacheFilePath(
+        fs::path const& cacheDirPath,
+        HdInstanceKey   key,
+        TfToken         extension)
+    {
+        std::ostringstream osFileName;
+        osFileName << std::hex << key << '.' << extension;
+        fs::path path = cacheDirPath / osFileName.str();
+
+        return path.string();
+    }
+
+    using _DeserializeFunc = std::function<
+        VtValue(                    // the return value
+            std::istringstream&     // the input stream to deserialize
+        )
+    >;
+
+    // These function objects implement deserialization of values of
+    // particular data types. They're used in two cases:
+    // 1. Importing values from MaterialX (the values are first serialized to
+    //    strings with MaterialX methods).
+    // 2. Deserializing values serialized to JSON files with `VtValue` 
+    //    streaming methods as part of the persistent cache.
+    //
+    struct _Deserializer
+    {
+        bool                isVectorType;
+        _DeserializeFunc    Deserialize;
+    };
+
+    // Deserializer implementations indexed by the USD type name. This is 
+    // convenient because the types names are read from JSON files as-is.
+    //
+    using _DeserializerMap = std::unordered_map<std::string, _Deserializer>;
+    static const _DeserializerMap _deserializerMap{
+        {
+            "bool",
+            {
+                false,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    bool val = false;
+                    issValue >> val;
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "float",
+            {
+                false,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    float val;
+                    issValue >> val;
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec2f",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec2f val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1];
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec3f",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec3f val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1] >> separator
+                        >> val[2];
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec4f",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec4f val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1] >> separator
+                        >> val[2] >> separator >> val[3];
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "int",
+            {
+                false,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    int val;
+                    issValue >> val;
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec2i",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec2i val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1];
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec3i",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec3i val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1] >> separator
+                        >> val[2];
+                    return VtValue(val);
+                }
+            }
+        },
+        {
+            "GfVec4i",
+            {
+                true,
+                [](std::istringstream& issValue) -> VtValue
+                {
+                    GfVec4i val;
+                    std::string separator;
+                    issValue >> val[0] >> separator >> val[1] >> separator
+                        >> val[2] >> separator >> val[3];
+                    return VtValue(val);
+                }
+            }
+        }
+    };
+}
+
+std::string const&
+HdSt_MaterialXShaderRegistry::GetCacheDirPathEnvSetting()
+{
+    return TfGetEnvSetting(HDST_MTLX_CODEGEN_CACHE_DIR_PATH);
+}
+
+HdSt_MaterialXShaderRegistry::HdSt_MaterialXShaderRegistry(
+    const char* cacheDirPath)
+    : _cacheDirPath(_ValidateCacheDirPath(cacheDirPath))
+{
+}
+
+void
+HdSt_MaterialXShaderRegistry::SaveToDisk(
+    HdInstanceKey                           key,
+    HdSt_MaterialXCodegenResultPtr const&   value)
+{
+    if (!value || _cacheDirPath.empty()) {
+        return;
+    }
+
+    value->SaveToDisk(_cacheDirPath, key);
+}
+
+HdSt_MaterialXCodegenResultPtr
+HdSt_MaterialXShaderRegistry::LoadFromDisk(HdInstanceKey key)
+{
+    HD_TRACE_FUNCTION();
+    std::ostringstream ossPixelShaderSource;
+
+    {
+        TRACE_FUNCTION_SCOPE("Load shader code")
+        
+        std::ifstream ifsGlslfx(_GenerateCacheFilePath(
+            _cacheDirPath, key, _tokens->glslfx).c_str());
+
+        if (!ifsGlslfx.is_open()) {
+            return nullptr;
+        }
+
+        ossPixelShaderSource << ifsGlslfx.rdbuf();
+    }
+
+    JsValue jsMetadata;
+
+    {
+        TRACE_FUNCTION_SCOPE("Load metadata from JSON")
+
+        std::string const& jsonFileName =
+            _GenerateCacheFilePath(_cacheDirPath, key, _tokens->json);
+
+        std::ifstream ifsJson(jsonFileName.c_str());
+
+        if (!ifsJson.is_open()) {
+            return nullptr;
+        }
+
+        jsMetadata = JsParseStream(ifsJson);
+    }
+
+    return std::make_shared<HdSt_MaterialXCodegenResult>(
+        ossPixelShaderSource.str(), jsMetadata);
+}
+
+HdSt_MaterialXCodegenResult::HdSt_MaterialXCodegenResult(
+    mx::Shader const& mxShader)
+{
+    HD_TRACE_FUNCTION();
+
+    const mx::ShaderStage& pixelShaderStage =
+        mxShader.getStage(mx::Stage::PIXEL);
+
+    _pixelShaderSource = pixelShaderStage.getSourceCode();
+
+    mx::VariableBlock const& uniformBlock =
+        pixelShaderStage.getUniformBlock(mx::HW::PUBLIC_UNIFORMS);
+
+    for (size_t iUniform = 0; iUniform < uniformBlock.size(); ++iUniform) {
+
+        // MaterialX parameter Information
+        const mx::ShaderPort* mxShaderPort = uniformBlock[iUniform];
+        const mx::TypeDesc mxTypeDesc =
+            HdStMaterialXHelpers::GetMxTypeDesc(mxShaderPort);
+
+        const std::string& mxVarName = mxShaderPort->getVariable();
+
+        // Create a corresponding HdSt_MaterialParam
+        HdSt_MaterialParam param;
+        param.paramType = HdSt_MaterialParam::ParamTypeFallback;
+        param.name = TfToken(mxVarName);
+
+        const char* fallbackParamType = nullptr;
+
+        switch (mxTypeDesc.getBaseType())
+        {
+            case mx::TypeDesc::SEMANTIC_FILENAME:
+                _textureParams.push_back(param.name);
+                break;
+            case mx::TypeDesc::BASETYPE_BOOLEAN:
+                fallbackParamType = "bool";
+                break;
+            case mx::TypeDesc::BASETYPE_FLOAT: {
+                switch (mxTypeDesc.getSize()) {
+                    case 1:
+                        fallbackParamType = "float";
+                        break;
+                    case 2:
+                        fallbackParamType = "GfVec2f";
+                        break;
+                    case 3:
+                        fallbackParamType = "GfVec3f";
+                        break;
+                    case 4:
+                        fallbackParamType = "GfVec4f";
+                        break;
+                }
+                break;
+            }
+            case mx::TypeDesc::BASETYPE_INTEGER: {
+                switch (mxTypeDesc.getSize()) {
+                    case 1:
+                        fallbackParamType = "int";
+                        break;
+                    case 2:
+                        fallbackParamType = "GfVec2i";
+                        break;
+                    case 3:
+                        fallbackParamType = "GfVec3i";
+                        break;
+                    case 4:
+                        fallbackParamType = "GfVec4i";
+                        break;
+                }
+                break;
+            }
+        }
+
+        if (fallbackParamType) {
+            auto const& itDeserializer = _deserializerMap.find(fallbackParamType);
+            if (TF_VERIFY(itDeserializer != _deserializerMap.end())) {
+
+                const mx::ValuePtr mxVarValue = mxShaderPort->getValue();
+                std::istringstream issValue(mxVarValue
+                    ? mxVarValue->getValueString() : std::string());
+                
+                issValue.imbue(std::locale::classic());
+                
+                // MaterialX serializes booleans as "true" and "false",
+                // while our cache serializes them as "1" and "0", in line with
+                // the default C++ stream behavior and the logic hard-coded in 
+                // `VtValue` serialization
+                issValue >> std::boolalpha;
+
+                param.fallbackValue =
+                    itDeserializer->second.Deserialize(issValue);
+
+                if (!param.fallbackValue.IsEmpty()) {
+                    _fallbackParams.push_back(std::move(param));
+                }
+            }
+        }
+    }
+}
+
+HdSt_MaterialXCodegenResult::HdSt_MaterialXCodegenResult(
+    std::string&&               pixelShaderSource,
+    HdSt_MaterialParamVector&&  fallbackParams,
+    TfTokenVector&&             textureParams
+)
+    : _pixelShaderSource(std::move(pixelShaderSource))
+    , _fallbackParams(std::move(fallbackParams))
+    , _textureParams(std::move(textureParams))
+{
+}
+
+HdSt_MaterialXCodegenResult::HdSt_MaterialXCodegenResult(
+    std::string&&   pixelShaderSource,
+    JsValue const&  jsMetadata
+)
+    : _pixelShaderSource(std::move(pixelShaderSource))
+{
+    TRACE_FUNCTION_SCOPE("Deserialize metadata")
+
+    JsObject jsMetadataObj = jsMetadata.GetJsObject();
+    JsArray const& jsTextureParams =
+        jsMetadataObj[_tokens->texture_parameters].GetJsArray();
+
+    for (JsValue name : jsTextureParams) {
+        _textureParams.push_back(TfToken(name.GetString()));
+    }
+
+    JsArray const& jsFallbackParamsArray =
+        jsMetadataObj[_tokens->fallback_parameters].GetJsArray();
+
+    for (JsValue const& jsFallbackParam : jsFallbackParamsArray) {
+        JsObject jsFallbackParamObj = jsFallbackParam.GetJsObject();
+
+        HdSt_MaterialParam param;
+
+        param.name = TfToken(jsFallbackParamObj[_tokens->name].GetString());
+        param.paramType = HdSt_MaterialParam::ParamTypeFallback;
+
+        std::string const& valueTypeName =
+            jsFallbackParamObj[_tokens->type].GetString();
+
+        auto const& itDeserializer = _deserializerMap.find(valueTypeName);
+        if (TF_VERIFY(itDeserializer != _deserializerMap.end())) {
+
+            std::string const& strValue =
+                jsFallbackParamObj[_tokens->value].GetString();
+
+            std::istringstream issValue(strValue);
+            issValue.imbue(std::locale::classic());
+
+            if (itDeserializer->second.isVectorType) {
+                // Skip the leading parenthesis
+                issValue.seekg(1, std::ios::cur);
+            }
+
+            param.fallbackValue =
+                itDeserializer->second.Deserialize(issValue);
+
+            if (!param.fallbackValue.IsEmpty()) {
+                _fallbackParams.push_back(std::move(param));
+            }
+        }
+    }
+}
+
+void
+HdSt_MaterialXCodegenResult::SaveMetadata(std::ostream& osFile) const
+{
+    HD_TRACE_FUNCTION();
+
+    JsArray jsFallbackParams;
+    jsFallbackParams.reserve(_fallbackParams.size());
+
+    for (HdSt_MaterialParam const& param : _fallbackParams) {
+
+        std::ostringstream osValue;
+        osValue.imbue(std::locale::classic());
+        osValue << param.fallbackValue;
+        
+        JsObject jsParam{
+            { _tokens->name,    JsValue(param.name) },
+            { _tokens->type,    JsValue(param.fallbackValue.GetTypeName()) },
+            { _tokens->value,   JsValue(osValue.str()) } };
+
+        jsFallbackParams.push_back(jsParam);
+    }
+
+    JsArray jsTextureParams;
+    jsTextureParams.reserve(_textureParams.size());
+
+    for (TfToken name : _textureParams) {
+        jsTextureParams.emplace_back(name);
+    }
+
+    JsObject jsMetadataObj{
+        { _tokens->fallback_parameters, JsValue(jsFallbackParams) },
+        { _tokens->texture_parameters,  JsValue(jsTextureParams) } };
+
+    JsWriteToStream(JsValue(jsMetadataObj), osFile);
+}
+
+void
+HdSt_MaterialXCodegenResult::SaveToDisk(
+    std::filesystem::path const&    cacheDirPath,
+    HdInstanceKey                   key) const
+{
+    HD_TRACE_FUNCTION();
+
+    {
+        TRACE_FUNCTION_SCOPE("Load shader code")
+
+        std::ofstream ofsGlslfx(
+            _GenerateCacheFilePath(cacheDirPath, key, _tokens->glslfx).c_str() );
+
+        if (ofsGlslfx.is_open()) {
+            ofsGlslfx.write(
+                _pixelShaderSource.c_str(), _pixelShaderSource.length());
+        }
+    }
+
+    {
+        std::ofstream ofsJson(
+            _GenerateCacheFilePath(cacheDirPath, key, _tokens->json).c_str() );
+
+        if (ofsJson.is_open()) {
+            SaveMetadata(ofsJson);
+        }
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hdSt/materialXShaderRegistry.h
+++ b/pxr/imaging/hdSt/materialXShaderRegistry.h
@@ -1,0 +1,125 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HD_ST_MATERIALX_SHADER_REGISTRY_H
+#define PXR_IMAGING_HD_ST_MATERIALX_SHADER_REGISTRY_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hd/instanceRegistry.h"
+#include "pxr/imaging/hdSt/materialParam.h"
+
+#include <MaterialXCore/Library.h>
+MATERIALX_NAMESPACE_BEGIN
+class Shader;
+MATERIALX_NAMESPACE_END
+
+namespace mx = MaterialX;
+
+#include <filesystem>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class JsValue;
+
+/// \class HdSt_MaterialXCodegenResult
+///
+/// Encapsulates all data extracted from a generated MaterialX shader object
+/// that's necessary for shader compilation, binding and rendering in Storm.
+/// Unlike a MaterialX shader, this object can be serialized to disk, as a 
+/// GLSLFX source file and a JSON metadata file. This makes it possible to 
+/// cache such objects in a persistent cache (see HdSt_MaterialXShaderRegistry
+/// below) as an optimization.
+/// 
+class HdSt_MaterialXCodegenResult
+{
+public:
+    /// Initialize from a MaterialX shader, which can now be destroyed.
+    HDST_API
+    explicit HdSt_MaterialXCodegenResult(mx::Shader const& mxShader);
+
+    HDST_API
+    HdSt_MaterialXCodegenResult(
+        std::string&&               pixelShaderSource,
+        HdSt_MaterialParamVector&&  fallbackParams,
+        TfTokenVector&&             textureParams
+    );
+
+    HDST_API
+    HdSt_MaterialXCodegenResult(
+        std::string&&   pixelShaderSource,
+        JsValue const&  jsMetadata
+    );
+
+    HDST_API
+    std::string const& GetPixelShaderSource() const {
+        return _pixelShaderSource;
+    }
+
+    HDST_API
+    HdSt_MaterialParamVector const& GetFallbackParams() const {
+        return _fallbackParams;
+    }
+
+    HDST_API
+    TfTokenVector const& GetTextureParams() const {
+        return _textureParams;
+    }
+
+    HDST_API
+    void SaveToDisk(
+        std::filesystem::path const& cacheDirPath,
+        HdInstanceKey key) const;
+
+    /// Public for unit tests' sake
+    HDST_API
+    void SaveMetadata(std::ostream& os) const;
+
+private:
+    std::string                 _pixelShaderSource;
+    HdSt_MaterialParamVector    _fallbackParams;
+    TfTokenVector               _textureParams;
+};
+
+using HdSt_MaterialXCodegenResultPtr =
+    std::shared_ptr<class HdSt_MaterialXCodegenResult>;
+
+/// \class HdSt_MaterialXShaderRegistry
+///
+/// A specialized instance registry which caches
+/// HdSt_MaterialXCodegenResult instances in memory and, optionally, on disk
+/// 
+class HdSt_MaterialXShaderRegistry
+    : public HdInstanceRegistryBase<
+        HdSt_MaterialXCodegenResultPtr,
+        HdSt_MaterialXShaderRegistry
+    >
+{
+public:
+    static std::string const& GetCacheDirPathEnvSetting();
+
+    /// \param cacheDirPath the path to the cache directory. If NULL or empty
+    /// then caching to disk is disabled.
+    /// 
+    explicit HdSt_MaterialXShaderRegistry(
+        const char* cacheDirPath);
+
+    /// Overrides the base method in a CRTP
+    void SaveToDisk(
+        HdInstanceKey                           key,
+        HdSt_MaterialXCodegenResultPtr const&   value);
+
+    /// Overrides the base method in a CRTP
+    HdSt_MaterialXCodegenResultPtr LoadFromDisk(
+        HdInstanceKey key);
+
+private:
+    std::filesystem::path const _cacheDirPath;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hdSt/renderDelegate.cpp
+++ b/pxr/imaging/hdSt/renderDelegate.cpp
@@ -45,6 +45,11 @@
 #include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/staticTokens.h"
 
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+#include "pxr/imaging/hdSt/materialXShaderRegistry.h"
+#include "pxr/imaging/hdSt/materialXSyncDispatcher.h"
+#endif
+
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -108,7 +113,12 @@ public:
 
     // Look-up resource registry by Hgi instance, create resource
     // registry for the instance if it didn't exist.
-    HdStResourceRegistrySharedPtr GetOrCreateRegistry(Hgi * const hgi)
+    HdStResourceRegistrySharedPtr GetOrCreateRegistry(
+        Hgi * const hgi
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+        , std::string const& mtlxCacheDirPath
+#endif
+    )
     {
         std::lock_guard<std::mutex> guard(_mutex);
 
@@ -121,7 +131,11 @@ public:
         // Create resource registry, custom deleter to remove corresponding
         // entry from map.
         HdStResourceRegistrySharedPtr result{
-            new HdStResourceRegistry(hgi),
+            new HdStResourceRegistry(hgi
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+                , mtlxCacheDirPath.c_str()
+#endif
+            ),
             [maybeSelf = weak_from_this()](
                 HdStResourceRegistry * const registry) {
                 // If a resource registry has a static lifetime object as its
@@ -205,7 +219,13 @@ HdStRenderDelegate::HdStRenderDelegate(HdRenderSettingsMap const& settingsMap)
         HdRenderSettingDescriptor{
             "Dome light camera visibility",
             HdRenderSettingsTokens->domeLightCameraVisibility,
-            VtValue(true) }
+            VtValue(true) },
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+        HdRenderSettingDescriptor{
+            "Path to the directory of the persistent MaterialX codegen cache",
+            HdStRenderSettingsTokens->hdstMtlxCodegenCacheDirPath,
+            VtValue(HdSt_MaterialXShaderRegistry::GetCacheDirPathEnvSetting()) }
+#endif
     };
 
     _PopulateDefaultSettings(_settingDescriptors);
@@ -258,8 +278,19 @@ HdStRenderDelegate::SetDrivers(HdDriverVector const& drivers)
     
     TF_VERIFY(_hgi, "HdSt requires Hgi HdDriver");
 
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+    const std::string cacheDirPath = GetRenderSetting<std::string>(
+        HdStRenderSettingsTokens->hdstMtlxCodegenCacheDirPath,
+        HdSt_MaterialXShaderRegistry::GetCacheDirPathEnvSetting());
+#endif
+
     _resourceRegistry =
-        _HgiToResourceRegistryMap::GetInstance().GetOrCreateRegistry(_hgi);
+        _HgiToResourceRegistryMap::GetInstance().GetOrCreateRegistry(
+            _hgi
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+            , cacheDirPath.c_str()
+#endif
+        );
 }
 
 const TfTokenVector &

--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -30,6 +30,7 @@
 
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
 #include <MaterialXGenShader/Shader.h>
+#include "pxr/imaging/hdSt/materialXShaderRegistry.h"
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -105,7 +106,12 @@ _Register(ID id, HdInstanceRegistry<T> &registry, TfToken const &perfToken)
     }
 }
 
-HdStResourceRegistry::HdStResourceRegistry(Hgi * const hgi)
+HdStResourceRegistry::HdStResourceRegistry(
+    Hgi * const hgi
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+    , const char* mtlxCacheDirPath
+#endif
+)
     : _hgi(hgi)
     , _numBufferSourcesToResolve(0)
     // default aggregation strategies for varying (vertex, varying) primvars
@@ -122,6 +128,10 @@ HdStResourceRegistry::HdStResourceRegistry(Hgi * const hgi)
     // default aggregation strategy for single buffers (for nested instancer)
     , _singleAggregationStrategy(
         std::make_unique<HdStVBOSimpleMemoryManager>(this))
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+    , _materialXShaderRegistry(
+        std::make_unique<HdSt_MaterialXShaderRegistry>(mtlxCacheDirPath))
+#endif
     , _textureHandleRegistry(std::make_unique<HdSt_TextureHandleRegistry>(this))
     , _stagingBuffer(std::make_unique<HdStStagingBuffer>(this))
 {
@@ -142,10 +152,9 @@ void HdStResourceRegistry::InvalidateShaderRegistry()
     _renderPassShaderRegistry.Invalidate();
     _glslfxFileRegistry.Invalidate();
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
-    _materialXShaderRegistry.Invalidate();
+    _materialXShaderRegistry->Invalidate();
 #endif
 }
-
 
 void HdStResourceRegistry::ReloadResource(TfToken const& resourceType,
                                           std::string const& path) 
@@ -647,26 +656,17 @@ HdStResourceRegistry::RegisterRenderPassShader(
 
 HdInstance<HdStGLSLProgramSharedPtr>
 HdStResourceRegistry::RegisterGLSLProgram(
-        HdInstance<HdStGLSLProgramSharedPtr>::ID id)
+    HdInstance<HdStGLSLProgramSharedPtr>::ID id)
 {
     return _glslProgramRegistry.GetInstance(id);
 }
 
 HdInstance<HioGlslfxSharedPtr>
 HdStResourceRegistry::RegisterGLSLFXFile(
-        HdInstance<HioGlslfxSharedPtr>::ID id)
+    HdInstance<HioGlslfxSharedPtr>::ID id)
 {
     return _glslfxFileRegistry.GetInstance(id);
 }
-
-#ifdef PXR_MATERIALX_SUPPORT_ENABLED
-HdInstance<MaterialX::ShaderPtr>
-HdStResourceRegistry::RegisterMaterialXShader(
-        HdInstance<MaterialX::ShaderPtr>::ID id)
-{
-    return _materialXShaderRegistry.GetInstance(id);
-}
-#endif
 
 HdInstance<HgiResourceBindingsSharedPtr>
 HdStResourceRegistry::RegisterResourceBindings(
@@ -1113,7 +1113,7 @@ HdStResourceRegistry::_GarbageCollect()
     _glslProgramRegistry.GarbageCollect();
     _glslfxFileRegistry.GarbageCollect();
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
-    _materialXShaderRegistry.GarbageCollect();
+    _materialXShaderRegistry->GarbageCollect();
 #endif
 
     _textureHandleRegistry->GarbageCollect();

--- a/pxr/imaging/hdSt/resourceRegistry.h
+++ b/pxr/imaging/hdSt/resourceRegistry.h
@@ -28,14 +28,11 @@
 #include <map>
 #include <memory>
 
-#ifdef PXR_MATERIALX_SUPPORT_ENABLED
-#include <MaterialXCore/Library.h>
-MATERIALX_NAMESPACE_BEGIN
-    using ShaderPtr = std::shared_ptr<class Shader>;
-MATERIALX_NAMESPACE_END
-#endif
-
 PXR_NAMESPACE_OPEN_SCOPE
+
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+class HdSt_MaterialXShaderRegistry;
+#endif
 
 using HdStComputationSharedPtr = std::shared_ptr<class HdStComputation>;
 using HdStDispatchBufferSharedPtr = std::shared_ptr<class HdStDispatchBuffer>;
@@ -109,7 +106,12 @@ public:
     HF_MALLOC_TAG_NEW("new HdStResourceRegistry");
 
     HDST_API
-    explicit HdStResourceRegistry(Hgi* hgi);
+    explicit HdStResourceRegistry(
+        Hgi* const hgi
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+        , const char* mtlxCacheDirPath = nullptr
+#endif
+    );
 
     HDST_API
     ~HdStResourceRegistry() override;
@@ -414,10 +416,15 @@ public:
     RegisterGLSLFXFile(HdInstance<HioGlslfxSharedPtr>::ID id);
 
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
-    /// Register MaterialX GLSLFX Shader.
     HDST_API
-    HdInstance<MaterialX::ShaderPtr>
-    RegisterMaterialXShader(HdInstance<MaterialX::ShaderPtr>::ID id);
+    HdSt_MaterialXShaderRegistry* GetMaterialXShaderRegistry() {
+        return _materialXShaderRegistry.get();
+    }
+
+    HDST_API
+    HdSt_MaterialXShaderRegistry* const GetMaterialXShaderRegistry() const {
+        return _materialXShaderRegistry.get();
+    }
 #endif
 
     /// Register a Hgi resource bindings into the registry.
@@ -682,8 +689,9 @@ private:
         _glslfxFileRegistry;
 
 #ifdef PXR_MATERIALX_SUPPORT_ENABLED
-    // MaterialX glslfx shader registry
-    HdInstanceRegistry<MaterialX::ShaderPtr> _materialXShaderRegistry;
+    // MaterialX codegen result registry
+    std::unique_ptr<class HdSt_MaterialXShaderRegistry>
+        _materialXShaderRegistry;
 #endif
 
     // texture handle registry

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
@@ -6,12 +6,18 @@
 //
 #include "pxr/imaging/hdSt/materialXFilter.h"
 #include "pxr/imaging/hdSt/materialXShaderGen.h"
+#include "pxr/imaging/hdSt/materialXShaderRegistry.h"
 #include "pxr/imaging/hdSt/tokens.h"
 #include "pxr/imaging/hdMtlx/hdMtlx.h"
 #include "pxr/imaging/hgi/tokens.h"
 
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/js/json.h"
 #include "pxr/base/tf/errorMark.h"
+
+#include "pxr/base/gf/vec2f.h"
+#include "pxr/base/gf/vec3f.h"
+#include "pxr/base/gf/vec4f.h"
 
 #include <MaterialXGenShader/Util.h>
 
@@ -104,7 +110,7 @@ _GetMaterialTag(mx::DocumentPtr const& mxDoc)
     return HdStMaterialTagTokens->defaultMaterialTag;
 }
 
-void TestShaderGen(
+void _TestShaderGen(
     const mx::FilePath& mtlxFilename, 
     HdSt_MxShaderGenInfo* mxHdInfo)
 {
@@ -141,6 +147,102 @@ void TestShaderGen(
     std::cout << glslfx->getSourceCode(mx::Stage::PIXEL);
 }
 
+void _TestCacheSerialization()
+{
+    HdSt_MaterialParamVector    fallbackParams;
+    TfTokenVector               textureParams;
+
+    auto addFallbackParam = [&fallbackParams](
+        const char* name, VtValue value) -> void
+    {
+        fallbackParams.emplace_back(
+            HdSt_MaterialParam::ParamTypeFallback,
+            TfToken(name), value);
+    };
+
+    addFallbackParam("BoolParamTrue", VtValue(true));
+    addFallbackParam("BoolParamFalse", VtValue(false));
+
+    addFallbackParam("FloatParam0", VtValue(0.0f));
+    addFallbackParam("FloatParam1", VtValue(1.0f));
+    addFallbackParam("FloatParam2", VtValue(-1.0f));
+    addFallbackParam("FloatParam3", VtValue(3.14159f));
+    addFallbackParam("FloatParam4", VtValue(1e6f));
+    addFallbackParam("FloatParam5",
+        VtValue(std::numeric_limits<float>::min()));
+    addFallbackParam("FloatParam6",
+        VtValue(std::numeric_limits<float>::max()));
+
+    addFallbackParam("GfVec2fParam", VtValue(GfVec2f(3.14159f, 1e6f)));
+    addFallbackParam("GfVec3fParam",
+        VtValue(GfVec3f(3.14159f, 1e6f,
+            std::numeric_limits<float>::min())));
+    addFallbackParam("GfVec4fParam",
+        VtValue(GfVec4f(3.14159f, 1e6f,
+            std::numeric_limits<float>::min(),
+            std::numeric_limits<float>::max())));
+
+    addFallbackParam("IntParam0", VtValue(0));
+    addFallbackParam("IntParam1", VtValue(1));
+    addFallbackParam("IntParam2",
+        VtValue(std::numeric_limits<int>::min()));
+    addFallbackParam("IntParam2",
+        VtValue(std::numeric_limits<int>::max()));
+
+    addFallbackParam("GfVec2iParam", VtValue(GfVec2i(0, 1)));
+    addFallbackParam("GfVec3iParam",
+        VtValue(GfVec3i(0,
+            std::numeric_limits<int>::min(),
+            std::numeric_limits<int>::max())));
+    addFallbackParam("GfVec4iParam",
+        VtValue(GfVec4i(0, 1,
+            std::numeric_limits<int>::min(),
+            std::numeric_limits<int>::max())));
+
+    HdSt_MaterialXCodegenResult codegenResult0(
+        "",
+        std::move(fallbackParams),
+        std::move(textureParams));
+
+    std::stringstream ss;
+    codegenResult0.SaveMetadata(ss);
+    ss.seekg(0);
+
+    JsValue jsMetadata = JsParseStream(ss);
+
+    HdSt_MaterialXCodegenResult codegenResult1(
+        "",
+        jsMetadata);
+
+    HdSt_MaterialParamVector const
+        &params0 = codegenResult0.GetFallbackParams(),
+        &params1 = codegenResult1.GetFallbackParams();
+
+    auto fail = []() {
+        throw std::runtime_error(
+            "Fallback parameters not serialized correctly");
+        };
+
+    if (params0.size() != params1.size()) {
+        fail();
+    }
+
+    for (size_t iParam = 0;
+        iParam < params0.size(); ++iParam) {
+
+        HdSt_MaterialParam const
+            & param0 = params0[iParam],
+            & param1 = params1[iParam];
+
+        if (param0.paramType != param1.paramType
+            || param0.name != param1.name
+            || param0.fallbackValue != param1.fallbackValue) {
+
+            fail();
+        }
+    }
+}
+
 int main(int argc, char *argv[])
 {
     TfErrorMark mark;
@@ -148,9 +250,20 @@ int main(int argc, char *argv[])
     HdSt_MxShaderGenInfo mxHdInfo;
     mx::FilePath mtlxFile = "standard_surface_default.mtlx";
 
-    for (int i=0; i<argc; ++i) {
+    for (int i = 0; i < argc; ++i) {
         const std::string arg(argv[i]);
 
+        if (arg == "--testCacheSerialization")
+        {
+            try {
+                _TestCacheSerialization();
+            }
+            catch (std::exception error) {
+                std::cerr << error.what() << '\n';
+                return EXIT_FAILURE;
+            }
+            return EXIT_SUCCESS;
+        }
         if (arg == "--filename") {
             mtlxFile = mx::FilePath(argv[++i]);
         }
@@ -186,7 +299,7 @@ int main(int argc, char *argv[])
             mxHdInfo.bindlessTexturesEnabled = true;
         }
     }
-    TestShaderGen(mtlxFile, &mxHdInfo);
+    _TestShaderGen(mtlxFile, &mxHdInfo);
 
     if (mark.IsClean()) {
         return EXIT_SUCCESS;

--- a/pxr/imaging/hdSt/tokens.h
+++ b/pxr/imaging/hdSt/tokens.h
@@ -82,12 +82,19 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define HDST_RENDER_BUFFER_TOKENS                       \
     ((stormMsaaSampleCount, "storm:msaaSampleCount"))
 
+#ifdef PXR_MATERIALX_SUPPORT_ENABLED
+#define HDST_MTLX_CODEGEN_CACHE_DIR_PATH_TOKEN (hdstMtlxCodegenCacheDirPath)
+#else
+#define HDST_MTLX_CODEGEN_CACHE_DIR_PATH_TOKEN
+#endif
+
 #define HDST_RENDER_SETTINGS_TOKENS             \
     (enableTinyPrimCulling)                     \
     (volumeRaymarchingStepSize)                 \
     (volumeRaymarchingStepSizeLighting)         \
     (volumeMaxTextureMemoryPerField)            \
-    (maxLights)
+    (maxLights)                                 \
+    HDST_MTLX_CODEGEN_CACHE_DIR_PATH_TOKEN
 
 // Material tags help bucket prims into different queues for draw submission.
 // The tags supported by Storm are:


### PR DESCRIPTION
### Description of Change(s)

This change extends the existing MaterialX shader registry (an in-memory cache) with a persistent on-disk cache as a performance optimization. If we've generated a MaterialX shader with a unique ID on a previous run of the application and encounter the same ID on a subsequent run, we avoid redoing the expensive codegen process and instead restore the necessary data from cached files.

The cache directory can be set with the `HDST_MTLX_CODEGEN_CACHE_DIR_PATH` environment variable or the `hdstMtlxCodegenCacheDirPath` render setting. It's left up to the application to manage the cache, such as:

- determine where to place the cache directory;
- cleaning the directory if the cached files become invalidated, e.g. due to upgrading the versions of USD and/or MaterialX;
- cleaning up cached files over a certain age or once a storage limit has been reached.

For reference, the optimization reduces the duration of `HdRenderIndex::SyncAll` for https://github.com/usd-wg/assets/tree/main/full_assets/OpenChessSet from about 550ms to about 250ms in our measurements.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
