### PR TITLE
NVIDIA: Add computation to deform normals for GPU

### DIFF
--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -1269,10 +1269,7 @@ HdStMesh::_PopulateVertexPrimvars(HdSceneDelegate *sceneDelegate,
                 _topology->GetGeomSubsets().size());
     primvars.insert(primvars.end(), varyingPvs.begin(), varyingPvs.end());
 
-    HdExtComputationPrimvarDescriptorVector compPrimvars =
-        sceneDelegate->GetExtComputationPrimvarDescriptors(id,
-            HdInterpolationVertex);
-
+    HdExtComputationPrimvarDescriptorVector compPrimvars;
     HdBufferSourceSharedPtrVector sources;
     HdBufferSourceSharedPtrVector reserveOnlySources;
     HdBufferSourceSharedPtrVector separateComputationSources;
@@ -1312,50 +1309,73 @@ HdStMesh::_PopulateVertexPrimvars(HdSceneDelegate *sceneDelegate,
     // and optimize if necessary.
     //
 
-    HdSt_GetExtComputationPrimvarsComputations(
-        id,
-        sceneDelegate,
-        compPrimvars,
-        *dirtyBits,
-        &sources,
-        &reserveOnlySources,
-        &separateComputationSources,
-        &computations);
-    
     bool isPointsComputedPrimvar = false;
-    {
-        // Update tracked state for points and normals that are computed.
-        for (HdBufferSourceSharedPtrVector const& computedSources :
-             {reserveOnlySources, sources}) {
-            for (HdBufferSourceSharedPtr const& source: computedSources) {
-                if (source->GetName() == HdTokens->points) {
-                    isPointsComputedPrimvar = true;
-                    _pointsDataType = source->GetTupleType().type;
-                }
-                if (source->GetName() == HdTokens->normals) {
-                    _sceneNormalsInterpolation = HdInterpolationVertex;
-                    _sceneNormals = true;
+    bool isNormalsComputedPrimvar = false;
+    const bool doRefine = (refineLevel > 0);
+    const bool doQuadrangulate = _UseQuadIndices(renderIndex, _topology);
+    for (HdInterpolation interpolation : {HdInterpolationVertex, HdInterpolationVarying}) {
+        HdBufferSourceSharedPtrVector localSources;
+        HdBufferSourceSharedPtrVector localReserveOnlySources;
+        HdBufferSourceSharedPtrVector localSeparateComputationSources;
+        HdStComputationComputeQueuePairVector localComputations;
+
+        HdExtComputationPrimvarDescriptorVector localCompPrimvars =
+            sceneDelegate->GetExtComputationPrimvarDescriptors(id,
+                interpolation);
+
+        HdSt_GetExtComputationPrimvarsComputations(
+            id,
+            sceneDelegate,
+            localCompPrimvars,
+            *dirtyBits,
+            &localSources,
+            &localReserveOnlySources,
+            &localSeparateComputationSources,
+            &localComputations);
+        sources.insert(sources.end(), localSources.begin(), localSources.end());
+        reserveOnlySources.insert(reserveOnlySources.end(), localReserveOnlySources.begin(),
+            localReserveOnlySources.end());
+        separateComputationSources.insert(separateComputationSources.end(),
+            localSeparateComputationSources.begin(), localSeparateComputationSources.end());
+        computations.insert(computations.end(), localComputations.begin(), localComputations.end());
+        compPrimvars.insert(compPrimvars.end(), localCompPrimvars.begin(), localCompPrimvars.end());
+    
+        {
+            // Update tracked state for points and normals that are computed.
+            for (HdBufferSourceSharedPtrVector const& computedSources :
+                {localReserveOnlySources, localSources}) {
+                for (HdBufferSourceSharedPtr const& source: computedSources) {
+                    if (source->GetName() == HdTokens->points) {
+                        isPointsComputedPrimvar = true;
+                        _pointsDataType = source->GetTupleType().type;
+                    }
+                    if (source->GetName() == HdTokens->normals) {
+                        isNormalsComputedPrimvar = true;
+                        _sceneNormalsInterpolation = interpolation;
+                        _sceneNormals = true;
+                    }
                 }
             }
         }
-    }
-    
-    const bool doRefine = (refineLevel > 0);
-    const bool doQuadrangulate = _UseQuadIndices(renderIndex, _topology);
+        
+        {
+            const HdSt_MeshTopology::Interpolation hdStInterpolation =
+                interpolation == HdInterpolationVertex ?
+                    HdSt_MeshTopology::INTERPOLATE_VERTEX :
+                    HdSt_MeshTopology::INTERPOLATE_VARYING;
+            for (HdBufferSourceSharedPtr const & source : localReserveOnlySources) {
+                _RefineOrQuadrangulateVertexAndVaryingPrimvar(
+                    source, _topology, id,  doRefine, doQuadrangulate,
+                    resourceRegistry,
+                    &localComputations, hdStInterpolation);
+            }
 
-    {
-        for (HdBufferSourceSharedPtr const & source : reserveOnlySources) {
-            _RefineOrQuadrangulateVertexAndVaryingPrimvar(
-                source, _topology, id,  doRefine, doQuadrangulate,
-                resourceRegistry,
-                &computations, HdSt_MeshTopology::INTERPOLATE_VERTEX);
-        }
-
-        for (HdBufferSourceSharedPtr const & source : sources) {
-            _RefineOrQuadrangulateVertexAndVaryingPrimvar(
-                source, _topology, id,  doRefine, doQuadrangulate,
-                resourceRegistry,
-                &computations, HdSt_MeshTopology::INTERPOLATE_VERTEX);
+            for (HdBufferSourceSharedPtr const & source : localSources) {
+                _RefineOrQuadrangulateVertexAndVaryingPrimvar(
+                    source, _topology, id,  doRefine, doQuadrangulate,
+                    resourceRegistry,
+                    &localComputations, hdStInterpolation);
+            }
         }
     }
 
@@ -1436,6 +1456,12 @@ HdStMesh::_PopulateVertexPrimvars(HdSceneDelegate *sceneDelegate,
             }
 
             if (source->GetName() == HdTokens->normals) {
+                if (!TF_VERIFY(!isNormalsComputedPrimvar)) {
+                    HF_VALIDATION_WARN(id, 
+                        "'normals' specified as both computed and authored "
+                        "primvar. Skipping authored value.");
+                    continue;
+                }
                 _sceneNormalsInterpolation =
                     isVarying ? HdInterpolationVarying : HdInterpolationVertex;
                 _sceneNormals = true;
@@ -1770,11 +1796,10 @@ HdStMesh::_PopulateFaceVaryingPrimvars(HdSceneDelegate *sceneDelegate,
         HdStGetPrimvarDescriptors(this, drawItem, sceneDelegate,
             HdInterpolationFaceVarying, repr, desc.geomStyle,
                 geomSubsetDescIndex, _topology->GetGeomSubsets().size());
-    if (primvars.empty() &&
-        !drawItem->GetFaceVaryingPrimvarRange())
-    {
-        return;
-    }
+
+    HdExtComputationPrimvarDescriptorVector compPrimvars =
+        sceneDelegate->GetExtComputationPrimvarDescriptors(id,
+            HdInterpolationFaceVarying);
 
     HdStResourceRegistrySharedPtr const& resourceRegistry = 
         std::static_pointer_cast<HdStResourceRegistry>(
@@ -1806,6 +1831,35 @@ HdStMesh::_PopulateFaceVaryingPrimvars(HdSceneDelegate *sceneDelegate,
     // If any primvars use doubles, we need to know if the Hgi backend supports
     // these, or if they need to be converted to floats.
     const bool doublesSupported = _GetDoubleSupport(resourceRegistry);
+
+
+    HdBufferSourceSharedPtrVector reserveOnlySources;
+    HdBufferSourceSharedPtrVector separateComputationSources;
+
+    HdSt_GetExtComputationPrimvarsComputations(
+        id,
+        sceneDelegate,
+        compPrimvars,
+        *dirtyBits,
+        &sources,
+        &reserveOnlySources,
+        &separateComputationSources,
+        &computations);
+    
+    bool isNormalsComputedPrimvar = false;
+    {
+        // Update tracked state for normals that are computed.
+        for (HdBufferSourceSharedPtrVector const& computedSources :
+             {reserveOnlySources, sources}) {
+            for (HdBufferSourceSharedPtr const& source: computedSources) {
+                if (source->GetName() == HdTokens->normals) {
+                    isNormalsComputedPrimvar = true;
+                    _sceneNormalsInterpolation = HdInterpolationFaceVarying;
+                    _sceneNormals = true;
+                }
+            }
+        }
+    }
 
     for (HdPrimvarDescriptor const& primvar: primvars) {
         if (!HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, primvar.name)) {
@@ -1846,6 +1900,12 @@ HdStMesh::_PopulateFaceVaryingPrimvars(HdSceneDelegate *sceneDelegate,
             }
 
             if (source->GetName() == HdTokens->normals) {
+                if (!TF_VERIFY(!isNormalsComputedPrimvar)) {
+                    HF_VALIDATION_WARN(id, 
+                        "'normals' specified as both computed and authored "
+                        "primvar. Skipping authored value.");
+                    continue;
+                }
                 _sceneNormalsInterpolation = HdInterpolationFaceVarying;
                 _sceneNormals = true;
             } else if (source->GetName() == HdTokens->displayOpacity) {
@@ -1901,6 +1961,7 @@ HdStMesh::_PopulateFaceVaryingPrimvars(HdSceneDelegate *sceneDelegate,
 
     HdBufferSpecVector bufferSpecs;
     HdBufferSpec::GetBufferSpecs(sources, &bufferSpecs);
+    HdBufferSpec::GetBufferSpecs(reserveOnlySources, &bufferSpecs);
     HdStGetBufferSpecsFromCompuations(computations, &bufferSpecs);
 
     HdBufferArrayRangeSharedPtr range =
@@ -1934,6 +1995,12 @@ HdStMesh::_PopulateFaceVaryingPrimvars(HdSceneDelegate *sceneDelegate,
         HdStComputeQueue queue = compQueuePair.second;
         resourceRegistry->AddComputation(
             drawItem->GetFaceVaryingPrimvarRange(), comp, queue);
+    }
+
+    if (!separateComputationSources.empty()) {
+        for (auto const& src : separateComputationSources) {
+            resourceRegistry->AddSource(src);
+        }
     }
 }
 

--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedExtComputationPrim.cpp
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedExtComputationPrim.cpp
@@ -666,7 +666,7 @@ _ExtComputationInputComputations(const SdfPath &primPath)
     HdPathDataSourceHandle const pathSrc =
         HdRetainedTypedSampledDataSource<SdfPath>::New(
             primPath.AppendChild(
-                UsdSkelImagingExtComputationNameTokens->aggregatorComputation));
+                UsdSkelImagingExtComputationNameTokens->pointsAggregatorComputation));
 
     std::vector<HdDataSourceBaseHandle> values;
     values.reserve(names.size());
@@ -754,13 +754,13 @@ UsdSkelImagingDataSourceResolvedExtComputationPrim(
     TRACE_FUNCTION();
 
     if (computationName == UsdSkelImagingExtComputationNameTokens
-                                ->computation) {
+                                ->pointsComputation) {
         return
             _ExtComputationPrimDataSource(
                 std::move(resolvedPrimSource));
     }
     if (computationName == UsdSkelImagingExtComputationNameTokens
-                                ->aggregatorComputation) {
+                                ->pointsAggregatorComputation) {
         return
             _ExtAggregatorComputationPrimDataSource(
                 std::move(resolvedPrimSource));

--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
@@ -204,7 +204,7 @@ _ExtComputationPrimvars(const SdfPath &primPath)
             .SetSourceComputation(
                 HdRetainedTypedSampledDataSource<SdfPath>::New(
                     primPath.AppendChild(
-                        UsdSkelImagingExtComputationNameTokens->computation)))
+                        UsdSkelImagingExtComputationNameTokens->pointsComputation)))
             .SetSourceComputationOutputName(
                 HdRetainedTypedSampledDataSource<TfToken>::New(
                     UsdSkelImagingExtComputationOutputNameTokens->skinnedPoints))
@@ -610,14 +610,14 @@ UsdSkelImagingDataSourceResolvedPointsBasedPrim::ProcessDirtyLocators(
             entries->push_back({
                 _primPath.AppendChild(
                     UsdSkelImagingExtComputationNameTokens
-                    ->aggregatorComputation),
+                    ->pointsAggregatorComputation),
                 std::move(dirtyLocatorsForAggregatorComputation)});
             sendPointsPrimvarValueDirty = true;
         }
         if (!dirtyLocatorsForComputation.IsEmpty()) {
             entries->push_back({
                 _primPath.AppendChild(
-                    UsdSkelImagingExtComputationNameTokens->computation),
+                    UsdSkelImagingExtComputationNameTokens->pointsComputation),
                 std::move(dirtyLocatorsForComputation)});
             sendPointsPrimvarValueDirty = true;
         }

--- a/pxr/usdImaging/usdSkelImaging/shaders/skinning.glslfx
+++ b/pxr/usdImaging/usdSkelImaging/shaders/skinning.glslfx
@@ -19,6 +19,12 @@
              },
             "skinPointsSimpleKernel": {
                 "source": [ "Compute.SkinPointsSimple" ]
+             },
+             "skinNormalsLBSKernel": {
+                "source": [ "Compute.SkinNormalsLBS" ]
+             },
+             "skinNormalsDQSKernel": {
+                "source": [ "Compute.SkinNormalsDQS" ]
              }
         }
     }
@@ -262,4 +268,233 @@ void compute(int index)
     p = skelToPrimLocal * p;
 
     HdSet_skinnedPoints(index, p.xyz);
+}
+
+
+-- glsl Compute.SkinNormalsLBS
+
+const float EPS = 1e-5;
+
+int GetPointIndex(int index)
+{
+    bool hasFaceVaryingNormals = HdGet_hasFaceVaryingNormals();
+    if (hasFaceVaryingNormals)
+    {
+        return HdGet_faceVertexIndices(index);
+    }
+    else
+    {
+        return index;
+    }
+}
+
+void compute(int index)
+{
+    vec3 restN = HdGet_restNormals(index);
+
+    int numInfluencesPerComponent = HdGet_numInfluencesPerComponent();
+    vec3 n;
+    if (numInfluencesPerComponent > 0) {
+        // model space -> bind space
+        mat4 geomBindXform = HdGet_geomBindXform();
+        mat3 geomBindXformInverseTranspose = transpose(inverse(mat3(geomBindXform)));
+        vec3 initN = geomBindXformInverseTranspose * restN;
+
+        n = vec3(0,0,0);
+
+        bool constantPointInfluence = HdGet_hasConstantInfluences();
+        int pointIndex = GetPointIndex(index);
+        int offset = constantPointInfluence? 0 : numInfluencesPerComponent*pointIndex;
+
+        for (int i = 0; i < numInfluencesPerComponent; i++) {
+            vec2 influence = HdGet_influences(offset + i);
+            float jointWeight = influence.y;
+
+            if (jointWeight > EPS) {
+                int jointIdx = int( influence.x );
+                mat4 skinningXform = HdGet_skinningXforms(jointIdx);
+                mat3 skinningXformInverseTranspose = transpose(inverse(mat3(skinningXform)));
+
+                n += ((skinningXformInverseTranspose * initN) * jointWeight);
+            }
+        }
+
+        // skel space -> world space -> model space
+        // XXX: Casts to mat4 below are necessary because the matrices passed
+        // down use doubles and not floats.
+        mat4 skelToPrimLocal = mat4( HdGet_primWorldToLocal() ) *
+                               mat4( HdGet_skelLocalToWorld() );
+        mat3 skelToPrimLocalInverseTranspose = transpose(inverse(mat3(skelToPrimLocal)));
+        n = skelToPrimLocalInverseTranspose * n;
+    } else {
+        n = restN;
+    }
+
+    HdSet_skinnedNormals(index, n);
+}
+
+
+-- glsl Compute.SkinNormalsDQS
+
+const float EPS = 1e-5;
+const float NORM_EPS = 1e-10;
+
+int GetPointIndex(int index)
+{
+    bool hasFaceVaryingNormals = HdGet_hasFaceVaryingNormals();
+    if (hasFaceVaryingNormals)
+    {
+        return HdGet_faceVertexIndices(index);
+    }
+    else
+    {
+        return index;
+    }
+}
+
+vec4 GetPivotQuaternion(int numInfluencesPerComponent, int offset)
+{
+    vec4 pivotQuat = vec4(0);
+    int pivotIdx = -1;
+    float maxw = -1;
+    for (int i = 0; i < numInfluencesPerComponent; i++) {
+        vec2 influence = HdGet_influences(offset + i);
+        float jointWeight = influence.y;
+        if (pivotIdx < 0 || maxw < jointWeight) {
+            int jointIdx = int( influence.x );
+            maxw = jointWeight;
+            pivotIdx = jointIdx;
+        }
+    }
+    if (pivotIdx >= 0)
+        pivotQuat = HdGet_skinningDualQuats(pivotIdx*2);
+
+    return pivotQuat;
+}
+
+vec3 TransformByQuaternion(vec4 quat, vec3 vec)
+{
+    // See GfQuat::Transform() for algorithm
+
+    float r1 = quat.w;
+    vec3  i1 = quat.xyz;
+
+    vec3  i2 = vec3(r1 * vec[0] + (i1[1] * vec[2] - i1[2] * vec[1]),
+                    r1 * vec[1] + (i1[2] * vec[0] - i1[0] * vec[2]),
+                    r1 * vec[2] + (i1[0] * vec[1] - i1[1] * vec[0]));
+
+    return vec3(vec[0] + 2.0 * (i1[1] * i2[2] - i1[2] * i2[1]),
+                vec[1] + 2.0 * (i1[2] * i2[0] - i1[0] * i2[2]),
+                vec[2] + 2.0 * (i1[0] * i2[1] - i1[1] * i2[0]));
+}
+
+vec3 GetDualQuaternionTranslation(vec4 real, vec4 dual)
+{
+    // See GfDualQuat::GetTranslation() for algorithm
+
+    float scale = -2.0;
+
+    float rw = real.w;
+    vec3  ri = real.xyz;
+
+    float dw = dual.w;
+    vec3  di = dual.xyz;
+
+    return vec3( (dw*ri[0] - rw*di[0] + di[1]*ri[2] - di[2]*ri[1])*scale,
+                 (dw*ri[1] - rw*di[1] + di[2]*ri[0] - di[0]*ri[2])*scale,
+                 (dw*ri[2] - rw*di[2] + di[0]*ri[1] - di[1]*ri[0])*scale );
+}
+
+void compute(int index)
+{
+    // NOTE: skinningXforms and Dual Quats has already been inversed and transposed
+    // from CPU side.
+
+    vec3 restN = HdGet_restNormals(index);
+
+    int numInfluencesPerComponent = HdGet_numInfluencesPerComponent();
+    vec3 n;
+    if (numInfluencesPerComponent > 0) {
+        // model space -> bind space
+        mat4 geomBindXform = HdGet_geomBindXform();
+        mat3 geomBindXformInverseTranspose = transpose(inverse(mat3(geomBindXform)));
+        vec3 initN = geomBindXformInverseTranspose * restN;
+
+#ifdef HD_HAS_skinningScaleXforms
+        vec3 scaledN = vec3(0, 0, 0);
+#endif
+
+        bool constantPointInfluence = HdGet_hasConstantInfluences();
+        int pointIndex = GetPointIndex(index);
+        int offset = constantPointInfluence ? 0 : numInfluencesPerComponent*pointIndex;
+
+        // find the pivot quaternion
+        vec4 pivotQuat = GetPivotQuaternion(numInfluencesPerComponent, offset);
+
+        // find the weighted sum dual quaternion
+        vec4 weightedSumDQReal = vec4(0);
+        vec4 weightedSumDQDual = vec4(0);
+
+        for (int i = 0; i < numInfluencesPerComponent; i++) {
+            vec2 influence = HdGet_influences(offset + i);
+            float jointWeight = influence.y;
+
+            if (jointWeight > EPS) {
+                int jointIdx = int(influence.x);
+
+#ifdef HD_HAS_skinningScaleXforms
+                // Apply scale using LBS, if any of the skinning xforms has scales
+                mat3 scaleXform = HdGet_skinningScaleXforms(jointIdx);
+                scaledN += ((scaleXform * initN) * jointWeight);
+#endif
+
+                // Apply rotation & translation using DQS
+                vec4 skinningDQReal = HdGet_skinningDualQuats(jointIdx*2);
+                vec4 skinningDQDual = HdGet_skinningDualQuats(jointIdx*2+1);
+                // Flip the dual quaternion, if necessary, to make it
+                // on the same hemisphere as the pivotQuat.
+                if (dot(skinningDQReal, pivotQuat) < 0.0)
+                   jointWeight = -jointWeight;
+
+                weightedSumDQReal += (skinningDQReal * jointWeight);
+                weightedSumDQDual += (skinningDQDual * jointWeight);
+            }
+        }
+
+        // normalize weightedSumDQ
+        float realLength = length(weightedSumDQReal);
+        if (realLength < NORM_EPS) {
+            weightedSumDQReal = vec4(0, 0, 0, 1);  // identity quaternion
+            weightedSumDQDual = vec4(0);           // zero quaternion
+        } else {
+            float inverseRealLength = 1.0 / realLength;
+            // rotation normalization
+            weightedSumDQReal *= inverseRealLength;
+            weightedSumDQDual *= inverseRealLength;
+            // plucker normalization
+            weightedSumDQDual -= (dot(weightedSumDQReal, weightedSumDQDual) * weightedSumDQReal);
+        }
+
+#ifdef HD_HAS_skinningScaleXforms
+        // transform scaledN by weightedSumDQ
+        n = TransformByQuaternion(weightedSumDQReal, scaledN)
+            + GetDualQuaternionTranslation(weightedSumDQReal, weightedSumDQDual);
+#else
+        // transform initP by weightedSumDQ
+        n = TransformByQuaternion(weightedSumDQReal, initN)
+            + GetDualQuaternionTranslation(weightedSumDQReal, weightedSumDQDual);
+#endif
+
+        // skel space -> world space -> model space
+        // XXX: Casts to mat4 below are necessary because the matrices passed
+        // down use doubles and not floats.
+        mat4 skelToPrimLocal = mat4(HdGet_primWorldToLocal()) *
+                               mat4(HdGet_skelLocalToWorld());
+        mat3 skelToPrimLocalInverseTranspose = transpose(inverse(mat3(skelToPrimLocal)));
+        n = skelToPrimLocalInverseTranspose * n;
+    } else {
+        n = restN;
+    }
+
+    HdSet_skinnedNormals(index, n);
 }

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.cpp
@@ -36,6 +36,7 @@
 #include "pxr/imaging/hd/mesh.h"
 #include "pxr/imaging/hd/perfLog.h"
 
+#include "pxr/base/work/loops.h"
 #include "pxr/base/gf/quaternion.h"
 #include "pxr/base/gf/dualQuatf.h"
 #include "pxr/base/tf/type.h"
@@ -52,6 +53,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     (skinPointsLBSKernel)
     (skinPointsDQSKernel)
     (skinPointsSimpleKernel)
+    (skinNormalsLBSKernel)
+    (skinNormalsDQSKernel)
+    (skinNormalsSimpleKernel)
 
     // skel primvar names
     ((skelJointIndices,  "skel:jointIndices"))
@@ -149,48 +153,65 @@ UsdSkelImagingSkeletonAdapter::Populate(
 
         for (UsdSkelSkinningQuery const& query : binding.GetSkinningTargets()) {
             
-            // Insert two computations ...
+            // Insert computations ...
             UsdPrim const& skinnedPrim = query.GetPrim();
             SdfPath skinnedPrimPath = ResolveCachePath(
                 skinnedPrim.GetPath(), instancerContext);
 
-            _skinnedPrimDataCache[skinnedPrimPath] =
-                _SkinnedPrimData(skelPath, skelData->skelQuery,
-                                 query, skelRootPath);
 
-            // 1. A skinning computation that computes the skinned points, and
-            SdfPath compPath = _GetSkinningComputationPath(skinnedPrimPath);
+            _SkinnedPrimData skinnedPrimData(skelPath, skelData->skelQuery,
+                                query, skelRootPath, this);
+            _skinnedPrimDataCache[skinnedPrimPath] = skinnedPrimData;
 
-            TF_DEBUG(USDIMAGING_COMPUTATIONS).Msg(
-                "[SkeletonAdapter::Populate] Inserting "
-                "computation %s for skinned prim %s\n",
-                compPath.GetText(), skinnedPrimPath.GetText());
+            for (ComputationType computationType : {ComputationType::Points, ComputationType::Normals}) {
+                // Skip computing normals if CPU compute is forced.
+                if(computationType == ComputationType::Normals && TfGetEnvSetting(USDSKELIMAGING_FORCE_CPU_COMPUTE)) {
+                    continue;
+                }
 
-            index->InsertSprim(
+                // 1. A skinning computation that computes the skinned points or skinned normals.
+                SdfPath compPath = _GetSkinningComputationPath(skinnedPrimPath, computationType);
+
+                TF_DEBUG(USDIMAGING_COMPUTATIONS).Msg(
+                    "[SkeletonAdapter::Populate] Inserting "
+                    "computation %s for skinned prim %s\n",
+                    compPath.GetText(), skinnedPrimPath.GetText());
+
+                index->InsertSprim(
+                        HdPrimTypeTokens->extComputation,
+                        compPath,
+                        skinnedPrim,
+                        shared_from_this());
+
+                // 2. An aggregator computation that aggregates inputs that
+                //    typically don't vary with time. This is necessary because
+                //    Hydra ExtComputations does not track dirtiness per input.
+                //    The aggregator computation is especially useful for GPU
+                //    compute and avoids re-uploading inputs that don't vary to the 
+                //    GPU.
+                SdfPath aggrCompPath =
+                    _GetSkinningInputAggregatorComputationPath(skinnedPrimPath, computationType);
+
+                TF_DEBUG(USDIMAGING_COMPUTATIONS).Msg(
+                    "[SkeletonAdapter::Populate] Inserting "
+                    "aggregator computation %s for skinned prim %s\n",
+                    aggrCompPath.GetText(), skinnedPrimPath.GetText());
+
+                index->InsertSprim(
                     HdPrimTypeTokens->extComputation,
-                    compPath,
+                    aggrCompPath,
                     skinnedPrim,
                     shared_from_this());
 
-            // 2. An aggregator computation that aggregates inputs that
-            //    typically don't vary with time. This is necessary because
-            //    Hydra ExtComputations does not track dirtiness per input.
-            //    The aggregator computation is especially useful for GPU
-            //    compute and avoids re-uploading inputs that don't vary to the
-            //    GPU.
-            SdfPath aggrCompPath =
-                _GetSkinningInputAggregatorComputationPath(skinnedPrimPath);
-
-            TF_DEBUG(USDIMAGING_COMPUTATIONS).Msg(
-                "[SkeletonAdapter::Populate] Inserting "
-                "aggregator computation %s for skinned prim %s\n",
-                aggrCompPath.GetText(), skinnedPrimPath.GetText());
-
-            index->InsertSprim(
-                HdPrimTypeTokens->extComputation,
-                aggrCompPath,
-                skinnedPrim,
-                shared_from_this());
+                // Constant or uniform normals skinning is not supported.
+                if (skinnedPrimData.normalsInterpolation == UsdGeomTokens->constant ||
+                    skinnedPrimData.normalsInterpolation == UsdGeomTokens->uniform) {
+                    TF_WARN("Skinned prim %s has constant or uniform normals"
+                            "interpolation. Skipping skinning computations.",
+                            skinnedPrimPath.GetText());
+                    break;
+                }
+            }
         }
     } else {
         // Do nothing. This isn't an error. We can have skeletons that
@@ -231,7 +252,8 @@ UsdSkelImagingSkeletonAdapter::TrackVariability(
         return;
     }
 
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
          _TrackSkinningComputationVariability(  prim,
                                                 cachePath,
                                                 timeVaryingBits,
@@ -239,7 +261,8 @@ UsdSkelImagingSkeletonAdapter::TrackVariability(
         return;
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
         // Nothing to do; these are not expected to be time varying.
         // XXX: Check if inputs from the skinned prim are time-varying and
         // issue a warning.
@@ -271,11 +294,13 @@ UsdSkelImagingSkeletonAdapter::UpdateForTime(
     // for them here and instead handle all pulls from the computation prims
     // directly in various GetExtComputation* calls on the adapter (called 
     // from the scene delegate).
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
         return;
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
         return;
     }
 
@@ -368,8 +393,10 @@ UsdSkelImagingSkeletonAdapter::ProcessPropertyChange(
         return dirtyBits;
     }
     
-    if (_IsSkinningComputationPath(cachePath) ||
-        _IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath) ||
+        _IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
         // Nothing to do.
         return HdChangeTracker::Clean;
     }
@@ -472,21 +499,27 @@ UsdSkelImagingSkeletonAdapter::MarkDirty(const UsdPrim& prim,
                 "[SkeletonAdapter::MarkDirty] Propagating dirtyness from "
                 "skinned prim %s to its computations\n", cachePath.GetText());
             
-            index->MarkSprimDirty(_GetSkinningComputationPath(cachePath),
+            index->MarkSprimDirty(_GetSkinningComputationPath(cachePath, ComputationType::Points),
                                   HdExtComputation::DirtySceneInput);
-
+            index->MarkSprimDirty(_GetSkinningComputationPath(cachePath, ComputationType::Normals),
+                                  HdExtComputation::DirtySceneInput);
         }
 
         // The aggregator computation pulls on primvars authored on the skinned
         // prim, but doesn't pull on its transform.
         if (dirty & HdChangeTracker::DirtyPrimvar) {
             index->MarkSprimDirty(
-                _GetSkinningInputAggregatorComputationPath(cachePath),
+                _GetSkinningInputAggregatorComputationPath(cachePath, ComputationType::Points),
+                HdExtComputation::DirtySceneInput);
+            index->MarkSprimDirty(
+                _GetSkinningInputAggregatorComputationPath(cachePath, ComputationType::Normals),
                 HdExtComputation::DirtySceneInput);
         }
     
-    } else if (_IsSkinningComputationPath(cachePath) ||
-              _IsSkinningInputAggregatorComputationPath(cachePath)) {
+    } else if (_IsSkinningPointsComputationPath(cachePath) ||
+               _IsSkinningNormalsComputationPath(cachePath) ||
+               _IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+               _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
 
          TF_DEBUG(USDIMAGING_COMPUTATIONS).Msg(
                 "[SkeletonAdapter::MarkDirty] Marking "
@@ -583,8 +616,10 @@ UsdSkelImagingSkeletonAdapter::MarkTransformDirty(const UsdPrim& prim,
         UsdImagingPrimAdapterSharedPtr adapter = _GetPrimAdapter(prim);
         adapter->MarkTransformDirty(prim, cachePath, index);
 
-    } else if (_IsSkinningComputationPath(cachePath) ||
-              _IsSkinningInputAggregatorComputationPath(cachePath)) {
+    } else if (_IsSkinningPointsComputationPath(cachePath) ||
+               _IsSkinningNormalsComputationPath(cachePath) ||
+               _IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+               _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
 
         // XXX: See comments in ProcessPropertyChange about dirtyness
         // propagation to the computations.
@@ -619,8 +654,10 @@ UsdSkelImagingSkeletonAdapter::MarkVisibilityDirty(const UsdPrim& prim,
         // at the start, we do sync once), and thus won't trigger the
         // computations.
 
-    } else if (_IsSkinningComputationPath(cachePath) ||
-              _IsSkinningInputAggregatorComputationPath(cachePath)) {
+    } else if (_IsSkinningPointsComputationPath(cachePath) ||
+               _IsSkinningNormalsComputationPath(cachePath) ||
+               _IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+               _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
 
         // Nothing to do. See comment above.
     
@@ -799,6 +836,13 @@ UsdSkelImagingSkeletonAdapter::InvokeComputation(
     HdExtComputationContext* context)
 {
     HD_TRACE_FUNCTION();
+
+    // Only invoke the computation if it's a points computation.
+    // Normals computations are not supported yet for CPU .
+    if(!_IsSkinningPointsComputationPath(cachePath)) {
+        return;
+    }
+
     TfToken skinningMethod = UsdSkelTokens->classicLinear;
     if (const _SkinnedPrimData* const skinnedPrimData =
             _GetSkinnedPrimData(cachePath.GetParentPath())) {
@@ -1030,8 +1074,8 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationSceneInputNames(
 {
     // This function provides the scene inputs for the skinning computation
     // for both CPU and GPU codepaths.
-    if (_IsSkinningComputationPath(cachePath)) {
-
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
         TfToken skinningMethod = UsdSkelTokens->classicLinear;
         const _SkinnedPrimData* skinnedPrimData =
             _GetSkinnedPrimData(cachePath.GetParentPath());
@@ -1094,29 +1138,37 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationSceneInputNames(
         }
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
+        bool isPointsInputAggregator =
+            _IsSkinningPointsInputAggregatorComputationPath(cachePath);
         // ExtComputation inputs
- 	// Scene inputs for the aggregator computation.
-        static TfTokenVector inputNames({
-            // Data authored on the skinned prim as primvars.
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->restPoints,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->geomBindXform,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->influences,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->numInfluencesPerComponent,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->hasConstantInfluences,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->blendShapeOffsets,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->blendShapeOffsetRanges,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->numBlendShapeOffsetRanges
-        });
-        return inputNames;
+        // Scene inputs for the aggregator computation.
+        if (isPointsInputAggregator) {
+            static TfTokenVector pointsInputNames({
+                // Data authored on the skinned prim as primvars.
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->restPoints,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->geomBindXform,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->influences,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->numInfluencesPerComponent,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->hasConstantInfluences,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->blendShapeOffsets,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->blendShapeOffsetRanges,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->numBlendShapeOffsetRanges
+            });
+            return pointsInputNames;
+        } else {
+            static TfTokenVector normalsInputNames({
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->restNormals,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->geomBindXform,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->influences,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->numInfluencesPerComponent,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->hasConstantInfluences,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->faceVertexIndices,
+                UsdSkelImagingExtAggregatorComputationInputNameTokens->hasFaceVaryingNormals
+            });
+            return normalsInputNames;
+        }
     }  
 
     return BaseAdapter::GetExtComputationSceneInputNames(cachePath);;
@@ -1131,33 +1183,40 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationInputs(
 {
     // See NOTE(s) in GetExtComputationSceneInputNames above.
     
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
+        bool isPointsComputation = _IsSkinningPointsComputationPath(cachePath);
 
-        // Computation inputs
-        static TfTokenVector compInputNames({
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->restPoints,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->geomBindXform,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->influences,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->numInfluencesPerComponent,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->hasConstantInfluences,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->blendShapeOffsets,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->blendShapeOffsetRanges,
-            UsdSkelImagingExtAggregatorComputationInputNameTokens
-                ->numBlendShapeOffsetRanges
+        static const TfTokenVector compPointsInputNames({
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->restPoints,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->geomBindXform,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->influences,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->numInfluencesPerComponent,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->hasConstantInfluences,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->blendShapeOffsets,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->blendShapeOffsetRanges,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->numBlendShapeOffsetRanges
         });
 
+        static const TfTokenVector compNormalsInputNames({
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->restNormals,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->geomBindXform,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->influences,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->numInfluencesPerComponent,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->hasConstantInfluences,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->faceVertexIndices,
+            UsdSkelImagingExtAggregatorComputationInputNameTokens->hasFaceVaryingNormals
+        });
+
+        // Computation inputs
         SdfPath skinnedPrimPath =
             ResolveCachePath(prim.GetPath(), instancerContext);
         SdfPath renderIndexAggrCompId = _ConvertCachePathToIndexPath(
-            _GetSkinningInputAggregatorComputationPath(skinnedPrimPath));
-        
+            _GetSkinningInputAggregatorComputationPath(skinnedPrimPath,
+            _GetSkinningComputationType(cachePath)));
+
+        const TfTokenVector& compInputNames =
+            isPointsComputation ? compPointsInputNames : compNormalsInputNames;
         HdExtComputationInputDescriptorVector compInputDescs;
         for (auto const& input : compInputNames) {
             compInputDescs.emplace_back(
@@ -1169,7 +1228,8 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationInputs(
 
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
         // No computation inputs
         return HdExtComputationInputDescriptorVector();
     }
@@ -1184,17 +1244,23 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationOutputs(
     SdfPath const& cachePath,
     const UsdImagingInstancerContext* instancerContext) const
 {
-    if (_IsSkinningComputationPath(cachePath)) {
-    
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
+        bool isPointsComputation = _IsSkinningPointsComputationPath(cachePath);
         HdTupleType pointsType;
         pointsType.type = HdTypeFloatVec3;
         pointsType.count = 1;
-        
+
         HdExtComputationOutputDescriptorVector outputsEntry;
-        outputsEntry.emplace_back(
-            UsdSkelImagingExtComputationOutputNameTokens
-                ->skinnedPoints,
-            pointsType);
+        if (isPointsComputation) {
+            outputsEntry.emplace_back(
+                UsdSkelImagingExtComputationOutputNameTokens->skinnedPoints,
+                pointsType);
+        } else {
+            outputsEntry.emplace_back(
+                UsdSkelImagingExtComputationOutputNameTokens->skinnedNormals,
+                pointsType);
+        }
 
         return outputsEntry;
     }
@@ -1212,11 +1278,6 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationPrimvars(
 {
     if (_IsSkinnedPrimPath(cachePath)) {
 
-        // We only support 'points' which is vertex interpolation
-        if (interpolation != HdInterpolationVertex) {
-            return HdExtComputationPrimvarDescriptorVector();
-        }
-
         // Note: We don't specify the # of points, since the prim already knows
         // how many to expect for a given topology.
         // The count field below indicates that we have one vec3f per point.
@@ -1227,16 +1288,59 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationPrimvars(
         const SdfPath skinnedPrimPath = ResolveCachePath(
             prim.GetPath(), instancerContext);
 
+        const _SkinnedPrimData* skinnedPrimData = _GetSkinnedPrimData(skinnedPrimPath);
+
         HdExtComputationPrimvarDescriptorVector compPrimvars;
-        compPrimvars.emplace_back(
+        if (interpolation == HdInterpolationVertex) {
+            compPrimvars.emplace_back(
                         HdTokens->points,
                         HdInterpolationVertex,
                         HdPrimvarRoleTokens->point,
                         _ConvertCachePathToIndexPath(
-                            _GetSkinningComputationPath(skinnedPrimPath)),
-                        UsdSkelImagingExtComputationOutputNameTokens
-                            ->skinnedPoints,
+                            _GetSkinningComputationPath(skinnedPrimPath,
+                            ComputationType::Points)),
+                        UsdSkelImagingExtComputationOutputNameTokens->skinnedPoints,
                         pointsType);
+            
+            if (skinnedPrimData && 
+                (skinnedPrimData->normalsInterpolation == UsdGeomTokens->vertex)) {
+                compPrimvars.emplace_back(
+                    HdTokens->normals,
+                    HdInterpolationVertex,
+                    HdPrimvarRoleTokens->normal,
+                    _ConvertCachePathToIndexPath(
+                        _GetSkinningComputationPath(skinnedPrimPath,
+                        ComputationType::Normals)),
+                    UsdSkelImagingExtComputationOutputNameTokens->skinnedNormals,
+                    pointsType);
+            }
+        }
+
+        if (interpolation == HdInterpolationVarying &&
+            skinnedPrimData && skinnedPrimData->normalsInterpolation == UsdGeomTokens->varying) {
+            compPrimvars.emplace_back(
+                HdTokens->normals,
+                HdInterpolationVarying,
+                HdPrimvarRoleTokens->normal,
+                _ConvertCachePathToIndexPath(
+                    _GetSkinningComputationPath(skinnedPrimPath,
+                    ComputationType::Normals)),
+                UsdSkelImagingExtComputationOutputNameTokens->skinnedNormals,
+                pointsType);
+        }
+
+        if (interpolation == HdInterpolationFaceVarying &&
+            skinnedPrimData && skinnedPrimData->normalsInterpolation == UsdGeomTokens->faceVarying) {
+            compPrimvars.emplace_back(
+                        HdTokens->normals,
+                        HdInterpolationFaceVarying,
+                        HdPrimvarRoleTokens->normal,
+                        _ConvertCachePathToIndexPath(
+                            _GetSkinningComputationPath(skinnedPrimPath,
+                            ComputationType::Normals)),
+                        UsdSkelImagingExtComputationOutputNameTokens->skinnedNormals,
+                        pointsType);
+        }
 
         return compPrimvars;
     }
@@ -1337,11 +1441,15 @@ _ComputeSubShapeWeights(const UsdSkelSkeletonQuery& skelQuery,
     return false;
 }
 
+} // namespace
+
+
 // Extract the Scale & Shear parts of 4x4 matrices by removing the
 // translation & rotation. Return only the upper-left 3x3 matrices.
 bool
-_ExtractSkinningScaleXforms(const VtMatrix4fArray& skinningXforms,
-                            VtMatrix3fArray* skinningScaleXforms)
+UsdSkelImagingSkeletonAdapter::_ExtractSkinningScaleXforms(const VtMatrix4fArray& skinningXforms,
+                            VtMatrix3fArray* skinningScaleXforms,
+                            ComputationType computationType)
 {
     if (!skinningScaleXforms) {
         TF_CODING_ERROR("'skinningScaleXforms' pointer is null.");
@@ -1350,25 +1458,30 @@ _ExtractSkinningScaleXforms(const VtMatrix4fArray& skinningXforms,
 
     // Convert skinningXforms to skinningScaleXforms
     skinningScaleXforms->resize(skinningXforms.size());
-    GfMatrix4f scaleOrientMat, factoredRotMat, perspMat;
-    GfVec3f scale, translation;
 
-    for (size_t i = 0; i < skinningXforms.size(); ++i) {
-        const GfMatrix4f &matrix = skinningXforms[i];
-        if (!matrix.Factor(&scaleOrientMat, &scale, &factoredRotMat,
-                           &translation, &perspMat)) {
-            // unable to decompose, set to identity
-            (*skinningScaleXforms)[i] = GfMatrix3f(1);
-        } else {
-            // Remove shear & extract rotation
-            factoredRotMat.Orthonormalize();
-            // Calculate the scale + shear transform
-            const GfMatrix4f tmpNonScaleXform =
-                factoredRotMat * GfMatrix4f(1.0).SetTranslate(translation);
-            (*skinningScaleXforms)[i] = (matrix * tmpNonScaleXform.GetInverse()).
-                ExtractRotationMatrix();   // Extract the upper-left 3x3 matrix
+    WorkParallelForN(skinningXforms.size(), [&](size_t start, size_t end) {
+        GfMatrix4f scaleOrientMat, factoredRotMat, perspMat;
+        GfVec3f scale, translation;
+        for (size_t i = start; i < end; ++i) {
+            const GfMatrix4f &matrix = computationType == ComputationType::Normals ?
+                GfMatrix4f(skinningXforms[i].GetInverse().GetTranspose()) :
+                skinningXforms[i];
+
+            if (!matrix.Factor(&scaleOrientMat, &scale, &factoredRotMat,
+                            &translation, &perspMat)) {
+                // unable to decompose, set to identity
+                (*skinningScaleXforms)[i] = GfMatrix3f(1);
+            } else {
+                // Remove shear & extract rotation
+                factoredRotMat.Orthonormalize();
+                // Calculate the scale + shear transform
+                const GfMatrix4f tmpNonScaleXform =
+                    factoredRotMat * GfMatrix4f(1.0).SetTranslate(translation);
+                (*skinningScaleXforms)[i] = (matrix * tmpNonScaleXform.GetInverse()).
+                    ExtractRotationMatrix();   // Extract the upper-left 3x3 matrix
+            }
         }
-    }
+    }, /*grainSize*/ 1000);
 
     return true;
 }
@@ -1376,8 +1489,9 @@ _ExtractSkinningScaleXforms(const VtMatrix4fArray& skinningXforms,
 // Extract the translation & rotation parts of 4x4 matrices into dual quaternions.
 // Use a pair of Vec4f to represent a dual quaternion.
 bool
-_ExtractSkinningDualQuats(const VtMatrix4fArray& skinningXforms,
-                          VtVec4fArray* skinningDualQuats)
+UsdSkelImagingSkeletonAdapter::_ExtractSkinningDualQuats(const VtMatrix4fArray& skinningXforms,
+                          VtVec4fArray* skinningDualQuats,
+                          ComputationType computationType)
 {
     if (!skinningDualQuats) {
         TF_CODING_ERROR("'skinningDualQuats' pointer is null.");
@@ -1386,39 +1500,41 @@ _ExtractSkinningDualQuats(const VtMatrix4fArray& skinningXforms,
 
     // Convert skinningXforms to skinningDualQuats
     skinningDualQuats->resize(skinningXforms.size()*2);
-    GfMatrix4f scaleOrientMat, factoredRotMat, perspMat;
-    GfVec3f scale, translation;
-    GfDualQuatf dq;
 
-    for (size_t i = 0; i < skinningXforms.size(); ++i) {
-        const GfMatrix4f &matrix = skinningXforms[i];
-        if (!matrix.Factor(&scaleOrientMat, &scale, &factoredRotMat,
-                           &translation, &perspMat)) {
-            // unable to decompose, set to zero
-            dq = GfDualQuatf::GetZero();
-        } else {
-            // Remove shear & extract rotation
-            factoredRotMat.Orthonormalize();
-            const GfQuaternion rotationQ = factoredRotMat.ExtractRotationMatrix()
-                .ExtractRotationQuaternion();
-            dq = GfDualQuatf(GfQuatf(GfQuatd(rotationQ.GetReal(), rotationQ.GetImaginary())),
-                             translation);
+    WorkParallelForN(skinningXforms.size(), [&](size_t start, size_t end) {
+        GfMatrix4f scaleOrientMat, factoredRotMat, perspMat;
+        GfVec3f scale, translation;
+        GfDualQuatf dq;
+        for (size_t i = start; i < end; ++i) {
+            const GfMatrix4f &matrix = computationType == ComputationType::Normals ?
+                GfMatrix4f(skinningXforms[i].GetInverse().GetTranspose()) :
+                skinningXforms[i];
+            if (!matrix.Factor(&scaleOrientMat, &scale, &factoredRotMat,
+                               &translation, &perspMat)) {
+                // unable to decompose, set to zero
+                dq = GfDualQuatf::GetZero();
+            } else {
+                // Remove shear & extract rotation
+                factoredRotMat.Orthonormalize();
+                const GfQuaternion rotationQ = factoredRotMat.ExtractRotationMatrix()
+                    .ExtractRotationQuaternion();
+                dq = GfDualQuatf(GfQuatf(GfQuatd(rotationQ.GetReal(), rotationQ.GetImaginary())),
+                                translation);
+            }
+
+            const float    real_r = dq.GetReal().GetReal();
+            const GfVec3f &real_i = dq.GetReal().GetImaginary();
+            (*skinningDualQuats)[i*2]   = GfVec4f(real_i[0], real_i[1], real_i[2], real_r);
+
+            const float    dual_r = dq.GetDual().GetReal();
+            const GfVec3f &dual_i = dq.GetDual().GetImaginary();
+            (*skinningDualQuats)[i*2+1] = GfVec4f(dual_i[0], dual_i[1], dual_i[2], dual_r);
         }
-
-        const float    real_r = dq.GetReal().GetReal();
-        const GfVec3f &real_i = dq.GetReal().GetImaginary();
-        (*skinningDualQuats)[i*2]   = GfVec4f(real_i[0], real_i[1], real_i[2], real_r);
-
-        const float    dual_r = dq.GetDual().GetReal();
-        const GfVec3f &dual_i = dq.GetDual().GetImaginary();
-        (*skinningDualQuats)[i*2+1] = GfVec4f(dual_i[0], dual_i[1], dual_i[2], dual_r);
-    }
+    }, /*grainSize*/ 1000);
 
     return true;
 }
 
-
-} // namespace
 
 VtValue 
 UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForSkinningComputation(
@@ -1426,7 +1542,8 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForSkinningComputation(
     SdfPath const& cachePath,
     TfToken const& name,
     UsdTimeCode time,
-    const UsdImagingInstancerContext* instancerContext) const
+    const UsdImagingInstancerContext* instancerContext,
+    ComputationType computationType) const
 {
     TRACE_FUNCTION();
 
@@ -1452,10 +1569,17 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForSkinningComputation(
         // For dispatchCount, elementCount, we need to know 
         // the number of points on the skinned prim. Pull only when 
         // required.
-        VtVec3fArray restPoints = _GetSkinnedPrimPoints(prim, 
+        if (computationType == ComputationType::Points) {
+            VtVec3fArray restPoints = _GetSkinnedPrimPoints(prim, 
                                         skinnedPrimCachePath, time);
-        size_t numPoints = restPoints.size();
-        return VtValue(numPoints);
+            size_t numPoints = restPoints.size();
+            return VtValue(numPoints);
+        } else {
+            VtVec3fArray restNormals = _GetSkinnedPrimNormals(prim, 
+                                        skinnedPrimCachePath, time);
+            size_t numNormals = restNormals.size();
+            return VtValue(numNormals);
+        }
     }
 
     // primWorldToLocal
@@ -1515,12 +1639,14 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForSkinningComputation(
                             ->skinningXforms)
                 return VtValue(skinningXforms);
 
+            ComputationType computationType = _GetSkinningComputationType(cachePath);
+
             if (name == UsdSkelImagingExtComputationInputNameTokens
                             ->skinningScaleXforms) {
                 // Extract skinningScaleXforms from skinningXforms
                 VtMatrix3fArray skinningScaleXforms;
                 if (!TF_VERIFY(_ExtractSkinningScaleXforms
-                               (skinningXforms, &skinningScaleXforms)))
+                               (skinningXforms, &skinningScaleXforms, computationType)))
                     return VtValue();
 
                 return VtValue(skinningScaleXforms);
@@ -1528,10 +1654,11 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForSkinningComputation(
 
             if (name == UsdSkelImagingExtComputationInputNameTokens
                             ->skinningDualQuats) {
+                
                 // Extract skinningDualQuats from skinningXforms
                 VtVec4fArray skinningDualQuats;
                 if (!TF_VERIFY(_ExtractSkinningDualQuats
-                               (skinningXforms, &skinningDualQuats)))
+                               (skinningXforms, &skinningDualQuats, computationType)))
                     return VtValue();
 
                 return VtValue(skinningDualQuats);
@@ -1586,7 +1713,8 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForInputAggregator(
     SdfPath const& cachePath,
     TfToken const& name,
     UsdTimeCode time,
-    const UsdImagingInstancerContext* instancerContext) const
+    const UsdImagingInstancerContext* instancerContext,
+    ComputationType computationType) const
 {
     // DispatchCount, ElementCount aren't relevant for an input aggregator
     // computation. 
@@ -1611,6 +1739,25 @@ UsdSkelImagingSkeletonAdapter::_GetExtComputationInputForInputAggregator(
         VtVec3fArray restPoints =
             _GetSkinnedPrimPoints(prim, skinnedPrimCachePath, time);
         return VtValue(restPoints);
+    }
+
+    // restNormals
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->restNormals) {
+        VtVec3fArray restNormals = _GetSkinnedPrimNormals(prim, 
+                                        skinnedPrimCachePath, time);
+        return VtValue(restNormals);
+    }
+
+    // hasFaceVaryingNormals
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->hasFaceVaryingNormals) {
+        return VtValue(skinnedPrimData->normalsInterpolation == UsdGeomTokens->faceVarying);
+    }
+
+    // faceVertexIndices
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->faceVertexIndices) {
+        VtIntArray faceVertexIndices = _GetSkinnedPrimFaceVertexIndices(prim, 
+                                        skinnedPrimCachePath, time);
+        return VtValue(faceVertexIndices);
     }
 
     // geomBindXform
@@ -1729,6 +1876,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
     UsdTimeCode time,
     const UsdImagingInstancerContext* instancerContext,
     size_t maxSampleCount,
+    ComputationType computationType,
     float *sampleTimes,
     VtValue *sampleValues)
 {
@@ -1761,12 +1909,21 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
         // For dispatchCount, elementCount, we need to know 
         // the number of points on the skinned prim. Pull only when 
         // required.
-        VtVec3fArray restPoints = _GetSkinnedPrimPoints(prim, 
+        if (computationType == ComputationType::Points) {
+            VtVec3fArray restPoints = _GetSkinnedPrimPoints(prim, 
                                         skinnedPrimCachePath, time);
-        size_t numPoints = restPoints.size();
-        sampleValues[0] = VtValue(numPoints);
-        sampleTimes[0] = 0.f;
-        return 1;
+            size_t numPoints = restPoints.size();
+            sampleValues[0] = VtValue(numPoints);
+            sampleTimes[0] = 0.f;
+            return 1;
+        } else {
+            VtVec3fArray restNormals = _GetSkinnedPrimNormals(prim, 
+                                        skinnedPrimCachePath, time);
+            size_t numNormals = restNormals.size();
+            sampleValues[0] = VtValue(numNormals);
+            sampleTimes[0] = 0.f;
+            return 1;
+        }
     }
 
     // primWorldToLocal
@@ -1838,6 +1995,8 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
                 const size_t numSamplesToEvaluate =
                     _UnionTimeSamples(interval, maxSampleCount, &times);
 
+                ComputationType computationType = _GetSkinningComputationType(cachePath);
+
                 for (size_t i = 0; i < numSamplesToEvaluate; ++i) {
                     sampleTimes[i] = times[i] - time.GetValue();
 
@@ -1857,13 +2016,15 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForSkinningComputation(
                                          ->skinningScaleXforms) {
                         VtMatrix3fArray skinningScaleXforms;
                         _ExtractSkinningScaleXforms(skinningXforms,
-                                                    &skinningScaleXforms);
+                                                    &skinningScaleXforms,
+                                                    computationType);
                         sampleValues[i] = VtValue::Take(skinningScaleXforms);
                     }
                     else {
                         VtVec4fArray skinningDualQuats;
                         _ExtractSkinningDualQuats(skinningXforms,
-                                                  &skinningDualQuats);
+                                                  &skinningDualQuats,
+                                                  computationType);
                         sampleValues[i] = VtValue::Take(skinningDualQuats);
                     }
                 }
@@ -1966,6 +2127,7 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
     UsdTimeCode time,
     const UsdImagingInstancerContext* instancerContext,
     size_t maxSampleCount,
+    ComputationType computationType,
     float *sampleTimes,
     VtValue *sampleValues)
 {
@@ -1996,6 +2158,31 @@ UsdSkelImagingSkeletonAdapter::_SampleExtComputationInputForInputAggregator(
         // Rest points aren't expected to be time-varying.
         sampleValues[0] =
             VtValue(_GetSkinnedPrimPoints(prim, skinnedPrimCachePath, time));
+        sampleTimes[0] = 0.f;
+        return 1;
+    }
+
+    // restNormals
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->restNormals) {
+        VtVec3fArray restNormals = _GetSkinnedPrimNormals(prim, 
+                                        skinnedPrimCachePath, time);
+        sampleValues[0] = VtValue(restNormals);
+        sampleTimes[0] = 0.f;
+        return 1;
+    }
+
+    // hasFaceVaryingNormals
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->hasFaceVaryingNormals) {
+        sampleValues[0] = VtValue(skinnedPrimData->normalsInterpolation == UsdGeomTokens->faceVarying);
+        sampleTimes[0] = 0.f;
+        return 1;
+    }
+
+    // faceVertexIndices
+    if (name == UsdSkelImagingExtAggregatorComputationInputNameTokens->faceVertexIndices) {
+        VtIntArray faceVertexIndices = _GetSkinnedPrimFaceVertexIndices(prim, 
+                                        skinnedPrimCachePath, time);
+        sampleValues[0] = VtValue(faceVertexIndices);
         sampleTimes[0] = 0.f;
         return 1;
     }
@@ -2109,14 +2296,20 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationInput(
 {
     TRACE_FUNCTION();
 
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
+        ComputationType computationType = _GetSkinningComputationType(cachePath);
         return _GetExtComputationInputForSkinningComputation(
-                prim, cachePath, name, time, instancerContext);
+                prim, cachePath, name, time, instancerContext,
+                computationType);
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
+        ComputationType computationType = _GetSkinningComputationType(cachePath);
         return _GetExtComputationInputForInputAggregator(
-                prim, cachePath, name, time, instancerContext);
+                prim, cachePath, name, time, instancerContext,
+                computationType);
     }
 
     return BaseAdapter::GetExtComputationInput(prim, cachePath, name, time,
@@ -2136,16 +2329,20 @@ UsdSkelImagingSkeletonAdapter::SampleExtComputationInput(
 {
     TRACE_FUNCTION();
 
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
+        ComputationType computationType = _GetSkinningComputationType(cachePath);
         return _SampleExtComputationInputForSkinningComputation(
             prim, cachePath, name, time, instancerContext, maxSampleCount,
-            sampleTimes, sampleValues);
+            computationType, sampleTimes, sampleValues);
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
+        ComputationType computationType = _GetSkinningComputationType(cachePath);
         return _SampleExtComputationInputForInputAggregator(
             prim, cachePath, name, time, instancerContext, maxSampleCount,
-            sampleTimes, sampleValues);
+            computationType, sampleTimes, sampleValues);
     }
 
     return BaseAdapter::SampleExtComputationInput(
@@ -2161,7 +2358,8 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationKernel(
 {
     TRACE_FUNCTION();
 
-    if (_IsSkinningComputationPath(cachePath)) {
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningNormalsComputationPath(cachePath)) {
         if (_IsEnabledCPUComputations()) {
             return std::string();
         } else {
@@ -2174,10 +2372,11 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationKernel(
                 skinningMethod = skinnedPrimData->skinningQuery.GetSkinningMethod();
             }
 
+            ComputationType computationType = _GetSkinningComputationType(cachePath);
             if (skinningMethod == UsdSkelTokens->classicLinear) {
-                return _GetLBSSkinningComputeKernel();
+                return _GetLBSSkinningComputeKernel(computationType);
             } else if (skinningMethod == UsdSkelTokens->dualQuaternion) {
-                return _GetDQSSkinningComputeKernel();
+                return _GetDQSSkinningComputeKernel(computationType);
             } else {
                 TF_WARN("Unknown skinning method: '%s' ", skinningMethod.GetText());
                 return std::string();
@@ -2185,7 +2384,8 @@ UsdSkelImagingSkeletonAdapter::GetExtComputationKernel(
         }
     }
 
-    if (_IsSkinningInputAggregatorComputationPath(cachePath)) {
+    if (_IsSkinningPointsInputAggregatorComputationPath(cachePath) ||
+        _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
         return std::string();
     }
 
@@ -2274,11 +2474,17 @@ UsdSkelImagingSkeletonAdapter::_RemoveSkinnedPrimAndComputations(
     index->RemoveRprim(cachePath);
 
     // Remove the computations it participates in.
-    SdfPath compPath = _GetSkinningComputationPath(cachePath);
+    SdfPath compPath = _GetSkinningComputationPath(cachePath, ComputationType::Points);
     index->RemoveSprim(HdPrimTypeTokens->extComputation, compPath);
     
     SdfPath aggrCompPath =
-        _GetSkinningInputAggregatorComputationPath(cachePath);
+        _GetSkinningInputAggregatorComputationPath(cachePath, ComputationType::Points);
+    index->RemoveSprim(HdPrimTypeTokens->extComputation, aggrCompPath);
+
+    compPath = _GetSkinningComputationPath(cachePath, ComputationType::Normals);
+    index->RemoveSprim(HdPrimTypeTokens->extComputation, compPath);
+
+    aggrCompPath = _GetSkinningInputAggregatorComputationPath(cachePath, ComputationType::Normals);
     index->RemoveSprim(HdPrimTypeTokens->extComputation, aggrCompPath);
 
     // Clear cache entry.
@@ -2290,37 +2496,73 @@ UsdSkelImagingSkeletonAdapter::_RemoveSkinnedPrimAndComputations(
 // ---------------------------------------------------------------------- //
 SdfPath
 UsdSkelImagingSkeletonAdapter::_GetSkinningComputationPath(
-    const SdfPath& skinnedPrimPath) const
+    const SdfPath& skinnedPrimPath, ComputationType computationType) const
 {
-    return skinnedPrimPath.AppendChild(
-        UsdSkelImagingExtComputationNameTokens->computation);
+    if (computationType == ComputationType::Points) {
+        return skinnedPrimPath.AppendChild(UsdSkelImagingExtComputationNameTokens->pointsComputation);
+    } else {
+        return skinnedPrimPath.AppendChild(UsdSkelImagingExtComputationNameTokens->normalsComputation);
+    }
 }
 
 
 SdfPath
 UsdSkelImagingSkeletonAdapter::_GetSkinningInputAggregatorComputationPath(
-    const SdfPath& skinnedPrimPath) const
+    const SdfPath& skinnedPrimPath, ComputationType computationType) const
 {
-    return skinnedPrimPath.AppendChild(
-        UsdSkelImagingExtComputationNameTokens->aggregatorComputation);
+    if (computationType == ComputationType::Points) {
+        return skinnedPrimPath.AppendChild(UsdSkelImagingExtComputationNameTokens->pointsAggregatorComputation);
+    } else {
+        return skinnedPrimPath.AppendChild(UsdSkelImagingExtComputationNameTokens->normalsAggregatorComputation);
+    }
 }
 
 
 bool
-UsdSkelImagingSkeletonAdapter::_IsSkinningComputationPath(
+UsdSkelImagingSkeletonAdapter::_IsSkinningPointsComputationPath(
     const SdfPath& cachePath) const
 {
-    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens
-                                      ->computation;
+    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens->pointsComputation;
 }
 
 
 bool
-UsdSkelImagingSkeletonAdapter::_IsSkinningInputAggregatorComputationPath(
+UsdSkelImagingSkeletonAdapter::_IsSkinningNormalsComputationPath(
     const SdfPath& cachePath) const
 {
-    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens
-                                      ->aggregatorComputation;
+    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens->normalsComputation;
+}
+
+
+UsdSkelImagingSkeletonAdapter::ComputationType
+UsdSkelImagingSkeletonAdapter::_GetSkinningComputationType(const SdfPath& cachePath) const
+{
+    if (_IsSkinningPointsComputationPath(cachePath) ||
+        _IsSkinningPointsInputAggregatorComputationPath(cachePath)) {
+        return ComputationType::Points;
+    } else if (_IsSkinningNormalsComputationPath(cachePath) ||
+               _IsSkinningNormalsInputAggregatorComputationPath(cachePath)) {
+        return ComputationType::Normals;
+    }
+
+    TF_CODING_ERROR("Invalid computation path: %s", cachePath.GetText());
+    return ComputationType::Points;
+}
+
+
+bool
+UsdSkelImagingSkeletonAdapter::_IsSkinningPointsInputAggregatorComputationPath(
+    const SdfPath& cachePath) const
+{
+    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens->pointsAggregatorComputation;
+}
+
+
+bool
+UsdSkelImagingSkeletonAdapter::_IsSkinningNormalsInputAggregatorComputationPath(
+    const SdfPath& cachePath) const
+{
+    return cachePath.GetName() == UsdSkelImagingExtComputationNameTokens->normalsAggregatorComputation;
 }
 
 
@@ -2369,6 +2611,59 @@ UsdSkelImagingSkeletonAdapter::_GetSkinnedPrimPoints(
 }
 
 
+VtVec3fArray
+UsdSkelImagingSkeletonAdapter::_GetSkinnedPrimNormals(
+    const UsdPrim& skinnedPrim,
+    const SdfPath& skinnedPrimCachePath,
+    UsdTimeCode time) const
+{
+    // Since only UsdGeomBased-type prims can be targeted by a skeleton,
+    // we expect the skinned prim adapter to derive from GprimAdapter.
+    UsdImagingPrimAdapterSharedPtr adapter = _GetPrimAdapter(skinnedPrim);
+    auto gprimAdapter =
+        std::dynamic_pointer_cast<UsdImagingGprimAdapter> (adapter);
+    if (!TF_VERIFY(gprimAdapter)) {
+        return VtVec3fArray();
+    }
+
+    VtValue normals = adapter->Get(skinnedPrim, skinnedPrimCachePath, HdTokens->normals, time, nullptr);
+    if (!TF_VERIFY(normals.IsHolding<VtVec3fArray>())) {
+        return VtVec3fArray();
+    }
+    
+    VtVec3fArray normalsArray = normals.UncheckedGet<VtVec3fArray>();
+    // FIXME: gprimAdapter->GetNormals() returns a single zero vector if the normals
+    // are not authored.
+    if(normalsArray.size() == 1 && normalsArray[0] == GfVec3f(0.0f, 0.0f, 0.0f)) {
+        return VtVec3fArray();
+    }
+    return normalsArray;
+}
+
+
+VtIntArray
+UsdSkelImagingSkeletonAdapter::_GetSkinnedPrimFaceVertexIndices(
+    const UsdPrim& skinnedPrim,
+    const SdfPath& skinnedPrimCachePath,
+    UsdTimeCode time) const
+{
+    UsdImagingPrimAdapterSharedPtr adapter = _GetPrimAdapter(skinnedPrim);
+    auto gprimAdapter =
+        std::dynamic_pointer_cast<UsdImagingGprimAdapter> (adapter);
+    if (!TF_VERIFY(gprimAdapter)) {
+        return VtIntArray();
+    }
+
+    const auto& topologyValue = gprimAdapter->GetTopology(skinnedPrim, skinnedPrimCachePath, time);
+    if (!TF_VERIFY(topologyValue.IsHolding<HdMeshTopology>())) {
+        return VtIntArray();
+    }
+
+    const auto& topology = topologyValue.UncheckedGet<HdMeshTopology>();
+
+    return topology.GetFaceVertexIndices();
+}
+
 /* static */
 std::string
 UsdSkelImagingSkeletonAdapter::_LoadSkinningComputeKernel(const TfToken& kernelKey)
@@ -2395,18 +2690,28 @@ UsdSkelImagingSkeletonAdapter::_LoadSkinningComputeKernel(const TfToken& kernelK
 
 /* static */
 const std::string&
-UsdSkelImagingSkeletonAdapter::_GetLBSSkinningComputeKernel()
+UsdSkelImagingSkeletonAdapter::_GetLBSSkinningComputeKernel(ComputationType computationType)
 {
-    static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinPointsLBSKernel));
-    return shaderSource;
+    if (computationType == ComputationType::Points) {
+        static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinPointsLBSKernel));
+        return shaderSource;
+    } else {
+        static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinNormalsLBSKernel));
+        return shaderSource;
+    }
 }
 
 /* static */
 const std::string&
-UsdSkelImagingSkeletonAdapter::_GetDQSSkinningComputeKernel()
+UsdSkelImagingSkeletonAdapter::_GetDQSSkinningComputeKernel(ComputationType computationType)
 {
-    static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinPointsDQSKernel));
-    return shaderSource;
+    if (computationType == ComputationType::Points) {
+        static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinPointsDQSKernel));
+        return shaderSource;
+    } else {
+        static const std::string shaderSource(_LoadSkinningComputeKernel(_tokens->skinNormalsDQSKernel));
+        return shaderSource;
+    }
 }
 
 // ---------------------------------------------------------------------- //
@@ -2439,6 +2744,7 @@ UsdSkelImagingSkeletonAdapter::_TrackSkinnedPrimVariability(
 
     if (_IsAffectedByTimeVaryingSkelAnim(cachePath)) {
         (*timeVaryingBits) |= HdChangeTracker::DirtyPoints;
+        (*timeVaryingBits) |= HdChangeTracker::DirtyNormals;
         HD_PERF_COUNTER_INCR(UsdImagingTokens->usdVaryingPrimvar);
     }
 }
@@ -2461,10 +2767,8 @@ UsdSkelImagingSkeletonAdapter::_UpdateSkinnedPrimForTime(
     TF_DEBUG(USDIMAGING_CHANGES).Msg
         ("[UpdateForTime] Cache path: <%s>\n", cachePath.GetText());
 
-    // Suppress the dirtybit for points, so we don't publish 'points' as a
-    // primvar. Also suppressing normals: normals will instead be computed
-    // post-skinning, as if they were unauthored (since GPU normal skinning
-    // is not yet supported).
+    // Suppress the dirtybit for points and normals, so we don't publish 'points'
+    // and 'normals' as primvars since they are computed.
     requestedBits &= ~(HdChangeTracker::DirtyPoints|
                        HdChangeTracker::DirtyNormals);
 
@@ -2722,7 +3026,8 @@ UsdSkelImagingSkeletonAdapter::_SkinnedPrimData::_SkinnedPrimData(
     const SdfPath& skelPath,
     const UsdSkelSkeletonQuery& skelQuery,
     const UsdSkelSkinningQuery& skinningQuery,
-    const SdfPath& skelRootPath)
+    const SdfPath& skelRootPath,
+    UsdSkelImagingSkeletonAdapter* adapter)
     : skinningQuery(skinningQuery),
       animQuery(skelQuery.GetAnimQuery()),
       skelPath(skelPath),
@@ -2732,6 +3037,29 @@ UsdSkelImagingSkeletonAdapter::_SkinnedPrimData::_SkinnedPrimData(
     if (skinningQuery.HasBlendShapes() && skelQuery.GetAnimQuery()) {
         blendShapeQuery = std::make_shared<UsdSkelBlendShapeQuery>(
             UsdSkelBindingAPI(skinningQuery.GetPrim()));
+    }
+
+    if(skinningQuery.GetPrim())
+    {
+        UsdGeomPrimvarsAPI primvarsApi(skinningQuery.GetPrim());
+        UsdGeomPrimvar pv = primvarsApi.GetPrimvar(
+                UsdImagingTokens->primvarsNormals);
+        bool normalsExists = false;
+        if(!pv) {
+            pv = adapter->_GetInheritedPrimvar(skinningQuery.GetPrim(), HdTokens->normals);
+            if(pv) {
+                normalsInterpolation = pv.GetInterpolation();
+                normalsExists = true;
+            }
+        } else {
+            normalsExists = true;
+            normalsInterpolation = pv.GetInterpolation();
+        }
+        
+        if(!normalsExists) {
+            UsdGeomMesh mesh(skinningQuery.GetPrim());
+            normalsInterpolation = mesh.GetNormalsInterpolation();
+        }
     }
 }
 

--- a/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
+++ b/pxr/usdImaging/usdSkelImaging/skeletonAdapter.h
@@ -273,6 +273,11 @@ protected:
                      UsdImagingIndexProxy* index) override;
 
 private:
+    enum class ComputationType : int{
+        Points,
+        Normals
+    };
+
     // ---------------------------------------------------------------------- //
     /// Handlers for the Bone Mesh
     // ---------------------------------------------------------------------- //
@@ -314,10 +319,15 @@ private:
     // ---------------------------------------------------------------------- //
     /// Handlers for the skinning computations
     // ---------------------------------------------------------------------- //
-    bool _IsSkinningComputationPath(const SdfPath& cachePath) const;
-    
-    bool
-    _IsSkinningInputAggregatorComputationPath(const SdfPath& cachePath)const;
+    bool _IsSkinningPointsComputationPath(const SdfPath& cachePath) const;
+
+    bool _IsSkinningNormalsComputationPath(const SdfPath& cachePath) const;
+
+    ComputationType _GetSkinningComputationType(const SdfPath& cachePath) const;
+
+    bool _IsSkinningPointsInputAggregatorComputationPath(const SdfPath& cachePath) const;
+
+    bool _IsSkinningNormalsInputAggregatorComputationPath(const SdfPath& cachePath) const;
 
     void _TrackSkinningComputationVariability(
             const UsdPrim& skinnedPrim,
@@ -330,21 +340,28 @@ private:
                                        const SdfPath& skinnedPrimCachePath,
                                        UsdTimeCode time) const;
     
-    SdfPath _GetSkinningComputationPath(const SdfPath& skinnedPrimPath) const;
+    VtVec3fArray _GetSkinnedPrimNormals(const UsdPrim& skinnedPrim,
+                                       const SdfPath& skinnedPrimCachePath,
+                                       UsdTimeCode time) const;
 
-    SdfPath _GetSkinningInputAggregatorComputationPath(
-        const SdfPath& skinnedPrimPath) const;
+    VtIntArray _GetSkinnedPrimFaceVertexIndices(const UsdPrim& skinnedPrim,
+                                       const SdfPath& skinnedPrimCachePath,
+                                       UsdTimeCode time) const;
+
+    SdfPath _GetSkinningComputationPath(const SdfPath& skinnedPrimPath, ComputationType computationType) const;
+
+    SdfPath _GetSkinningInputAggregatorComputationPath(const SdfPath& skinnedPrimPath, ComputationType computationType) const;
 
     // Static helper methods
     static
     std::string _LoadSkinningComputeKernel(const TfToken& kernelKey);
 
     static
-    const std::string& _GetLBSSkinningComputeKernel();
+    const std::string& _GetLBSSkinningComputeKernel(ComputationType computationType);
 
     static
-    const std::string& _GetDQSSkinningComputeKernel();
-
+    const std::string& _GetDQSSkinningComputeKernel(ComputationType computationType);
+    
     // ---------------------------------------------------------------------- //
     /// Handlers for the skinned prim
     // ---------------------------------------------------------------------- //
@@ -374,7 +391,8 @@ private:
             SdfPath const& cachePath,
             TfToken const& name,
             UsdTimeCode time,
-            const UsdImagingInstancerContext* instancerContext) const;
+            const UsdImagingInstancerContext* instancerContext,
+            ComputationType computationType) const;
 
     VtValue 
     _GetExtComputationInputForInputAggregator(
@@ -382,7 +400,8 @@ private:
             SdfPath const& cachePath,
             TfToken const& name,
             UsdTimeCode time,
-            const UsdImagingInstancerContext* instancerContext) const;
+            const UsdImagingInstancerContext* instancerContext,
+            ComputationType computationType) const;
 
     size_t
     _SampleExtComputationInputForSkinningComputation(
@@ -392,6 +411,7 @@ private:
             UsdTimeCode time,
             const UsdImagingInstancerContext* instancerContext,
             size_t maxSampleCount,
+            ComputationType computationType,
             float *sampleTimes,
             VtValue *sampleValues);
 
@@ -403,9 +423,23 @@ private:
             UsdTimeCode time,
             const UsdImagingInstancerContext* instancerContext,
             size_t maxSampleCount,
+            ComputationType computationType,
             float *sampleTimes,
             VtValue *sampleValues);
 
+    // ---------------------------------------------------------------------- //
+    /// Matrix helpers
+    static
+    bool
+    _ExtractSkinningScaleXforms(const VtMatrix4fArray& skinningXforms,
+                                VtMatrix3fArray* skinningScaleXforms,
+                                ComputationType computationType);
+
+    static
+    bool
+    _ExtractSkinningDualQuats(const VtMatrix4fArray& skinningXforms,
+                              VtVec4fArray* skinningDualQuats,
+                              ComputationType computationType);
 
     // ---------------------------------------------------------------------- //
     /// Populated skeleton state
@@ -452,13 +486,15 @@ private:
         _SkinnedPrimData(const SdfPath& skelPath,
                          const UsdSkelSkeletonQuery& skelQuery,
                          const UsdSkelSkinningQuery& skinningQuery,
-                         const SdfPath& skelRootPath);
+                         const SdfPath& skelRootPath,
+                         UsdSkelImagingSkeletonAdapter* adapter);
 
         std::shared_ptr<UsdSkelBlendShapeQuery> blendShapeQuery;
         UsdSkelSkinningQuery skinningQuery;
         UsdSkelAnimQuery animQuery;
         SdfPath skelPath, skelRootPath;
         bool hasJointInfluences = false;
+        TfToken normalsInterpolation;
     };
 
     const _SkinnedPrimData* _GetSkinnedPrimData(const SdfPath& cachePath) const;

--- a/pxr/usdImaging/usdSkelImaging/tokens.h
+++ b/pxr/usdImaging/usdSkelImaging/tokens.h
@@ -23,8 +23,10 @@ TF_DECLARE_PUBLIC_TOKENS(
     USDSKELIMAGING_API, USD_SKEL_IMAGING_PRIM_TYPE_TOKENS);
 
 #define USD_SKEL_IMAGING_EXT_COMPUTATION_NAME_TOKENS                \
-    ((aggregatorComputation, "skinningInputAggregatorComputation")) \
-    ((computation,           "skinningComputation"))
+    ((pointsAggregatorComputation, "skinningPointsInputAggregatorComputation")) \
+    ((pointsComputation,           "skinningPointsComputation")) \
+    ((normalsAggregatorComputation, "skinningNormalsInputAggregatorComputation")) \
+    ((normalsComputation,           "skinningNormalsComputation"))
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdSkelImagingExtComputationNameTokens, USDSKELIMAGING_API,
@@ -38,7 +40,10 @@ TF_DECLARE_PUBLIC_TOKENS(
     (hasConstantInfluences)                                           \
     (blendShapeOffsets)                                               \
     (blendShapeOffsetRanges)                                          \
-    (numBlendShapeOffsetRanges)
+    (numBlendShapeOffsetRanges)                                       \
+    (restNormals)                                                     \
+    (faceVertexIndices)                                               \
+    (hasFaceVaryingNormals)
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdSkelImagingExtAggregatorComputationInputNameTokens, USDSKELIMAGING_API,
@@ -57,7 +62,8 @@ TF_DECLARE_PUBLIC_TOKENS(
     USD_SKEL_IMAGING_EXT_COMPUTATION_INPUT_NAME_TOKENS);
 
 #define USD_SKEL_IMAGING_EXT_COMPUTATION_OUTPUT_NAME_TOKENS \
-    (skinnedPoints)                                    
+    (skinnedPoints)                                         \
+    (skinnedNormals)
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdSkelImagingExtComputationOutputNameTokens, USDSKELIMAGING_API,


### PR DESCRIPTION
### Description of Change(s)

USD supresses normals, and instead normals will be computed post skinning as if they were authored. This PR is to support normals deformation for GPU.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3406

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
