### PR TITLE
APPLE: Make timeCodeRange pointer operators const

### DIFF
--- a/pxr/usd/usdUtils/timeCodeRange.h
+++ b/pxr/usd/usdUtils/timeCodeRange.h
@@ -70,12 +70,12 @@ public:
         using difference_type = std::ptrdiff_t;
 
         /// Returns the UsdTimeCode referenced by this iterator.
-        reference operator*() {
+        reference operator*() const {
             return _currTimeCode;
         }
 
         /// Returns a pointer to the UsdTimeCode referenced by this iterator.
-        pointer operator->() {
+        pointer operator->() const {
             return &_currTimeCode;
         }
 


### PR DESCRIPTION
### Description of Change(s)

We have a need to make iterators const so we can use them in contexts that mandate const iterators.
This should have no change to the runtime for OpenUSD as stands right now.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
