### PR TITLE
tf: do not install pxr.Tf.testenv Python module when PXR_BUILD_TESTS is disabled

### DIFF
--- a/pxr/base/tf/CMakeLists.txt
+++ b/pxr/base/tf/CMakeLists.txt
@@ -110,6 +110,21 @@ function(add_py_dll_link_test)
 
 endfunction()
 
+set(pyModuleTestFiles "")
+if (PXR_BUILD_TESTS)
+    set(pyModuleTestFiles
+        testenv/__init__.py
+        testenv/testTfScriptModuleLoader_AAA_RaisesError.py
+        testenv/testTfScriptModuleLoader_DepLoadsAll.py
+        testenv/testTfScriptModuleLoader_LoadsAll.py
+        testenv/testTfScriptModuleLoader_LoadsUnknown.py
+        testenv/testTfScriptModuleLoader_Other.py
+        testenv/testTfScriptModuleLoader_Test.py
+        testenv/testTfScriptModuleLoader_Unknown.py
+        testenv/testTfPyInvoke_callees.py
+    )
+endif()
+
 pxr_library(tf
     LIBRARIES
         arch
@@ -333,15 +348,7 @@ pxr_library(tf
 
     PYMODULE_FILES 
         __init__.py
-        testenv/__init__.py
-        testenv/testTfScriptModuleLoader_AAA_RaisesError.py
-        testenv/testTfScriptModuleLoader_DepLoadsAll.py
-        testenv/testTfScriptModuleLoader_LoadsAll.py
-        testenv/testTfScriptModuleLoader_LoadsUnknown.py
-        testenv/testTfScriptModuleLoader_Other.py
-        testenv/testTfScriptModuleLoader_Test.py
-        testenv/testTfScriptModuleLoader_Unknown.py
-        testenv/testTfPyInvoke_callees.py
+        ${pyModuleTestFiles}
 
     DOXYGEN_FILES
         diagnosticOverview.dox


### PR DESCRIPTION
Hello!

This is a simple change to avoid installing the `pxr.Tf.testenv` Python module (and its contents) when `PXR_BUILD_TESTS=OFF`, since the stuff in there is only relevant in the context of tests.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
