### PR TITLE
Autodesk: Template class support for macro HD_DECLARE_DATASOURCE

### DIFF
--- a/pxr/imaging/hd/dataSource.h
+++ b/pxr/imaging/hd/dataSource.h
@@ -68,6 +68,52 @@ PXR_NAMESPACE_OPEN_SCOPE
     using type##Handle = type::Handle; \
     using type##AtomicHandle = type::AtomicHandle;
 
+/// HD_DECLARE_DATASOURCE_ABSTRACT_TEMPLATE
+/// Used for templated non-instantiable classes, this defines a set of functions
+/// for manipulating handles to this type of datasource.
+#define HD_DECLARE_DATASOURCE_ABSTRACT_TEMPLATE(type, ...) \
+    using Handle =  std::shared_ptr<type< __VA_ARGS__ > >; \
+    using AtomicHandle = Handle; \
+    static Handle AtomicLoad(AtomicHandle &ptr) { \
+        return std::atomic_load(&ptr); \
+    } \
+    static void AtomicStore(AtomicHandle &ptr, const Handle &v) { \
+        std::atomic_store(&ptr, v); \
+    } \
+    static bool AtomicCompareExchange(AtomicHandle &ptr, \
+                                      AtomicHandle &expected, \
+                                      const Handle &desired) { \
+        return std::atomic_compare_exchange_strong(&ptr, &expected, desired); \
+    } \
+    static Handle Cast(const HdDataSourceBase::Handle &v) { \
+        return std::dynamic_pointer_cast<type< __VA_ARGS__ > >(v); \
+    }
+
+/// HD_DECLARE_DATASOURCE
+/// Used for templated instantiable classes, this defines functions for manipulating
+/// and allocating handles to this type of datasource.
+/// 
+/// Use of this macro in derived classes is important to make sure that
+/// core and client code share the same handle type and allocator.
+#define HD_DECLARE_DATASOURCE_TEMPLATE(type, ...) \
+    HD_DECLARE_DATASOURCE_ABSTRACT_TEMPLATE(type, __VA_ARGS__ ) \
+    template <typename ... Args> \
+    static Handle New(Args&& ... args) { \
+        return Handle(new type< __VA_ARGS__ >(std::forward<Args>(args) ... )); \
+    }
+
+/// HD_DECLARE_DATASOURCE_INITIALIZER_LIST_NEW_TEMPLATE
+/// Used for declaring a `New` function for datasource types that have a
+/// constructor that takes an initializer_list<T>.
+#define HD_DECLARE_DATASOURCE_INITIALIZER_LIST_NEW_TEMPLATE(type, T, ...) \
+    static Handle New(std::initializer_list<T> initList) { \
+        return Handle(new type< __VA_ARGS__ >(initList)); \
+    }
+
+#define HD_DECLARE_DATASOURCE_HANDLES_TEMPLATE(type, ...) \
+    using type< __VA_ARGS__ >##Handle = type< __VA_ARGS__ >::Handle; \
+    using type< __VA_ARGS__ >##AtomicHandle = type< __VA_ARGS__ >::AtomicHandle;
+
 /// \class HdDataSourceBase
 ///
 /// Represents an object which can produce scene data.

--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -153,6 +153,7 @@ pxr_library(usdImaging
 
     PUBLIC_HEADERS
         api.h
+        dataSourceConvertedPrimvar.h
         types.h
         unitTestHelper.h
         version.h

--- a/pxr/usdImaging/usdImaging/dataSourceConvertedPrimvar.h
+++ b/pxr/usdImaging/usdImaging/dataSourceConvertedPrimvar.h
@@ -1,0 +1,138 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_USD_IMAGING_USD_IMAGING_DATA_SOURCE_CONVERTED_PRIMVARS_H
+#define PXR_USD_IMAGING_USD_IMAGING_DATA_SOURCE_CONVERTED_PRIMVARS_H
+
+#include "pxr/usdImaging/usdImaging/dataSourceAttribute.h"
+#include "pxr/usdImaging/usdImaging/dataSourcePrimvars.h"
+
+#include "pxr/usd/usdGeom/primvar.h"
+#include "pxr/usd/usdGeom/primvarsAPI.h"
+
+#include "pxr/imaging/hd/primvarSchema.h"
+PXR_NAMESPACE_OPEN_SCOPE
+
+
+/// \class UsdImagingDataSourceConvertedAttribute<primvarType, attributeType>
+///
+/// A data source that represents a USD Attribute which requires conversion.
+/// A converter function is provided to convert the attribute type to the primvar type.
+///
+template <typename primvarType, typename attributeType>
+class UsdImagingDataSourceConvertedAttribute : public UsdImagingDataSourceAttribute<attributeType>
+{
+public:
+    HD_DECLARE_DATASOURCE_TEMPLATE(UsdImagingDataSourceConvertedAttribute, primvarType, attributeType)
+
+    using Base = UsdImagingDataSourceAttribute<attributeType>;
+    using ConverterFunction = std::function<primvarType(const attributeType&)>;
+
+    /// Returns the VtValue of this attribute at a given \p shutterOffset
+    ///
+    VtValue GetValue(HdSampledDataSource::Time shutterOffset) override
+    {
+        // Do conversion before return the value.
+        primvarType result = _converter(Base::GetTypedValue(shutterOffset));
+        return VtValue(result);
+    }
+
+protected:
+    UsdImagingDataSourceConvertedAttribute(
+        ConverterFunction converter,
+        const UsdAttribute& usdAttr,
+        const UsdImagingDataSourceStageGlobals& stageGlobals,
+        const SdfPath& sceneIndexPath = SdfPath::EmptyPath(),
+        const HdDataSourceLocator& timeVaryingFlagLocator =
+        HdDataSourceLocator::EmptyLocator())
+        : UsdImagingDataSourceAttribute<attributeType>(usdAttr, stageGlobals, sceneIndexPath, timeVaryingFlagLocator),
+        _converter(converter)
+    {}
+
+    UsdImagingDataSourceConvertedAttribute(
+        ConverterFunction converter,
+        const UsdAttributeQuery& usdAttrQuery,
+        const UsdImagingDataSourceStageGlobals& stageGlobals,
+        const SdfPath& sceneIndexPath = SdfPath::EmptyPath(),
+        const HdDataSourceLocator& timeVaryingFlagLocator =
+        HdDataSourceLocator::EmptyLocator())
+        : UsdImagingDataSourceAttribute<attributeType>(usdAttrQuery, stageGlobals, sceneIndexPath, timeVaryingFlagLocator),
+        _converter(converter)
+    {}
+
+    ConverterFunction _converter;
+};
+
+/// \class UsdImagingDataSourceConvertedPrimvar<primvarType, attributeType>
+///
+/// A data source that represents a USD Primvar which requires conversion.
+/// A converter function is provided to convert the attribute type to the primvar type.
+///
+template <typename primvarType, typename attributeType>
+class UsdImagingDataSourceConvertedPrimvar : public UsdImagingDataSourcePrimvar
+{
+public:
+    // Because there are more than one template arguments, we can not use the HD_DECLARE_DATASOURCE macro.
+    HD_DECLARE_DATASOURCE_TEMPLATE(UsdImagingDataSourceConvertedPrimvar, primvarType, attributeType)
+
+    using ConverterFunction = std::function<primvarType(const attributeType&)>;
+
+    HdDataSourceBaseHandle Get(const TfToken & name) override
+    {
+        TRACE_FUNCTION();
+
+        const bool indexed = (_indicesQuery.IsValid() && _indicesQuery.HasValue());
+
+        if (indexed) {
+            if (name == HdPrimvarSchemaTokens->indexedPrimvarValue) {
+                return UsdImagingDataSourceConvertedAttribute<primvarType, attributeType>::New(
+                    _converter, _valueQuery, _stageGlobals);
+            }
+            else if (name == HdPrimvarSchemaTokens->indices) {
+                return UsdImagingDataSourceConvertedAttribute<primvarType, attributeType>::New(
+                    _converter, _indicesQuery, _stageGlobals);
+            }
+        }
+        else {
+            if (name == HdPrimvarSchemaTokens->primvarValue) {
+                return UsdImagingDataSourceConvertedAttribute<primvarType, attributeType>::New(
+                    _converter, _valueQuery, _stageGlobals);
+            }
+        }
+
+        if (name == HdPrimvarSchemaTokens->interpolation) {
+            return _interpolation;
+        }
+        if (name == HdPrimvarSchemaTokens->role) {
+            return _role;
+        }
+        if (name == HdPrimvarSchemaTokens->elementSize) {
+            return _elementSize;
+        }
+        return nullptr;
+    }
+
+private:
+    UsdImagingDataSourceConvertedPrimvar(
+        ConverterFunction converter, 
+        const SdfPath &sceneIndexPath,
+        const TfToken &name,
+        const UsdImagingDataSourceStageGlobals &stageGlobals,
+        UsdAttributeQuery valueQuery,
+        UsdAttributeQuery indicesQuery,
+        HdTokenDataSourceHandle interpolation,
+        HdTokenDataSourceHandle role,
+        HdIntDataSourceHandle elementSize = nullptr)
+        : UsdImagingDataSourcePrimvar(sceneIndexPath, name, stageGlobals, valueQuery, indicesQuery, interpolation, role, elementSize),
+        _converter(converter)
+    {}
+
+    ConverterFunction _converter;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_IMAGING_USD_IMAGING_DATA_SOURCE_CONVERTED_PRIMVARS_H

--- a/pxr/usdImaging/usdImaging/dataSourcePrimvars.h
+++ b/pxr/usdImaging/usdImaging/dataSourcePrimvars.h
@@ -129,18 +129,17 @@ public:
     TfTokenVector GetNames() override;
     HdDataSourceBaseHandle Get(const TfToken & name) override;
 
-private:
+protected:
     UsdImagingDataSourcePrimvar(
-            const SdfPath &sceneIndexPath,
-            const TfToken &name,
-            const UsdImagingDataSourceStageGlobals &stageGlobals,
-            UsdAttributeQuery valueQuery,
-            UsdAttributeQuery indicesQuery,
-            HdTokenDataSourceHandle interpolation,
-            HdTokenDataSourceHandle role,
-            HdIntDataSourceHandle elementSize = nullptr);
+        const SdfPath &sceneIndexPath,
+        const TfToken &name,
+        const UsdImagingDataSourceStageGlobals &stageGlobals,
+        UsdAttributeQuery valueQuery,
+        UsdAttributeQuery indicesQuery,
+        HdTokenDataSourceHandle interpolation,
+        HdTokenDataSourceHandle role,
+        HdIntDataSourceHandle elementSize = nullptr);
 
-private:
     const UsdImagingDataSourceStageGlobals &_stageGlobals;
     UsdAttributeQuery _valueQuery;
     UsdAttributeQuery _indicesQuery;


### PR DESCRIPTION
### Description of Change(s)

Add template class support for the macro `HD_DECLARE_DATASOURCE`.

Add two classes `UsdImagingDataSourceConvertedAttribute` and `UsdImagingDataSourceConvertedPrimvar` for the primvar which doesn't directly get value from an attribute, but will do a conversion from the value of an attribute.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
