### PR TITLE
Fix #3666: Crash when using Vulkan + AMD

### DIFF
--- a/pxr/imaging/hgiVulkan/computeCmds.cpp
+++ b/pxr/imaging/hgiVulkan/computeCmds.cpp
@@ -119,10 +119,11 @@ HgiVulkanComputeCmds::Dispatch(int dimX, int dimY)
     // Determine device's num compute work group limits
     const VkPhysicalDeviceLimits limits = 
         _hgi->GetCapabilities()->vkDeviceProperties2.properties.limits;
+    const uint32_t maxAllowedLimit = (1 << 31) - 1;
     const GfVec3i maxNumWorkGroups = GfVec3i(
-        limits.maxComputeWorkGroupCount[0],
-        limits.maxComputeWorkGroupCount[1],
-        limits.maxComputeWorkGroupCount[2]);
+        std::min<uint32_t>(maxAllowedLimit, limits.maxComputeWorkGroupCount[0]),
+        std::min<uint32_t>(maxAllowedLimit, limits.maxComputeWorkGroupCount[1]),
+        std::min<uint32_t>(maxAllowedLimit, limits.maxComputeWorkGroupCount[2]));
 
     if (numWorkGroupsX > maxNumWorkGroups[0]) {
         TF_WARN("Max number of work group available from device is %i, larger "


### PR DESCRIPTION
### Description of Change(s)

AMD driver (both Mesa + Pro) have limits that cannot fit inside an int.
This resulted in sending incorrect vulkan commands as the number of work
send to the GPU would be set to the max limit in stead of the max amount
of work that needed to be done.
    
A better solution would be to introduce `GfVec3u`.
    
This has been validated to work on Windows/Linux with several GPU
generations (RDNA3.5, RDNA4, RDNA3).

### Fixes Issue(s)

Issue: #3666

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [ ] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
