### PR TITLE
APPLE: Move HgiShaderProgramDesc operator== to header

### DIFF
--- a/pxr/imaging/hgi/shaderProgram.cpp
+++ b/pxr/imaging/hgi/shaderProgram.cpp
@@ -26,19 +26,4 @@ HgiShaderProgramDesc::HgiShaderProgramDesc()
 {
 }
 
-bool operator==(
-    const HgiShaderProgramDesc& lhs,
-    const HgiShaderProgramDesc& rhs)
-{
-    return lhs.debugName == rhs.debugName &&
-           lhs.shaderFunctions == rhs.shaderFunctions;
-}
-
-bool operator!=(
-    const HgiShaderProgramDesc& lhs,
-    const HgiShaderProgramDesc& rhs)
-{
-    return !(lhs == rhs);
-}
-
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgi/shaderProgram.h
+++ b/pxr/imaging/hgi/shaderProgram.h
@@ -41,14 +41,17 @@ struct HgiShaderProgramDesc
 };
 
 HGI_API
-inline bool operator==(
-    const HgiShaderProgramDesc& lhs,
-    const HgiShaderProgramDesc& rhs);
+inline bool operator==(const HgiShaderProgramDesc& lhs,
+                       const HgiShaderProgramDesc& rhs) {
+    return lhs.debugName == rhs.debugName &&
+           lhs.shaderFunctions == rhs.shaderFunctions;
+}
 
 HGI_API
-inline bool operator!=(
-    const HgiShaderProgramDesc& lhs,
-    const HgiShaderProgramDesc& rhs);
+inline bool operator!=(const HgiShaderProgramDesc& lhs,
+                       const HgiShaderProgramDesc& rhs) {
+    return !(lhs == rhs);
+}
 
 
 ///


### PR DESCRIPTION
### Description of Change(s)

This PR moves the HgiShaderProgramDesc's `operator==` to the header, since its marked inline, but is only defined in the cpp file, therefore cannot actually be inlined.

(Thanks to Maddy Adams)

pxr/imaging/hgi/shaderProgram.h contains:

```
HGI_API
inline bool operator==(
    const HgiShaderProgramDesc& lhs,
    const HgiShaderProgramDesc& rhs);
```

But, the definition is only in the .cpp file, so calling it results in a linker error:

```
Undefined symbols for architecture arm64:
  "pxrInternal_v0_25_5__pxrReserved__::operator==(pxrInternal_v0_25_5__pxrReserved__::HgiShaderProgramDesc const&, pxrInternal_v0_25_5__pxrReserved__::HgiShaderProgramDesc const&)", referenced from:
      reproducer(pxrInternal_v0_25_5__pxrReserved__::HgiShaderProgramDesc const&, pxrInternal_v0_25_5__pxrReserved__::HgiShaderProgramDesc const&) in main-d9ce5a.o
ld: symbol(s) not found for architecture arm64
```

Clang also emits this warning:

```
/opt/local/OpenUSD_no-python/include/pxr/imaging/hgi/shaderProgram.h:44:13: warning: inline function 'pxrInternal_v0_25_5__pxrReserved__::operator==' is not defined [-Wundefined-inline]
   44 | inline bool operator==(
      |             ^
main.cpp:44:16: note: used here
   44 |     bool x = l == r;
      |                ^
```

I think the `inline` keyword should be removed from the function declaration, or the function definition should be moved into the header file. (Note that the fix should also be applied to `operator!=`.)


## Reproduction

```cpp
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-W#pragma-messages" // Silence TBB deprecation warning from pxr/base/work/dispatcher.h

#include <iostream>
#include "pxr/usd/usd/stage.h"
#include "pxr/usd/sdf/layer.h"
#include "pxr/base/tf/token.h"
#include "pxr/usd/usdGeom/tokens.h"
#include "pxr/usd/sdf/path.h"
#include "pxr/usd/usd/prim.h"
#include "pxr/usd/usdPhysics/tokens.h"
#include "pxr/usd/usdPhysics/rigidBodyAPI.h"
#include "pxr/imaging/hgi/shaderProgram.h"

#pragma clang diagnostic pop


/// Basic smoke test that the OpenUSD install is usable
void smokeTest() {
    pxr::UsdStageRefPtr mainStage = pxr::UsdStage::CreateNew("main.usda");
    mainStage->DefinePrim(pxr::SdfPath("/hello"), pxr::UsdGeomTokens->Cube);
    mainStage->DefinePrim(pxr::SdfPath("/hello/world"), pxr::UsdGeomTokens->Sphere);
    std::string s;
    mainStage->ExportToString(&s);
    std::cout << s << std::endl;
}

/*
PXR_NAMESPACE_OPEN_SCOPE

bool operator==(
                const HgiShaderProgramDesc& lhs,
                const HgiShaderProgramDesc& rhs)
{
    return lhs.debugName == rhs.debugName &&
           lhs.shaderFunctions == rhs.shaderFunctions;
}

PXR_NAMESPACE_CLOSE_SCOPE
*/

void reproducer(const pxr::HgiShaderProgramDesc& l,
                const pxr::HgiShaderProgramDesc& r) {
    bool x = l == r;
}




int main() {
    smokeTest();
    return 0;
}
```

and compiled with

```bash
set -e

# Vanilla v25.05.01 with --no-python
OPENUSD_INSTALL=/opt/local/OpenUSD_no-python


# Remove stale files
rm -f ./a.out

# Compile
clang++ main.cpp -std=c++17 \
        -I $OPENUSD_INSTALL/include \
        -L $OPENUSD_INSTALL/lib \
        -Xlinker -rpath -Xlinker $OPENUSD_INSTALL/lib \
        -lusd_usd -lusd_sdf -lusd_tf -lusd_usdGeom -lusd_hgi

./a.out
```

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
