### PR TITLE
Fix plugin path globbing by preserving trailing slash

### DIFF
--- a/pxr/base/arch/fileSystem.cpp
+++ b/pxr/base/arch/fileSystem.cpp
@@ -224,7 +224,7 @@ _GetTokenType(pair<Iter, Iter> t) {
 }
 
 string
-_NormPath(string const &inPath)
+_NormPath(string const &inPath, unsigned int flags)
 {
     // We take one pass through the string, transforming it into a normalized
     // path in-place.  This works since the normalized path never grows, except
@@ -335,10 +335,11 @@ _NormPath(string const &inPath)
         };
     }
     
-    // Remove a trailing slash if we wrote one.  We're careful to use const
+    // Remove a trailing slash if necessary.  We're careful to use const
     // iterators here to avoid incurring a string copy if it's not necessary (in
     // the case of libstdc++'s copy-on-write basic_string)
-    if (writeIdx > firstWriteIdx && path.cbegin()[writeIdx-1] == '/')
+    if (!(flags & ARCH_NORM_PATH_KEEP_TRAILING_SLASH) &&
+        writeIdx > firstWriteIdx && path.cbegin()[writeIdx-1] == '/')
         --writeIdx;
 
     // Trim the string to length if necessary.
@@ -355,7 +356,7 @@ _NormPath(string const &inPath)
 
 #if defined(ARCH_OS_WINDOWS)
 string
-ArchNormPath(const string& inPath, bool stripDriveSpecifier)
+ArchNormPath(const string& inPath, unsigned int flags)
 {
     // Convert backslashes to forward slashes.
     string path = inPath;
@@ -365,20 +366,20 @@ ArchNormPath(const string& inPath, bool stripDriveSpecifier)
     // UNC paths or paths that start with \\? (which allow longer paths).
     string prefix;
     if (path.size() >= 2 && path[1] == ':') {
-        if (!stripDriveSpecifier) {
+        if (!(flags & ARCH_NORM_PATH_STRIP_DRIVE)) {
             prefix = path.substr(0,2);
         }
         path.erase(0, 2);
     }
 
     // Normalize and prepend drive specifier, if any.
-    return prefix + _NormPath(path);
+    return prefix + _NormPath(path, flags);
 }
 #else
 string
-ArchNormPath(const string& inPath, bool /*stripDriveSpecifier*/)
+ArchNormPath(const string& inPath, unsigned int flags)
 {
-    return _NormPath(inPath);
+    return _NormPath(inPath, flags);
 }
 #endif // defined(ARCH_OS_WINDOWS)
 

--- a/pxr/base/arch/fileSystem.h
+++ b/pxr/base/arch/fileSystem.h
@@ -197,17 +197,27 @@ ARCH_API bool ArchGetModificationTime(const char* pathname, double* time);
 /// available in the stat structure for the current platform.
 ARCH_API double ArchGetModificationTime(const ArchStatType& st);
 
+enum ArchNormPathFlags {
+    ARCH_NORM_PATH_NONE                = 0u,
+    ARCH_NORM_PATH_STRIP_DRIVE         = 1u << 0,
+    ARCH_NORM_PATH_KEEP_TRAILING_SLASH = 1u << 1
+};
+
 /// Normalizes the specified path, eliminating double slashes, etc.
 ///
-/// This canonicalizes paths, removing any double slashes, and eliminiating
+/// This canonicalizes paths, removing any double slashes, and eliminating
 /// '.', and '..' components of the path.  This emulates the behavior of
 /// os.path.normpath in Python.
 ///
 /// On Windows, all backslashes are converted to forward slashes and drive
-/// specifiers (e.g., "C:") are lower-cased. If \p stripDriveSpecifier
-/// is \c true, these drive specifiers are removed from the path.
+/// specifiers (e.g., "C:") are lower-cased.
+///
+/// Behavior can be customized using \p flags:
+/// \li If ARCH_NORM_PATH_STRIP_DRIVE is set, drive specifiers are removed.
+/// \li If ARCH_NORM_PATH_KEEP_TRAILING_SLASH is set, any trailing slash is
+///     preserved.
 ARCH_API std::string ArchNormPath(const std::string& path,
-                                  bool stripDriveSpecifier = false);
+                                  unsigned int flags = ARCH_NORM_PATH_NONE);
 
 /// Returns the canonical absolute path of the specified filename.
 ///

--- a/pxr/base/arch/testenv/testFileSystem.cpp
+++ b/pxr/base/arch/testenv/testFileSystem.cpp
@@ -35,6 +35,13 @@ TestArchNormPath()
     ARCH_AXIOM(ArchNormPath("///..//./foo/.//bar") == "/foo/bar");
     ARCH_AXIOM(ArchNormPath(
             "foo/bar/../../../../../../baz") == "../../../../baz");
+    ARCH_AXIOM(ArchNormPath("/", ARCH_NORM_PATH_KEEP_TRAILING_SLASH) == "/");
+    ARCH_AXIOM(ArchNormPath(
+            "foobar/../barbaz",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH) == "barbaz/");
+    ARCH_AXIOM(ArchNormPath(
+            "///foo/.//bar//",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH) == "/foo/bar/");
 
 #if defined(ARCH_OS_WINDOWS)
     ARCH_AXIOM(ArchNormPath("C:\\foo\\bar") == "C:/foo/bar");
@@ -42,9 +49,25 @@ TestArchNormPath()
     ARCH_AXIOM(ArchNormPath("c:\\foo\\bar") == "c:/foo/bar");
     ARCH_AXIOM(ArchNormPath("c:foo\\bar") == "c:foo/bar");
     ARCH_AXIOM(ArchNormPath(
-            "C:\\foo\\bar", /* stripDriveSpecifier = */ true) == "/foo/bar");
+            "C:\\foo\\bar",
+            ARCH_NORM_PATH_STRIP_DRIVE) == "/foo/bar");
     ARCH_AXIOM(ArchNormPath(
-            "C:foo\\bar", /* stripDriveSpecifier = */ true) == "foo/bar");
+            "C:foo\\bar",
+            ARCH_NORM_PATH_STRIP_DRIVE) == "foo/bar");
+    ARCH_AXIOM(ArchNormPath(
+            "c:\\foo\\bar\\",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH) == "c:/foo/bar/");
+    ARCH_AXIOM(ArchNormPath(
+            "c:foo\\bar\\",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH) == "c:foo/bar/");
+    ARCH_AXIOM(ArchNormPath(
+            "c:\\foo\\bar\\",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH |
+            ARCH_NORM_PATH_STRIP_DRIVE) == "/foo/bar/");
+    ARCH_AXIOM(ArchNormPath(
+            "c:foo\\bar\\",
+            ARCH_NORM_PATH_KEEP_TRAILING_SLASH |
+            ARCH_NORM_PATH_STRIP_DRIVE) == "foo/bar/");
 #endif
 
     return true;

--- a/pxr/base/plug/initConfig.cpp
+++ b/pxr/base/plug/initConfig.cpp
@@ -42,7 +42,9 @@ _AppendPathList(
         // Anchor all relative paths to the shared library path.
         const bool isLibraryRelativePath = TfIsRelativePath(path);
         if (isLibraryRelativePath) {
-            result->push_back(TfStringCatPaths(sharedLibPath, path));
+            result->push_back(
+                TfStringCatPaths(sharedLibPath, path,
+                                 TF_NORM_PATH_KEEP_TRAILING_SLASH));
         }
         else {
             result->push_back(path);

--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -216,9 +216,14 @@ TfFindLongestAccessiblePrefix(string const &path, string* error)
 }
 
 string
-TfNormPath(string const &inPath, bool stripDriveSpecifier)
+TfNormPath(string const &inPath, unsigned int flags)
 {
-    return ArchNormPath(inPath, stripDriveSpecifier);
+    unsigned int archFlags = ARCH_NORM_PATH_NONE;
+    if (flags & TF_NORM_PATH_STRIP_DRIVE)
+        archFlags |= ARCH_NORM_PATH_STRIP_DRIVE;
+    if (flags & TF_NORM_PATH_KEEP_TRAILING_SLASH)
+        archFlags |= ARCH_NORM_PATH_KEEP_TRAILING_SLASH;
+    return ArchNormPath(inPath, archFlags);
 }
 
 string

--- a/pxr/base/tf/pathUtils.h
+++ b/pxr/base/tf/pathUtils.h
@@ -42,18 +42,28 @@ std::string TfRealPath(std::string const& path,
                        bool allowInaccessibleSuffix = false,
                        std::string* error = 0);
 
+enum TfNormPathFlags {
+    TF_NORM_PATH_NONE                = 0u,
+    TF_NORM_PATH_STRIP_DRIVE         = 1u << 0,
+    TF_NORM_PATH_KEEP_TRAILING_SLASH = 1u << 1
+};
+
 /// Normalizes the specified path, eliminating double slashes, etc.
 ///
-/// This canonicalizes paths, removing any double slashes, and eliminiating
+/// This canonicalizes paths, removing any double slashes, and eliminating
 /// '.', and '..' components of the path.  This emulates the behavior of
 /// os.path.normpath in Python.
 ///
 /// On Windows, all backslashes are converted to forward slashes and drive
-/// specifiers (e.g., "C:") are lower-cased. If \p stripDriveSpecifier
-/// is \c true, these drive specifiers are removed from the path.
+/// specifiers (e.g., "C:") are lower-cased.
+///
+/// Behavior can be customized using \p flags:
+/// \li If TF_NORM_PATH_STRIP_DRIVE is set, drive specifiers are removed.
+/// \li If TF_NORM_PATH_KEEP_TRAILING_SLASH is set, any trailing slash is
+///     preserved.
 TF_API
-std::string TfNormPath(std::string const& path, 
-                       bool stripDriveSpecifier = false);
+std::string TfNormPath(std::string const& path,
+                       unsigned int flags = TF_NORM_PATH_NONE);
 
 /// Return the index delimiting the longest accessible prefix of \a path.
 ///

--- a/pxr/base/tf/stringUtils.cpp
+++ b/pxr/base/tf/stringUtils.cpp
@@ -1133,9 +1133,10 @@ TfEscapeString(const std::string &in)
 }
 
 string 
-TfStringCatPaths( const string &prefix, const string &suffix )
+TfStringCatPaths(
+    const string &prefix, const string &suffix, unsigned int flags)
 {
-    return TfNormPath(prefix + "/" + suffix);
+    return TfNormPath(prefix + "/" + suffix, flags);
 }
 
 std::string

--- a/pxr/base/tf/stringUtils.h
+++ b/pxr/base/tf/stringUtils.h
@@ -18,6 +18,7 @@
 #include "pxr/base/arch/inttypes.h"
 #include "pxr/base/tf/api.h"
 #include "pxr/base/tf/enum.h"
+#include "pxr/base/tf/pathUtils.h"
 
 #include <cstdarg>
 #include <cstring>
@@ -680,13 +681,13 @@ TF_API void TfEscapeStringReplaceChar(const char** in, char** out);
 /// Tokenize the input strings using a '/' delimiter. Look for '..' tokens in
 /// the suffix and construct the appropriate result.
 ///
-/// Examples:
-/// 
-/// \li TfStringCatPaths( "foo/bar", "jive" ) => "foo/bar/jive"
-/// \li TfStringCatPaths( "foo/bar", "../jive" ) => "foo/jive"
+/// Behavior can be customized using \p TfNormPathFlags passed via \p flags.
+/// For example, setting TF_NORM_PATH_KEEP_TRAILING_SLASH will preserve a
+/// trailing slash in the result.
 TF_API
 std::string TfStringCatPaths( const std::string &prefix, 
-                              const std::string &suffix );
+                              const std::string &suffix,
+                              unsigned int flags = TF_NORM_PATH_NONE );
 
 /// Test whether \a identifier is valid.
 ///

--- a/pxr/base/tf/testenv/pathUtils.cpp
+++ b/pxr/base/tf/testenv/pathUtils.cpp
@@ -160,7 +160,13 @@ TestTfNormPath()
     TF_AXIOM(TfNormPath("///foo/.//bar//.//..//.//baz") == "/foo/baz");
     TF_AXIOM(TfNormPath("///..//./foo/.//bar") == "/foo/bar");
     TF_AXIOM(TfNormPath("foo/bar/../../../../../../baz") == "../../../../baz");
-
+    TF_AXIOM(TfNormPath("/", TF_NORM_PATH_KEEP_TRAILING_SLASH) == "/");
+    TF_AXIOM(TfNormPath(
+            "foobar/../barbaz",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "barbaz/");
+    TF_AXIOM(TfNormPath(
+            "///foo/.//bar//",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "/foo/bar/");
     return true;
 }
 

--- a/pxr/base/tf/testenv/stringUtils.cpp
+++ b/pxr/base/tf/testenv/stringUtils.cpp
@@ -473,6 +473,12 @@ TestStrings()
     TF_AXIOM(TfStringCatPaths("foo", "../bar") == "bar");
     TF_AXIOM(TfStringCatPaths("/foo", "../bar") == "/bar");
     TF_AXIOM(TfStringCatPaths("foo/crud/crap", "../bar") == "foo/crud/bar");
+    TF_AXIOM(TfStringCatPaths(
+            "foo", "bar/",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "foo/bar/");
+    TF_AXIOM(TfStringCatPaths(
+            "/foo", "../bar/",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "/bar/");
 #if defined(ARCH_OS_WINDOWS)
     // Same on Windows but with backslashes.
     TF_AXIOM(TfStringCatPaths("foo", "bar") == "foo/bar");
@@ -480,6 +486,12 @@ TestStrings()
     TF_AXIOM(TfStringCatPaths("foo", "..\\bar") == "bar");
     TF_AXIOM(TfStringCatPaths("\\foo", "..\\bar") == "/bar");
     TF_AXIOM(TfStringCatPaths("foo\\crud\\crap", "..\\bar") == "foo/crud/bar");
+    TF_AXIOM(TfStringCatPaths(
+            "foo", "bar/",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "foo/bar/");
+    TF_AXIOM(TfStringCatPaths(
+            "foo\\crud", "..\\bar\\",
+            TF_NORM_PATH_KEEP_TRAILING_SLASH) == "foo/bar/");
 #endif
 
     return true;

--- a/pxr/usd/sdf/zipFile.cpp
+++ b/pxr/usd/sdf/zipFile.cpp
@@ -858,7 +858,7 @@ _ZipFilePath(const std::string& filePath)
     // TfNormPath will flip all backslashes to forward slashes and
     // strip drive letters.
     std::string result = 
-        TfNormPath(filePath, /* stripDriveSpecifier = */ true);
+        TfNormPath(filePath, TF_NORM_PATH_STRIP_DRIVE);
 
     // Strip off any initial slashes.
     result = TfStringTrimLeft(result, "/");


### PR DESCRIPTION
Previously, TfStringCatPaths would strip trailing slashes during normalization, causing plugin discovery to misinterpret directory prefixes with glob patterns as file paths. This broke logic that appends plugInfo.json to the path.

This commit introduces flag-based control for path normalization:

* Introduced `TfNormPathFlags` and `ArchNormPathFlags` enums
* Replaced `stripDriveSpecifier` boolean with `*_STRIP_DRIVE` flag
* Added `*_KEEP_TRAILING_SLASH` flag to preserve trailing slashes
* Updated `TfNormPath`, `ArchNormPath`, and `TfStringCatPaths` to accept flags
* Adjusted call sites and added tests for both flags

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Fixes: https://github.com/PixarAnimationStudios/OpenUSD/issues/3679

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))