### PR TITLE
Autodesk: resolve TaskControllerSceneIndex compatibility issue

### DIFF
--- a/pxr/imaging/hdx/taskControllerSceneIndex.cpp
+++ b/pxr/imaging/hdx/taskControllerSceneIndex.cpp
@@ -26,6 +26,7 @@
 #include "pxr/imaging/hdx/visualizeAovTask.h"
 
 #include "pxr/imaging/hdSt/tokens.h"
+#include "pxr/imaging/hdSt/renderDelegate.h"
 
 #include "pxr/imaging/hd/light.h"
 #include "pxr/imaging/hd/legacyTaskSchema.h"
@@ -1056,23 +1057,23 @@ HD_DECLARE_DATASOURCE_HANDLES(_LightPrimDataSource);
 HdxTaskControllerSceneIndexRefPtr
 HdxTaskControllerSceneIndex::New(
     const SdfPath &prefix,
-    const TfToken &rendererPluginName,
+    const HdRenderDelegate &renderDelegate,
     const AovDescriptorCallback &aovDescriptorCallback,
     const bool gpuEnabled)
 {
     return TfCreateRefPtr(
         new HdxTaskControllerSceneIndex(
-            prefix, rendererPluginName, aovDescriptorCallback, gpuEnabled));
+            prefix, renderDelegate, aovDescriptorCallback, gpuEnabled));
 }
 
 
 HdxTaskControllerSceneIndex::HdxTaskControllerSceneIndex(
     const SdfPath &prefix,
-    const TfToken &rendererPluginName,
+    const HdRenderDelegate &renderDelegate,
     const AovDescriptorCallback &aovDescriptorCallback,
     const bool gpuEnabled)
  : _prefix(prefix)
- , _isForStorm(rendererPluginName == _rendererPluginNameTokens->storm)
+ , _isForStorm(dynamic_cast<const HdStRenderDelegate*>(&renderDelegate) != nullptr)
  , _aovDescriptorCallback(aovDescriptorCallback)
  , _runGpuAovTasks(gpuEnabled || _isForStorm)
  , _retainedSceneIndex(HdRetainedSceneIndex::New())

--- a/pxr/imaging/hdx/taskControllerSceneIndex.h
+++ b/pxr/imaging/hdx/taskControllerSceneIndex.h
@@ -33,6 +33,8 @@ extern TfEnvSetting<int> HDX_MSAA_SAMPLE_COUNT;
 TF_DECLARE_REF_PTRS(HdRetainedSceneIndex);
 TF_DECLARE_REF_PTRS(HdxTaskControllerSceneIndex);
 
+class HdRenderDelegate;
+
 /// \class HdxTaskControllerSceneIndex
 ///
 /// Manages tasks necessary to render an image (or perform picking)
@@ -66,7 +68,7 @@ public:
     static
     HdxTaskControllerSceneIndexRefPtr
     New(const SdfPath &prefix,
-        const TfToken &rendererPluginName,
+        const HdRenderDelegate& renderDelegate,
         const AovDescriptorCallback &aovDescriptorCallback,
         bool gpuEnabled = true);
 
@@ -268,7 +270,7 @@ public:
 private:
     HdxTaskControllerSceneIndex(
         const SdfPath &prefix,
-        const TfToken &rendererPluginName,
+        const HdRenderDelegate &renderDelegate,
         const AovDescriptorCallback &aovDescriptorCallback,
         bool gpuEnabled);
 

--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -1551,9 +1551,10 @@ UsdImagingGLEngine::_SetRenderDelegate(
             _ComputeControllerPath(_renderDelegate);
         _taskControllerSceneIndex = HdxTaskControllerSceneIndex::New(
             taskControllerPath,
-            renderDelegate.GetPluginId(),
+            *_renderIndex.get()->GetRenderDelegate(),
             [renderDelegate = _renderDelegate.Get()](const TfToken &name) {
-                return renderDelegate->GetDefaultAovDescriptor(name); },
+                return renderDelegate->GetDefaultAovDescriptor(name);
+            },
             _gpuEnabled);
         _renderIndex->InsertSceneIndex(
             _taskControllerSceneIndex,

--- a/pxr/usdImaging/usdImagingGL/testenv/testUsdImagingGLBasicDrawing.cpp
+++ b/pxr/usdImaging/usdImagingGL/testenv/testUsdImagingGLBasicDrawing.cpp
@@ -81,6 +81,7 @@ My_TestGLDrawing::InitTest()
         IsEnabledUnloadedAsBounds() ? UsdStage::LoadNone : UsdStage::LoadAll);
 
     UsdImagingGLEngine::Parameters parameters;
+    parameters.rendererPluginId = _GetRenderer();
     parameters.rootPath = _stage->GetPseudoRoot().GetPath();
     parameters.displayUnloadedPrimsWithBounds = IsEnabledUnloadedAsBounds();
 


### PR DESCRIPTION
### Description of Change(s)

- This change will make `TaskControllerSceneIndex` be compatible with all storm based renderDelegate.
   - By using `dynamic_cast()` for testing instead of `TfToken` testing, this is the same behavior as original `HdxTaskController`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
