### PR TITLE
UsdSkelImaging Hydra 2.0: block normals to match Hydra 1.0

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
@@ -221,12 +221,14 @@ _ExtComputationPrimvars(const SdfPath &primPath)
 
 static
 HdContainerDataSourceHandle
-_BlockPointsPrimvars()
+_BlockPointsAndNormalsPrimvars()
 {
     const TfToken names[] = {
-        HdPrimvarsSchemaTokens->points
+        HdPrimvarsSchemaTokens->points,
+        HdPrimvarsSchemaTokens->normals
     };
     HdDataSourceBaseHandle const values[] = {
+        HdBlockDataSource::New(),
         HdBlockDataSource::New()
     };
 
@@ -251,7 +253,9 @@ UsdSkelImagingDataSourceResolvedPointsBasedPrim::Get(const TfToken &name)
 
     if (name == HdPrimvarsSchema::GetSchemaToken()) {
         // Block points primvar.
-        static HdContainerDataSourceHandle ds = _BlockPointsPrimvars();
+        // The normals are also blocked so they are recomputed after skinning,
+        // since normals currently aren't deformed by the computation.
+        static HdContainerDataSourceHandle ds = _BlockPointsAndNormalsPrimvars();
         return ds;
     }
 


### PR DESCRIPTION
### Description of Change(s)

This forces the normals to be computed post-skinning, rather than using the undeformed normals from the rest geometry, and matches the Hydra 1.0 behavior (bug #3699 contains additional details)

Note that the open PRs (e.g. #3664) to add support for normals in the skinning computation would supersede this

### Fixes Issue(s)
#3699

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
