### PR TITLE
Caching seen connections during shading network traversal

### DIFF
--- a/pxr/usd/usdShade/connectableAPI.h
+++ b/pxr/usd/usdShade/connectableAPI.h
@@ -806,6 +806,14 @@ struct UsdShadeConnectionSourceInfo {
     bool operator!=(const UsdShadeConnectionSourceInfo &other) const {
         return !(*this == other);
     }
+
+    template <typename HashState>
+    friend void TfHashAppend(HashState& h, const UsdShadeConnectionSourceInfo& info) {
+        // Using the same criteria as operator==(...)
+        h.Append(info.sourceName);
+        h.Append(info.sourceType);
+        h.Append(info.source.GetPrim());
+    }
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -123,10 +123,17 @@ _IsConnectionDirty(
     const UsdPrim& dirtyPrim,
     const TfTokenVector& dirtyProperties,
     const UsdShadeMaterial& material,
-    const UsdShadeConnectionSourceInfo& connection)
+    const UsdShadeConnectionSourceInfo& connection,
+    TfHashMap<UsdShadeConnectionSourceInfo, bool, TfHash>& seenConnections)
 {
+    if (bool seen; TfMapLookup(seenConnections, connection, &seen))
+        return seen;
+
     if (!connection.IsValid())
+    {
+        seenConnections.insert({connection, false});
         return false;
+    }
 
     // If we reach the root material only dirty if we are connected to the
     // specific property which is dirty and don't recurse further.
@@ -141,15 +148,18 @@ _IsConnectionDirty(
                         && dirtyProperty
                             == connection.source.GetInput(connection.sourceName)
                                    .GetFullName())) {
+                    seenConnections.insert({connection, true});
                     return true;
                 }
             }
         }
+        seenConnections.insert({connection, false});
         return false;
     }
 
     // We are connected to the dirty prim
     if (connection.source.GetPrim() == dirtyPrim) {
+        seenConnections.insert({connection, true});
         return true;
     }
 
@@ -162,7 +172,8 @@ _IsConnectionDirty(
                  output.GetConnectedSources()) {
                 if (_IsConnectionDirty(
                         dirtyPrim, dirtyProperties, material,
-                        outputConnection)) {
+                        outputConnection, seenConnections)) {
+                    seenConnections.insert({connection, true});
                     return true;
                 }
             }
@@ -174,12 +185,14 @@ _IsConnectionDirty(
         for (UsdShadeConnectionSourceInfo& inputConnection :
              input.GetConnectedSources()) {
             if (_IsConnectionDirty(
-                    dirtyPrim, dirtyProperties, material, inputConnection)) {
+                    dirtyPrim, dirtyProperties, material, inputConnection, seenConnections)) {
+                seenConnections.insert({connection, true});
                 return true;
             }
         }
     }
 
+    seenConnections.insert({connection, false});
     return false;
 }
 
@@ -201,7 +214,8 @@ UsdImagingMaterialAdapter::InvalidateImagingSubprim(
     for (UsdShadeOutput& output : material.GetOutputs()) {
         for (UsdShadeConnectionSourceInfo& connection :
              output.GetConnectedSources()) {
-            if (_IsConnectionDirty(prim, properties, material, connection)) {
+            TfHashMap<UsdShadeConnectionSourceInfo, bool, TfHash> seenConnections;
+            if (_IsConnectionDirty(prim, properties, material, connection, seenConnections)) {
                 result.insert(_CreateTerminalLocator(output.GetBaseName()));
             }
         }
@@ -235,8 +249,9 @@ UsdImagingMaterialAdapter::InvalidateImagingSubprimFromDescendent(
     for (UsdShadeOutput& output : material.GetOutputs()) {
         for (UsdShadeConnectionSourceInfo& connection :
              output.GetConnectedSources()) {
+            TfHashMap<UsdShadeConnectionSourceInfo, bool, TfHash> seenConnections;
             if (_IsConnectionDirty(
-                    descendentPrim, properties, material, connection)) {
+                    descendentPrim, properties, material, connection, seenConnections)) {
                 result.insert(_CreateTerminalLocator(output.GetBaseName()));
             }
         }


### PR DESCRIPTION
### Description of Change(s)

Making UsdShadeConnectionSourceInfo hashable, and keeping a cache (map) of seen connections (along with their dirty status) when traversing shading networks. This resolves in issue we're observing where "very large" (and I apologise that I've been unable to quantify or better describe this - depth vs breadth vs fan-in vs fan-out...) shading networks can take a prohibitively long time to traverse due to repeated evaluation of connection hierarchies.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
