### PR TITLE
APPLE: Extract TBB Patches

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -120,19 +120,28 @@ def SupportsMacOSUniversalBinaries():
     XcodeVersion = XcodeOutput[XcodeFind:].split(' ')[1]
     return (XcodeVersion > '11.0')
 
-def GetSDKRoot(context) -> Optional[str]:
+def GetSDKName(context) -> str:
     sdk = "macosx"
     if context.buildTarget == TARGET_IOS:
-        sdk = "iphoneos"
+        sdk = "iPhoneOS"
     elif context.buildTarget == TARGET_VISIONOS:
-        sdk = "xros"
+        sdk = "xrOS"
+
+    return sdk
+
+def GetSDKRoot(context) -> Optional[str]:
+    sdk = GetSDKName(context).lower()
 
     for arg in (context.cmakeBuildArgs or '').split():
         if "CMAKE_OSX_SYSROOT" in arg:
             override = arg.split('=')[1].strip('"').strip()
             if override:
                 sdk = override
-    return GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+
+    sdkroot = GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+    if not sdkroot:
+        raise RuntimeError(f"Could not find an sdk path. Make sure you have the {sdk} sdk installed.")
+    return sdkroot
 
 def SetTarget(context, targetName):
     context.targetNative = (targetName == TARGET_NATIVE)
@@ -250,3 +259,30 @@ def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
         args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
 
     return args
+
+def GetTBBPatches(context):
+    if context.buildTarget not in EMBEDDED_PLATFORMS or context.buildTarget == TARGET_IOS:
+        # TBB already handles these so we don't patch them out
+        return [], []
+
+    sdk_name = GetSDKName(context)
+
+    # Standard Target based names
+    target_config_patches = [("ios", context.buildTarget.lower()),
+                             ("iOS", context.buildTarget),
+                             ("IPHONEOS", sdk_name.upper())]
+
+    clang_config_patches = [("ios",context.buildTarget.lower()),
+                            ("iOS", context.buildTarget),
+                            ("IPHONEOS",sdk_name.upper())]
+
+    if context.buildTarget == TARGET_VISIONOS:
+        target_config_patches.extend([("iPhone", "XR"),
+                                      ("?= 8.0", "?= 1.0")])
+
+        clang_config_patches.append(("iPhone", "XR"),)
+
+    if context.buildTarget == TARGET_VISIONOS:
+        clang_config_patches.append(("-miphoneos-version-min=", "-target arm64-apple-xros"))
+
+    return target_config_patches, clang_config_patches

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1035,30 +1035,21 @@ def InstallTBB_MacOS(context, force, buildArgs):
                   "ifeq ($(arch),$(filter $(arch),armv7 armv7s {0}))"
                         .format(apple_utils.GetTargetArmArch()))])
 
-        if context.buildTarget == apple_utils.TARGET_VISIONOS:
-            # Create visionOS config from iOS config
+        if MacOSTargetEmbedded(context) and context.buildTarget != apple_utils.TARGET_IOS:
+            target_config_patches, clang_config_patches  = apple_utils.GetTBBPatches(context)
+            # Create config from iOS config
             shutil.copy(
                 src="build/ios.macos.inc",
-                dst="build/visionos.macos.inc")
+                dst=f"build/{context.buildTarget.lower()}.macos.inc")
 
-            PatchFile("build/visionos.macos.inc",
-                      [("ios","visionos"),
-                       ("iOS", "visionOS"),
-                       ("iPhone", "XR"),
-                       ("IPHONEOS","XROS"),
-                       ("?= 8.0", "?= 1.0")])
+            PatchFile(f"build/{context.buildTarget.lower()}.macos.inc", target_config_patches)
 
             # iOS clang just reuses the macOS one,
             # so it's easier to copy it directly.
             shutil.copy(src="build/macos.clang.inc",
-                        dst="build/visionos.clang.inc")
+                        dst=f"build/{context.buildTarget.lower()}.clang.inc")
 
-            PatchFile("build/visionos.clang.inc",
-                      [("ios","visionos"),
-                       ("-miphoneos-version-min=", "-target arm64-apple-xros"),
-                       ("iOS", "visionOS"),
-                       ("iPhone", "XR"),
-                       ("IPHONEOS","XROS")])
+            PatchFile(f"build/{context.buildTarget.lower()}.clang.inc",clang_config_patches)
 
         (primaryArch, secondaryArch) = apple_utils.GetTargetArchPair(context)
 


### PR DESCRIPTION
### Description of Change(s)
As discussed with @meshula , this PR moves the TBB patches from the main build_usd.py to apple_utils.py so that we can introduce more platform specific patches in the future. This PR will be necessary for adding future PRs for Simulator support or any other apple platforms that might get added here (e.g tvOS or watchOS purely hypothetically)

TBB will still be required once GCD lands in OpenUSD for some of the algorithms, so this patch is still necessary.

There is no functional behaviour change here.

Additionally, as part of this change, GetSDKRoot has been split into GetSDKName and GetSDKRoot, and now verifies that the SDK is installed in the currently active Xcode.


### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
