### PR TITLE
APPLE: Support building for iOS and visionOS Simulators

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -120,19 +120,28 @@ def SupportsMacOSUniversalBinaries():
     XcodeVersion = XcodeOutput[XcodeFind:].split(' ')[1]
     return (XcodeVersion > '11.0')
 
-def GetSDKRoot(context) -> Optional[str]:
+def GetSDKName(context) -> str:
     sdk = "macosx"
     if context.buildTarget == TARGET_IOS:
-        sdk = "iphoneos"
+        sdk = "iPhoneOS"
     elif context.buildTarget == TARGET_VISIONOS:
-        sdk = "xros"
+        sdk = "xrOS"
+
+    return sdk
+
+def GetSDKRoot(context) -> Optional[str]:
+    sdk = GetSDKName(context).lower()
 
     for arg in (context.cmakeBuildArgs or '').split():
         if "CMAKE_OSX_SYSROOT" in arg:
             override = arg.split('=')[1].strip('"').strip()
             if override:
                 sdk = override
-    return GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+
+    sdkroot = GetCommandOutput(["xcrun", "--sdk", sdk, "--show-sdk-path"])
+    if not sdkroot:
+        raise RuntimeError(f"Could not find an sdk path. Make sure you have the {sdk} sdk installed.")
+    return sdkroot
 
 def SetTarget(context, targetName):
     context.targetNative = (targetName == TARGET_NATIVE)
@@ -250,3 +259,30 @@ def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
         args.append(f"-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
 
     return args
+
+def GetTBBPatches(context):
+    if context.buildTarget not in EMBEDDED_PLATFORMS or context.buildTarget == TARGET_IOS:
+        # TBB already handles these so we don't patch them out
+        return [], []
+
+    sdk_name = GetSDKName(context)
+
+    # Standard Target based names
+    target_config_patches = [("ios", context.buildTarget.lower()),
+                             ("iOS", context.buildTarget),
+                             ("IPHONEOS", sdk_name.upper())]
+
+    clang_config_patches = [("ios",context.buildTarget.lower()),
+                            ("iOS", context.buildTarget),
+                            ("IPHONEOS",sdk_name.upper())]
+
+    if context.buildTarget == TARGET_VISIONOS:
+        target_config_patches.extend([("iPhone", "XR"),
+                                      ("?= 8.0", "?= 1.0")])
+
+        clang_config_patches.append(("iPhone", "XR"),)
+
+    if context.buildTarget == TARGET_VISIONOS:
+        clang_config_patches.append(("-miphoneos-version-min=", "-target arm64-apple-xros"))
+
+    return target_config_patches, clang_config_patches

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -25,9 +25,12 @@ TARGET_X86 = "x86_64"
 TARGET_ARM64 = "arm64"
 TARGET_UNIVERSAL = "universal"
 TARGET_IOS = "iOS"
+TARGET_IOS_SIMULATOR = "iOSSimulator"
 TARGET_VISIONOS = "visionOS"
+TARGET_VISIONOS_SIMULATOR = "visionOSSimulator"
 
-EMBEDDED_PLATFORMS = [TARGET_IOS, TARGET_VISIONOS]
+EMBEDDED_PLATFORMS = [TARGET_IOS, TARGET_IOS_SIMULATOR,
+                      TARGET_VISIONOS, TARGET_VISIONOS_SIMULATOR]
 
 def GetBuildTargets():
     return [TARGET_NATIVE,
@@ -35,7 +38,9 @@ def GetBuildTargets():
             TARGET_ARM64,
             TARGET_UNIVERSAL,
             TARGET_IOS,
-            TARGET_VISIONOS]
+            TARGET_IOS_SIMULATOR,
+            TARGET_VISIONOS,
+            TARGET_VISIONOS_SIMULATOR]
 
 def GetBuildTargetDefault():
     return TARGET_NATIVE
@@ -124,8 +129,12 @@ def GetSDKName(context) -> str:
     sdk = "macosx"
     if context.buildTarget == TARGET_IOS:
         sdk = "iPhoneOS"
+    elif context.buildTarget == TARGET_IOS_SIMULATOR:
+        sdk = "iPhoneSimulator"
     elif context.buildTarget == TARGET_VISIONOS:
         sdk = "xrOS"
+    elif context.buildTarget == TARGET_VISIONOS_SIMULATOR:
+        sdk = "xrSimulator"
 
     return sdk
 
@@ -148,8 +157,9 @@ def SetTarget(context, targetName):
     context.targetX86 = (targetName == TARGET_X86)
     context.targetARM64 = (targetName == GetTargetArmArch())
     context.targetUniversal = (targetName == TARGET_UNIVERSAL)
-    context.targetIOS = (targetName == TARGET_IOS)
-    context.targetVisionOS = (targetName == TARGET_VISIONOS)
+    context.targetIOS = (targetName in (TARGET_IOS, TARGET_IOS_SIMULATOR))
+    context.targetVisionOS = (targetName in (TARGET_VISIONOS, TARGET_VISIONOS_SIMULATOR))
+    context.targetSimulator = (targetName in (TARGET_IOS_SIMULATOR, TARGET_VISIONOS_SIMULATOR))
     if context.targetUniversal and not SupportsMacOSUniversalBinaries():
         context.targetUniversal = False
         raise ValueError(
@@ -161,6 +171,9 @@ def GetTargetName(context):
             GetTargetArmArch() if context.targetARM64 else
             TARGET_UNIVERSAL if context.targetUniversal else
             context.buildTarget)
+
+def GetTargetPlatform(context):
+    return GetTargetName(context).replace("Simulator", "")
 
 devout = open(os.devnull, 'w')
 
@@ -247,7 +260,7 @@ def CreateUniversalBinaries(context, libNames, x86Dir, armDir):
 def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
     system_name = None
     if TargetEmbeddedOS(context):
-        system_name = context.buildTarget
+        system_name = GetTargetPlatform(context)
 
     if system_name:
         args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")
@@ -276,7 +289,7 @@ def GetTBBPatches(context):
                             ("iOS", context.buildTarget),
                             ("IPHONEOS",sdk_name.upper())]
 
-    if context.buildTarget == TARGET_VISIONOS:
+    if context.buildTarget in (TARGET_VISIONOS, TARGET_VISIONOS_SIMULATOR):
         target_config_patches.extend([("iPhone", "XR"),
                                       ("?= 8.0", "?= 1.0")])
 
@@ -284,5 +297,13 @@ def GetTBBPatches(context):
 
     if context.buildTarget == TARGET_VISIONOS:
         clang_config_patches.append(("-miphoneos-version-min=", "-target arm64-apple-xros"))
+    else:
+        sdk_root = GetSDKRoot(context)
+        version=os.path.basename(sdk_root).split("Simulator")[-1].replace(".sdk","")
+
+        if context.buildTarget == TARGET_VISIONOS_SIMULATOR:
+            clang_config_patches.append(("-miphoneos-version-min=", f"-target arm64-apple-xros{version}-simulator"))
+        elif context.buildTarget == TARGET_IOS_SIMULATOR:
+            clang_config_patches.append(("-miphoneos-version-min=", f"-target arm64-apple-ios{version}-simulator"))
 
     return target_config_patches, clang_config_patches

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1035,30 +1035,21 @@ def InstallTBB_MacOS(context, force, buildArgs):
                   "ifeq ($(arch),$(filter $(arch),armv7 armv7s {0}))"
                         .format(apple_utils.GetTargetArmArch()))])
 
-        if context.buildTarget == apple_utils.TARGET_VISIONOS:
-            # Create visionOS config from iOS config
+        if MacOSTargetEmbedded(context) and context.buildTarget != apple_utils.TARGET_IOS:
+            target_config_patches, clang_config_patches  = apple_utils.GetTBBPatches(context)
+            # Create config from iOS config
             shutil.copy(
                 src="build/ios.macos.inc",
-                dst="build/visionos.macos.inc")
+                dst=f"build/{context.buildTarget.lower()}.macos.inc")
 
-            PatchFile("build/visionos.macos.inc",
-                      [("ios","visionos"),
-                       ("iOS", "visionOS"),
-                       ("iPhone", "XR"),
-                       ("IPHONEOS","XROS"),
-                       ("?= 8.0", "?= 1.0")])
+            PatchFile(f"build/{context.buildTarget.lower()}.macos.inc", target_config_patches)
 
             # iOS clang just reuses the macOS one,
             # so it's easier to copy it directly.
             shutil.copy(src="build/macos.clang.inc",
-                        dst="build/visionos.clang.inc")
+                        dst=f"build/{context.buildTarget.lower()}.clang.inc")
 
-            PatchFile("build/visionos.clang.inc",
-                      [("ios","visionos"),
-                       ("-miphoneos-version-min=", "-target arm64-apple-xros"),
-                       ("iOS", "visionOS"),
-                       ("iPhone", "XR"),
-                       ("IPHONEOS","XROS")])
+            PatchFile(f"build/{context.buildTarget.lower()}.clang.inc",clang_config_patches)
 
         (primaryArch, secondaryArch) = apple_utils.GetTargetArchPair(context)
 


### PR DESCRIPTION
### Description of Change(s)

This PR adds support for building for the iOS and visionOS simulator targets. This enables developers to test and run locally without deploying to a device, especially useful if they don't have a device yet.

Requires https://github.com/PixarAnimationStudios/OpenUSD/pull/3706 to be merged first.

Note: Storm does not render in a simulator, but the codepaths still execute. This is due to the limited metal support in Simulator environments. However, since the codepaths still execute, its still valuable to be able to run imaging on a simulator to test other aspects of the build.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
