### PR TITLE
APPLE: Make codesigning improvements

### DIFF
--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -181,11 +181,8 @@ def GetCodeSigningIdentifiers() -> Dict[str, str]:
     XcodeVersion = GetXcodeVersion()[0]
     codeSignIDs = _GetCodeSignStringFromTerminal()
 
-    if not codeSignIDs:
-        return {"-": None}
-
     identifiers = {}
-    for codeSignID in codeSignIDs.splitlines():
+    for codeSignID in (codeSignIDs or "").splitlines():
         if "CSSMERR_TP_CERT_REVOKED" in codeSignID:
             continue
         if ")" not in codeSignID:
@@ -200,9 +197,7 @@ def GetCodeSigningIdentifiers() -> Dict[str, str]:
 
             identifiers[identifier] = identifier_hash
 
-    if not identifiers:
-        raise RuntimeError("Could not find a valid codesigning ID. Try re-logging into your Xcode developer account.")
-
+    identifiers["-"] = None
     return identifiers
 
 
@@ -225,6 +220,8 @@ def GetDevelopmentTeamID(identifier=None):
 
     if not identifier:
         identifier = GetCodeSignID()
+    if identifier == "-":
+        return None
 
     identifier_hash = GetCodeSigningIdentifiers().get(identifier)
     if not identifier_hash:

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -365,6 +365,9 @@ def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
     if TargetEmbeddedOS(context):
         system_name = context.buildTarget
 
+    if context.macOSCodesign:
+        args.append(f"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY={context.macOSCodesign}")
+
     if system_name:
         args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")
         args.append(f"-DCMAKE_OSX_SYSROOT={GetSDKRoot(context)}")

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -4,7 +4,6 @@
 # Licensed under the terms set forth in the LICENSE.txt file available at
 # https://openusd.org/license.
 #
-
 # Utilities for managing Apple OS build concerns.
 #
 # NOTE: This file and its contents may change significantly as we continue
@@ -19,6 +18,7 @@ import re
 import platform
 import shlex
 import subprocess
+import glob
 from typing import Optional, List, Dict
 
 TARGET_NATIVE = "native"
@@ -278,7 +278,7 @@ def Codesign(install_path, identifier=None, force=False, verbose_output=False) -
     if not MacOS():
         return False
 
-    codeSignID = identifier or GetCodeSignID()
+    identifier = identifier or GetCodeSignID()
 
     if verbose_output:
         global devout
@@ -286,22 +286,35 @@ def Codesign(install_path, identifier=None, force=False, verbose_output=False) -
         print(f"Code-signing files in {install_path} with {identifier}", file=devout)
 
     try:
-        team_identifier = GetDevelopmentTeamID(codeSignID)
+        team_identifier = GetDevelopmentTeamID(identifier)
     except:
+        if verbose_output:
+            print("Could not get team_identifier")
         team_identifier = None
 
-    for root, dirs, files in os.walk(install_path, topdown=True):
-        for f in files:
+    codesignPaths = [
+        os.path.join(install_path, 'lib'),
+        os.path.join(install_path, 'plugin'),
+        os.path.join(install_path, 'share/usd'),
+        os.path.join(install_path, "frameworks")
+    ]
+        
+    for basePath in codesignPaths:
+        if not os.path.exists(basePath):
+            continue
 
-            _, ext = os.path.splitext(f)
-            if ext in (".dylib", ".so"):
-                path = os.path.join(root, f)
-                result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force, is_framework=False)
-                if verbose_output:
-                    if result:
-                        print(f"Code-signed binary: {path}")
-                    else:
-                        print(f"Did not code-sign binary: {path}")
+        for root, dirs, files in os.walk(basePath, topdown=True):
+            for f in files:
+
+                _, ext = os.path.splitext(f)
+                if ext in (".dylib", ".so"):
+                    path = os.path.join(root, f)
+                    result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force, is_framework=False)
+                    if verbose_output:
+                        if result:
+                            print(f"Code-signed binary: {path}")
+                        else:
+                            print(f"Did not code-sign binary: {path}")
 
         # Bit annoying to have to do this twice, but seems the fastest way to skip traversing frameworks
         frameworks = [d for d in dirs if d.endswith(".framework")]

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -215,7 +215,7 @@ def GetCodeSignID() -> str:
 
 
 def GetDevelopmentTeamID(identifier=None):
-    if os.environ.get("DEVELOPMENT_TEAM"):
+    if "DEVELOPMENT_TEAM" in os.environ:
         return os.environ.get("DEVELOPMENT_TEAM")
 
     if not identifier:
@@ -243,19 +243,21 @@ def GetDevelopmentTeamID(identifier=None):
     return team
 
 
-def CodesignPath(path, identifier, team_identifier, force=False) -> bool:
+def CodesignPath(path, identifier, team_identifier, force=False, is_framework=False) -> bool:
     resign = force
     if not force:
         codesigning_info = GetCommandOutput(["codesign", "-vd", path])
         if not codesigning_info:
             resign = True
         else:
+            # The output has multiple lines here
             for line in codesigning_info.splitlines():
                 if line.startswith("TeamIdentifier="):
                     current_team_identifier = line.split("=")[-1]
-                    if not team_identifier and "not set" in team_identifier:
+                    if not current_team_identifier or "not set" in current_team_identifier:
+                        resign = True
                         break
-                    elif team_identifier == current_team_identifier:
+                    elif current_team_identifier == team_identifier:
                         break
             else:
                 resign = True
@@ -264,8 +266,8 @@ def CodesignPath(path, identifier, team_identifier, force=False) -> bool:
         return False
 
     # Frameworks need to be signed with different parameters than loose binaries
-    if path.endswith(".framework"):
-        subprocess.check_output(
+    if is_framework:
+        subprocess.check_call(
             ["codesign", "--force", "--sign", identifier, "--generate-entitlement-der", "--verbose", path])
     else:
         subprocess.check_call(["codesign", "--force", "--sign", identifier, path], stdout=devout, stderr=devout)
@@ -294,7 +296,7 @@ def Codesign(install_path, identifier=None, force=False, verbose_output=False) -
             _, ext = os.path.splitext(f)
             if ext in (".dylib", ".so"):
                 path = os.path.join(root, f)
-                result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force)
+                result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force, is_framework=False)
                 if verbose_output:
                     if result:
                         print(f"Code-signed binary: {path}")
@@ -307,7 +309,7 @@ def Codesign(install_path, identifier=None, force=False, verbose_output=False) -
 
         for framework in frameworks:
             path = os.path.join(root, framework)
-            result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force)
+            result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force, is_framework=True)
             if verbose_output:
                 if result:
                     print(f"Code-signed framework: {path}")
@@ -361,9 +363,6 @@ def ConfigureCMakeExtraArgs(context, args:List[str]) -> List[str]:
     system_name = None
     if TargetEmbeddedOS(context):
         system_name = context.buildTarget
-
-    if context.macOSCodesign:
-        args.append(f"-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY={context.macOSCodesign}")
 
     if system_name:
         args.append(f"-DCMAKE_SYSTEM_NAME={system_name}")

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -308,6 +308,9 @@ def Codesign(install_path, identifier=None, force=False, verbose_output=False) -
         dirs[:] = [d for d in dirs if not d.endswith(".framework")]
 
         for framework in frameworks:
+            framework_name = os.path.splitext(framework)[0]
+            if framework_name.lower() not in ["openusd", "opensubdiv", "materialx"]:
+                continue
             path = os.path.join(root, framework)
             result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force, is_framework=True)
             if verbose_output:

--- a/build_scripts/apple_utils.py
+++ b/build_scripts/apple_utils.py
@@ -15,10 +15,11 @@
 import sys
 import locale
 import os
+import re
 import platform
 import shlex
 import subprocess
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 TARGET_NATIVE = "native"
 TARGET_X86 = "x86_64"
@@ -115,10 +116,8 @@ def GetTargetArchPair(context):
 def SupportsMacOSUniversalBinaries():
     if not MacOS():
         return False
-    XcodeOutput = GetCommandOutput(["/usr/bin/xcodebuild", "-version"])
-    XcodeFind = XcodeOutput.rfind('Xcode ', 0, len(XcodeOutput))
-    XcodeVersion = XcodeOutput[XcodeFind:].split(' ')[1]
-    return (XcodeVersion > '11.0')
+    XcodeVersion = GetXcodeVersion()[0]
+    return (XcodeVersion > 11)
 
 def GetSDKRoot(context) -> Optional[str]:
     sdk = "macosx"
@@ -163,36 +162,162 @@ def ExtractFilesRecursive(path, cond):
                 files.append(os.path.join(r, file))
     return files
 
-def CodesignFiles(files):
-    SDKVersion  = subprocess.check_output(
-        ['xcodebuild', '-version']).strip()[6:10]
-    codeSignIDs = subprocess.check_output(
-        ['security', 'find-identity', '-vp', 'codesigning'])
+def _GetCodeSignStringFromTerminal():
+    """Return the output from the string codesigning variables"""
+    codeSignIDs = GetCommandOutput(['security', 'find-identity', '-vp', 'codesigning'])
+    return codeSignIDs
 
-    codeSignID = "-"
-    if os.environ.get('CODE_SIGN_ID'):
-        codeSignID = os.environ.get('CODE_SIGN_ID')
-    elif float(SDKVersion) >= 11.0 and \
-                codeSignIDs.find(b'Apple Development') != -1:
-        codeSignID = "Apple Development"
-    elif codeSignIDs.find(b'Mac Developer') != -1:
-        codeSignID = "Mac Developer"
 
-    for f in files:
-        subprocess.call(['codesign', '-f', '-s', '{codesignid}'
-                              .format(codesignid=codeSignID), f],
-                        stdout=devout, stderr=devout)
+def GetXcodeVersion():
+    output = GetCommandOutput(['xcodebuild', '-version']).split()
+    version = float(output[1])
+    build = output[-1]
 
-def Codesign(install_path, verbose_output=False):
+    return version, build
+
+
+def GetCodeSigningIdentifiers() -> Dict[str, str]:
+    """Returns a dictionary of codesigning identifiers and their hashes"""
+    XcodeVersion = GetXcodeVersion()[0]
+    codeSignIDs = _GetCodeSignStringFromTerminal()
+
+    if not codeSignIDs:
+        return {"-": None}
+
+    identifiers = {}
+    for codeSignID in codeSignIDs.splitlines():
+        if "CSSMERR_TP_CERT_REVOKED" in codeSignID:
+            continue
+        if ")" not in codeSignID:
+            continue
+        if (XcodeVersion >= 11 and "Apple Development" in codeSignID) or "Mac Developer" in codeSignID:
+            identifier = codeSignID.split()[1]
+            identifier_hash = re.search(r'\(.*?\)', codeSignID)
+            if identifier_hash:
+                identifier_hash = identifier_hash[0][1:-1]
+            else:
+                identifier_hash = None
+
+            identifiers[identifier] = identifier_hash
+
+    if not identifiers:
+        raise RuntimeError("Could not find a valid codesigning ID. Try re-logging into your Xcode developer account.")
+
+    return identifiers
+
+
+def GetCodeSignID() -> str:
+    """Return the first code signing identifier"""
+    identifiers = GetCodeSigningIdentifiers()
+    env_signing_id = os.environ.get('CODE_SIGN_ID')
+    if env_signing_id:
+        if env_signing_id in identifiers:
+            return env_signing_id
+        raise RuntimeError(
+            f"Could not find environment specified identifier {env_signing_id} in registered code signing identifiers")
+
+    return list(GetCodeSigningIdentifiers().keys())[0]
+
+
+def GetDevelopmentTeamID(identifier=None):
+    if os.environ.get("DEVELOPMENT_TEAM"):
+        return os.environ.get("DEVELOPMENT_TEAM")
+
+    if not identifier:
+        identifier = GetCodeSignID()
+
+    identifier_hash = GetCodeSigningIdentifiers().get(identifier)
+    if not identifier_hash:
+        raise RuntimeError("Could not get identifiers hash")
+
+    certs = subprocess.check_output(["security", "find-certificate", "-c", identifier_hash, "-p"])
+    subject = GetCommandOutput(["openssl", "x509", "-subject"], input=certs)
+    subject = subject.splitlines()[0]
+    match = re.search("OU\s*=\s*(?P<team>([A-Za-z0-9_])+)", subject)
+    if not match:
+        raise RuntimeError("Could not parse the output certificate to find the team ID")
+
+    groups = match.groupdict()
+    team = groups.get("team")
+
+    if not team:
+        raise RuntimeError("Could not extract team id from certificate")
+
+    return team
+
+
+def CodesignPath(path, identifier, team_identifier, force=False) -> bool:
+    resign = force
+    if not force:
+        codesigning_info = GetCommandOutput(["codesign", "-vd", path])
+        if not codesigning_info:
+            resign = True
+        else:
+            for line in codesigning_info.splitlines():
+                if line.startswith("TeamIdentifier="):
+                    current_team_identifier = line.split("=")[-1]
+                    if not team_identifier and "not set" in team_identifier:
+                        break
+                    elif team_identifier == current_team_identifier:
+                        break
+            else:
+                resign = True
+
+    if not resign:
+        return False
+
+    # Frameworks need to be signed with different parameters than loose binaries
+    if path.endswith(".framework"):
+        subprocess.check_output(
+            ["codesign", "--force", "--sign", identifier, "--generate-entitlement-der", "--verbose", path])
+    else:
+        subprocess.check_call(["codesign", "--force", "--sign", identifier, path], stdout=devout, stderr=devout)
+    return True
+
+
+def Codesign(install_path, identifier=None, force=False, verbose_output=False) -> bool:
     if not MacOS():
         return False
+
+    codeSignID = identifier or GetCodeSignID()
+
     if verbose_output:
         global devout
         devout = sys.stdout
+        print(f"Code-signing files in {install_path} with {identifier}", file=devout)
 
-    files = ExtractFilesRecursive(install_path,
-                 (lambda file: '.so' in file or '.dylib' in file))
-    CodesignFiles(files)
+    try:
+        team_identifier = GetDevelopmentTeamID(codeSignID)
+    except:
+        team_identifier = None
+
+    for root, dirs, files in os.walk(install_path, topdown=True):
+        for f in files:
+
+            _, ext = os.path.splitext(f)
+            if ext in (".dylib", ".so"):
+                path = os.path.join(root, f)
+                result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force)
+                if verbose_output:
+                    if result:
+                        print(f"Code-signed binary: {path}")
+                    else:
+                        print(f"Did not code-sign binary: {path}")
+
+        # Bit annoying to have to do this twice, but seems the fastest way to skip traversing frameworks
+        frameworks = [d for d in dirs if d.endswith(".framework")]
+        dirs[:] = [d for d in dirs if not d.endswith(".framework")]
+
+        for framework in frameworks:
+            path = os.path.join(root, framework)
+            result = CodesignPath(path, identifier, team_identifier=team_identifier, force=force)
+            if verbose_output:
+                if result:
+                    print(f"Code-signed framework: {path}")
+                else:
+                    print(f"Did not code-sign framework: {path}")
+
+    return True
 
 def CreateUniversalBinaries(context, libNames, x86Dir, armDir):
     if not MacOS():

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2082,6 +2082,7 @@ if MacOS():
                        default=codesignDefault, action="store_true",
                        help=("Enable code signing for macOS builds "
                              "(defaults to enabled on Apple Silicon)"))
+    group.add_argument("--codesign-id", dest="macos_codesign_id", type=str)
 
 if Linux():
     group.add_argument("--use-cxx11-abi", type=int, choices=[0, 1],
@@ -2392,9 +2393,9 @@ class InstallContext:
         if MacOS():
             apple_utils.SetTarget(self, self.buildTarget)
 
-            self.macOSCodesign = \
-                (args.macos_codesign if hasattr(args, "macos_codesign")
-                 else False)
+            self.macOSCodesign = False
+            if args.macos_codesign:
+                self.macOSCodesign = args.macos_codesign_id or apple_utils.GetCodeSignID()
             if apple_utils.IsHostArm() and args.ignore_homebrew:
                 self.ignorePaths.append("/opt/homebrew")
         else:
@@ -2977,7 +2978,9 @@ if Windows():
 
 if MacOS():
     if context.macOSCodesign:
-        apple_utils.Codesign(context.usdInstDir, verbosity > 1)
+        apple_utils.Codesign(context.usdInstDir,
+                             identifier=context.macOSCodesign,
+                             verbose_output=verbosity > 1)
 
 additionalInstructions = any([context.buildPython, context.buildTools, context.buildPrman])
 if additionalInstructions:

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2082,7 +2082,8 @@ if MacOS():
                        default=codesignDefault, action="store_true",
                        help=("Enable code signing for macOS builds "
                              "(defaults to enabled on Apple Silicon)"))
-    group.add_argument("--codesign-id", dest="macos_codesign_id", type=str)
+    group.add_argument("--codesign-id", dest="macos_codesign_id", type=str,
+                       help="A specific code-sign ID to use. If not provided, the build will try and find one or use '-'")
 
 if Linux():
     group.add_argument("--use-cxx11-abi", type=int, choices=[0, 1],


### PR DESCRIPTION
### Description of Change(s)

This PR overhauls the current code signing setup with the following changes:

1. Developers can now pass in code signing identifiers directly to the build_usd.py script.
2. Codesigning identifiers are now passed to CMake for Xcode targets if they want to sign anything.
3. The code signing identifier is calculated less often
4. Codesigning now supports signing frameworks
5. Codesigning supports checking previous signing status and only re-signing as needed. Note: Since USD's cmake always installs all targets again, they're always re-signed. Future work might help optimize this, but at the least we're not re-signing every dependency.
6. Codesigning is validated earlier to prevent running through a whole build just to find code signing fails

This makes code signing much more reliable and faster overall. 

This work is needed to enable properly building OpenUSD as a framework

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
