### PR TITLE
APPLE: Ignore Homebrew by default

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -1970,8 +1970,12 @@ if MacOS():
     if apple_utils.IsHostArm():
         # Intel Homebrew stores packages in /usr/local which unfortunately can
         # be where a lot of other things are too. So we only add this flag on arm macs.
-        group.add_argument("--ignore-homebrew", action="store_true",
-                           help="Specify that CMake should ignore Homebrew packages.")
+        subgroup = group.add_mutually_exclusive_group()
+        # Provided to avoid breaking automation scripts that may have specified it.
+        subgroup.add_argument("--ignore-homebrew", action="store_true", dest="ignore_homebrew",
+                           help="Specify that CMake should ignore Homebrew packages.", default=True)
+        subgroup.add_argument("--allow-homebrew", action="store_false", dest="ignore_homebrew",
+                           help="Specify that CMake should allow searching Homebrew packages.")
 
 group.add_argument("--build-args", type=str, nargs="*", default=[],
                    help=("Custom arguments to pass to build system when "


### PR DESCRIPTION
### Description of Change(s)

We still often get a lot of people who hit issues because they forgot to `--ignore-homebrew`, so we feel its best to make that the default, and instead only allow people to opt-in to home-brew when requested.

For a standard build of USD, this provides the least problematic experience.


### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
