### PR TITLE
Autodesk: Rprims dirtybits/locators custom translator

### DIFF
--- a/pxr/imaging/hd/dirtyBitsTranslator.cpp
+++ b/pxr/imaging/hd/dirtyBitsTranslator.cpp
@@ -80,6 +80,9 @@ using _BToSMap = std::unordered_map<TfToken,
 
 static TfStaticData<_SToBMap> Hd_SPrimSToBFncs;
 static TfStaticData<_BToSMap> Hd_SPrimBToSFncs;
+static TfStaticData<_SToBMap> Hd_RPrimSToBFncs;
+static TfStaticData<_BToSMap> Hd_RPrimBToSFncs;
+
 
 /*static*/
 void
@@ -217,6 +220,14 @@ HdDirtyBitsTranslator::RprimDirtyBitsToLocatorSet(TfToken const& primType,
 
     if (bits & HdChangeTracker::DirtyTransform) {
         set->append(HdXformSchema::GetDefaultLocator());
+    }
+
+    if (!Hd_RPrimBToSFncs->empty()) {
+        const auto fncIt = Hd_RPrimBToSFncs->find(primType);
+        if (fncIt != Hd_RPrimBToSFncs->end()) {
+            // call custom handler registered for this type
+            fncIt->second(bits, set);
+        }
     }
 }
 
@@ -794,7 +805,15 @@ HdDirtyBitsTranslator::RprimLocatorSetToDirtyBits(
     if (_FindLocator(HdXformSchema::GetDefaultLocator(), end, &it)) {
         bits |= HdChangeTracker::DirtyTransform;
     }
-
+    
+    if (!Hd_RPrimSToBFncs->empty())
+    {
+        const auto fncIt = Hd_RPrimSToBFncs->find(primType);
+        if (fncIt != Hd_RPrimSToBFncs->end()) {
+            // call custom handler registered for this type
+            fncIt->second(set, &bits);
+        }
+    }
     return bits;
 }
 
@@ -1175,6 +1194,16 @@ HdDirtyBitsTranslator::RegisterTranslatorsForCustomSprimType(
 {
     Hd_SPrimSToBFncs->insert({primType, sToBFnc});
     Hd_SPrimBToSFncs->insert({primType, bToSFnc});
+}
+
+void
+HdDirtyBitsTranslator::RegisterTranslatorsForCustomRprimType(
+    TfToken const& primType,
+    LocatorSetToDirtyBitsFnc sToBFnc,
+    DirtyBitsToLocatorSetFnc bToSFnc)
+{
+    Hd_RPrimSToBFncs->insert({primType, sToBFnc});
+    Hd_RPrimBToSFncs->insert({primType, bToSFnc});
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hd/dirtyBitsTranslator.h
+++ b/pxr/imaging/hd/dirtyBitsTranslator.h
@@ -69,6 +69,10 @@ public:
     static void RegisterTranslatorsForCustomSprimType(TfToken const& primType,
         LocatorSetToDirtyBitsFnc sToBFnc, DirtyBitsToLocatorSetFnc bToSFnc);
 
+    /// Allows for customization of translation for rprim types.
+    HD_API
+    static void RegisterTranslatorsForCustomRprimType(TfToken const& primType,
+        LocatorSetToDirtyBitsFnc sToBFnc, DirtyBitsToLocatorSetFnc bToSFnc);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hd/testenv/testHdDirtyBitsTranslator.cpp
+++ b/pxr/imaging/hd/testenv/testHdDirtyBitsTranslator.cpp
@@ -110,6 +110,42 @@ TestCustomSprimTypes()
     return true;
 }
 
+bool
+TestCustomRprimTypes()
+{
+    // This call would normally go in the type registry for something like a
+    // prim adapter, render delegate or scene delegate (who might care deeply
+    // about the dirtiness of tacos)
+    HdDirtyBitsTranslator::RegisterTranslatorsForCustomRprimType(
+        _tokens->taco,
+        _ConvertLocatorSetToDirtyBitsForTacos,
+        _ConvertDirtyBitsToLocatorSetForTacos);
+
+    // confirm that dirtying an unrelated locator does not dirty a taco
+    HdDataSourceLocatorSet dirtyStuff(HdCameraSchema::GetDefaultLocator());
+
+    if (HdDirtyBitsTranslator::RprimLocatorSetToDirtyBits(
+            _tokens->taco, dirtyStuff) != HdChangeTracker::Clean) {
+        std::cerr << "Expected clean taco." << std::endl;
+        return false;
+    }
+
+    // test round trip of bits
+    HdDirtyBits bits = DirtyTortilla | DirtyProtein;
+    HdDataSourceLocatorSet set;
+    HdDirtyBitsTranslator::RprimDirtyBitsToLocatorSet(
+        _tokens->taco, bits, &set);
+
+    if (HdDirtyBitsTranslator::RprimLocatorSetToDirtyBits(_tokens->taco, set)
+            != bits) {
+        std::cerr << "Roundtrip of dirty taco doesn't match." << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+
 //-----------------------------------------------------------------------------
 
 #define xstr(s) str(s)
@@ -125,7 +161,7 @@ int main(int argc, char**argv)
 
     int i = 0;
     TEST(TestCustomSprimTypes);
-
+    TEST(TestCustomRprimTypes);
     // ------------------------------------------------------------------------
     std::cout << "DONE testHdDirtyBitsTranslator: SUCCESS" << std::endl;
     return 0;


### PR DESCRIPTION
### Description of Change(s)

This PR allows to register custom translators between dirtybits and locators for Rprims. It mimics the logic used for Sprims, except that if the prim type is not found there will be no invalidation.

This was discussed in more details here: https://forum.aousd.org/t/scene-index-invalidation-of-custom-prim-types/2544

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/3694

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
