### PR TITLE
Fix Doxygen exclusion of ArchVStringPrintf.

### DIFF
--- a/pxr/base/arch/vsnprintf.h
+++ b/pxr/base/arch/vsnprintf.h
@@ -78,8 +78,8 @@ ARCH_API
 std::string ArchVStringPrintf(const char *fmt, va_list ap)
 #ifndef doxygen
     ARCH_PRINTF_FUNCTION(1, 0)
+#endif /* doxygen */
     ;
-#endif
 
 /// @}
 


### PR DESCRIPTION
### Description of Change(s)

The `ARCH_PRINTF_FUNCTION` macro was conditionally compiled with a misplaced
`#endif`, causing Doxygen to exclude the `ArchVStringPrintf` declaration entirely.

### Fixes Issue(s)

Fixes #3723 

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
