### PR TITLE
Apple: Fix EXR write compression artifacts

### DIFF
--- a/pxr/imaging/hio/OpenEXR/openexr-c.c
+++ b/pxr/imaging/hio/OpenEXR/openexr-c.c
@@ -355,7 +355,8 @@ exr_result_t nanoexr_write_exr(
     exr_set_longname_support(exr, 1);
 
     /// XXX In the future Hio may be able to specify compression levels
-    result = exr_set_zip_compression_level(exr, 0, 4);
+    /// For now, we disable compression if less than 4 channels are written
+    result = exr_set_zip_compression_level(exr, 0, channelCount == 4 ? 4 : 0);
     if (result != EXR_ERR_SUCCESS) {
         return result;
     }


### PR DESCRIPTION
### Description of Change(s)

We were finding that the EXR write out would often have weird artifacts like the red lines below if we wrote RGB instead of RGBA.

<img width="2092" height="646" alt="image" src="https://github.com/user-attachments/assets/2e5cb6a8-a474-4981-9a17-eddeb82301fc" />

As such, we disable compression if writing fewer than 4 channels.
I couldn't think of a good way to test this unfortunately, so I don't have a test but I'm happy to add one if someone could think of something.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
