### PR TITLE
Autodesk: [hdSt] Fix `CRLF` diffs in codegen unit tests on Windows

### DIFF
--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -162,7 +162,7 @@ def _diff(fileName, baselineDir, verbose, failuresDir=None):
     isWindows = platform.system() == 'Windows'
 
     diffTool = shutil.which('diff')
-    diffToolBaseArgs = ['--strip-trailing-cr']
+    diffToolBaseArgs = []
     if not diffTool and isWindows:
         diffTool = 'fc.exe'
         diffToolBaseArgs = ['/t']

--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -238,7 +238,7 @@ pxr_build_test(testHdStBasicDrawing
 )
 endif()
 
-if (X11_FOUND)
+if (X11_FOUND OR PXR_ENABLE_VULKAN_SUPPORT)
 pxr_build_test(testHdStBarAllocationLimit
     LIBRARIES
         hdSt
@@ -626,6 +626,111 @@ pxr_register_test(testHdStQualifiers
         TF_DEBUG=HD_SAFE_MODE
 )
 
+function(register_codegen_tests suffix hgi_env)
+    pxr_install_test_dir(
+        SRC testenv/testHdStCodeGen${suffix}
+        DEST testHdStCodeGen${suffix}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_indirect.out
+        DIFF_COMPARE codegen_mesh_indirect.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_SmoothNormals
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --smoothNormals"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_indirect_smoothNormals.out
+        DIFF_COMPARE codegen_mesh_indirect_smoothNormals.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_DoubleSided
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --doubleSided"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_indirect_doubleSided.out
+        DIFF_COMPARE codegen_mesh_indirect_doubleSided.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_FaceVarying
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --faceVarying"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_indirect_faceVarying.out
+        DIFF_COMPARE codegen_mesh_indirect_faceVarying.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_Instance
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --instance"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_indirect_instance.out
+        DIFF_COMPARE codegen_mesh_indirect_instance.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_EdgeOnly
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --edgeOnly"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_edgeonly.out
+        DIFF_COMPARE codegen_mesh_edgeonly.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Mesh_EdgeOnly_BlendWireframe
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --edgeOnly --blendWireframe"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_mesh_edgeonly_blendwireframe.out
+        DIFF_COMPARE codegen_mesh_edgeonly_blendwireframe.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Curves_Indirect
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --curves"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_curves_indirect.out
+        DIFF_COMPARE codegen_curves_indirect.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+    pxr_register_test(testHdStCodeGen${suffix}_Points_Indirect
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --points"
+        EXPECTED_RETURN_CODE 0
+        STDOUT_REDIRECT codegen_points_indirect.out
+        DIFF_COMPARE codegen_points_indirect.out
+        TESTENV testHdStCodeGen${suffix}
+        ENV
+            TF_DEBUG=HD_SAFE_MODE
+            ${hgi_env}
+    )
+endfunction()
+
+# OpenGL codegen tests require X11 to create a context
+if(PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
+    register_codegen_tests(_GL "HGI_ENABLE_VULKAN=0;HGIGL_ENABLE_BINDLESS_BUFFER=1;HGIGL_ENABLE_BINDLESS_TEXTURE=1;HGIGL_GLSL_VERSION=450")
+endif()
+if(PXR_ENABLE_VULKAN_SUPPORT)
+    register_codegen_tests(_Vulkan "HGI_ENABLE_VULKAN=1;")
+endif()
+
 if (APPLE)
     message(STATUS "Skipping rest of ${PXR_PACKAGE} tests because they are currently unsupported on macOS")
     return()
@@ -666,14 +771,6 @@ pxr_install_test_dir(
 pxr_install_test_dir(
     SRC testenv/testHdStClipPlanes
     DEST testHdStClipPlanes
-)
-pxr_install_test_dir(
-    SRC testenv/testHdStCodeGen_GL
-    DEST testHdStCodeGen_GL
-)
-pxr_install_test_dir(
-    SRC testenv/testHdStCodeGen_Vulkan
-    DEST testHdStCodeGen_Vulkan
 )
 pxr_install_test_dir(
     SRC testenv/testHdStCurveDrawing
@@ -2378,106 +2475,6 @@ pxr_register_test(testHdStClipPlanes2
     ENV
         TF_DEBUG=HD_SAFE_MODE
 )
-
-function(register_codegen_tests suffix hgi_env)
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_indirect.out
-        DIFF_COMPARE codegen_mesh_indirect.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_SmoothNormals
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --smoothNormals"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_indirect_smoothNormals.out
-        DIFF_COMPARE codegen_mesh_indirect_smoothNormals.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_DoubleSided
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --doubleSided"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_indirect_doubleSided.out
-        DIFF_COMPARE codegen_mesh_indirect_doubleSided.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_FaceVarying
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --faceVarying"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_indirect_faceVarying.out
-        DIFF_COMPARE codegen_mesh_indirect_faceVarying.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_Indirect_Instance
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --instance"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_indirect_instance.out
-        DIFF_COMPARE codegen_mesh_indirect_instance.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_EdgeOnly
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --edgeOnly"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_edgeonly.out
-        DIFF_COMPARE codegen_mesh_edgeonly.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Mesh_EdgeOnly_BlendWireframe
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --mesh --edgeOnly --blendWireframe"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_mesh_edgeonly_blendwireframe.out
-        DIFF_COMPARE codegen_mesh_edgeonly_blendwireframe.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Curves_Indirect
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --curves"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_curves_indirect.out
-        DIFF_COMPARE codegen_curves_indirect.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-    pxr_register_test(testHdStCodeGen${suffix}_Points_Indirect
-        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCodeGen --points"
-        EXPECTED_RETURN_CODE 0
-        STDOUT_REDIRECT codegen_points_indirect.out
-        DIFF_COMPARE codegen_points_indirect.out
-        TESTENV testHdStCodeGen${suffix}
-        ENV
-            TF_DEBUG=HD_SAFE_MODE
-            ${hgi_env}
-    )
-endfunction()
-# OpenGL codegen tests require X11 to create a context
-if(PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
-    register_codegen_tests(_GL "HGI_ENABLE_VULKAN=0;HGIGL_ENABLE_BINDLESS_BUFFER=1;HGIGL_ENABLE_BINDLESS_TEXTURE=1;HGIGL_GLSL_VERSION=450")
-endif()
-if(PXR_ENABLE_VULKAN_SUPPORT)
-    register_codegen_tests(_Vulkan "HGI_ENABLE_VULKAN=1;")
-endif()
 
 pxr_register_test(testHdStCurveDrawing_lv0_refined
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStCurveDrawing --offscreen --repr refined --refineLevel 0 --write testHdStCurveDrawing_lv0_refined.png"

--- a/pxr/imaging/hdSt/testenv/.gitattributes
+++ b/pxr/imaging/hdSt/testenv/.gitattributes
@@ -1,0 +1,1 @@
+*.out		text


### PR DESCRIPTION
### Description of Change(s)

This PR reworks the handling of line-ending differences between platforms in codegen tests with a Git mechanism. This fixes test failures in Windows configurations where the `diff` tool is missing. As a way to verify the change, the `testHdStCodeGen` tests are enabled for Vulkan on Windows.

The original motivation for this work was to enable `testHdStMaterialXShaderGen` tests across multiple platforms, but those will have to wait for other fixes and a MaterialX update, which will finally remove all differences between platforms in the code generated by MaterialX.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
