### PR TITLE
Autodesk: [hdSt] Make the order of MaterialX texture uniforms consistent across platforms

### DIFF
--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -426,14 +426,14 @@ _AddFallbackDomeLightTextureNode(
 }
 
 // Store texture node connections, default dome light texture path and any
-// filename inputs from the terminal nodeto the mxHdTextureMap
+// filename inputs from the terminal node to the mxHdTextureMap
 static void 
 _UpdateMxHdTextureMap(
     std::set<SdfPath> const& hdTextureNodes,
     HdMtlxTexturePrimvarData::TextureMap const& hdMtlxTextureInfo,
     HdMaterialNode2 const& hdTerminalNode,
     SdfPath const& hdTerminalNodePath,
-    mx::StringMap* mxHdTextureMap)
+    std::map<std::string, std::string>* mxHdTextureMap)
 {
     // Store the added connection to the terminal node for MaterialXShaderGen
     for (SdfPath const& texturePath : hdTextureNodes) {
@@ -1267,11 +1267,11 @@ _GenerateMaterialXShader(
     // get generated in MaterialXShaderGen
     _UpdateMxHdTextureMap(
         hdMtlxData.hdTextureNodes, hdMtlxData.mxHdTextureMap,
-        terminalNode, terminalNodePath, &mxHdInfo.textureMap);
+        terminalNode, terminalNodePath, &mxHdInfo.mxHdTextureMap);
 
     _UpdatePrimvarNodes(
         mtlxDoc, hdNetwork, hdMtlxData.hdPrimvarNodes, 
-        &mxHdInfo.primvarMap, &mxHdInfo.primvarDefaultValueMap);
+        &mxHdInfo.mxHdPrimvarMap, &mxHdInfo.mxHdPrimvarDefaultValueMap);
 
     mxHdInfo.materialTag = materialTagToken.GetString();
     mxHdInfo.bindlessTexturesEnabled = bindlessTexturesEnabled;

--- a/pxr/imaging/hdSt/materialXFilter.h
+++ b/pxr/imaging/hdSt/materialXFilter.h
@@ -21,15 +21,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 // Storing MaterialX-Hydra counterparts and other Hydra specific information
 struct HdSt_MxShaderGenInfo {
     HdSt_MxShaderGenInfo() 
-        : textureMap(MaterialX::StringMap()), 
-          primvarMap(MaterialX::StringMap()), 
-          primvarDefaultValueMap(MaterialX::StringMap()), 
-          defaultTexcoordName("st"),
+        : defaultTexcoordName("st"),
           materialTag(HdStMaterialTagTokens->defaultMaterialTag.GetString()),
           bindlessTexturesEnabled(false) {}
-    MaterialX::StringMap textureMap;
-    MaterialX::StringMap primvarMap;
-    MaterialX::StringMap primvarDefaultValueMap;
+
+    std::map<std::string, std::string> mxHdTextureMap;
+    MaterialX::StringMap mxHdPrimvarMap;
+    MaterialX::StringMap mxHdPrimvarDefaultValueMap;
     std::string defaultTexcoordName;
     std::string materialTag;
     bool bindlessTexturesEnabled;

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -887,9 +887,9 @@ HdStMaterialXShaderGen<mx::GlslShaderGenerator>::HdStMaterialXShaderGen(
 #else
     : mx::GlslShaderGenerator(mx::TypeSystem::create()),
 #endif
-      _mxHdTextureMap(mxHdInfo.textureMap),
-      _mxHdPrimvarMap(mxHdInfo.primvarMap),
-      _mxHdPrimvarDefaultValueMap(mxHdInfo.primvarDefaultValueMap),
+      _mxHdTextureMap(mxHdInfo.mxHdTextureMap),
+      _mxHdPrimvarMap(mxHdInfo.mxHdPrimvarMap),
+      _mxHdPrimvarDefaultValueMap(mxHdInfo.mxHdPrimvarDefaultValueMap),
       _materialTag(mxHdInfo.materialTag),
       _bindlessTexturesEnabled(mxHdInfo.bindlessTexturesEnabled),
       _emittingSurfaceNode(false)
@@ -1046,9 +1046,9 @@ HdStMaterialXShaderGen<mx::VkShaderGenerator>::HdStMaterialXShaderGen(
 #else
     : mx::VkShaderGenerator(mx::TypeSystem::create()),
 #endif
-      _mxHdTextureMap(mxHdInfo.textureMap),
-      _mxHdPrimvarMap(mxHdInfo.primvarMap),
-      _mxHdPrimvarDefaultValueMap(mxHdInfo.primvarDefaultValueMap),
+      _mxHdTextureMap(mxHdInfo.mxHdTextureMap),
+      _mxHdPrimvarMap(mxHdInfo.mxHdPrimvarMap),
+      _mxHdPrimvarDefaultValueMap(mxHdInfo.mxHdPrimvarDefaultValueMap),
       _materialTag(mxHdInfo.materialTag),
       _bindlessTexturesEnabled(mxHdInfo.bindlessTexturesEnabled),
       _emittingSurfaceNode(false)
@@ -1204,9 +1204,9 @@ HdStMaterialXShaderGen<mx::MslShaderGenerator>::HdStMaterialXShaderGen(
 #else
     : mx::MslShaderGenerator(mx::TypeSystem::create()),
 #endif
-      _mxHdTextureMap(mxHdInfo.textureMap),
-      _mxHdPrimvarMap(mxHdInfo.primvarMap),
-      _mxHdPrimvarDefaultValueMap(mxHdInfo.primvarDefaultValueMap),
+      _mxHdTextureMap(mxHdInfo.mxHdTextureMap),
+      _mxHdPrimvarMap(mxHdInfo.mxHdPrimvarMap),
+      _mxHdPrimvarDefaultValueMap(mxHdInfo.mxHdPrimvarDefaultValueMap),
       _materialTag(mxHdInfo.materialTag),
       _bindlessTexturesEnabled(mxHdInfo.bindlessTexturesEnabled),
       _emittingSurfaceNode(false)

--- a/pxr/imaging/hdSt/materialXShaderGen.h
+++ b/pxr/imaging/hdSt/materialXShaderGen.h
@@ -13,6 +13,8 @@
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 #include <MaterialXGenGlsl/VkShaderGenerator.h>
 
+#include <map>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 struct HdSt_MxShaderGenInfo;
@@ -88,7 +90,7 @@ protected:
     // Store MaterialX and Hydra counterparts and other Hydra specific info
     // to generate an appropriate glslfx header and properly initialize 
     // MaterialX values.
-    MaterialX::StringMap _mxHdTextureMap;
+    std::map<std::string, std::string> _mxHdTextureMap;
     MaterialX::StringMap _mxHdPrimvarMap;
     MaterialX::StringMap _mxHdPrimvarDefaultValueMap;
     std::string _defaultTexcoordName;

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
             if (npos != std::string::npos) {
                 const std::string mx = textureMap.substr(0, npos);
                 const std::string hd = textureMap.substr(npos + 1);
-                mxHdInfo.textureMap[mx] = hd;
+                mxHdInfo.mxHdTextureMap[mx] = hd;
             }
             else {
                 std::cerr << "textureMap input not formatted correctly.\n";
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
             if (npos != std::string::npos) {
                 const std::string name = primvarMap.substr(0, npos);
                 const std::string type = primvarMap.substr(npos + 1);
-                mxHdInfo.primvarMap[name] = type;
+                mxHdInfo.mxHdPrimvarMap[name] = type;
             }
             else {
                 std::cerr << "primvarMap input not formatted correctly.\n";

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_SStextured.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_SStextured.out
@@ -15,9 +15,9 @@
         }
     }, 
     "textures": {
-        "roughness": {
-        },
         "diffuseColor": {
+        },
+        "roughness": {
         }
     }, 
     "techniques": {
@@ -157,8 +157,8 @@ int u_numActiveLightSources = 0;
 #endif
 
 // Define MaterialX to Hydra Sampler mappings
-#define image_roughness_file HdGetSampler_roughness()
 #define image_color_file HdGetSampler_diffuseColor()
+#define image_roughness_file HdGetSampler_roughness()
 
 struct LightData
 {

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_SStextured_bindless.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_SStextured_bindless.out
@@ -15,9 +15,9 @@
         }
     }, 
     "textures": {
-        "roughness": {
-        },
         "diffuseColor": {
+        },
+        "roughness": {
         }
     }, 
     "techniques": {
@@ -273,8 +273,8 @@ void mxInit(vec4 Peye, vec3 Neye)
     u_envRadianceMips = textureQueryLevels(u_envRadiance);
 
     // Initialize Material Textures
-    image_roughness_file = HdGetSampler_roughness();
     image_color_file = HdGetSampler_diffuseColor();
+    image_roughness_file = HdGetSampler_roughness();
 
     mat4 hdTransformationMatrix = mat4(1.0);
 #if NUM_LIGHTS > 0

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPStextured.out
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/baseline/shadergen_UsdPStextured.out
@@ -10,9 +10,9 @@
         "materialTag": "defaultMaterialTag"
     }, 
     "textures": {
-        "roughness": {
-        },
         "diffuseColor": {
+        },
+        "roughness": {
         }
     }, 
     "techniques": {
@@ -130,8 +130,8 @@ int u_numActiveLightSources = 0;
 #endif
 
 // Define MaterialX to Hydra Sampler mappings
-#define image_roughness_file HdGetSampler_roughness()
 #define image_color_file HdGetSampler_diffuseColor()
+#define image_roughness_file HdGetSampler_roughness()
 
 struct LightData
 {


### PR DESCRIPTION
### Description of Change(s)

While investigating the possibility of enabling the [testHdStMaterialXShaderGen](https://github.com/PixarAnimationStudios/OpenUSD/blob/dev/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp) tests across multiple platforms, we realized that the generated code differs between platforms due to an `std::unordered_map`. This PR fixes that situation.

Actually enabling [testHdStMaterialXShaderGen](https://github.com/PixarAnimationStudios/OpenUSD/blob/dev/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp) on more platforms will have to wait until USD is upgraded to a new MaterialX version because of a similar problem fixed on the MaterialX side: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2462

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
