### PR TITLE
Ensure MakeStaticCopy is fully recursive

### DIFF
--- a/pxr/imaging/hd/retainedDataSource.cpp
+++ b/pxr/imaging/hd/retainedDataSource.cpp
@@ -422,7 +422,7 @@ _MakeStaticCopy(HdVectorDataSourceHandle const &ds)
     std::vector<HdDataSourceBaseHandle> values;
     values.reserve(n);
     for (size_t i = 0; i < n; ++i) {
-        values.push_back(ds->GetElement(i));
+        values.push_back(HdMakeStaticCopy(ds->GetElement(i)));
     }
     return HdRetainedSmallVectorDataSource::New(n, values.data());
 }


### PR DESCRIPTION
### Description of Change(s)

MakeStaticCopy would previously switch to a shallow copy when it hit a VectorDataSource. This change ensures we continue with the deep copy.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
