### PR TITLE
Support for disabling complex macro TF_DECLARE_PUBLIC_TOKENS for intellisense

### DIFF
--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -70,6 +70,7 @@
 /// PRIVATE, you only need to use the DEFINE macro.
 
 #include "pxr/pxr.h"
+#include "pxr/base/arch/defines.h"
 #include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/staticData.h"
 #include "pxr/base/tf/token.h"

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -95,7 +95,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Macro to define public tokens. This declares a list of tokens that can be
 /// used globally.  Use in conjunction with TF_DEFINE_PUBLIC_TOKENS.
 /// \hideinitializer
+#ifdef __INTELLISENSE__
+#define TF_DECLARE_PUBLIC_TOKENS(...)
+#else
 #define TF_DECLARE_PUBLIC_TOKENS(...) _TF_DECLARE_PUBLIC_TOKENS_EXPAND( _TF_DECLARE_PUBLIC_TOKENS_EVAL(_TF_DECLARE_PUBLIC_TOKENS_EXPAND( TF_PP_VARIADIC_SIZE(__VA_ARGS__) ))(__VA_ARGS__) )
+#endif
 
 /// Macro to define public tokens.  Use in conjunction with
 /// TF_DECLARE_PUBLIC_TOKENS.

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -95,7 +95,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Macro to define public tokens. This declares a list of tokens that can be
 /// used globally.  Use in conjunction with TF_DEFINE_PUBLIC_TOKENS.
 /// \hideinitializer
-#ifdef __INTELLISENSE__
+#if defined(ARCH_PREPROCESSOR_MSVC_TRADITIONAL) && defined(__INTELLISENSE__)
 #define TF_DECLARE_PUBLIC_TOKENS(...)
 #else
 #define TF_DECLARE_PUBLIC_TOKENS(...) _TF_DECLARE_PUBLIC_TOKENS_EXPAND( _TF_DECLARE_PUBLIC_TOKENS_EVAL(_TF_DECLARE_PUBLIC_TOKENS_EXPAND( TF_PP_VARIADIC_SIZE(__VA_ARGS__) ))(__VA_ARGS__) )


### PR DESCRIPTION
### Description of Change(s)

The boost free version of the preprocessor macros on MSVC can cause issues with Intellisense processing, particularly around `TF_DECLARE_PUBLIC_TOKENS`.  This change suppresses that macro when processed by intellisense to prevent it from spending major processing power attempting to interpret the macro.

https://github.com/microsoft/vscode-cpptools/issues/13205#issuecomment-2732102126

Adds a check for the traditional preprocessor so it should be fine if / when the conformant preprocessor is enabled:

https://github.com/PixarAnimationStudios/OpenUSD/pull/3565

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
