### PR TITLE
Fix bug with removing instances in _InstanceObserver::PrimsRemoved()

### DIFF
--- a/pxr/usdImaging/usdImaging/niInstanceAggregationSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/niInstanceAggregationSceneIndex.cpp
@@ -1310,7 +1310,7 @@ _InstanceObserver::PrimsRemoved(const HdSceneIndexBase &sender,
         auto it = _instanceToInfo.lower_bound(path);
         while (it != _instanceToInfo.end() &&
                it->first.HasPrefix(path)) {
-            it = _RemoveInstance(path, it, &retainedSceneIndexOperations);
+            it = _RemoveInstance(it->first, it, &retainedSceneIndexOperations);
         }
     }
 }


### PR DESCRIPTION
### Description of Change(s)

`_RemoveInstance()` was repeatedly called with the same original path from the `RemovedPrimEntry`, rather than the path of each child being removed.

This fixes some incorrect updates we encountered involving native instances (will attach an example once I can isolate it from Houdini)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
