### PR TITLE
Fix some forward declarations to avoid class/struct mismatches

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.h
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.h
@@ -16,8 +16,8 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-class UsdSkelImagingSkelData;
-class UsdSkelImagingSkelGuideData;
+struct UsdSkelImagingSkelData;
+struct UsdSkelImagingSkelGuideData;
 
 /// \class UsdSkelImagingDataSourceResolvedSkeletonPrim
 ///


### PR DESCRIPTION
### Description of Change(s)

Make forward declarations of UsdSkelImagingSkelData and UsdSkelImagingSkelGuideData use struct instead of class to match the actual declarations of these structs.

### Checklist

- [ X ] I have created this PR based on the dev branch

- [ X ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ N/A ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ X ] I have verified that all unit tests pass with the proposed changes

- [ X ] I have submitted a signed Contributor License Agreement (Reference: 