### PR TITLE
Autodesk: [hd] Add some fast paths for triangles meshes in HdMeshUtil

### DIFF
--- a/pxr/imaging/hd/meshUtil.cpp
+++ b/pxr/imaging/hd/meshUtil.cpp
@@ -58,6 +58,42 @@ bool _FanTriangulate(GfVec3i *dst, int const *src,
     return _FanTriangulate(dst->data(), src, offset, index, size, flip);
 }
 
+/// The first value is the number of triangles for the triangulated mesh.
+/// The second value is true only if the mesh is already all triangles.
+static std::pair<int, bool>
+_CountTriangles(SdfPath const& id,
+    VtIntArray const& faceVertexCounts,
+    VtIntArray const& holeIndices)
+{
+    const int numFaces = static_cast<int>(faceVertexCounts.size());
+    const int numHoleFaces = static_cast<int>(holeIndices.size());
+    const auto numVertsPtr = faceVertexCounts.cdata();
+    const auto holeFacesPtr = holeIndices.cdata();
+    int numTris = 0;
+    bool invalidTopology = false;
+    bool allTriangles = true;
+    for (int i = 0, holeIndex = 0; i < numFaces; ++i) {
+        const int nv = numVertsPtr[i];
+        if (nv < 3) {
+            // skip degenerated face
+            invalidTopology = true;
+            allTriangles = false;
+        } else if (holeIndex < numHoleFaces && holeFacesPtr[holeIndex] == i) {
+            // skip hole face
+            ++holeIndex;
+            allTriangles = false;
+        } else {
+            numTris += nv - 2;
+            allTriangles &= (nv == 3);
+        }
+    }
+    if (invalidTopology) {
+        TF_WARN("degenerated face found [%s]", id.GetText());
+    }
+
+    return {numTris, allTriangles};
+}
+
 void
 HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
                                    VtIntArray *primitiveParams,
@@ -77,34 +113,10 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
 
     // generate triangle index buffer
 
-    int const * numVertsPtr = _topology->GetFaceVertexCounts().cdata();
-    int const * vertsPtr = _topology->GetFaceVertexIndices().cdata();
-    int const * holeFacesPtr = _topology->GetHoleIndices().cdata();
-    const int numFaces = _topology->GetFaceVertexCounts().size();
-    const int numVertIndices = _topology->GetFaceVertexIndices().size();
-    int numTris = 0;
-    const int numHoleFaces = _topology->GetHoleIndices().size();
-    bool invalidTopology = false;
-    bool allTriangles = true;
-    for (int i = 0, holeIndex = 0; i < numFaces; ++i) {
-        const int nv = numVertsPtr[i];
-        if (nv < 3) {
-            // skip degenerated face
-            invalidTopology = true;
-            allTriangles = false;
-        } else if (holeIndex < numHoleFaces && holeFacesPtr[holeIndex] == i) {
-            // skip hole face
-            ++holeIndex;
-            allTriangles = false;
-        } else {
-            numTris += nv - 2;
-            allTriangles &= (nv == 3);
-        }
-    }
-    if (invalidTopology) {
-        TF_WARN("degenerated face found [%s]", _id.GetText());
-        invalidTopology = false;
-    }
+    const VtIntArray& faceVertexCounts = _topology->GetFaceVertexCounts();
+    const VtIntArray& holeIndices = _topology->GetHoleIndices();
+    const auto [numTris, allTriangles] =
+        _CountTriangles(_id, faceVertexCounts, holeIndices);
 
     indices->resize(numTris); // vec3 per face
     primitiveParams->resize(numTris); // int per face
@@ -113,6 +125,9 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
     }
 
     const bool flip = (_topology->GetOrientation() != HdTokens->rightHanded);
+
+    const VtIntArray& faceVertexIndices = _topology->GetFaceVertexIndices();
+    const auto vertsPtr = faceVertexIndices.cdata();
 
     // Fast path for already triangulated
     if (allTriangles && !flip) {
@@ -134,10 +149,17 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
         return;
     }
 
+    const auto numVertsPtr = faceVertexCounts.cdata();
+    const auto holeFacesPtr = holeIndices.cdata();
+    const int numFaces = static_cast<int>(faceVertexCounts.size());
+    const int numVertIndices = static_cast<int>(faceVertexIndices.size());
+    const int numHoleFaces = static_cast<int>(holeIndices.size());
+
     // i  -> authored face index [0, numFaces)
     // tv -> triangulated face index [0, numTris)
     // v  -> index to the first vertex (index) for face i
     // ev -> edges visited
+    bool invalidTopology = false;
     for (int i = 0, tv = 0, v = 0, ev = 0, holeIndex = 0; i < numFaces; ++i) {
         int nv = numVertsPtr[i];
         if (nv < 3) {
@@ -224,7 +246,7 @@ static HdMeshComputationResult
 _TriangulateFaceVarying(
         SdfPath const& id,
         VtIntArray const &faceVertexCounts,
-        VtIntArray const &holeFaces,
+        VtIntArray const &holeIndices,
         bool flip,
         void const* sourceUntyped,
         int numElements,
@@ -232,44 +254,26 @@ _TriangulateFaceVarying(
 {
     T const* source = static_cast<T const*>(sourceUntyped);
 
-    // CPU face-varying triangulation
-    const int numFaces = static_cast<int>(faceVertexCounts.size());
-    const int numHoleFaces = static_cast<int>(holeFaces.size());
-    int numTris = 0;
-    bool invalidTopology = false;
-    bool allTriangles = true;
-    for (int i = 0, holeIndex = 0; i < numFaces; ++i) {
-        const int nv = faceVertexCounts[i];
-        if (nv < 3) {
-            // skip degenerated face
-            invalidTopology = true;
-            allTriangles = false;
-        } else if (holeIndex < numHoleFaces && holeFaces[holeIndex] == i) {
-            // skip hole face
-            ++holeIndex;
-            allTriangles = false;
-        } else {
-            numTris += nv - 2;
-            allTriangles &= (nv == 3);
-        }
-    }
-    if (invalidTopology) {
-        TF_WARN("degenerated face found [%s]", id.GetText());
-        invalidTopology = false;
-    }
+    const auto [numTris, allTriangles] =
+        _CountTriangles(id, faceVertexCounts, holeIndices);
 
     // Already triangulated
     if (allTriangles && !flip) {
         return HdMeshComputationResult::Unchanged;
     }
 
+    // CPU face-varying triangulation
+    const int numFaces = static_cast<int>(faceVertexCounts.size());
+    const int numHoleFaces = static_cast<int>(holeIndices.size());
+
     VtArray<T> results(numTris * 3);
+    bool invalidTopology = false;
     for (int i = 0, v = 0, holeIndex = 0, dstIndex = 0; i < numFaces; ++i) {
         const int nVerts = faceVertexCounts[i];
 
         if (nVerts < 3) {
             // Skip degenerate faces.
-        } else if (holeIndex < numHoleFaces && holeFaces[holeIndex] == i) {
+        } else if (holeIndex < numHoleFaces && holeIndices[holeIndex] == i) {
             // Skip hole faces.
             ++holeIndex;
         } else {

--- a/pxr/imaging/hd/meshUtil.cpp
+++ b/pxr/imaging/hd/meshUtil.cpp
@@ -80,22 +80,25 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
     int const * numVertsPtr = _topology->GetFaceVertexCounts().cdata();
     int const * vertsPtr = _topology->GetFaceVertexIndices().cdata();
     int const * holeFacesPtr = _topology->GetHoleIndices().cdata();
-    int numFaces = _topology->GetFaceVertexCounts().size();
-    int numVertIndices = _topology->GetFaceVertexIndices().size();
+    const int numFaces = _topology->GetFaceVertexCounts().size();
+    const int numVertIndices = _topology->GetFaceVertexIndices().size();
     int numTris = 0;
-    int numHoleFaces = _topology->GetHoleIndices().size();
+    const int numHoleFaces = _topology->GetHoleIndices().size();
     bool invalidTopology = false;
-    int holeIndex = 0;
-    for (int i=0; i<numFaces; ++i) {
-        int nv = numVertsPtr[i]-2;
-        if (nv < 1) {
+    bool allTriangles = true;
+    for (int i = 0, holeIndex = 0; i < numFaces; ++i) {
+        const int nv = numVertsPtr[i];
+        if (nv < 3) {
             // skip degenerated face
             invalidTopology = true;
+            allTriangles = false;
         } else if (holeIndex < numHoleFaces && holeFacesPtr[holeIndex] == i) {
             // skip hole face
             ++holeIndex;
+            allTriangles = false;
         } else {
-            numTris += nv;
+            numTris += nv - 2;
+            allTriangles &= (nv == 3);
         }
     }
     if (invalidTopology) {
@@ -109,16 +112,33 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
         edgeIndices->resize(numTris); // int per face
     }
 
-    bool flip = (_topology->GetOrientation() != HdTokens->rightHanded);
+    const bool flip = (_topology->GetOrientation() != HdTokens->rightHanded);
 
-    // reset holeIndex
-    holeIndex = 0;
+    // Fast path for already triangulated
+    if (allTriangles && !flip) {
+        // We'd really like to reuse the pointer, but unfortunately that can't
+        // be done without violating strict aliasing due to the datatype change.
+        using TriIndices = std::remove_reference_t<decltype(*indices->data())>;
+        using PolyIndices = std::remove_reference_t<decltype(*vertsPtr)>;
+        static_assert(std::is_trivially_copyable_v<TriIndices>);
+        static_assert(std::is_trivially_copyable_v<PolyIndices>);
+        // Casting to void here to prevent an excessively strict warning from
+        // GCC. This memcpy is safe as long as the static asserts above pass.
+        std::memcpy(static_cast<void*>(indices->data()), static_cast<const void*>(vertsPtr), numTris * sizeof(TriIndices));
+        for (int i = 0; i < numTris; ++i) {
+            (*primitiveParams)[i] = EncodeCoarseFaceParam(i, 0);
+            if (edgeIndices) {
+                (*edgeIndices)[i] = 3 * i;
+            }
+        }
+        return;
+    }
 
     // i  -> authored face index [0, numFaces)
     // tv -> triangulated face index [0, numTris)
     // v  -> index to the first vertex (index) for face i
     // ev -> edges visited
-    for (int i=0,tv=0,v=0,ev=0; i<numFaces; ++i) {
+    for (int i = 0, tv = 0, v = 0, ev = 0, holeIndex = 0; i < numFaces; ++i) {
         int nv = numVertsPtr[i];
         if (nv < 3) {
             // Skip degenerate faces.
@@ -200,8 +220,8 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
 
 // Face-varying triangulation helper function, to deal with type polymorphism.
 template <typename T>
-static
-void _TriangulateFaceVarying(
+static bool
+_TriangulateFaceVarying(
         SdfPath const& id,
         VtIntArray const &faceVertexCounts,
         VtIntArray const &holeFaces,
@@ -213,20 +233,24 @@ void _TriangulateFaceVarying(
     T const* source = static_cast<T const*>(sourceUntyped);
 
     // CPU face-varying triangulation
+    const int numFaces = static_cast<int>(faceVertexCounts.size());
+    const int numHoleFaces = static_cast<int>(holeFaces.size());
+    int numTris = 0;
     bool invalidTopology = false;
-    int numFVarValues = 0;
-    int holeIndex = 0;
-    int numHoleFaces = holeFaces.size();
-    for (int i = 0; i < (int)faceVertexCounts.size(); ++i) {
-        int nv = faceVertexCounts[i] - 2;
-        if (nv < 1) {
+    bool allTriangles = true;
+    for (int i = 0, holeIndex = 0; i < numFaces; ++i) {
+        const int nv = faceVertexCounts[i];
+        if (nv < 3) {
             // skip degenerated face
             invalidTopology = true;
+            allTriangles = false;
         } else if (holeIndex < numHoleFaces && holeFaces[holeIndex] == i) {
             // skip hole face
             ++holeIndex;
+            allTriangles = false;
         } else {
-            numFVarValues += 3 * nv;
+            numTris += nv - 2;
+            allTriangles &= (nv == 3);
         }
     }
     if (invalidTopology) {
@@ -234,13 +258,14 @@ void _TriangulateFaceVarying(
         invalidTopology = false;
     }
 
-    VtArray<T> results(numFVarValues);
-    // reset holeIndex
-    holeIndex = 0;
+    // Already triangulated
+    if (allTriangles && !flip) {
+        return false;
+    }
 
-    int dstIndex = 0;
-    for (int i = 0, v = 0; i < (int)faceVertexCounts.size(); ++i) {
-        int nVerts = faceVertexCounts[i];
+    VtArray<T> results(numTris * 3);
+    for (int i = 0, v = 0, holeIndex = 0, dstIndex = 0; i < numFaces; ++i) {
+        const int nVerts = faceVertexCounts[i];
 
         if (nVerts < 3) {
             // Skip degenerate faces.
@@ -277,6 +302,7 @@ void _TriangulateFaceVarying(
     }
 
     *triangulated = results;
+    return true;
 }
 
 bool
@@ -308,44 +334,34 @@ HdMeshUtil::ComputeTriangulatedFaceVaryingPrimvar(void const* source,
 
     switch (dataType) {
     case HdTypeFloat:
-        _TriangulateFaceVarying<float>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<float>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeFloatVec2:
-        _TriangulateFaceVarying<GfVec2f>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec2f>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeFloatVec3:
-        _TriangulateFaceVarying<GfVec3f>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec3f>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeFloatVec4:
-        _TriangulateFaceVarying<GfVec4f>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec4f>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeDouble:
-        _TriangulateFaceVarying<double>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<double>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeDoubleVec2:
-        _TriangulateFaceVarying<GfVec2d>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec2d>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeDoubleVec3:
-        _TriangulateFaceVarying<GfVec3d>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec3d>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     case HdTypeDoubleVec4:
-        _TriangulateFaceVarying<GfVec4d>(_id, faceVertexCounts, holeFaces, flip,
+        return _TriangulateFaceVarying<GfVec4d>(_id, faceVertexCounts, holeFaces, flip,
                 source, numElements, triangulated);
-        break;
     default:
         TF_CODING_ERROR("Unsupported primvar type for triangulation [%s]",
                         _id.GetText());
         return false;
     }
-
-    return true;
 }
 
 //-------------------------------------------------------------------------

--- a/pxr/imaging/hd/meshUtil.cpp
+++ b/pxr/imaging/hd/meshUtil.cpp
@@ -220,7 +220,7 @@ HdMeshUtil::ComputeTriangleIndices(VtVec3iArray *indices,
 
 // Face-varying triangulation helper function, to deal with type polymorphism.
 template <typename T>
-static bool
+static HdMeshComputationResult
 _TriangulateFaceVarying(
         SdfPath const& id,
         VtIntArray const &faceVertexCounts,
@@ -260,7 +260,7 @@ _TriangulateFaceVarying(
 
     // Already triangulated
     if (allTriangles && !flip) {
-        return false;
+        return HdMeshComputationResult::Unchanged;
     }
 
     VtArray<T> results(numTris * 3);
@@ -302,10 +302,10 @@ _TriangulateFaceVarying(
     }
 
     *triangulated = results;
-    return true;
+    return HdMeshComputationResult::Success;
 }
 
-bool
+HdMeshComputationResult
 HdMeshUtil::ComputeTriangulatedFaceVaryingPrimvar(void const* source,
                                                   int numElements,
                                                   HdType dataType,
@@ -315,11 +315,11 @@ HdMeshUtil::ComputeTriangulatedFaceVaryingPrimvar(void const* source,
 
     if (_topology == nullptr) {
         TF_CODING_ERROR("No topology provided for triangulation");
-        return false;
+        return HdMeshComputationResult::Error;
     }
     if (triangulated == nullptr) {
         TF_CODING_ERROR("No output buffer provided for triangulation");
-        return false;
+        return HdMeshComputationResult::Error;
     }
 
     VtIntArray const &faceVertexCounts = _topology->GetFaceVertexCounts();
@@ -360,7 +360,7 @@ HdMeshUtil::ComputeTriangulatedFaceVaryingPrimvar(void const* source,
     default:
         TF_CODING_ERROR("Unsupported primvar type for triangulation [%s]",
                         _id.GetText());
-        return false;
+        return HdMeshComputationResult::Error;
     }
 }
 

--- a/pxr/imaging/hd/meshUtil.h
+++ b/pxr/imaging/hd/meshUtil.h
@@ -22,6 +22,8 @@
 #include "pxr/base/vt/array.h"
 #include "pxr/base/vt/value.h"
 
+#include "pxr/base/tf/pxrCLI11/CLI11.h"
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class HdQuadInfo
@@ -56,6 +58,18 @@ struct HdQuadInfo {
     int maxNumVert;
     std::vector<int> numVerts;  // num vertices of non-quads
     std::vector<int> verts;     // vertex indices of non-quads
+};
+
+/// Return status for a computation
+enum class CLI11_NODISCARD HdMeshComputationResult
+{
+    /// Computation failed
+    Error,
+    /// Computation succeeded and a result was produced
+    Success,
+    /// Computation succeeded but no result was produced,
+    /// because it is the same as the input.
+    Unchanged
 };
 
 /// \class HdMeshUtil
@@ -100,17 +114,17 @@ public:
                                 VtIntArray *primitiveParams,
                                 VtIntArray *edgeIndices = nullptr) const;
 
-    /// Return a triangulation of a face-varying primvar. source is
+    /// Perform a triangulation of a face-varying primvar. source is
     /// a buffer of size numElements and type corresponding to dataType
     /// (e.g. HdTypeFloatVec3); the result is a VtArray<T> of the
-    /// correct type written to the variable "triangulated".
-    /// Returns false if triangulation isn't necessary or possible
-    // (such as if it can't resolve dataType).
+    /// correct type written to the variable "triangulated", unless the
+    /// result is not "Success", in which case the argument is unmodified.
     HD_API
-    bool ComputeTriangulatedFaceVaryingPrimvar(void const* source,
-                                               int numElements,
-                                               HdType dataType,
-                                               VtValue *triangulated) const;
+    HdMeshComputationResult ComputeTriangulatedFaceVaryingPrimvar(
+        void const* source,
+        int numElements,
+        HdType dataType,
+        VtValue *triangulated) const;
 
     /// @}
 

--- a/pxr/imaging/hd/meshUtil.h
+++ b/pxr/imaging/hd/meshUtil.h
@@ -104,7 +104,8 @@ public:
     /// a buffer of size numElements and type corresponding to dataType
     /// (e.g. HdTypeFloatVec3); the result is a VtArray<T> of the
     /// correct type written to the variable "triangulated".
-    /// This function returns false if it can't resolve dataType.
+    /// Returns false if triangulation isn't necessary or possible
+    // (such as if it can't resolve dataType).
     HD_API
     bool ComputeTriangulatedFaceVaryingPrimvar(void const* source,
                                                int numElements,

--- a/pxr/imaging/hdSt/triangulate.cpp
+++ b/pxr/imaging/hdSt/triangulate.cpp
@@ -111,17 +111,24 @@ HdSt_TriangulateFaceVaryingComputation::Resolve()
     HD_PERF_COUNTER_INCR(HdPerfTokens->triangulateFaceVarying);
 
     VtValue result;
-    HdMeshUtil meshUtil(_topology, _id);
-    if(meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
-            _source->GetData(),
-            _source->GetNumElements(),
-            _source->GetTupleType().type,
-            &result)) {
-        _SetResult(std::make_shared<HdVtBufferSource>(
-                        _source->GetName(),
-                        result));
-    } else {
+    HdMeshUtil meshUtil{_topology, _id};
+    const auto status = meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
+        _source->GetData(),
+        _source->GetNumElements(),
+        _source->GetTupleType().type,
+        &result);
+    switch (status) {
+    case HdMeshComputationResult::Error:
+        TF_CODING_ERROR("[%s] Could not triangulate face-varying data.",
+            _source->GetName().GetText());
+        break;
+    case HdMeshComputationResult::Success:
+        _SetResult(std::make_shared<HdVtBufferSource>(_source->GetName(),
+            result));
+        break;
+    case HdMeshComputationResult::Unchanged:
         _SetResult(_source);
+        break;
     }
 
     _SetResolved();
@@ -142,4 +149,3 @@ HdSt_TriangulateFaceVaryingComputation::_CheckValid() const
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/imaging/plugin/hdEmbree/meshSamplers.cpp
+++ b/pxr/imaging/plugin/hdEmbree/meshSamplers.cpp
@@ -126,16 +126,21 @@ HdEmbreeTriangleFaceVaryingSampler::_Triangulate(TfToken const& name,
 {
     HdVtBufferSource buffer(name, value);
     VtValue triangulated;
-    if (!meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
-            buffer.GetData(),
-            buffer.GetNumElements(),
-            buffer.GetTupleType().type,
-            &triangulated)) {
+    const auto status = meshUtil.ComputeTriangulatedFaceVaryingPrimvar(
+        buffer.GetData(),
+        buffer.GetNumElements(),
+        buffer.GetTupleType().type,
+        &triangulated);
+    switch (status) {
+    case HdMeshComputationResult::Error:
         TF_CODING_ERROR("[%s] Could not triangulate face-varying data.",
             name.GetText());
-        return VtValue();
+        return triangulated;
+    case HdMeshComputationResult::Success:
+        return triangulated;
+    case HdMeshComputationResult::Unchanged:
+        return value;
     }
-    return triangulated;
 }
 
 // HdEmbreeSubdivVertexSampler


### PR DESCRIPTION
### Description of Change(s)

- Don't create a redundant copy of face-varying primvars when already triangulated.
- Implement a fast path for triangle indices when we already have a triangle mesh.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
