### PR TITLE
Allowing for explicitly-invisible prototypes to remain invisible

### DIFF
--- a/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.cpp
@@ -76,6 +76,26 @@ _ComputeUnderlaySource(const SdfPath &instancer, const SdfPath &prototypeRoot)
 }
 
 HdContainerDataSourceHandle
+_ComputePrototypeRootUnderlaySource(const SdfPath &instancer)
+{
+    if (instancer.IsEmpty()) {
+        return nullptr;
+    }
+
+    static HdContainerDataSourceHandle const ds =
+        HdRetainedContainerDataSource::New(
+            // By underlaying this data, we do not override visibility explicitly authored on a prototype instanced
+            // by a point instancer in USD.
+            HdVisibilitySchema::GetSchemaToken(),
+            HdVisibilitySchema::Builder()
+                .SetVisibility(
+                    HdRetainedTypedSampledDataSource<bool>::New(
+                        true))
+                .Build());
+    return ds;
+}
+
+HdContainerDataSourceHandle
 _ComputePrototypeRootOverlaySource(const SdfPath &instancer)
 {
     if (instancer.IsEmpty()) {
@@ -87,14 +107,6 @@ _ComputePrototypeRootOverlaySource(const SdfPath &instancer)
             HdXformSchema::GetSchemaToken(),
             HdXformSchema::Builder()
                 .SetResetXformStack(
-                    HdRetainedTypedSampledDataSource<bool>::New(
-                        true))
-                .Build(),
-            // We ignore the visibility authored on a prototype instanced
-            // by a point instancer in USD.
-            HdVisibilitySchema::GetSchemaToken(),
-            HdVisibilitySchema::Builder()
-                .SetVisibility(
                     HdRetainedTypedSampledDataSource<bool>::New(
                         true))
                 .Build());
@@ -132,11 +144,8 @@ UsdImaging_PiPrototypeSceneIndex(
     const SdfPath &instancer,
     const SdfPath &prototypeRoot)
   : HdSingleInputFilteringSceneIndexBase(inputSceneIndex)
+  , _instancer(instancer)
   , _prototypeRoot(prototypeRoot)
-  , _underlaySource(
-      _ComputeUnderlaySource(instancer, prototypeRoot))
-  , _prototypeRootOverlaySource(
-      _ComputePrototypeRootOverlaySource(instancer))
 {
     _Populate();
 }
@@ -211,20 +220,28 @@ UsdImaging_PiPrototypeSceneIndex::GetPrim(const SdfPath &primPath) const
         return prim;
     }
 
-    if (_underlaySource) {
+    TfSmallVector<HdContainerDataSourceHandle, 4> dsVec;
+
+    if (HdContainerDataSourceHandle ds =
+            _ComputePrototypeRootOverlaySource(_instancer);
+            ds && primPath == _prototypeRoot)
+        dsVec.emplace_back(ds);
+    
+    dsVec.emplace_back(prim.dataSource);
+    
+    if (HdContainerDataSourceHandle ds =
+            _ComputePrototypeRootUnderlaySource(_instancer);
+            ds && primPath == _prototypeRoot)
+        dsVec.emplace_back(ds);
+
+    if (HdContainerDataSourceHandle ds =
+            _ComputeUnderlaySource(_instancer, _prototypeRoot))
+        dsVec.emplace_back(ds);
+
+    if (dsVec.size() > 1)
         prim.dataSource = HdOverlayContainerDataSource::New(
-            prim.dataSource,
-            _underlaySource);
-    }
-
-    if (_prototypeRootOverlaySource) {
-        if (primPath == _prototypeRoot) {
-            prim.dataSource = HdOverlayContainerDataSource::New(
-                _prototypeRootOverlaySource,
-                prim.dataSource);
-        }
-    }
-
+            dsVec.size(), dsVec.data());
+    
     return prim;
 }
 

--- a/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.h
+++ b/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.h
@@ -148,9 +148,8 @@ protected:
 
     void _Populate();
 
+    SdfPath _instancer;
     SdfPath _prototypeRoot;
-    HdContainerDataSourceHandle _underlaySource;
-    HdContainerDataSourceHandle _prototypeRootOverlaySource;
 
     // Instancers and overs within the prototype.
     // Note that this does not include instancers or overs nested


### PR DESCRIPTION
### Description of Change(s)

This change moves the visibility data from an *overlay* to an *underlay* where explicit visibility authoring will effectively be respected. This also lays a bit more groundwork to address issue #3693

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#3748 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
