### PR TITLE
[usdlux] fix formula for inputs:ies:angleScale (missing +pi term)

### DIFF
--- a/pxr/usd/usdLux/schema.usda
+++ b/pxr/usd/usdLux/schema.usda
@@ -850,7 +850,7 @@ class "ShapingAPI" (
 
         * <i>if angleScale < 0:</i>
         <center><b>
-                𝛳<sub>ies</sub> = (𝛳<sub>light</sub> - π) / -angleScale
+                𝛳<sub>ies</sub> = (𝛳<sub>light</sub> - π) / -angleScale + π
         </b></center>
 
         Usage guidelines for artists / lighting TDs:


### PR DESCRIPTION
### Description of Change(s)

My [original proposal of a bimodal formula for ies:angleScale](https://github.com/pmolodo/OpenUSD/blob/ies-angleScale-findings-questions/pxr/usd/usdLux/iesAngleScale/UsdLux-IESAngleScale-FindingsAndQuestions.md) included a `+ π` term when `angleScale < 0`:

$$
    \frac{\theta_{light} - \pi}{-angleScale} + \pi, \newline
         \quad\text{if } {angleScale < 0}   \\
$$ 

...and my [actual implementation of the formula for an HdEmbree reference UsdLux renderer](https://github.com/PixarAnimationStudios/OpenUSD/pull/3193/commits/fdf0da0f5647ad145aecf52c26ff9269da3e0f4b#diff-77b2c6df291efe4099038fa3e6d029fac5e1dd4eb2638675f2de3af4e7ea892fR140) includes the  `+ π`  term:

```cpp
theta = (_pi<float> - theta) / angleScale + _pi<float>;
```

...but somehow I left it out of [the schema docs](https://github.com/PixarAnimationStudios/OpenUSD/blob/d0d5c33d5655f206a02b58311efa841890fb3894/pxr/usd/usdLux/schema.usda#L853):

```
𝛳<sub>ies</sub> = (𝛳<sub>light</sub> - π) / -angleScale
```

This fixes that mistake.

Thanks Ali Fatoorechi for catching this!

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/PixarAnimationStudios/OpenUSD-proposals/pull/77

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
