### PR TITLE
Expose HdPrimOriginSchemaTokens->primOrigin through UsdImagingDrawModeStandin

### DIFF
--- a/pxr/usdImaging/usdImaging/drawModeStandin.cpp
+++ b/pxr/usdImaging/usdImaging/drawModeStandin.cpp
@@ -25,6 +25,7 @@
 #include "pxr/imaging/hd/materialSchema.h"
 #include "pxr/imaging/hd/meshSchema.h"
 #include "pxr/imaging/hd/meshTopologySchema.h"
+#include "pxr/imaging/hd/primOriginSchema.h"
 #include "pxr/imaging/hd/primvarSchema.h"
 #include "pxr/imaging/hd/primvarsSchema.h"
 #include "pxr/imaging/hd/purposeSchema.h"
@@ -352,6 +353,7 @@ protected:
 /// - purpose (from the given prim data source)
 /// - visibility (from the given prim data source)
 /// - displayStyle (constant)
+/// - primOrigin (HdPrimOriginSchema to map picking back to the USD prim)
 ///
 class _PrimDataSource : public HdContainerDataSource
 {
@@ -363,14 +365,16 @@ public:
             HdPurposeSchemaTokens->purpose,
             HdVisibilitySchemaTokens->visibility,
             HdInstancedBySchemaTokens->instancedBy,
-            HdLegacyDisplayStyleSchemaTokens->displayStyle };
+            HdLegacyDisplayStyleSchemaTokens->displayStyle,
+            HdPrimOriginSchemaTokens->primOrigin };
     }
 
     HdDataSourceBaseHandle Get(const TfToken &name) override {
         if (name == HdXformSchemaTokens->xform ||
             name == HdPurposeSchemaTokens->purpose ||
             name == HdVisibilitySchemaTokens->visibility ||
-            name == HdInstancedBySchemaTokens->instancedBy) {
+            name == HdInstancedBySchemaTokens->instancedBy ||
+            name == HdPrimOriginSchemaTokens->primOrigin) {
             if (_primSource) {
                 return _primSource->Get(name);
             }


### PR DESCRIPTION
### Description of Change(s)

Expose the HdPrimOriginSchemaTokens->primOrigin data source through the base draw mode prim source to allow HdxPrimOriginInfo::FromPickHits to properly resolve draw mode standin prims to the original USD prims they represent.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Checklist

- [ X ] I have created this PR based on the dev branch

- [ X ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ N/A ] I have added unit tests that exercise this functionality (Reference: 

- [ X ] I have verified that all unit tests pass with the proposed changes

- [ X ] I have submitted a signed Contributor License Agreement (Reference: 
