### PR TITLE
Include prototypes when repopulating the root path.

### DIFF
--- a/pxr/usdImaging/usdImaging/stageSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/stageSceneIndex.cpp
@@ -672,6 +672,12 @@ UsdImagingStageSceneIndex::_ApplyPendingResyncs()
         removedPrims.emplace_back(primPath);
         _PopulateSubtree(prim, &addedPrims);
 
+        if (primPath.IsAbsoluteRootPath()) {
+            for (const UsdPrim &protoPrim : _stage->GetPrototypes()) {
+                _PopulateSubtree(protoPrim, &addedPrims);
+            }
+        }
+
         // Prune property updates of resynced prims, which are redundant.
         _DeletePrefix(primPath, &_usdPropertiesToResync);
         _DeletePrefix(primPath, &_usdPropertiesToUpdate);


### PR DESCRIPTION
### Description of Change(s)

This is a proposed fix for issue #3752, to fix missing added/removed notifications for prototypes. Prototypes are not picked up by `_PopulateSubtree(rootPath)` and are also skipped by the coalescing if the root path and prototype path are both in `_usdPrimsToResync`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Fixes: #3752

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
