### PR TITLE
HdMergingSceneIndex: improve performance of _RebuildInputsPathTable()

### DIFF
--- a/pxr/imaging/hd/mergingSceneIndex.cpp
+++ b/pxr/imaging/hd/mergingSceneIndex.cpp
@@ -117,11 +117,11 @@ HdMergingSceneIndex::_RebuildInputsPathTable()
     for (auto const &inputEntry: _inputs) {
         _inputsPathTable[inputEntry.sceneRoot];
     }
-    for (auto& [path, entriesForPath]: _inputsPathTable) {
-        for (auto const &inputEntry: _inputs) {
-            if (path.HasPrefix(inputEntry.sceneRoot)) {
-                entriesForPath.push_back(inputEntry);
-            }
+
+    for (auto const &inputEntry: _inputs) {
+        auto range = _inputsPathTable.FindSubtreeRange(inputEntry.sceneRoot);
+        for (auto it = range.first; it != range.second; ++it) {
+            it->second.push_back(inputEntry);
         }
     }
 }


### PR DESCRIPTION
### Description of Change(s)

This became an n^2 loop when there were many inputs with non-overlapping scene roots (e.g. native instancing with a large number of prototypes) and the size of `_inputsPathTable` approached the number of inputs.

In this scenario the majority of the scene roots are of the form:
- `/UsdNiPropagatedPrototypes/__hash_1__/__Prototype_1/UsdNiInstancer`
-  ...
- `/UsdNiPropagatedPrototypes/__hash_N__/__Prototype_1/UsdNiInstancer`

We can instead use `FindSubtreeRange(sceneRoot)` to find which table entries each input should be added to, eliminating the `HasPrefix()` check against every entry.

Attached is an example scene with 10k prototypes ([usdskel_instanced.zip](https://github.com/user-attachments/files/21473773/usdskel_instanced.zip)) along before & after stats of time spent in `_RebuildInputsPathTable()`

Before:
```
    0.002 ms     0.002 ms       1 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.001 ms     0.001 ms       3 samples    |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.002 ms     0.002 ms       2 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.001 ms     0.001 ms       2 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    6.611 ms     6.611 ms   20000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
 1958.234 ms  1958.234 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.003 ms     0.003 ms       1 samples    |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.003 ms     0.003 ms       1 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
```

After:
```
    0.002 ms     0.002 ms       1 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.001 ms     0.001 ms       3 samples    |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.002 ms     0.002 ms       2 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.001 ms     0.001 ms       2 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    5.930 ms     5.930 ms   20000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    5.691 ms     5.691 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.004 ms     0.004 ms       1 samples    |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
    0.002 ms     0.002 ms       1 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::_RebuildInputsPathTable
```


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
