### PR TITLE
Improve performance of HdMergingSceneIndex::InsertInputScenes()

### DIFF
--- a/pxr/imaging/hd/mergingSceneIndex.cpp
+++ b/pxr/imaging/hd/mergingSceneIndex.cpp
@@ -47,22 +47,6 @@ _FillAddedChildEntriesRecursively(
     }
 }
 
-static
-bool
-_Contains(const SdfPath &path, const SdfPathVector &v)
-{
-    return std::find(v.begin(), v.end(), path) != v.end();
-}
-
-static
-bool
-_HasPrim(HdSceneIndexBase * const sceneIndex, const SdfPath &path)
-{
-    TRACE_FUNCTION();
-    
-    return _Contains(path, sceneIndex->GetChildPrimPaths(path.GetParentPath()));
-}
-
 void
 HdMergingSceneIndex::AddInputScene(
     const HdSceneIndexBaseRefPtr &inputScene,
@@ -138,13 +122,16 @@ HdMergingSceneIndex::InsertInputScenes(
 
     HdSceneIndexObserver::AddedPrimEntries addedEntries;
     if (_IsObserved()) {
+        TRACE_SCOPE("Adding prefixes of input scene roots");
+
         // Add prefixes of activeInputSceneRoot.
         //
         // If adding a scene inde at, e.g., /A/B/C, make
         // AddedPrimEntries for /A and /A/B.
 
         // Set to prevent sending the same AddedPrimEntries for
-        // prefixes multiple times.
+        // prefixes multiple times, and to avoid repeated GetChildPrimPaths()
+        // queries.
         std::unordered_set<SdfPath, SdfPath::Hash> visited;
 
         for (const InputScene &inputScene : inputScenes) {
@@ -169,8 +156,22 @@ HdMergingSceneIndex::InsertInputScenes(
             size_t i = 0;
             // Add 1 to skip the activeInputSceneRoot itself.
             for ( ; i + 1 < prefixes.size(); i++) {
-                if (!(_HasPrim(this, prefixes[i]) ||
-                      visited.count(prefixes[i]))) {
+                const SdfPath &prefix = prefixes[i];
+
+                // Skip if we already know a prim exists here, or it has an
+                // AddedPrimEntry already.
+                if (visited.count(prefix)) {
+                    continue;
+                }
+
+                // Record the existence of the sibling paths to avoid n^2
+                // behavior with many siblings.
+                SdfPathVector siblingPaths = GetChildPrimPaths(
+                    prefix.GetParentPath());
+                visited.insert(siblingPaths.begin(), siblingPaths.end());
+
+                // Check whether we've found a prefix without an existing prim.
+                if (!visited.count(prefix)) {
                     break;
                 }
             }


### PR DESCRIPTION
### Description of Change(s)

When inserting many scenes at once, the loop to add prefixes of the input scene roots could result in n^2 performance (from querying and searching through `GetChildPrimPaths(parent)` for each sibling path)

As an example, for native instancing with a large number of prototypes, the input scenes' roots may look like:
- `/UsdNiPropagatedPrototypes/__hash_1__/__Prototype_1/UsdNiInstancer`
- ...
- `/UsdNiPropagatedPrototypes/__hash_N__/__Prototype_1/UsdNiInstancer`

This results in N calls to `GetChildPrimPaths("/UsdNiPropagatedPrototypes")`, which generates a list of N paths that is linearly searched through.

The change here is to make use the of the `visited` set to also record the existence of siblings that were discovered via `GetChildPrimPaths(parent)`

Attached is an example scene with 10k prototypes ([usdskel_instanced.zip](https://github.com/user-attachments/files/21475089/usdskel_instanced.zip)), along with before & after stats of the **total** time spent in `InsertInputScenes()`. 

Before:
```
    0.004 ms     0.002 ms       1 samples    |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.015 ms     0.012 ms       3 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.003 ms     0.001 ms       2 samples    |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    2.358 ms     0.054 ms       2 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
   12.630 ms     6.018 ms   20000 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.267 ms     0.267 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
16965.960 ms   304.298 ms       1 samples    |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
```

After:
```
    0.005 ms     0.002 ms       1 samples    |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.016 ms     0.012 ms       3 samples    |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.004 ms     0.002 ms       2 samples    |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    2.875 ms     0.044 ms       2 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
   11.634 ms     5.476 ms   20000 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
    0.314 ms     0.314 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
 2722.158 ms   284.471 ms       1 samples    |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::InsertInputScenes
```

Note: most of the remaining time in `InsertInputScenes()` in this case is from rebuilding the path table, which #3757 addresses

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
