### PR TITLE
pxrConfig.cmake.in : Do not pin exact Python patch version

### DIFF
--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -43,7 +43,7 @@ if(@PXR_ENABLE_PYTHON_SUPPORT@)
     endif()
 
     if (NOT DEFINED Python3_VERSION)
-        find_dependency(Python3 "@Python3_VERSION@" EXACT COMPONENTS Development)
+        find_dependency(Python3 "@Python3_VERSION_MAJOR@.@Python3_VERSION_MINOR@" EXACT COMPONENTS Development)
     else()
         find_dependency(Python3 COMPONENTS Development)
     endif()


### PR DESCRIPTION
### Description of Change(s)

In `pxrConfig.cmake.in`, CMake was looking for exactly the same Python version used to build OpenUSD, so if a OpenUSD was built against Python 3.11.3, `find_package(pxr REQUIRED)` would fail on a machine with Python 3.11.5, even if different patch versions of Python are ABI compatible if the minor version is the same, see https://docs.python.org/3/c-api/stable.html .



### Fixes Issue(s)

This PR fixes downstream problems such as https://github.com/dreamworksanimation/openmoonray/issues/141 and https://github.com/conda-forge/openusd-feedstock/issues/11 .

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
