### PR TITLE
Autodesk: [hdSt, hgiVulkan] UMA and ReBAR support

### DIFF
--- a/pxr/imaging/hdSt/resourceRegistry.cpp
+++ b/pxr/imaging/hdSt/resourceRegistry.cpp
@@ -843,15 +843,18 @@ HdStResourceRegistry::_Commit()
                                 if (req.range && req.range->RequiresStaging()) {
                                     const size_t numElements =
                                         source->GetNumElements();
-                                    // Avoid calling functions on 
+                                    // Avoid calling functions on
                                     // HdNullBufferSources
                                     if (numElements > 0) {
-                                        stagingBufferSize += numElements *
+                                        stagingBufferSize.fetch_add(
+                                            numElements *
                                             HdDataSizeOfTupleType(
-                                                source->GetTupleType());
+                                                source->GetTupleType()),
+                                                std::memory_order_relaxed);
                                     }
-                                    stagingBufferSize += 
-                                        _GetChainedStagingSize(source);
+                                    stagingBufferSize.fetch_add(
+                                        _GetChainedStagingSize(source),
+                                        std::memory_order_relaxed);
                                 }
                             }
                         }
@@ -934,7 +937,8 @@ HdStResourceRegistry::_Commit()
         HD_TRACE_SCOPE("Copy");
         // 4. copy phase:
         //
-        _stagingBuffer->Resize(stagingBufferSize);
+        _stagingBuffer->Resize(
+            stagingBufferSize.load(std::memory_order_relaxed));
 
         for (_PendingSource &pendingSource : _pendingSources) {
             HdBufferArrayRangeSharedPtr &dstRange = pendingSource.range;

--- a/pxr/imaging/hdSt/stagingBuffer.h
+++ b/pxr/imaging/hdSt/stagingBuffer.h
@@ -65,11 +65,11 @@ private:
 
     HdStResourceRegistry *_resourceRegistry;
     HgiBufferHandle _handles[MULTIBUFFERING];
+    std::vector<HgiBufferGpuToGpuOp> _gpuCopyOps;
     size_t _head;
     size_t _capacity;
     size_t _activeSlot;
-    bool _tripleBuffered;
-    std::vector<HgiBufferGpuToGpuOp> _gpuCopyOps;
+    bool _isUma;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/blitCmds.cpp
+++ b/pxr/imaging/hgiVulkan/blitCmds.cpp
@@ -419,24 +419,24 @@ void HgiVulkanBlitCmds::CopyBufferCpuToGpu(
     if (!buffer->IsCPUStagingAddress(copyOp.cpuSourceBuffer) ||
         copyOp.sourceByteOffset != copyOp.destinationByteOffset) {
 
-        // Offset into the src buffer.
-        const uint8_t* const src =
-            static_cast<const uint8_t*>(copyOp.cpuSourceBuffer) +
-                copyOp.sourceByteOffset;
+        // Offset into the src buffer
+        const auto src =
+            static_cast<const std::byte*>(copyOp.cpuSourceBuffer) +
+            copyOp.sourceByteOffset;
 
         // Offset into the dst buffer.
-        uint8_t* const dst =
-            static_cast<uint8_t*>(buffer->GetCPUStagingAddress()) +
-                copyOp.destinationByteOffset;
+        const auto dst =
+            static_cast<std::byte*>(buffer->GetCPUStagingAddress()) +
+            copyOp.destinationByteOffset;
 
         memcpy(dst, src, copyOp.byteSize);
     }
 
-    // Schedule copy data from staging buffer to device-local buffer.
-    HgiVulkanBuffer* stagingBuffer = buffer->GetStagingBuffer();
-
-    if (TF_VERIFY(stagingBuffer)) {
-        VkBufferCopy copyRegion = {};
+    // Schedule copy data from staging buffer to device-local buffer if needed.
+    // With UMA/ReBAR, the staging address is already the device buffer, so no
+    // additional copy is necessary.
+    if (HgiVulkanBuffer* stagingBuffer = buffer->GetStagingBuffer()) {
+        VkBufferCopy copyRegion{};
         // Note we use the destinationByteOffset as the srcOffset here. The staging buffer
         // should be prepared with the same data layout of the destination buffer.
         copyRegion.srcOffset = copyOp.destinationByteOffset;
@@ -444,10 +444,10 @@ void HgiVulkanBlitCmds::CopyBufferCpuToGpu(
         copyRegion.size = copyOp.byteSize;
 
         vkCmdCopyBuffer(
-            _commandBuffer->GetVulkanCommandBuffer(), 
+            _commandBuffer->GetVulkanCommandBuffer(),
             stagingBuffer->GetVulkanBuffer(),
             buffer->GetVulkanBuffer(),
-            1, 
+            1,
             &copyRegion);
     }
 }
@@ -467,43 +467,44 @@ HgiVulkanBlitCmds::CopyBufferGpuToCpu(HgiBufferGpuToCpuOp const& copyOp)
     HgiVulkanBuffer* buffer = static_cast<HgiVulkanBuffer*>(
         copyOp.gpuSourceBuffer.Get());
 
-    // Make sure there is a staging buffer in the buffer by asking for cpuAddr.
-    void* cpuAddress = buffer->GetCPUStagingAddress();
-    HgiVulkanBuffer* stagingBuffer = buffer->GetStagingBuffer();
-    if (!TF_VERIFY(stagingBuffer)) {
-        return;
+    // Schedule copy data from device-local buffer to staging buffer if needed.
+    // With UMA/ReBAR, the staging address is already the device buffer, so no
+    // additional copy is necessary.
+    size_t srcOffset = copyOp.sourceByteOffset;
+    if (HgiVulkanBuffer* stagingBuffer = buffer->GetStagingBuffer()) {
+        // Copy from device-local GPU buffer into CPU staging buffer
+        VkBufferCopy copyRegion = {};
+        copyRegion.srcOffset = srcOffset;
+        // No need to use dst offset during intermediate step of copying into 
+        // staging buffer.
+        copyRegion.dstOffset = 0;
+        copyRegion.size = copyOp.byteSize;
+        vkCmdCopyBuffer(
+            _commandBuffer->GetVulkanCommandBuffer(), 
+            buffer->GetVulkanBuffer(),
+            stagingBuffer->GetVulkanBuffer(),
+            1, 
+            &copyRegion);
+        // No need to offset into the staging buffer for the next copy.
+        srcOffset = 0;
     }
 
-    // Copy from device-local GPU buffer into GPU staging buffer
-    VkBufferCopy copyRegion = {};
-    copyRegion.srcOffset = copyOp.sourceByteOffset;
-    // No need to use dst offset during intermediate step of copying into 
-    // staging buffer.
-    copyRegion.dstOffset = 0;
-    copyRegion.size = copyOp.byteSize;
-    vkCmdCopyBuffer(
-        _commandBuffer->GetVulkanCommandBuffer(), 
-        buffer->GetVulkanBuffer(),
-        stagingBuffer->GetVulkanBuffer(),
-        1, 
-        &copyRegion);
-
-    // Next schedule a callback when the above GPU-GPU copy completes.
+    // Next schedule a callback when the above GPU-CPU copy completes.
 
     // Offset into the dst buffer
-    char* dst = ((char*) copyOp.cpuDestinationBuffer) +
+    const auto dst = static_cast<std::byte*>(copyOp.cpuDestinationBuffer) +
         copyOp.destinationByteOffset;
 
-    // No need to offset into src buffer since we copied into staging buffer
-    // without dst offset.
-    const char* src = ((const char*) cpuAddress);
+    const auto src =
+        static_cast<const std::byte*>(buffer->GetCPUStagingAddress()) +
+        srcOffset;
 
     // bytes to copy
-    size_t size = copyOp.byteSize;
+    const size_t size = copyOp.byteSize;
 
     // Copy to cpu buffer when cmd buffer has been executed
     _commandBuffer->AddCompletedHandler(
-        [dst, src, size]{ memcpy(dst, src, size);}
+        [dst, src, size]{ memcpy(dst, src, size); }
     );
 }
 

--- a/pxr/imaging/hgiVulkan/buffer.cpp
+++ b/pxr/imaging/hgiVulkan/buffer.cpp
@@ -17,7 +17,6 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-
 HgiVulkanBuffer::HgiVulkanBuffer(
     HgiVulkan* hgi,
     HgiVulkanDevice* device,
@@ -27,8 +26,8 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     , _vkBuffer(nullptr)
     , _vmaAllocation(nullptr)
     , _inflightBits(0)
-    , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _isUma(false)
 {
     if (_descriptor.byteSize == 0) {
         TF_CODING_ERROR("The size of buffer [%p] is zero.", this);
@@ -52,9 +51,16 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     VmaAllocationCreateInfo ai = {};
     ai.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT; // GPU efficient
 
+    if (hgi->GetCapabilities()->
+        IsSet(HgiDeviceCapabilitiesBitsUnifiedMemory)) {
+        _isUma = true;
+        ai.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                           VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    }
+
     HGIVULKAN_VERIFY_VK_RESULT(
-        vmaCreateBuffer(vma,&bi,&ai,&_vkBuffer,&_vmaAllocation,0)
-    );
+        vmaCreateBuffer(vma, &bi, &ai, &_vkBuffer, &_vmaAllocation, 0));
 
     // Debug label
     if (!_descriptor.debugName.empty()) {
@@ -67,53 +73,58 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     }
 
     if (_descriptor.initialData) {
-        // Use a 'staging buffer' to schedule uploading the 'initialData' to
-        // the device-local GPU buffer.
-        HgiBufferDesc stagingDesc = _descriptor;
-        if (!stagingDesc.debugName.empty()) {
-            stagingDesc.debugName =
-                "Staging Buffer for " + stagingDesc.debugName;
+        if (const auto umaPointer = GetUmaPointer()) {
+            memcpy(umaPointer.get(), _descriptor.initialData,
+                _descriptor.byteSize);
+        } else {
+            // Use a 'staging buffer' to schedule uploading the 'initialData' to
+            // the device-local GPU buffer.
+            HgiBufferDesc stagingDesc = _descriptor;
+            if (!stagingDesc.debugName.empty()) {
+                stagingDesc.debugName =
+                    "Staging Buffer for " + stagingDesc.debugName;
+            }
+
+            std::unique_ptr<HgiVulkanBuffer> stagingBuffer = CreateStagingBuffer(
+                _device, stagingDesc);
+            VkBuffer vkStagingBuf = stagingBuffer->GetVulkanBuffer();
+
+            HgiVulkanCommandQueue* queue = device->GetCommandQueue();
+            HgiVulkanCommandBuffer* cb = queue->AcquireResourceCommandBuffer();
+            VkCommandBuffer vkCmdBuf = cb->GetVulkanCommandBuffer();
+
+            // Copy data from staging buffer to device-local buffer.
+            VkBufferCopy copyRegion = {};
+            copyRegion.srcOffset = 0;
+            copyRegion.dstOffset = 0;
+            copyRegion.size = stagingDesc.byteSize;
+            vkCmdCopyBuffer(vkCmdBuf, vkStagingBuf, _vkBuffer, 1, &copyRegion);
+
+            VkBufferMemoryBarrier memoryBarrier {
+                VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER };
+            memoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
+            memoryBarrier.dstAccessMask =
+                VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
+            memoryBarrier.buffer = _vkBuffer;
+            memoryBarrier.offset = 0;
+            memoryBarrier.size = stagingDesc.byteSize;
+            vkCmdPipelineBarrier(
+                vkCmdBuf,
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                0,
+                0, nullptr,
+                1, &memoryBarrier,
+                0, nullptr);
+
+            // We don't know if this buffer is a static (immutable) or
+            // dynamic (animated) buffer. We assume that most buffers are
+            // static and schedule garbage collection of staging resource.
+            HgiBufferHandle stagingHandle(stagingBuffer.release(), 0);
+            hgi->TrashObject(
+                &stagingHandle,
+                hgi->GetGarbageCollector()->GetBufferList());
         }
-
-        HgiVulkanBuffer* stagingBuffer = CreateStagingBuffer(
-            _device, stagingDesc);
-        VkBuffer vkStagingBuf = stagingBuffer->GetVulkanBuffer();
-
-        HgiVulkanCommandQueue* queue = device->GetCommandQueue();
-        HgiVulkanCommandBuffer* cb = queue->AcquireResourceCommandBuffer();
-        VkCommandBuffer vkCmdBuf = cb->GetVulkanCommandBuffer();
-
-        // Copy data from staging buffer to device-local buffer.
-        VkBufferCopy copyRegion = {};
-        copyRegion.srcOffset = 0;
-        copyRegion.dstOffset = 0;
-        copyRegion.size = stagingDesc.byteSize;
-        vkCmdCopyBuffer(vkCmdBuf, vkStagingBuf, _vkBuffer, 1, &copyRegion);
-
-        VkBufferMemoryBarrier memoryBarrier {
-            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER };
-        memoryBarrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
-        memoryBarrier.dstAccessMask =
-            VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
-        memoryBarrier.buffer = _vkBuffer;
-        memoryBarrier.offset = 0;
-        memoryBarrier.size = stagingDesc.byteSize;
-        vkCmdPipelineBarrier(
-            vkCmdBuf,
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-            0,
-            0, nullptr,
-            1, &memoryBarrier,
-            0, nullptr);
-
-        // We don't know if this buffer is a static (immutable) or
-        // dynamic (animated) buffer. We assume that most buffers are
-        // static and schedule garbage collection of staging resource.
-        HgiBufferHandle stagingHandle(stagingBuffer, 0);
-        hgi->TrashObject(
-            &stagingHandle,
-            hgi->GetGarbageCollector()->GetBufferList());
     }
 
     _descriptor.initialData = nullptr;
@@ -131,19 +142,13 @@ HgiVulkanBuffer::HgiVulkanBuffer(
     , _inflightBits(0)
     , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _isUma(false)
 {
 }
 
 HgiVulkanBuffer::~HgiVulkanBuffer()
 {
-    if (_cpuStagingAddress && _stagingBuffer) {
-        vmaUnmapMemory(
-            _device->GetVulkanMemoryAllocator(),
-            _stagingBuffer->GetVulkanMemoryAllocation());
-        _cpuStagingAddress = nullptr;
-    }
-
-    delete _stagingBuffer;
+    _cpuStagingAddress = nullptr;
     _stagingBuffer = nullptr;
 
     vmaDestroyBuffer(
@@ -167,36 +172,37 @@ HgiVulkanBuffer::GetRawResource() const
 void*
 HgiVulkanBuffer::GetCPUStagingAddress()
 {
-    if (!_stagingBuffer) {
-        HgiBufferDesc stagingDesc = _descriptor;
-        stagingDesc.initialData = nullptr;
-        if (!stagingDesc.debugName.empty()) {
-            stagingDesc.debugName =
-                "Staging Buffer for " + stagingDesc.debugName;
-        }
-
-        _stagingBuffer = CreateStagingBuffer(_device, stagingDesc);
+    if (!_cpuStagingAddress) {
+        _cpuStagingAddress = GetUmaPointer();
     }
 
     if (!_cpuStagingAddress) {
-        HGIVULKAN_VERIFY_VK_RESULT(
-            vmaMapMemory(
-                _device->GetVulkanMemoryAllocator(),
-                _stagingBuffer->GetVulkanMemoryAllocation(),
-                &_cpuStagingAddress)
-        );
+        if (!_stagingBuffer) {
+            HgiBufferDesc stagingDesc = _descriptor;
+            stagingDesc.initialData = nullptr;
+            if (!stagingDesc.debugName.empty()) {
+                stagingDesc.debugName =
+                    "Staging Buffer for " + stagingDesc.debugName;
+            }
+
+            _stagingBuffer = CreateStagingBuffer(_device, stagingDesc);
+        }
+
+        VmaAllocator vma = _device->GetVulkanMemoryAllocator();
+        VmaAllocation allocation = _stagingBuffer->GetVulkanMemoryAllocation();
+        void* memory = nullptr;
+        HGIVULKAN_VERIFY_VK_RESULT(vmaMapMemory(vma, allocation, &memory));
+        _cpuStagingAddress = HgiVulkanMappedMemoryUniquePointer{memory,
+            {vma, allocation}};
     }
 
-    // This lets the client code memcpy into the staging buffer directly.
-    // The staging data must be explicitely copied to the device-local
-    // GPU buffer via CopyBufferCpuToGpu cmd by the client.
-    return _cpuStagingAddress;
+    return _cpuStagingAddress.get();
 }
 
 bool
 HgiVulkanBuffer::IsCPUStagingAddress(const void* address) const
 {
-    return (address == _cpuStagingAddress);
+    return address == _cpuStagingAddress.get();
 }
 
 VkBuffer
@@ -212,9 +218,10 @@ HgiVulkanBuffer::GetVulkanMemoryAllocation() const
 }
 
 HgiVulkanBuffer*
-HgiVulkanBuffer::GetStagingBuffer() const
+HgiVulkanBuffer::GetStagingBuffer()
 {
-    return _stagingBuffer;
+    (void)GetCPUStagingAddress();
+    return _stagingBuffer.get();
 }
 
 HgiVulkanDevice*
@@ -229,7 +236,20 @@ HgiVulkanBuffer::GetInflightBits()
     return _inflightBits;
 }
 
-HgiVulkanBuffer*
+HgiVulkanMappedMemoryUniquePointer
+HgiVulkanBuffer::GetUmaPointer() const
+{
+    if (!_isUma) {
+        return {};
+    }
+
+    VmaAllocator vma = _device->GetVulkanMemoryAllocator();
+    void* memory = nullptr;
+    HGIVULKAN_VERIFY_VK_RESULT(vmaMapMemory(vma, _vmaAllocation, &memory));
+    return HgiVulkanMappedMemoryUniquePointer(memory, {vma, _vmaAllocation});
+}
+
+std::unique_ptr<HgiVulkanBuffer>
 HgiVulkanBuffer::CreateStagingBuffer(
     HgiVulkanDevice* device,
     HgiBufferDesc const& desc)
@@ -264,8 +284,8 @@ HgiVulkanBuffer::CreateStagingBuffer(
         vmaUnmapMemory(vma, alloc);
     }
 
-    // Return new staging buffer (caller manages lifetime)
-    return new HgiVulkanBuffer(device, buffer, alloc, desc);
+    return std::unique_ptr<HgiVulkanBuffer>(
+        new HgiVulkanBuffer{device, buffer, alloc, desc});
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/buffer.h
+++ b/pxr/imaging/hgiVulkan/buffer.h
@@ -18,6 +18,36 @@ class HgiVulkanCommandBuffer;
 class HgiVulkanDevice;
 
 ///
+/// \struct HgiVulkanUmaUniquePointerDeleter
+///
+/// For use with std::unique_ptr. Unmaps a pointer to host visible memory when
+/// the owning pointer is destroyed.
+///
+struct HgiVulkanMappedMemoryUniquePointerDeleter
+{
+    void operator()([[maybe_unused]] void* memory) const
+    {
+        vmaUnmapMemory(_vma, _allocation);
+    }
+
+    HgiVulkanMappedMemoryUniquePointerDeleter() = default;
+
+    HgiVulkanMappedMemoryUniquePointerDeleter(VmaAllocator vma,
+        VmaAllocation allocation)
+        : _vma(vma)
+        , _allocation(allocation)
+    {
+    }
+
+private:
+    VmaAllocator _vma{};
+    VmaAllocation _allocation{};
+};
+
+using HgiVulkanMappedMemoryUniquePointer =
+    std::unique_ptr<void, HgiVulkanMappedMemoryUniquePointerDeleter>;
+
+///
 /// \class HgiVulkanBuffer
 ///
 /// Vulkan implementation of HgiBuffer
@@ -51,7 +81,7 @@ public:
 
     /// Returns the staging buffer.
     HGIVULKAN_API
-    HgiVulkanBuffer* GetStagingBuffer() const;
+    HgiVulkanBuffer* GetStagingBuffer();
 
     /// Returns the device used to create this object.
     HGIVULKAN_API
@@ -61,10 +91,17 @@ public:
     HGIVULKAN_API
     uint64_t & GetInflightBits();
 
+    /// Returns a device local, host writeable pointer to the buffer allocaiton,
+    /// if UMA or equivalent like ReBAR is available. Returns null otherwise.
+    /// Writing sequentially to this pointer should be the fastest way to write
+    /// to device memory.
+    HGIVULKAN_API
+    HgiVulkanMappedMemoryUniquePointer GetUmaPointer() const;
+
     /// Creates a staging buffer.
     /// The caller is responsible for the lifetime (destruction) of the buffer.
     HGIVULKAN_API
-    static HgiVulkanBuffer* CreateStagingBuffer(
+    static std::unique_ptr<HgiVulkanBuffer> CreateStagingBuffer(
         HgiVulkanDevice* device,
         HgiBufferDesc const& desc);
 
@@ -95,8 +132,9 @@ private:
     VkBuffer _vkBuffer;
     VmaAllocation _vmaAllocation;
     uint64_t _inflightBits;
-    HgiVulkanBuffer* _stagingBuffer;
-    void* _cpuStagingAddress;
+    std::unique_ptr<HgiVulkanBuffer> _stagingBuffer;
+    HgiVulkanMappedMemoryUniquePointer _cpuStagingAddress;
+    bool _isUma;
 };
 
 

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -23,6 +23,11 @@ TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_BUILTIN_BARYCENTRICS, false,
                       "Use Vulkan built in barycentric coordinates");
 TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_NATIVE_INTEROP, true,
                       "Enable native interop with OpenGL (if device supports)");
+TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_UMA, true,
+                      "Use Vulkan with UMA (if device supports)");
+TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_REBAR, false,
+                      "Use Vulkan with ReBAR (if device supports)");
+
 static void _DumpDeviceDeviceMemoryProperties(
     const VkPhysicalDeviceMemoryProperties& vkMemoryProperties)
 {
@@ -78,6 +83,58 @@ static void _DumpDeviceDeviceMemoryProperties(
         }
     }
     std::cout << std::flush;
+}
+
+// Returns true if the device memory can be accessed from the host directly,
+// as-if it was local to the host. This is typically made available by UMA
+// (uniform memory access) or ReBAR (resizable base address register). This
+// should be true for integrated GPUs, dedicated GPUs on systems with ReBAR
+// enabled, and software renderers (like Lavapipe).
+static bool
+_SupportsHostAccessibleDeviceMemory(
+    const VkPhysicalDeviceMemoryProperties& memoryProperties)
+{
+    for (uint32_t heapIndex = 0;
+        heapIndex < memoryProperties.memoryHeapCount; heapIndex++) {
+        const auto& heap = memoryProperties.memoryHeaps[heapIndex];
+
+        // ReBAR has a more basic predecessor called simply BAR. It's limited
+        // to only 256MiB, but otherwise has the exact same flags. While it has
+        // its uses for small resources that change often like uniforms, it
+        // would be much more difficult to use with Hgi, so we'll ignore it.
+        static constexpr size_t barMaxSize = 256 * 1024 * 1024;
+        if (!(heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) ||
+            heap.size <= barMaxSize) {
+            continue;
+        }
+
+         for (uint32_t typeIndex = 0;
+                typeIndex < memoryProperties.memoryTypeCount; typeIndex++) {
+            const auto& memoryType = memoryProperties.memoryTypes[typeIndex];
+            if (memoryType.heapIndex != heapIndex) {
+                continue;
+            }
+
+            // We're looking for a heap that's on the device, but is host
+            // visible. We also want host coherence so writes are automatically
+            // visible and available on the device. Heaps with these properties
+            // show up on UMA and ReBAR enabled GPUs. See:
+            // https://asawicki.info/news_1740_vulkan_memory_types_on_pc_and_how_to_use_them
+            // We don't strictly need HOST_COHERENT_BIT, but it'll make things
+            // simpler. It's really only on less recent mobile devices that
+            // it's not available (mostly before 2021).
+            static constexpr auto deviceLocalHostAccessibleFlags =
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
+                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+             if ((memoryType.propertyFlags & deviceLocalHostAccessibleFlags) ==
+                deviceLocalHostAccessibleFlags) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
@@ -198,8 +255,29 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     TF_VERIFY(
         vkVertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor);
 
+    const bool hostAccessibleDeviceMemory =
+        _SupportsHostAccessibleDeviceMemory(vkMemoryProperties);
+    // If the device is located on or near the host, then it's probably UMA,
+    // anything else is probably ReBAR.
+    const bool uma = hostAccessibleDeviceMemory &&
+        (vkDeviceProperties2.properties.deviceType ==
+            VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ||
+        vkDeviceProperties2.properties.deviceType ==
+            VK_PHYSICAL_DEVICE_TYPE_CPU);
+    const bool rebar = hostAccessibleDeviceMemory && !uma;
+    // For simplicity we'll treat UMA and ReBAR as the same using the
+    // HgiDeviceCapabilitiesBitsUnifiedMemory flag.
+    const bool unifiedMemory =
+        (uma && TfGetEnvSetting(HGIVULKAN_ENABLE_UMA)) ||
+        (rebar && TfGetEnvSetting(HGIVULKAN_ENABLE_REBAR));
+
     if (HgiVulkanIsDebugEnabled()) {
-        TF_STATUS("Selected GPU %s", vkDeviceProperties2.properties.deviceName);
+        auto memoryAccessString = "";
+        if (unifiedMemory) {
+            memoryAccessString = rebar ? " (ReBAR)" : " (UMA)";
+        }
+        TF_STATUS("Selected GPU: \"%s\"%s",
+            vkDeviceProperties2.properties.deviceName, memoryAccessString);
     }
 
     _maxClipDistances = vkDeviceProperties2.properties.limits.maxClipDistances;
@@ -210,8 +288,8 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     _uniformBufferOffsetAlignment =
         vkDeviceProperties2.properties.limits.minUniformBufferOffsetAlignment;
 
-    const bool conservativeRasterEnabled = (device->IsSupportedExtension(
-        VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME));
+    const bool conservativeRasterEnabled = device->IsSupportedExtension(
+        VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     const bool shaderDrawParametersEnabled =
         vkVulkan11Features.shaderDrawParameters;
     bool multiDrawIndirectEnabled = true;
@@ -227,6 +305,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
         builtinBarycentricsEnabled = false;
     }
 
+    _SetFlag(HgiDeviceCapabilitiesBitsUnifiedMemory, unifiedMemory);
     _SetFlag(HgiDeviceCapabilitiesBitsDepthRangeMinusOnetoOne, false);
     _SetFlag(HgiDeviceCapabilitiesBitsStencilReadback, true);
     _SetFlag(HgiDeviceCapabilitiesBitsShaderDoublePrecision, true);

--- a/pxr/imaging/hgiVulkan/texture.cpp
+++ b/pxr/imaging/hgiVulkan/texture.cpp
@@ -19,6 +19,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+
 static bool
 _CheckFormatSupport(
     VkPhysicalDevice pDevice,
@@ -60,7 +61,6 @@ HgiVulkanTexture::HgiVulkanTexture(
     bool optimalTiling,
     bool interop)
     : HgiTexture(desc)
-    , _isTextureView(false)
     , _vkImage(nullptr)
     , _vkImageView(nullptr)
     , _vkImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
@@ -69,6 +69,7 @@ HgiVulkanTexture::HgiVulkanTexture(
     , _inflightBits(0)
     , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _isTextureView(false)
 {
     GfVec3i const& dimensions = desc.dimensions;
     bool const isDepthBuffer = desc.usage & HgiTextureUsageBitsDepthTarget;
@@ -235,18 +236,18 @@ HgiVulkanTexture::HgiVulkanTexture(
         stageDesc.byteSize = 
             std::min(GetByteSizeOfResource(), desc.pixelsByteSize);
         stageDesc.initialData = desc.initialData;
-        HgiVulkanBuffer* stagingBuffer = 
+        std::unique_ptr<HgiVulkanBuffer> stagingBuffer =
             HgiVulkanBuffer::CreateStagingBuffer(_device, stageDesc);
 
         // Schedule transfer from staging buffer to device-local texture
         HgiVulkanCommandQueue* queue = device->GetCommandQueue();
         HgiVulkanCommandBuffer* cb = queue->AcquireResourceCommandBuffer();
-        CopyBufferToTexture(cb, stagingBuffer);
+        CopyBufferToTexture(cb, stagingBuffer.get());
 
         // We don't know if this texture is a static (immutable) or
         // dynamic (animated) texture. We assume that most textures are
         // static and schedule garbage collection of staging resource.
-        HgiBufferHandle stagingHandle(stagingBuffer, 0);
+        HgiBufferHandle stagingHandle(stagingBuffer.release(), 0);
         hgi->TrashObject(
             &stagingHandle,
             hgi->GetGarbageCollector()->GetBufferList());
@@ -284,7 +285,6 @@ HgiVulkanTexture::HgiVulkanTexture(
     HgiVulkanDevice* device,
     HgiTextureViewDesc const & desc)
     : HgiTexture(desc.sourceTexture->GetDescriptor())
-    , _isTextureView(true)
     , _vkImage(nullptr)
     , _vkImageView(nullptr)
     , _vkImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
@@ -293,6 +293,7 @@ HgiVulkanTexture::HgiVulkanTexture(
     , _inflightBits(0)
     , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _isTextureView(true)
 {
     // Update the texture descriptor to reflect the view desc
     _descriptor.debugName = desc.debugName;
@@ -359,7 +360,6 @@ HgiVulkanTexture::~HgiVulkanTexture()
         _cpuStagingAddress = nullptr;
     }
 
-    delete _stagingBuffer;
     _stagingBuffer = nullptr;
 
     if (_vkImageView) {
@@ -426,7 +426,7 @@ HgiVulkanTexture::IsCPUStagingAddress(const void* address) const
 HgiVulkanBuffer*
 HgiVulkanTexture::GetStagingBuffer() const
 {
-    return _stagingBuffer;
+    return _stagingBuffer.get();
 }
 
 VkImage
@@ -488,12 +488,12 @@ HgiVulkanTexture::CopyBufferToTexture(
             _descriptor.layerCount,
             srcBuffer->GetDescriptor().byteSize);
 
-    const size_t mipLevels = std::min(
-        mipInfos.size(), size_t(_descriptor.mipLevels));
+    const int mipLevels = std::min(static_cast<int>(mipInfos.size()),
+        static_cast<int>(_descriptor.mipLevels));
 
-    for (size_t mip = 0; mip < mipLevels; mip++) {
+    for (int mip = 0; mip < mipLevels; mip++) {
         // Skip this mip if it isn't a mipLevel we want to copy
-        if (mipLevel > -1 && (int)mip != mipLevel) {
+        if (mipLevel > -1 && mip != mipLevel) {
             continue;
         }
 
@@ -501,7 +501,7 @@ HgiVulkanTexture::CopyBufferToTexture(
         VkBufferImageCopy bufferCopyRegion = {};
         bufferCopyRegion.imageSubresource.aspectMask =
             HgiVulkanConversions::GetImageAspectFlag(_descriptor.usage);
-        bufferCopyRegion.imageSubresource.mipLevel = (uint32_t) mip;
+        bufferCopyRegion.imageSubresource.mipLevel = static_cast<uint32_t>(mip);
         bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
         bufferCopyRegion.imageSubresource.layerCount = _descriptor.layerCount;
         bufferCopyRegion.imageExtent.width = mipInfo.dimensions[0];

--- a/pxr/imaging/hgiVulkan/texture.h
+++ b/pxr/imaging/hgiVulkan/texture.h
@@ -8,8 +8,9 @@
 #define PXR_IMAGING_HGI_VULKAN_TEXTURE_H
 
 #include "pxr/pxr.h"
-#include "pxr/imaging/hgiVulkan/api.h"
 #include "pxr/imaging/hgi/texture.h"
+#include "pxr/imaging/hgiVulkan/api.h"
+#include "pxr/imaging/hgiVulkan/vulkan.h"
 
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -142,15 +143,15 @@ private:
     HgiVulkanTexture & operator=(const HgiVulkanTexture&) = delete;
     HgiVulkanTexture(const HgiVulkanTexture&) = delete;
 
-    bool _isTextureView;
     VkImage _vkImage;
     VkImageView _vkImageView;
     VkImageLayout _vkImageLayout;
     VmaAllocation _vmaImageAllocation;
     HgiVulkanDevice* _device;
     uint64_t _inflightBits;
-    HgiVulkanBuffer* _stagingBuffer;
+    std::unique_ptr<HgiVulkanBuffer> _stagingBuffer;
     void* _cpuStagingAddress;
+    bool _isTextureView;
 };
 
 


### PR DESCRIPTION
### Description of Change(s)

- Detect UMA and ReBAR in HgiVulkan by examining heap properties
- Do a direct copy to device heap when it's host visible and coherent
    - Avoid staging buffers entirely
- This isn't applicable to images because we need to convert the format to "tiling optimal"
- Misc cleanup

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
