### PR TITLE
Autodesk: Add glPolygonOffset support for lines & points when using Hydra depthBias

### DIFF
--- a/pxr/imaging/hdSt/renderPassState.cpp
+++ b/pxr/imaging/hdSt/renderPassState.cpp
@@ -671,9 +671,13 @@ HdStRenderPassState::Bind(HgiCapabilities const &hgiCapabilities)
     if (!GetDepthBiasUseDefault()) {
         if (GetDepthBiasEnabled()) {
             glEnable(GL_POLYGON_OFFSET_FILL);
+            glEnable(GL_POLYGON_OFFSET_LINE);
+            glEnable(GL_POLYGON_OFFSET_POINT);
             glPolygonOffset(_depthBiasSlopeFactor, _depthBiasConstantFactor);
         } else {
             glDisable(GL_POLYGON_OFFSET_FILL);
+            glDisable(GL_POLYGON_OFFSET_LINE);
+            glDisable(GL_POLYGON_OFFSET_POINT);
         }
     }
 
@@ -788,6 +792,8 @@ HdStRenderPassState::Unbind(HgiCapabilities const &hgiCapabilities)
 
     if (!GetDepthBiasUseDefault()) {
         glDisable(GL_POLYGON_OFFSET_FILL);
+        glDisable(GL_POLYGON_OFFSET_LINE);
+        glDisable(GL_POLYGON_OFFSET_POINT);
         glPolygonOffset(0, 0);
     }
 

--- a/pxr/imaging/hdSt/renderPassState.h
+++ b/pxr/imaging/hdSt/renderPassState.h
@@ -66,6 +66,8 @@ public:
     ///   glEnable(GL_BLEND);
     ///   glEnable(GL_CULL_FACE);
     ///   glEnable(GL_POLYGON_OFFSET_FILL)
+    ///   glEnable(GL_POLYGON_OFFSET_LINE);
+    ///   glEnable(GL_POLYGON_OFFSET_POINT);
     ///   glEnable(GL_PROGRAM_POINT_SIZE);
     ///   glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE)
     ///   glEnable(GL_DEPTH_TEST);

--- a/pxr/imaging/hdx/drawTargetTask.cpp
+++ b/pxr/imaging/hdx/drawTargetTask.cpp
@@ -516,9 +516,13 @@ HdxDrawTargetTask::Execute(HdTaskContext* ctx)
     if (!_depthBiasUseDefault) {
         if (_depthBiasEnable) {
             glEnable(GL_POLYGON_OFFSET_FILL);
+            glEnable(GL_POLYGON_OFFSET_LINE);
+            glEnable(GL_POLYGON_OFFSET_POINT);
             glPolygonOffset(_depthBiasSlopeFactor, _depthBiasConstantFactor);
         } else {
             glDisable(GL_POLYGON_OFFSET_FILL);
+            glDisable(GL_POLYGON_OFFSET_LINE);
+            glDisable(GL_POLYGON_OFFSET_POINT);
         }
     }
 
@@ -552,6 +556,8 @@ HdxDrawTargetTask::Execute(HdTaskContext* ctx)
     glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
     glDisable(GL_PROGRAM_POINT_SIZE);
     glDisable(GL_POLYGON_OFFSET_FILL);
+    glDisable(GL_POLYGON_OFFSET_LINE);
+    glDisable(GL_POLYGON_OFFSET_POINT);
     glFrontFace(GL_CCW);
 }
 

--- a/pxr/imaging/hgiGL/graphicsPipeline.cpp
+++ b/pxr/imaging/hgiGL/graphicsPipeline.cpp
@@ -105,10 +105,14 @@ HgiGLGraphicsPipeline::BindPipeline()
 
     if (_descriptor.depthState.depthBiasEnabled) {
         glEnable(GL_POLYGON_OFFSET_FILL);
+        glEnable(GL_POLYGON_OFFSET_LINE);
+        glEnable(GL_POLYGON_OFFSET_POINT);
         glPolygonOffset(_descriptor.depthState.depthBiasSlopeFactor,
                         _descriptor.depthState.depthBiasConstantFactor);
     } else {
         glDisable(GL_POLYGON_OFFSET_FILL);
+        glDisable(GL_POLYGON_OFFSET_LINE);
+        glDisable(GL_POLYGON_OFFSET_POINT);
     }
 
     glDepthMask(_descriptor.depthState.depthWriteEnabled ? GL_TRUE : GL_FALSE);

--- a/pxr/imaging/hgiGL/scopedStateHolder.cpp
+++ b/pxr/imaging/hgiGL/scopedStateHolder.cpp
@@ -162,8 +162,12 @@ HgiGL_ScopedStateHolder::~HgiGL_ScopedStateHolder()
 
     if (_restoreDepthBias) {
         glEnable(GL_POLYGON_OFFSET_FILL);
+        glEnable(GL_POLYGON_OFFSET_LINE);
+        glEnable(GL_POLYGON_OFFSET_POINT);
     } else {
         glDisable(GL_POLYGON_OFFSET_FILL);
+        glDisable(GL_POLYGON_OFFSET_LINE);
+        glDisable(GL_POLYGON_OFFSET_POINT);
     }
     glPolygonOffset(_restoreDepthBiasSlopeFactor,
                     _restoreDepthBiasConstantFactor);


### PR DESCRIPTION
### Description of Change(s)

Adds glEnable/glDisable calls for GL_POLYGON_OFFSET_LINE & GL_POLYGON_OFFSET_POINT alongside the existing calls for GL_POLYGON_OFFSET_FILL.

When using the depth bias in Hydra, the bias was only applied to polygons, and not lines/points. We use the depth bias to resolve some z-fighting artifacts, but we had problems when using meshes rendered as wireframes, as those are rendered as lines instead of polygons.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
