### PR TITLE
Autodesk: Correct computing hash in ShaderKey and DrawItem

### DIFF
--- a/pxr/imaging/hdSt/commandBuffer.cpp
+++ b/pxr/imaging/hdSt/commandBuffer.cpp
@@ -156,14 +156,17 @@ _InsertDrawItemInstance(
 
     // The draw item instances in a batch need to have compatible
     // pipeline configurations and resource allocations.
-    // Currently, draw items with distinct geometric shader hashes
-    // or buffer array hashes can never be part of the same batch.
-    // We combine these two hashes into a key that can be used to to
+    // Currently, draw items with distinct geometric shader hashes,
+    // materialNetwork shader hashes, buffer array hashes or material
+    // tag hashes can never be part of the same batch.
+    // We combine these four hashes into a key that can be used to to
     // reduce the number of batches which need to be considered
     // as candidate batches.
     size_t key = TfHash::Combine(
         drawItem->GetGeometricShader()->ComputeHash(),
-        drawItem->GetBufferArraysHash()
+        drawItem->GetMaterialNetworkShader()->ComputeHash(),
+        drawItem->GetBufferArraysHash(),
+        drawItem->GetMaterialTag().Hash()
     );
 
     // When we're not allowing texture resource rebinding within a

--- a/pxr/imaging/hdSt/shaderKey.cpp
+++ b/pxr/imaging/hdSt/shaderKey.cpp
@@ -87,6 +87,7 @@ HdSt_ShaderKey::ComputeHash() const
     }
     hash = TfHash::Combine(
         hash,
+        UseMetalTessellation(),
         GetPolygonMode(),
         IsFrustumCullingPass(),
         GetLineWidth(),


### PR DESCRIPTION
### Description of Change(s)

Add UseMetalTessellation to the hash computing of the shaderKey. And include the hash of materialNetworkShader and materialTag in the hash of the drawItem. Because these will impact the generated shader and the drawItems with different shader should be put in different batch.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
