### PR TITLE
Implement vectorized HdMergingSceneIndex::RemoveInputScenes()

### DIFF
--- a/pxr/imaging/hd/CMakeLists.txt
+++ b/pxr/imaging/hd/CMakeLists.txt
@@ -334,6 +334,16 @@ pxr_build_test(testHdDataSource
        testenv/testHdDataSource.cpp
 )
 
+pxr_build_test(testHdMergingSceneIndex
+   LIBRARIES
+       hd
+       sdf
+       tf
+
+   CPPFILES
+       testenv/testHdMergingSceneIndex.cpp
+)
+
 pxr_build_test(testHdSceneIndex
    LIBRARIES
        hd
@@ -435,6 +445,10 @@ pxr_register_test(testHdPerfLog
 
 pxr_register_test(testHdDataSource
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdDataSource"
+)
+
+pxr_register_test(testHdMergingSceneIndex
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdMergingSceneIndex"
 )
 
 pxr_register_test(testHdSceneIndex

--- a/pxr/imaging/hd/mergingSceneIndex.cpp
+++ b/pxr/imaging/hd/mergingSceneIndex.cpp
@@ -253,59 +253,76 @@ HdMergingSceneIndex::RemoveInputScenes(
 {
     TRACE_FUNCTION();
 
-    // Vectorization not implemented yet :(
-
-    for (const HdSceneIndexBaseRefPtr &sceneIndex : sceneIndices) {
-        RemoveInputScene(sceneIndex);
-    }
-}
-
-void
-HdMergingSceneIndex::RemoveInputScene(const HdSceneIndexBaseRefPtr &sceneIndex)
-{
-    TRACE_FUNCTION();
-
-    auto it = std::find_if(
-        _inputs.begin(), _inputs.end(),
-        [&sceneIndex](const _InputEntry &entry) {
-            return sceneIndex == entry.sceneIndex; });
-
-    if (it == _inputs.end()) {
+    if (sceneIndices.empty()) {
         return;
     }
 
-    std::vector<SdfPath> removalTestQueue = { it->sceneRoot };
+    // Remove our observer from the scene indices being removed.
+    HdSceneIndexObserverPtr observerPtr(&_observer);
+    for (const HdSceneIndexBaseRefPtr &sceneIndex : sceneIndices) {
+        sceneIndex->RemoveObserver(observerPtr);
+    }
 
-    sceneIndex->RemoveObserver(HdSceneIndexObserverPtr(&_observer));
-    _inputs.erase(it);
+    // Remove the scene indices from our list of inputs, and record a list of
+    // their scene roots for generating the added/removed notifications below.
+    std::vector<_InputEntry> removedInputs;
+    {
+        std::unordered_set<HdSceneIndexBaseRefPtr, TfHash> sceneIndicesSet;
+        sceneIndicesSet.insert(sceneIndices.begin(), sceneIndices.end());
+
+        auto it = std::stable_partition(
+            _inputs.begin(), _inputs.end(),
+            [&sceneIndicesSet](const _InputEntry &entry) {
+              return !sceneIndicesSet.count(entry.sceneIndex);
+            });
+
+        removedInputs.assign(it, _inputs.end());
+        _inputs.erase(it, _inputs.end());
+    }
+
     _RebuildInputsPathTable();
 
     if (!_IsObserved()) {
         return;
     }
 
-    // prims unique to this input get removed
+    // prims unique to these inputs get removed
     HdSceneIndexObserver::RemovedPrimEntries removedEntries;
 
-    // prims which this input contributed to are resynced via
+    // prims which these inputs contributed to are resynced via
     // PrimsAdded.
     HdSceneIndexObserver::AddedPrimEntries addedEntries;
 
-    // signal removal for anything not present once this scene is
-    // removed
-    while (!removalTestQueue.empty()) {
-        const SdfPath path = removalTestQueue.back();
-        removalTestQueue.pop_back();
+    // Set to prevent sending duplicate notifications.
+    std::unordered_set<SdfPath, SdfPath::Hash> visitedPaths;
 
-        const HdSceneIndexPrim prim = GetPrim(path);
-        if (!prim.dataSource
-                 && GetChildPrimPaths(path).empty()) {
-            removedEntries.emplace_back(path);
-        } else {
-            addedEntries.emplace_back(path, prim.primType);
-            for (const SdfPath &childPath :
-                     sceneIndex->GetChildPrimPaths(path)) {
-                removalTestQueue.push_back(childPath);
+    std::vector<SdfPath> removalTestQueue;
+    for (const _InputEntry &removedInput : removedInputs) {
+        // signal removal for anything not present once this scene is
+        // removed
+        removalTestQueue.push_back(removedInput.sceneRoot);
+
+        while (!removalTestQueue.empty()) {
+            const SdfPath path = removalTestQueue.back();
+            removalTestQueue.pop_back();
+
+            auto [_, notVisited] = visitedPaths.insert(path);
+
+            const HdSceneIndexPrim prim = GetPrim(path);
+            if (!prim.dataSource
+                     && GetChildPrimPaths(path).empty()) {
+                if (notVisited) {
+                    removedEntries.emplace_back(path);
+                }
+            } else {
+                if (notVisited) {
+                    addedEntries.emplace_back(path, prim.primType);
+                }
+
+                for (const SdfPath &childPath :
+                         removedInput.sceneIndex->GetChildPrimPaths(path)) {
+                    removalTestQueue.push_back(childPath);
+                }
             }
         }
     }
@@ -316,6 +333,12 @@ HdMergingSceneIndex::RemoveInputScene(const HdSceneIndexBaseRefPtr &sceneIndex)
     if (!addedEntries.empty()) {
         _SendPrimsAdded(addedEntries);
     }
+}
+
+void
+HdMergingSceneIndex::RemoveInputScene(const HdSceneIndexBaseRefPtr &sceneIndex)
+{
+    RemoveInputScenes({sceneIndex});
 }
 
 std::vector<HdSceneIndexBaseRefPtr>

--- a/pxr/imaging/hd/testenv/testHdMergingSceneIndex.cpp
+++ b/pxr/imaging/hd/testenv/testHdMergingSceneIndex.cpp
@@ -8,26 +8,14 @@
 #include "pxr/imaging/hd/api.h"
 #include "pxr/imaging/hd/filteringSceneIndex.h"
 #include "pxr/imaging/hd/mergingSceneIndex.h"
+#include "pxr/imaging/hd/retainedDataSource.h"
 #include "pxr/imaging/hd/retainedSceneIndex.h"
 
 #include "pxr/base/tf/declarePtrs.h"
 
 #include <iostream>
 
-template <typename T>
-bool
-_CompareValue(const char* msg, const T& v1, const T& v2)
-{
-    if (v1 == v2) {
-        std::cout << msg << " matches." << std::endl;
-    }
-    else {
-        std::cerr << msg << " doesn't match. Expecting " << v2 << " got " << v1
-                  << std::endl;
-        return false;
-    }
-    return true;
-}
+PXR_NAMESPACE_USING_DIRECTIVE
 
 TF_DECLARE_REF_PTRS(_MySceneIndex);
 
@@ -51,6 +39,21 @@ operator<<(std::ostream& out, const std::vector<T>& v)
     }
     out << "]";
     return out;
+}
+
+template <typename T>
+bool
+_CompareValue(const char* msg, const T& v1, const T& v2)
+{
+    if (v1 == v2) {
+        std::cout << msg << " matches." << std::endl;
+    }
+    else {
+        std::cerr << msg << " doesn't match. Expecting " << v2 << " got " << v1
+                  << std::endl;
+        return false;
+    }
+    return true;
 }
 
 class _MySceneIndex final : public HdSingleInputFilteringSceneIndexBase
@@ -225,6 +228,47 @@ _TestNoticesAfterRemove()
         });
 }
 
+static bool
+_TestRemoveInputScenes()
+{
+    const TfToken primType("PrimType");
+    auto dataSource = HdRetainedContainerDataSource::New();
+
+    HdRetainedSceneIndexRefPtr siA = HdRetainedSceneIndex::New();
+    siA->AddPrims({ { SdfPath("/A/B/C/D/E/F"), primType, dataSource },
+                    { SdfPath("/A/B/C/D2"), primType, dataSource } });
+
+    HdRetainedSceneIndexRefPtr siB = HdRetainedSceneIndex::New();
+    siB->AddPrims({ { SdfPath("/A/B/C/D"), primType, dataSource } });
+
+    HdRetainedSceneIndexRefPtr siC = HdRetainedSceneIndex::New();
+    siC->AddPrims({ { SdfPath("/A/B/C"), primType, dataSource } });
+
+    HdMergingSceneIndexRefPtr mergingSceneIndex = HdMergingSceneIndex::New();
+    mergingSceneIndex->AddInputScene(siA, SdfPath("/A/B"));
+    mergingSceneIndex->AddInputScene(siB, SdfPath("/A/B/C"));
+    mergingSceneIndex->AddInputScene(siC, SdfPath::AbsoluteRootPath());
+
+    _Logger logger;
+    mergingSceneIndex->AddObserver(HdSceneIndexObserverPtr(&logger));
+
+    mergingSceneIndex->RemoveInputScenes({siA, siB});
+
+    auto logEntries = logger.GetLog();
+
+    return _CompareValue(
+        "NOTICES", logEntries,
+        {
+            _LogEntry("remove", "/A/B/C/D/E"),
+            _LogEntry("remove", "/A/B/C/D2"),
+            _LogEntry("add", "/A/B"),
+            _LogEntry("add", "/A/B/C"),
+            _LogEntry("add", "/A/B/C/D"),
+            _LogEntry("remove", "/A/B/C/D"),
+            _LogEntry("add", "/A/B/C"),
+        });
+}
+
 #define xstr(s) str(s)
 #define str(s) #s
 #define TEST(X)                                                                \
@@ -244,6 +288,7 @@ main(int argc, char** argv)
 
     int i = 0;
     TEST(_TestNoticesAfterRemove);
+    TEST(_TestRemoveInputScenes);
 
     //-------------------------------------------------------------------------
     std::cout << "DONE testHdMergingSceneIndex" << std::endl;

--- a/pxr/imaging/hd/testenv/testHdMergingSceneIndex.cpp
+++ b/pxr/imaging/hd/testenv/testHdMergingSceneIndex.cpp
@@ -259,12 +259,9 @@ _TestRemoveInputScenes()
     return _CompareValue(
         "NOTICES", logEntries,
         {
-            _LogEntry("remove", "/A/B/C/D/E"),
+            _LogEntry("remove", "/A/B/C/D"),
             _LogEntry("remove", "/A/B/C/D2"),
             _LogEntry("add", "/A/B"),
-            _LogEntry("add", "/A/B/C"),
-            _LogEntry("add", "/A/B/C/D"),
-            _LogEntry("remove", "/A/B/C/D"),
             _LogEntry("add", "/A/B/C"),
         });
 }


### PR DESCRIPTION
### Description of Change(s)

This improves performance with some stage updates for instances, such as the attached example [removeinputscenes_example.zip](https://github.com/user-attachments/files/21621894/removeinputscenes_example.zip)

- With `USDIMAGINGGL_ENGINE_ENABLE_SCENE_INDEX=1`, run `usdview usdskel_instanced.usd`
- In the interpreter, run `usdviewApi.stage.GetSessionLayer().subLayerPaths.append("layer_materials.usda")`
- (example timings for the performance difference are listed below)

While implementing this I also noticed that the HdMergingSceneIndex test was never enabled, so this PR also re-enables it and adds a test for `RemoveInputScenes()` (the first commit adds a test for the original behaviour, with the second commit updating the expected result for the different notifications when removing a batch of scenes at once).

#### Timings

Snippets of timings before and after this change (note these timings also incorporated #3757 to improve the `_RebuildInputsPathTable()` performance)

Before:
```
    0.000 ms     0.000 ms       1 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.332 ms     0.332 ms   10000 samples    |   |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
161665.226 ms     3.050 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
161662.176 ms   467.425 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScene
    0.301 ms     0.301 ms   10000 samples    |   |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
40771.477 ms     1.323 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
40770.153 ms   199.747 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScene
    0.261 ms     0.261 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
  113.224 ms     0.016 ms       1 samples    |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScene
    0.009 ms     0.005 ms       1 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScene
```

After:
```
    0.000 ms     0.000 ms       1 samples    |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.548 ms     0.548 ms   10000 samples    |   |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
   67.336 ms    14.657 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.437 ms     0.437 ms   10000 samples    |   |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
  124.699 ms    33.524 ms       1 samples    |   |   |   |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.370 ms     0.370 ms   10000 samples    |   |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.000 ms     0.000 ms       1 samples    |   |   |   |   |   |   pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
  109.827 ms     0.025 ms       1 samples    |   |   |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes
    0.015 ms     0.010 ms       1 samples    |   | pxrInternal_v0_25_8__pxrReserved__::HdMergingSceneIndex::RemoveInputScenes

```


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
N/A

### Fixes Issue(s)
N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
