### PR TITLE
Autodesk: Add environment variable for thread consistency check

### DIFF
--- a/pxr/imaging/hgiVulkan/hgi.cpp
+++ b/pxr/imaging/hgiVulkan/hgi.cpp
@@ -32,6 +32,16 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+TF_DEFINE_ENV_SETTING(HGIVULKAN_THREAD_CONSISTENCY_CHECK, true,
+   "Check that end frame and command submission are called from the same "
+   "thread which created the HgiVulkan instance");
+
+static bool
+_IsThreadConsistencyCheckEnabled()
+{
+   static bool enabled = TfGetEnvSetting(HGIVULKAN_THREAD_CONSISTENCY_CHECK);
+   return enabled;
+}
 
 TF_REGISTRY_FUNCTION(TfType)
 {
@@ -321,10 +331,13 @@ HgiVulkan::EndFrame()
 void
 HgiVulkan::GarbageCollect()
 {
-    if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
-        TF_CODING_ERROR("Secondary thread violation");
-        return;
+    if (_IsThreadConsistencyCheckEnabled()) {
+        if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
+            TF_CODING_ERROR("Secondary thread violation");
+            return;
+        }
     }
+
     HgiVulkanDevice* device = GetPrimaryDevice();
 
     // Perform garbage collection for each device.
@@ -363,9 +376,11 @@ HgiVulkan::_SubmitCmds(HgiCmds* cmds, HgiSubmitWaitType wait)
     // However, since we currently call garbage collection here and because
     // we only have one resource command buffer, we cannot support submitting
     // cmds from secondary threads until those issues are resolved.
-    if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
-        TF_CODING_ERROR("Secondary threads should not submit cmds");
-        return false;
+    if (_IsThreadConsistencyCheckEnabled()) {
+        if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
+            TF_CODING_ERROR("Secondary threads should not submit cmds");
+            return false;
+        }
     }
 
     // Submit Cmds work
@@ -390,9 +405,11 @@ HgiVulkan::_EndFrameSync()
 {
     // The garbage collector and command buffer reset must happen on the
     // main-thread when no threads are recording.
-    if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
-        TF_CODING_ERROR("Secondary thread violation");
-        return;
+    if (_IsThreadConsistencyCheckEnabled()) {
+        if (ARCH_UNLIKELY(_threadId != std::this_thread::get_id())) {
+            TF_CODING_ERROR("Secondary thread violation");
+            return;
+        }
     }
 
     HgiVulkanDevice* device = GetPrimaryDevice();


### PR DESCRIPTION
### Description of Change(s)

To allow for applications to call the hgi from different threads when the applications don't work with the hgi on different threads concurrently.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
