### PR TITLE
Suppress warning of converting int to size_t in listProxy.h

### DIFF
--- a/pxr/usd/sdf/listProxy.h
+++ b/pxr/usd/sdf/listProxy.h
@@ -43,7 +43,7 @@ public:
 
     /// Returned from \ref Find when a value could not be located in the
     /// list of operations. 
-    static const size_t invalidIndex = -1;
+    static const size_t invalidIndex = size_t(-1);
 
 private:
     // Proxies an item in a list editor list.


### PR DESCRIPTION
### Description of Change(s)

Since 24.08, there was a new line added in listProxy.h that triggered compiler warnings, which was not presented in 24.05.

Compiler: MSVC
Commit that introduced this: https://github.com/PixarAnimationStudios/OpenUSD/commit/a162961b763fc0ff7f255cded91103b2fb518cf5
Error message: `warning C4245: 'initializing': conversion from 'int' to 'const size_t', signed/unsigned mismatch`

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
