### PR TITLE
Enable valgrind make defined marker only on x64

### DIFF
--- a/pxr/exec/vdf/executorDataVector.cpp
+++ b/pxr/exec/vdf/executorDataVector.cpp
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 static inline void
 Vdf_ExecutorDataVector_ValgrindMakeDefined(void *ptr, size_t size)
 {
-#if defined(ARCH_OS_LINUX)
+#if defined(ARCH_OS_LINUX) && defined(ARCH_CPU_INTEL) && defined(ARCH_BITS_64)
     // Pass a result and a pointer to some arguments via registers
     volatile unsigned long long int result;
     volatile unsigned long long int args[6] = {


### PR DESCRIPTION
Until VALGRIND_MAKE_MEM_DEFINED can be used directly.

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Doesn't build on linux-arm64 otherwise

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
