### PR TITLE
Make static `TfToken` macros usable outside of `PXR_NS`

### DIFF
--- a/pxr/base/tf/pyStaticTokens.h
+++ b/pxr/base/tf/pyStaticTokens.h
@@ -28,9 +28,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 ///
 /// \hideinitializer
 #define TF_PY_WRAP_PUBLIC_TOKENS(name, key, seq)                        \
-    pxr_boost::python::class_<                                          \
-        _TF_TOKENS_STRUCT_NAME(key), pxr_boost::python::noncopyable>(   \
-            name, pxr_boost::python::no_init)                           \
+    PXR_NS::pxr_boost::python::class_<                                  \
+        _TF_TOKENS_STRUCT_NAME(key),                                    \
+        PXR_NS::pxr_boost::python::noncopyable>(                        \
+            name, PXR_NS::pxr_boost::python::no_init)                   \
         _TF_PY_TOKENS_WRAP_SEQ(key, seq)
 
 /// Macro to wrap static tokens defined with \c TF_DEFINE_PUBLIC_TOKENS to
@@ -43,7 +44,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 // Private macros to add a single data member.
 #define _TF_PY_TOKENS_WRAP_ATTR_MEMBER(r, key, name)                        \
-    pxr_boost::python::scope().attr(                                            \
+    PXR_NS::pxr_boost::python::scope().attr(                                \
         TF_PP_STRINGIZE(name)) = key->name.GetString();
 
 // We wrap tokens as Python strings, but simply wrapping the token using 

--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -68,10 +68,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 #define _TF_DECLARE_PUBLIC_TOKENS3(key, eiapi, seq)                         \
     _TF_DECLARE_TOKENS3(key, seq, eiapi)                                    \
-    extern eiapi TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    extern eiapi PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 #define _TF_DECLARE_PUBLIC_TOKENS2(key, seq)                                \
     _TF_DECLARE_TOKENS2(key, seq)                                           \
-    extern TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    extern PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 #define _TF_DECLARE_PUBLIC_TOKENS(N) _TF_DECLARE_PUBLIC_TOKENS##N
 #define _TF_DECLARE_PUBLIC_TOKENS_EVAL(N) _TF_DECLARE_PUBLIC_TOKENS(N)
 #define _TF_DECLARE_PUBLIC_TOKENS_EXPAND(x) x
@@ -92,7 +92,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \hideinitializer
 #define TF_DEFINE_PUBLIC_TOKENS(key, seq)                                   \
     _TF_DEFINE_TOKENS(key)                                                  \
-    TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
+    PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME(key)> key
 
 /// Macro to define private tokens.
 /// \hideinitializer
@@ -103,7 +103,7 @@ PXR_NAMESPACE_OPEN_SCOPE
         _TF_TOKENS_DECLARE_MEMBERS(seq)                                     \
     };                                                                      \
     }                                                                       \
-    static TfStaticData<_TF_TOKENS_STRUCT_NAME_PRIVATE(key)> key
+    static PXR_NS::TfStaticData<_TF_TOKENS_STRUCT_NAME_PRIVATE(key)> key
 
 ///////////////////////////////////////////////////////////////////////////////
 // Private Macros
@@ -129,17 +129,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 // be a tuple on the form (name, value) or just a name.
 //
 #define _TF_TOKENS_DECLARE_MEMBER(unused, elem)                             \
-    TfToken _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                \
+    PXR_NS::TfToken _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                        \
         TF_PP_TUPLE_ELEM(0, elem), elem){                                   \
             _TF_PP_IFF(TF_PP_IS_TUPLE(elem),                                \
                 TF_PP_TUPLE_ELEM(1, elem), TF_PP_STRINGIZE(elem)),          \
-            TfToken::Immortal};
+            PXR_NS::TfToken::Immortal};
 #define _TF_TOKENS_DECLARE_TOKEN_MEMBERS(seq)                               \
     TF_PP_SEQ_FOR_EACH(_TF_TOKENS_DECLARE_MEMBER, ~, seq)
 
 #define _TF_TOKENS_FORWARD_TOKEN(unused, elem) TF_PP_TUPLE_ELEM(0, elem),
 #define _TF_TOKENS_DECLARE_ALL_TOKENS(seq)                                  \
-    std::vector<TfToken> allTokens =                                        \
+    std::vector<PXR_NS::TfToken> allTokens =                                \
         {TF_PP_SEQ_FOR_EACH(_TF_TOKENS_FORWARD_TOKEN, ~, seq)};
 
 // Private macro used to declare the list of members as TfTokens

--- a/pxr/base/tf/wrapTestPyStaticTokens.cpp
+++ b/pxr/base/tf/wrapTestPyStaticTokens.cpp
@@ -10,18 +10,12 @@
 
 #include "pxr/base/tf/pyStaticTokens.h"
 
-PXR_NAMESPACE_OPEN_SCOPE
-
 #define TF_TEST_TOKENS                  \
     (orange)                            \
     ((pear, "d'Anjou"))                 
 
 TF_DECLARE_PUBLIC_TOKENS(tfTestStaticTokens, TF_API, TF_TEST_TOKENS);
 TF_DEFINE_PUBLIC_TOKENS(tfTestStaticTokens, TF_TEST_TOKENS);
-
-PXR_NAMESPACE_CLOSE_SCOPE
-
-PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 struct _DummyScope {
@@ -34,9 +28,10 @@ wrapTf_TestPyStaticTokens()
     TF_PY_WRAP_PUBLIC_TOKENS("_testStaticTokens",
                              tfTestStaticTokens, TF_TEST_TOKENS);
 
-    pxr_boost::python::class_<_DummyScope, pxr_boost::python::noncopyable>
-        cls("_TestStaticTokens", pxr_boost::python::no_init);
-    pxr_boost::python::scope testScope = cls;
+    PXR_NS::pxr_boost::python::class_<
+        _DummyScope, PXR_NS::pxr_boost::python::noncopyable>
+        cls("_TestStaticTokens", PXR_NS::pxr_boost::python::no_init);
+    PXR_NS::pxr_boost::python::scope testScope = cls;
 
     TF_PY_WRAP_PUBLIC_TOKENS_IN_CURRENT_SCOPE(
         tfTestStaticTokens, TF_TEST_TOKENS);


### PR DESCRIPTION
### Description of Change(s)

The static `TfToken` macros make unqualified lookups to various types in the `PXR_NS` namespace. This limits their usage in headers to the `PXR_NS` (source `.cpp` files can use the `PXR_NAMESPACE_USING_DIRECTIVE` macro). This prefixes all usage of types in macros with `PXR_NS` to enable usage in headers.

(Originated as #2899, but was accidently closed.)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#1184 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
