### PR TITLE
Support isolated "!resetXformStack!"

### DIFF
--- a/pxr/usdImaging/usdImaging/dataSourcePrim.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourcePrim.cpp
@@ -657,7 +657,8 @@ UsdImagingDataSourcePrim::Get(const TfToken &name)
         }
 
         UsdGeomXformable::XformQuery xformQuery(xformable);
-        if (xformQuery.HasNonEmptyXformOpOrder()) {
+        if (xformQuery.HasNonEmptyXformOpOrder() ||
+            xformQuery.GetResetXformStack()) {
             return UsdImagingDataSourceXform::New(
                     xformQuery, _sceneIndexPath, _GetStageGlobals());
         } else {


### PR DESCRIPTION
### Description of Change(s)

Even if there aren't any Ops, we still want to author data when `resetXformStack` is `true`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#3781 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
