### PR TITLE
Don't clear DirtyRenderTag bit and not skip sync of non-visible rprim when display purpose is changed

### DIFF
--- a/pxr/imaging/hd/dirtyList.cpp
+++ b/pxr/imaging/hd/dirtyList.cpp
@@ -40,8 +40,11 @@ _DirtyRprimIdsFilterPredicate(
     
     if (mask == HdChangeTracker::Clean || bits & mask) {
         // Update the render tag if needed.
+        TfToken oldRenderTag = renderIndex->GetRenderTag(rprimID);
+        // Why we don't clear the dirty bit of DirtyRenderTag?
+        // Because rprim sync needs to detect the change of render tag.
         const TfToken& primRenderTag =
-            renderIndex->UpdateRenderTag(rprimID, bits);
+            renderIndex->_UpdateRenderTagInternal(rprimID, bits, false);
 
         // XXX An empty render tag set means everything passes the filter
         //     We should use an explicit token to indicate all render tags.
@@ -50,6 +53,14 @@ _DirtyRprimIdsFilterPredicate(
         //     Primary user is tests, but some single task render delegates
         //     that don't support render tags yet also use it.
         if (filterParam->renderTags.empty()) {
+            return true;
+        }
+        
+        // If the render tag has changed, we need to give rprim a chance to 
+        // sync the render tag so rprim can be updated.
+        // This is a hack to get around the fact that hydra skips the sync of
+        // rprims when the render tags are not meant to be rendered below.
+        if (oldRenderTag != primRenderTag) {
             return true;
         }
 

--- a/pxr/imaging/hd/renderIndex.cpp
+++ b/pxr/imaging/hd/renderIndex.cpp
@@ -1152,6 +1152,14 @@ TfToken
 HdRenderIndex::UpdateRenderTag(SdfPath const& id,
                                HdDirtyBits bits)
 {
+    return _UpdateRenderTagInternal(id, bits, true);
+}
+
+TfToken
+HdRenderIndex::_UpdateRenderTagInternal(SdfPath const& id,
+                                        HdDirtyBits bits,
+                                        bool clearDirtyRenderTag)
+{
     _RprimInfo const* info = TfMapLookupPtr(_rprimMap, id);
     if (info == nullptr) {
         return HdRenderTagTokens->hidden;
@@ -1160,8 +1168,10 @@ HdRenderIndex::UpdateRenderTag(SdfPath const& id,
     if (bits & HdChangeTracker::DirtyRenderTag) {
         info->rprim->UpdateRenderTag(info->sceneDelegate,
                                     _renderDelegate->GetRenderParam());
-        _tracker.MarkRprimClean(id,
-                                bits & ~HdChangeTracker::DirtyRenderTag);
+        if (clearDirtyRenderTag) {
+            _tracker.MarkRprimClean(id,
+                                    bits & ~HdChangeTracker::DirtyRenderTag);
+        }
     }
     return info->rprim->GetRenderTag();
 }

--- a/pxr/imaging/hd/renderIndex.h
+++ b/pxr/imaging/hd/renderIndex.h
@@ -233,6 +233,14 @@ public:
     TfToken UpdateRenderTag(SdfPath const& id,
                             HdDirtyBits bits);
 
+    // Like UpdateRenderTag, but can be called by the client to 
+    // update the render tag without clearing the dirty render tag bit.
+    // We keep this function since we don't want to break API compatibility
+    // of the public UpdateRenderTag.
+    TfToken _UpdateRenderTagInternal(SdfPath const& id,
+                                     HdDirtyBits bits,
+                                     bool clearDirtyRenderTag);
+
     /// Returns a sorted list of all Rprims in the render index.
     /// The list is sorted by std::less<SdfPath>
     HD_API


### PR DESCRIPTION
### Description of Change(s)

When the display purpose of a prim is modified to a value that is not meant to be rendered, Hydra skips some syncs because it counts as invisible. This PR fixes it by not clearing DirtyRenderTag bit and not skipping sync of non-visible rprim when display purpose is changed.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/801

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
