### PR TITLE
Include export/import macro in `staticTokens.h` documentation

### DIFF
--- a/pxr/base/tf/staticTokens.h
+++ b/pxr/base/tf/staticTokens.h
@@ -29,7 +29,11 @@
 ///        // Syntax when string name differs from symbol.
 ///        ((foo, "bar"))
 ///
-///    TF_DECLARE_PUBLIC_TOKENS(MfTokens, MF_TOKENS);
+///    // Include an export/import macro (e.g., MF_API) as the second argument
+///    // if you need the symbols to be exported. Othwerise, the two argument
+///    // version `TF_DECLARE_PUBLIC_TOKENS(MfTokens, MF_TOKENS);` is
+///    // sufficient.
+///    TF_DECLARE_PUBLIC_TOKENS(MfTokens, MF_API, MF_TOKENS);
 /// \endcode
 ///
 /// In cpp file:


### PR DESCRIPTION
### Description of Change(s)

Most usages of the `TF_DECLARE_PUBLIC_TOKENS` macro require symbols to be exported, but the example in the doxygen docs uses the two argument version that doesn't explicitly export symbols.  The example has been updated to use the three argument version that exports symbols with a comment noting that if you don't need to export symbols, how to use the two argument version.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#3779

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
