### PR TITLE
[usdMtlx] Copy relative paths for the MaterialX standard library files for all platforms

### DIFF
--- a/pxr/usd/usdMtlx/CMakeLists.txt
+++ b/pxr/usd/usdMtlx/CMakeLists.txt
@@ -15,27 +15,25 @@ if (MATERIALX_STDLIB_DIR)
     # CMakeLists and documentation files
     list(FILTER MATERIALX_STDLIB_RESOURCES EXCLUDE REGEX ".*\\.(txt|md)$")
 
-    if (WIN32)
-        foreach(file ${MATERIALX_STDLIB_RESOURCES})
-            # Create the relative path for the destination in the resource destination
-            file(RELATIVE_PATH _resource_relative ${MATERIALX_STDLIB_DIR} ${file})
+    foreach(file ${MATERIALX_STDLIB_RESOURCES})
+        # Create the relative path for the destination in the resource destination
+        file(RELATIVE_PATH _resource_relative ${MATERIALX_STDLIB_DIR} ${file})
 
-            # XXX Create the path for the source file relative to the current source
-            # directory. This is done to avoid absolute paths which is not compatible with
-            # _install_resource_files in Private.cmake which uses : as a separator. This breaks 
-            # for absolute paths on windows which uses them for drive letters (c:\blah)
-            # This will still fail if MATERIALX_STDLIB_DIR points to assets on a different
-            # drive than the usd source directory on windows
-            file(RELATIVE_PATH _source_relative ${CMAKE_CURRENT_SOURCE_DIR} ${file})
+        # XXX Create the path for the source file relative to the current source
+        # directory. This is done to avoid absolute paths which is not compatible with
+        # _install_resource_files in Private.cmake which uses : as a separator. This breaks
+        # for absolute paths on windows which uses them for drive letters (c:\blah)
+        # This will still fail if MATERIALX_STDLIB_DIR points to assets on a different
+        # drive than the usd source directory on windows
+        file(RELATIVE_PATH _source_relative ${CMAKE_CURRENT_SOURCE_DIR} ${file})
 
-            # Make a list of : separated paths of source files and destination files for
-            # the materialx library files so they can be installed in the resource
-            # directory for the plugin
-            list(APPEND MATERIALX_STDLIB_FILES "${_source_relative}:libraries/${_resource_relative}")
-        endforeach()
+        # Make a list of : separated paths of source files and destination files for
+        # the materialx library files so they can be installed in the resource
+        # directory for the plugin
+        list(APPEND MATERIALX_STDLIB_FILES "${_source_relative}:libraries/${_resource_relative}")
+    endforeach()
 
-        set(MATERIALX_STDLIB_RESOURCES ${MATERIALX_STDLIB_FILES})
-    endif()
+    set(MATERIALX_STDLIB_RESOURCES ${MATERIALX_STDLIB_FILES})
 endif()
 
 pxr_library(usdMtlx


### PR DESCRIPTION

### Description of Change(s)

Removes the Windows specific conditional for copying files from the MaterialX standard library to USD, so that absolute paths are no longer embedded into paths on Linux and macOS.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
N/A

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3796

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
