### PR TITLE
Add RENDERMAN_OSL_INCLUDE_DIR

### DIFF
--- a/cmake/modules/FindRenderman.cmake
+++ b/cmake/modules/FindRenderman.cmake
@@ -11,6 +11,7 @@
 #   RENDERMAN_LIBRARY     - path to renderman library files
 #   RENDERMAN_EXECUTABLE  - path the prman executable
 #   RENDERMAN_BINARY_DIR  - path to the renderman binary directory
+#   RENDERMAN_OSL_INCLUDE_DIR - path to the renderman OSL header directory
 #       RENDERMAN_FOUND   - true if renderman was found
 #   RENDERMAN_VERSION_MAJOR - major version of renderman found
 #   RENDERMAN_VERSION_MINOR - minor version of renderman found
@@ -103,6 +104,16 @@ find_path(RENDERMAN_INCLUDE_DIR
         "Renderman headers path"
 )
 
+find_path(RENDERMAN_OSL_INCLUDE_DIR
+    stdosl.h
+    HINTS
+        "${RENDERMAN_LOCATION}/lib/osl/include"
+        "$ENV{RENDERMAN_LOCATION}/lib/osl/include"
+        "$ENV{RMANTREE}/lib/osl/include"
+    DOC
+        "Renderman OSL headers path"
+)
+
 find_program(RENDERMAN_EXECUTABLE
     prman
     HINTS
@@ -142,6 +153,7 @@ list(APPEND required_vars "RENDERMAN_VERSION")
 list(APPEND required_vars "PRMAN_LIBRARY")
 list(APPEND required_vars "PRMAN_STATS_LIBRARY")
 list(APPEND required_vars "PXRCORE_LIBRARY")
+list(APPEND required_vars "RENDERMAN_OSL_INCLUDE_DIR")
 
 find_package_handle_standard_args(Renderman
   REQUIRED_VARS

--- a/third_party/renderman-26/shaders/CMakeLists.txt
+++ b/third_party/renderman-26/shaders/CMakeLists.txt
@@ -10,7 +10,7 @@ function(prman_osl SHADER_NAME SHADER_DIR)
     set(outfile ${CMAKE_CURRENT_BINARY_DIR}/${SHADER_NAME}.oso)
     add_custom_command(
         OUTPUT ${outfile}
-        COMMAND ${RENDERMAN_BINARY_DIR}/oslc -o ${outfile} ${infile}
+        COMMAND ${RENDERMAN_BINARY_DIR}/oslc -I${RENDERMAN_OSL_INCLUDE_DIR} -o ${outfile} ${infile}
         MAIN_DEPENDENCY ${infile}
         VERBATIM
     )


### PR DESCRIPTION
Add RENDERMAN_OSL_INCLUDE_DIR to FindRenderman.cmake and use it when building OSL shaders.

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- When building the renderman-26 plugin, often the OSL include to get `stdosl.h` is left undefined and will try to find it either from another OSL build and not the one found bundled with Renderman, or in Windows' case, will find one with forward-slashes or a resolved UNC path from a network and fail to find the file.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
