### PR TITLE
Explicitly handle SdfAssetPath primvars specified on native instances

### DIFF
--- a/pxr/usdImaging/usdImaging/niInstanceAggregationSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/niInstanceAggregationSceneIndex.cpp
@@ -220,6 +220,13 @@ public:
     }
 
     HdDataSourceBaseHandle operator()(const VtValue &v) const {
+        // There are some types that VtVisitValue can't handle (i.e., they
+        // don't appear in VT_VALUE_TYPES) that we still care about, so check
+        // for them explicitly here.   
+        if (v.IsHolding<SdfAssetPath>()) {
+            return _PrimvarValueDataSource<SdfAssetPath>::New(
+                _inputSceneIndex, _instances, _primvarName);
+        }
         return nullptr;
     }
 


### PR DESCRIPTION
### Description of Change(s)

Explicitly handling SdfAsstPath primvars in the Native Instance Aggregation Scene Index.

### Fixes Issue(s)

#3801 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
