### PR TITLE
Extend the list of supported types for flattening primvars

### DIFF
--- a/pxr/usd/usdGeom/primvar.cpp
+++ b/pxr/usd/usdGeom/primvar.cpp
@@ -8,7 +8,9 @@
 #include "pxr/usd/usdGeom/primvar.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/relationship.h"
+#include "pxr/usd/sdf/types.h"
 
+#include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/staticTokens.h"
 
@@ -376,38 +378,25 @@ UsdGeomPrimvar::ComputeFlattened(
     }
 
     // Handle all known supported array value types.
-    bool foundSupportedType =
-        _ComputeFlattenedArray<VtVec2fArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec2dArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec2iArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec2hArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec3fArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec3dArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec3iArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec3hArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec4fArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec4dArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec4iArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtVec4hArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtMatrix3dArray>(attrVal, indices, elementSize, value, 
-                errStr)    ||
-        _ComputeFlattenedArray<VtMatrix4dArray>(attrVal, indices, elementSize, value, 
-                errStr)    ||
-        _ComputeFlattenedArray<VtStringArray>(attrVal, indices, elementSize, value, errStr)||
-        _ComputeFlattenedArray<VtDoubleArray>(attrVal, indices, elementSize, value, errStr)||
-        _ComputeFlattenedArray<VtIntArray>(attrVal, indices, elementSize, value, errStr)   ||
-        _ComputeFlattenedArray<VtUIntArray>(attrVal, indices, elementSize, value, errStr)  ||
-        _ComputeFlattenedArray<VtFloatArray>(attrVal, indices, elementSize, value, errStr) ||
-        _ComputeFlattenedArray<VtHalfArray>(attrVal, indices, elementSize, value, errStr);
+#define USDGEOM_TRY_FLATTEN_TYPE(unused, elem)                                 \
+    if (_ComputeFlattenedArray<SDF_VALUE_CPP_ARRAY_TYPE(elem)>(                \
+            attrVal, indices, elementSize, value, errStr)) {                   \
+        return true;                                                           \
+    }
 
-    if (!foundSupportedType && errStr) {
+    TF_PP_SEQ_FOR_EACH(USDGEOM_TRY_FLATTEN_TYPE, ~, SDF_VALUE_TYPES);
+
+#undef USDGEOM_TRY_FLATTEN_TYPE
+
+    // If we reached here, the value is not a supported type.
+    if (errStr) {
         std::string thisErr = TfStringPrintf(
             "Unsupported indexed primvar value type %s.", 
             attrVal.GetTypeName().c_str());
         *errStr = errStr->empty() ? thisErr : *errStr + "\n" + thisErr;
     }
 
-    return !value->IsEmpty();
+    return false;
 }
 
 UsdGeomPrimvar::UsdGeomPrimvar(const UsdPrim& prim, 

--- a/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
+++ b/pxr/usd/usdGeom/testenv/testUsdGeomPrimvar.py
@@ -715,5 +715,24 @@ class TestUsdGeomPrimvarsAPI(unittest.TestCase):
         self.assertEqual(primvar, meshPrimvarsAPI.GetPrimvar("pv"))
         self.assertEqual(hash(primvar), hash(meshPrimvarsAPI.GetPrimvar("pv")))
 
+    def test_FlattenAssetPaths(self):
+        stage = Usd.Stage.CreateInMemory()
+        mesh = UsdGeom.Mesh.Define(stage, '/mesh')
+        pv_api = UsdGeom.PrimvarsAPI(mesh)
+
+        vals = [Sdf.AssetPath('foo.png'), Sdf.AssetPath('bar.png')]
+        indices = [1, 0, 1]
+
+        primvar = pv_api.CreateIndexedPrimvar(
+            "assetprimvar", Sdf.ValueTypeNames.AssetArray,
+            vals, indices, UsdGeom.Tokens.vertex)
+
+        self.assertEqual(primvar.ComputeFlattened(), [
+            Sdf.AssetPath("bar.png"),
+            Sdf.AssetPath("foo.png"),
+            Sdf.AssetPath("bar.png")
+        ])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)

When doing some tests with `asset[]` primvars for texture variation on point instancers, I noticed that flattening an indexed `asset[]` primvar failed  with `Unsupported indexed primvar value type`

This proposed change uses `SDF_VALUE_TYPES` to support all of the standard types. There were several other missing types from the list, such as int64, uint64, bool, TfToken, SdfAssetPath, GfMatrix2d, and GfQuat*

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
N/A

### Fixes Issue(s)
N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
