### PR TITLE
usdrecord update (added drawMode, disableSceneMaterials arguments)

### DIFF
--- a/pxr/usdImaging/bin/usdrecord/usdrecord.py
+++ b/pxr/usdImaging/bin/usdrecord/usdrecord.py
@@ -238,6 +238,19 @@ def main() -> int:
             'Will have no effect if MallocTags are not supported in the '
             'USD installation.'))
 
+    parser.add_argument('--drawMode', action='store', type=str,
+        default='SmoothShaded',
+        help=(
+            'Render mode ("Points", "Wireframe", "WireframeOnSurface", "Flat Shaded", '
+            '"Smooth Shaded", "Geom Only", "Geom Flat", "Geom Smooth").'))
+
+    # Note: The argument passed via the command line (disableSceneMaterials)
+    # is inverted from the variable in which it is stored (sceneMaterialsEnabled)
+    parser.add_argument('--disableSceneMaterials', action='store_false',
+        dest='sceneMaterialsEnabled',
+        help=(
+            'Disable scene materials for rendering.'))
+
     args = parser.parse_args()
 
     args.imageWidth = max(args.imageWidth, 1)
@@ -366,6 +379,8 @@ def main() -> int:
     frameRecorder.SetIncludedPurposes(purposes)
     frameRecorder.SetDomeLightVisibility(args.domeLightVisibility)
     frameRecorder.SetPrimaryCameraPrimPath(usdCamera.GetPath())
+    frameRecorder.SetDrawMode(args.drawMode)
+    frameRecorder.SetSceneMaterialsEnabled(args.sceneMaterialsEnabled)
 
     _Msg('Camera: %s' % usdCamera.GetPath().pathString)
     _Msg('Renderer plugin: %s' % frameRecorder.GetCurrentRendererId())

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.cpp
@@ -65,7 +65,9 @@ UsdAppUtilsFrameRecorder::UsdAppUtilsFrameRecorder(
     _colorCorrectionMode(HdxColorCorrectionTokens->disabled),
     _purposes({UsdGeomTokens->default_, UsdGeomTokens->proxy}),
     _cameraLightEnabled(true),
-    _domeLightsVisible(false)
+    _domeLightsVisible(false),
+    _drawMode(UsdImagingGLDrawMode::DRAW_SHADED_SMOOTH),
+    _sceneMaterialsEnabled(true)
 {
     // Disable presentation to avoid the need to create an OpenGL context when
     // using other graphics APIs such as Metal and Vulkan.
@@ -152,6 +154,37 @@ void
 UsdAppUtilsFrameRecorder::SetPrimaryCameraPrimPath(const SdfPath& cameraPath)
 {
     _imagingEngine.SetCameraPath(cameraPath);
+}
+
+void
+UsdAppUtilsFrameRecorder::SetDrawMode(const TfToken& drawMode)
+{
+    if (drawMode == TfToken("Points")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_POINTS;
+    } else if (drawMode == TfToken("Wireframe")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_WIREFRAME;
+    } else if (drawMode == TfToken("WireframeOnSurface")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_WIREFRAME_ON_SURFACE;
+    } else if (drawMode == TfToken("Flat Shaded")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_SHADED_FLAT;
+    } else if (drawMode == TfToken("Smooth Shaded")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_SHADED_SMOOTH;
+    } else if (drawMode == TfToken("Geom Only")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_GEOM_ONLY;
+    } else if (drawMode == TfToken("Geom Flat")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_GEOM_FLAT;
+    } else if (drawMode == TfToken("Geom Smooth")) {
+        _drawMode = UsdImagingGLDrawMode::DRAW_GEOM_SMOOTH;
+    } else {
+        // Default fallback
+        _drawMode = UsdImagingGLDrawMode::DRAW_SHADED_SMOOTH;
+    }
+}
+
+void
+UsdAppUtilsFrameRecorder::SetSceneMaterialsEnabled(bool enabled)
+{
+    _sceneMaterialsEnabled = enabled;
 }
 
 static GfCamera
@@ -467,6 +500,8 @@ UsdAppUtilsFrameRecorder::Record(
     renderParams.showProxy = _HasPurpose(_purposes, UsdGeomTokens->proxy);
     renderParams.showRender = _HasPurpose(_purposes, UsdGeomTokens->render);
     renderParams.showGuides = _HasPurpose(_purposes, UsdGeomTokens->guide);
+    renderParams.drawMode = _drawMode;
+    renderParams.enableSceneMaterials = _sceneMaterialsEnabled;
 
     const UsdPrim& pseudoRoot = stage->GetPseudoRoot();
 

--- a/pxr/usdImaging/usdAppUtils/frameRecorder.h
+++ b/pxr/usdImaging/usdAppUtils/frameRecorder.h
@@ -164,6 +164,12 @@ public:
             const UsdTimeCode timeCode,
             const std::string& outputImagePath);
 
+    USDAPPUTILS_API
+    void SetDrawMode(const TfToken& drawMode);
+    
+    USDAPPUTILS_API
+    void SetSceneMaterialsEnabled(bool enabled);
+
 private:
     UsdImagingGLEngine _imagingEngine;
     size_t _imageWidth;
@@ -174,6 +180,8 @@ private:
     SdfPath _renderSettingsPrimPath;
     bool _cameraLightEnabled;
     bool _domeLightsVisible;
+    UsdImagingGLDrawMode _drawMode;
+    bool _sceneMaterialsEnabled;
 };
 
 

--- a/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
+++ b/pxr/usdImaging/usdAppUtils/wrapFrameRecorder.cpp
@@ -41,6 +41,8 @@ wrapFrameRecorder()
         .def("SetComplexity", &This::SetComplexity)
         .def("SetColorCorrectionMode", &This::SetColorCorrectionMode)
         .def("SetPrimaryCameraPrimPath", &This::SetPrimaryCameraPrimPath)
+        .def("SetDrawMode", &UsdAppUtilsFrameRecorder::SetDrawMode)
+        .def("SetSceneMaterialsEnabled", &UsdAppUtilsFrameRecorder::SetSceneMaterialsEnabled)
         .def("SetIncludedPurposes", &This::SetIncludedPurposes,
              (arg("purposes")))
         .def(


### PR DESCRIPTION
### Description of Change(s)

This PR adds support for additional rendering options to the **`usdrecord`** tool.

**New arguments:**
- `--drawMode DRAWMODE`  
  Allows choosing the render mode. Supported modes:  
  - `Points`  
  - `Wireframe`  
  - `WireframeOnSurface`  
  - `Flat Shaded`  
  - `Smooth Shaded`  
  - `Geom Only`  
  - `Geom Flat`  
  - `Geom Smooth`  

- `--disableSceneMaterials`  
  Disables scene materials for rendering. 

### Link to proposal
N/A (minor feature enhancement to usdrecord).

### Fixes Issue(s)
N/A (new functionality).

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes
The following tests FAILED:
        980 - testUsdviewNavigationKeys (Failed)
        995 - testUsdResolverExample (Failed)

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
