### PR TITLE
Remove unnecessary render tags

### DIFF
--- a/pxr/imaging/hd/dirtyList.cpp
+++ b/pxr/imaging/hd/dirtyList.cpp
@@ -137,15 +137,9 @@ HdDirtyList::UpdateRenderTagsAndReprSelectors(
     {
         // See comment in_DirtyRprimIdsFilterPredicate re: empty render tags.
         TRACE_SCOPE("Render tag combine");
-        TfTokenVector combinedRenderTags;
-        std::set_union(_trackedRenderTags.cbegin(),
-                       _trackedRenderTags.cend(),
-                       tags.cbegin(),
-                       tags.cend(),
-                       std::back_inserter(combinedRenderTags));
 
-        if (_trackedRenderTags != combinedRenderTags) {
-            _trackedRenderTags.swap(combinedRenderTags);
+        if (tags != _trackedRenderTags) {
+            _trackedRenderTags = tags;
             trackedRenderTagsChanged = true;
         }
     }

--- a/pxr/imaging/hd/testenv/testHdDirtyList.cpp
+++ b/pxr/imaging/hd/testenv/testHdDirtyList.cpp
@@ -127,15 +127,15 @@ BasicTest()
             TfTokenVector({HdRenderTagTokens->guide}),
             HdReprSelectorVector({surface}));
 
-        _VerifyDirtyListSize(&dl, numGeometryPrims + numGuidePrims);
-        _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 2);
+        _VerifyDirtyListSize(&dl, numGuidePrims);
+        _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 1);
 
         // guide -> geometry : Dirty list will be rebuilt to just the varying
         // ones (which is none).
         dl.UpdateRenderTagsAndReprSelectors(
             TfTokenVector({HdRenderTagTokens->geometry}),
             HdReprSelectorVector({surface}));
-        _VerifyDirtyListSize(&dl, 0);
+        _VerifyDirtyListSize(&dl, 2);
         _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 3);
     }
 
@@ -148,7 +148,7 @@ BasicTest()
         delegate.AddCube(SdfPath("/cube4"), GfMatrix4f());
         numGeometryPrims++;
 
-        _VerifyDirtyListSize(&dl, numGeometryPrims + numGuidePrims);
+        _VerifyDirtyListSize(&dl, numGeometryPrims);
         _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 1);
     }
 
@@ -168,7 +168,7 @@ BasicTest()
         tracker.MarkRprimDirty(SdfPath("/cube1"), HdChangeTracker::DirtyPrimvar);
         tracker.MarkRprimDirty(SdfPath("/cube3"), HdChangeTracker::DirtyPoints);
 
-        _VerifyDirtyListSize(&dl, 2);
+        _VerifyDirtyListSize(&dl, 1);
         _VerifyCounter(&perfLog, HdPerfTokens->dirtyListsRebuilt, 1);
 
         // Querying the dirty ids again when nothing has changed should return


### PR DESCRIPTION
### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
Currently render tags are present forever once they are being tracked one. That leads to unnecessary prim synchronization  and slowdown.

### Fixes Issue(s)
This is a fix for https://github.com/PixarAnimationStudios/OpenUSD/issues/3605

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
