### PR TITLE
By default, include default, render, and proxy purpose bounds when calculating extents

### DIFF
--- a/pxr/usdImaging/usdImaging/extentResolvingSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/extentResolvingSceneIndex.cpp
@@ -24,7 +24,7 @@ namespace UsdImagingExtentResolvingSceneIndex_Impl
 TfToken::HashSet
 _GetPurposes(HdContainerDataSourceHandle const &inputArgs)
 {
-    static const TfToken defaultTokens[] = { HdTokens->geometry };
+    static const TfToken defaultTokens[] = { HdRenderTagTokens->geometry };
     static const TfToken::HashSet defaultSet{ std::begin(defaultTokens),
                                               std::end(defaultTokens) };
 

--- a/pxr/usdImaging/usdImaging/extentResolvingSceneIndex.h
+++ b/pxr/usdImaging/usdImaging/extentResolvingSceneIndex.h
@@ -41,7 +41,7 @@ public:
     
     // Datasource purposes at inputArgs is supposed to be a vector data source
     // of token data sources. These tokens are hydra purposes (in particular,
-    // use HdTokens->geometry rather than the corresponding
+    // use HdRenderTagTokens->geometry rather than the corresponding
     // UsdGeomTokens->default_).
     USDIMAGING_API
     static UsdImagingExtentResolvingSceneIndexRefPtr

--- a/pxr/usdImaging/usdImaging/sceneIndices.cpp
+++ b/pxr/usdImaging/usdImaging/sceneIndices.cpp
@@ -89,14 +89,20 @@ _AdditionalStageSceneIndexInputArgs(
     return ds;
 }
 
-// Use extentsHint (of models) for purpose geometry
+// Use extentsHint (of models) for purpose geometry, render, and proxy. If
+// we don't include all purposes, setting an extent-based draw mode on a
+// prim with only some extent purposes authored may return invalid extents.
 static
 HdContainerDataSourceHandle
 _ExtentResolvingSceneIndexInputArgs()
 {
     HdDataSourceBaseHandle const purposeDataSources[] = {
         HdRetainedTypedSampledDataSource<TfToken>::New(
-            HdTokens->geometry) };
+            HdRenderTagTokens->geometry),
+        HdRetainedTypedSampledDataSource<TfToken>::New(
+            HdRenderTagTokens->render),
+        HdRetainedTypedSampledDataSource<TfToken>::New(
+            HdRenderTagTokens->proxy) };
 
     return
         HdRetainedContainerDataSource::New(


### PR DESCRIPTION
### Description of Change(s)
The hydra1 draw mode code calculates the bounds for a prim by taking the union of default, proxy, and render purpose extents on the prim. hydra2, while capable of unioning multiple purposes, only ever pulled the default purpose bounds. If an asset has no child default geometry, only proxy and/or render geometry, no draw mode stand in is rendered. This change modifies the set of purposes queried to include default, proxy, and render just as hydra1 did.

### Fixes Issue(s)
#3813 

### Checklist

- [ X ] I have created this PR based on the dev branch

- [ X ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ no ] I have added unit tests that exercise this functionality (Reference: 

- [ X ] I have verified that all unit tests pass with the proposed changes

- [ X ] I have submitted a signed Contributor License Agreement (Reference: 
