### PR TITLE
Enable clang-cl support

### DIFF
--- a/cmake/defaults/clangdefaults.cmake
+++ b/cmake/defaults/clangdefaults.cmake
@@ -5,9 +5,12 @@
 # https://openusd.org/license.
 #
 
-include(gccclangshareddefaults)
-
-set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")
+if (MSVC)
+    include(msvcdefaults)
+else()
+    include(gccclangshareddefaults)
+    set(_PXR_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS}")
+endif()
 
 # Prevent floating point result discrepancies on Apple platforms
 # due to multiplication+additions being converted to FMA

--- a/pxr/base/arch/attributes.h
+++ b/pxr/base/arch/attributes.h
@@ -144,7 +144,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// [[no_unique_address]] tag.
 #   define ARCH_EMPTY_BASES
 
-#elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#elif defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 
 #   define ARCH_PRINTF_FUNCTION(_fmt, _firstArg) \
         __attribute__((format(printf, _fmt, _firstArg)))
@@ -241,7 +241,7 @@ struct Arch_ConstructorEntry {
     };                                                                         \
     static void _name()
 
-#elif defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#elif defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 
 // The used attribute is required to prevent these apparently unused functions
 // from being removed by the linker.

--- a/pxr/base/arch/debugger.h
+++ b/pxr/base/arch/debugger.h
@@ -83,7 +83,7 @@ void ArchAbort(bool logging = true);
 /// possible, code to prevent optimization so the caller appears in the
 /// debugger's stack trace.  The calling functions should also use the
 /// \c ARCH_NOINLINE function attribute.
-#if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#if defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 #define ARCH_DEBUGGER_TRAP do { ArchDebuggerTrap(); asm(""); } while (0)
 #else
 #define ARCH_DEBUGGER_TRAP do { ArchDebuggerTrap(); } while (0)

--- a/pxr/base/arch/defines.h
+++ b/pxr/base/arch/defines.h
@@ -63,6 +63,10 @@
 #define ARCH_COMPILER_CLANG_MAJOR __clang_major__
 #define ARCH_COMPILER_CLANG_MINOR __clang_minor__
 #define ARCH_COMPILER_CLANG_PATCHLEVEL __clang_patchlevel__
+#if defined(_MSC_VER)
+    #define ARCH_COMPILER_MSVC
+    #define ARCH_COMPILER_MSVC_VERSION _MSC_VER
+#endif
 #elif defined(__GNUC__)
 #define ARCH_COMPILER_GCC
 #define ARCH_COMPILER_GCC_MAJOR __GNUC__
@@ -95,7 +99,7 @@
 // custom versions of macros.
 // See here for more detail about MSVC's preprocessors:
 // https://learn.microsoft.com/en-us/cpp/preprocessor/preprocessor-experimental-overview
-#if defined(ARCH_COMPILER_MSVC)
+#if defined(ARCH_COMPILER_MSVC) && !defined(ARCH_COMPILER_CLANG)
     #if !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL
     #define ARCH_PREPROCESSOR_MSVC_TRADITIONAL
     #endif

--- a/pxr/base/arch/demangle.cpp
+++ b/pxr/base/arch/demangle.cpp
@@ -17,7 +17,8 @@
 using std::string;
 
 #if (ARCH_COMPILER_GCC_MAJOR == 3 && ARCH_COMPILER_GCC_MINOR >= 1) || \
-    ARCH_COMPILER_GCC_MAJOR > 3 || defined(ARCH_COMPILER_CLANG)
+    ARCH_COMPILER_GCC_MAJOR > 3 || (defined(ARCH_COMPILER_CLANG) && \
+    !defined(ARCH_COMPILER_MSVC))
 #define _AT_LEAST_GCC_THREE_ONE_OR_CLANG
 #endif
 

--- a/pxr/base/arch/export.h
+++ b/pxr/base/arch/export.h
@@ -140,7 +140,8 @@
 #include "pxr/base/arch/defines.h" 
 
 #if defined(ARCH_OS_WINDOWS)
-#   if defined(ARCH_COMPILER_GCC) && ARCH_COMPILER_GCC_MAJOR >= 4 || defined(ARCH_COMPILER_CLANG)
+#   if defined(ARCH_COMPILER_GCC) && ARCH_COMPILER_GCC_MAJOR >= 4 || \
+       (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 #       define ARCH_EXPORT __attribute__((dllexport))
 #       define ARCH_IMPORT __attribute__((dllimport))
 #       define ARCH_HIDDEN

--- a/pxr/base/arch/functionLite.h
+++ b/pxr/base/arch/functionLite.h
@@ -21,14 +21,14 @@
 #define __ARCH_FUNCTION__ __func__
 
 #if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_ICC) || \
-    defined(ARCH_COMPILER_CLANG)
+    (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 #    define __ARCH_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #elif defined(ARCH_COMPILER_MSVC)
 #    define __ARCH_PRETTY_FUNCTION__ __FUNCSIG__
 #else
 #    define __ARCH_PRETTY_FUNCTION__ __ARCH_FUNCTION__
 #endif /* defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_ICC) ||
-          defined(ARCH_COMPILER_CLANG)*/
+          (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC)) */
 
 #if defined(BUILD_COMPONENT_SRC_PREFIX)
 #    define __ARCH_FILE__ BUILD_COMPONENT_SRC_PREFIX __FILE__

--- a/pxr/base/arch/hints.h
+++ b/pxr/base/arch/hints.h
@@ -19,7 +19,7 @@
 /// outcome of bool-expr to a very high degree of certainty.  For example,
 /// fatal-error cases, invariants, first-time initializations, etc.
 
-#if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#if defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 
 #define ARCH_LIKELY(x) (__builtin_expect((bool)(x), true))
 #define ARCH_UNLIKELY(x) (__builtin_expect((bool)(x), false))

--- a/pxr/base/arch/mallocHook.cpp
+++ b/pxr/base/arch/mallocHook.cpp
@@ -217,7 +217,7 @@ bool
 ArchIsStlAllocatorOff()
 {
 #if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_ICC) || \
-    defined(ARCH_COMPILER_CLANG)
+    (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
     // I'm assuming that ICC compiles will use the gcc STL library.
 
     /*

--- a/pxr/base/arch/math.h
+++ b/pxr/base/arch/math.h
@@ -119,7 +119,8 @@ inline void ArchSinCos(double v, double *s, double *c) {
 inline int
 ArchCountTrailingZeros(uint64_t x)
 {
-#if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG) && \
+#if defined(ARCH_COMPILER_GCC) || \
+    (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC)) && \
     !defined(ARCH_OS_WASM_VM)
     return __builtin_ctzl(x);
 #elif defined(ARCH_COMPILER_MSVC)

--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -51,7 +51,7 @@
     #define ARCH_PRAGMA_STRINGOP_OVERFLOW \
         _Pragma("GCC diagnostic ignored \"-Wstringop-overflow=\"")
 
-#elif defined(ARCH_COMPILER_CLANG)
+#elif (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 
     #define ARCH_PRAGMA_PUSH \
         _Pragma("clang diagnostic push")

--- a/pxr/base/arch/threads.h
+++ b/pxr/base/arch/threads.h
@@ -35,13 +35,13 @@ ARCH_API std::thread::id ArchGetMainThreadId();
 
 /// ARCH_SPIN_PAUSE -- 'pause' on x86, 'yield' on arm.
 #if defined(ARCH_CPU_INTEL)
-#if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#if defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 #define ARCH_SPIN_PAUSE() __builtin_ia32_pause()
 #elif defined(ARCH_COMPILER_MSVC)
 #define ARCH_SPIN_PAUSE() _mm_pause()
 #endif
 #elif defined(ARCH_CPU_ARM)
-#if defined(ARCH_COMPILER_GCC) || defined(ARCH_COMPILER_CLANG)
+#if defined(ARCH_COMPILER_GCC) || (defined(ARCH_COMPILER_CLANG) && !defined(ARCH_COMPILER_MSVC))
 #define ARCH_SPIN_PAUSE() asm volatile ("yield" ::: "memory")
 #elif defined(ARCH_COMPILER_MSVC)
 #define ARCH_SPIN_PAUSE() __yield();


### PR DESCRIPTION
### Description of Change(s)

Enable clang-cl support, using both ARCH_COMPILER_MSVC and ARCH_COMPILER_CLANG

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Using the MSVC-compatible clang-cl doesn't build OpenUSD out of the box, this addresses it.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
