### PR TITLE
Autodesk: [hgiVulkan] Add support for VK_EXT_host_image_copy

### DIFF
--- a/pxr/imaging/hgiVulkan/blitCmds.cpp
+++ b/pxr/imaging/hgiVulkan/blitCmds.cpp
@@ -143,9 +143,8 @@ HgiVulkanBlitCmds::CopyTextureGpuToCpu(
     const VkImageLayout oldLayout = srcTexture->GetImageLayout();
     const auto [srcAccess, srcStage] =
         _GetOldAccessAndPipelineStageFlags(oldLayout);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         oldLayout,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, // transition tex to this layout
         srcAccess,
@@ -172,9 +171,8 @@ HgiVulkanBlitCmds::CopyTextureGpuToCpu(
     // Transition image back to what it was.
     VkAccessFlags access = HgiVulkanTexture::GetDefaultAccessFlags(
         srcTexture->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         oldLayout,                           // transition tex to this layout
         HgiVulkanTexture::NO_PENDING_WRITES, // no pending writes
@@ -338,9 +336,8 @@ void HgiVulkanBlitCmds::BlitTexture(HgiTextureHandle src, HgiTextureHandle dst)
     const VkImageLayout oldLayoutSrc = srcTexture->GetImageLayout();
     const auto [srcAccessSrc, srcStageSrc] =
         _GetOldAccessAndPipelineStageFlags(oldLayoutSrc);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         oldLayoutSrc,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         srcAccessSrc,
@@ -352,9 +349,8 @@ void HgiVulkanBlitCmds::BlitTexture(HgiTextureHandle src, HgiTextureHandle dst)
     const VkImageLayout oldLayoutDst = dstTexture->GetImageLayout();
     const auto [srcAccessDst, srcStageDst] =
         _GetOldAccessAndPipelineStageFlags(oldLayoutDst);
-    HgiVulkanTexture::TransitionImageBarrier(
+    dstTexture->LayoutBarrier(
         _commandBuffer,
-        dstTexture,
         oldLayoutDst,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         srcAccessDst,
@@ -374,9 +370,8 @@ void HgiVulkanBlitCmds::BlitTexture(HgiTextureHandle src, HgiTextureHandle dst)
     // Transition src image back to what it was.
     const VkAccessFlags accessSrc = HgiVulkanTexture::GetDefaultAccessFlags(
         srcTexture->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         oldLayoutSrc,
         HgiVulkanTexture::NO_PENDING_WRITES,
@@ -387,9 +382,8 @@ void HgiVulkanBlitCmds::BlitTexture(HgiTextureHandle src, HgiTextureHandle dst)
     // Transition dst image back to what it was.
     const VkAccessFlags accessDst = HgiVulkanTexture::GetDefaultAccessFlags(
         dstTexture->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    dstTexture->LayoutBarrier(
         _commandBuffer,
-        dstTexture,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         oldLayoutDst,
         VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -545,9 +539,8 @@ HgiVulkanBlitCmds::CopyTextureToBuffer(HgiTextureToBufferOp const& copyOp)
     VkImageLayout oldLayout = srcTexture->GetImageLayout();
     const auto [srcAccess, srcStage] =
         _GetOldAccessAndPipelineStageFlags(oldLayout);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         /*oldLayout*/oldLayout,
         /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         /*producerAccess*/srcAccess,
@@ -592,9 +585,8 @@ HgiVulkanBlitCmds::CopyTextureToBuffer(HgiTextureToBufferOp const& copyOp)
     // Transition image layout back to original layout.
     const VkAccessFlags access = HgiVulkanTexture::GetDefaultAccessFlags(
         srcTexture->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    srcTexture->LayoutBarrier(
         _commandBuffer,
-        srcTexture,
         /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         /*newLayout*/oldLayout,
         /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -634,9 +626,8 @@ HgiVulkanBlitCmds::CopyBufferToTexture(HgiBufferToTextureOp const& copyOp)
     VkImageLayout oldLayout = dstTexture->GetImageLayout();
     const auto [srcAccess, srcStage] =
         _GetOldAccessAndPipelineStageFlags(oldLayout);
-    HgiVulkanTexture::TransitionImageBarrier(
+    dstTexture->LayoutBarrier(
         _commandBuffer,
-        dstTexture,
         /*oldLayout*/oldLayout,
         /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         /*producerAccess*/srcAccess,
@@ -680,9 +671,8 @@ HgiVulkanBlitCmds::CopyBufferToTexture(HgiBufferToTextureOp const& copyOp)
     // Transition image layout back to original layout.
     const VkAccessFlags access = HgiVulkanTexture::GetDefaultAccessFlags(
         dstTexture->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    dstTexture->LayoutBarrier(
         _commandBuffer,
-        dstTexture,
         /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         /*newLayout*/oldLayout,
         /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -726,9 +716,8 @@ HgiVulkanBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
     const VkImageLayout oldLayout = vkTex->GetImageLayout();
     const auto [srcAccess, srcStage] =
         _GetOldAccessAndPipelineStageFlags(oldLayout);
-    HgiVulkanTexture::TransitionImageBarrier(
+    vkTex->LayoutBarrier(
         _commandBuffer,
-        vkTex,
         oldLayout,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         srcAccess,
@@ -758,9 +747,8 @@ HgiVulkanBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
         imageBlit.dstOffsets[1].z = 1;
 
         // Transition current mip level to image blit destination
-        HgiVulkanTexture::TransitionImageBarrier(
+        vkTex->LayoutBarrier(
             _commandBuffer,
-            vkTex,
             oldLayout,
             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
             srcAccess,
@@ -781,9 +769,8 @@ HgiVulkanBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
             VK_FILTER_LINEAR);
 
         // Prepare current mip level as image blit source for next level
-        HgiVulkanTexture::TransitionImageBarrier(
+        vkTex->LayoutBarrier(
             _commandBuffer,
-            vkTex,
             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
             VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
             VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -796,9 +783,8 @@ HgiVulkanBlitCmds::GenerateMipMaps(HgiTextureHandle const& texture)
     // Return all mips from TRANSFER_SRC to their original layout
     const VkAccessFlags access = HgiVulkanTexture::GetDefaultAccessFlags(
         vkTex->GetDescriptor().usage);
-    HgiVulkanTexture::TransitionImageBarrier(
+    vkTex->LayoutBarrier(
         _commandBuffer,
-        vkTex,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         oldLayout,
         VK_ACCESS_TRANSFER_READ_BIT,

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -27,6 +27,8 @@ TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_UMA, true,
                       "Use Vulkan with UMA (if device supports)");
 TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_REBAR, false,
                       "Use Vulkan with ReBAR (if device supports)");
+TF_DEFINE_ENV_SETTING(HGIVULKAN_ENABLE_HOST_IMAGE_COPY, true,
+                      "Use Vulkan direct image copy from host");
 
 static void _DumpDeviceDeviceMemoryProperties(
     const VkPhysicalDeviceMemoryProperties& vkMemoryProperties)
@@ -181,6 +183,19 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     vkPhysicalDeviceIdProperties.pNext = vkDeviceProperties2.pNext;
     vkDeviceProperties2.pNext =  &vkPhysicalDeviceIdProperties;
 
+    // Host image copy feature
+    const bool hostImageCopyExtAvailable =
+        TfGetEnvSetting(HGIVULKAN_ENABLE_HOST_IMAGE_COPY) &&
+        device->IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
+    if (hostImageCopyExtAvailable) {
+        vkHostImageCopyProperties.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT;
+        vkHostImageCopyProperties.pNext = vkDeviceProperties2.pNext;
+        vkHostImageCopyProperties.pCopyDstLayouts = vkHostImageCopyDstLayouts.data();
+        vkHostImageCopyProperties.copyDstLayoutCount = vkHostImageCopyDstLayouts.size();
+        vkDeviceProperties2.pNext =  &vkHostImageCopyProperties;
+    }
+
     // Query device properties
     vkGetPhysicalDeviceProperties2(physicalDevice, &vkDeviceProperties2);
     vkGetPhysicalDeviceMemoryProperties(physicalDevice, &vkMemoryProperties);
@@ -223,7 +238,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     vkVertexAttributeDivisorFeatures.pNext = vkDeviceFeatures2.pNext;
     vkDeviceFeatures2.pNext = &vkVertexAttributeDivisorFeatures;
 
-    // Barycentric features
+    // Barycentric feature
     const bool barycentricExtSupported = device->IsSupportedExtension(
         VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     if (barycentricExtSupported) {
@@ -232,8 +247,8 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
         vkBarycentricFeatures.pNext = vkDeviceFeatures2.pNext;
         vkDeviceFeatures2.pNext =  &vkBarycentricFeatures;
     }
-    
-    // Line rasterization features
+
+    // Line rasterization feature
     const bool lineRasterizationExtSupported = device->IsSupportedExtension(
         VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME);
     if (lineRasterizationExtSupported) {
@@ -241,6 +256,14 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR;
         vkLineRasterizationFeatures.pNext = vkDeviceFeatures2.pNext;
         vkDeviceFeatures2.pNext =  &vkLineRasterizationFeatures;
+    }
+
+    // Host image copy feature
+    if (hostImageCopyExtAvailable) {
+        vkHostImageCopyFeatures.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT;
+        vkHostImageCopyFeatures.pNext = vkDeviceFeatures2.pNext;
+        vkDeviceFeatures2.pNext =  &vkHostImageCopyFeatures;
     }
 
     // Query device features

--- a/pxr/imaging/hgiVulkan/capabilities.h
+++ b/pxr/imaging/hgiVulkan/capabilities.h
@@ -12,6 +12,7 @@
 #include "pxr/imaging/hgiVulkan/api.h"
 #include "pxr/imaging/hgiVulkan/vulkan.h"
 
+#include <array>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -41,10 +42,13 @@ public:
     bool supportsNativeInterop;
 
     VkPhysicalDeviceProperties2 vkDeviceProperties2 {};
+    VkPhysicalDeviceMemoryProperties vkMemoryProperties {};
+    VkPhysicalDeviceIDProperties vkPhysicalDeviceIdProperties {};
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT
         vkVertexAttributeDivisorProperties {};
-    
-    VkPhysicalDeviceMemoryProperties vkMemoryProperties {};
+    VkPhysicalDeviceHostImageCopyPropertiesEXT vkHostImageCopyProperties {};
+    // Storage for VkPhysicalDeviceHostImageCopyProperties::pCopyDstLayouts
+    std::array<VkImageLayout, 32> vkHostImageCopyDstLayouts {};
 
     VkPhysicalDeviceFeatures2 vkDeviceFeatures2 {};
     VkPhysicalDeviceVulkan11Features vkVulkan11Features {};
@@ -53,8 +57,7 @@ public:
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR
         vkBarycentricFeatures {};
     VkPhysicalDeviceLineRasterizationFeaturesKHR vkLineRasterizationFeatures {};
-
-    VkPhysicalDeviceIDProperties vkPhysicalDeviceIdProperties {};
+    VkPhysicalDeviceHostImageCopyFeaturesEXT vkHostImageCopyFeatures {};
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/conversions.cpp
+++ b/pxr/imaging/hgiVulkan/conversions.cpp
@@ -125,14 +125,14 @@ _TextureUsageTable[][2] =
 };
 static_assert(HgiTextureUsageCustomBitsBegin == 1 << 5, "");
 
-static const uint32_t
-_FormatFeatureTable[][2] =
+static const uint64_t
+_FormatFeature2Table[][2] =
 {
-    {HgiTextureUsageBitsColorTarget,   VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT},
-    {HgiTextureUsageBitsDepthTarget,   VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT},
-    {HgiTextureUsageBitsStencilTarget, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT},
-    {HgiTextureUsageBitsShaderRead,    VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT},
-    {HgiTextureUsageBitsShaderWrite,   VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT},
+    {HgiTextureUsageBitsColorTarget,   VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT},
+    {HgiTextureUsageBitsDepthTarget,   VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT},
+    {HgiTextureUsageBitsStencilTarget, VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT},
+    {HgiTextureUsageBitsShaderRead,    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT},
+    {HgiTextureUsageBitsShaderWrite,   VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT},
 };
 static_assert(HgiTextureUsageCustomBitsBegin == 1 << 5, "");
 
@@ -440,11 +440,11 @@ HgiVulkanConversions::GetTextureUsage(HgiTextureUsage tu)
     return vkFlags;
 }
 
-VkFormatFeatureFlags
-HgiVulkanConversions::GetFormatFeature(HgiTextureUsage tu)
+VkFormatFeatureFlags2
+HgiVulkanConversions::GetFormatFeature2(HgiTextureUsage tu)
 {
-    VkFormatFeatureFlags vkFlags = 0;
-    for (const auto& f : _FormatFeatureTable) {
+    VkFormatFeatureFlags2 vkFlags = 0;
+    for (const auto& f : _FormatFeature2Table) {
         if (tu & f[0]) vkFlags |= f[1];
     }
 

--- a/pxr/imaging/hgiVulkan/conversions.h
+++ b/pxr/imaging/hgiVulkan/conversions.h
@@ -37,7 +37,7 @@ public:
     static VkImageUsageFlags GetTextureUsage(HgiTextureUsage tu);
 
     HGIVULKAN_API
-    static VkFormatFeatureFlags GetFormatFeature(HgiTextureUsage tu);
+    static VkFormatFeatureFlags2 GetFormatFeature2(HgiTextureUsage tu);
 
     HGIVULKAN_API
     static VkAttachmentLoadOp GetLoadOp(HgiAttachmentLoadOp op);
@@ -107,4 +107,3 @@ public:
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif
-

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -114,7 +114,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
             continue;
         }
 
-        if (props.apiVersion < VK_API_VERSION_1_0) continue;
+        if (props.apiVersion < VK_API_VERSION_1_3) continue;
 
         // Try to find a preferred device type. Until we find one, store the
         // first non-preferred device as fallback in case we never find a
@@ -264,6 +264,11 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         extensions.push_back(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME);
     }
 
+    // Allow use of host image copy
+    if (IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
+        extensions.push_back(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
+    }
+
     // This extension is needed to allow the viewport to be flipped in Y so that
     // shaders and vertex data can remain the same between opengl and vulkan.
     extensions.push_back(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
@@ -351,6 +356,16 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         features2.pNext = &lineRasterFeatures;
     }
 
+    VkPhysicalDeviceHostImageCopyFeaturesEXT hostImageCopyFeatures {
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT
+    };
+    if (IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
+        hostImageCopyFeatures.hostImageCopy =
+            _capabilities->vkHostImageCopyFeatures.hostImageCopy;
+        hostImageCopyFeatures.pNext = features2.pNext;
+        features2.pNext = &hostImageCopyFeatures;
+    }
+
     VkDeviceCreateInfo createInfo = {VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
     createInfo.queueCreateInfoCount = 1;
     createInfo.pQueueCreateInfos = &queueInfo;
@@ -373,23 +388,30 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     //
 
     vkCreateRenderPass2KHR = (PFN_vkCreateRenderPass2KHR)
-    vkGetDeviceProcAddr(_vkDevice, "vkCreateRenderPass2KHR");
+        vkGetDeviceProcAddr(_vkDevice, "vkCreateRenderPass2KHR");
 
     if (_capabilities->supportsNativeInterop) {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
         vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)
-        vkGetDeviceProcAddr(_vkDevice, "vkGetMemoryWin32HandleKHR");
+            vkGetDeviceProcAddr(_vkDevice, "vkGetMemoryWin32HandleKHR");
 
         vkGetSemaphoreWin32HandleKHR = (PFN_vkGetSemaphoreWin32HandleKHR)
-        vkGetDeviceProcAddr(_vkDevice, "vkGetSemaphoreWin32HandleKHR");
+            vkGetDeviceProcAddr(_vkDevice, "vkGetSemaphoreWin32HandleKHR");
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
         vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)
-        vkGetDeviceProcAddr(_vkDevice, "vkGetMemoryFdKHR");
+            vkGetDeviceProcAddr(_vkDevice, "vkGetMemoryFdKHR");
 
         vkGetSemaphoreFdKHR = (PFN_vkGetSemaphoreFdKHR)
-        vkGetDeviceProcAddr(_vkDevice, "vkGetSemaphoreFdKHR");
+            vkGetDeviceProcAddr(_vkDevice, "vkGetSemaphoreFdKHR");
 #elif defined(VK_USE_PLATFORM_METAL_EXT)
 #endif
+    }
+
+    if (_capabilities->vkHostImageCopyFeatures.hostImageCopy) {
+        vkTransitionImageLayoutEXT = (PFN_vkTransitionImageLayoutEXT)
+            vkGetDeviceProcAddr(_vkDevice, "vkTransitionImageLayoutEXT");
+        vkCopyMemoryToImageEXT = (PFN_vkCopyMemoryToImageEXT)
+            vkGetDeviceProcAddr(_vkDevice, "vkCopyMemoryToImageEXT");
     }
 
     //

--- a/pxr/imaging/hgiVulkan/device.h
+++ b/pxr/imaging/hgiVulkan/device.h
@@ -84,21 +84,23 @@ public:
     bool IsSupportedExtension(const char* extensionName) const;
 
     /// Device extension function pointers
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR = 0;
+    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR = nullptr;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR = 0;
-    PFN_vkGetSemaphoreWin32HandleKHR vkGetSemaphoreWin32HandleKHR = 0;
+    PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR = nullptr;
+    PFN_vkGetSemaphoreWin32HandleKHR vkGetSemaphoreWin32HandleKHR = nullptr;
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
-    PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR = 0;
-    PFN_vkGetSemaphoreFdKHR vkGetSemaphoreFdKHR = 0;
+    PFN_vkGetMemoryFdKHR vkGetMemoryFdKHR = nullptr;
+    PFN_vkGetSemaphoreFdKHR vkGetSemaphoreFdKHR = nullptr;
 #elif defined(VK_USE_PLATFORM_METAL_EXT)
 #endif
-    PFN_vkCmdBeginDebugUtilsLabelEXT vkCmdBeginDebugUtilsLabelEXT = 0;
-    PFN_vkCmdEndDebugUtilsLabelEXT vkCmdEndDebugUtilsLabelEXT = 0;
-    PFN_vkCmdInsertDebugUtilsLabelEXT vkCmdInsertDebugUtilsLabelEXT = 0;
-    PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = 0;
-    PFN_vkQueueBeginDebugUtilsLabelEXT vkQueueBeginDebugUtilsLabelEXT = 0;
-    PFN_vkQueueEndDebugUtilsLabelEXT vkQueueEndDebugUtilsLabelEXT = 0;
+    PFN_vkCmdBeginDebugUtilsLabelEXT vkCmdBeginDebugUtilsLabelEXT = nullptr;
+    PFN_vkCmdEndDebugUtilsLabelEXT vkCmdEndDebugUtilsLabelEXT = nullptr;
+    PFN_vkCmdInsertDebugUtilsLabelEXT vkCmdInsertDebugUtilsLabelEXT = nullptr;
+    PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT = nullptr;
+    PFN_vkQueueBeginDebugUtilsLabelEXT vkQueueBeginDebugUtilsLabelEXT = nullptr;
+    PFN_vkQueueEndDebugUtilsLabelEXT vkQueueEndDebugUtilsLabelEXT = nullptr;
+    PFN_vkTransitionImageLayoutEXT vkTransitionImageLayoutEXT = nullptr;
+    PFN_vkCopyMemoryToImageEXT vkCopyMemoryToImageEXT = nullptr;
 
 private:
     HgiVulkanDevice() = delete;

--- a/pxr/imaging/hgiVulkan/graphicsCmds.cpp
+++ b/pxr/imaging/hgiVulkan/graphicsCmds.cpp
@@ -415,9 +415,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                 vkImageSubRange.layerCount =
                     texture->GetDescriptor().layerCount;
                 
-                HgiVulkanTexture::TransitionImageBarrier(
+                texture->LayoutBarrier(
                     _commandBuffer,
-                    texture,
                     /*oldLayout*/oldVkLayout,
                     /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                     /*producerAccess*/VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -433,9 +432,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                     1,
                     &vkImageSubRange);
 
-                HgiVulkanTexture::TransitionImageBarrier(
+                texture->LayoutBarrier(
                     _commandBuffer,
-                    texture,
                     /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                     /*newLayout*/oldVkLayout,
                     /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -462,9 +460,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                 vkImageSubRange.layerCount =
                     texture->GetDescriptor().layerCount;
                     
-                HgiVulkanTexture::TransitionImageBarrier(
+                texture->LayoutBarrier(
                     _commandBuffer,
-                    texture,
                     /*oldLayout*/oldVkLayout,
                     /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                     /*producerAccess*/VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -480,9 +477,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                     1,
                     &vkImageSubRange);
                 
-                HgiVulkanTexture::TransitionImageBarrier(
+                texture->LayoutBarrier(
                     _commandBuffer,
-                    texture,
                     /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                     /*newLayout*/oldVkLayout,
                     /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -517,9 +513,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
             vkImageSubRange.layerCount =
                 texture->GetDescriptor().layerCount;
                 
-            HgiVulkanTexture::TransitionImageBarrier(
+            texture->LayoutBarrier(
                 _commandBuffer,
-                texture,
                 /*oldLayout*/oldVkLayout,
                 /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 /*producerAccess*/VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
@@ -535,9 +530,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                 1,
                 &vkImageSubRange);
                 
-            HgiVulkanTexture::TransitionImageBarrier(
+            texture->LayoutBarrier(
                 _commandBuffer,
-                texture,
                 /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 /*newLayout*/oldVkLayout,
                 /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,
@@ -562,9 +556,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
             vkImageSubRange.layerCount =
                 texture->GetDescriptor().layerCount;
             
-            HgiVulkanTexture::TransitionImageBarrier(
+            texture->LayoutBarrier(
                 _commandBuffer,
-                texture,
                 /*oldLayout*/oldVkLayout,
                 /*newLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 /*producerAccess*/VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
@@ -580,9 +573,8 @@ HgiVulkanGraphicsCmds::_ClearAttachmentsIfNeeded()
                 1,
                 &vkImageSubRange);
             
-            HgiVulkanTexture::TransitionImageBarrier(
+            texture->LayoutBarrier(
                 _commandBuffer,
-                texture,
                 /*oldLayout*/VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                 /*newLayout*/oldVkLayout,
                 /*producerAccess*/VK_ACCESS_TRANSFER_WRITE_BIT,

--- a/pxr/imaging/hgiVulkan/texture.cpp
+++ b/pxr/imaging/hgiVulkan/texture.cpp
@@ -21,13 +21,38 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 static bool
 _CheckFormatSupport(
-    VkPhysicalDevice pDevice,
+    VkPhysicalDevice device,
     VkFormat format,
-    VkFormatFeatureFlags flags )
+    bool optimalTiling,
+    VkFormatFeatureFlags2 requiredFlags,
+    VkFormatFeatureFlags2& optionalFlags)
 {
-    VkFormatProperties props;
-    vkGetPhysicalDeviceFormatProperties(pDevice, format, &props);
-    return (props.optimalTilingFeatures & flags) == flags;
+    VkFormatProperties2 props2{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2};
+    VkFormatProperties3 props3{VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3};
+    props2.pNext = &props3;
+    vkGetPhysicalDeviceFormatProperties2(device, format, &props2);
+    const auto featureFlags = optimalTiling ?
+        props3.optimalTilingFeatures : props3.linearTilingFeatures;
+    optionalFlags &= featureFlags;
+    return (featureFlags & requiredFlags) == requiredFlags;
+}
+
+static bool
+_HasOptimalHostImageCopy(
+    VkPhysicalDevice device,
+    const VkImageCreateInfo& createInfo)
+{
+    VkPhysicalDeviceImageFormatInfo2 imageFormatInfo{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2};
+    imageFormatInfo.format = createInfo.format;
+    imageFormatInfo.type = createInfo.imageType;
+    imageFormatInfo.tiling = createInfo.tiling;
+    imageFormatInfo.usage = createInfo.usage | VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT;
+    imageFormatInfo.flags = createInfo.flags;
+    VkImageFormatProperties2 imageFormatProperties{VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2};
+    VkHostImageCopyDevicePerformanceQueryEXT hostImageCopyPerformance{VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT};
+    imageFormatProperties.pNext = &hostImageCopyPerformance;
+    HGIVULKAN_VERIFY_VK_RESULT(vkGetPhysicalDeviceImageFormatProperties2(device, &imageFormatInfo, &imageFormatProperties));
+    return hostImageCopyPerformance.identicalMemoryLayout || hostImageCopyPerformance.optimalDeviceAccess;
 }
 
 static HgiTextureUsage
@@ -68,11 +93,16 @@ HgiVulkanTexture::HgiVulkanTexture(
     , _inflightBits(0)
     , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _hasHostImageCopy(false)
     , _isTextureView(false)
 {
     GfVec3i const& dimensions = desc.dimensions;
     bool const isDepthBuffer = desc.usage & HgiTextureUsageBitsDepthTarget;
     bool const isStencilBuffer = desc.usage & HgiTextureUsageBitsStencilTarget;
+
+    if (!optimalTiling && desc.mipLevels > 1) {
+        TF_WARN("Linear tiled images usually do not support mips");
+    }
 
     //
     // Gather image create info
@@ -91,9 +121,9 @@ HgiVulkanTexture::HgiVulkanTexture(
         VK_IMAGE_TILING_OPTIMAL : VK_IMAGE_TILING_LINEAR;
     imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    imageCreateInfo.extent = { (uint32_t) dimensions[0],
-                               (uint32_t) dimensions[1],
-                               (uint32_t) dimensions[2] };
+    imageCreateInfo.extent = { static_cast<uint32_t>(dimensions[0]),
+                               static_cast<uint32_t>(dimensions[1]),
+                               static_cast<uint32_t>(dimensions[2]) };
 
     if (desc.type == HgiTextureTypeCubemap) {
         imageCreateInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
@@ -103,9 +133,9 @@ HgiVulkanTexture::HgiVulkanTexture(
     if (imageCreateInfo.usage == 0) {
         TF_CODING_ERROR("Texture usage missing in descriptor");
         imageCreateInfo.usage = 
-            HgiTextureUsageBitsColorTarget | 
-            HgiTextureUsageBitsShaderRead |
-            HgiTextureUsageBitsShaderWrite;
+            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+            VK_IMAGE_USAGE_SAMPLED_BIT |
+            VK_IMAGE_USAGE_STORAGE_BIT;
     }
 
     // XXX VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT could be a useful
@@ -122,22 +152,39 @@ HgiVulkanTexture::HgiVulkanTexture(
         imageCreateInfo.pNext = &exportInfo;
     }
 
-    // XXX STORAGE_IMAGE requires VK_IMAGE_USAGE_STORAGE_BIT, but Hgi
-    // doesn't tell us if a texture will be used as image load/store.
+    const auto capabilities = hgi->GetCapabilities();
+    // Tentative: we still need to check for format support and performance
+    // implications below.
+    _hasHostImageCopy = !interop &&
+        capabilities->vkHostImageCopyFeatures.hostImageCopy &&
+        (capabilities->vkHostImageCopyProperties.identicalMemoryTypeRequirements ||
+            capabilities->IsSet(HgiDeviceCapabilitiesBitsUnifiedMemory));
 
-    VkFormatFeatureFlags formatValidationFlags =
-        HgiVulkanConversions::GetFormatFeature(desc.usage);
+    VkFormatFeatureFlags2 requiredFormatFeatures =
+        HgiVulkanConversions::GetFormatFeature2(desc.usage);
 
-    if (!_CheckFormatSupport(
-            device->GetVulkanPhysicalDevice(),
-            imageCreateInfo.format,
-            formatValidationFlags)) {
+    VkFormatFeatureFlags2 optionalFormatFeatures{};
+    if (_hasHostImageCopy) {
+        optionalFormatFeatures |=
+            VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT;
+    }
+
+    const auto physicalDevice = device->GetVulkanPhysicalDevice();
+    if (!_CheckFormatSupport(physicalDevice, imageCreateInfo.format,
+        optimalTiling, requiredFormatFeatures, optionalFormatFeatures)) {
         TF_CODING_ERROR("Image format / usage combo not supported on device");
         return;
-    };
+    }
 
-    if (imageCreateInfo.tiling != VK_IMAGE_TILING_OPTIMAL && desc.mipLevels>1) {
-        TF_WARN("Linear tiled images usually do not support mips");
+    if (optionalFormatFeatures & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT) {
+        _hasHostImageCopy &= _HasOptimalHostImageCopy(physicalDevice,
+            imageCreateInfo);
+    } else {
+        _hasHostImageCopy = false;
+    }
+
+    if (_hasHostImageCopy) {
+        imageCreateInfo.usage |= VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT;
     }
 
     //
@@ -162,11 +209,11 @@ HgiVulkanTexture::HgiVulkanTexture(
     TF_VERIFY(_vkImage, "Failed to create image");
 
     // Debug label
-    if (!_descriptor.debugName.empty()) {
-        std::string debugLabel = "Image " + _descriptor.debugName;
+    if (!desc.debugName.empty()) {
+        std::string debugLabel = "Image " + desc.debugName;
         HgiVulkanSetDebugName(
             device,
-            (uint64_t)_vkImage,
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_vkImage)),
             VK_OBJECT_TYPE_IMAGE,
             debugLabel.c_str());
     }
@@ -218,62 +265,78 @@ HgiVulkanTexture::HgiVulkanTexture(
     );
 
     // Debug label
-    if (!_descriptor.debugName.empty()) {
-        std::string debugLabel = "ImageView " + _descriptor.debugName;
+    if (!desc.debugName.empty()) {
+        std::string debugLabel = "ImageView " + desc.debugName;
         HgiVulkanSetDebugName(
             device,
-            (uint64_t)_vkImageView,
+            static_cast<uint64_t>(
+                reinterpret_cast<uintptr_t>(_vkImageView)),
             VK_OBJECT_TYPE_IMAGE_VIEW,
             debugLabel.c_str());
     }
 
     //
-    // Upload data
+    // Upload data & transition image
     //
-    if (desc.initialData && desc.pixelsByteSize > 0) {
-        HgiBufferDesc stageDesc;
-        stageDesc.byteSize = 
-            std::min(GetByteSizeOfResource(), desc.pixelsByteSize);
-        stageDesc.initialData = desc.initialData;
-        std::unique_ptr<HgiVulkanBuffer> stagingBuffer =
-            HgiVulkanBuffer::CreateStagingBuffer(_device, stageDesc);
 
-        // Schedule transfer from staging buffer to device-local texture
+    if (SupportsMemoryToTextureCopy() &&
+        TF_VERIFY(_device->vkTransitionImageLayoutEXT)) {
+        const VkImageLayout newLayout = GetDefaultImageLayout(desc.usage);
+
+        VkImageSubresourceRange subresourceRange{};
+        subresourceRange.aspectMask = HgiVulkanConversions::GetImageAspectFlag(desc.usage);
+        subresourceRange.baseMipLevel = 0;
+        subresourceRange.levelCount = desc.mipLevels;
+        subresourceRange.baseArrayLayer = 0;
+        subresourceRange.layerCount = desc.layerCount;
+
+        VkHostImageLayoutTransitionInfoEXT hostImageLayoutTransitionInfo{VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT};
+        hostImageLayoutTransitionInfo.image = _vkImage;
+        hostImageLayoutTransitionInfo.oldLayout = _vkImageLayout;
+        hostImageLayoutTransitionInfo.newLayout = newLayout;
+        hostImageLayoutTransitionInfo.subresourceRange = subresourceRange;
+
+        // With VK_EXT_host_image_copy we transition to the final desired layout
+        // first, then we do the copy. No need to go through a transfer layout.
+        HGIVULKAN_VERIFY_VK_RESULT(_device->vkTransitionImageLayoutEXT(_device->GetVulkanDevice(), 1, &hostImageLayoutTransitionInfo));
+        _vkImageLayout = newLayout;
+
+        if (desc.initialData && desc.pixelsByteSize > 0) {
+            CopyMemoryToTexture({static_cast<const std::byte*>(desc.initialData), desc.pixelsByteSize});
+        }
+    } else {
         HgiVulkanCommandQueue* queue = device->GetCommandQueue();
         HgiVulkanCommandBuffer* cb = queue->AcquireResourceCommandBuffer();
-        CopyBufferToTexture(cb, stagingBuffer.get());
+        if (desc.initialData && desc.pixelsByteSize > 0) {
+            HgiBufferDesc stageDesc;
+            stageDesc.byteSize =
+                std::min(GetByteSizeOfResource(), desc.pixelsByteSize);
+            stageDesc.initialData = desc.initialData;
+            std::unique_ptr<HgiVulkanBuffer> stagingBuffer =
+                HgiVulkanBuffer::CreateStagingBuffer(_device, stageDesc);
 
-        // We don't know if this texture is a static (immutable) or
-        // dynamic (animated) texture. We assume that most textures are
-        // static and schedule garbage collection of staging resource.
-        HgiBufferHandle stagingHandle(stagingBuffer.release(), 0);
-        hgi->TrashObject(
-            &stagingHandle,
-            hgi->GetGarbageCollector()->GetBufferList());
-    }
+            // Schedule transfer from staging buffer to device-local texture.
+            // This will also do the necessary final desired layout transitions.
+            CopyBufferToTexture(cb, stagingBuffer.get());
 
-    //
-    // Transition image
-    //
-
-    // Transition image to default image layout and access,flags.
-    // XXX We lack information about how this texture will be used so
-    // we have none-optimal assumptions for imageLayout, access and stageFlags.
-    VkImageLayout layout = GetDefaultImageLayout(desc.usage);
-
-    if (_vkImageLayout != layout) {
-        HgiVulkanCommandQueue* queue = device->GetCommandQueue();
-        HgiVulkanCommandBuffer* cb = queue->AcquireResourceCommandBuffer();
-
-        TransitionImageBarrier(
-            cb,
-            this,
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            layout,
-            NO_PENDING_WRITES,
-            GetDefaultAccessFlags(desc.usage),
-            VK_PIPELINE_STAGE_TRANSFER_BIT,
-            VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT);
+            // We don't know if this texture is a static (immutable) or
+            // dynamic (animated) texture. We assume that most textures are
+            // static and schedule garbage collection of staging resource.
+            HgiBufferHandle stagingHandle(stagingBuffer.release(), 0);
+            hgi->TrashObject(
+                &stagingHandle,
+                hgi->GetGarbageCollector()->GetBufferList());
+        } else {
+            // Just transition to the final desired layout.
+            LayoutBarrier(
+                cb,
+                _vkImageLayout,
+                GetDefaultImageLayout(desc.usage),
+                NO_PENDING_WRITES,
+                GetDefaultAccessFlags(desc.usage),
+                VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT);
+        }
     }
 
     _descriptor.initialData = nullptr;
@@ -292,6 +355,7 @@ HgiVulkanTexture::HgiVulkanTexture(
     , _inflightBits(0)
     , _stagingBuffer(nullptr)
     , _cpuStagingAddress(nullptr)
+    , _hasHostImageCopy(false)
     , _isTextureView(true)
 {
     // Update the texture descriptor to reflect the view desc
@@ -344,7 +408,7 @@ HgiVulkanTexture::HgiVulkanTexture(
         std::string debugLabel = "ImageView " + _descriptor.debugName;
         HgiVulkanSetDebugName(
             device,
-            (uint64_t)_vkImageView,
+            static_cast<uint64_t>(reinterpret_cast<uintptr_t>(_vkImageView)),
             VK_OBJECT_TYPE_IMAGE_VIEW,
             debugLabel.c_str());
     }
@@ -477,9 +541,6 @@ HgiVulkanTexture::CopyBufferToTexture(
     int mipLevel)
 {
     // Setup buffer copy regions for each mip level
-
-    std::vector<VkBufferImageCopy> bufferCopyRegions;
-
     const std::vector<HgiMipInfo> mipInfos =
         HgiGetMipInfos(
             _descriptor.format,
@@ -490,6 +551,7 @@ HgiVulkanTexture::CopyBufferToTexture(
     const int mipLevels = std::min(static_cast<int>(mipInfos.size()),
         static_cast<int>(_descriptor.mipLevels));
 
+    std::vector<VkBufferImageCopy> bufferCopyRegions;
     for (int mip = 0; mip < mipLevels; mip++) {
         // Skip this mip if it isn't a mipLevel we want to copy
         if (mipLevel > -1 && mip != mipLevel) {
@@ -497,7 +559,7 @@ HgiVulkanTexture::CopyBufferToTexture(
         }
 
         const HgiMipInfo &mipInfo = mipInfos[mip];
-        VkBufferImageCopy bufferCopyRegion = {};
+        VkBufferImageCopy bufferCopyRegion{};
         bufferCopyRegion.imageSubresource.aspectMask =
             HgiVulkanConversions::GetImageAspectFlag(_descriptor.usage);
         bufferCopyRegion.imageSubresource.mipLevel = static_cast<uint32_t>(mip);
@@ -514,17 +576,16 @@ HgiVulkanTexture::CopyBufferToTexture(
     }
 
     // Transition image so we can copy into it
-    TransitionImageBarrier(
+    LayoutBarrier(
         cb,
-        this,
         GetImageLayout(),
-        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, // Transition tex to this layout
-        NO_PENDING_WRITES,                    // No pending writes
-        VK_ACCESS_TRANSFER_WRITE_BIT,         // Write access to image
-        VK_PIPELINE_STAGE_HOST_BIT,           // Producer stage
-        VK_PIPELINE_STAGE_TRANSFER_BIT);      // Consumer stage
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        NO_PENDING_WRITES,
+        VK_ACCESS_TRANSFER_WRITE_BIT,
+        VK_PIPELINE_STAGE_HOST_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT);
 
-    // Copy pixels (all mip levels) from staging buffer to gpu image
+    // Copy pixels from staging buffer to gpu image
     vkCmdCopyBufferToImage(
         cb->GetVulkanCommandBuffer(),
         srcBuffer->GetVulkanBuffer(),
@@ -537,15 +598,94 @@ HgiVulkanTexture::CopyBufferToTexture(
     VkImageLayout layout = GetDefaultImageLayout(_descriptor.usage);
     VkAccessFlags access = GetDefaultAccessFlags(_descriptor.usage);
 
-    TransitionImageBarrier(
+    LayoutBarrier(
         cb,
-        this,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
-        layout,                              // Transition tex to this
-        VK_ACCESS_TRANSFER_WRITE_BIT,        // Pending vkCmdCopyBufferToImage
-        access,                              // Shader read access
-        VK_PIPELINE_STAGE_TRANSFER_BIT,      // Producer stage
-        VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT); // Consumer stage
+        layout,
+        VK_ACCESS_TRANSFER_WRITE_BIT,
+        access,
+        VK_PIPELINE_STAGE_TRANSFER_BIT,
+        VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT);
+}
+
+bool
+HgiVulkanTexture::SupportsMemoryToTextureCopy() const
+{
+    const auto& capabilities = _device->GetDeviceCapabilities();
+    return _hasHostImageCopy &&
+        std::find(capabilities.vkHostImageCopyDstLayouts.begin(),
+        capabilities.vkHostImageCopyDstLayouts.begin() +
+            capabilities.vkHostImageCopyProperties.copyDstLayoutCount,
+        _vkImageLayout) != capabilities.vkHostImageCopyDstLayouts.end();
+}
+
+bool
+HgiVulkanTexture::TryCopyMemoryToTexture(
+    TfSpan<const std::byte> srcBuffer,
+    GfVec3i const& dstTexelOffset,
+    int mipLevel)
+{
+    if (!SupportsMemoryToTextureCopy()) {
+        return false;
+    }
+
+    CopyMemoryToTexture(srcBuffer, dstTexelOffset, mipLevel);
+    return true;
+}
+
+void
+HgiVulkanTexture::CopyMemoryToTexture(
+    TfSpan<const std::byte> srcBuffer,
+    GfVec3i const& dstTexelOffset,
+    int mipLevel)
+{
+    if (!TF_VERIFY(_device->vkCopyMemoryToImageEXT)) {
+        return;
+    }
+
+    // Setup buffer copy regions for each mip level
+    const std::vector<HgiMipInfo> mipInfos =
+        HgiGetMipInfos(
+            _descriptor.format,
+            _descriptor.dimensions,
+            _descriptor.layerCount,
+            srcBuffer.size());
+
+    const int mipLevels = std::min(static_cast<int>(mipInfos.size()),
+        static_cast<int>(_descriptor.mipLevels));
+
+    std::vector<VkMemoryToImageCopyEXT> bufferCopyRegions;
+    for (int mip = 0; mip < mipLevels; mip++) {
+        // Skip this mip if it isn't a mipLevel we want to copy
+        if (mipLevel > -1 && mip != mipLevel) {
+            continue;
+        }
+
+        const HgiMipInfo &mipInfo = mipInfos[mip];
+        VkMemoryToImageCopyEXT bufferCopyRegion{VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT};
+        bufferCopyRegion.imageSubresource.aspectMask =
+            HgiVulkanConversions::GetImageAspectFlag(_descriptor.usage);
+        bufferCopyRegion.imageSubresource.mipLevel = static_cast<uint32_t>(mip);
+        bufferCopyRegion.imageSubresource.baseArrayLayer = 0;
+        bufferCopyRegion.imageSubresource.layerCount = _descriptor.layerCount;
+        bufferCopyRegion.imageExtent.width = mipInfo.dimensions[0];
+        bufferCopyRegion.imageExtent.height = mipInfo.dimensions[1];
+        bufferCopyRegion.imageExtent.depth = mipInfo.dimensions[2];
+        bufferCopyRegion.pHostPointer = srcBuffer.data() + mipInfo.byteOffset;
+        bufferCopyRegion.imageOffset.x = dstTexelOffset[0];
+        bufferCopyRegion.imageOffset.y = dstTexelOffset[1];
+        bufferCopyRegion.imageOffset.z = dstTexelOffset[2];
+        bufferCopyRegions.push_back(bufferCopyRegion);
+    }
+
+    VkCopyMemoryToImageInfoEXT copyMemoryToImageInfo{VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT};
+    copyMemoryToImageInfo.dstImage = _vkImage;
+    copyMemoryToImageInfo.dstImageLayout = _vkImageLayout;
+    copyMemoryToImageInfo.regionCount = static_cast<uint32_t>(bufferCopyRegions.size());
+    copyMemoryToImageInfo.pRegions = bufferCopyRegions.data();
+
+    // Immediately copy pixels from memory directly to gpu image
+    HGIVULKAN_VERIFY_VK_RESULT(_device->vkCopyMemoryToImageEXT(_device->GetVulkanDevice(), &copyMemoryToImageInfo));
 }
 
 HgiTextureUsage
@@ -613,12 +753,11 @@ HgiVulkanTexture::SubmitLayoutChange(HgiTextureUsage newLayout)
         break;
     }
 
-    TransitionImageBarrier(
+    LayoutBarrier(
         cb,
-        this,
         oldVkLayout,
         newVkLayout,
-        srcAccessMask, 
+        srcAccessMask,
         dstAccessMask,
         srcStageMask,
         dstStageMask);
@@ -627,9 +766,8 @@ HgiVulkanTexture::SubmitLayoutChange(HgiTextureUsage newLayout)
 }
 
 void
-HgiVulkanTexture::TransitionImageBarrier(
+HgiVulkanTexture::LayoutBarrier(
     HgiVulkanCommandBuffer* cb,
-    HgiVulkanTexture* tex,
     VkImageLayout oldLayout,
     VkImageLayout newLayout,
     VkAccessFlags producerAccess,
@@ -638,25 +776,25 @@ HgiVulkanTexture::TransitionImageBarrier(
     VkPipelineStageFlags consumerStage,
     int32_t mipLevel)
 {
-    HgiTextureDesc const& desc = tex->GetDescriptor();
+    HgiTextureDesc const& desc = GetDescriptor();
 
-    uint32_t firstMip = mipLevel < 0 ? 0 : (uint32_t)mipLevel;
-    uint32_t mipCnt = mipLevel < 0 ? desc.mipLevels : 1;
+    const auto firstMip = static_cast<uint32_t>(std::max(0, mipLevel));
+    const auto mipCount = mipLevel < 0 ? desc.mipLevels : 1u;
 
-    VkImageMemoryBarrier barrier[1] = {};
-    barrier[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier[0].srcAccessMask = producerAccess; // what producer does / changes.
-    barrier[0].dstAccessMask = consumerAccess; // what consumer does / changes.
-    barrier[0].oldLayout = oldLayout;
-    barrier[0].newLayout = newLayout;
-    barrier[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    barrier[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    barrier[0].image = tex->GetImage();
-    barrier[0].subresourceRange.aspectMask = 
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcAccessMask = producerAccess;
+    barrier.dstAccessMask = consumerAccess;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.image = GetImage();
+    barrier.subresourceRange.aspectMask =
         HgiVulkanConversions::GetImageAspectFlag(desc.usage);
-    barrier[0].subresourceRange.baseMipLevel = firstMip;
-    barrier[0].subresourceRange.levelCount = mipCnt;
-    barrier[0].subresourceRange.layerCount = desc.layerCount;
+    barrier.subresourceRange.baseMipLevel = firstMip;
+    barrier.subresourceRange.levelCount = mipCount;
+    barrier.subresourceRange.layerCount = desc.layerCount;
 
     // Insert a memory dependency at the proper pipeline stages that will
     // execute the image layout transition.
@@ -665,10 +803,12 @@ HgiVulkanTexture::TransitionImageBarrier(
         cb->GetVulkanCommandBuffer(),
         producerStage,
         consumerStage,
-        0, 0, NULL, 0, NULL, 1,
-        barrier);
+        0,
+        0, NULL,
+        0, NULL,
+        1, &barrier);
 
-    tex->_vkImageLayout = newLayout;
+    _vkImageLayout = newLayout;
 }
 
 VkImageLayout

--- a/pxr/imaging/hgiVulkan/texture.h
+++ b/pxr/imaging/hgiVulkan/texture.h
@@ -8,6 +8,7 @@
 #define PXR_IMAGING_HGI_VULKAN_TEXTURE_H
 
 #include "pxr/pxr.h"
+#include "pxr/base/tf/span.h"
 #include "pxr/imaging/hgi/texture.h"
 #include "pxr/imaging/hgiVulkan/api.h"
 #include "pxr/imaging/hgiVulkan/vulkan.h"
@@ -86,7 +87,18 @@ public:
         HgiVulkanCommandBuffer* cb,
         HgiVulkanBuffer* srcBuffer,
         GfVec3i const& dstTexelOffset = GfVec3i(0),
-        int mipLevel=-1);
+        int mipLevel = -1);
+
+    /// Immediately copy texels from the provided CPU buffer into the texture.
+    /// If mipLevel is less than one, all mip levels will be copied from buffer.
+    /// This feature is only available on certain hardware, and enables skipping
+    /// a staging copy. This function returns false when unavailable. In that
+    /// case, use CopyBufferToTexture() as a fallback.
+    HGIVULKAN_API
+    bool TryCopyMemoryToTexture(
+        TfSpan<const std::byte> srcBuffer,
+        GfVec3i const& dstTexelOffset = GfVec3i(0),
+        int mipLevel = -1);
 
     /// This function issues a layout change barrier. However, the layout 
     /// transition isn't immediately executed. The command buffer simply 
@@ -101,16 +113,15 @@ public:
     ///    Multiple passes can go back to back which all read the resource.
     /// If mipLevel is > -1 only that mips level will be transitioned.
     HGIVULKAN_API
-    static void TransitionImageBarrier(
+    void LayoutBarrier(
         HgiVulkanCommandBuffer* cb,
-        HgiVulkanTexture* tex,
         VkImageLayout oldLayout,
         VkImageLayout newLayout,
         VkAccessFlags producerAccess,
         VkAccessFlags consumerAccess,
         VkPipelineStageFlags producerStage,
         VkPipelineStageFlags consumerStage,
-        int32_t mipLevel=-1);
+        int32_t mipLevel = -1);
 
     /// Returns the layout for a texture based on its usage flags.
     HGIVULKAN_API
@@ -143,6 +154,13 @@ private:
     HgiVulkanTexture & operator=(const HgiVulkanTexture&) = delete;
     HgiVulkanTexture(const HgiVulkanTexture&) = delete;
 
+    bool SupportsMemoryToTextureCopy() const;
+
+    void CopyMemoryToTexture(
+        TfSpan<const std::byte> srcBuffer,
+        GfVec3i const& dstTexelOffset = GfVec3i(0),
+        int mipLevel = -1);
+
     VkImage _vkImage;
     VkImageView _vkImageView;
     VkImageLayout _vkImageLayout;
@@ -151,6 +169,7 @@ private:
     uint64_t _inflightBits;
     std::unique_ptr<HgiVulkanBuffer> _stagingBuffer;
     void* _cpuStagingAddress;
+    bool _hasHostImageCopy;
     bool _isTextureView;
 };
 


### PR DESCRIPTION
### Description of Change(s)

- Based on the UMA/ReBAR branch due to dependencies
- Use VK_EXT_host_image_copy to initialize image data on `HgiVulkanTexture` creation
    - Main upload path used by Storm.
    - Only when this has no performance penalty on the image performance.
- `HgiVulkanTexture::TryCopyMemoryToTexture()` could be used to implement host image copy in `HgiVulkanBlitCmds::CopyTextureCpuToGpu()`, but since the only user is `HdxAovInputTask` it doesn't seem worth it for now.
- Device to host copy (GPU to CPU) was also left as a future improvement.
- Misc. cleanup.
- 

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
