### PR TITLE
Autodesk: [hgi*] Hgi helpers for texture allocation

### DIFF
--- a/pxr/imaging/hgi/capabilities.h
+++ b/pxr/imaging/hgi/capabilities.h
@@ -8,9 +8,11 @@
 #define PXR_IMAGING_HGI_CAPABILITIES_H
 
 #include "pxr/pxr.h"
+
 #include "pxr/imaging/hgi/api.h"
 #include "pxr/imaging/hgi/enums.h"
 
+#include <array>
 #include <cstddef>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -60,6 +62,14 @@ public:
         return _pageSizeAlignment;
     }
 
+    /// The max texture dimension for 1D, 2D and 3D, in their respective
+    /// element. In other words, when checking *all* dimensions for a N-D
+    /// texture, use the N'th element as the allowed maximum.
+    HGI_API
+    const std::array<uint32_t, 3>& GetMaxTextureDimension() const {
+        return _maxTextureDimension;
+    }
+
 protected:
     HgiCapabilities()
         : _maxUniformBlockSize(0)
@@ -67,6 +77,7 @@ protected:
         , _uniformBufferOffsetAlignment(0)
         , _maxClipDistances(0)
         , _pageSizeAlignment(1)
+        , _maxTextureDimension{}
         , _flags(0)
     {}
 
@@ -83,6 +94,7 @@ protected:
     size_t _uniformBufferOffsetAlignment;
     size_t _maxClipDistances;
     size_t _pageSizeAlignment;
+    std::array<uint32_t, 3> _maxTextureDimension;
 
 private:
     HgiCapabilities & operator=(const HgiCapabilities&) = delete;

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -29,6 +29,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -332,6 +333,15 @@ public:
     /// well (e.g. EndFrame).
     HGI_API
     virtual void GarbageCollect() = 0;
+
+    /// Attempt to get the amount of available memory on the GPU. On systems
+    /// with dedicated GPUs, this should be the amount of free VRAM available.
+    /// For integrated GPUs or software rasterizers, this should be the amount
+    /// of free RAM available. This is only a rough estimate to help guide
+    /// memory usage strategies. This information might not be available on all
+    /// platforms, hence the optional return value.
+    HGI_API
+    virtual std::optional<size_t> GetAvailableGpuMemory() const = 0;
 
 protected:
     // Returns a unique id for handle creation.

--- a/pxr/imaging/hgi/testenv/testHgiCommand.cpp
+++ b/pxr/imaging/hgi/testenv/testHgiCommand.cpp
@@ -22,10 +22,21 @@ HgiBasicTest()
 {
     HgiInitializationTestDriver driver;
 
-    if (driver.GetHgi() == nullptr) {
+    Hgi* hgi = driver.GetHgi();
+    if (!hgi) {
         return false;
     }
-    
+
+    std::cout << "Hgi API: " << hgi->GetAPIName() << "\n";
+
+    std::cout << "Hgi GPU memory: ";
+    if (const std::optional<size_t> memory = hgi->GetAvailableGpuMemory()) {
+        std::cout << *memory;
+    } else {
+        std::cout << "<unavailable>";
+    }
+    std::cout << "\n";
+
     return true;
 }
 

--- a/pxr/imaging/hgiGL/CMakeLists.txt
+++ b/pxr/imaging/hgiGL/CMakeLists.txt
@@ -93,6 +93,8 @@ pxr_register_test(testHgiGL
     FAIL_PERCENT 0.001
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
+    ENV
+        HGI_ENABLE_VULKAN=0
 )
 
 # This test is not currently supported on static builds as it relies on 
@@ -111,6 +113,8 @@ pxr_register_test(testHgiGLCommand
     FAIL_PERCENT 0.001
     PERCEPTUAL
     EXPECTED_RETURN_CODE 0
+    ENV
+        HGI_ENABLE_VULKAN=0
 )
 
 endif() # BUILD_SHARED_LIBS

--- a/pxr/imaging/hgiGL/capabilities.cpp
+++ b/pxr/imaging/hgiGL/capabilities.cpp
@@ -105,6 +105,16 @@ HgiGLCapabilities::_LoadCapabilities()
     glGetIntegerv(GL_MAX_CLIP_PLANES, &maxClipDistances);
     _maxClipDistances = maxClipDistances;
 
+    // 1D and 2D
+    GLint maxTextureSize = 0;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &maxTextureSize);
+    _maxTextureDimension[0] = _maxTextureDimension[1] =
+        static_cast<uint32_t>(maxTextureSize);
+    // 3D
+    GLint max3dTextureSize = 0;
+    glGetIntegerv(GL_MAX_3D_TEXTURE_SIZE, &max3dTextureSize);
+    _maxTextureDimension[2] = static_cast<uint32_t>(max3dTextureSize);
+
     // initialize by Core versions
     if (_glVersion >= 310) {
         GLint maxUniformBlockSize = 0;

--- a/pxr/imaging/hgiGL/capabilities.cpp
+++ b/pxr/imaging/hgiGL/capabilities.cpp
@@ -64,6 +64,7 @@ HgiGLCapabilities::_LoadCapabilities()
     bool builtinBarycentricsEnabled   = false;
     bool shaderDrawParametersEnabled  = false;
     bool conservativeRasterEnabled    = false;
+    bool gpuMemoryInfoEnabled         = false;
     bool nativeRoundPointsEnabled     = true;
 
     const char *glVendorStr = (const char*)glGetString(GL_VENDOR);
@@ -159,6 +160,9 @@ HgiGLCapabilities::_LoadCapabilities()
     if (GARCH_GLAPI_HAS(NV_conservative_raster)) {
         conservativeRasterEnabled = true;
     }
+    if (GARCH_GLAPI_HAS(NVX_gpu_memory_info)) {
+        gpuMemoryInfoEnabled = true;
+    }
 
     // Environment variable overrides (only downgrading is possible)
     if (!TfGetEnvSetting(HGIGL_ENABLE_BINDLESS_TEXTURE)) {
@@ -244,6 +248,8 @@ HgiGLCapabilities::_LoadCapabilities()
             <<    bindlessBufferEnabled << "\n"
             << "  NV_conservative_raster             = "
             <<    conservativeRasterEnabled << "\n"
+            << "  NVX_gpu_memory_info                = "
+            <<    gpuMemoryInfoEnabled << "\n"
             ;
     }
 }

--- a/pxr/imaging/hgiGL/hgi.cpp
+++ b/pxr/imaging/hgiGL/hgi.cpp
@@ -307,6 +307,19 @@ HgiGL::GarbageCollect()
     #endif
 }
 
+std::optional<size_t>
+HgiGL::GetAvailableGpuMemory() const
+{
+    if (!GARCH_GLAPI_HAS(NVX_gpu_memory_info)) {
+        return std::nullopt;
+    }
+
+    GLint availableMemoryKib = 0;
+    glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX,
+        &availableMemoryKib);
+    return static_cast<size_t>(availableMemoryKib) * 1024;
+}
+
 HgiGLContextArenaHandle
 HgiGL::CreateContextArena()
 {

--- a/pxr/imaging/hgiGL/hgi.h
+++ b/pxr/imaging/hgiGL/hgi.h
@@ -159,6 +159,9 @@ public:
     HGIGL_API
     void GarbageCollect() override;
 
+    HGIGL_API
+    std::optional<size_t> GetAvailableGpuMemory() const override;
+
     /// ------------------------------------------------------------------------
     // HgiGL specific API
     /// ------------------------------------------------------------------------

--- a/pxr/imaging/hgiMetal/capabilities.mm
+++ b/pxr/imaging/hgiMetal/capabilities.mm
@@ -117,6 +117,18 @@ HgiMetalCapabilities::HgiMetalCapabilities(id<MTLDevice> device)
     _maxClipDistances             = 8;
     _pageSizeAlignment            = 4096;
 
+    uint32_t max1dAnd2dDimension = 16384;
+#if defined(ARCH_OS_IPHONE)
+    if (![device supportsFeatureSet:MTLFeatureSet_iOS_GPUFamily3_v1]) {
+        max1dAnd2dDimension = 8192;
+    }
+#endif
+    _maxTextureDimension = {
+        max1dAnd2dDimension,
+        max1dAnd2dDimension,
+        2048
+    };
+
     // Apple Silicon only support memory barriers between vertex stages after
     // macOS 12.3.
     hasVertexMemoryBarrier = !hasAppleSilicon;

--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -140,6 +140,9 @@ public:
     HGIMETAL_API
     void GarbageCollect() override;
 
+    HGIMETAL_API
+    std::optional<size_t> GetAvailableGpuMemory() const override;
+
     //
     // HgiMetal specific
     //

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -382,6 +382,22 @@ HgiMetal::GarbageCollect()
 {
 }
 
+std::optional<size_t>
+HgiMetal::GetAvailableGpuMemory() const
+{
+    // recommendedMaxWorkingSetSize is supported in iOS 16+,
+    // but is only marked available starting in iOS SDK 17+.
+#if !defined(ARCH_OS_IPHONE) || (defined(__IPHONE_17_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_17_0)
+    if (@available(macOS 10.13, ios 16.0, *)) {
+        return _device.recommendedMaxWorkingSetSize -
+        _device.currentAllocatedSize;
+    }
+#endif
+
+    return std::nullopt;
+}
+
 id<MTLCommandQueue>
 HgiMetal::GetQueue() const
 {

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -81,8 +81,8 @@ static void _DumpDeviceDeviceMemoryProperties(
 }
 
 HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
-    : supportsTimeStamps(false),
-    supportsNativeInterop(false)
+    : supportsTimeStamps(false)
+    , supportsNativeInterop(false)
 {
     VkPhysicalDevice physicalDevice = device->GetVulkanPhysicalDevice();
 
@@ -203,6 +203,11 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     }
 
     _maxClipDistances = vkDeviceProperties2.properties.limits.maxClipDistances;
+    _maxTextureDimension = {
+        vkDeviceProperties2.properties.limits.maxImageDimension1D,
+        vkDeviceProperties2.properties.limits.maxImageDimension2D,
+        vkDeviceProperties2.properties.limits.maxImageDimension3D,
+    };
     _maxUniformBlockSize =
         vkDeviceProperties2.properties.limits.maxUniformBufferRange;
     _maxShaderStorageBlockSize =

--- a/pxr/imaging/hgiVulkan/capabilities.h
+++ b/pxr/imaging/hgiVulkan/capabilities.h
@@ -36,10 +36,6 @@ public:
     HGIVULKAN_API
     int GetShaderVersion() const override;
 
-    bool supportsTimeStamps;
-
-    bool supportsNativeInterop;
-
     VkPhysicalDeviceProperties2 vkDeviceProperties2 {};
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT
         vkVertexAttributeDivisorProperties {};
@@ -55,6 +51,9 @@ public:
     VkPhysicalDeviceLineRasterizationFeaturesKHR vkLineRasterizationFeatures {};
 
     VkPhysicalDeviceIDProperties vkPhysicalDeviceIdProperties {};
+
+    bool supportsTimeStamps;
+    bool supportsNativeInterop;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -216,9 +216,9 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
 #endif
 
     // Memory budget query extension
-    bool supportsMemExtension = false;
+    bool supportsMemoryBudget = false;
     if (IsSupportedExtension(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) {
-        supportsMemExtension = true;
+        supportsMemoryBudget = true;
         extensions.push_back(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
     }
 
@@ -404,7 +404,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         allocatorInfo.flags |=VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
     }
 
-    if (supportsMemExtension) {
+    if (supportsMemoryBudget) {
         allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
     }
 

--- a/pxr/imaging/hgiVulkan/hgi.cpp
+++ b/pxr/imaging/hgiVulkan/hgi.cpp
@@ -30,6 +30,8 @@
 #include "pxr/base/tf/registryManager.h"
 #include "pxr/base/tf/type.h"
 
+#include <array>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 
@@ -329,6 +331,27 @@ HgiVulkan::GarbageCollect()
 
     // Perform garbage collection for each device.
     _garbageCollector->PerformGarbageCollection(device);
+}
+
+std::optional<size_t>
+HgiVulkan::GetAvailableGpuMemory() const
+{
+    std::array<VmaBudget, VK_MAX_MEMORY_HEAPS> budgets{};
+    vmaGetHeapBudgets(GetPrimaryDevice()->GetVulkanMemoryAllocator(),
+        budgets.data());
+
+    const auto& memoryProperties = GetCapabilities()->vkMemoryProperties;
+    for (uint32_t heapIndex = 0;
+        heapIndex < memoryProperties.memoryHeapCount; heapIndex++) {
+        const auto& heap = memoryProperties.memoryHeaps[heapIndex];
+
+        if ((heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) ==
+            VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+            return budgets[heapIndex].budget - budgets[heapIndex].usage;
+        }
+    }
+
+    return std::nullopt;
 }
 
 /* Multi threaded */

--- a/pxr/imaging/hgiVulkan/hgi.h
+++ b/pxr/imaging/hgiVulkan/hgi.h
@@ -139,6 +139,9 @@ public:
     HGIVULKAN_API
     void GarbageCollect() override;
 
+    HGIVULKAN_API
+    std::optional<size_t> GetAvailableGpuMemory() const override;
+
     //
     // HgiVulkan specific
     //


### PR DESCRIPTION
### Description of Change(s)

Provide a way for applications to query device texture and memory limits via Hgi. This helps applications make safer resource allocation decisions.

Add and implement:
- `std::array<uint32_t, 3> HgiCapabilities::GetMaxTextureDimension() const`
    - Return the max 1D, 2D and 3D texture dimensions respectively.
- `std::optional<size_t> Hgi::GetAvailableGpuMemory() const`
    - If available, get the approximate amount of memory freely available on the GPU.

`Hgi::GetAvailableGpuMemory()` can't really be tested, but I added it to `testHgiCommand` as a "smoke" test.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
