### PR TITLE
[wasm64] Add wasm64 support

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -39,3 +39,5 @@ Our test machines have the following software versions installed.
 | OpenVDB       | 10.1.0               | 10.1.0                       | 10.1.0                         |
 | Vulkan SDK    | 1.4.321.0            | 1.4.321.0                    | 1.4.321.0                      |
 | Draco         | 1.5.6                | 1.5.6                        | 1.5.6                          |
+| Emscripten    | 4.0.15               | 4.0.15                       | 4.0.15                         |
+| node          | 24.9.0               | 24.9.0                       | 24.9.0                         |

--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -37,6 +37,8 @@ from shutil import which
 
 # Helpers for printing output
 verbosity = 1
+EMSCRIPTEN_CMAKE_EXE_LINKER_FLAGS='-pthread'
+EMSCRIPTEN_CMAKE_CXX_FLAGS='-pthread --use-port=zlib'
 
 def Print(msg):
     if verbosity > 0:
@@ -82,14 +84,15 @@ def GetBuildTargetDefault():
         return ''
 
 TARGET_WASM='wasm'
+TARGET_WASM64='wasm64'
 
 def GetBuildTargets():
     if MacOS():
-        return apple_utils.GetBuildTargets() + [TARGET_WASM]
+        return apple_utils.GetBuildTargets() + [TARGET_WASM, TARGET_WASM64]
     elif Linux():
-        return [TARGET_WASM]
+        return [TARGET_WASM, TARGET_WASM64]
     elif Windows():
-        return [TARGET_WASM]        
+        return [TARGET_WASM, TARGET_WASM64]
     else:
         return []
 
@@ -1007,7 +1010,10 @@ def InstallOneTBB(context, force, buildArgs):
     with CurrentWorkingDirectory(DownloadURL(ONETBB_URL, context, force)):
         cmakeOptions = ['-DTBB_TEST=OFF', '-DTBB_STRICT=OFF']
         if context.targetWasm:
-            cmakeOptions += ['-DBUILD_SHARED_LIBS=OFF', '-DCMAKE_CXX_FLAGS="-pthread"']
+            cmakeOptions += [
+                '-DBUILD_SHARED_LIBS=OFF',
+                '-DCMAKE_CXX_FLAGS="' + EMSCRIPTEN_CMAKE_CXX_FLAGS + '"'
+            ]
 
         cmakeOptions += buildArgs
         RunCMake(context, force, cmakeOptions)
@@ -1878,6 +1884,10 @@ def InstallUSD(context, force, buildArgs):
 
             extraArgs.append('-DBUILD_SHARED_LIBS=OFF')
 
+            extraArgs.append('-DCMAKE_CXX_FLAGS="' + EMSCRIPTEN_CMAKE_CXX_FLAGS + '"')
+            extraArgs.append('-DCMAKE_C_FLAGS="' + EMSCRIPTEN_CMAKE_CXX_FLAGS + '"')
+            extraArgs.append('-DCMAKE_EXE_LINKER_FLAGS="' + EMSCRIPTEN_CMAKE_EXE_LINKER_FLAGS + '"')
+
         RunCMake(context, force, extraArgs, context.usdInstDir)
 
 USD = Dependency("USD", InstallUSD, "include/pxr/pxr.h")
@@ -2339,7 +2349,7 @@ class InstallContext:
 
         self.ignorePaths = args.ignore_paths or []
         # Build target and code signing
-        self.targetWasm = (args.build_target == TARGET_WASM)
+        self.targetWasm = (args.build_target == TARGET_WASM or args.build_target == TARGET_WASM64)
         self.buildTarget = args.build_target
         if MacOS():
             apple_utils.SetTarget(self, self.buildTarget)
@@ -2459,6 +2469,10 @@ except Exception as e:
     sys.exit(1)
 
 verbosity = args.verbosity
+
+if args.build_target == TARGET_WASM64:
+    EMSCRIPTEN_CMAKE_EXE_LINKER_FLAGS+=' -sMEMORY64=1'
+    EMSCRIPTEN_CMAKE_CXX_FLAGS+=' -sMEMORY64=1'
 
 # Augment PATH on Windows so that 3rd-party dependencies can find libraries
 # they depend on. In particular, this is needed for building IlmBase/OpenEXR.

--- a/cmake/defaults/ProjectDefaults.cmake
+++ b/cmake/defaults/ProjectDefaults.cmake
@@ -28,7 +28,7 @@ if(APPLE)
 endif()
 
 if(EMSCRIPTEN)
-    set(EMSCRIPTEN_COMPILE_FLAGS "-sMAXIMUM_MEMORY=4GB -fexceptions")
+    set(EMSCRIPTEN_COMPILE_FLAGS "-fexceptions")
     add_compile_options("SHELL:${EMSCRIPTEN_COMPILE_FLAGS}")
     add_link_options("SHELL:${EMSCRIPTEN_COMPILE_FLAGS} -sALLOW_MEMORY_GROWTH=1")
 endif()

--- a/pxr/base/tf/mallocTag.cpp
+++ b/pxr/base/tf/mallocTag.cpp
@@ -115,10 +115,10 @@ struct Tf_MallocBlockInfo {
     Tf_MallocPathNode *pathNode = nullptr;
 };
 
-#if defined (__wasm64__)
+#if defined(ARCH_OS_WASM_VM) && defined(ARCH_BITS_64)
 static_assert(sizeof(Tf_MallocBlockInfo) == 16,
           "Unexpected size for Tf_MallocBlockInfo");
-#elif defined (__wasm32__)
+#elif defined(ARCH_OS_WASM_VM) && defined(ARCH_BITS_32)
 static_assert(sizeof(Tf_MallocBlockInfo) == 8,
           "Unexpected size for Tf_MallocBlockInfo");
 #elif !defined(ARCH_OS_WINDOWS)

--- a/pxr/base/tf/smallVector.cpp
+++ b/pxr/base/tf/smallVector.cpp
@@ -9,7 +9,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#ifndef ARCH_OS_WASM_VM
+#ifdef ARCH_BITS_64
 static_assert(
     sizeof(TfSmallVector<int, 1>) == 16,
     "Expecting sizeof(TfSmallVector<int, N = 1>) to be 16 bytes.");
@@ -31,7 +31,7 @@ static_assert(
     sizeof(TfSmallVector<double, 2>) == 24,
     "Expecting sizeof(TfSmallVector<double, N = 2>) to be 24 bytes.");
 
-#ifndef ARCH_OS_WASM_VM
+#ifdef ARCH_BITS_64
 static_assert(
     TfSmallVectorBase::ComputeSerendipitousLocalCapacity<char>() == 8,
     "Expecting 8 bytes of local capacity.");

--- a/pxr/usd/usd/primData.cpp
+++ b/pxr/usd/usd/primData.cpp
@@ -28,8 +28,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 // Static assertion on PrimData size.  We want to be warned when its size
 // changes.
+#ifdef ARCH_BITS_32
+static_assert(sizeof(Usd_PrimData) == 48,
+              "Expected sizeof(Usd_PrimData) == 48");
+#else
 static_assert(sizeof(Usd_PrimData) == 64,
               "Expected sizeof(Usd_PrimData) == 64");
+#endif
 
 // Usd_PrimData need to be always initialized with a valid type info pointer
 static const UsdPrimTypeInfo *_GetEmptyPrimTypeInfo() 


### PR DESCRIPTION
### Description of Change(s)
- Add wasm64 build target to build_usd.py
- Extend static asserts in `pxr/base/tf/mallocTag.cpp`, `pxr/base/tf/smallVector.cpp` and `pxr/usd/usd/primData.cpp` to handle 32 and 64 bits architectures
- Add required emscripten and node versions to VERSIONS.md