### PR TITLE
[wasm] Add wasm support for building pxr/usd

### DIFF
--- a/pxr/CMakeLists.txt
+++ b/pxr/CMakeLists.txt
@@ -2,9 +2,7 @@ pxr_core_prologue()
 
 add_subdirectory(external)
 add_subdirectory(base)
-if (NOT EMSCRIPTEN)
-    add_subdirectory(usd)
-endif()
+add_subdirectory(usd)
 
 if (${PXR_BUILD_EXEC})
     add_subdirectory(exec)

--- a/pxr/usd/ar/CMakeLists.txt
+++ b/pxr/usd/ar/CMakeLists.txt
@@ -265,10 +265,6 @@ pxr_register_test(testArDefaultResolver
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver"
 )
 
-pxr_register_test(testArDefaultResolver_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver_CPP"
-)
-
 pxr_register_test(testArOpenAsset
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArOpenAsset"
@@ -298,6 +294,15 @@ pxr_register_test(testArResolverContext_CPP
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArResolverContext_CPP"
 )
 
-pxr_register_test(testArThreadedAssetCreation
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArThreadedAssetCreation"
-)
+# Note the following tests are disabled when building for emscripten due to
+# plugin loading failures. Emscripten cannot locate plugInfo.json files for
+# ArDefaultResolver in the virtual filesystem.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testArDefaultResolver_CPP
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArDefaultResolver_CPP"
+    )
+
+    pxr_register_test(testArThreadedAssetCreation
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testArThreadedAssetCreation"
+    )
+endif()

--- a/pxr/usd/pcp/CMakeLists.txt
+++ b/pxr/usd/pcp/CMakeLists.txt
@@ -2065,19 +2065,8 @@ pxr_register_test(testPcpMuseum_VariantSpecializesAndReference
     DIFF_COMPARE compositionResults_VariantSpecializesAndReference.txt
 )
 
-pxr_register_test(testPcpIterator
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpIterator"
-    DIFF_COMPARE iteration_results.txt
-    EXPECTED_RETURN_CODE 0
-)
-
 pxr_register_test(testPcpMapExpression
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpMapExpression"
-    EXPECTED_RETURN_CODE 0
-)
-
-pxr_register_test(testPcpPathTranslation_HardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation_HardToReach"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -2099,10 +2088,26 @@ pxr_register_test(testPcpDependencies
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testPcpHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpHardToReach"
-    EXPECTED_RETURN_CODE 0
-)
+# Note the following tests are disabled when building for emscripten due to
+# plugin loading failures. Emscripten cannot locate plugInfo.json files in
+# the virtual filesystem.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testPcpIterator
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpIterator"
+        DIFF_COMPARE iteration_results.txt
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testPcpPathTranslation_HardToReach
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpPathTranslation_HardToReach"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testPcpHardToReach
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testPcpHardToReach"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testPcpInstanceKey
     PYTHON

--- a/pxr/usd/sdf/CMakeLists.txt
+++ b/pxr/usd/sdf/CMakeLists.txt
@@ -535,10 +535,6 @@ pxr_register_test(testSdfAttributeBlocking
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking"
 )
 
-pxr_register_test(testSdfAttributeBlocking_Cpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking_Cpp"
-)
-
 pxr_register_test(testSdfBatchNamespaceEdit
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfBatchNamespaceEdit"
@@ -579,10 +575,6 @@ pxr_register_test(testSdfDetachedLayerEnvVar2
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfDetachedLayer"
 )
 
-pxr_register_test(testSdfHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfHardToReach"
-)
-
 pxr_register_test(testSdfFileFormat
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfFileFormat"
@@ -601,10 +593,6 @@ pxr_register_test(testSdfIntegerCoding
 pxr_register_test(testSdfLayer
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayer"
-)
-
-pxr_register_test(testSdfLayerHints
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerHints"
 )
 
 pxr_register_test(testSdfLayerMuting
@@ -629,10 +617,6 @@ pxr_register_test(testSdfLegacyFileFormat_Error
 pxr_register_test(testSdfListOp
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfListOp"
-)
-
-pxr_register_test(testSdfMetaDataPlugInfo
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfMetaDataPlugInfo"
 )
 
 pxr_register_test(testSdfPathExpression
@@ -720,16 +704,6 @@ pxr_register_test(testSdfTargetFileFormat
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTargetFileFormat"
 )
-pxr_register_test(testSdfTextFile
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTextFile"
-    EXPECTED_RETURN_CODE 0
-)
-pxr_register_test(testSdfTextFile_1.1
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTextFile"
-    EXPECTED_RETURN_CODE 0
-    ENV
-        USD_WRITE_NEW_USDA_FILES_AS_VERSION=1.1
-)
 pxr_register_test(testSdfTimeCode
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTimeCode"
@@ -749,14 +723,6 @@ pxr_register_test(testSdfZipFileLimits
     EXPECTED_RETURN_CODE 0
     ENV 
         SDF_MAX_ZIPFILE_SIZE=195
-)
-pxr_register_test(testSdfZipFile_CPP
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfZipFile_CPP"
-    EXPECTED_RETURN_CODE 0
-)
-pxr_register_test(testSdfUsdzResolver
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfUsdzResolver"
-    EXPECTED_RETURN_CODE 0
 )
 pxr_register_test(testSdfVariableExpression
     PYTHON
@@ -780,3 +746,46 @@ pxr_register_test(testSdfUsdcInvalidPrimChildren
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfUsdcInvalidPrimChildren"
     EXPECTED_RETURN_CODE 0
 )
+
+# Note the following tests are disabled when building for emscripten due to
+# plugin loading failures. These tests fail because Emscripten cannot locate
+# plugInfo.json files in the virtual filesystem.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testSdfAttributeBlocking_Cpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfAttributeBlocking_Cpp"
+    )
+
+    pxr_register_test(testSdfHardToReach
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfHardToReach"
+    )
+
+    pxr_register_test(testSdfLayerHints
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfLayerHints"
+    )
+
+    pxr_register_test(testSdfMetaDataPlugInfo
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfMetaDataPlugInfo"
+    )
+
+    pxr_register_test(testSdfTextFile
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTextFile"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testSdfTextFile_1.1
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfTextFile"
+        EXPECTED_RETURN_CODE 0
+        ENV
+            USD_WRITE_NEW_USDA_FILES_AS_VERSION=1.1
+    )
+
+    pxr_register_test(testSdfZipFile_CPP
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfZipFile_CPP"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testSdfUsdzResolver
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testSdfUsdzResolver"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()

--- a/pxr/usd/sdf/path.h
+++ b/pxr/usd/sdf/path.h
@@ -45,9 +45,15 @@ void TfDelegatedCountDecrement(Sdf_PathNode const *) noexcept;
 struct Sdf_PathPrimTag;
 struct Sdf_PathPropTag;
 
+// SdfPath always contains two 32-bit handles (primPart and propPart), regardless of architecture.
+static constexpr size_t Sdf_SizeofSdfPath = 2 * sizeof(uint32_t);
+
 // These are validated below.
-static constexpr size_t Sdf_SizeofPrimPathNode = sizeof(void *) * 3;
-static constexpr size_t Sdf_SizeofPropPathNode = sizeof(void *) * 3;
+static constexpr size_t Sdf_SizeofPrimPathNode = sizeof(TfToken) + 2 * sizeof(unsigned int) + sizeof(void*);
+// Property nodes can have either TfToken or SdfPath members. SdfPath (8 bytes) is larger than 
+// TfToken (4 bytes) on 32-bit architectures. Use the larger size to accommodate all node types.
+static constexpr size_t Sdf_SizeofPropPathNode =
+    (sizeof(TfToken) > Sdf_SizeofSdfPath ? sizeof(TfToken) : Sdf_SizeofSdfPath) + 2 * sizeof(unsigned int) + sizeof(void*);
 
 using Sdf_PathPrimPartPool = Sdf_Pool<
     Sdf_PathPrimTag, Sdf_SizeofPrimPathNode, /*regionBits=*/8>;
@@ -1424,7 +1430,11 @@ PXR_NAMESPACE_CLOSE_SCOPE
 PXR_NAMESPACE_OPEN_SCOPE
 
 static_assert(Sdf_SizeofPrimPathNode == sizeof(Sdf_PrimPathNode), "");
-static_assert(Sdf_SizeofPropPathNode == sizeof(Sdf_PrimPropertyPathNode), "");
+// Property pool must be sized for the largest property node type.
+// Sdf_TargetPathNode has an SdfPath member (8 bytes) which is larger than TfToken (4 bytes on 32-bit).
+static_assert(Sdf_SizeofPropPathNode >= sizeof(Sdf_PrimPropertyPathNode), "");
+static_assert(Sdf_SizeofPropPathNode >= sizeof(Sdf_RelationalAttributePathNode), "");
+static_assert(Sdf_SizeofPropPathNode >= sizeof(Sdf_TargetPathNode), "");
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/pxr/usd/sdf/pathNode.cpp
+++ b/pxr/usd/sdf/pathNode.cpp
@@ -38,8 +38,8 @@ SDF_INSTANTIATE_POOL(Sdf_PathPropTag, Sdf_SizeofPropPathNode, /*regionBits=*/8);
 
 // Size of path nodes is important, so we want the compiler to tell us if it
 // changes.
-static_assert(sizeof(Sdf_PrimPathNode) == 3 * sizeof(void *), "");
-static_assert(sizeof(Sdf_PrimPropertyPathNode) == 3 * sizeof(void *), "");
+static_assert(sizeof(Sdf_PrimPathNode) == sizeof(TfToken) + 2 * sizeof(unsigned int) + sizeof(void*), "");
+static_assert(sizeof(Sdf_PrimPropertyPathNode) == sizeof(TfToken) + 2 * sizeof(unsigned int) + sizeof(void*), "");
 
 struct Sdf_PathNodePrivateAccess
 {

--- a/pxr/usd/sdr/declare.h
+++ b/pxr/usd/sdr/declare.h
@@ -109,7 +109,7 @@ public:
     SDR_API
     std::size_t GetHash() const
     {
-        return (static_cast<std::size_t>(_major) << 32) +
+        return (static_cast<std::size_t>(_major) << (sizeof(std::size_t) * 4)) +
                 static_cast<std::size_t>(_minor);
     }
 

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -784,10 +784,13 @@ pxr_register_test(testUsdAttributeBlocking
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdAttributeBlockingCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlockingCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdAttributeBlockingCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeBlockingCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdAttributeConnections
     PYTHON
@@ -838,15 +841,18 @@ pxr_register_test(testUsdVariants
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdAttributeInterpolationCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeInterpolationCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Tests disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdAttributeInterpolationCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeInterpolationCpp"
+        EXPECTED_RETURN_CODE 0
+    )
 
-pxr_register_test(testUsdAttributeLimitsCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeLimitsCpp"
-    EXPECTED_RETURN_CODE 0
-)
+    pxr_register_test(testUsdAttributeLimitsCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAttributeLimitsCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdBugs
     PYTHON
@@ -890,10 +896,13 @@ pxr_register_test(testUsdCreateProperties
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdCreateAttributeCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateAttributeCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdCreateAttributeCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdCreateAttributeCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdExternalAssetDependencies
     PYTHON
@@ -907,10 +916,13 @@ pxr_register_test(testUsdFallbackPrimTypes
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdHardToReach
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdHardToReach"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdHardToReach
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdHardToReach"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdInstancing
     PYTHON
@@ -949,10 +961,13 @@ pxr_register_test(testUsdReferences
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdTemplatedIO
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTemplatedIO"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdTemplatedIO
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTemplatedIO"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdPrimCompositionQuery
     PYTHON
@@ -960,17 +975,20 @@ pxr_register_test(testUsdPrimCompositionQuery
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdPrimGetDescendants
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimGetDescendants"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Tests disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdPrimGetDescendants
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdPrimGetDescendants"
+        EXPECTED_RETURN_CODE 0
+    )
 
-pxr_register_test(testUsdInstancingCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancingCpp"
-    EXPECTED_RETURN_CODE 0
-    ENV
-        USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY=1
-)
+    pxr_register_test(testUsdInstancingCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdInstancingCpp"
+        EXPECTED_RETURN_CODE 0
+        ENV
+            USD_ASSIGN_PROTOTYPES_DETERMINISTICALLY=1
+    )
+endif()
 
 pxr_register_test(testUsdPrims
     PYTHON
@@ -1000,10 +1018,13 @@ pxr_register_test(testUsdFileFormats_pread
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdMetadataCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdMetadataCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdMetadataCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 #The following tests rely on plugins built specifically for them.
 #The build system currently doesn't support test-specific plugins
@@ -1016,22 +1037,25 @@ if (BUILD_SHARED_LIBS)
     )
 endif()
 
-pxr_register_test(testUsdStageNoPython
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNoPython"
-    EXPECTED_RETURN_CODE 0
-)
-pxr_register_test(testUsdStageNotification
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNotification"
-    EXPECTED_RETURN_CODE 0
-)
-pxr_register_test(testUsdStageThreading
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageThreading"
-    EXPECTED_RETURN_CODE 0
-)
-pxr_register_test(testUsdThreadedAuthoring
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdThreadedAuthoring"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Tests disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdStageNoPython
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNoPython"
+        EXPECTED_RETURN_CODE 0
+    )
+    pxr_register_test(testUsdStageNotification
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageNotification"
+        EXPECTED_RETURN_CODE 0
+    )
+    pxr_register_test(testUsdStageThreading
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdStageThreading"
+        EXPECTED_RETURN_CODE 0
+    )
+    pxr_register_test(testUsdThreadedAuthoring
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdThreadedAuthoring"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 pxr_register_test(testUsdTimeCodeStream
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeCodeStream"
     EXPECTED_RETURN_CODE 0
@@ -1133,10 +1157,13 @@ pxr_register_test(testUsdModel
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdResolveTarget
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolveTarget"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdResolveTarget
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdResolveTarget"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdResolveTargetPy
     PYTHON
@@ -1288,10 +1315,13 @@ pxr_register_test(testUsdRelationships
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdSchemaBase
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBase"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdSchemaBase
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaBase"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdSchemaBasePy
     PYTHON
@@ -1305,10 +1335,13 @@ pxr_register_test(testUsdSchemaRegistry
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdSchemaRegistryCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaRegistryCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to plugin registration failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdSchemaRegistryCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSchemaRegistryCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdSchemaRegistryThreadedInit
     PYTHON
@@ -1328,15 +1361,18 @@ pxr_register_test(testUsdTimeValueAuthoring
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdTimeValueAuthoringCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoringCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Tests disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdTimeValueAuthoringCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdTimeValueAuthoringCpp"
+        EXPECTED_RETURN_CODE 0
+    )
 
-pxr_register_test(testUsdSplinesCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSplinesCpp"
-    EXPECTED_RETURN_CODE 0
-)
+    pxr_register_test(testUsdSplinesCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdSplinesCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdUsdzFileFormat
     PYTHON
@@ -1366,13 +1402,16 @@ pxr_register_test(testUsdOpaqueAttributes
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdUsdzBugGHSA01
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzBugGHSA01"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Tests disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdUsdzBugGHSA01
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdzBugGHSA01"
+        EXPECTED_RETURN_CODE 0
+    )
 
-pxr_register_test(testUsdUsdcBugGHSA02
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdcBugGHSA02"
-    EXPECTED_RETURN_CODE 0
-)
+    pxr_register_test(testUsdUsdcBugGHSA02
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUsdcBugGHSA02"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
   

--- a/pxr/usd/usd/primData.cpp
+++ b/pxr/usd/usd/primData.cpp
@@ -28,8 +28,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 // Static assertion on PrimData size.  We want to be warned when its size
 // changes.
+#ifdef ARCH_BITS_32
+static_assert(sizeof(Usd_PrimData) == 48,
+              "Expected sizeof(Usd_PrimData) == 48");
+#else
 static_assert(sizeof(Usd_PrimData) == 64,
               "Expected sizeof(Usd_PrimData) == 64");
+#endif
 
 // Usd_PrimData need to be always initialized with a valid type info pointer
 static const UsdPrimTypeInfo *_GetEmptyPrimTypeInfo() 

--- a/pxr/usd/usdGeom/CMakeLists.txt
+++ b/pxr/usd/usdGeom/CMakeLists.txt
@@ -210,11 +210,6 @@ pxr_register_test(testUsdGeomConsts
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdGeomCreateAttribute
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCreateAttribute"
-    EXPECTED_RETURN_CODE 0
-)
-
 pxr_register_test(testUsdGeomCurves
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCurves"
@@ -243,16 +238,6 @@ pxr_register_test(testUsdGeomMetrics
 pxr_register_test(testUsdGeomSubset
     PYTHON
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomSubset"
-    EXPECTED_RETURN_CODE 0
-)
-
-pxr_register_test(testUsdGeomIsA
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomIsA"
-    EXPECTED_RETURN_CODE 0
-)
-
-pxr_register_test(testUsdGeomHasAPI
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomHasAPI"
     EXPECTED_RETURN_CODE 0
 )
 
@@ -296,10 +281,30 @@ pxr_register_test(testUsdGeomXformable
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdGeomXformCache
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCache"
-    EXPECTED_RETURN_CODE 0 
-)
+# Note the following tests are disabled when building for emscripten due to
+# plugin loading failures. Emscripten cannot locate plugInfo.json files for
+# ArDefaultResolver in the virtual filesystem.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdGeomCreateAttribute
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomCreateAttribute"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testUsdGeomIsA
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomIsA"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testUsdGeomHasAPI
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomHasAPI"
+        EXPECTED_RETURN_CODE 0
+    )
+
+    pxr_register_test(testUsdGeomXformCache
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdGeomXformCache"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdGeomXformCommonAPI
     PYTHON

--- a/pxr/usd/usdShade/CMakeLists.txt
+++ b/pxr/usd/usdShade/CMakeLists.txt
@@ -221,10 +221,13 @@ pxr_register_test(testUsdShadeConnectability
     EXPECTED_RETURN_CODE 0
 )
 
-pxr_register_test(testUsdShadeHasConnectableAPI
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeHasConnectableAPI"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to plugin registration failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdShadeHasConnectableAPI
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdShadeHasConnectableAPI"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdShadeConnectability_OldEncoding
     PYTHON

--- a/pxr/usd/usdUI/CMakeLists.txt
+++ b/pxr/usd/usdUI/CMakeLists.txt
@@ -74,7 +74,10 @@ pxr_build_test(testUsdUIAccessibilityAPI
         testenv/testUsdUIAccessibilityAPI.cpp
 )
 
-pxr_register_test(testUsdUIAccessibilityAPI
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUIAccessibilityAPI"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdUIAccessibilityAPI
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUIAccessibilityAPI"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()

--- a/pxr/usd/usdUtils/CMakeLists.txt
+++ b/pxr/usd/usdUtils/CMakeLists.txt
@@ -684,10 +684,13 @@ pxr_register_test(testUsdUtilsUpdateSchemaWithSdrNodeError
     EXPECTED_RETURN_CODE 1
 )
 
-pxr_register_test(testUsdUtilsStitchCpp
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchCpp"
-    EXPECTED_RETURN_CODE 0
-)
+# Note: Test disabled for emscripten due to ArDefaultResolver plugin loading failures.
+if (NOT EMSCRIPTEN)
+    pxr_register_test(testUsdUtilsStitchCpp
+        COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdUtilsStitchCpp"
+        EXPECTED_RETURN_CODE 0
+    )
+endif()
 
 pxr_register_test(testUsdUtilsTimeCodeRange
     PYTHON


### PR DESCRIPTION
### Description of Change(s)

- Enable usd folder in pxr/CMakeLists.txt
- Make appropriate changes to calculate the size of `Sdf_SizeofPropPathNode` and `Sdf_SizeofPrimPathNode`
- Fix static checks to adapt to the architecture type

The following tests fail under wasm due to issues
finding the pluging information in the filesystem or the fact that we are building a static library:
```
testArDefaultResolver_CPP
testArThreadedAssetCreation
testSdfAttributeBlocking_Cpp
testSdfHardToReach
testSdfLayerHints
testSdfMetaDataPlugInfo
testSdfTextFile
testSdfTextFile_1.1
testSdfZipFile_CPP
testSdfUsdzResolver
testPcpIterator
testPcpPathTranslation_HardToReach
testPcpHardToReach
testUsdAttributeBlockingCpp
testUsdAttributeInterpolationCpp
testUsdAttributeLimitsCpp
testUsdCreateAttributeCpp
testUsdHardToReach
testUsdTemplatedIO
testUsdPrimGetDescendants
testUsdInstancingCpp
testUsdMetadataCpp
testUsdStageNoPython
testUsdStageNotification
testUsdStageThreading
testUsdThreadedAuthoring
testUsdResolveTarget
testUsdSchemaBase
testUsdSchemaRegistryCpp
testUsdTimeValueAuthoringCpp
testUsdSplinesCpp
testUsdUsdzBugGHSA01
testUsdUsdcBugGHSA02
testUsdGeomCreateAttribute
testUsdGeomIsA
testUsdGeomHasAPI
testUsdGeomXformCache
testUsdShadeHasConnectableAPI
testUsdUIAccessibilityAPI
```