### PR TITLE
Remove verbose mip level warning trace from Hio_OpenEXRImage

### DIFF
--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXRImage.cpp
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXRImage.cpp
@@ -762,8 +762,6 @@ bool Hio_OpenEXRImage::_OpenForReading(std::string const &filename,
     }
 
     if (_exrReader.numMipLevels <= mip) {
-        TF_DIAGNOSTIC_WARNING("In image \"%s\" mip level %d does not exist",
-                        filename.c_str(), mip);
         return false;
     }
     


### PR DESCRIPTION
### Description of Change(s)

Due to the code inside `HdStTextureUtils::GetAllMipImages` always trying to load 32 mip levels from each image, the warning trace inside `Hio_OpenEXRImage::_OpenForReading` is guaranteed to fire for every EXR in existence.

This is probably not necessary. Additionally, the other `Hio_*` image plugins are not nearly this verbose. For example, none of the others even trace a warning if they cannot open the image, yet the EXR plugin also does so.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
