### PR TITLE
hioOiio: remove use of OIIO_NAMESPACE_USING macro

### DIFF
--- a/pxr/imaging/plugin/hioOiio/metadata.cpp
+++ b/pxr/imaging/plugin/hioOiio/metadata.cpp
@@ -18,7 +18,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 class TfToken;
 class VtValue;
 
-OIIO_NAMESPACE_USING
+using namespace OIIO;
 
 bool
 HioOIIO_ExtractCustomMetadata(

--- a/pxr/imaging/plugin/hioOiio/oiioImage.cpp
+++ b/pxr/imaging/plugin/hioOiio/oiioImage.cpp
@@ -33,7 +33,7 @@ ARCH_PRAGMA_POP
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-OIIO_NAMESPACE_USING
+using namespace OIIO;
 
 // _ioProxySupportedExtensions is a list of hardcoded file extensions that
 // support ioProxy. Although OIIO has an api call for checking whether or


### PR DESCRIPTION
### Description of Change(s)

This macro was removed in OpenImageIO 3.1, but it previously expanded simply to `using namespace OIIO;` and had been that way since at least OpenImageIO v2.0.14, so we can just use that directly instead.

@lgritz was considering adding the macro back in, but his comment here makes a good case for not doing so and fixing up existing usages instead:
https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4920

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
