### PR TITLE
Ensure Sdf.Payload does not allow direct editing of attributes

### DIFF
--- a/pxr/usd/sdf/testenv/testSdfPayload.py
+++ b/pxr/usd/sdf/testenv/testSdfPayload.py
@@ -82,6 +82,15 @@ class TestSdfPayload(unittest.TestCase):
             hash(Sdf.Payload(payload))
         )
 
+    def test_attributes_cant_be_set(self):
+        payload = Sdf.Payload()
+        with self.assertRaises(AttributeError):
+            payload.assetPath = "/path/to/asset"
+        with self.assertRaises(AttributeError):
+            payload.primPath = Sdf.Path("/path/to/prim")
+        with self.assertRaises(AttributeError):
+            payload.layerOffset = Sdf.LayerOffset(offset = 10.0, scale = 1.5)
+
 
 
 if __name__ == "__main__":

--- a/pxr/usd/sdf/wrapPayload.cpp
+++ b/pxr/usd/sdf/wrapPayload.cpp
@@ -74,18 +74,15 @@ void wrapPayload()
 
         .add_property("assetPath",
             make_function(
-                &This::GetAssetPath, return_value_policy<return_by_value>()),
-            &This::SetAssetPath)
+                &This::GetAssetPath, return_value_policy<return_by_value>()))
 
         .add_property("primPath",
             make_function(
-                &This::GetPrimPath, return_value_policy<return_by_value>()),
-            &This::SetPrimPath)
+                &This::GetPrimPath, return_value_policy<return_by_value>()))
 
         .add_property("layerOffset",
             make_function(
-                &This::GetLayerOffset, return_value_policy<return_by_value>()),
-            &This::SetLayerOffset)
+                &This::GetLayerOffset, return_value_policy<return_by_value>()))
 
         .def(self == self)
         .def(self != self)


### PR DESCRIPTION
### Description of Change(s)

This PR is a proposal to address the issue detailed in [this issue](https://github.com/PixarAnimationStudios/OpenUSD/issues/3809) by omitting the `&This::Set<Attribute>` from each attribute in `Sdf.Payload`

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3809

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
