### PR TITLE
Autodesk: Add missing sort of reprs for use in sdt::set_union

### DIFF
--- a/pxr/imaging/hd/renderIndex.cpp
+++ b/pxr/imaging/hd/renderIndex.cpp
@@ -1467,6 +1467,8 @@ namespace {
             }
         }
 
+        std::sort(reprs.begin(), reprs.end());
+
         return reprs;
     }
 };


### PR DESCRIPTION
### Description of Change(s)

Simple fix to prevent unpredictable behavior when calling std::set_union with reprs argument in USD\pxr\imaging\hd\dirtyList.cpp, in HdDirtyList::UpdateRenderTagsAndReprSelectors()

```
            // Combine.
            HdReprSelectorVector combinedReprs;
            std::set_union(_trackedReprs.cbegin(),
                        _trackedReprs.cend(),
                        reprs.cbegin(),
                        reprs.cend(),
                        std::back_inserter(combinedReprs));
```

As the reprs are unsorted, I'm getting a crash on Windows when toggling the view rendering representation from "smoothHull" to "hull" and then to "wireOnSurf".

When it crashes, the reprs (provided as input to the method) contain:
(0) wireOnSurf
(1) smoothHull

And the cached _trackedReprs contain:
(0) hull
(1) smoothHull

So the _trackedRepr contain the entries set on the first change (when switching from smoothHull to hull) and the repr contains the new values when switching from smoothHull to wireOnSurf.

This issue could lead to crashes or memory corruption, as the behavior of std::set_union is undefined when inputs are not sorted (see https://en.cppreference.com/w/cpp/algorithm/ranges/set_union).

The fix is to simply return sorted representations in _GetReprSelectors() in USD\pxr\imaging\hd\renderIndex.cpp.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
