### PR TITLE
Make asset resolver case insensitive

### DIFF
--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -1444,7 +1444,7 @@ private:
 
         bool HandlesFormat(const std::string& extension) const
         {
-            return _packageFormat == extension;
+            return _packageFormat == TfStringToLowerAscii(extension);
         }
 
     private:

--- a/pxr/usd/ar/resolver.cpp
+++ b/pxr/usd/ar/resolver.cpp
@@ -1254,9 +1254,8 @@ private:
                 if (extension.empty()) {
                     continue;
                 }
-
                 _packageResolvers.push_back(std::make_shared<_PackageResolver>(
-                    extension, plugin, packageResolverType));
+                    TfStringToLowerAscii(extension), plugin, packageResolverType));
 
                 TF_DEBUG(AR_RESOLVER_INIT).Msg(
                     "ArGetResolver(): Using package resolver %s for %s "


### PR DESCRIPTION
### Description of Change(s)

Ensure asset resolver can be run against files where the extension is capitalized e.g; `seahorse_anim_mtl_variant_2.USDZ` vs `seahorse_anim_mtl_variant_2.usdz` to address https://github.com/PixarAnimationStudios/OpenUSD/issues/3771.

Validated by running through steps detailed in issue:

- Download any USDZ from https://developer.apple.com/augmented-reality/quick-look/
- Use `usdcat` to read it
- Rename it to `foo.USDZ`
- Use `usdcat` to read it again

And indeed, `usdcat` works with the update.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3771
### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
