### PR TITLE
Fix LNK4217/LNK4286 warnings

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1202,20 +1202,26 @@ function(pxr_toplevel_epilogue)
             )
         endif()
 
-        # When building a monolithic library (static or shared) we want all API functions to be
-        # exported. So add FOO_EXPORTS=1 for every library in PXR_OBJECT_LIBS,
-        # where FOO is the uppercase version of the library name, to every
-        # library in PXR_OBJECT_LIBS.
+        # When building a monolithic library (static or shared) we want all
+        # API functions to be exported. So add FOO_EXPORTS=1 for every
+        #library in PXR_OBJECT_LIBS, where FOO is the uppercase version
+        #of the library name, to every library in PXR_OBJECT_LIBS.
         set(exports "")
         foreach(lib ${PXR_OBJECT_LIBS})
             string(TOUPPER ${lib} uppercaseName)
             list(APPEND exports "${uppercaseName}_EXPORTS=1")
         endforeach()
 
+        if (TARGET python)
+            # The boost python target uses a different export macro so
+            # add that as well.
+            list(APPEND exports "PXR_BOOST_PYTHON_SOURCE=1")
+        endif()
+
         foreach(lib ${PXR_OBJECT_LIBS})
             target_compile_definitions(${lib} PRIVATE ${exports})
         endforeach()
-    
+
         if(BUILD_SHARED_LIBS)
             target_link_libraries(usd_m
                 PUBLIC

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1202,6 +1202,20 @@ function(pxr_toplevel_epilogue)
             )
         endif()
 
+        # When building a monolithic library (static or shared) we want all API functions to be
+        # exported. So add FOO_EXPORTS=1 for every library in PXR_OBJECT_LIBS,
+        # where FOO is the uppercase version of the library name, to every
+        # library in PXR_OBJECT_LIBS.
+        set(exports "")
+        foreach(lib ${PXR_OBJECT_LIBS})
+            string(TOUPPER ${lib} uppercaseName)
+            list(APPEND exports "${uppercaseName}_EXPORTS=1")
+        endforeach()
+
+        foreach(lib ${PXR_OBJECT_LIBS})
+            target_compile_definitions(${lib} PRIVATE ${exports})
+        endforeach()
+    
         if(BUILD_SHARED_LIBS)
             target_link_libraries(usd_m
                 PUBLIC
@@ -1215,13 +1229,7 @@ function(pxr_toplevel_epilogue)
             _pxr_add_rpath(rpath "${CMAKE_INSTALL_PREFIX}/lib")
             _pxr_install_rpath(rpath usd_m)
         else()
-            # When building a static monolithic library we want all API functions to be
-            # exported. So add FOO_EXPORTS=1 for every library in PXR_OBJECT_LIBS,
-            # where FOO is the uppercase version of the library name, to every
-            # library in PXR_OBJECT_LIBS.
             foreach(lib ${PXR_OBJECT_LIBS})
-                string(TOUPPER ${lib} uppercaseName)
-                target_compile_definitions(${lib} PRIVATE "${uppercaseName}_EXPORTS=1")
                 target_link_libraries(usd_m
                     PUBLIC
                         ${lib}


### PR DESCRIPTION
### Description of Change(s)

We observed and increased number of LNK4217/LNK4286 warnings.

- Build configuration: This ocurrs in v25.11-alpha.
- Platform: Windows
- Approximate number of linker warnings: 18129
- Suspected commit: See https://gitlab-master.nvidia.com/omniverse/USD/-/commit/f5da4e26a598a14fa80811d080e8243cdf6617a4
- References to the code: Up to 25.08 the following code existed
```diff
-    # When building a monolithic library we want all API functions to be
-    # exported.  So add FOO_EXPORTS=1 for every library in PXR_OBJECT_LIBS,
-    # where FOO is the uppercase version of the library name, to every
-    # library in PXR_OBJECT_LIBS.
-    set(exports "")
-    foreach(lib ${PXR_OBJECT_LIBS})
-        string(TOUPPER ${lib} uppercaseName)
-        list(APPEND exports "${uppercaseName}_EXPORTS=1")
-    endforeach()
-    foreach(lib ${PXR_OBJECT_LIBS})
-        set(objects "${objects};\$<TARGET_OBJECTS:${lib}>")
-        target_compile_definitions(${lib} PRIVATE ${exports})
-    endforeach()
```
i.e. https://gitlab-master.nvidia.com/omniverse/USD/-/blob/v25.08/cmake/macros/Public.cmake#L1244-1252, it was added in 25.11 for static, but not for shared libraries.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
