### PR TITLE
[gf] Remove C4018 warnings from GfNumericCast

### DIFF
--- a/pxr/base/gf/numericCast.h
+++ b/pxr/base/gf/numericCast.h
@@ -30,15 +30,6 @@ template <class T, class U>
 constexpr bool
 GfIntegerCompareLess(T t, U u) noexcept
 {
-    // XXX: 
-    // On Visual Studio warning C4018 (signed/unsigned mismatch) is emitted
-    // when this function is used with boolean values. Just disable this
-    // for now.
-#if defined(ARCH_COMPILER_MSVC)
-    ARCH_PRAGMA_PUSH
-    ARCH_PRAGMA(warning(disable:4018))
-#endif    
-
     static_assert(std::is_integral_v<T> && std::is_integral_v<U>);
 
     if constexpr (std::is_signed_v<T> == std::is_signed_v<U>) {
@@ -50,10 +41,6 @@ GfIntegerCompareLess(T t, U u) noexcept
     else {
         return u >= 0 && t < std::make_unsigned_t<U>(u);
     }
-
-#if defined(ARCH_COMPILER_MSVC)
-    ARCH_PRAGMA_POP
-#endif
 }
 
 enum GfNumericCastFailureType {

--- a/pxr/base/gf/numericCast.h
+++ b/pxr/base/gf/numericCast.h
@@ -103,7 +103,7 @@ GfNumericCast(From from, GfNumericCastFailureType *failType = nullptr)
     // bool -> int
     if constexpr (std::is_same_v<From, bool> && std::is_integral_v<To>) {
         // No need to range check bool to int
-        return from ? static_cast<To>(1) : static_cast<To>(0);
+        return To{from};
     }
     // int -> bool
     else if constexpr (std::is_integral_v<From> && std::is_same_v<To, bool>) {

--- a/pxr/base/gf/numericCast.h
+++ b/pxr/base/gf/numericCast.h
@@ -100,9 +100,27 @@ GfNumericCast(From from, GfNumericCastFailureType *failType = nullptr)
         };
     };
 
+    // bool -> int
+    if constexpr (std::is_same_v<From, bool> && std::is_integral_v<To>) {
+        // No need to range check bool to int
+        return from ? static_cast<To>(1) : static_cast<To>(0);
+    }
+    // int -> bool
+    else if constexpr (std::is_integral_v<From> && std::is_same_v<To, bool>) {
+        // Range check int to bool
+        if (GfIntegerCompareLess(from, 0)) {
+            setFail(GfNumericCastNegOverflow);
+            return {};
+        }
+        if (GfIntegerCompareLess(1, from)) {
+            setFail(GfNumericCastPosOverflow);
+            return {};
+        }
+        return from != 0;
+    }
     // int -> int.
-    if constexpr (std::is_integral_v<From> &&
-                  std::is_integral_v<To>) {
+    else if constexpr (std::is_integral_v<From> &&
+                       std::is_integral_v<To>) {
         // Range check integer to integer.
         if (GfIntegerCompareLess(from, ToLimits::min())) {
             setFail(GfNumericCastNegOverflow);


### PR DESCRIPTION
### Description of Change(s)

Using boolean types with GfNumericCast would implicitly cast to a signed integer in GfIntegerCompareLess, causing Windows to issue C4018 warnings.

The change in this PR checks to see if either type used in `GfNumericCast` is a bool. If it is, the bool will either be explicitly cast to `0` or `1` or the the integer type will be tested for `true` or `false`. This eliminates the `warning C4018: '<': signed/unsigned mismatch` on WIndows

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
