### PR TITLE
Fix parentheses around assignment warning for GCC13

### DIFF
--- a/pxr/usd/usd/primDefinition.cpp
+++ b/pxr/usd/usd/primDefinition.cpp
@@ -405,8 +405,8 @@ UsdPrimDefinition::_FindOrCreateSpecForComposition(
     // we create a new layer for this prim definition to write its composed
     // properties and metadata.
     if (_composedPropertyLayer) {
-        if (destSpec = _composedPropertyLayer->GetObjectAtPath(
-                primPath.AppendProperty(propName))) {
+        if ((destSpec = _composedPropertyLayer->GetObjectAtPath(
+                primPath.AppendProperty(propName)))) {
             return destSpec;
         }
     } else {


### PR DESCRIPTION
### Description of Change(s)
https://github.com/PixarAnimationStudios/OpenUSD/blob/b8dbd195adf75e8de2c956fc7e55d3d5124d3f26/pxr/usd/usd/primDefinition.cpp#L408

The previous line produces a warning on GCC13.

```
warning: suggest parentheses around assignment used as truth value [-Wparentheses]
  408 |         if (destSpec = (_composedPropertyLayer->GetObjectAtPath(
      |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  409 |                 primPath.AppendProperty(propName)))) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

In #3334, @dgovil suggests this occurs on clang 16 too.  Putting parentheses around the expression confirms that the assignment as truth value is intentional.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)
#3334 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
