### PR TITLE
Fix `self-move` warning on gcc

### DIFF
--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -51,6 +51,9 @@
     #define ARCH_PRAGMA_STRINGOP_OVERFLOW \
         _Pragma("GCC diagnostic ignored \"-Wstringop-overflow=\"")
 
+    #define ARCH_PRAGMA_SELF_MOVE \
+        _Pragma("GCC diagnostic ignored \"-Wself-move\"")
+
 #elif defined(ARCH_COMPILER_CLANG)
 
     #define ARCH_PRAGMA_PUSH \


### PR DESCRIPTION
### Description of Change(s)

@dgovil reported compiler warnings for self assignment in #3341. This was fixed for clang with c1e36e833921eb5fb5ddc82304f6f1e2513b3350 but still occurs on gcc. This extends the pragma to gcc.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#3341 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
