### PR TITLE
UsdSkelImaging Hydra 2.0: Use rest transforms if the animation is empty.

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/skelData.cpp
+++ b/pxr/usdImaging/usdSkelImaging/skelData.cpp
@@ -165,6 +165,16 @@ _ComputeJointLocalTransforms(
         return UsdSkelImagingGetTypedValue(restTransforms);
     }
 
+    // If all transform components were empty, that could mean:
+    // - the attributes were never authored
+    // - the attributes were blocked
+    // - the attributes were authored with empty arrays (possibly intentionally)
+    // In many of these cases, we should expect the animation to be silently
+    // ignored, so throw no warning.
+    if (animTransforms.empty()) {
+        return UsdSkelImagingGetTypedValue(restTransforms);
+    }
+
     if (data.animMapper.IsIdentity()) {
         return animTransforms;
     }


### PR DESCRIPTION
### Description of Change(s)

See issue #3873 for an example file and steps to reproduce.

This matches the behavior of how an empty list of transforms is handled in `UsdSkel_SkelAnimationQueryImpl::_ComputeJointLocalTransforms()`, if e.g. none of the transform attributes have authored values.


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A

### Fixes Issue(s)

Fixes: #3873

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
