### PR TITLE
Documentation: Fix ReadTheDocs's narrow viewport layout issues

### DIFF
--- a/docs/_static/css/pxr_custom.css
+++ b/docs/_static/css/pxr_custom.css
@@ -5,6 +5,11 @@
     --monospace: ui-monospace, -apple-system-ui-serif, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, 'Andale Mono', 'Ubuntu Mono', monospace;
 }
 
+.document {
+  container-type: inline-size;
+  container-name: document;
+}
+
 body, .rst-content {
     font-family: var(--san-serif);
 }
@@ -35,6 +40,10 @@ h4 {
 .iu {
   font-style: italic;
   text-decoration: underline;
+}
+
+.mono {
+  overflow-wrap: break-word;
 }
 
 .mono, .rst-content .linenodiv pre, .rst-content div[class^=highlight] pre, .rst-content pre.literal-block {
@@ -153,3 +162,24 @@ div.usd-tutorial-admonition > p {
   color: #6A0E0E;
 } 
 
+@container document (max-width: 72rem) {
+  .fourcolumn {
+    -webkit-column-count: 3; /* Chrome, Safari, Opera */
+    -moz-column-count: 3; /* Firefox */
+    column-count: 3;
+  }
+}
+
+@container document (max-width: 48rem) {
+  .fourcolumn {
+    -webkit-column-count: 2; /* Chrome, Safari, Opera */
+    -moz-column-count: 2; /* Firefox */
+    column-count: 2;
+  }
+
+  .threecolumn {
+    -webkit-column-count: 2; /* Chrome, Safari, Opera */
+    -moz-column-count: 2; /* Firefox */
+    column-count: 2;
+  }
+}


### PR DESCRIPTION
### Description of Change(s)
I noticed that there tends to be a problem in the USD docs theme where code (text wrapped in an element with the `mono` class) does not get properly wrapped, causing significant X-overflow. I found that a simple `.mono` selector, setting `overflow-wrap: break-word` fixed it quite cleanly.

Additionally, on narrow viewport widths, the Glossary page's list of terms is pretty hard to read due to a hardcoded four column layout. To address this, I drop both the `fourcolumn` and `threecolumn` classes down to two columns. This seems to work well, even for the "iPhone SE" dimensions. Initially, I took the standard `@media` query approach, but realized the sidebar should actually impact whether the columns drop to a smaller count. So instead, this utilizes the __somewhat newer__ container queries (which already has [baseline support](https://caniuse.com/css-container-queries) for all major web browsers) against the `document` container. It works like a charm!

This also fixes the layout for the **Products Using USD** page, as it uses the `.threecolumn` class.

### Fixes Issue(s)
Not an outstanding issue that I could find, but this addresses layout issues for the documentation pages (ReadTheDocs, not Doxygen) on narrow viewports (mobile).

### Checklist

- [x] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))



