### PR TITLE
Remove `_CRT_SECURE_NO_WARNINGS` from `testArchUtil`

### DIFF
--- a/pxr/base/arch/testenv/testArchUtil.cpp
+++ b/pxr/base/arch/testenv/testArchUtil.cpp
@@ -4,8 +4,6 @@
 // Licensed under the terms set forth in the LICENSE.txt file available at
 // https://openusd.org/license.
 //
-#define _CRT_SECURE_NO_WARNINGS
-
 #include "pxr/pxr.h"
 #include "pxr/base/arch/testArchUtil.h"
 #include "pxr/base/arch/debugger.h"


### PR DESCRIPTION
### Description of Change(s)

 `_CRT_SECURE_NO_WARNINGS` is defined in two places on Windows.
https://github.com/PixarAnimationStudios/OpenUSD/blob/a32790e3aa13dc739e56612b6be9a281a229b21f/pxr/base/arch/testenv/testArchUtil.cpp#L7
https://github.com/PixarAnimationStudios/OpenUSD/blob/a32790e3aa13dc739e56612b6be9a281a229b21f/cmake/defaults/msvcdefaults.cmake#L88

This yields the following warning when building `testArchUtil`.

```
testArchUtil.cpp(7): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition
testArchUtil.cpp: note: see previous definition of '_CRT_SECURE_NO_WARNINGS'
```

This PR removes the unneeded `_CRT_SECURE_NO_WARNINGS`.  It's not clear what warning `_CRT_SECURE_NO_WARNINGS` was being introduced to suppress in `testArchUtil` as disabling both the `#define` and `msvcdefaults.cmake` doesn't yield any additional warnings in `testArchUtil`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
