### PR TITLE
APPLE: Make Accessibility Priority variable

### DIFF
--- a/pxr/usd/usdUI/accessibilityAPI.cpp
+++ b/pxr/usd/usdUI/accessibilityAPI.cpp
@@ -231,7 +231,7 @@ UsdUIAccessibilityAPI::CreatePriorityAttr(VtValue const &defaultValue, bool writ
                            UsdUITokens->accessibility_MultipleApplyTemplate_Priority),
                        SdfValueTypeNames->Token,
                        /* custom = */ false,
-                       SdfVariabilityUniform,
+                       SdfVariabilityVarying,
                        defaultValue,
                        writeSparsely);
 }

--- a/pxr/usd/usdUI/accessibilityAPI.h
+++ b/pxr/usd/usdUI/accessibilityAPI.h
@@ -310,15 +310,12 @@ public:
     /// ignore, if they feel there are other necessities that take precedence
     /// over the prioritization values.
     /// 
-    /// Priority may not be time varying.
-    /// 
     ///
     /// | ||
     /// | -- | -- |
-    /// | Declaration | `uniform token priority = "standard"` |
+    /// | Declaration | `token priority = "standard"` |
     /// | C++ Type | TfToken |
     /// | \ref Usd_Datatypes "Usd Type" | SdfValueTypeNames->Token |
-    /// | \ref SdfVariability "Variability" | SdfVariabilityUniform |
     /// | \ref UsdUITokens "Allowed Values" | low, standard, high |
     USDUI_API
     UsdAttribute GetPriorityAttr() const;

--- a/pxr/usd/usdUI/generatedSchema.usda
+++ b/pxr/usd/usdUI/generatedSchema.usda
@@ -110,7 +110,7 @@ provide more details."""
 prim."""
         }
     )
-    uniform token accessibility:__INSTANCE_NAME__:priority = "standard" (
+    token accessibility:__INSTANCE_NAME__:priority = "standard" (
         allowedTokens = ["low", "standard", "high"]
         customData = {
             string userDocBrief = """A hint to the accessibility runtime of how 

--- a/pxr/usd/usdUI/schema.usda
+++ b/pxr/usd/usdUI/schema.usda
@@ -268,15 +268,13 @@ class "AccessibilityAPI" (
         """
     )
 
-    uniform token priority = "standard" (
+    token priority = "standard" (
         doc = """A hint to the accessibility runtime of how to prioritize this
         instance's label and description, relative to others.
 
         This attribute is optional and is considered a hint that runtimes may
         ignore, if they feel there are other necessities that take precedence
         over the prioritization values.
-
-        Priority may not be time varying.
         """
         allowedTokens = ["low", "standard", "high"]
     )


### PR DESCRIPTION
### Description of Change(s)

We have been showing the USD Accessibility API to more members of the accessibility community and a request was made to make priority not be time varying. Originally, we made this uniform because we were thinking of it as a way to help prioritize accessibility purposes globally, but have realized that this would also benefit from being varying.

For example, if there was an accessibility purpose that was only high priority for a given part of an animation, like flashing red lights, that would be useful for a system to know when it changes. These would be temporary priority increases as a result.

Looking at the USD code and spec, this should be a change that doesn't necessitate versioning the schema. Coupled with the low likelihood of anything having adopted the schema yet, and the even lower likelihood of people using the priority attribute yet, I think this is a safe assumption. I've done a few tests to make sure that nothing in USD seems to get mad when the uniform token is taken away or added as well, and all seems fine.

This should only be an issue if someone authored a file after this PR was merged with time sampled information and tried to read it into an older version of USD where the attribute was uniform. But in that case it appears USD will default to reading just the static default value, which we always recommend be authored.

Therefore I'd posit that this does not require versioning since its loosening things up, and the impact is very low.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
