### PR TITLE
Address minor warnings during build

### DIFF
--- a/pxr/base/ts/sample.cpp
+++ b/pxr/base/ts/sample.cpp
@@ -263,8 +263,6 @@ namespace
         size_t _firstInnerProtoIndex = 0;
         bool _havePreExtrapLoops = false;
         bool _havePostExtrapLoops = false;
-        double _extrapTimeDelta = 0.0;
-        double _extrapValueDelta = 0.0;
         TsTime _firstTime = 0;
         TsTime _lastTime = 0;
         TsTime _firstInnerLoop = 0;
@@ -273,10 +271,6 @@ namespace
         TsTime _lastInnerProto = 0;
         bool _firstTimeLooped = false;
         bool _lastTimeLooped = false;
-        bool _betweenPreUnloopedAndLooped = false;
-        bool _betweenLoopedAndPostUnlooped = false;
-        Ts_DoubleKnotData _extrapKnot1;
-        Ts_DoubleKnotData _extrapKnot2;
 
         std::vector<_SourceInterval> _sourceIntervals;
 

--- a/pxr/usd/pcp/cache.cpp
+++ b/pxr/usd/pcp/cache.cpp
@@ -1032,7 +1032,7 @@ PcpCache::Apply(const PcpCacheChanges& changes, PcpLifeboat* lifeboat)
         }
 
         // Blow property stacks and update spec dependencies on prims.
-        auto updateSpecStacks = [this, &lifeboat, &changes](const SdfPath& path) {
+        auto updateSpecStacks = [this, &lifeboat](const SdfPath& path) {
             if (path.IsAbsoluteRootOrPrimPath()) {
                 // We've possibly changed the prim spec stack.  Note that
                 // we may have blown the prim index so check that it exists.

--- a/pxr/usd/pcp/changes.cpp
+++ b/pxr/usd/pcp/changes.cpp
@@ -2379,7 +2379,7 @@ PcpChanges::_DidAddOrRemoveSublayer(
         layer ? layer->GetIdentifier().c_str() : "invalid");
 
     const auto& processChanges = 
-        [this, &cache, &sublayerPath, &debugSummary, &layer, &cacheChanges](
+        [this, &cache, &sublayerPath, &debugSummary, &cacheChanges](
             const SdfLayerRefPtr sublayer,
             const PcpLayerStackPtrVector& layerStacks,
             _SublayerChangeType sublayerChange)

--- a/pxr/usd/usdSkel/bakeSkinning.cpp
+++ b/pxr/usd/usdSkel/bakeSkinning.cpp
@@ -2433,7 +2433,7 @@ UsdSkelBakeSkinning(const UsdSkelCache& skelCache,
             // but different layers may be written to at the same time.
             WorkParallelForN(
                 parms.layers.size(),
-                [time, ti, &parms, &skinningAdapters, &bytesStoredPerLayer]
+                [time, ti, &skinningAdapters, &bytesStoredPerLayer]
                 (size_t start, size_t end)
                 {
                     for (size_t i = start; i < end; ++i) {


### PR DESCRIPTION

### Description of Change(s)
Address `warning: private field ` (outside of `_originalCacheSize` as that was listed as being used for debugging) as well as `warning: lambda capture ...`.
### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
