### PR TITLE
Backport fixes for CVE-2025-64181 etc. in OpenEXRCore

### DIFF
--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/chunk.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/chunk.c
@@ -1292,6 +1292,16 @@ exr_read_tile_chunk_info (
         return pctxt->report_error (
             pctxt, EXR_ERR_INVALID_ARGUMENT, "Invalid packed size of 0");
 
+    if (part->comp_type == EXR_COMPRESSION_NONE &&
+       cinfo->packed_size != cinfo->unpacked_size)
+    {
+         return pctxt->print_error (
+             pctxt,
+             EXR_ERR_BAD_CHUNK_LEADER,
+             "Mismatch between unpacked and packed size with uncompressed data: packed is %" PRIu64 "; unpacked is %" PRIu64,
+             cinfo->packed_size, cinfo->unpacked_size);
+    }
+
     return EXR_ERR_SUCCESS;
 }
 
@@ -1350,11 +1360,15 @@ exr_read_chunk (
         rv    = pctxt->do_read (
             pctxt, packed_data, toread, &dataoffset, &nread, rmode);
 
-        if (rmode == EXR_ALLOW_SHORT_READ && nread < (int64_t) toread)
+        if (rmode == EXR_ALLOW_SHORT_READ &&
+            nread >= 0 &&
+            nread < (int64_t) toread)
+        {
             memset (
                 ((uint8_t*) packed_data) + nread,
-                0,
-                toread - (uint64_t) (nread));
+                    0,
+            (size_t)(toread - (uint64_t)nread));
+        }
     }
     else
         rv = EXR_ERR_SUCCESS;

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_util.h
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_util.h
@@ -31,10 +31,10 @@ compute_sampled_height (int height, int y_sampling, int start_y)
         else
             start = start_y;
         end = start_y + height - 1;
-        end -= (end < 0) ? (-end % y_sampling) : (end % y_sampling);
+        end -= (end < 0 ? -end : end) % y_sampling;
 
         if (start > end)
-            nlines = 0;
+            nlines = start == start_y ? 1 : 0;
         else
             nlines = (end - start) / y_sampling + 1;
     }

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/parse_header.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/parse_header.c
@@ -2293,7 +2293,9 @@ internal_exr_compute_chunk_offset_size (struct _internal_exr_part* curpart)
 
     w = (uint64_t) (((int64_t) dw.max.x) - ((int64_t) dw.min.x) + 1);
 
-    if (curpart->tiles)
+    if (curpart->storage_mode != EXR_STORAGE_SCANLINE &&
+       curpart->storage_mode != EXR_STORAGE_DEEP_SCANLINE &&
+       curpart->tiles)
     {
         const exr_attr_tiledesc_t* tiledesc  = curpart->tiles->tiledesc;
         int64_t                    tilecount = 0;


### PR DESCRIPTION
### Description of Change(s)

This PR attempts to backport fixes for [CVE-2025-64181](https://www.cve.org/CVERecord?id=CVE-2025-64181) / [GHSA-3h9h-qfvw-98hq](https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-3h9h-qfvw-98hq) and other issues from [OpenEXR 3.4.3](https://github.com/AcademySoftwareFoundation/openexr/compare/v3.4.2..v3.4.3).

I have made a reasonable effort to backport these intelligently, but it’s not easy for me to test this PR properly other than confirming that it still compiles.

It might be even better to rebase the bundled and modified copy of OpenEXRCore (as described in https://github.com/PixarAnimationStudios/OpenUSD/issues/2619) on a later version, but that’s far beyond what I can reasonably offer in a PR.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

*N/A*

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

**N/A, no new functionality**

- [ ] I have verified that all unit tests pass with the proposed changes

**N/A; it is hard for me to run these locally**

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
