### PR TITLE
Fix Windows static monolithic builds

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1202,7 +1202,7 @@ function(pxr_toplevel_prologue)
                 ARCHIVE DESTINATION ${libInstallPrefix}
                 RUNTIME DESTINATION ${libInstallPrefix}
             )
-            if(WIN32)
+            if(WIN32 AND BUILD_SHARED_LIBS)
                 install(
                     FILES $<TARGET_PDB_FILE:usd_m>
                     DESTINATION ${libInstallPrefix}


### PR DESCRIPTION
### Description of Change(s)
Ensures that TARGET_PDB_FILE is only used on shared builds since linker artifacts are required, and static builds only produce compiler artifacts. The monolithic build is missing this guard.

### Fixes Issue(s)
Fixes cmake error during static monolithic builds on Windows.
```
python3 ./build_scripts/build_usd.py --build-monolithic --no-imaging --no-python --no-tests --cmake-build-args=-DBUILD_SHARED_LIBS=OFF {install_dir}
```

Error fixed by change:
```
CMake Error:
  Error evaluating generator expression:
    $<TARGET_PDB_FILE:usd_m>
  TARGET_PDB_FILE is allowed only for targets with linker created artifacts.
```

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
