### PR TITLE
Autodesk: [hgi*] device filter

### DIFF
--- a/pxr/imaging/hgi/CMakeLists.txt
+++ b/pxr/imaging/hgi/CMakeLists.txt
@@ -38,6 +38,7 @@ pxr_library(hgi
     PUBLIC_HEADERS
         api.h
         blitCmdsOps.h
+        deviceFilter.h
         enums.h
         handle.h
         version.h

--- a/pxr/imaging/hgi/deviceFilter.h
+++ b/pxr/imaging/hgi/deviceFilter.h
@@ -1,0 +1,59 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HGI_DEVICE_FILTER_H
+#define PXR_IMAGING_HGI_DEVICE_FILTER_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/imaging/hgi/api.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HgiCapabilities;
+
+///
+/// \class HgiDeviceFilter
+///
+/// Implement this interface and pass an instance to
+/// `Hgi::CreatePlatformDefaultHgi()` or `Hgi::CreateNamedHgi()` to hook into
+/// the device selection process. Note that an implementations might choose to
+/// ignore the device filter if it can't be supported (for example only one
+/// device is ever available). The specific Hgi backends might offer a more
+/// advanced subinterfaces that allow more control not only over device
+/// filtering, but also creation.
+///
+/// Have a look at the subinterface documentation for more information on
+/// limitations and additional features.
+class HgiDeviceFilter
+{
+public:
+    virtual ~HgiDeviceFilter() = default;
+
+    /// If this filter should only be used for a certain Hgi implementation,
+    /// then this function should return the name of that Hgi (for example
+    /// HgiTokens->Vulkan). This is optional, by default this returns the empty
+    /// token, which means "all Hgi implementations".
+    virtual const TfToken& GetTargetHgiName() const
+    {
+        static const TfToken anyHgi{};
+        return anyHgi;
+    }
+
+    /// Called by the Hgi backend with the computed capabilities for the device.
+    /// Return true to accept this device, or false to reject it and try
+    /// another. Note that if no other device is available, then the
+    /// implementation might ignore the results and proceed anyway, or it might
+    /// cause Hgi creation will fail.
+    virtual bool FilterDevice(const HgiCapabilities& capabilities) = 0;
+};
+
+/// A list of HgiDeviceFilters. Only one filter per target Hgi is expected.
+using HgiDeviceFilters = std::vector<HgiDeviceFilter*>;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgi/hgi.cpp
+++ b/pxr/imaging/hgi/hgi.cpp
@@ -29,7 +29,7 @@ TF_REGISTRY_FUNCTION(TfType)
     TfType::Define<Hgi>();
 }
 
-Hgi::Hgi()
+Hgi::Hgi(HgiDeviceFilter* filter)
     : _uniqueIdCounter(1)
 {
 }
@@ -174,8 +174,28 @@ Hgi::SubmitCmds(HgiCmds* cmds, HgiSubmitWaitType wait)
     }
 }
 
+static const std::unordered_map<std::string_view, TfToken> _hgiTypeToToken {
+    {"HgiGL", HgiTokens->OpenGL},
+    {"HgiMetal", HgiTokens->Metal},
+    {"HgiVulkan", HgiTokens->Vulkan},
+};
+
+static HgiDeviceFilter*
+_FindDeviceFilterForHgi(const HgiDeviceFilters& filters, const TfToken& hgiToken)
+{
+    HgiDeviceFilter* defaultFilter = nullptr;
+    for (const auto filter : filters) {
+        if (filter->GetTargetHgiName().IsEmpty()) {
+            defaultFilter = filter;
+        } else if (filter->GetTargetHgiName() == hgiToken) {
+            return filter;
+        }
+    }
+    return defaultFilter;
+}
+
 static Hgi*
-_MakeNewPlatformDefaultHgi()
+_MakeNewPlatformDefaultHgi(const HgiDeviceFilters& filters)
 {
     TF_DEBUG(HGI_DEBUG_INSTANCE_CREATION).Msg("Attempting to create platform "
         "default Hgi\n");
@@ -227,7 +247,9 @@ _MakeNewPlatformDefaultHgi()
         return nullptr;
     }
 
-    Hgi* instance = factory->New();
+    HgiDeviceFilter* filter = _FindDeviceFilterForHgi(filters,
+        _hgiTypeToToken.at(hgiType));
+    Hgi* instance = factory->New(filter);
     if (!instance) {
         TF_CODING_ERROR("[PluginLoad] Cannot construct instance of type '%s'\n",
                 plugType.GetTypeName().c_str());
@@ -252,7 +274,7 @@ _MakeNewPlatformDefaultHgi()
 }
 
 static Hgi*
-_MakeNamedHgi(const TfToken& hgiToken)
+_MakeNamedHgi(const TfToken& hgiToken, HgiDeviceFilter* filter)
 {
     TF_DEBUG(HGI_DEBUG_INSTANCE_CREATION).Msg("Attempting to create named Hgi "
         "%s\n", hgiToken.GetText());
@@ -272,7 +294,11 @@ _MakeNamedHgi(const TfToken& hgiToken)
         hgiType = "HgiMetal";
 #endif
     } else if (hgiToken.IsEmpty()) {
-        return _MakeNewPlatformDefaultHgi();
+        HgiDeviceFilters filters{};
+        if (filter) {
+            filters = {filter};
+        }
+        return _MakeNewPlatformDefaultHgi(filters);
     } else {
         // If an invalid token is provided, return nullptr.
         TF_CODING_ERROR("Unsupported token %s was provided.",
@@ -307,7 +333,19 @@ _MakeNamedHgi(const TfToken& hgiToken)
         return nullptr;
     }
 
-    Hgi* instance = factory->New();
+    if (filter) {
+        const auto targetHgi = filter->GetTargetHgiName();
+        if (!targetHgi.IsEmpty() &&
+            _hgiTypeToToken.at(hgiType.c_str()) != targetHgi) {
+            filter = nullptr;
+            TF_WARN("Wrong HgiDeviceFilter target for filter passed to "
+                "CreateNamedHgi(). Hgi: %s, HgiDeviceFilter: %s",
+            _hgiTypeToToken.at(hgiType.c_str()).GetText(),
+            targetHgi.GetText());
+        }
+    }
+
+    Hgi* instance = factory->New(filter);
     if (!instance) {
         TF_CODING_ERROR("[PluginLoad] Cannot construct instance of type '%s'\n",
             plugType.GetTypeName().c_str());
@@ -333,23 +371,23 @@ Hgi::GetPlatformDefaultHgi()
     TF_WARN("GetPlatformDefaultHgi is deprecated. "
             "Please use CreatePlatformDefaultHgi");
 
-    return _MakeNewPlatformDefaultHgi();
+    return _MakeNewPlatformDefaultHgi({});
 }
 
 HgiUniquePtr
-Hgi::CreatePlatformDefaultHgi()
+Hgi::CreatePlatformDefaultHgi(const HgiDeviceFilters& filters)
 {
-    return HgiUniquePtr(_MakeNewPlatformDefaultHgi());
+    return HgiUniquePtr(_MakeNewPlatformDefaultHgi(filters));
 }
 
 HgiUniquePtr 
-Hgi::CreateNamedHgi(const TfToken& hgiToken)
+Hgi::CreateNamedHgi(const TfToken& hgiToken, HgiDeviceFilter* filter)
 {
-    return HgiUniquePtr(_MakeNamedHgi(hgiToken));
+    return HgiUniquePtr(_MakeNamedHgi(hgiToken, filter));
 }
 
 bool
-Hgi::IsSupported(const TfToken& hgiToken)
+Hgi::IsSupported(const TfToken& hgiToken, const HgiDeviceFilters& filters)
 {
     // TODO: By current design, a Hgi instance is created and initialized as a 
     // method of confirming support on a platform. Once this is done, the 
@@ -359,9 +397,10 @@ Hgi::IsSupported(const TfToken& hgiToken)
 
     HgiUniquePtr instance = nullptr;
     if (hgiToken.IsEmpty()) {
-        instance = CreatePlatformDefaultHgi();
+        instance = CreatePlatformDefaultHgi(filters);
     } else {
-        instance = CreateNamedHgi(hgiToken);
+        HgiDeviceFilter* filter = _FindDeviceFilterForHgi(filters, hgiToken);
+        instance = CreateNamedHgi(hgiToken, filter);
     }
 
     if (instance) {

--- a/pxr/imaging/hgi/hgi.h
+++ b/pxr/imaging/hgi/hgi.h
@@ -16,6 +16,7 @@
 #include "pxr/imaging/hgi/buffer.h"
 #include "pxr/imaging/hgi/computeCmds.h"
 #include "pxr/imaging/hgi/computeCmdsDesc.h"
+#include "pxr/imaging/hgi/deviceFilter.h"
 #include "pxr/imaging/hgi/graphicsCmds.h"
 #include "pxr/imaging/hgi/graphicsCmdsDesc.h"
 #include "pxr/imaging/hgi/graphicsPipeline.h"
@@ -95,7 +96,7 @@ class Hgi
 {
 public:
     HGI_API
-    Hgi();
+    Hgi(HgiDeviceFilter* filter = nullptr);
 
     HGI_API
     virtual ~Hgi();
@@ -121,9 +122,11 @@ public:
     /// For example on Linux this may return HgiGL while on macOS HgiMetal.
     /// Caller, usually the application, owns the lifetime of the Hgi object and
     /// the object is destroyed when the caller drops the unique ptr.
+    /// Optionally a set of device filters can be used to hook into device
+    /// selection. Only one filter per target Hgi is allowed.
     /// Thread safety: Not thread safe.
     HGI_API
-    static HgiUniquePtr CreatePlatformDefaultHgi();
+    static HgiUniquePtr CreatePlatformDefaultHgi(const HgiDeviceFilters& filters = {});
 
     /// Helper function to return a Hgi object of choice supported by current 
     /// platform and build configuration.
@@ -137,9 +140,10 @@ public:
     /// HgiTokens.
     /// Caller, usually the application, owns the lifetime of the Hgi object and
     /// the object is destroyed when the caller drops the unique ptr.
+    /// Optionally a device filtes can be used to hook into device selection.
     /// Thread safety: Not thread safe.
     HGI_API
-    static HgiUniquePtr CreateNamedHgi(const TfToken& hgiToken);
+    static HgiUniquePtr CreateNamedHgi(const TfToken& hgiToken, HgiDeviceFilter* filter = nullptr);
 
     /// Determine if Hgi instance can run on current hardware.
     /// Thread safety: This call is thread safe.
@@ -154,9 +158,11 @@ public:
     /// token from HgiTokens. 
     /// An empty token will check support for creating the platform default Hgi.
     /// An invalid token will result in this function returning false.
+    /// Optionally a set of device filters can be used to hook into device
+    /// selection. Only one filter per target Hgi is allowed.
     /// Thread safety: Not thread safe.
     HGI_API
-    static bool IsSupported(const TfToken& hgiToken = TfToken());
+    static bool IsSupported(const TfToken& hgiToken = TfToken(), const HgiDeviceFilters& filters = {});
 
     /// Returns a GraphicsCmds object (for temporary use) that is ready to
     /// record draw commands. GraphicsCmds is a lightweight object that
@@ -373,14 +379,14 @@ private:
 ///
 class HgiFactoryBase : public TfType::FactoryBase {
 public:
-    virtual Hgi* New() const = 0;
+    virtual Hgi* New(HgiDeviceFilter* filter) const = 0;
 };
 
 template <class T>
 class HgiFactory : public HgiFactoryBase {
 public:
-    Hgi* New() const {
-        return new T;
+    Hgi* New(HgiDeviceFilter* filter) const {
+        return new T(filter);
     }
 };
 

--- a/pxr/imaging/hgiGL/CMakeLists.txt
+++ b/pxr/imaging/hgiGL/CMakeLists.txt
@@ -45,6 +45,7 @@ pxr_library(hgiGL
 
     PUBLIC_HEADERS
         api.h
+        deviceFilter.h
 
     RESOURCE_FILES
         plugInfo.json

--- a/pxr/imaging/hgiGL/deviceFilter.h
+++ b/pxr/imaging/hgiGL/deviceFilter.h
@@ -1,0 +1,43 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HGIGL_DEVICE_FILTER_H
+#define PXR_IMAGING_HGIGL_DEVICE_FILTER_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgi/deviceFilter.h"
+#include "pxr/imaging/hgi/tokens.h"
+
+#include "pxr/imaging/hgiGL/api.h"
+#include "pxr/imaging/hgiGL/capabilities.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+///
+/// \class HgiGLDeviceFilter
+///
+/// HgiGL doesn't support device filtering. Context creation is handled by the
+/// application. FilterDevice() is called but the return value is ignored.
+class HgiGLDeviceFilter : public HgiDeviceFilter
+{
+public:
+    virtual ~HgiGLDeviceFilter() = default;
+
+    const TfToken& GetTargetHgiName() const override final
+    {
+        return HgiTokens->OpenGL;
+    }
+
+    bool FilterDevice(const HgiCapabilities& capabilities) final
+    {
+        return true;
+    }
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiGL/hgi.cpp
+++ b/pxr/imaging/hgiGL/hgi.cpp
@@ -16,6 +16,7 @@
 #include "pxr/imaging/hgiGL/contextArena.h"
 #include "pxr/imaging/hgiGL/conversions.h"
 #include "pxr/imaging/hgiGL/device.h"
+#include "pxr/imaging/hgiGL/deviceFilter.h"
 #include "pxr/imaging/hgiGL/diagnostic.h"
 #include "pxr/imaging/hgiGL/graphicsCmds.h"
 #include "pxr/imaging/hgiGL/graphicsPipeline.h"
@@ -43,7 +44,7 @@ TF_REGISTRY_FUNCTION(TfType)
 }
 
 
-HgiGL::HgiGL()
+HgiGL::HgiGL(HgiDeviceFilter* filter)
     : _device(nullptr)
     , _frameDepth(0)
 {
@@ -63,6 +64,11 @@ HgiGL::HgiGL()
     _device = new HgiGLDevice();
 
     _capabilities.reset(new HgiGLCapabilities());
+
+    if (filter && !filter->FilterDevice(*_capabilities)) {
+        TF_WARN("HgiDeviceFilter returned false: ignoring this since HgiGL"
+            " only ever has one device.");
+    }
 }
 
 HgiGL::~HgiGL()

--- a/pxr/imaging/hgiGL/hgi.h
+++ b/pxr/imaging/hgiGL/hgi.h
@@ -55,7 +55,7 @@ class HgiGL final : public Hgi
 {
 public:
     HGIGL_API
-    HgiGL();
+    HgiGL(HgiDeviceFilter* filter = nullptr);
 
     HGIGL_API
     ~HgiGL() override;

--- a/pxr/imaging/hgiMetal/CMakeLists.txt
+++ b/pxr/imaging/hgiMetal/CMakeLists.txt
@@ -30,6 +30,7 @@ pxr_library(hgiMetal
         capabilities.h
         computeCmds.h
         computePipeline.h
+        deviceFilter.h
         diagnostic.h
         graphicsCmds.h
         graphicsPipeline.h

--- a/pxr/imaging/hgiMetal/deviceFilter.h
+++ b/pxr/imaging/hgiMetal/deviceFilter.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HGIMETAL_DEVICE_FILTER_H
+#define PXR_IMAGING_HGIMETAL_DEVICE_FILTER_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgi/deviceFilter.h"
+#include "pxr/imaging/hgi/tokens.h"
+
+#include "pxr/imaging/hgiMetal/api.h"
+#include "pxr/imaging/hgiMetal/capabilities.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+///
+/// \class HgiMetalDeviceFilter
+///
+/// If all devices are filtered out, then HgiMetal will default to
+/// MTLCreateSystemDefaultDevice().
+class HgiMetalDeviceFilter : public HgiDeviceFilter
+{
+public:
+    virtual ~HgiMetalDeviceFilter() = default;
+
+     const TfToken& GetTargetHgiName() const override final
+    {
+        return HgiTokens->Metal;
+    }
+
+    virtual bool FilterDevice(const HgiCapabilities& capabilities) override
+    {
+        return true;
+    }
+
+    /// Overload for more detailed device filtering.
+    virtual bool FilterDevice(const HgiMetalCapabilities& capabilities,
+        id<MTLDevice> device) = 0;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiMetal/hgi.h
+++ b/pxr/imaging/hgiMetal/hgi.h
@@ -40,7 +40,7 @@ public:
     };
     
     HGIMETAL_API
-    HgiMetal(id<MTLDevice> device = nil);
+    HgiMetal(HgiDeviceFilter* filter = nullptr);
 
     HGIMETAL_API
     ~HgiMetal() override;
@@ -202,6 +202,9 @@ protected:
 private:
     HgiMetal & operator=(const HgiMetal&) = delete;
     HgiMetal(const HgiMetal&) = delete;
+
+    static std::pair<id<MTLDevice>, std::unique_ptr<HgiMetalCapabilities>>
+        _FindDevice(HgiDeviceFilter* filter);
 
     // Invalidates the resource handle and destroys the object.
     // Metal's internal garbage collection will handle the rest.

--- a/pxr/imaging/hgiMetal/hgi.mm
+++ b/pxr/imaging/hgiMetal/hgi.mm
@@ -14,6 +14,7 @@
 #include "pxr/imaging/hgiMetal/computePipeline.h"
 #include "pxr/imaging/hgiMetal/capabilities.h"
 #include "pxr/imaging/hgiMetal/conversions.h"
+#include "pxr/imaging/hgiMetal/deviceFilter.h"
 #include "pxr/imaging/hgiMetal/diagnostic.h"
 #include "pxr/imaging/hgiMetal/graphicsCmds.h"
 #include "pxr/imaging/hgiMetal/graphicsPipeline.h"
@@ -27,6 +28,7 @@
 
 #include "pxr/base/tf/getenv.h"
 #include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/smallVector.h"
 #include "pxr/base/tf/type.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -36,6 +38,18 @@ TF_REGISTRY_FUNCTION(TfType)
     TfType t = TfType::Define<HgiMetal, TfType::Bases<Hgi> >();
     t.SetFactory<HgiFactory<HgiMetal>>();
 }
+
+#if defined(ARCH_OS_OSX)
+TF_DEFINE_ENV_SETTING(HGIMETAL_USE_INTEGRATED_GPU, false,
+   "Always use an integrated GPU (if one is available)");
+
+static bool
+_UseIntegratedGpu()
+{
+   static bool enabled = TfGetEnvSetting(HGIMETAL_USE_INTEGRATED_GPU);
+   return enabled;
+}
+#endif
 
 struct HgiMetal::AutoReleasePool
 {
@@ -61,29 +75,65 @@ struct HgiMetal::AutoReleasePool
 #endif
 };
 
-HgiMetal::HgiMetal(id<MTLDevice> device)
-: _device(device)
+std::pair<id<MTLDevice>, std::unique_ptr<HgiMetalCapabilities>>
+HgiMetal::_FindDevice(HgiDeviceFilter* filter)
+{
+    TfSmallVector<id<MTLDevice>, 4> devices;
+#if defined(ARCH_OS_OSX)
+    if (!filter && !_UseIntegratedGpu()) {
+        // No special device selection logic, ensure we use the default device.
+        devices.push_back(MTLCreateSystemDefaultDevice());
+    } else {
+        for (id<MTLDevice> device in MTLCopyAllDevices()) {
+            if (!_UseIntegratedGpu() || [device isLowPower]) {
+                devices.push_back(device);
+            }
+        }
+    }
+#else
+    // On Apple embedded it's currently always one device
+    devices.push_back(MTLCreateSystemDefaultDevice());
+#endif
+
+    if (!filter) {
+        id<MTLDevice> device = devices.front();
+        return {device,
+            std::unique_ptr<HgiMetalCapabilities>{
+                new HgiMetalCapabilities(device)}};
+    }
+
+    for (id<MTLDevice> device : devices) {
+        std::unique_ptr<HgiMetalCapabilities> capabilities{
+            new HgiMetalCapabilities(device)};
+        bool useDevice{};
+        if (const auto mtlFilter =
+                dynamic_cast<HgiMetalDeviceFilter*>(filter)) {
+            useDevice = mtlFilter->FilterDevice(*capabilities, device);
+        } else {
+            useDevice = filter->FilterDevice(*capabilities);
+        }
+        if (useDevice) {
+            return {device, std::move(capabilities)};
+        }
+    }
+
+    TF_WARN(
+        "All devices filtered, falling back to MTLCreateSystemDefaultDevice()");
+
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    return {device,
+        std::unique_ptr<HgiMetalCapabilities>{
+            new HgiMetalCapabilities(device)}};
+}
+
+HgiMetal::HgiMetal(HgiDeviceFilter* filter)
+: _device(nil)
 , _currentCmds(nullptr)
 , _frameDepth(0)
 , _workToFlush(false)
 , _pool(std::make_unique<AutoReleasePool>())
 {
-    if (!_device) {
-#if defined(ARCH_OS_OSX)
-        if( TfGetenvBool("HGIMETAL_USE_INTEGRATED_GPU", false)) {
-            auto devices = MTLCopyAllDevices();
-            for (id<MTLDevice> d in devices) {
-                if ([d isLowPower]) {
-                    _device = d;
-                    break;
-                }
-            }
-        }
-#endif
-        if (!_device) {
-            _device = MTLCreateSystemDefaultDevice();
-        }
-    }
+    std::tie(_device, _capabilities) = _FindDevice(filter);
 
     static int const commandBufferPoolSize = 256;
 
@@ -92,7 +142,9 @@ HgiMetal::HgiMetal(id<MTLDevice> device)
     _commandBuffer = [_commandQueue commandBuffer];
     [_commandBuffer retain];
 
-    _capabilities.reset(new HgiMetalCapabilities(_device));
+    if (!_capabilities) {
+        _capabilities.reset(new HgiMetalCapabilities(_device));
+    }
     _indirectCommandEncoder.reset(new HgiMetalIndirectCommandEncoder(this));
 
     MTLArgumentDescriptor *argumentDescBuffer =

--- a/pxr/imaging/hgiVulkan/CMakeLists.txt
+++ b/pxr/imaging/hgiVulkan/CMakeLists.txt
@@ -45,6 +45,7 @@ pxr_library(hgiVulkan
 
     PUBLIC_HEADERS
         api.h
+        deviceFilter.h
         vulkan.h
 
     PRIVATE_CLASSES

--- a/pxr/imaging/hgiVulkan/capabilities.cpp
+++ b/pxr/imaging/hgiVulkan/capabilities.cpp
@@ -143,14 +143,18 @@ _SupportsHostAccessibleDeviceMemory(
 
     return false;
 }
+HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device) :
+    HgiVulkanCapabilities(device->GetVulkanPhysicalDevice(),
+    device->GetGfxQueueFamilyIndex(), device->GetExtensions())
+{
+}
 
-HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
+HgiVulkanCapabilities::HgiVulkanCapabilities(VkPhysicalDevice physicalDevice,
+    uint32_t gfxQueueIndex, const HgiVulkanExtensionSet& extensions)
     : supportsTimeStamps(false),
     supportsNativeInterop(false),
     supportsHostImageCopy(false)
 {
-    VkPhysicalDevice physicalDevice = device->GetVulkanPhysicalDevice();
-
     uint32_t queueCount = 0;
     vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &queueCount, 0);
     std::vector<VkQueueFamilyProperties> queues(queueCount);
@@ -159,9 +163,6 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
         physicalDevice,
         &queueCount,
         queues.data());
-
-    // Grab the properties of all queues up until the (gfx) queue we are using.
-    uint32_t gfxQueueIndex = device->GetGfxQueueFamilyIndex();
 
     // The last queue we grabbed the properties of is our gfx queue.
     if (TF_VERIFY(gfxQueueIndex < queues.size())) {
@@ -192,7 +193,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     // Host image copy feature
     const bool hostImageCopyExtAvailable =
         TfGetEnvSetting(HGIVULKAN_ENABLE_HOST_IMAGE_COPY) &&
-        device->IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
+        extensions.Contains(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
     VkPhysicalDeviceHostImageCopyPropertiesEXT vkHostImageCopyProperties {};
     std::vector<VkImageLayout> hostImageCopySrcLayoutsVec;
     std::vector<VkImageLayout> hostImageCopyDstLayoutsVec;
@@ -250,24 +251,25 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     // Interop features
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     if (TfGetEnvSetting(HGIVULKAN_ENABLE_NATIVE_INTEROP) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME)) {
+        extensions.Contains(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME)) {
         supportsNativeInterop = true;
     }
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
     if (TfGetEnvSetting(HGIVULKAN_ENABLE_NATIVE_INTEROP) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME) &&
-        device->IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
+        extensions.Contains(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME) &&
+        extensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
         supportsNativeInterop = true;
     }
 #elif defined(VK_USE_PLATFORM_METAL_EXT)
     // To be added, either through MoltenVK adding GL interop,
     // or a later change if necessary
 #endif
+
 
     // Vertex attribute divisor features ext
     vkVertexAttributeDivisorFeatures.sType =
@@ -276,7 +278,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     vkDeviceFeatures2.pNext = &vkVertexAttributeDivisorFeatures;
 
     // Barycentric feature
-    const bool barycentricExtSupported = device->IsSupportedExtension(
+    const bool barycentricExtSupported = extensions.Contains(
         VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     if (barycentricExtSupported) {
         vkBarycentricFeatures.sType =
@@ -286,7 +288,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     }
 
     // Line rasterization feature
-    const bool lineRasterizationExtSupported = device->IsSupportedExtension(
+    const bool lineRasterizationExtSupported = extensions.Contains(
         VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME);
     if (lineRasterizationExtSupported) {
         vkLineRasterizationFeatures.sType =
@@ -343,15 +345,6 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
         (uma && TfGetEnvSetting(HGIVULKAN_ENABLE_UMA)) ||
         (rebar && TfGetEnvSetting(HGIVULKAN_ENABLE_REBAR));
 
-    if (HgiVulkanIsDebugEnabled()) {
-        auto memoryAccessString = "";
-        if (unifiedMemory) {
-            memoryAccessString = rebar ? " (ReBAR)" : " (UMA)";
-        }
-        TF_STATUS("Selected GPU: \"%s\"%s",
-            vkDeviceProperties2.properties.deviceName, memoryAccessString);
-    }
-
     _maxClipDistances = vkDeviceProperties2.properties.limits.maxClipDistances;
     _maxUniformBlockSize =
         vkDeviceProperties2.properties.limits.maxUniformBufferRange;
@@ -360,7 +353,7 @@ HgiVulkanCapabilities::HgiVulkanCapabilities(HgiVulkanDevice* device)
     _uniformBufferOffsetAlignment =
         vkDeviceProperties2.properties.limits.minUniformBufferOffsetAlignment;
 
-    const bool conservativeRasterEnabled = device->IsSupportedExtension(
+    const bool conservativeRasterEnabled = extensions.Contains(
         VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     const bool shaderDrawParametersEnabled =
         vkVulkan11Features.shaderDrawParameters;

--- a/pxr/imaging/hgiVulkan/capabilities.h
+++ b/pxr/imaging/hgiVulkan/capabilities.h
@@ -19,6 +19,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 class HgiVulkanDevice;
+class HgiVulkanExtensionSet;
 
 struct HgiVulkanFormatInfo
 {
@@ -36,6 +37,10 @@ struct HgiVulkanFormatInfo
 class HgiVulkanCapabilities final : public HgiCapabilities
 {
 public:
+    HGIVULKAN_API
+    HgiVulkanCapabilities(VkPhysicalDevice physicalDevice,
+        uint32_t gfxQueueIndex, const HgiVulkanExtensionSet& extensions);
+
     HGIVULKAN_API
     HgiVulkanCapabilities(HgiVulkanDevice* device);
 

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -14,6 +14,8 @@
 #include "pxr/imaging/hgiVulkan/vk_mem_alloc.h"
 
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/smallVector.h"
+#include "pxr/base/tf/span.h"
 
 #include <fstream>
 
@@ -23,15 +25,16 @@ TF_DEFINE_ENV_SETTING(HGIVULKAN_PREFERRED_DEVICE_TYPE,
     VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU,
     "Preferred device type. Use VkPhysicalDeviceType enum values.");
 
+namespace {
 // VMA links this to the interop pool
-static VkExportMemoryAllocateInfoKHR _exportInfo =
+VkExportMemoryAllocateInfoKHR _exportInfo =
 {
     VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO,
     nullptr,
     VK_EXTERNAL_MEMORY_HANDLE_AUTO
 };
 
-static uint32_t
+uint32_t
 _GetGraphicsQueueFamilyIndex(VkPhysicalDevice physicalDevice)
 {
     uint32_t queueCount = 0;
@@ -76,115 +79,30 @@ _SupportsPresentation(
 #endif
 }
 
-HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
-    : _vkPhysicalDevice(nullptr)
-    , _vkDevice(nullptr)
-    , _vmaAllocator(nullptr)
-    , _commandQueue(nullptr)
-    , _capabilities(nullptr)
-    , _pipelineCache(nullptr)
+VkDevice
+_CreateDevice(VkPhysicalDevice physicalDevice, uint32_t gfxsQueueFamilyIndex,
+    const HgiVulkanExtensionSet& supportedExtensions,
+    const HgiVulkanCapabilities& capabilities, HgiDeviceFilter* filter)
 {
-    //
-    // Determine physical device
-    //
-
-    const uint32_t maxDevices = 64;
-    VkPhysicalDevice physicalDevices[maxDevices];
-    uint32_t physicalDeviceCount = maxDevices;
-    HGIVULKAN_VERIFY_VK_RESULT(
-        vkEnumeratePhysicalDevices(
-            instance->GetVulkanInstance(),
-            &physicalDeviceCount,
-            physicalDevices)
-    );
-
-    const auto preferredDeviceType = static_cast<VkPhysicalDeviceType>(
-        TfGetEnvSetting(HGIVULKAN_PREFERRED_DEVICE_TYPE));
-    for (uint32_t i = 0; i < physicalDeviceCount; i++) {
-        VkPhysicalDeviceProperties props;
-        vkGetPhysicalDeviceProperties(physicalDevices[i], &props);
-
-        uint32_t familyIndex =
-            _GetGraphicsQueueFamilyIndex(physicalDevices[i]);
-
-        if (familyIndex == VK_QUEUE_FAMILY_IGNORED) continue;
-
-        // Assume we always want a presentation capable device for now.
-        if (instance->HasPresentation() &&
-            !_SupportsPresentation(physicalDevices[i], familyIndex)) {
-            continue;
-        }
-
-        if (props.apiVersion < VK_API_VERSION_1_3) continue;
-
-        // Try to find a preferred device type. Until we find one, store the
-        // first non-preferred device as fallback in case we never find a
-        // preferred device at all.
-        if (props.deviceType == preferredDeviceType) {
-            _vkPhysicalDevice = physicalDevices[i];
-            _vkGfxsQueueFamilyIndex = familyIndex;
-            break;
-        }
-        if (!_vkPhysicalDevice) {
-            _vkPhysicalDevice = physicalDevices[i];
-            _vkGfxsQueueFamilyIndex = familyIndex;
-        }
-    }
-
-    if (!_vkPhysicalDevice) {
-        TF_CODING_ERROR("VULKAN_ERROR: Unable to determine physical device");
-        return;
-    }
-
-    //
-    // Query supported extensions for device
-    //
-
-    uint32_t extensionCount = 0;
-    HGIVULKAN_VERIFY_VK_RESULT(
-        vkEnumerateDeviceExtensionProperties(
-            _vkPhysicalDevice,
-            nullptr,
-            &extensionCount,
-            nullptr)
-    );
-
-    _vkExtensions.resize(extensionCount);
-
-    HGIVULKAN_VERIFY_VK_RESULT(
-        vkEnumerateDeviceExtensionProperties(
-            _vkPhysicalDevice,
-            nullptr,
-            &extensionCount,
-            _vkExtensions.data())
-    );
-
-    //
-    // Create Device
-    //
-    _capabilities = new HgiVulkanCapabilities(this);
-
     VkDeviceQueueCreateInfo queueInfo =
         {VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
     float queuePriorities[] = {1.0f};
-    queueInfo.queueFamilyIndex = _vkGfxsQueueFamilyIndex;
+    queueInfo.queueFamilyIndex = gfxsQueueFamilyIndex;
     queueInfo.queueCount = 1;
     queueInfo.pQueuePriorities = queuePriorities;
 
     std::vector<const char*> extensions;
 
     // Not available if we're surfaceless (minimal Lavapipe build for example).
-    if (IsSupportedExtension(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_SWAPCHAIN_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     }
 
     // Allow certain buffers/images to have dedicated memory allocations to
     // improve performance on some GPUs.
-    bool dedicatedAllocations = false;
-    if (IsSupportedExtension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME)
-        && IsSupportedExtension(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
+    if (supportedExtensions.Contains(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME)
+        && supportedExtensions.Contains(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME))
     {
-        dedicatedAllocations = true;
         extensions.push_back(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
         extensions.push_back(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
     }
@@ -192,20 +110,20 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     // Allow OpenGL interop
     // Note requires four extensions in HgiVulkanInstance.
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    if (IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
         extensions.push_back(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
         extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     }
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
-    if (IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME) &&
-        IsSupportedExtension(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME) &&
+        supportedExtensions.Contains(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
         extensions.push_back(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
@@ -217,14 +135,12 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
 #endif
 
     // Memory budget query extension
-    bool supportsMemExtension = false;
-    if (IsSupportedExtension(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) {
-        supportsMemExtension = true;
+    if (supportedExtensions.Contains(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME);
     }
 
     // Resolve depth during render pass resolve extension
-    if (IsSupportedExtension(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
         extensions.push_back(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
         extensions.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
@@ -233,7 +149,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
 
     // Allows the same layout in structs between c++ and glsl (share structs).
     // This means instead of 'std430' you can now use 'scalar'.
-    if (IsSupportedExtension(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
     } else {
         TF_WARN("Unsupported VK_EXT_scalar_block_layout."
@@ -241,32 +157,32 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     }
 
     // Allow conservative rasterization.
-    if (IsSupportedExtension(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     }
 
     // Allow use of built-in shader barycentrics.
-    if (IsSupportedExtension(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     }
 
     // Allow use of shader draw parameters.
-    if (IsSupportedExtension(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
     }
 
     // Allow use of vertex attribute divisors.
-    if (IsSupportedExtension(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
     }
 
     // Allow use of line rasterization ext
-    if (IsSupportedExtension(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME);
     }
 
     // Allow use of host image copy
-    if (IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
         extensions.push_back(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME);
     }
 
@@ -275,7 +191,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     extensions.push_back(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    if (IsSupportedExtension(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     }
 #endif
@@ -287,58 +203,58 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
 
     features2.features.multiDrawIndirect =
-        _capabilities->vkDeviceFeatures2.features.multiDrawIndirect;
+        capabilities.vkDeviceFeatures2.features.multiDrawIndirect;
     features2.features.samplerAnisotropy =
-        _capabilities->vkDeviceFeatures2.features.samplerAnisotropy;
+        capabilities.vkDeviceFeatures2.features.samplerAnisotropy;
     features2.features.shaderSampledImageArrayDynamicIndexing =
-        _capabilities->vkDeviceFeatures2.features.shaderSampledImageArrayDynamicIndexing;
+        capabilities.vkDeviceFeatures2.features.shaderSampledImageArrayDynamicIndexing;
     features2.features.shaderStorageImageArrayDynamicIndexing =
-        _capabilities->vkDeviceFeatures2.features.shaderStorageImageArrayDynamicIndexing;
+        capabilities.vkDeviceFeatures2.features.shaderStorageImageArrayDynamicIndexing;
     features2.features.sampleRateShading =
-        _capabilities->vkDeviceFeatures2.features.sampleRateShading;
+        capabilities.vkDeviceFeatures2.features.sampleRateShading;
     features2.features.shaderClipDistance =
-        _capabilities->vkDeviceFeatures2.features.shaderClipDistance;
+        capabilities.vkDeviceFeatures2.features.shaderClipDistance;
     features2.features.tessellationShader =
-        _capabilities->vkDeviceFeatures2.features.tessellationShader;
+        capabilities.vkDeviceFeatures2.features.tessellationShader;
     features2.features.depthClamp =
-        _capabilities->vkDeviceFeatures2.features.depthClamp;
+        capabilities.vkDeviceFeatures2.features.depthClamp;
     features2.features.shaderFloat64 =
-        _capabilities->vkDeviceFeatures2.features.shaderFloat64;
+        capabilities.vkDeviceFeatures2.features.shaderFloat64;
     features2.features.fillModeNonSolid =
-        _capabilities->vkDeviceFeatures2.features.fillModeNonSolid;
+        capabilities.vkDeviceFeatures2.features.fillModeNonSolid;
     features2.features.alphaToOne =
-        _capabilities->vkDeviceFeatures2.features.alphaToOne;
+        capabilities.vkDeviceFeatures2.features.alphaToOne;
     // Needed to write to storage buffers from vertex shader (eg. GPU culling).
     features2.features.vertexPipelineStoresAndAtomics =
-        _capabilities->vkDeviceFeatures2.features.vertexPipelineStoresAndAtomics;
+        capabilities.vkDeviceFeatures2.features.vertexPipelineStoresAndAtomics;
     // Needed to write to storage buffers from fragment shader (eg. OIT).
     features2.features.fragmentStoresAndAtomics =
-        _capabilities->vkDeviceFeatures2.features.fragmentStoresAndAtomics;
+        capabilities.vkDeviceFeatures2.features.fragmentStoresAndAtomics;
     // Needed for buffer address feature
     features2.features.shaderInt64 =
-        _capabilities->vkDeviceFeatures2.features.shaderInt64;
+        capabilities.vkDeviceFeatures2.features.shaderInt64;
     // Needed for gl_primtiveID
     features2.features.geometryShader =
-        _capabilities->vkDeviceFeatures2.features.geometryShader;
+        capabilities.vkDeviceFeatures2.features.geometryShader;
 
     VkPhysicalDeviceVulkan11Features vulkan11Features =
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES};
     vulkan11Features.shaderDrawParameters =
-        _capabilities->vkVulkan11Features.shaderDrawParameters;
+        capabilities.vkVulkan11Features.shaderDrawParameters;
     vulkan11Features.pNext = features2.pNext;
     features2.pNext = &vulkan11Features;
 
     VkPhysicalDeviceVulkan12Features vulkan12Features =
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
     vulkan12Features.timelineSemaphore =
-        _capabilities->vkVulkan12Features.timelineSemaphore;
+        capabilities.vkVulkan12Features.timelineSemaphore;
     vulkan12Features.pNext = features2.pNext;
     features2.pNext = &vulkan12Features;
 
     VkPhysicalDeviceVulkan13Features vulkan13Features =
         {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES};
     vulkan13Features.shaderDemoteToHelperInvocation =
-        _capabilities->vkVulkan13Features.shaderDemoteToHelperInvocation;
+        capabilities.vkVulkan13Features.shaderDemoteToHelperInvocation;
     vulkan13Features.pNext = features2.pNext;
     features2.pNext = &vulkan13Features;
 
@@ -346,7 +262,7 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertexAttributeDivisorFeatures
     { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT };
     vertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor =
-        _capabilities->vkVertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor;
+        capabilities.vkVertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor;
     vertexAttributeDivisorFeatures.pNext = features2.pNext;
     features2.pNext = &vertexAttributeDivisorFeatures;
 
@@ -354,9 +270,9 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR barycentricFeatures {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR
     };
-    if (IsSupportedExtension(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME)) {
         barycentricFeatures.fragmentShaderBarycentric =
-            _capabilities->vkBarycentricFeatures.fragmentShaderBarycentric;
+            capabilities.vkBarycentricFeatures.fragmentShaderBarycentric;
         barycentricFeatures.pNext = features2.pNext;
         features2.pNext = &barycentricFeatures;
     }
@@ -364,9 +280,9 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     // Line rasterization features needed for Bresenham line rasterization
     VkPhysicalDeviceLineRasterizationFeaturesKHR lineRasterFeatures {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_KHR };
-    if (IsSupportedExtension(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME)) {
         lineRasterFeatures.bresenhamLines =
-            _capabilities->vkLineRasterizationFeatures.bresenhamLines;
+            capabilities.vkLineRasterizationFeatures.bresenhamLines;
         lineRasterFeatures.pNext = features2.pNext;
         features2.pNext = &lineRasterFeatures;
     }
@@ -374,9 +290,9 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     VkPhysicalDeviceHostImageCopyFeaturesEXT hostImageCopyFeatures {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT
     };
-    if (IsSupportedExtension(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
+    if (supportedExtensions.Contains(VK_EXT_HOST_IMAGE_COPY_EXTENSION_NAME)) {
         hostImageCopyFeatures.hostImageCopy =
-            _capabilities->supportsHostImageCopy;
+            capabilities.supportsHostImageCopy;
         hostImageCopyFeatures.pNext = features2.pNext;
         features2.pNext = &hostImageCopyFeatures;
     }
@@ -388,13 +304,182 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     createInfo.enabledExtensionCount = (uint32_t) extensions.size();
     createInfo.pNext = &features2;
 
+    if (filter) {
+        bool useDevice{};
+        if (const auto vkFilter = dynamic_cast<HgiVulkanDeviceFilter*>(filter)) {
+            useDevice = vkFilter->FilterDevice(capabilities, physicalDevice, createInfo);
+        } else {
+            useDevice = filter->FilterDevice(capabilities);
+        }
+        if (!useDevice) {
+            return nullptr;
+        }
+    }
+
+    VkDevice device{};
     HGIVULKAN_VERIFY_VK_RESULT(
         vkCreateDevice(
-            _vkPhysicalDevice,
+            physicalDevice,
             &createInfo,
             HgiVulkanAllocator(),
-            &_vkDevice)
+            &device)
     );
+    return device;
+}
+}
+
+HgiVulkanExtensionSet::HgiVulkanExtensionSet(VkPhysicalDevice physicalDevice)
+{
+    uint32_t extensionCount = 0;
+    HGIVULKAN_VERIFY_VK_RESULT(
+        vkEnumerateDeviceExtensionProperties(
+            physicalDevice,
+            nullptr,
+            &extensionCount,
+            nullptr)
+    );
+    _extensions.resize(extensionCount);
+
+    HGIVULKAN_VERIFY_VK_RESULT(
+        vkEnumerateDeviceExtensionProperties(
+            physicalDevice,
+            nullptr,
+            &extensionCount,
+            _extensions.data())
+    );
+
+    for (const auto& extension : _extensions) {
+        _extensionsByName.emplace(extension.extensionName, std::cref(extension));
+    }
+}
+
+bool HgiVulkanExtensionSet::Contains(std::string_view name) const
+{
+    return _extensionsByName.count(name);
+}
+
+const VkExtensionProperties* HgiVulkanExtensionSet::Find(std::string_view name) const
+{
+    if (const auto iter = _extensionsByName.find(name);
+        iter != _extensionsByName.end()) {
+        return &iter->second.get();
+    }
+
+    return nullptr;
+}
+
+HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance,
+    HgiDeviceFilter* filter)
+    : _vkPhysicalDevice(nullptr)
+    , _vkDevice(nullptr)
+    , _vmaAllocator(nullptr)
+{
+    //
+    // Determine physical device
+    //
+
+    TfSmallVector<VkPhysicalDevice, 64> physicalDevices{};
+    physicalDevices.resize(physicalDevices.internal_capacity());
+    uint32_t physicalDeviceCount = physicalDevices.size();
+    HGIVULKAN_VERIFY_VK_RESULT(
+        vkEnumeratePhysicalDevices(
+            instance->GetVulkanInstance(),
+            &physicalDeviceCount,
+            physicalDevices.data())
+    );
+    physicalDevices.resize(physicalDeviceCount);
+
+    std::vector<std::pair<VkPhysicalDevice, uint32_t>> candidateDevices;
+    const auto preferredDeviceType = static_cast<VkPhysicalDeviceType>(
+        TfGetEnvSetting(HGIVULKAN_PREFERRED_DEVICE_TYPE));
+    for (const auto physicalDevice : physicalDevices) {
+        VkPhysicalDeviceProperties props;
+        vkGetPhysicalDeviceProperties(physicalDevice, &props);
+
+        uint32_t familyIndex =
+            _GetGraphicsQueueFamilyIndex(physicalDevice);
+
+        if (familyIndex == VK_QUEUE_FAMILY_IGNORED) continue;
+
+        // Assume we always want a presentation capable device for now.
+        if (instance->HasPresentation() &&
+            !_SupportsPresentation(physicalDevice, familyIndex)) {
+            continue;
+        }
+
+        if (props.apiVersion < VK_API_VERSION_1_3) continue;
+
+        if (filter) {
+            candidateDevices.push_back({physicalDevice, familyIndex});
+        } else {
+            // Try to find a preferred device type. Until we find one, store the
+            // first non-preferred device as fallback in case we never find a
+            // preferred device at all.
+            if (props.deviceType == preferredDeviceType) {
+                _vkPhysicalDevice = physicalDevice;
+                _vkGfxsQueueFamilyIndex = familyIndex;
+                break;
+            }
+            if (!_vkPhysicalDevice) {
+                _vkPhysicalDevice = physicalDevice;
+                _vkGfxsQueueFamilyIndex = familyIndex;
+            }
+        }
+    }
+
+    if (filter) {
+        if (candidateDevices.empty()) {
+            TF_RUNTIME_ERROR(
+                "Unable to find a suitable Vulkan physical device");
+            return;
+        }
+
+        for (const auto& [physicalDevice, gfxQueueIndex] : candidateDevices) {
+            HgiVulkanExtensionSet extensions{physicalDevice};
+            auto capabilities = std::make_unique<HgiVulkanCapabilities>(
+                physicalDevice, gfxQueueIndex, extensions);
+            if (const VkDevice device = _CreateDevice(physicalDevice,
+                    gfxQueueIndex, extensions, *capabilities, filter)) {
+                _vkDevice = device;
+                _vkPhysicalDevice = physicalDevice;
+                _vkGfxsQueueFamilyIndex = gfxQueueIndex;
+                _vkExtensions = std::move(extensions);
+                _capabilities = std::move(capabilities);
+                break;
+            }
+        }
+
+        if (!_vkPhysicalDevice) {
+            TF_RUNTIME_ERROR(
+                "All physical devices were rejected by the device filter");
+            return;
+        }
+    } else {
+        if (!_vkPhysicalDevice) {
+            TF_RUNTIME_ERROR(
+                "Unable to find a suitable Vulkan physical device");
+            return;
+        }
+
+        _vkExtensions = HgiVulkanExtensionSet{_vkPhysicalDevice};
+        _capabilities = std::make_unique<HgiVulkanCapabilities>(this);
+        _vkDevice = _CreateDevice(_vkPhysicalDevice, _vkGfxsQueueFamilyIndex,
+            _vkExtensions, *_capabilities, nullptr);
+    }
+
+    if (HgiVulkanIsDebugEnabled()) {
+        const auto& deviceProperties =
+            _capabilities->vkDeviceProperties2.properties;
+        auto memoryAccessString = "";
+        if (_capabilities->IsSet(HgiDeviceCapabilitiesBitsUnifiedMemory)) {
+            const bool uma = deviceProperties.deviceType ==
+                VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ||
+                deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU;
+            memoryAccessString = uma ? " (UMA)" : " (ReBAR)";
+        }
+        TF_STATUS("Selected GPU: \"%s\"%s",
+            deviceProperties.deviceName, memoryAccessString);
+    }
 
     HgiVulkanSetupDeviceDebug(instance, this);
 
@@ -437,11 +522,12 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     allocatorInfo.instance = instance->GetVulkanInstance();
     allocatorInfo.physicalDevice = _vkPhysicalDevice;
     allocatorInfo.device = _vkDevice;
-    if (dedicatedAllocations) {
+    if (_vkExtensions.Contains(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME)
+        && _vkExtensions.Contains(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME)) {
         allocatorInfo.flags |=VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT;
     }
 
-    if (supportsMemExtension) {
+    if (_vkExtensions.Contains(VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) {
         allocatorInfo.flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
     }
 
@@ -453,13 +539,13 @@ HgiVulkanDevice::HgiVulkanDevice(HgiVulkanInstance* instance)
     // Command Queue
     //
 
-    _commandQueue = new HgiVulkanCommandQueue(this);
+    _commandQueue = std::make_unique<HgiVulkanCommandQueue>(this);
 
     //
     // Pipeline cache
     //
 
-    _pipelineCache = new HgiVulkanPipelineCache(this);
+    _pipelineCache = std::make_unique<HgiVulkanPipelineCache>(this);
 }
 
 HgiVulkanDevice::~HgiVulkanDevice()
@@ -477,9 +563,9 @@ HgiVulkanDevice::~HgiVulkanDevice()
         vmaDestroyPool(_vmaAllocator, entry.second);
     }
 
-    delete _pipelineCache;
-    delete _commandQueue;
-    delete _capabilities;
+    _pipelineCache.reset();
+    _commandQueue.reset();
+    _capabilities.reset();
     vmaDestroyAllocator(_vmaAllocator);
     vkDestroyDevice(_vkDevice, HgiVulkanAllocator());
 }
@@ -565,7 +651,7 @@ HgiVulkanDevice::GetWin32HandleForMemory(VkDeviceMemory memory)
 HgiVulkanCommandQueue*
 HgiVulkanDevice::GetCommandQueue() const
 {
-    return _commandQueue;
+    return _commandQueue.get();
 }
 
 HgiVulkanCapabilities const&
@@ -589,7 +675,7 @@ HgiVulkanDevice::GetVulkanPhysicalDevice() const
 HgiVulkanPipelineCache*
 HgiVulkanDevice::GetPipelineCache() const
 {
-    return _pipelineCache;
+    return _pipelineCache.get();
 }
 
 void
@@ -598,18 +684,6 @@ HgiVulkanDevice::WaitForIdle()
     // HgiVulkan only uses a single command queue at the moment,
     // so we flush that queue and wait.
     GetCommandQueue()->Flush(HgiSubmitWaitTypeWaitUntilCompleted);
-}
-
-bool
-HgiVulkanDevice::IsSupportedExtension(const char* extensionName) const
-{
-    for (VkExtensionProperties const& ext : _vkExtensions) {
-        if (!strcmp(extensionName, ext.extensionName)) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 void

--- a/pxr/imaging/hgiVulkan/device.h
+++ b/pxr/imaging/hgiVulkan/device.h
@@ -10,6 +10,7 @@
 #include "pxr/pxr.h"
 
 #include "pxr/imaging/hgiVulkan/api.h"
+#include "pxr/imaging/hgiVulkan/deviceFilter.h"
 #include "pxr/imaging/hgiVulkan/vulkan.h"
 
 #include <mutex>
@@ -23,6 +24,34 @@ class HgiVulkanCommandQueue;
 class HgiVulkanInstance;
 class HgiVulkanPipelineCache;
 
+/// \class HgiVulkanExtensionSet
+///
+/// Convenience wrapper for a list of VkExtensionProperties.
+///
+class HgiVulkanExtensionSet
+{
+public:
+    HGIVULKAN_API
+    HgiVulkanExtensionSet() = default;
+
+    /// Query the extensions from a physical device and populate the set.
+    HGIVULKAN_API
+    explicit HgiVulkanExtensionSet(VkPhysicalDevice device);
+
+    /// Check if the set contains and extension with a given name.
+    HGIVULKAN_API
+    bool Contains(std::string_view name) const;
+
+    /// Get the extensions properties for a given extension name. Returns null
+    /// if the extension isn't found.
+    HGIVULKAN_API
+    const VkExtensionProperties* Find(std::string_view name) const;
+
+private:
+    std::vector<VkExtensionProperties> _extensions;
+    std::unordered_map<std::string_view,
+        std::reference_wrapper<const VkExtensionProperties>> _extensionsByName;
+};
 
 /// \class HgiVulkanDevice
 ///
@@ -32,7 +61,7 @@ class HgiVulkanDevice final
 {
 public:
     HGIVULKAN_API
-    HgiVulkanDevice(HgiVulkanInstance* instance);
+    HgiVulkanDevice(HgiVulkanInstance* instance, HgiDeviceFilter* filter);
 
     HGIVULKAN_API
     ~HgiVulkanDevice();
@@ -80,8 +109,18 @@ public:
     HGIVULKAN_API
     void WaitForIdle();
 
+    HGIVULKAN_API
+    const HgiVulkanExtensionSet& GetExtensions() const
+    {
+        return _vkExtensions;
+    }
+
     /// Returns true if the provided extension is supported by the device
-    bool IsSupportedExtension(const char* extensionName) const;
+    HGIVULKAN_API
+    bool IsSupportedExtension(const char* extensionName) const
+    {
+        return _vkExtensions.Contains(extensionName);
+    }
 
     // Dumps detailed stats from VMA to VmaStatsOut.json in the working dir.
     // Can be processed with GpuMemDumpVis.py for easier readability.
@@ -115,7 +154,7 @@ private:
     // Vulkan device objects
     VkPhysicalDevice _vkPhysicalDevice;
     VkDevice _vkDevice;
-    std::vector<VkExtensionProperties> _vkExtensions;
+    HgiVulkanExtensionSet _vkExtensions;
     VmaAllocator _vmaAllocator;
     std::mutex _vmaInteropPoolsLock;
     std::unordered_map<uint32_t, VmaPool> _vmaInteropPoolsForMemoryType;
@@ -126,9 +165,9 @@ private:
     std::unordered_map<VkDeviceMemory, HANDLE> _vmaInteropWin32HandleForMemory;
 #endif
     uint32_t _vkGfxsQueueFamilyIndex;
-    HgiVulkanCommandQueue* _commandQueue;
-    HgiVulkanCapabilities* _capabilities;
-    HgiVulkanPipelineCache* _pipelineCache;
+    std::unique_ptr<HgiVulkanCommandQueue> _commandQueue;
+    std::unique_ptr<HgiVulkanCapabilities> _capabilities;
+    std::unique_ptr<HgiVulkanPipelineCache> _pipelineCache;
 };
 
 

--- a/pxr/imaging/hgiVulkan/deviceFilter.h
+++ b/pxr/imaging/hgiVulkan/deviceFilter.h
@@ -1,0 +1,66 @@
+//
+// Copyright 2025 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HGIVULKAN_DEVICE_FILTER_H
+#define PXR_IMAGING_HGIVULKAN_DEVICE_FILTER_H
+
+#include "pxr/pxr.h"
+
+#include "pxr/imaging/hgi/deviceFilter.h"
+#include "pxr/imaging/hgi/tokens.h"
+
+#include "pxr/imaging/hgiVulkan/api.h"
+#include "pxr/imaging/hgiVulkan/capabilities.h"
+#include "pxr/imaging/hgiVulkan/vulkan.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+///
+/// \class HgiVulkanDeviceFilter
+///
+/// Hgi creation will fail if all devices are filtered out.
+class HgiVulkanDeviceFilter : public HgiDeviceFilter
+{
+public:
+    virtual ~HgiVulkanDeviceFilter() = default;
+
+    const TfToken& GetTargetHgiName() const override final
+    {
+        return HgiTokens->Vulkan;
+    }
+
+    /// If the filter is directly loading a driver, then instance extensions are
+    /// unknown until the instance is actually created. Override this function
+    /// to provide the missing extensions, using the workarounds described here:
+    /// https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderDriverInterface.md#limitations-of-vk_lunarg_direct_driver_loading
+    virtual std::vector<VkExtensionProperties>
+    GetDirectDriverInstanceExtensions() const
+    {
+        return {};
+    }
+
+    /// Edit the instance creation info just before it is created. This will
+    /// already have been pre-populated according to the HgiVulkan requirements.
+    /// Changes should be compatible with the existing instance parameters.
+    virtual void PreInstantiate(VkInstanceCreateInfo& info)
+    {
+    }
+
+    virtual bool FilterDevice(const HgiCapabilities& capabilities) override
+    {
+        return true;
+    }
+
+    /// Overload for more detailed device filtering. This will already have been
+    /// pre-populated according to the HgiVulkan requirements. Changes should be
+    /// compatible with the existing device parameters.
+    virtual bool FilterDevice(const HgiVulkanCapabilities& capabilities,
+        VkPhysicalDevice device, VkDeviceCreateInfo& info) = 0;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hgiVulkan/hgi.cpp
+++ b/pxr/imaging/hgiVulkan/hgi.cpp
@@ -12,6 +12,7 @@
 #include "pxr/imaging/hgiVulkan/computeCmds.h"
 #include "pxr/imaging/hgiVulkan/computePipeline.h"
 #include "pxr/imaging/hgiVulkan/device.h"
+#include "pxr/imaging/hgiVulkan/deviceFilter.h"
 #include "pxr/imaging/hgiVulkan/diagnostic.h"
 #include "pxr/imaging/hgiVulkan/garbageCollector.h"
 #include "pxr/imaging/hgiVulkan/graphicsCmds.h"
@@ -40,9 +41,9 @@ TF_REGISTRY_FUNCTION(TfType)
     t.SetFactory<HgiFactory<HgiVulkan>>();
 }
 
-HgiVulkan::HgiVulkan()
-    : _instance(new HgiVulkanInstance())
-    , _device(new HgiVulkanDevice(_instance))
+HgiVulkan::HgiVulkan(HgiDeviceFilter* filter)
+    : _instance(new HgiVulkanInstance(dynamic_cast<HgiVulkanDeviceFilter*>(filter)))
+    , _device(new HgiVulkanDevice(_instance, filter))
     , _garbageCollector(new HgiVulkanGarbageCollector(this))
     , _threadId(std::this_thread::get_id())
     , _frameDepth(0)
@@ -75,17 +76,17 @@ HgiVulkan::IsBackendSupported() const
         return false;
     }
 
-    // Want Vulkan 1.2 or higher.
+    // Want Vulkan 1.3 or higher.
     const uint32_t apiVersion = GetCapabilities()->GetAPIVersion();
     const uint32_t majorVersion = VK_VERSION_MAJOR(apiVersion);
     const uint32_t minorVersion = VK_VERSION_MINOR(apiVersion);
 
     bool support = (majorVersion > 1) ||
-        ((majorVersion == 1) && (minorVersion >= 2));
+        ((majorVersion == 1) && (minorVersion >= 3));
     if (!support) {
         TF_DEBUG(HGI_DEBUG_IS_SUPPORTED).Msg(
             "HgiVulkan unsupported due to Vulkan API version: %d.%d "
-            "(must be >= 1.2)\n",
+            "(must be >= 1.3)\n",
             majorVersion, minorVersion);
     }
     return support;

--- a/pxr/imaging/hgiVulkan/hgi.h
+++ b/pxr/imaging/hgiVulkan/hgi.h
@@ -34,7 +34,7 @@ class HgiVulkan final : public Hgi
 {
 public:
     HGIVULKAN_API
-    HgiVulkan();
+    HgiVulkan(HgiDeviceFilter* filter = nullptr);
 
     HGIVULKAN_API
     ~HgiVulkan() override;

--- a/pxr/imaging/hgiVulkan/instance.cpp
+++ b/pxr/imaging/hgiVulkan/instance.cpp
@@ -59,7 +59,8 @@ _RemoveUnsupportedInstanceLayers(
 static
 std::vector<const char*>
 _RemoveUnsupportedInstanceExtensions(
-    const std::vector<const char*>& desiredExtensions)
+    const std::vector<const char*>& desiredExtensions,
+    HgiVulkanDeviceFilter* filter)
 {
     // Determine available instance extensions.
     uint32_t numAvailableExtensions = 0u;
@@ -70,6 +71,15 @@ _RemoveUnsupportedInstanceExtensions(
     HGIVULKAN_VERIFY_VK_RESULT(vkEnumerateInstanceExtensionProperties(
         nullptr, &numAvailableExtensions,
         availableExtensions.data()));
+
+    if (filter) {
+        // Merge in extensions provided by the device filter (e.g. from a
+        // direct-loaded ICD that the loader doesn't know about yet).
+        const auto driverExtensions =
+            filter->GetDirectDriverInstanceExtensions();
+        availableExtensions.insert(availableExtensions.end(),
+            driverExtensions.begin(), driverExtensions.end());
+    }
 
     std::vector<const char*> extensions;
 
@@ -88,7 +98,7 @@ _RemoveUnsupportedInstanceExtensions(
     return extensions;
 }
 
-HgiVulkanInstance::HgiVulkanInstance()
+HgiVulkanInstance::HgiVulkanInstance(HgiVulkanDeviceFilter* filter)
     : vkDebugMessenger(nullptr)
     , vkCreateDebugUtilsMessengerEXT(nullptr)
     , vkDestroyDebugUtilsMessengerEXT(nullptr)
@@ -151,7 +161,7 @@ HgiVulkanInstance::HgiVulkanInstance()
     }
 
     layers = _RemoveUnsupportedInstanceLayers(layers);
-    extensions = _RemoveUnsupportedInstanceExtensions(extensions);
+    extensions = _RemoveUnsupportedInstanceExtensions(extensions, filter);
 
     _hasPresentation = std::any_of(extensions.begin(), extensions.end(),
         [](const char* extensionName) {
@@ -172,6 +182,10 @@ HgiVulkanInstance::HgiVulkanInstance()
                 VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
         }
     #endif
+
+    if (filter) {
+        filter->PreInstantiate(createInfo);
+    }
 
     HGIVULKAN_VERIFY_VK_RESULT(
         vkCreateInstance(

--- a/pxr/imaging/hgiVulkan/instance.h
+++ b/pxr/imaging/hgiVulkan/instance.h
@@ -10,6 +10,7 @@
 #include "pxr/pxr.h"
 
 #include "pxr/imaging/hgiVulkan/api.h"
+#include "pxr/imaging/hgiVulkan/deviceFilter.h"
 #include "pxr/imaging/hgiVulkan/vulkan.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -23,7 +24,7 @@ class HgiVulkanInstance final
 {
 public:
     HGIVULKAN_API
-    HgiVulkanInstance();
+    HgiVulkanInstance(HgiVulkanDeviceFilter* filter);
 
     HGIVULKAN_API
     ~HgiVulkanInstance();

--- a/pxr/usdImaging/usdImagingGL/engine.cpp
+++ b/pxr/usdImaging/usdImagingGL/engine.cpp
@@ -413,12 +413,13 @@ UsdImagingGLEngine::UsdImagingGLEngine(
     , _allowAsynchronousSceneProcessing(allowAsynchronousSceneProcessing)
     , _enableUsdDrawModes(enableUsdDrawModes)
 {
-    if (!_gpuEnabled && _hgiDriver.name == HgiTokens->renderDriver &&
-        _hgiDriver.driver.IsHolding<Hgi*>()) {
-        TF_WARN("Trying to share GPU resources while disabling the GPU.");
-        _gpuEnabled = true;
+    if (_hgiDriver.driver.IsHolding<Hgi*>()) {
+        if (!_gpuEnabled && _hgiDriver.name == HgiTokens->renderDriver) {
+            TF_WARN("Trying to share GPU resources while disabling the GPU.");
+            _gpuEnabled = true;
+        }
+        _hgi = _hgiDriver.driver.Get<Hgi*>();
     }
-
     // _renderIndex, _taskController, and _sceneDelegate/_sceneIndex
     // are initialized by the plugin system.
     if (!SetRendererPlugin(!rendererPluginId.IsEmpty() ?
@@ -1604,9 +1605,10 @@ UsdImagingGLEngine::_InitializeHgiIfNecessary()
     // may have multiple UsdImagingGLEngines in one app that ideally all use
     // the same HdDriver and Hgi to share GPU resources.
     if (_gpuEnabled && _hgiDriver.driver.IsEmpty()) {
-        _hgi = Hgi::CreatePlatformDefaultHgi();
+        _ownedHgi = Hgi::CreatePlatformDefaultHgi();
+        _hgi = _ownedHgi.get();
         _hgiDriver.name = HgiTokens->renderDriver;
-        _hgiDriver.driver = VtValue(_hgi.get());
+        _hgiDriver.driver = VtValue(_hgi);
     }
 }
 
@@ -1620,7 +1622,7 @@ UsdImagingGLEngine::SetRendererPlugin(TfToken const &id)
 
     HdRendererCreateArgs rendererCreateArgs;
     rendererCreateArgs.gpuEnabled = _gpuEnabled;
-    rendererCreateArgs.hgi = _hgi.get();
+    rendererCreateArgs.hgi = _hgi;
 
     const TfToken resolvedId =
         id.IsEmpty()
@@ -2613,7 +2615,7 @@ UsdImagingGLEngine::GetHgi()
         return nullptr;
     }
 
-    return _hgi.get();
+    return _hgi;
 }
 
 //----------------------------------------------------------------------------

--- a/pxr/usdImaging/usdImagingGL/engine.h
+++ b/pxr/usdImaging/usdImagingGL/engine.h
@@ -125,6 +125,8 @@ public:
     /// An HdDriver, containing the Hgi of your choice, can be optionally passed
     /// in during construction. This can be helpful if you application creates
     /// multiple UsdImagingGLEngine that wish to use the same HdDriver / Hgi.
+    /// The caller must ensure that the Hgi instance outlives the
+    /// UsdImagingGLEngine one.
     /// The \p rendererPluginId argument indicates the renderer plugin that
     /// Hyrda should use. If the empty token is passed in, a default renderer
     /// plugin will be chosen depending on the value of \p gpuEnabled.
@@ -796,7 +798,7 @@ protected:
     // in the future and subclasses should use the above getters
     // to access them instead.
 
-    HgiUniquePtr _hgi;
+    Hgi* _hgi;
     // Similar for HdDriver.
     HdDriver _hgiDriver;
 
@@ -871,6 +873,10 @@ private:
     /* Hydra 1.0 */
     std::unique_ptr<UsdImagingDelegate> _sceneDelegate;
     std::unique_ptr<HdEngine> _engine;
+
+    // If an Hgi instance was create for this engine instance,
+    // this pointer owns it. Otherwise it is null.
+    HgiUniquePtr _ownedHgi;
 
     bool _allowAsynchronousSceneProcessing = false;
     bool _enableUsdDrawModes = true;


### PR DESCRIPTION
### Description of Change(s)

- Fix usage of `Hgi` in `UsdImagingGLEngine`.
  - It was mostly ignoring a user provided `Hgi` instance.
- Add `HgiDeviceFilter` which lets you hook into the `Hgi` instance and/or device selection and creation.
  - This can be used implementation agnostic, but limits you information exposed by the `HgiCapabilities` API.
    - If you link against a specific Hgi implementation, then you can downcast to the backend class, which might expose more API specific information (especially the case with Vulkan).
  - To hook into the creation arguments, you insteead need to implement the backend specific subinterface of `HgiDeviceFilter`. Those unlock the full power of the API.
  - Since the OpenGL context (the closest thing it has to a device) is created externally, it ignores the device filter result (with a warning). It only ever enumerates a single device, and it should have already been setup by the application.

Examples:
```cpp
class UmaHgiDeviceFilter : public HgiDeviceFilter
{
public:
   ~UmaHgiDeviceFilter() override = default;

   bool FilterDevice(const HgiCapabilities& capabilities) override
   {
      return capabilities.IsSet(HgiDeviceCapabilitiesBitsUnifiedMemory);
   }
};

class SoftwareVkHgiDeviceFilter : public HgiDeviceFilter
{
public:
   ~SoftwareVkHgiDeviceFilter() override = default;

   const TfToken& GetTargetHgiName() const override
   {
      return HgiTokens->Vulkan;
   }

   bool FilterDevice(const HgiCapabilities& capabilities) override
   {
      return dynamic_cast<const HgiVulkanCapabilities*>(&capabilities)->vkDeviceProperties2.properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU;
   }
};

class FixMoltenVkHgiDeviceFitler : public HgiVulkanDeviceFilter
{
public:
   ~FixMoltenVkHgiDeviceFitler() override = default;

   bool FilterDevice(const HgiVulkanCapabilities& capabilities,
        VkPhysicalDevice device, VkDeviceCreateInfo& info) override
   {
      static constexpr uint32_t appleVendorID = 0x106B;
      if (capabilities.vkDeviceProperties2.properties.vendorID == appleVendorID) {
         // Disable host image copy on MoltenVK because it's bugged and crashes
         auto next = reinterpret_cast<const VkBaseOutStructure*>(info.pNext);
         while (next != nullptr) {
            switch (next->sType) {
               case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT:
                  {
                     auto hostImageCopyFeatures = reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeaturesEXT*>(next);
                     const_cast<VkPhysicalDeviceHostImageCopyFeaturesEXT*>(hostImageCopyFeatures)->hostImageCopy = false;
                  }
                  break;
               default:
                  break;
            }

            next = reinterpret_cast<VkBaseOutStructure*>(next->pNext);
         }
      }

      return true;
   }
};
```

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
