### PR TITLE
Ensure that the Light Filter adapter handles updates from child shader nodes to dirty its `material` locator.

### DIFF
--- a/pxr/usdImaging/usdImaging/lightFilterAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/lightFilterAdapter.cpp
@@ -264,4 +264,31 @@ UsdImagingLightFilterAdapter::InvalidateImagingSubprim(
     return result;
 }
 
+UsdImagingPrimAdapter::PopulationMode
+UsdImagingLightFilterAdapter::GetPopulationMode()
+{
+    return RepresentsSelfAndDescendents;
+}
+
+HdDataSourceLocatorSet
+UsdImagingLightFilterAdapter::InvalidateImagingSubprimFromDescendent(
+        UsdPrim const& prim,
+        UsdPrim const& descendentPrim,
+        TfToken const& subprim,
+        TfTokenVector const& properties,
+        const UsdImagingPropertyInvalidationType invalidationType)
+{
+    HdDataSourceLocatorSet result;
+
+    UsdLuxLightFilter filter(prim);
+    if (!filter) {
+        return result;
+    }
+
+    // TODO: perhaps enable more selective dirtying, as is done in UsdImagingMaterialAdapter
+    result.insert(HdMaterialSchema::GetDefaultLocator());
+
+    return result;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImaging/lightFilterAdapter.h
+++ b/pxr/usdImaging/usdImaging/lightFilterAdapter.h
@@ -124,6 +124,17 @@ public:
             TfTokenVector const& properties,
             UsdImagingPropertyInvalidationType invalidationType) override;
 
+    USDIMAGING_API
+    PopulationMode GetPopulationMode() override;
+
+    USDIMAGING_API
+    HdDataSourceLocatorSet InvalidateImagingSubprimFromDescendent(
+            UsdPrim const& prim,
+            UsdPrim const& descendentPrim,
+            TfToken const& subprim,
+            TfTokenVector const& properties,
+            UsdImagingPropertyInvalidationType invalidationType) override;
+
 protected:
     USDIMAGING_API
     void _RemovePrim(SdfPath const& cachePath,


### PR DESCRIPTION
### Description of Change(s)

Ensuring the Light Filter adapter returns RepresentsSelfAndDescendents and handles the updates for any child shading nodes. This allows updates to flow through Hydra 2.

### Fixes Issue(s)

This partially addresses #3908 but I suspect there could be more work still to do

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
