### PR TITLE
Autodesk: [hdx] Improve pickTask to use deep selection only when enabled

### DIFF
--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -51,6 +51,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     (PickBufferBinding)
     (Picking)
 
+    (withDeepSelect)
+    (noDeepSelect)
+
     (overlayDepthStencil)
 );
 
@@ -69,19 +72,32 @@ static const int PICK_BUFFER_HEADER_SIZE = 8;
 static const int PICK_BUFFER_SUBBUFFER_CAPACITY = 32;
 static const int PICK_BUFFER_ENTRY_SIZE = 3;
 
+static HdStRenderPassShaderSharedPtr
+_CreatePickingShader(bool deepSelect)
+{
+    HioGlslfxSharedPtr glslfx = std::make_shared<HioGlslfx>(
+        HdxPackageRenderPassPickingShader(), 
+        deepSelect ? _tokens->withDeepSelect : _tokens->noDeepSelect);
+    return std::make_shared<HdStRenderPassShader>(glslfx);
+}
+
+static void
+_UpdateRenderPassStateShader(HdRenderPassStateSharedPtr const& rps, 
+                             bool deepSelect)
+{
+    if (HdStRenderPassState* extendedState =
+            dynamic_cast<HdStRenderPassState*>(rps.get())) {
+        extendedState->SetRenderPassShader(_CreatePickingShader(deepSelect));
+    }
+}
+
 static HdRenderPassStateSharedPtr
-_InitIdRenderPassState(HdRenderIndex *index)
+_InitIdRenderPassState(HdRenderIndex *index, bool deepSelect)
 {
     HdRenderPassStateSharedPtr rps =
         index->GetRenderDelegate()->CreateRenderPassState();
 
-    if (HdStRenderPassState* extendedState =
-            dynamic_cast<HdStRenderPassState*>(
-                rps.get())) {
-        extendedState->SetRenderPassShader(
-            std::make_shared<HdStRenderPassShader>(
-                HdxPackageRenderPassPickingShader()));
-    }
+    _UpdateRenderPassStateShader(rps, deepSelect);
 
     return rps;
 }
@@ -111,6 +127,7 @@ HdxPickTask::HdxPickTask(HdSceneDelegate* delegate, SdfPath const& id)
     : HdTask(id)
     , _renderTags()
     , _useOverlayPass(false)
+    , _useDeepSelection(false)
     , _index(nullptr)
     , _hgi(nullptr)
     , _pickableDepthIndex(0)
@@ -126,10 +143,13 @@ HdxPickTask::~HdxPickTask()
 void
 HdxPickTask::_InitIfNeeded()
 {
+    const bool deepSelectionIsDirty =
+        (_contextParams.resolveMode == HdxPickTokens->resolveDeep) != _useDeepSelection;
+    _useDeepSelection = _contextParams.resolveMode == HdxPickTokens->resolveDeep;
     // Init pick buffer
-    if (!_pickBuffer) {
+    if (!_pickBuffer && _useDeepSelection) {
         HdStResourceRegistrySharedPtr const& hdStResourceRegistry =
-            std::dynamic_pointer_cast<HdStResourceRegistry>(
+            std::dynamic_pointer_cast<HdStResourceRegistry >(
                 _index->GetResourceRegistry());
 
         if (hdStResourceRegistry) {
@@ -142,6 +162,8 @@ HdxPickTask::_InitIfNeeded()
                         _tokens->Picking, 
                         bufferSpecs, HdBufferArrayUsageHintBitsStorage);
         }
+    } else if (_pickBuffer && !_useDeepSelection) {
+        _pickBuffer = nullptr;
     }
 
     if (_pickableAovBuffers.empty()) {
@@ -168,10 +190,11 @@ HdxPickTask::_InitIfNeeded()
         _overlayRenderPass = 
             _index->GetRenderDelegate()->CreateRenderPass(&*_index, col);
 
+        // Initialize _useDeepSelection based on current context params
         // initialize renderPassStates with ID render shader
-        _pickableRenderPassState = _InitIdRenderPassState(_index);
-        _occluderRenderPassState = _InitIdRenderPassState(_index);
-        _overlayRenderPassState = _InitIdRenderPassState(_index);
+        _pickableRenderPassState = _InitIdRenderPassState(_index, _useDeepSelection);
+        _occluderRenderPassState = _InitIdRenderPassState(_index, _useDeepSelection);
+        _overlayRenderPassState = _InitIdRenderPassState(_index, _useDeepSelection);
         // Turn off color writes for the occluders, wherein we want to only
         // condition the depth buffer and not write out any IDs.
         // XXX: This is a hacky alternative to using a different shader mixin
@@ -179,6 +202,17 @@ HdxPickTask::_InitIfNeeded()
         _occluderRenderPassState->SetColorMaskUseDefault(false);
         _occluderRenderPassState->SetColorMasks(
             {HdRenderPassState::ColorMaskNone});
+    }
+
+    if (deepSelectionIsDirty) {
+        if (_pickableRenderPassState && _occluderRenderPassState && _overlayRenderPassState) {
+            _UpdateRenderPassStateShader(_pickableRenderPassState, 
+                                         _useDeepSelection);
+            _UpdateRenderPassStateShader(_occluderRenderPassState, 
+                                         _useDeepSelection);
+            _UpdateRenderPassStateShader(_overlayRenderPassState, 
+                                         _useDeepSelection);
+        }
     }
 }
 
@@ -655,7 +689,7 @@ HdxPickTask::Prepare(HdTaskContext* ctx,
         extendedState ? extendedState->GetRenderPassShader() : nullptr;
 
     if (renderPassShader) {
-        if (_pickBuffer) {
+        if (_pickBuffer && _useDeepSelection) {
             renderPassShader->AddBufferBinding(
                 HdStBindingRequest(
                     HdStBinding::SSBO,

--- a/pxr/imaging/hdx/pickTask.h
+++ b/pxr/imaging/hdx/pickTask.h
@@ -347,6 +347,7 @@ private:
     HdxPickTaskContextParams _contextParams;
     TfTokenVector _renderTags;
     bool _useOverlayPass;
+    bool _useDeepSelection;
 
     // We need to cache a pointer to the render index so Execute() can
     // map prim ID to paths.

--- a/pxr/imaging/hdx/shaders/renderPass.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPass.glslfx
@@ -138,59 +138,14 @@ void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
     }
 }
 
--- layout HdxRenderPass.RenderPick
+-- layout HdxRenderPass.RenderPickDeepSelect
 
 [
-    ["out", "int", "primIdOut"],
-    ["out", "int", "instanceIdOut"],
-    ["out", "int", "elementIdOut"],
-    ["out", "int", "edgeIdOut"],
-    ["out", "int", "pointIdOut"],
-    ["out", "vec4", "neyeOut"],
     ["buffer readWrite", "CounterBuffer", "PickBuffer", ["atomic_int", "PickBuffer"]]
 ]
 
--- glsl HdxRenderPass.RenderPick
+-- glsl HdxRenderPass.RenderPickDeepSelect
 
-vec4 IntToVec4(int id)
-{
-    return vec4(((id >>  0) & 0xff) / 255.0,
-                ((id >>  8) & 0xff) / 255.0,
-                ((id >> 16) & 0xff) / 255.0,
-                ((id >> 24) & 0xff) / 255.0);
-}
-
-// Fwd declare necessary methods to determine the subprim id of a fragment.
-FORWARD_DECL(int GetElementID()); // generated via codeGen
-FORWARD_DECL(int GetPrimitiveEdgeId()); // defined in edgeId.glslfx, or generated via codeGen
-FORWARD_DECL(int GetPointId()); // defined in pointId.glslfx
-
-// Declared below.
-#if defined(HD_HAS_PickBuffer)
-FORWARD_DECL(void RenderDeepPicks(int primId, int instanceId, int elementId, int edgeId, int pointId));
-#endif
-
-void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
-{
-    primIdOut = HdGet_primID();
-
-    // instanceIndex is a tuple of integers (num nested levels).
-    // for picking, we store global instanceId (instanceIndex[0]) in the
-    // selection framebuffer and then reconstruct the tuple in postprocess.
-    instanceIdOut = GetDrawingCoord().instanceIndex[0];
-
-    elementIdOut = GetElementID();
-    edgeIdOut = GetPrimitiveEdgeId();
-    pointIdOut = GetPointId();
-    
-    neyeOut = IntToVec4(hd_vec4_2_10_10_10_set(vec4(Neye,0)));
-
-#if defined(HD_HAS_PickBuffer)
-    RenderDeepPicks(primIdOut, instanceIdOut, elementIdOut, edgeIdOut, pointIdOut);
-#endif
-}
-
-#if defined(HD_HAS_PickBuffer)
 int cantor(int a, int b) {
    return (a + b + 1) * (a + b) / 2 + b;
 }
@@ -331,7 +286,57 @@ void RenderDeepPicks(int primId, int instanceId, int elementId,
     }
     while (bufferNumber != subBufferNumber);
 }
-#endif // HD_HAS_PickBuffer
+
+-- layout HdxRenderPass.RenderPick
+
+[
+    ["out", "int", "primIdOut"],
+    ["out", "int", "instanceIdOut"],
+    ["out", "int", "elementIdOut"],
+    ["out", "int", "edgeIdOut"],
+    ["out", "int", "pointIdOut"],
+    ["out", "vec4", "neyeOut"]
+]
+
+-- glsl HdxRenderPass.RenderPick
+
+vec4 IntToVec4(int id)
+{
+    return vec4(((id >>  0) & 0xff) / 255.0,
+                ((id >>  8) & 0xff) / 255.0,
+                ((id >> 16) & 0xff) / 255.0,
+                ((id >> 24) & 0xff) / 255.0);
+}
+
+// Fwd declare necessary methods to determine the subprim id of a fragment.
+FORWARD_DECL(int GetElementID()); // generated via codeGen
+FORWARD_DECL(int GetPrimitiveEdgeId()); // defined in edgeId.glslfx, or generated via codeGen
+FORWARD_DECL(int GetPointId()); // defined in pointId.glslfx
+
+// Declared below.
+#if defined(HD_HAS_PickBuffer)
+FORWARD_DECL(void RenderDeepPicks(int primId, int instanceId, int elementId, int edgeId, int pointId));
+#endif
+
+void RenderOutput(vec4 Peye, vec3 Neye, vec4 color, vec4 patchCoord)
+{
+    primIdOut = HdGet_primID();
+
+    // instanceIndex is a tuple of integers (num nested levels).
+    // for picking, we store global instanceId (instanceIndex[0]) in the
+    // selection framebuffer and then reconstruct the tuple in postprocess.
+    instanceIdOut = GetDrawingCoord().instanceIndex[0];
+
+    elementIdOut = GetElementID();
+    edgeIdOut = GetPrimitiveEdgeId();
+    pointIdOut = GetPointId();
+    
+    neyeOut = IntToVec4(hd_vec4_2_10_10_10_set(vec4(Neye,0)));
+
+#if defined(HD_HAS_PickBuffer)
+    RenderDeepPicks(primIdOut, instanceIdOut, elementIdOut, edgeIdOut, pointIdOut);
+#endif
+}
 
 -- layout HdxRenderPass.RenderColorAndSelection
 

--- a/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
+++ b/pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx
@@ -16,7 +16,39 @@
 -- configuration
 {
     "techniques": {
-        "default": {
+        "withDeepSelect": {
+            "vertexShader" : {
+                "source": [ "RenderPass.Camera",
+                            "RenderPass.ApplyClipPlanes" ]
+            },
+            "postTessControlShader" : {
+                "source": [ "RenderPass.Camera" ]
+            },
+            "postTessVertexShader" : {
+                "source": [ "RenderPass.Camera",
+                            "RenderPass.ApplyClipPlanes" ]
+            },
+            "tessControlShader" : {
+                "source": [ "RenderPass.Camera" ]
+            },
+            "tessEvalShader" : {
+                "source": [ "RenderPass.Camera",
+                            "RenderPass.ApplyClipPlanes" ]
+            },
+            "geometryShader" : {
+                "source": [ "RenderPass.Camera",
+                            "RenderPass.ApplyClipPlanes" ]
+            },
+            "fragmentShader" : {
+                "source": [ "RenderPass.Camera",
+                            "RenderPass.CameraFS",
+                            "RenderPass.NoSelection",
+                            "RenderPass.NoColorOverrides",
+                            "HdxRenderPass.RenderPickDeepSelect",
+                            "HdxRenderPass.RenderPick" ]
+            }
+        },
+        "noDeepSelect": {
             "vertexShader" : {
                 "source": [ "RenderPass.Camera",
                             "RenderPass.ApplyClipPlanes" ]


### PR DESCRIPTION
### Description of Change(s)

- Add logic to change the technique used when creating the glslfx shader to include or exclude deep selection code. Before the change, the `RenderDeepPicks` was always executed since the PickBuffer binding was always included in the shader through the glslfx layout.
- Add logic to clean up the pick buffer when deep selection is disabled.
- Add the `technique` attribute to the hash computation of a HioGlslfx object.
- Change the pxr/imaging/hdx/shaders/renderPassPickingShader.glslfx file to define a `withDeepSelect` and a `noDeepSelect` technique,

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
