### PR TITLE
Autodesk: [hd] Allow passing HdRendererCreateArgs to CreateDelegate() so IsSupported() can work correctly

### DIFF
--- a/pxr/imaging/hd/rendererCreateArgs.h
+++ b/pxr/imaging/hd/rendererCreateArgs.h
@@ -23,6 +23,16 @@ struct HdRendererCreateArgs
     bool gpuEnabled { true };
     // An Hgi instance to check backend support against.
     Hgi* hgi { nullptr };
+
+    bool operator==(const HdRendererCreateArgs& other) const
+    {
+        return gpuEnabled == other.gpuEnabled && hgi == other.hgi;
+    }
+
+    bool operator!=(const HdRendererCreateArgs& other) const
+    {
+        return !(*this == other);
+    }
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/imaging/hd/rendererPlugin.cpp
+++ b/pxr/imaging/hd/rendererPlugin.cpp
@@ -48,7 +48,14 @@ HdRendererPlugin::~HdRendererPlugin() = default;
 HdPluginRenderDelegateUniqueHandle
 HdRendererPlugin::CreateDelegate(HdRenderSettingsMap const& settingsMap)
 {
-    if (!IsSupported()) {
+    HdRendererCreateArgs rendererCreateArgs;
+    if (const auto iter = settingsMap.find(TfToken("rendererCreateArgs"));
+        iter != settingsMap.end()) {
+        rendererCreateArgs =
+            iter->second.GetWithDefault<HdRendererCreateArgs>();
+    }
+
+    if (!IsSupported(rendererCreateArgs)) {
         return nullptr;
     }
 


### PR DESCRIPTION
### Description of Change(s)

The main issue is that the `IsSupported()` call checks the default Hgi, which isn't necessarily what one is trying to use. If the default isn't supported, then you can't create a render delegate even if a non-default is supported. We've encountered an issue (Windows laptop) where HgiGL fails to create due to an OpenGL version problem, but HgiVulkan works. It should be possible to use HgiVulkan (non-default) even when HgiGL (default) doesn't work. This solution addresses this issue.

Note: You can set `HGI_ENABLE_VULKAN` to change the defaults, but that's not always an option, and isn't a proper solution as the environment variables are for development, not production.

Example use case: https://github.com/Autodesk/hydra-viewport-toolbox/blob/a24d055fcf0d146249afb7e6a693fd5763355ca0/source/engine/renderIndexProxy.cpp#L49-L56

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
