### PR TITLE
Fix geometry_opacity type in OpenPBR material tag check

### DIFF
--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -593,7 +593,7 @@ _GetOpenPBRSurfaceMaterialTag(HdMaterialNode2 const& terminal)
     // See https://academysoftwarefoundation.github.io/OpenPBR/
     // and the provided implementation
     if (_ParamDiffersFrom(terminal, _tokens->transmission_weight, 0.0f) ||
-        _ParamDiffersFrom(terminal, _tokens->geometry_opacity, GfVec3f(1.0f))) {
+        _ParamDiffersFrom(terminal, _tokens->geometry_opacity, 1.0f)) {
         return HdStMaterialTagTokens->translucent.GetString();
     }
 


### PR DESCRIPTION
Fixes #3172

Change geometry_opacity comparison from GfVec3f(1.0f) to 1.0f to match
the OpenPBR specification where geometry_opacity is a scalar float.