### PR TITLE
pxrConfig.cmake - don't bake in absolute paths for MaterialX/Imath/"work"

### DIFF
--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -77,41 +77,21 @@ if (PXR_FIND_OPENSUBDIV_IN_CONFIG)
     find_dependency(OpenSubdiv @OpenSubdiv_VERSION@ CONFIG)
 endif()
 
-# If MaterialX support was enabled for this USD build, try to find the
-# associated import targets by invoking the same FindMaterialX.cmake
-# module that was used for that build. This can be overridden by
-# specifying a different MaterialX_DIR when running cmake.
+# If MaterialX support was enabled for this USD build
+# find the MaterialX dependency
 if(@PXR_ENABLE_MATERIALX_SUPPORT@)
-    if (NOT DEFINED MaterialX_DIR)
-        if (NOT [[@MaterialX_DIR@]] STREQUAL "")
-            set(MaterialX_DIR [[@MaterialX_DIR@]])
-        endif()
-    endif()
     find_dependency(MaterialX)
 endif()
 
-# Similar to MaterialX above, we are using Imath's cmake package config, so set
-# the Imath_DIR accordingly to find the associated import targets which were
-# used for this USD build. 
-# Note that we only need to do this, when it is determined by Imath is being
-# used instead of OpenExr (refer Packages.cmake)
+# If Imath support was enabled for this USD build
+# find the Imath dependency
 if(@Imath_FOUND@)
-    if (NOT DEFINED Imath_DIR)
-        if (NOT [[@Imath_DIR@]] STREQUAL "")
-            set(Imath_DIR [[@Imath_DIR@]])
-        endif()
-    endif()
     find_dependency(Imath)
 endif()
 
 # If this build is using a custom work implementation, find the package
 # providing that implementation.
 if(NOT "@PXR_WORK_IMPL_PACKAGE@" STREQUAL "")
-    if (NOT DEFINED @PXR_WORK_IMPL_CONFIG_DIR_VAR@)
-        if (NOT [[@PXR_WORK_IMPL_CONFIG_DIR@]] STREQUAL "")
-            set(@PXR_WORK_IMPL_CONFIG_DIR_VAR@ [[@PXR_WORK_IMPL_CONFIG_DIR@]])
-        endif()
-    endif()
     find_dependency(@PXR_WORK_IMPL_PACKAGE@)
 endif()
 


### PR DESCRIPTION
### Description of Change(s)
Avoids baking absolute paths for MaterialX/Imath/"work".

The baking of the absolute path locations for various CMake dependencies into pxrConfig.cmake makes it less portable.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/15

### Fixes Issue(s)
- absolute paths getting baked into pxrConfig.cmake

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
