### PR TITLE
pxrConfig.cmake: don't bake in absolute python paths

### DIFF
--- a/pxr/pxrConfig.cmake.in
+++ b/pxr/pxrConfig.cmake.in
@@ -19,32 +19,9 @@ set(PXR_VERSION "@PXR_VERSION@")
 include(CMakeFindDependencyMacro)
 
 # If Python support was enabled for this USD build, find the import
-# targets by invoking the appropriate FindPython module. Use the same
-# LIBRARY and INCLUDE_DIR settings from the original build if they
-# were set. This can be overridden by specifying different values when
-# running cmake.
+# targets by invoking the appropriate FindPython module.
 if(@PXR_ENABLE_PYTHON_SUPPORT@)
-    if (NOT DEFINED Python3_EXECUTABLE)
-        if (NOT [[@Python3_EXECUTABLE@]] STREQUAL "")
-            set(Python3_EXECUTABLE [[@Python3_EXECUTABLE@]])
-        endif()
-    endif()
-
-    if (NOT DEFINED Python3_LIBRARY)
-        if (NOT [[@Python3_LIBRARY@]] STREQUAL "")
-            set(Python3_LIBRARY [[@Python3_LIBRARY@]])
-        endif()
-    endif()
-
-    if (NOT DEFINED Python3_INCLUDE_DIR)
-        if (NOT [[@Python3_INCLUDE_DIR@]] STREQUAL "")
-            set(Python3_INCLUDE_DIR [[@Python3_INCLUDE_DIR@]])
-        endif()
-    endif()
-
-    if (NOT DEFINED Python3_VERSION)
-        find_dependency(Python3 "@Python3_VERSION@" EXACT COMPONENTS Development)
-    else()
+    if(NOT Python3_FOUND)
         find_dependency(Python3 COMPONENTS Development)
     endif()
 endif()


### PR DESCRIPTION
### Description of Change(s)

Avoids baking absolute paths for python.

The baking of the absolute path locations for various CMake dependencies into pxrConfig.cmake makes it less portable.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/15

### Fixes Issue(s)

- absolute paths getting baked into pxrConfig.cmake

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
