### PR TITLE
only add PYTHON_INCLUDE_DIRS if PXR_PY_UNDEFINED_DYNAMIC_LOOKUP set

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -267,7 +267,16 @@ function(pxr_library NAME)
 
         if(libraryRequiresPython)
             list(APPEND args_LIBRARIES ${PYTHON_LIBRARIES} python)
-            list(APPEND args_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+            if(PXR_PY_UNDEFINED_DYNAMIC_LOOKUP)
+                # if PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is defined
+                # the Python3::Python target won't get added
+                # hence the INTERFACE_INCLUDE_DIRECTORIES for that
+                # target won't be available, so we add the Python
+                # includes explicitly here, otherwise don't add
+                # them so they are picked up via the cmake target's
+                # interface includes
+                list(APPEND args_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+            endif()
         endif()
     endif()
 

--- a/pxr/external/boost/python/CMakeLists.txt
+++ b/pxr/external/boost/python/CMakeLists.txt
@@ -29,12 +29,6 @@ pxr_library(python
         # PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is respected.
         ${PYTHON_LIBRARIES}
 
-    INCLUDE_DIRS
-        # Specify PYTHON_INCLUDE_DIRS explicitly to ensure this library
-        # picks up Python headers when PXR_PY_UNDEFINED_DYNAMIC_LOOKUP
-        # is set.
-        ${PYTHON_INCLUDE_DIRS}
-
     PUBLIC_HEADERS
         arg_from_python.hpp
         args.hpp


### PR DESCRIPTION
### Description of Change(s)

If PXR_PY_UNDEFINED_DYNAMIC_LOOKUP is not set, there is no need to explicitly add ${PYTHON_INCLUDE_DIRS}.  By avoiding doing so, we prevent some baking of absolute paths into pxrConfig.cmake

The baking of the absolute path locations for various CMake dependencies into pxrConfig.cmake makes it less portable.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/15

### Fixes Issue(s)

- absolute paths getting baked into pxrConfig.cmake

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))