### PR TITLE
[arch] Handle partial writes for stackTrace.cpp

### DIFF
--- a/pxr/base/arch/stackTrace.cpp
+++ b/pxr/base/arch/stackTrace.cpp
@@ -72,7 +72,6 @@
 
 #if defined(ARCH_OS_WINDOWS)
 #define getpid() _getpid()
-#define write(fd_, data_, size_) _write(fd_, data_, size_)
 #define strdup(str_) _strdup(str_)
 #endif
 
@@ -491,7 +490,23 @@ char* asitoa(char* s, long x)
 void aswrite(int fd, const char* msg)
 {
     int saved = errno;
-    write(fd, msg, asstrlen(msg));
+    size_t len = asstrlen(msg);
+    size_t written = 0;
+    while (written < len) {
+    #if defined(ARCH_OS_WINDOWS)
+        int n = _write(fd, msg + written, len - written);
+    #else
+        ssize_t n = write(fd, msg + written, len - written);
+    #endif
+        if (n < 0) {
+            // retry if the write is interrupted by a signal.
+            if (errno == EINTR)
+                continue;
+            // Fail on any other error.
+            break;
+        }
+        written += n;
+    }
     errno = saved;
 }
 


### PR DESCRIPTION
### Description of Change(s)

`aswrite` issues calls to `write()` which may perform a partial write depending on the size of the data. The change here checks the number of bytes written and writes any remaining data if needed.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
