### PR TITLE
UsdAbc: translate the property's arrayExtent metadata into elementSize

### DIFF
--- a/pxr/usd/plugin/usdAbc/CMakeLists.txt
+++ b/pxr/usd/plugin/usdAbc/CMakeLists.txt
@@ -74,6 +74,7 @@ pxr_plugin(usdAbc
 
 pxr_test_scripts(
     testenv/testUsdAbcAlembicData.py
+    testenv/testUsdAbcArrayExtent.py
     testenv/testUsdAbcBugs.py
     testenv/testUsdAbcCamera.py
     testenv/testUsdAbcConversionBasisCurves.py
@@ -96,6 +97,13 @@ pxr_register_test(testUsdAbcAlembicData
     EXPECTED_RETURN_CODE 0
     ENV 
         USD_ABC_NUM_OGAWA_STREAMS=2
+)
+
+pxr_register_test(testUsdAbcArrayExtent
+    PYTHON
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testUsdAbcArrayExtent"
+    TESTENV testenv/testUsdAbcArrayExtent
+    EXPECTED_RETURN_CODE 0
 )
 
 pxr_register_test(testUsdAbcBugs

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -2283,6 +2283,16 @@ _PrimReaderContext::_GetPropertyMetadata(
         }
     }
 
+    // The "arrayExtent" metadata is equivalent to USD's elementSize.
+    std::string arrayExtentValue = alembicMetadata.get("arrayExtent");
+    if (!arrayExtentValue.empty()) {
+        size_t end;
+        const int arrayExtent = std::stoi(arrayExtentValue, &end);
+        if (end == arrayExtentValue.size() && arrayExtent > 1) {
+            usdMetadata[UsdGeomTokens->elementSize] = arrayExtent;
+        }
+    }
+
     // Other Sdf metadata.
     _GetStringMetadata(alembicMetadata, usdMetadata, SdfFieldKeys->DisplayGroup);
     _GetStringMetadata(alembicMetadata, usdMetadata, SdfFieldKeys->Documentation);

--- a/pxr/usd/plugin/usdAbc/alembicReader.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicReader.cpp
@@ -2283,13 +2283,18 @@ _PrimReaderContext::_GetPropertyMetadata(
         }
     }
 
-    // The "arrayExtent" metadata is equivalent to USD's elementSize.
+    // The "arrayExtent" metadata is equivalent to USD's 'arraySizeConstraint'
+    // (the preferred choice), or 'elementSize' for primvars.
     std::string arrayExtentValue = alembicMetadata.get("arrayExtent");
     if (!arrayExtentValue.empty()) {
         size_t end;
         const int arrayExtent = std::stoi(arrayExtentValue, &end);
         if (end == arrayExtentValue.size() && arrayExtent > 1) {
             usdMetadata[UsdGeomTokens->elementSize] = arrayExtent;
+
+            // A value less than 0 indicates the array's tuple length.
+            int64_t sizeConstraint = -arrayExtent;
+            usdMetadata[SdfFieldKeys->ArraySizeConstraint] = sizeConstraint;
         }
     }
 
@@ -4338,4 +4343,3 @@ UsdAbc_AlembicDataReader::ListTimeSamplesForPath(
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -2037,6 +2037,15 @@ _GetPropertyMetadata(
         metadata.set("interpretation", interpretation);
     }
 
+    // The "arrayExtent" metadata is equivalent to USD's elementSize.
+    value = context.GetPropertyField(usdName, UsdGeomTokens->elementSize);
+    if (value.IsHolding<int>()) {
+        const int elementSize = value.UncheckedGet<int>();
+        if (elementSize > 1) {
+            metadata.set("arrayExtent", TfIntToString(elementSize));
+        }
+    }
+
     // Other Sdf metadata.
     _SetStringMetadata(&metadata, context, SdfFieldKeys->DisplayGroup, usdName);
     _SetStringMetadata(&metadata, context, SdfFieldKeys->Documentation,usdName);

--- a/pxr/usd/plugin/usdAbc/alembicWriter.cpp
+++ b/pxr/usd/plugin/usdAbc/alembicWriter.cpp
@@ -1996,6 +1996,40 @@ _SetDoubleMetadata(
     }
 }
 
+/// Return the array extent, using either the USD 'arraySizeConstraint'
+/// metadata (the preferred choice) or the 'elementSize' metadata for primvars.
+static
+bool
+_GetArrayExtent(
+    const _PrimWriterContext& context,
+    const TfToken& usdName,
+    int *outArrayExtent)
+{
+    VtValue value = context.GetPropertyField(
+        usdName, SdfFieldKeys->ArraySizeConstraint);
+    if (value.IsHolding<int64_t>()) {
+        // A value less than 0 indicates the array has a tuple size.
+        const int64_t sizeConstraint = value.UncheckedGet<int64_t>();
+        if (sizeConstraint < 0) {
+            *outArrayExtent = -sizeConstraint;
+            return true;
+        }
+
+        return false;
+    }
+
+    value = context.GetPropertyField(usdName, UsdGeomTokens->elementSize);
+    if (value.IsHolding<int>()) {
+        const int elementSize = value.UncheckedGet<int>();
+        if (elementSize > 1) {
+            *outArrayExtent = elementSize;
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static
 MetaData
 _GetPropertyMetadata(
@@ -2037,13 +2071,9 @@ _GetPropertyMetadata(
         metadata.set("interpretation", interpretation);
     }
 
-    // The "arrayExtent" metadata is equivalent to USD's elementSize.
-    value = context.GetPropertyField(usdName, UsdGeomTokens->elementSize);
-    if (value.IsHolding<int>()) {
-        const int elementSize = value.UncheckedGet<int>();
-        if (elementSize > 1) {
-            metadata.set("arrayExtent", TfIntToString(elementSize));
-        }
+    int arrayExtent = 0;
+    if (_GetArrayExtent(context, usdName, &arrayExtent)) {
+        metadata.set("arrayExtent", TfIntToString(arrayExtent));
     }
 
     // Other Sdf metadata.

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent.py
@@ -1,0 +1,43 @@
+#!/pxrpythonsubst
+#
+# Copyright 2025 Pixar
+#
+# Licensed under the terms set forth in the LICENSE.txt file available at
+# https://openusd.org/license.
+
+import unittest
+
+from pxr import Usd, UsdAbc, UsdGeom
+
+
+class TestUsdAbcArrayExtent(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        usdFile = 'original.usda'
+        abcFile = 'converted.abc'
+
+        UsdAbc._WriteAlembic(usdFile, abcFile)
+        cls.stage = Usd.Stage.Open(abcFile)
+
+    def test_Roundtrip(self):
+
+        prim = self.stage.GetPrimAtPath("/Prim")
+        self.assertTrue(prim)
+
+        primvarsToTest = [
+            ("arrayExtent1", False, 1),
+            ("podExtent2", False, 1),
+            ("arrayExtent2", True, 2),
+            ("arrayExtent3", True, 3),
+        ]
+
+        pvApi = UsdGeom.PrimvarsAPI(prim)
+        for name, authored, size in primvarsToTest:
+            pv = pvApi.GetPrimvar(name)
+            self.assertEqual(pv.HasAuthoredElementSize(), authored)
+            self.assertEqual(pv.GetElementSize(), size)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent.py
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent.py
@@ -33,10 +33,15 @@ class TestUsdAbcArrayExtent(unittest.TestCase):
         ]
 
         pvApi = UsdGeom.PrimvarsAPI(prim)
-        for name, authored, size in primvarsToTest:
+        for name, authored, tupleSize in primvarsToTest:
             pv = pvApi.GetPrimvar(name)
             self.assertEqual(pv.HasAuthoredElementSize(), authored)
-            self.assertEqual(pv.GetElementSize(), size)
+            self.assertEqual(pv.GetElementSize(), tupleSize)
+
+            attr = pv.GetAttr()
+            sizeConstraint = -tupleSize if authored else 0
+            self.assertEqual(attr.HasAuthoredArraySizeConstraint(), authored)
+            self.assertEqual(attr.GetArraySizeConstraint(), sizeConstraint)
 
 
 if __name__ == "__main__":

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent/original.usda
@@ -1,0 +1,34 @@
+#usda 1.0
+(
+    defaultPrim = "Prim"
+    endTimeCode = 1
+    startTimeCode = 0
+    timeCodesPerSecond = 24
+    upAxis = "Y"
+)
+
+def Mesh "Prim"
+{
+    int[] faceVertexCounts = [4]
+    int[] faceVertexIndices = [0, 1, 3, 2]
+    uniform token orientation = "leftHanded"
+    point3f[] points = [(-0.5, 0, -0.5), (0.5, 0, -0.5), (-0.5, 0, 0.5), (0.5, 0, 0.5)] (
+        interpolation = "vertex"
+    )
+    custom float[] primvars:arrayExtent1 = [0, 1, 2, 3] (
+        interpolation = "varying"
+    )
+    custom float[] primvars:arrayExtent2 = [0, 0, 1, 0, 2, 0, 3, 0] (
+        elementSize = 2
+        interpolation = "varying"
+    )
+    custom float2[] primvars:podExtent2 = [(0, 0), (1, 0), (2, 0), (3, 0)] (
+        interpolation = "varying"
+    )
+    custom float[] primvars:arrayExtent3 = [0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0] (
+        elementSize = 3
+        interpolation = "varying"
+    )
+    uniform token subdivisionScheme = "none"
+}
+

--- a/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent/original.usda
+++ b/pxr/usd/plugin/usdAbc/testenv/testUsdAbcArrayExtent/original.usda
@@ -26,7 +26,7 @@ def Mesh "Prim"
         interpolation = "varying"
     )
     custom float[] primvars:arrayExtent3 = [0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 0] (
-        elementSize = 3
+        arraySizeConstraint = -3
         interpolation = "varying"
     )
     uniform token subdivisionScheme = "none"


### PR DESCRIPTION
### Description of Change(s)

For the example file in the referenced bug report, the Alembic property has the metadata `arrayExtent: 3, podExtent: 1, podName: float32_t`.
This was translated into a `float[]` array with too many elements since the `arrayExtent` was ignored. This metadata seems to have an equivalent meaning to USD's elementSize, describing a grouping of consecutive elements in the array.

Houdini's Alembic exporter, for example, uses this in the generic case for translating float tuple attributes (which might have an arbitrary tuple size) if they're not a standard type like positions or colors.

(Note that if the property instead had metadata `arrayExtent:1, podExtent:3`, this behaved correctly as-is and would translate into a `float3[]` array)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A

### Fixes Issue(s)

Fixes: #3362

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
