### PR TITLE
HgiVulkan: Allow Headless Rendering on X11

### DIFF
--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -62,6 +62,10 @@ _SupportsPresentation(
                     physicalDevice, familyIndex);
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
         Display* dsp = XOpenDisplay(nullptr);
+        // Allow headless rendering
+        if (dsp == nullptr) {
+            return true;
+        }
         VisualID visualID = XVisualIDFromVisual(
             DefaultVisual(dsp, DefaultScreen(dsp)));
         return vkGetPhysicalDeviceXlibPresentationSupportKHR(


### PR DESCRIPTION
This is a change to allow headless rendering on Linux systems. In this case the 
instance will have enabled `VK_KHR_surface` and `VK_KHR_xlib_surface` but no
X11 display could be created.

`XOpenDisplay` will return `nullptr` (See https://www.x.org/releases/X11R7.7/doc/man/man3/XOpenDisplay.3.xhtml)
but `vkGetPhysicalDeviceXlibPresentationSupportKHR` requires a valid pointer to
a display struct.

Other solutions would be to check this during instance creation. I didn't go for
that solution as instance creation only does extension checking and not usage
checking.

A more future proof solution would be for the client to tell the renderer in what setup
it is being used. Now it is a bit hardcoded.

This fixes an issue in Blender to be able to render usd/Hydra images headless.
See https://projects.blender.org/blender/blender/issues/149631

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
