### PR TITLE
build: miscellaneous doc build fixes

### DIFF
--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -1357,14 +1357,6 @@ HTML_COLORSTYLE_SAT    = 100
 
 HTML_COLORSTYLE_GAMMA  = 80
 
-# If the HTML_TIMESTAMP tag is set to YES then the footer of each generated HTML
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: YES.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-HTML_TIMESTAMP         = YES
-
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
 # are dynamically created via JavaScript. If disabled, the navigation index will

--- a/docs/python/convertDoxygen.py
+++ b/docs/python/convertDoxygen.py
@@ -87,8 +87,8 @@ if dll_path != None and os.name == "nt":
 #
 try:
     cdWriterModule = importlib.import_module(".cdWriter" + output_format, package="doxygenlib")
-except ImportError:
-    Error("No writer plugin exists for format '%s'" % output_format)
+except ImportError as err:
+    Error(f"No writer plugin exists for format '{output_format}': {err}")
 else:
     Writer = cdWriterModule.Writer
 

--- a/docs/python/doxygenlib/cdWriterDocstring.py
+++ b/docs/python/doxygenlib/cdWriterDocstring.py
@@ -245,11 +245,11 @@ class Writer:
         # support the PARA and NEWLINE tokens that we inserted above
         newlines = []
         for x in lines:
-            x = re.sub("PARA\s*::", "::", x)  # don't para break before ::
+            x = re.sub(r"PARA\s*::", "::", x)  # don't para break before ::
             #x = re.sub("::", "NEWLINE::", x)  # but do put :: on a new line
             # Original line above, KRC's hack below
-            x = re.sub("::\s*$", "NEWLINE::", x)  # No, but do NOT put a :: on a new line willy nilly!
-                                                  # Only if the :: is at the end of a line.  
+            x = re.sub(r"::\s*$", "NEWLINE::", x)  # No, but do NOT put a :: on a new line willy nilly!
+                                                   # Only if the :: is at the end of a line.
 
             for y in x.split('PARA'):
                 for z in y.strip().split("NEWLINE"):


### PR DESCRIPTION
Remove an obsolete doxygen setting.
Make doc builds slightly easier to debug.
Fix a Python syntax warning.