### PR TITLE
build: cmake QOL improvements

### DIFF
--- a/cmake/defaults/ProjectDefaults.cmake
+++ b/cmake/defaults/ProjectDefaults.cmake
@@ -39,6 +39,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Turn on folder usage
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+# Generate compile_commands.json for use by developer tools.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")

--- a/cmake/macros/shebang.py
+++ b/cmake/macros/shebang.py
@@ -29,5 +29,8 @@ if len(sys.argv) == 3:
 else:
     with open(sys.argv[2], 'r') as s:
         with open(sys.argv[3], 'w') as d:
-            for line in s:
-                d.write(line.replace('/pxrpythonsubst', sys.argv[1]))
+            for idx, line in enumerate(s):
+                if idx == 0:
+                    d.write(line.replace('/pxrpythonsubst', sys.argv[1]))
+                else:
+                    d.write(line)

--- a/extras/performance/parseTimingOutput.py
+++ b/extras/performance/parseTimingOutput.py
@@ -9,19 +9,19 @@
 """
 import re
 
-make_re = lambda s: re.compile('(Time\ to\ )' + s + '(.*s)')
+make_re = lambda s: re.compile(r'(Time\ to\ )' + s + '(.*s)')
 
 # `usdview --timing` metrics
 METRICS = [
-    ("configure_and_load_plugins",  make_re('(configure\ and\ load\ plugins:)')),
-    ("open_stage", make_re('(open\ stage.*:)')),
-    ("reset_prim_browser", make_re('(reset\ Prim\ Browser\ to.*:)')),
-    ("bring_up_the_ui", make_re('(bring\ up\ the\ UI:)')),
-    ("create_first_image", make_re('(create\ first\ image:)')),
-    ("shut_down_hydra", make_re('(shut\ down\ Hydra:)')),
-    ("close_stage", make_re('(close\ stage.*:)')),
-    ("tear_down_the_ui", make_re('(tear\ down\ the\ UI:)')),
-    ("open_and_close_usdview", make_re('(open\ and\ close\ usdview:)')),
+    ("configure_and_load_plugins",  make_re(r'(configure\ and\ load\ plugins:)')),
+    ("open_stage", make_re(r'(open\ stage.*:)')),
+    ("reset_prim_browser", make_re(r'(reset\ Prim\ Browser\ to.*:)')),
+    ("bring_up_the_ui", make_re(r'(bring\ up\ the\ UI:)')),
+    ("create_first_image", make_re(r'(create\ first\ image:)')),
+    ("shut_down_hydra", make_re(r'(shut\ down\ Hydra:)')),
+    ("close_stage", make_re(r'(close\ stage.*:)')),
+    ("tear_down_the_ui", make_re(r'(tear\ down\ the\ UI:)')),
+    ("open_and_close_usdview", make_re(r'(open\ and\ close\ usdview:)')),
 ]
 
 


### PR DESCRIPTION
Provide `compile_commands.json` for use by developer tools.
Make `shebang.py` slightly safer.
Fix trivial Python syntax warnings.

Related-to: https://github.com/aousd/build-ig-initiatives/issues/8