### PR TITLE
Fix usdview --ff/--lf flags issue in 25.08+

### DIFF
--- a/pxr/usdImaging/usdviewq/rootDataModel.py
+++ b/pxr/usdImaging/usdviewq/rootDataModel.py
@@ -5,10 +5,12 @@
 # https://openusd.org/license.
 #
 
+from numbers import Real
 from pxr import Usd, UsdGeom, UsdShade, UsdSemantics
 from .qt import QtCore
 from .common import IncludedPurposes, Timer
 from pxr.UsdUtils.constantsGroup import ConstantsGroup
+
 
 class ChangeNotice(ConstantsGroup):
     NONE = 0
@@ -113,8 +115,9 @@ class RootDataModel(QtCore.QObject):
         """Set the start of the current frame range"""
         if value is None:
             value = 0.0
-        if not isinstance(value, float):
-            raise ValueError("Expected float, got: {}".format(value))
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError("Expected real number, got: {}".format(value))
+        value = float(value)
 
         if value != self._frameRangeBegin:
             self._frameRangeBegin = value
@@ -131,8 +134,10 @@ class RootDataModel(QtCore.QObject):
         """Set the end of the current frame range"""
         if value is None:
             value = 0.0
-        if not isinstance(value, float):
-            raise ValueError("Expected float, got: {}".format(value))
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError("Expected real number, got: {}".format(value))
+        value = float(value)
+
         if value != self._frameRangeEnd:
             self._frameRangeEnd = value
             self.frameRangeChanged.emit(

--- a/pxr/usdImaging/usdviewq/testenv/testUsdviewqRootDataModel.py
+++ b/pxr/usdImaging/usdviewq/testenv/testUsdviewqRootDataModel.py
@@ -26,7 +26,7 @@ class SignalCounter(object):
         self._numSignals = 0
 
     def _stageReplaced(self):
-        """Fired when a signal is recieved. Simply increment the count."""
+        """Fired when a signal is received. Simply increment the count."""
 
         self._numSignals += 1
 
@@ -208,6 +208,30 @@ class TestRootDataModel(unittest.TestCase):
                         0, 1, 0, 0,
                         0, 0, 1, 0,
                         2, 2, 2, 1))
+        
+    def test_FrameRangeBeginEndAcceptInts(self):
+
+        rootDataModel = RootDataModel()
+
+        # frame range values initialized when a stage is set.
+        rootDataModel.stage = Usd.Stage.CreateInMemory()
+
+        # model should accept int inputs and normalize them to float.
+        rootDataModel.frameRangeBegin = 1
+        self.assertEqual(rootDataModel.frameRangeBegin, 1.0)
+
+        rootDataModel.frameRangeEnd = 10
+        self.assertEqual(rootDataModel.frameRangeEnd, 10.0)
+
+        # floats should still work.
+        rootDataModel.frameRangeBegin = 2.5
+        self.assertEqual(rootDataModel.frameRangeBegin, 2.5)
+
+        # bool should still be rejected.
+        with self.assertRaises(ValueError):
+            rootDataModel.frameRangeBegin = True
+
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
### Description of Change(s)

This fixes the issue in OpenUSD 25.08 where usdview fails to start when using the --ff and/or --lf flags. It was caused by overly strict type checks in RootDataModel.frameRangeBegin/frameRangeEnd (which essentially rejected integer values passed in from the command line). I've relaxed the check to accept any real numeric type (while still rejecting bool) + normalizes values to float.

I’ve also added a small unit test to cover integer inputs and confirm existing error cases still behave as expected.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A

### Fixes Issue(s)

Fixes #3942

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
