### PR TITLE
Autodesk: vt: fix the VtValueRef implicit casting that leads to unwanted casting.

### DIFF
--- a/pxr/base/vt/dictionary.cpp
+++ b/pxr/base/vt/dictionary.cpp
@@ -35,7 +35,7 @@ _OverBackground(VtDictionary const &strong, VtBackgroundType const &)
 {
     VtDictionary result;
     for (auto const &[key, val]: strong) {
-        if (auto compVal = VtValueTryComposeOver(val, VtBackground)) {
+        if (auto compVal = VtValueTryComposeOver(VtValueRef(val), VtValueRef(VtBackground))) {
             result[key] = *compVal;
         }
         else {

--- a/pxr/base/vt/testenv/testVtCpp.cpp
+++ b/pxr/base/vt/testenv/testVtCpp.cpp
@@ -2003,7 +2003,7 @@ static void testVtValueRef()
         // *, will properly convert to VtValues holding std::strings.
         std::string fromLiteral = [](VtValueRef literal) {
             return VtValue { literal }.Get<std::string>();
-        }("hello literal");
+        }(VtValueRef("hello literal"));
         TF_AXIOM(fromLiteral == "hello literal");
     }
 
@@ -2129,7 +2129,7 @@ testVtValueComposeOver()
             }
         };
 
-        VtValue comp = VtValueComposeOver(strong, weak);
+        VtValue comp = VtValueComposeOver(VtValueRef(strong), VtValueRef(weak));
         TF_AXIOM(comp.IsHolding<VtDictionary>());
 
         const VtDictionary expectedComp = {
@@ -2145,7 +2145,7 @@ testVtValueComposeOver()
         };
         TF_AXIOM(comp == expectedComp);
 
-        VtValue compBG = VtValueComposeOver(strong, VtBackground);
+        VtValue compBG = VtValueComposeOver(VtValueRef(strong), VtValueRef(VtBackground));
         TF_AXIOM(compBG.IsHolding<VtDictionary>());
         const VtDictionary expectedCompBG = {
             { "zn", VtValue { VtIntArray { 0,9 } } },
@@ -2186,8 +2186,8 @@ testVtValueTransform()
     XFormTestSwitch on = SwitchOn;
     XFormTestToggle toggle;
 
-    VtValueRef offRef = off;
-    VtValueRef onRef = on;
+    VtValueRef offRef(off);
+    VtValueRef onRef(on);
 
     using SwitchArray = VtArray<XFormTestSwitch>;
     using SwitchArrayEdit = VtArrayEdit<XFormTestSwitch>;
@@ -2231,7 +2231,7 @@ testVtValueTransform()
 
     // Check that VtArray can transform.
     {
-        VtValue xf = VtValueTryTransform(swa, toggle);
+        VtValue xf = VtValueTryTransform(VtValueRef(swa), toggle);
         TF_AXIOM(!xf.IsEmpty());
         TF_AXIOM(xf.IsHolding<SwitchArray>());
         TF_AXIOM((xf.Get<SwitchArray>() == SwitchArray { on, off, on, off }));
@@ -2240,7 +2240,7 @@ testVtValueTransform()
     // Check that a VtDictionary holding both scalar, array, and arrayEdit
     // elements can transform.
     {
-        VtValue oxfd = VtValueTryTransform(dict, toggle);
+        VtValue oxfd = VtValueTryTransform(VtValueRef(dict), toggle);
         TF_AXIOM(oxfd.IsHolding<VtDictionary>());
         VtDictionary xfd = oxfd.Remove<VtDictionary>();
 
@@ -2259,7 +2259,7 @@ testVtValueTransform()
     // Check that a VtDictionary holding both scalar, array, and arrayEdit
     // elements can transform recursively.
     {
-        VtValue oxfd = VtValueTryTransform(recursiveDict, toggle);
+        VtValue oxfd = VtValueTryTransform(VtValueRef(recursiveDict), toggle);
         TF_AXIOM(oxfd.IsHolding<VtDictionary>());
         VtDictionary xfd = oxfd.Remove<VtDictionary>();
 

--- a/pxr/base/vt/value.h
+++ b/pxr/base/vt/value.h
@@ -1554,14 +1554,14 @@ template <class T>
 VtValueRef
 VtValue::_TypedProxyHelper<T>::GetValueRef(T const &obj)
 {
-    return VtGetProxiedObject(obj);
+    return VtValueRef(VtGetProxiedObject(obj));
 }
 
 template <class T>
 VtValueRef
 VtValue::_ErasedProxyHelper<T>::GetValueRef(T const &obj)
 {
-    return *VtGetErasedProxiedVtValue(obj);
+    return VtValueRef(*VtGetErasedProxiedVtValue(obj));
 }
 
 template <class T, class C, class D>
@@ -1574,7 +1574,7 @@ VtValue::_TypeInfoImpl<T, C, D>
         // called by a non-const member function, so it is safe to cast away
         // constness here.
         if (rvalue) {
-            return std::move(GetMutableObj(const_cast<_Storage &>(storage)));
+            return VtValueRef(std::move(GetMutableObj(const_cast<_Storage &>(storage))));
         }
     }
     return ProxyHelper::GetValueRef(GetObj(storage));

--- a/pxr/base/vt/valueRef.h
+++ b/pxr/base/vt/valueRef.h
@@ -371,7 +371,7 @@ public:
     /// Implicitly convert or construct a VtValueRef referring to \p obj.  The
     /// passed \p obj must outlive this VtValueRef instance.
     template <class T>
-    VtValueRef(T &&obj, std::enable_if_t<
+    explicit VtValueRef(T &&obj, std::enable_if_t<
                !std::is_same_v<std::decay_t<T>, VtValueRef> &&
                !std::is_same_v<std::decay_t<T>, VtValue>> * = 0) {
         using TypeInfo = _TypeInfoFor<T>;


### PR DESCRIPTION
### Description of Change(s)

The detailed description is is described in Issue https://github.com/PixarAnimationStudios/OpenUSD/issues/3944 . In brief - the `VtValueRef` implicit constructor can leads to unexpected casting, especially on visual studio compilers. From our testing, this leads to a stack overflow problem.

This PR fix the crash by converting the `VtValueRef` implicit constructor of any T an explicit constructor thus no unexpected cast can happen.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/3944

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
