### PR TITLE
Report return code during failures

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -307,13 +307,20 @@ def Run(cmd, logCommandOutput = True, env = None):
             p.wait()
 
     if p.returncode != 0:
+        with codecs.open("log.txt", "a", "utf-8") as logfile:
+            logfile.write(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+            logfile.write("\n")
+            logfile.write("{cmd} exited with returncode {returncode}"
+                          .format(cmd=cmd, returncode=p.returncode))
+            logfile.write("\n")
+            
         # If verbosity >= 3, we'll have already been printing out command output
         # so no reason to print the log file again.
         if verbosity < 3:
             with open("log.txt", "r") as logfile:
                 Print(logfile.read())
-        raise RuntimeError("Failed to run '{cmd}' in {path}.\nSee {log} for more details."
-                           .format(cmd=cmd, path=os.getcwd(), log=os.path.abspath("log.txt")))
+        raise RuntimeError("Failed to run '{cmd}' in {path} (exited with returncode {returncode}).\nSee {log} for more details."
+                           .format(cmd=cmd, path=os.getcwd(), returncode=p.returncode, log=os.path.abspath("log.txt")))
 
 @contextlib.contextmanager
 def CurrentWorkingDirectory(dir):


### PR DESCRIPTION

### Description of Change(s)
Patch thanks to Maddy Adams who finds that reporting the return code during any failures allows for better CI debugging rather than trying to discern when one of the processes failed for an unknown issue.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
