### PR TITLE
Replace usage of std::is_pod, which is deprecated in C++20

### DIFF
--- a/pxr/base/tf/type_Impl.h
+++ b/pxr/base/tf/type_Impl.h
@@ -62,9 +62,13 @@ TfType::Define()
 {
     Tf_BaseTypeInfos<BaseTypes> btis;
     Tf_TypeCastFunctions<T, BaseTypes> tcfs;
+
+    constexpr bool isPodType =
+        std::is_trivial_v<T> && std::is_standard_layout_v<T>;
+
     return _DefineImpl(
         typeid(T), btis.baseTypeInfos, tcfs.castFunctions, btis.NumBases,
-        TfSizeofType<T>::value, std::is_pod_v<T>, std::is_enum_v<T>);
+        TfSizeofType<T>::value, isPodType, std::is_enum_v<T>);
 }
 
 template <typename T>


### PR DESCRIPTION
### Description of Change(s)

`std::is_pod` was deprecated in C++20, and is replaced with more specific categories. Checking for "trivial and standard layout" is equivalent to the previous behaviour

This fixes deprecation warnings with some compilers (e.g. clang 21 on Linux)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A 

### Fixes Issue(s)

N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
