### PR TITLE
crate: issue error for duplicate key in crate map

### DIFF
--- a/pxr/usd/sdf/crateFile.cpp
+++ b/pxr/usd/sdf/crateFile.cpp
@@ -1145,6 +1145,13 @@ public:
             // separate because the two modifications to 'src' must be correctly
             // sequenced.
             auto key = Read<typename Map::key_type>();
+            if constexpr (SafetyOverSpeed) {
+                if map.find(key) != map.end() {
+                    TF_RUNTIME_ERROR("Corrupt asset <%s>: Duplicate map key %s",
+                                     crate->GetAssetPath().c_str(),
+                                     key.GetText().c_str());
+                }
+            }
             map[key] = Read<typename Map::mapped_type>();
         }
         return map;


### PR DESCRIPTION
### Description of Change(s)

crate: issue error for duplicate key in crate map

...if PXR_PREFER_SAFETY_OVER_SPEED is set

Currently, when the [crate file format reads maps or variant selections](https://github.com/PixarAnimationStudios/OpenUSD/blob/v25.11/pxr/usd/sdf/crateFile.cpp#L1184-L1186), it [does no checking for duplicate keys](https://github.com/PixarAnimationStudios/OpenUSD/blob/v25.11/pxr/usd/sdf/crateFile.cpp#L1140-L1151).

This came up in the AOUSD core spec working group, where it was determined that this was likely:

- unintentional (or at least, a situation the original OpenUSD authors didn't really care about)
- changing behavior by making it error would likely have little practical impact (besides performance implications), as we expect there are very few actual assets with this condition.

Therefore, we were wondering if OpenUSD would consider making the crate reader error when encountering such data, for clearer alignment with the spec.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
