### PR TITLE
Adding MotionAPIAdapter

### DIFF
--- a/pxr/usdImaging/usdImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdImaging/CMakeLists.txt
@@ -106,6 +106,7 @@ pxr_library(usdImaging
         materialBindingsSchema
         materialBindingsResolvingSceneIndex
         meshAdapter
+        motionAPIAdapter
         niPrototypePropagatingSceneIndex
         nurbsCurvesAdapter
         nurbsPatchAdapter

--- a/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
@@ -29,8 +29,12 @@ const UsdImagingDataSourceCustomPrimvars::Mappings &
 _GetMotionPrimvarMappings()
 {
     static const UsdImagingDataSourceCustomPrimvars::Mappings mappings = {
-        {HdTokens->blurScale, UsdGeomTokens->motionBlurScale},
-        {HdTokens->nonlinearSampleCount, UsdGeomTokens->motionNonlinearSampleCount},
+        { HdTokens->blurScale,
+          UsdGeomTokens->motionBlurScale,
+          HdPrimvarSchemaTokens->constant },
+        { HdTokens->nonlinearSampleCount,
+          UsdGeomTokens->motionNonlinearSampleCount,
+          HdPrimvarSchemaTokens->constant },
     };
     return mappings;
 }

--- a/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Pixar
+// Copyright 2026 Pixar
 //
 // Licensed under the terms set forth in the LICENSE.txt file available at
 // https://openusd.org/license.

--- a/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/motionAPIAdapter.cpp
@@ -1,0 +1,82 @@
+//
+// Copyright 2024 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#include "pxr/usdImaging/usdImaging/motionAPIAdapter.h"
+#include "pxr/usdImaging/usdImaging/dataSourcePrimvars.h"
+
+#include "pxr/usd/usdGeom/motionAPI.h"
+#include "pxr/usd/usdGeom/tokens.h"
+
+#include "pxr/imaging/hd/primvarsSchema.h"
+#include "pxr/imaging/hd/retainedDataSource.h"
+#include "pxr/imaging/hd/tokens.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    using Adapter = UsdImagingMotionAPIAdapter;
+    TfType t = TfType::Define<Adapter, TfType::Bases<Adapter::BaseAdapter>>();
+    t.SetFactory<UsdImagingAPISchemaAdapterFactory<Adapter>>();
+}
+
+namespace {
+
+const UsdImagingDataSourceCustomPrimvars::Mappings &
+_GetMotionPrimvarMappings()
+{
+    static const UsdImagingDataSourceCustomPrimvars::Mappings mappings = {
+        {HdTokens->blurScale, UsdGeomTokens->motionBlurScale},
+        {HdTokens->nonlinearSampleCount, UsdGeomTokens->motionNonlinearSampleCount},
+    };
+    return mappings;
+}
+
+} // anonymous namespace
+
+HdContainerDataSourceHandle
+UsdImagingMotionAPIAdapter::GetImagingSubprimData(
+    UsdPrim const& prim,
+    TfToken const& subprim,
+    TfToken const& appliedInstanceName,
+    const UsdImagingDataSourceStageGlobals &stageGlobals)
+{
+    // MotionAPI is not a multi-apply schema.
+    if (!appliedInstanceName.IsEmpty()) {
+        return nullptr;
+    }
+
+    // This adapter only contributes to the primary prim, not subprims.
+    if (!subprim.IsEmpty()) {
+        return nullptr;
+    }
+
+    return HdRetainedContainerDataSource::New(
+        HdPrimvarsSchema::GetSchemaToken(),
+        UsdImagingDataSourceCustomPrimvars::New(
+            prim.GetPath(),
+            prim,
+            _GetMotionPrimvarMappings(),
+            stageGlobals));
+}
+
+HdDataSourceLocatorSet
+UsdImagingMotionAPIAdapter::InvalidateImagingSubprim(
+    UsdPrim const& prim,
+    TfToken const& subprim,
+    TfToken const& appliedInstanceName,
+    TfTokenVector const& properties,
+    UsdImagingPropertyInvalidationType invalidationType)
+{
+    if (!appliedInstanceName.IsEmpty() || !subprim.IsEmpty()) {
+        return HdDataSourceLocatorSet();
+    }
+
+    return UsdImagingDataSourceCustomPrimvars::Invalidate(
+        properties, _GetMotionPrimvarMappings());
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usdImaging/usdImaging/motionAPIAdapter.h
+++ b/pxr/usdImaging/usdImaging/motionAPIAdapter.h
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Pixar
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_USD_IMAGING_USD_IMAGING_MOTION_API_ADAPTER_H
+#define PXR_USD_IMAGING_USD_IMAGING_MOTION_API_ADAPTER_H
+
+#include "pxr/usdImaging/usdImaging/apiSchemaAdapter.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class UsdImagingMotionAPIAdapter : public UsdImagingAPISchemaAdapter
+{
+public:
+    using BaseAdapter = UsdImagingAPISchemaAdapter;
+
+    USDIMAGING_API
+    HdContainerDataSourceHandle GetImagingSubprimData(
+        UsdPrim const& prim,
+        TfToken const& subprim,
+        TfToken const& appliedInstanceName,
+        const UsdImagingDataSourceStageGlobals &stageGlobals) override;
+
+    USDIMAGING_API
+    HdDataSourceLocatorSet InvalidateImagingSubprim(
+        UsdPrim const& prim,
+        TfToken const& subprim,
+        TfToken const& appliedInstanceName,
+        TfTokenVector const& properties,
+        UsdImagingPropertyInvalidationType invalidationType) override;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // PXR_USD_IMAGING_USD_IMAGING_MOTION_API_ADAPTER_H

--- a/pxr/usdImaging/usdImaging/plugInfo.json
+++ b/pxr/usdImaging/usdImaging/plugInfo.json
@@ -137,6 +137,11 @@
                         "isInternal": true,
                         "primTypeName": "Mesh"
                     },
+                    "UsdImagingMotionAPIAdapter": {
+                        "bases": ["UsdImagingAPISchemaAdapter"],
+                        "isInternal": true,
+                        "apiSchemaName": "MotionAPI"
+                    },
                     "UsdImagingTetMeshAdapter": {
                         "bases": [
                             "UsdImagingGprimAdapter"


### PR DESCRIPTION
### Description of Change(s)

Adding a MotionAPIAdapter so that the schema can be applied to arbitrary prims and the data will survive translation via Hydra (in particular we want it for GenerativeProcedural prims).

### Fixes Issue(s)

#3970 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
