### PR TITLE
Makes the 'ids' for a UsdGeomPointInstancer available to shaders

### DIFF
--- a/pxr/imaging/hd/tokens.h
+++ b/pxr/imaging/hd/tokens.h
@@ -55,6 +55,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     (geometry)                                  \
     (hermite)                                   \
     (hullIndices)                               \
+    (ids)                                       \
     (indices)                                   \
     (isFlipped)                                 \
     (itemsDrawn)                                \

--- a/pxr/usdImaging/usdImaging/dataSourcePointInstancer.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourcePointInstancer.cpp
@@ -204,6 +204,11 @@ _GetCustomPrimvarMappings(const UsdPrim &usdPrim)
             HdTokens->angularVelocities,
             UsdGeomTokens->angularVelocities,
             HdPrimvarSchemaTokens->instance
+        },
+        {
+            HdTokens->ids,
+            UsdGeomTokens->ids,
+            HdPrimvarSchemaTokens->instance
         }
     };
 


### PR DESCRIPTION
### Description of Change(s)

Makes the 'ids' for a UsdGeomPointInstancer available to shaders, without requiring users author a separate Primvar for this purpose. The mesh has matching values for ids, authored as a Primvar, just to visually ensure we're getting the same results.

<img width="1156" height="1046" alt="Storm_PointInstancer_IDs" src="https://github.com/user-attachments/assets/7608fb0f-8c7d-4e9a-925b-bbfa7478de64" />

It doesn't preclude authoring a different `primvars:ids`, as explicitly authored `primvars:ids` take precedence. We also did some testing with an internal build of Karma, and are seeing the same, expected behavior.

<img width="1158" height="1046" alt="Storm_PointInstancer_IDs_existing" src="https://github.com/user-attachments/assets/1726ee3e-58f5-4c14-81f7-a3bbf2680a56" />

Here are the scene files we used for testing:

[PointInstancer_IDs_test_scenes.zip](https://github.com/user-attachments/files/25190536/PointInstancer_IDs_test_scenes.zip)

### Fixes Issue(s)

#3976

### Storm

In order to validate this with Storm, we had to make some changes, which are in this patch. However we aren't sure if the Storm/UsdMaterialX changes are the best way forward. We leave the patch here, for any interested parties to pick up as a starting point for having Storm to support integer primvars, as we probably aren't best situation to shepherd this into the baseline :)

[ids_Storm_MtlX_support.patch](https://github.com/user-attachments/files/25190485/ids_Storm_MtlX_support.patch)