### PR TITLE
Add usd dependency to sdr

### DIFF
--- a/pxr/usd/sdr/CMakeLists.txt
+++ b/pxr/usd/sdr/CMakeLists.txt
@@ -11,6 +11,7 @@ pxr_library(sdr
         work
         ar
         sdf
+        usd
 
     PUBLIC_HEADERS
         api.h


### PR DESCRIPTION
### Description of Change(s)

e4c69e6 adds a dependency from `usd/sdr` on `usd/usd` via an include file, but does not reflect that in CMake which can cause build breakages.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
  Submitting under Adobe corp agreement