### PR TITLE
Autodesk: Fix deferred command buffer submission issue

### DIFF
--- a/pxr/imaging/hgiVulkan/commandQueue.cpp
+++ b/pxr/imaging/hgiVulkan/commandQueue.cpp
@@ -250,6 +250,23 @@ HgiVulkanCommandQueue::Flush(
     HgiSubmitWaitType wait,
     VkSemaphore signalSemaphore)
 {
+    // Finalize and include any pending resource command buffer in this flush.
+    // The resource command buffer accumulates internal work (staging copies,
+    // layout transitions) from Create* calls and is normally submitted via
+    // SubmitToQueue. If no SubmitToQueue follows the last Create*, it must
+    // still be submitted here so its inflight bit can eventually be released,
+    // allowing garbage collection to free dependent objects.
+    if (_resourceCommandBuffer) {
+        _resourceCommandBuffer->EndCommandBuffer();
+        _resourceCommandBuffer->SetCompletedTimelineValue(_timelineNextVal);
+        _queuedBuffers.push_back(_resourceCommandBuffer);
+        _resourceCommandBuffer = nullptr;
+    }
+
+    if (_queuedBuffers.empty() && !signalSemaphore) {
+        return;
+    }
+
     std::vector<VkCommandBuffer> commandBuffers;
     commandBuffers.reserve(_queuedBuffers.size());
     for (auto& buffer : _queuedBuffers) {

--- a/pxr/imaging/hgiVulkan/device.cpp
+++ b/pxr/imaging/hgiVulkan/device.cpp
@@ -594,6 +594,15 @@ HgiVulkanDevice::GetPipelineCache() const
 void
 HgiVulkanDevice::WaitForIdle()
 {
+    // Flush any deferred command buffers so they are actually submitted to the
+    // GPU queue before we wait. Without this, vkDeviceWaitIdle would return
+    // immediately since the deferred work was never submitted.
+    // We use WaitUntilCompleted so that completed handlers (e.g. staging buffer
+    // cleanup) run as part of the wait rather than being deferred.
+    _commandQueue->Flush(HgiSubmitWaitTypeWaitUntilCompleted);
+
+    // Wait for any remaining GPU work that may have been submitted outside of
+    // the deferred queue (e.g. earlier flushes).
     HGIVULKAN_VERIFY_VK_RESULT(
         vkDeviceWaitIdle(_vkDevice)
     );

--- a/pxr/imaging/hgiVulkan/hgi.cpp
+++ b/pxr/imaging/hgiVulkan/hgi.cpp
@@ -51,13 +51,16 @@ HgiVulkan::HgiVulkan()
 HgiVulkan::~HgiVulkan()
 {
     if (HgiVulkanCommandQueue* queue = _device->GetCommandQueue()) {
-        // Wait for command buffers to complete, then reset command buffers for
-        // each device's queue.
+        // Flush all pending commands (including any pending resource command
+        // buffer from Create* calls) and wait for GPU completion.
+        _device->WaitForIdle();
+
+        // Now that all commands have been submitted and completed, reset
+        // command buffers to release their inflight bits.
         queue->ResetConsumedCommandBuffers(
             HgiSubmitWaitTypeWaitUntilCompleted);
 
-        // Wait for all devices and perform final garbage collection.
-        _device->WaitForIdle();
+        // Perform final garbage collection with all inflight bits cleared.
         _garbageCollector->PerformGarbageCollection(_device);
     }
 


### PR DESCRIPTION
### Description of Change(s)

With help from AI.

The introduction of deferred command buffer submission means `vkQueueSubmit` calls are now buffered rather than executed immediately, but `HgiVulkanDevice::WaitForIdle()` still only called `vkDeviceWaitIdle()` — which returns instantly when no work has been submitted to the GPU. This leaves command buffers permanently stuck in "in-flight" state, preventing their reuse and blocking the garbage collector from freeing dependent GPU resources (since their inflight bits are never released).

This fix ensures deferred commands are properly flushed before any wait: `WaitForIdle()` now explicitly calls `Flush(WaitUntilCompleted)` to submit buffered work, `Flush()` itself is extended to finalize and include any pending resource command buffer (from Create* calls), and the `~HgiVulkan` destructor is reordered to flush/wait, then reset command buffers, then run garbage collection — guaranteeing all inflight bits are cleared before final cleanup.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/3980

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
