### PR TITLE
Autodesk: [HgiMetal] Fix edge rendering gaps due to near 0 barycentric coords on edges

### DIFF
--- a/pxr/imaging/hdSt/shaders/meshWire.glslfx
+++ b/pxr/imaging/hdSt/shaders/meshWire.glslfx
@@ -70,7 +70,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -96,7 +96,7 @@ float GetMinEdgeDistance()
     vec2 rightTop = vec2(1.0) - leftBottom;
 
     vec4 param = vec4(leftBottom.y, rightTop.x, rightTop.y, leftBottom.x);
-    vec4 edgeDistance = max(vec4(0.0), param / fwidth(param));
+    vec4 edgeDistance = max(vec4(0.0), param / max(fwidth(param), 1e-6));
 
     // Hide internal edges introduced by quadrangulation
     if (GetEdgeFlag() != 0) edgeDistance.yz += vec2(2.0);
@@ -130,7 +130,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -146,7 +146,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 --- --------------------------------------------------------------------------

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_edgeonly.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_edgeonly.out
@@ -2606,7 +2606,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -2636,7 +2636,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2652,7 +2652,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5664,7 +5664,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -5694,7 +5694,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5710,7 +5710,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_edgeonly_blendwireframe.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_edgeonly_blendwireframe.out
@@ -2606,7 +2606,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -2636,7 +2636,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2652,7 +2652,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5670,7 +5670,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -5700,7 +5700,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5716,7 +5716,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect.out
@@ -2610,7 +2610,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2626,7 +2626,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5619,7 +5619,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5635,7 +5635,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_doubleSided.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_doubleSided.out
@@ -2609,7 +2609,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2625,7 +2625,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5617,7 +5617,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5633,7 +5633,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_faceVarying.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_faceVarying.out
@@ -2610,7 +2610,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2626,7 +2626,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5619,7 +5619,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5635,7 +5635,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_instance.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_instance.out
@@ -2715,7 +2715,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2731,7 +2731,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5829,7 +5829,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5845,7 +5845,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_smoothNormals.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_GL/baseline/codegen_mesh_indirect_smoothNormals.out
@@ -2610,7 +2610,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2626,7 +2626,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5619,7 +5619,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5635,7 +5635,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_edgeonly.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_edgeonly.out
@@ -2592,7 +2592,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -2622,7 +2622,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2638,7 +2638,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5636,7 +5636,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -5666,7 +5666,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5682,7 +5682,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_edgeonly_blendwireframe.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_edgeonly_blendwireframe.out
@@ -2592,7 +2592,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -2622,7 +2622,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2638,7 +2638,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5642,7 +5642,7 @@ float GetMinEdgeDistance()
 {
     // Hide triangle edges by adding edge mask.
     vec3 param = GetEdgeCoord() + GetPrimitiveEdgeMask();
-    vec3 edgeDistance = max(vec3(0.0), param / fwidth(param));
+    vec3 edgeDistance = max(vec3(0.0), param / max(fwidth(param), 1e-6));
     return min(edgeDistance.x,
                min(edgeDistance.y,
                    edgeDistance.z));
@@ -5672,7 +5672,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5688,7 +5688,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect.out
@@ -2596,7 +2596,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2612,7 +2612,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5591,7 +5591,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5607,7 +5607,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_doubleSided.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_doubleSided.out
@@ -2595,7 +2595,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2611,7 +2611,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5589,7 +5589,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5605,7 +5605,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_faceVarying.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_faceVarying.out
@@ -2596,7 +2596,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2612,7 +2612,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5591,7 +5591,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5607,7 +5607,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_instance.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_instance.out
@@ -2701,7 +2701,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2717,7 +2717,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5801,7 +5801,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5817,7 +5817,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 

--- a/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_smoothNormals.out
+++ b/pxr/imaging/hdSt/testenv/testHdStCodeGen_Vulkan/baseline/codegen_mesh_indirect_smoothNormals.out
@@ -2596,7 +2596,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -2612,7 +2612,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 
@@ -5591,7 +5591,7 @@ vec3 GetEdgeParamTriangle()
 vec3 GetEdgeDistanceTriangle()
 {
     vec3 param = GetEdgeParamTriangle();
-    return max(vec3(0.0), param / fwidth(param));
+    return max(vec3(0.0), param / max(fwidth(param), 1e-6));
 }
 
 vec4 GetEdgeParamQuad()
@@ -5607,7 +5607,7 @@ vec4 GetEdgeParamQuad()
 vec4 GetEdgeDistanceQuad()
 {
     vec4 param = GetEdgeParamQuad();
-    return max(vec4(0.0), param / fwidth(param));
+    return max(vec4(0.0), param / max(fwidth(param), 1e-6));
 }
 
 


### PR DESCRIPTION
### Description of Change(s)

Caused by fwdith(param) being zero or almost 0.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
