### PR TITLE
Autodesk: [hdx] Fix undefined behaviour in test assertions

### DIFF
--- a/pxr/base/tf/diagnostic.h
+++ b/pxr/base/tf/diagnostic.h
@@ -434,7 +434,9 @@ struct Tf_DiagnosticHelper {
 
     TF_API void IssueError(std::string const &msg) const;
     TF_API void IssueError(char const *fmt, ...) const ARCH_PRINTF_FUNCTION(2,3);
+    [[noreturn]]
     TF_API void IssueFatalError(std::string const &msg) const;
+    [[noreturn]]
     TF_API void IssueFatalError(char const *fmt, ...) const ARCH_PRINTF_FUNCTION(2,3);
     TF_API void IssueWarning(std::string const &msg) const;
     TF_API void IssueWarning(char const *fmt, ...) const ARCH_PRINTF_FUNCTION(2,3);

--- a/pxr/imaging/hdx/testenv/testHdxCameraAndLight.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxCameraAndLight.cpp
@@ -47,7 +47,9 @@ static void CameraAndLightTest()
     HdStRenderDelegate renderDelegate;
     std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
-    TF_VERIFY(index);
+    if (!index) {
+        TF_FATAL_ERROR("Failed to create HdRenderIndex");
+    }
     std::unique_ptr<Hdx_UnitTestDelegate> delegate(
                                          new Hdx_UnitTestDelegate(index.get()));
 
@@ -193,4 +195,3 @@ int main()
         return EXIT_FAILURE;
     }
 }
-

--- a/pxr/imaging/hdx/testenv/testHdxDrawTarget.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxDrawTarget.cpp
@@ -59,7 +59,9 @@ int main(int argc, char *argv[])
     HdStRenderDelegate renderDelegate;
     std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
-    TF_VERIFY(index);
+    if (!index) {
+        TF_FATAL_ERROR("Failed to create HdRenderIndex");
+    }
     std::unique_ptr<Hdx_UnitTestDelegate> delegate =
         std::make_unique<Hdx_UnitTestDelegate>(index.get());
     HdEngine engine;

--- a/pxr/imaging/hdx/testenv/testHdxLightAndShadow.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxLightAndShadow.cpp
@@ -47,7 +47,9 @@ int main(int argc, char *argv[])
     HdStRenderDelegate renderDelegate;
     std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
-    TF_VERIFY(index);
+    if (!index) {
+        TF_FATAL_ERROR("Failed to create HdRenderIndex");
+    }
     std::unique_ptr<Hdx_UnitTestDelegate> delegate(
                                          new Hdx_UnitTestDelegate(index.get()));
     HdEngine engine;

--- a/pxr/imaging/hdx/testenv/testHdxPickAndHighlight.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxPickAndHighlight.cpp
@@ -52,8 +52,7 @@ _GetSelectedInstances(HdSelectionSharedPtr const& sel,
         HdSelection::PrimSelectionState const* primSelState =
             sel->GetPrimSelectionState(mode, path);
 
-        TF_VERIFY(primSelState);
-        if (!primSelState->instanceIndices.empty()) {
+        if (TF_VERIFY(primSelState) && !primSelState->instanceIndices.empty()) {
             selInstances[path] = primSelState->instanceIndices;
         }
     }
@@ -367,8 +366,9 @@ My_TestGLDrawing::OffscreenTest()
     _selTracker->SetSelection(selection);
     DrawScene();
     _driver->WriteToFile("color", "color2_select.png");
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube2"));
+    if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube2"));
+    }
 
     // select cube1, /protoTop:1, /protoTop:2, /protoBottom:1, /protoBottom:2
     selection = _Pick(GfVec2i(105,62), GfVec2i(328,288), mode);
@@ -380,19 +380,23 @@ My_TestGLDrawing::OffscreenTest()
     // prims with non-empty instance indices {protoTop, protoBottom}
     InstanceMap selInstances = _GetSelectedInstances(selection, mode);
     TF_VERIFY(selInstances.size() == 2);
+    if (const auto iter = selInstances.find(SdfPath("/protoTop"));
+        iter != selInstances.end())
     {
-        std::vector<VtIntArray> const& indices
-            = selInstances[SdfPath("/protoTop")];
-        TF_VERIFY(indices.size() == 2);
-        TF_VERIFY(indices[0][0] == 1 || indices[0][0] == 2);
-        TF_VERIFY(indices[1][0] == 1 || indices[1][0] == 2);
+        const auto& indices = iter->second;
+        if (TF_VERIFY(indices.size() == 2)) {
+            TF_VERIFY(indices[0][0] == 1 || indices[0][0] == 2);
+            TF_VERIFY(indices[1][0] == 1 || indices[1][0] == 2);
+        }
     }
+    if (const auto iter = selInstances.find(SdfPath("/protoBottom"));
+        iter != selInstances.end())
     {
-        std::vector<VtIntArray> const& indices
-            = selInstances[SdfPath("/protoBottom")];
-        TF_VERIFY(indices.size() == 2);
-        TF_VERIFY(indices[0][0] == 1 || indices[0][0] == 2);
-        TF_VERIFY(indices[1][0] == 1 || indices[1][0] == 2);
+        const auto& indices = iter->second;
+        if (TF_VERIFY(indices.size() == 2)) {
+            TF_VERIFY(indices[0][0] == 1 || indices[0][0] == 2);
+            TF_VERIFY(indices[1][0] == 1 || indices[1][0] == 2);
+        }
     }
 
     // --------------------- locate (rollover) selection -----------------------
@@ -402,8 +406,9 @@ My_TestGLDrawing::OffscreenTest()
     _selTracker->SetSelection(selection);
     DrawScene();
     _driver->WriteToFile("color", "color4_locate.png");
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube0"));
+    if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube0"));
+    }
 
     // select cube3, /protoBottom:0
     selection = _Pick(GfVec2i(408,246), GfVec2i(546,420), mode);
@@ -413,11 +418,13 @@ My_TestGLDrawing::OffscreenTest()
     TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 2);
     selInstances = _GetSelectedInstances(selection, mode);
     TF_VERIFY(selInstances.size() == 1);
+    if (const auto iter = selInstances.find(SdfPath("/protoBottom"));
+        iter != selInstances.end())
     {
-        std::vector<VtIntArray> const& indices
-            = selInstances[SdfPath("/protoBottom")];
-        TF_VERIFY(indices.size() == 1);
-        TF_VERIFY(indices[0][0] == 0);
+        const auto& indices = iter->second;
+        if (TF_VERIFY(indices.size() == 1)) {
+            TF_VERIFY(indices[0][0] == 0);
+        }
     }
 
     // deselect
@@ -531,4 +538,3 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 }
-

--- a/pxr/imaging/hdx/testenv/testHdxPickResolveMode.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxPickResolveMode.cpp
@@ -372,9 +372,10 @@ My_TestGLDrawing::OffscreenTest()
             HdxPickTokens->resolveNearestToCamera,
             &allHits);
         TF_VERIFY(allHits.size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] ==
-                 SdfPath("/protoTop"));
+        if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+            TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] ==
+                    SdfPath("/protoTop"));
+        }
     }
 
     // 2. Nearest to center (of pick region)
@@ -385,9 +386,10 @@ My_TestGLDrawing::OffscreenTest()
             HdxPickTokens->resolveNearestToCenter,
             &allHits);
         TF_VERIFY(allHits.size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0]
-                  == SdfPath("/protoBottom"));
+        if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+            TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0]
+                    == SdfPath("/protoBottom"));
+        }
     }
 
     // 3. Unique
@@ -537,4 +539,3 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 }
-

--- a/pxr/imaging/hdx/testenv/testHdxPickTarget.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxPickTarget.cpp
@@ -321,8 +321,9 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color10_tet1_pick_prims.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/tet1"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->fullySelected);
+        if (TF_VERIFY(selState)) {
+            TF_VERIFY(selState->fullySelected);
+        }
     }
 
     //---------------------------- face picking --------------------------------
@@ -335,10 +336,10 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color2_cube0_pick_face.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/cube0"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->elementIndices.size() == 1);
-        VtIntArray const& facesSelected = selState->elementIndices[0];
-        TF_VERIFY(facesSelected.size() == 1 && facesSelected[0] == 3);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->elementIndices.size() == 1)) {
+            VtIntArray const& facesSelected = selState->elementIndices[0];
+            TF_VERIFY(facesSelected.size() == 1 && facesSelected[0] == 3);
+        }
     }
     
     // select faces 3 & 5 of tet1.
@@ -351,10 +352,10 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color3_tet1_pick_faces.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/tet1"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->elementIndices.size() == 1);
-        VtIntArray const& facesSelected = selState->elementIndices[0];
-        TF_VERIFY(facesSelected.size() == 2);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->elementIndices.size() == 1)) {
+            VtIntArray const& facesSelected = selState->elementIndices[0];
+            TF_VERIFY(facesSelected.size() == 2);
+        }
     }
 
     // test wireframe face highlighting
@@ -369,10 +370,10 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color9_cube0_wire_pick_face.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/cube0"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->elementIndices.size() == 1);
-        VtIntArray const& facesSelected = selState->elementIndices[0];
-        TF_VERIFY(facesSelected.size() == 2);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->elementIndices.size() == 1)) {
+            VtIntArray const& facesSelected = selState->elementIndices[0];
+            TF_VERIFY(facesSelected.size() == 2);
+        }
     }
     //---------------------------- edge picking --------------------------------
     // Picking or highlighting edges requires the GS stage, so use a repr that
@@ -396,11 +397,11 @@ My_TestGLDrawing::OffscreenTest()
         SdfPath meshPath("/tet0");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, meshPath);
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->edgeIndices.size() == 1);
-        VtIntArray const& edgeIndicesSelected = selState->edgeIndices[0];
-        MeshEdges edgesSelected = _GetMeshEdges(meshPath, edgeIndicesSelected);
-        TF_VERIFY(edgesSelected.size() == 1);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->edgeIndices.size() == 1)) {
+            VtIntArray const& edgeIndicesSelected = selState->edgeIndices[0];
+            MeshEdges edgesSelected = _GetMeshEdges(meshPath, edgeIndicesSelected);
+            TF_VERIFY(edgesSelected.size() == 1);
+        }
     }
 
     // select edges of cube1
@@ -414,11 +415,11 @@ My_TestGLDrawing::OffscreenTest()
         SdfPath meshPath("/cube1");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, meshPath);
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->edgeIndices.size() == 1);
-        VtIntArray const& edgeIndicesSelected = selState->edgeIndices[0];
-        MeshEdges edgesSelected = _GetMeshEdges(meshPath, edgeIndicesSelected);
-        TF_VERIFY(edgesSelected.size() == 2);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->edgeIndices.size() == 1)) {
+            VtIntArray const& edgeIndicesSelected = selState->edgeIndices[0];
+            MeshEdges edgesSelected = _GetMeshEdges(meshPath, edgeIndicesSelected);
+            TF_VERIFY(edgesSelected.size() == 2);
+        }
     }
 
     //---------------------------- point picking -------------------------------
@@ -441,10 +442,10 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color6_cube1_pick_points.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/cube1"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->pointIndices.size() == 1);
-        VtIntArray const& pointsSelected = selState->pointIndices[0];
-        TF_VERIFY(pointsSelected.size() == 4);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->pointIndices.size() == 1)) {
+            VtIntArray const& pointsSelected = selState->pointIndices[0];
+            TF_VERIFY(pointsSelected.size() == 4);
+        }
     }
 
     {
@@ -461,10 +462,10 @@ My_TestGLDrawing::OffscreenTest()
         _driver->WriteToFile("color", "color7_cube1_pick_points_pick_through.png");
         HdSelection::PrimSelectionState const* selState =
             selection->GetPrimSelectionState(mode, SdfPath("/cube1"));
-        TF_VERIFY(selState);
-        TF_VERIFY(selState->pointIndices.size() == 1);
-        VtIntArray const& pointsSelected = selState->pointIndices[0];
-        TF_VERIFY(pointsSelected.size() == 5);
+        if (TF_VERIFY(selState) && TF_VERIFY(selState->pointIndices.size() == 1)) {
+            VtIntArray const& pointsSelected = selState->pointIndices[0];
+            TF_VERIFY(pointsSelected.size() == 5);
+        }
     }
 
     // manually verify if specifying a color for a set of points works.

--- a/pxr/imaging/hdx/testenv/testHdxPickingWithReprAndRefineChanges.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxPickingWithReprAndRefineChanges.cpp
@@ -320,8 +320,9 @@ My_TestGLDrawing::OffscreenTest()
         _selTracker->SetSelection(selection);
         DrawScene();
         _driver->WriteToFile("color", "color3_repr_change_cube2.png");
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube2"));
+        if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+            TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube2"));
+        }
     }
 
     // (c)
@@ -334,8 +335,9 @@ My_TestGLDrawing::OffscreenTest()
         _selTracker->SetSelection(selection);
         DrawScene();
         _driver->WriteToFile("color", "color4_repr_and_refine_change_cube1.png");
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube1"));
+        if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+            TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube1"));
+        }
     }
 
 

--- a/pxr/imaging/hdx/testenv/testHdxRenderTask.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxRenderTask.cpp
@@ -47,7 +47,9 @@ int main(int argc, char *argv[])
     HdStRenderDelegate renderDelegate;
     std::unique_ptr<HdRenderIndex> index(
         HdRenderIndex::New(&renderDelegate, {&driver}));
-    TF_VERIFY(index != nullptr);
+    if (!index) {
+        TF_FATAL_ERROR("Failed to create HdRenderIndex");
+    }
     std::unique_ptr<Hdx_UnitTestDelegate> delegate(
                                          new Hdx_UnitTestDelegate(index.get()));
     HdEngine engine;

--- a/pxr/imaging/hdx/testenv/testHdxUnpickablesAsOccluders.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxUnpickablesAsOccluders.cpp
@@ -266,8 +266,9 @@ My_TestGLDrawing::OffscreenTest()
     _driver->WriteToFile("color", "color2_cube0_pickable.png");
     HdSelection::HighlightMode mode = HdSelection::HighlightModeSelect;
 
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1);
-    TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube0"));
+    if (TF_VERIFY(selection->GetSelectedPrimPaths(mode).size() == 1)) {
+        TF_VERIFY(selection->GetSelectedPrimPaths(mode)[0] == SdfPath("/cube0"));
+    }
 
     // make cube0 unpickable; it should not let us pick cube1 since it occludes
     _driver->SetUnpickable({ SdfPath("/cube0") });


### PR DESCRIPTION
### Description of Change(s)

Code paths that would trigger UB are not allowed in C++, and the optimizer is allowed to assume they never happen and optimize around it, which can lead to surprising behaviour (could include even removing everything along that code path, before and after).

In this case the pointer checks need to conditional, otherwise the optimizer can assume that the pointer is never null, and through value decomposition, generate some surprising code.

If you want to see this in action: https://godbolt.org/z/eMnd9d41M

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
