### PR TITLE
Autodesk: [hdx] Picking fixes

### DIFF
--- a/pxr/imaging/hdx/CMakeLists.txt
+++ b/pxr/imaging/hdx/CMakeLists.txt
@@ -369,28 +369,33 @@ pxr_register_test(testHdxUnpickablesAsOccluders
 # Certain tests use plugins that require shared libraries.
 if (TARGET shared_libs)
 
-pxr_build_test(testHdxDrawTarget
-    LIBRARIES
-        hdx
-        hd
-        sdf
-        glf
-        arch
-        tf
-    CPPFILES
-        testenv/testHdxDrawTarget.cpp
-)
-pxr_register_test(testHdxDrawTarget
-    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdxDrawTarget"
-    TESTENV testenv/testHdxDrawTarget
-    EXPECTED_RETURN_CODE 0
-    IMAGE_DIFF_COMPARE
-        color1.png
-    FAIL 1
-    FAIL_PERCENT 1
-    PERCEPTUAL
-    ENV
-        TF_DEBUG=HD_SAFE_MODE
-)
+    # HdxDrawTargetTask::Execute has OpenGL calls
+    if (PXR_ENABLE_GL_SUPPORT AND X11_FOUND)
+        pxr_build_test(testHdxDrawTarget
+            LIBRARIES
+                hdx
+                hd
+                sdf
+                glf
+                arch
+                tf
+            CPPFILES
+                testenv/testHdxDrawTarget.cpp
+        )
+        pxr_register_test(testHdxDrawTarget
+            COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdxDrawTarget"
+            TESTENV testenv/testHdxDrawTarget
+            EXPECTED_RETURN_CODE 0
+            IMAGE_DIFF_COMPARE
+                color1.png
+            FAIL 1
+            FAIL_PERCENT 1
+            PERCEPTUAL
+            ENV
+                TF_DEBUG=HD_SAFE_MODE
+                HGI_ENABLE_VULKAN=0
+                HGI_ENABLE_WEBGPU=0
+        )
+    endif()
 
 endif() # TARGET shared_libs

--- a/pxr/imaging/hdx/pickTask.cpp
+++ b/pxr/imaging/hdx/pickTask.cpp
@@ -1366,7 +1366,10 @@ HdxPickResult::_IsValidHit(int index) const
     if (_GetPrimId(index) == -1) {
         return false;
     }
-    if (_pickTarget == HdxPickTokens->pickEdges) {
+
+    if (_pickTarget == HdxPickTokens->pickFaces) {
+        return (_GetElementId(index) != -1);
+    } else if (_pickTarget == HdxPickTokens->pickEdges) {
         return (_GetEdgeId(index) != -1);
     } else if (_pickTarget == HdxPickTokens->pickPoints) {
         return (_GetPointId(index) != -1);

--- a/pxr/imaging/hdx/testenv/testHdxPickResolveMode.cpp
+++ b/pxr/imaging/hdx/testenv/testHdxPickResolveMode.cpp
@@ -11,6 +11,8 @@
 #include "pxr/imaging/hd/mesh.h"
 #include "pxr/imaging/hd/selection.h"
 
+#include "pxr/imaging/hgi/capabilities.h"
+
 #include "pxr/imaging/hdSt/unitTestGLDrawing.h"
 #include "pxr/imaging/hdSt/unitTestHelper.h"
 
@@ -257,10 +259,10 @@ My_TestGLDrawing::_InitScene()
 {
     Hdx_UnitTestDelegate &delegate = _driver->GetDelegate();
 
-    delegate.AddCube(SdfPath("/cube0"), _GetTranslate( 5, 0, 5));
-    delegate.AddCube(SdfPath("/cube1"), _GetTranslate(-5, 0, 5));
-    delegate.AddCube(SdfPath("/cube2"), _GetTranslate(-5, 0,-5));
-    delegate.AddCube(SdfPath("/cube3"), _GetTranslate( 5, 0,-5));
+    delegate.AddCube(SdfPath("/cube0"), _GetTranslate( 5, 0.1, 5));
+    delegate.AddCube(SdfPath("/cube1"), _GetTranslate(-5, 0.1, 5));
+    delegate.AddCube(SdfPath("/cube2"), _GetTranslate(-5, 0.1,-5));
+    delegate.AddCube(SdfPath("/cube3"), _GetTranslate( 5, 0.1,-5));
 
     {
         delegate.AddInstancer(SdfPath("/instancerTop"));
@@ -390,23 +392,34 @@ My_TestGLDrawing::OffscreenTest()
                   == SdfPath("/protoBottom"));
     }
 
+    const auto conservativeRaster = _driver->GetHgi()->GetCapabilities()->
+        IsSet(HgiDeviceCapabilitiesBitsConservativeRaster);
     // 3. Unique
     {
         // The pick target influences what a "unique" hit is, so cycle through
         // all the supported pickTarget, and verify that a different number of
         // hits is returned each time.
-        TfTokenVector pickTargets = {
+        const TfTokenVector pickTargets = {
             HdxPickTokens->pickPrimsAndInstances,
             HdxPickTokens->pickFaces,
             HdxPickTokens->pickEdges,
             HdxPickTokens->pickPoints
         };
-        size_t expectedHitCount[] = {
+        const size_t expectedHitCountConventional[] = {
             6  /*primsAndInstances*/,
-            69 /*faces*/,
-           135 /*edges*/,
-            39 /*points*/};
-        
+            35 /*faces*/,
+            114 /*edges*/,
+            42 /*points*/
+        };
+        const size_t expectedHitCountConservative[] = {
+            6  /*primsAndInstances*/,
+            63 /*faces*/,
+            135 /*edges*/,
+            41 /*points*/
+        };
+        const auto expectedHitCount = conservativeRaster ?
+            expectedHitCountConservative : expectedHitCountConventional;
+
         for (size_t i = 0; i < pickTargets.size(); i++) {
             allHits.clear();
             HdSelectionSharedPtr selection = _Pick(pickStartPos, pickEndPos,
@@ -427,9 +440,7 @@ My_TestGLDrawing::OffscreenTest()
             HdxPickTokens->pickPrimsAndInstances,
             HdxPickTokens->resolveAll,
             &allHits);
-        const size_t expectedHitCount = 
-            _driver->GetHgi()->GetAPIName() == HgiTokens->Vulkan ?  22440 :
-            22438;
+        const size_t expectedHitCount = conservativeRaster ? 22558 : 21914;
         std::cout << "allHits: " << allHits.size()
                   << " expectedHitCount:  " << expectedHitCount
                   << std::endl;
@@ -537,4 +548,3 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 }
-


### PR DESCRIPTION
### Description of Change(s)

* Fixes ambiguous `resolveNearestToCamera` due to all the prims being at the same distance from the camera.
* Fixes picking generating invalid faces ids when points are resolved
* Handle the different expected test results for conservative vs conventional rasterization. Note that I had difficulty getting access to a GPU which supports conservative rasterization, so it's possible the numbers are slightly wrong.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
