### PR TITLE
Fix wireframe rendering in HdStorm on macOS

### DIFF
--- a/pxr/imaging/hdSt/shaders/meshWire.glslfx
+++ b/pxr/imaging/hdSt/shaders/meshWire.glslfx
@@ -250,7 +250,9 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+    }
 
     vec4 wireColor = GetWireframeColor();
 
@@ -267,7 +269,9 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+    }
 
     return ApplyFinalEdgeOpacity(Cfill, p);
 }
@@ -320,7 +324,9 @@ vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 vec4 ApplyEdgeColor(vec4 Cfill, vec4 patchCoord)
 {
     float p = GetEdgeOpacity();
-    if (p < 0.5) discard;
+    if (p < 0.5) {
+        discard;
+    }
 
     return ApplyFinalEdgeOpacity(Cfill, p);
 }


### PR DESCRIPTION
### Description of Change(s)

Adds braces to several if statement in the mesh wire shaders. For some reason on macOS, the fragments are unconditionally discarded otherwise.

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/3905

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
