### PR TITLE
Strip SDF format args before resolve

### DIFF
--- a/pxr/usd/sdf/assetPathResolver.h
+++ b/pxr/usd/sdf/assetPathResolver.h
@@ -10,6 +10,7 @@
 /// \file sdf/assetPathResolver.h
 
 #include "pxr/pxr.h"
+#include "pxr/usd/sdf/api.h"
 #include "pxr/usd/sdf/declareHandles.h"
 #include "pxr/usd/sdf/layer.h"
 
@@ -111,7 +112,7 @@ std::string Sdf_GetAnonLayerIdentifierTemplate(
 /// If \p identifier contains file format arguments
 /// (e.g. foo.sdf:SDF_FORMAT_ARGS:a=b), strip them, assign the resulting string
 /// to *strippedIdentifier and return true.  Otherwise just return false.
-bool Sdf_StripIdentifierArgumentsIfPresent(
+SDF_API bool Sdf_StripIdentifierArgumentsIfPresent(
     const std::string &identifier,
     std::string *strippedIdentifier);
 

--- a/pxr/usd/sdf/layerUtils.cpp
+++ b/pxr/usd/sdf/layerUtils.cpp
@@ -208,7 +208,16 @@ SdfResolveAssetPathRelativeToLayer(
         return computedAssetPath;
     }
 
-    return ArGetResolver().Resolve(computedAssetPath);
+    std::string pathToResolve;
+    std::string stripped;
+    if (Sdf_StripIdentifierArgumentsIfPresent(computedAssetPath, &stripped)) {
+        pathToResolve = stripped;
+    }
+    else {
+        pathToResolve = computedAssetPath;
+    }
+
+    return ArGetResolver().Resolve(pathToResolve);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/pxr/usd/usdUtils/assetLocalization.cpp
+++ b/pxr/usd/usdUtils/assetLocalization.cpp
@@ -13,6 +13,7 @@
 #include "pxr/usd/ar/packageUtils.h"
 #include "pxr/usd/ar/resolver.h"
 #include "pxr/usd/sdf/assetPath.h"
+#include "pxr/usd/sdf/assetPathResolver.h"
 #include "pxr/usd/sdf/fileFormat.h"
 #include "pxr/usd/sdf/layerUtils.h"
 #include "pxr/usd/sdf/primSpec.h"
@@ -94,7 +95,16 @@ UsdUtils_LocalizationContext::_EnqueueDependency(
         return;
     }
 
-    ArResolvedPath resolvedPath = ArGetResolver().Resolve(anchoredPath);
+    std::string pathToResolve;
+    std::string stripped;
+    if (Sdf_StripIdentifierArgumentsIfPresent(anchoredPath, &stripped)) {
+        pathToResolve = stripped;
+    }
+    else {
+        pathToResolve = anchoredPath;
+    }
+
+    ArResolvedPath resolvedPath = ArGetResolver().Resolve(pathToResolve);
     if (resolvedPath.empty()) {
         TF_WARN("Failed to resolve reference @%s@ with computed asset path "
             "@%s@ found in layer @%s@.",

--- a/pxr/usd/usdUtils/dependencies.cpp
+++ b/pxr/usd/usdUtils/dependencies.cpp
@@ -14,6 +14,7 @@
 #include "pxr/usd/usdUtils/dependencies.h"
 #include "pxr/usd/usdUtils/debugCodes.h"
 #include "pxr/usd/sdf/assetPath.h"
+#include "pxr/usd/sdf/assetPathResolver.h"
 #include "pxr/usd/sdf/fileFormat.h"
 #include "pxr/usd/sdf/layerUtils.h"
 
@@ -119,7 +120,16 @@ struct UsdUtils_ComputeAllDependenciesClient
     {
         const std::string anchoredPath = 
             SdfComputeAssetPathRelativeToLayer(layer, dependency);
-        const std::string resolvedPath = ArGetResolver().Resolve(anchoredPath);
+        std::string pathToResolve;
+        std::string stripped;
+        if (Sdf_StripIdentifierArgumentsIfPresent(anchoredPath, &stripped)) {
+            pathToResolve = stripped;
+        }
+        else {
+            pathToResolve = anchoredPath;
+        }
+
+        const std::string resolvedPath = ArGetResolver().Resolve(pathToResolve);
 
         if (resolvedPath.empty()) {
             if (PathShouldResolve(layer, resolvedPath, dependencyType)) {

--- a/pxr/usd/usdUtils/testenv/computeAllDependenciesFormatArgs/root.usda
+++ b/pxr/usd/usdUtils/testenv/computeAllDependenciesFormatArgs/root.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def "Root"
+{
+    asset myAsset = @./material.sbsar:SDF_FORMAT_ARGS:param=1@
+}

--- a/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
+++ b/pxr/usd/usdUtils/testenv/testUsdUtilsDependencies.py
@@ -113,6 +113,23 @@ class TestUsdUtilsDependencies(unittest.TestCase):
                     for f in ["image_d.<UDIM>.exr",
                             "image_e.<UDIM>.exr"]]))
 
+    def test_ComputeAllDependenciesSdfFormatArgs(self):
+        """Test that SDF_FORMAT_ARGS are stripped before resolving assets."""
+
+        rootLayer = "computeAllDependenciesFormatArgs/root.usda"
+        layers, assets, unresolved = \
+            UsdUtils.ComputeAllDependencies(rootLayer)
+
+        self.assertEqual(set(layers), set([Sdf.Layer.Find(rootLayer)]))
+
+        expectedAsset = os.path.abspath(
+            "computeAllDependenciesFormatArgs/material.sbsar")
+        self.assertEqual(
+            set([os.path.normcase(f) for f in assets]),
+            set([os.path.normcase(expectedAsset)]))
+
+        self.assertEqual(unresolved, [])
+
     def test_ComputeAllDependenciesAnonymousLayer(self):
         """Test for resolving dependencies of anonymous layers"""
         layer = Sdf.Layer.CreateAnonymous(".usda")


### PR DESCRIPTION
### Description of Change(s)
- Strip SDF format arguments before resolving asset paths in SdfResolveAssetPathRelativeToLayer, usdUtils dependency collection, and asset localization.
- Add a usdUtils dependency test for asset paths with SDF format args.
### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
N/A.
### Fixes Issue(s)
https://github.com/PixarAnimationStudios/OpenUSD/issues/3785
### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
