### PR TITLE
Ensuring that calls to Python's decref only happen when we haven't already been finalised.

### DIFF
--- a/pxr/external/boost/python/handle.hpp
+++ b/pxr/external/boost/python/handle.hpp
@@ -180,7 +180,13 @@ inline handle<T>::handle()
 template <class T>
 inline handle<T>::~handle()
 {
-    python::xdecref(m_p);
+    // This may leak memory (i.e., if the decref isn't called), 
+    // but that should only happen in the context of program termination 
+    // (where the OS will clean up the memory anyway).
+    if (Py_IsInitialized())
+    {
+        python::xdecref(m_p);
+    }
 }
 
 template <class T>

--- a/pxr/external/boost/python/object_core.hpp
+++ b/pxr/external/boost/python/object_core.hpp
@@ -426,8 +426,14 @@ inline api::object_base& api::object_base::operator=(api::object_base const& rhs
 
 inline api::object_base::~object_base()
 {
-    assert( Py_REFCNT(m_ptr) > 0 );
-    Py_DECREF(m_ptr);
+    // This may leak memory (i.e., if the decref isn't called), 
+    // but that should only happen in the context of program termination 
+    // (where the OS will clean up the memory anyway).
+    if (Py_IsInitialized())
+    {
+        assert( Py_REFCNT(m_ptr) > 0 );
+        Py_DECREF(m_ptr);
+    }
 }
 
 inline object::object(detail::borrowed_reference p)


### PR DESCRIPTION
### Description of Change(s)

Ensuring that calls to Python's decref only happen when Python hasn't already been finalised.
This addresses a crash in the debug build of Python3.13.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#3951 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
