### PR TITLE
Physics parser rigid body collider multithreaded fix

### DIFF
--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -2957,7 +2957,8 @@ bool LoadUsdPhysicsFromRange(const UsdStageWeakPtr stage,
     // first get the type
     std::vector<UsdPhysicsObjectType> collisionTypes;
     collisionTypes.resize(collisionPrims.size());
-    std::vector<TfToken> customTokens;
+    std::vector<TfToken> customGeomTokens;
+    customGeomTokens.resize(collisionPrims.size());
     {
         const auto workLambda = [&](const size_t beginIdx, const size_t endIdx)
         {
@@ -2967,18 +2968,18 @@ bool LoadUsdPhysicsFromRange(const UsdStageWeakPtr stage,
                 {
                     TfToken shapeToken;
                     const UsdPhysicsObjectType shapeType =
-                        _GetCollisionType(collisionPrims[i], 
-                                         &customPhysicsTokens->shapeTokens, 
+                        _GetCollisionType(collisionPrims[i],
+                                         &customPhysicsTokens->shapeTokens,
                                          &shapeToken);
                     collisionTypes[i] = shapeType;
                     if (shapeType == UsdPhysicsObjectType::CustomShape)
                     {
-                        customTokens.push_back(shapeToken);
+                        customGeomTokens[i] = shapeToken;
                     }
                 }
                 else
                 {
-                    collisionTypes[i] = _GetCollisionType(collisionPrims[i], 
+                    collisionTypes[i] = _GetCollisionType(collisionPrims[i],
                                                          nullptr, nullptr);
                 }
             }
@@ -2999,6 +3000,7 @@ bool LoadUsdPhysicsFromRange(const UsdStageWeakPtr stage,
     std::vector<UsdPrim> meshShapePrims;
     std::vector<UsdPrim> spherePointsShapePrims;
     std::vector<UsdPrim> customShapePrims;
+    std::vector<TfToken> customTokens;
     for (size_t i = 0; i < collisionTypes.size(); i++)
     {
         UsdPhysicsObjectType type = collisionTypes[i];
@@ -3052,6 +3054,7 @@ bool LoadUsdPhysicsFromRange(const UsdStageWeakPtr stage,
         case UsdPhysicsObjectType::CustomShape:
         {
             customShapePrims.push_back(collisionPrims[i]);
+            customTokens.push_back(customGeomTokens[i]);
         }
         break;
         case UsdPhysicsObjectType::SpherePointsShape:

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -2045,17 +2045,20 @@ void _FinalizeCollisionDescs(
     const size_t numPrimPerBatch = 10;
     WorkParallelForN(physicsPrims.size(), workLambda, numPrimPerBatch);
 
-    // Merge into bodyDesc->collisions single-threaded. Sort by body pointer
-    // so all collisions for the same body are consecutive (better locality).
+    // Merge into bodyDesc->collisions single-threaded. Sort by body path
+    // so all collisions for the same body are consecutive (better locality)
+    // and by collision path for deterministic ordering.
     if (!bodyCollisionPairs.empty())
     {
-        std::vector<BodyCollisionPair> sorted(
-            bodyCollisionPairs.begin(), bodyCollisionPairs.end());
-        std::sort(sorted.begin(), sorted.end(),
+        std::sort(bodyCollisionPairs.begin(), bodyCollisionPairs.end(),
             [](const BodyCollisionPair& a, const BodyCollisionPair& b) {
-                return a.first < b.first;
+                if (a.first->primPath < b.first->primPath)
+                    return true;
+                if (b.first->primPath < a.first->primPath)
+                    return false;
+                return a.second < b.second;
             });
-        for (const BodyCollisionPair& pair : sorted)
+        for (const BodyCollisionPair& pair : bodyCollisionPairs)
         {
             pair.first->collisions.push_back(pair.second);
         }

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -55,6 +55,9 @@
 #include "pxr/base/work/dispatcher.h"
 #include "pxr/base/work/loops.h"
 
+#include <algorithm>
+#include <tbb/concurrent_vector.h>
+
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -1984,13 +1987,19 @@ void _FinalizeCollision(UsdStageWeakPtr stage,
 // Finalize the collision desc, run in parallel
 template <typename DescType>
 void _FinalizeCollisionDescs(
-    UsdGeomXformCache& xfCache, const std::vector<UsdPrim>& physicsPrims, 
+    UsdGeomXformCache& xfCache, const std::vector<UsdPrim>& physicsPrims,
     std::vector<DescType>& physicsDesc, const RigidBodyMap& bodyMap,
-    const std::map<SdfPath, std::unordered_set<SdfPath, 
+    const std::map<SdfPath, std::unordered_set<SdfPath,
     SdfPath::Hash>>& collisionGroups)
 {
-    const auto workLambda = [physicsPrims, &physicsDesc, bodyMap, 
-        collisionGroups]
+    // Collect (body, collision path) pairs in a thread-safe container so we
+    // avoid concurrent push_back on bodyDesc->collisions (not thread-safe).
+    using BodyCollisionPair =
+        std::pair<UsdPhysicsRigidBodyDesc*, SdfPath>;
+    tbb::concurrent_vector<BodyCollisionPair> bodyCollisionPairs;
+
+    const auto workLambda = [physicsPrims, &physicsDesc, bodyMap,
+        collisionGroups, &bodyCollisionPairs]
     (const size_t beginIdx, const size_t endIdx)
     {
         for (size_t i = beginIdx; i < endIdx; i++)
@@ -2001,23 +2010,23 @@ void _FinalizeCollisionDescs(
                 const UsdPrim prim = physicsPrims[i];
                 // get the body
                 SdfPath bodyPath = _GetRigidBody(prim, bodyMap);
-                // body was found, add collision to the body
                 UsdPhysicsRigidBodyDesc* bodyDesc = nullptr;
                 if (bodyPath != SdfPath())
                 {
-                    RigidBodyMap::const_iterator bodyIt = 
+                    RigidBodyMap::const_iterator bodyIt =
                             bodyMap.find(bodyPath);
                     if (bodyIt != bodyMap.end())
                     {
                         bodyDesc = bodyIt->second;
-                        bodyDesc->collisions.push_back(colDesc.primPath);
+                        bodyCollisionPairs.push_back(
+                            BodyCollisionPair(bodyDesc, colDesc.primPath));
                     }
                 }
 
                 // check if collision belongs to collision groups
-                for (std::map<SdfPath, 
-                    std::unordered_set<SdfPath, 
-                        SdfPath::Hash>>::const_iterator it = 
+                for (std::map<SdfPath,
+                    std::unordered_set<SdfPath,
+                        SdfPath::Hash>>::const_iterator it =
                             collisionGroups.begin();
                     it != collisionGroups.end(); ++it)
                 {
@@ -2035,6 +2044,22 @@ void _FinalizeCollisionDescs(
 
     const size_t numPrimPerBatch = 10;
     WorkParallelForN(physicsPrims.size(), workLambda, numPrimPerBatch);
+
+    // Merge into bodyDesc->collisions single-threaded. Sort by body pointer
+    // so all collisions for the same body are consecutive (better locality).
+    if (!bodyCollisionPairs.empty())
+    {
+        std::vector<BodyCollisionPair> sorted(
+            bodyCollisionPairs.begin(), bodyCollisionPairs.end());
+        std::sort(sorted.begin(), sorted.end(),
+            [](const BodyCollisionPair& a, const BodyCollisionPair& b) {
+                return a.first < b.first;
+            });
+        for (const BodyCollisionPair& pair : sorted)
+        {
+            pair.first->collisions.push_back(pair.second);
+        }
+    }
 }
 
 struct ArticulationLink

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -1309,6 +1309,66 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(scene_found)
         self.assertTrue(custom_geometry_found)
 
+    def test_custom_geometry_multithreading_parse(self):
+        """Check that many custom-shape colliders parsed in parallel produce
+        the correct customGeometryToken for every descriptor, and that the
+        token-to-descriptor ordering is deterministic.
+        """
+        NUM_CUSTOM_COLLIDERS = 500
+
+        stage = Usd.Stage.CreateInMemory()
+        scene = UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        layer = stage.GetEditTarget().GetLayer()
+
+        # Use two distinct custom API tokens so we can verify that the
+        # right token ends up on the right descriptor.
+        token_a = "CustomGeomA_API"
+        token_b = "CustomGeomB_API"
+
+        expected = []
+        for k in range(NUM_CUSTOM_COLLIDERS):
+            prim_path = f"/Body/CustomCollider_{k}"
+            UsdGeom.Cube.Define(stage, prim_path)
+
+            token = token_a if k % 2 == 0 else token_b
+            expected.append((prim_path, token))
+
+            primSpec = Sdf.CreatePrimInLayer(layer, prim_path)
+            listOp = Sdf.TokenListOp()
+            listOp.prependedItems = [token, "PhysicsCollisionAPI"]
+            primSpec.SetInfo(Usd.Tokens.apiSchemas, listOp)
+
+        custom_tokens = UsdPhysics.CustomUsdPhysicsTokens()
+        custom_tokens.shapeTokens.append(token_a)
+        custom_tokens.shapeTokens.append(token_b)
+
+        ret_dict = UsdPhysics.LoadUsdPhysicsFromRange(
+            stage, [Sdf.Path.absoluteRootPath], [], custom_tokens)
+
+        self.assertIn(UsdPhysics.ObjectType.CustomShape, ret_dict)
+        prim_paths, descs = ret_dict[UsdPhysics.ObjectType.CustomShape]
+
+        self.assertEqual(len(descs), NUM_CUSTOM_COLLIDERS)
+
+        # Build a map from prim path -> expected token for easy lookup,
+        # since the parser may return prims in arbitrary (but internally
+        # consistent) order.
+        expected_map = {p: t for p, t in expected}
+
+        for prim_path, desc in zip(prim_paths, descs):
+            path_str = str(prim_path)
+            self.assertIn(path_str, expected_map,
+                          f"Unexpected prim path {path_str}")
+            self.assertEqual(
+                desc.customGeometryToken, expected_map[path_str],
+                f"Wrong customGeometryToken for {path_str}: "
+                f"got {desc.customGeometryToken}, "
+                f"expected {expected_map[path_str]}")
+
     # simulation owner tests
     def test_rigid_body_simulation_owner_parse(self):
         stage = Usd.Stage.CreateInMemory()

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -425,7 +425,7 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
-    def test_rigidbody_collision_multihreading_parse(self):
+    def test_rigidbody_collision_multithreading_parse(self):
         """Check that if a single rigid body has many collision objects, the
         multithreaded parsing works correctly.
         """
@@ -442,7 +442,16 @@ class TestUsdPhysicsParsing(unittest.TestCase):
             sphere = UsdGeom.Sphere.Define(stage, f"/Body/SphereCollider_{k}")
             UsdPhysics.CollisionAPI.Apply(sphere.GetPrim())
 
-        UsdPhysics.LoadUsdPhysicsFromRange(stage, [Sdf.Path.absoluteRootPath])
+        ret_dict = UsdPhysics.LoadUsdPhysicsFromRange(stage, [Sdf.Path.absoluteRootPath])
+
+        collider_count = 0
+        for key, value in ret_dict.items():
+            prim_paths, descs = value
+            if key == UsdPhysics.ObjectType.SphereShape:
+                collider_count = len(prim_paths)
+
+        self.assertEqual(collider_count, NUM_COLLIDERS,
+            f"Expected {NUM_COLLIDERS} colliders, got {collider_count}")
 
     def test_filtering_pairs_parse(self):
         stage = Usd.Stage.CreateInMemory()

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -425,6 +425,25 @@ class TestUsdPhysicsParsing(unittest.TestCase):
         self.assertTrue(rigidbody_found)
         self.assertTrue(cube_found)
 
+    def test_rigidbody_collision_multihreading_parse(self):
+        """Check that if a single rigid body has many collision objects, the
+        multithreaded parsing works correctly.
+        """
+        # somewhat arbitrary number - enough to reliably reproduce the
+        # multithreded multiple-colliders-under-one-rigidbody bug, but still
+        # finish in < .5s on my test machine.
+        NUM_COLLIDERS = 1000
+
+        stage = Usd.Stage.CreateInMemory()
+        body = UsdGeom.Xform.Define(stage, "/Body")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+
+        for k in range(NUM_COLLIDERS):
+            sphere = UsdGeom.Sphere.Define(stage, f"/Body/SphereCollider_{k}")
+            UsdPhysics.CollisionAPI.Apply(sphere.GetPrim())
+
+        UsdPhysics.LoadUsdPhysicsFromRange(stage, [Sdf.Path.absoluteRootPath])
+
     def test_filtering_pairs_parse(self):
         stage = Usd.Stage.CreateInMemory()
         self.assertTrue(stage)

--- a/pxr/usd/usdPhysics/wrapParseUtils.cpp
+++ b/pxr/usd/usdPhysics/wrapParseUtils.cpp
@@ -456,11 +456,17 @@ _PlaneShapeDesc_Repr(const UsdPhysicsPlaneShapeDesc& self)
 }
 
 static std::string
+_CustomShapeDesc_GetCustomGeometryToken(const UsdPhysicsCustomShapeDesc& self)
+{
+    return self.customGeometryToken.GetString();
+}
+
+static std::string
 _CustomShapeDesc_Repr(const UsdPhysicsCustomShapeDesc& self)
 {
     return TfStringPrintf("%sCustomShapeDesc(customGeometryToken=%s), parent %s",
         TF_PY_REPR_PREFIX.c_str(),
-        TfPyRepr(self.customGeometryToken).c_str(),
+        TfPyRepr(self.customGeometryToken.GetString()).c_str(),
         _ShapeDesc_Repr(self).c_str());
 }
 
@@ -855,8 +861,8 @@ void wrapParseUtils()
         bases<UsdPhysicsShapeDesc>>
             cuscls("CustomShapeDesc", no_init);
     cuscls
-        .def_readonly("customGeometryToken", 
-                      &UsdPhysicsCustomShapeDesc::customGeometryToken)
+        .add_property("customGeometryToken",
+                      _CustomShapeDesc_GetCustomGeometryToken)
         .def("__repr__", _CustomShapeDesc_Repr);
 
     class_<UsdPhysicsCubeShapeDesc, 


### PR DESCRIPTION
### Description of Change(s)

There is a bug in the multithreaded code for parsing UsdPhysics colliders - when multiple colliders are under the same rigid body, the multithreaded code can call `std::vector::push`, leading to possible race conditions / crash if the vector has to re-allocate.

I've included a unittest to replicate the issue.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- multithreaded crash when parsing multiple colliders under same rigid body

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [X] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
