### PR TITLE
Rigid body mass computation fix

### DIFF
--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -483,7 +483,7 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
 
         // traverse all collisions below this body and get their collision information
         // first gather all collisions
-        UsdPrimRange range(usdPrim);
+        UsdPrimRange range(usdPrim, UsdTraverseInstanceProxies());
         for (auto it = range.begin(); it != range.end(); ++it)
         {
             UsdPrim collisionPrim = *it;

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -595,5 +595,40 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
         self.compare_mass_information(
             rigidBodyAPI1, 8000.0, expectedCoM=Gf.Vec3f(0.0))
 
+    # instance proxy collider test - collider comes from an internal reference
+    # on an instanceable prim; the instance proxy must still be found during
+    # mass aggregation.
+    def test_mass_rigid_body_instance_proxy_collider(self):
+        self.setup_scene()
+
+        # Prototype collider authored outside the rigid-body hierarchy.
+        self.stage.OverridePrim("/Prototype_Collisions")
+        cube = UsdGeom.Cube.Define(
+            self.stage, "/Prototype_Collisions/cube")
+        cube.CreateSizeAttr(1.0)
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+
+        # Body with density only; mass is computed from colliders.
+        bodyXform = UsdGeom.Xform.Define(self.stage, "/World/Body")
+        body = bodyXform.GetPrim()
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(body)
+        UsdPhysics.MassAPI.Apply(body).CreateDensityAttr().Set(1000.0)
+
+        # Reference the prototype under the body and make it instanceable.
+        collisions = self.stage.DefinePrim("/World/Body/collisions")
+        collisions.GetReferences().AddInternalReference(
+            "/Prototype_Collisions")
+        collisions.SetInstanceable(True)
+
+        self.rigidBodyWorldTransform = \
+            UsdGeom.Xformable(body).ComputeLocalToWorldTransform(
+                Usd.TimeCode.Default())
+        self.rigidBodyPrim = body
+
+        # Expected: same as a unit cube at default density (1000 * 1^3).
+        self.compare_mass_information(
+            rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0),
+            expectedInertia=Gf.Vec3f(166.667))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of Change(s)
Root cause: rigidBodyAPI.cpp:486 used UsdPrimRange(usdPrim) which applies the default traversal predicate that skips instance proxies. When a collider is under an instanceable prim, it becomes an instance
  proxy and is never visited during mass aggregation.

Fix (1 line in pxr/usd/usdPhysics/rigidBodyAPI.cpp):
  // Before:
  UsdPrimRange range(usdPrim);
  // After:
  UsdPrimRange range(usdPrim, UsdTraverseInstanceProxies());

Test added test_mass_rigid_body_instance_proxy_collider to testUsdPhysicsRigidBodyAPI.py — verifies that a collider referenced via an instanceable prim is correctly included in mass computation.


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Fixes issue: https://github.com/PixarAnimationStudios/OpenUSD/issues/4005

### Checklist

- [x ] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
