### PR TITLE
APPLE: Add caveats to hdParticleField renderer example

### DIFF
--- a/extras/imaging/examples/hdParticleField/README.md
+++ b/extras/imaging/examples/hdParticleField/README.md
@@ -1,11 +1,24 @@
 # hdParticleField Render Delegate
+
 hdParticleField is a sample render delegate implementing rendering of the
 "particleField" prim type. It was designed to be a reference for gaussian
 splat rendering, to assist in schema development, but does not currently
 support other geometry types. It outputs a color/depth/primId tuple to support
 compositing into the usdview viewport and picking/selection highlighting.
 
+## Caveats
+
+This renderer is provided as-is for validating the schema data.
+
+The implementation is purely CPU based for maximum portability with minimum dependencies.
+As such, performance is not an explicit goal.
+
+While the renderer attempts to be accurate for the purposes of schema validation, it does not
+guarantee production quality accuracy for aspects like color reproduction. This can be highly
+dependent on the source data provided.
+
 ## Using hdParticleField
+
 hdParticleField is a render delegate that is registered as a plugin. It can be
 used as a viewport renderer (e.g. in usdview) through renderer discovery,
 or it can be instantiated directly. 


### PR DESCRIPTION
### Description of Change(s)

We received a few reports of people assuming the example renderer was for use outside of verification purposes.

While I think that was clear during the review and development period, I feel like we should explicitly call it out in the README so as to avoid providing false expectations. Perhaps it might even encourage someone to provide a more production focused addition as well

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
