### PR TITLE
Backport fix for CVE-2026-34544 in OpenEXRCore

### DIFF
--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_b44.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_b44.c
@@ -390,13 +390,13 @@ compress_b44_impl (exr_encode_pipeline_t* encode, int flat_field)
             // rightmost column and the bottom row.
             //
             uint16_t *row0, *row1, *row2, *row3;
+            /* row offset in elements: use uint64_t so y*nx cannot overflow int */
+            uint64_t row_off = (uint64_t) (y) * (uint64_t) (nx);
 
-            row0 = (uint16_t*) scratch;
-            row0 += y * nx;
-
-            row1 = row0 + nx;
-            row2 = row1 + nx;
-            row3 = row2 + nx;
+            row0 = (uint16_t*) scratch + row_off;
+            row1 = row0 + (uint64_t) nx;
+            row2 = row1 + (uint64_t) nx;
+            row3 = row2 + (uint64_t) nx;
 
             if (y + 3 >= ny)
             {
@@ -512,11 +512,12 @@ uncompress_b44_impl (
 
         for (int y = 0; y < ny; y += 4)
         {
-            row0 = (uint16_t*) scratch;
-            row0 += y * nx;
-            row1 = row0 + nx;
-            row2 = row1 + nx;
-            row3 = row2 + nx;
+            /* row offset in elements: use uint64_t so y*nx cannot overflow int */
+            uint64_t row_off = (uint64_t) (y) * (uint64_t) (nx);
+            row0 = (uint16_t*) scratch + row_off;
+            row1 = row0 + (uint64_t) nx;
+            row2 = row1 + (uint64_t) nx;
+            row3 = row2 + (uint64_t) nx;
             for (int x = 0; x < nx; x += 4)
             {
                 if (bIn + 3 > comp_buf_size) return EXR_ERR_OUT_OF_MEMORY;


### PR DESCRIPTION
### Description of Change(s)

This backports https://github.com/AcademySoftwareFoundation/openexr/commit/35e7aa35e22c1975606be86e859f31cc1fc598ee from OpenEXR upstream to address https://www.cve.org/CVERecord?id=CVE-2026-34544 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-h762-rhv3-h25v.

All I did was the following, in a git checkout of OpenUSD:

```
curl -L -O https://github.com/AcademySoftwareFoundation/openexr/commit/35e7aa35e22c1975606be86e859f31cc1fc598ee.patch
git am --directory=pxr/imaging/plugin/hioOpenEXR/OpenEXR -p3 35e7aa35e22c1975606be86e859f31cc1fc598ee.patch
```

The following text is from the upstream commit message. Note that the upstream fix was LLM-assisted, but I did not use an LLM to backport it or to write this PR text.

----

Fix B44/B44A integer overflow: use uint64_t for row offset (#2312)

The B44 and B44A decoder and encoder use channel width (`nx`) and height (`ny`) in row pointer math. `nx` and `ny` are `int`; the scratch buffer is correctly sized with `(uint64_t)ny * (uint64_t)nx * bytes_per_element`, but row bases were computed as:

```
  row0 = (uint16_t*)scratch;
  row0 += y * nx;   // int * int -> signed overflow when y*nx > INT_MAX
```

For large `nx` (e.g. 268435456), `y*nx` overflows, so `row0`/`row1`/`row2`/`row3` point before the scratch buffer.

Fix: compute the row offset in `uint64_t` before pointer arithmetic in both `uncompress_b44_impl` (decoder) and `compress_b44_impl` (encoder).

Analysis and solution with the help of Curor / Claude Opus 4.5

### Fixes Issue(s)

N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

N/A; no new functionality

- [ ] I have verified that all unit tests pass with the proposed changes

N/A; it is hard for me to run these locally

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
