### PR TITLE
Backport several OpenEXRCore security fixes

### DIFF
--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_dwa_decoder.h
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_dwa_decoder.h
@@ -265,7 +265,7 @@ LossyDctDecoder_execute (
     }
 
     for (int comp = 1; comp < numComp; ++comp)
-        rowBlock[comp] = rowBlock[comp - 1] + numBlocksX * 64;
+        rowBlock[comp] = rowBlock[comp - 1] + (size_t) numBlocksX * 64;
 
     //
     // Pack DC components together by common plane, so we can get
@@ -275,7 +275,7 @@ LossyDctDecoder_execute (
 
     currDcComp[0] = (uint16_t*) d->_packedDc;
     for (int comp = 1; comp < numComp; ++comp)
-        currDcComp[comp] = currDcComp[comp - 1] + numBlocksX * numBlocksY;
+        currDcComp[comp] = currDcComp[comp - 1] + (size_t) numBlocksX * numBlocksY;
 
     for (int blocky = 0; blocky < numBlocksY; ++blocky)
     {

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_dwa_decoder.h
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_dwa_decoder.h
@@ -651,13 +651,22 @@ LossyDctDecoder_execute (
         /* process in place in reverse to avoid temporary buffer */
         for (int y = 0; y < d->_height; ++y)
         {
-            float*    floatXdrPtr = (float*) chanData[chan]->_rows[y];
-            uint16_t* halfXdr     = (uint16_t*) floatXdrPtr;
+            uint8_t* rowBytes = chanData[chan]->_rows[y];
 
             for (int x = d->_width - 1; x >= 0; --x)
             {
-                floatXdrPtr[x] = one_from_native_float (
-                    half_to_float (one_to_native16 (halfXdr[x])));
+                // TODO: make an unaligned_store32f that takes the float and
+                // packages up a one_from_native_float and calls memcpy
+                // instead of the two memcpy. We should look at the metrics
+                // for dwa and see if there's a performance difference to do
+                // so at some point. See:
+                // https://github.com/AcademySoftwareFoundation/openexr/pull/2324
+
+                uint16_t h = unaligned_load16 (rowBytes + x * sizeof (uint16_t));
+                float    f = half_to_float (h);
+                uint32_t bits;
+                memcpy (&bits, &f, sizeof (bits));
+                unaligned_store32 (rowBytes + x * sizeof (float), bits);
             }
         }
     }

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_piz.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_piz.c
@@ -10,6 +10,7 @@
 #include "internal_huf.h"
 #include "internal_xdr.h"
 
+#include <limits.h>
 #include <string.h>
 
 /**************************************/
@@ -171,10 +172,11 @@ wdec16 (uint16_t l, uint16_t h, uint16_t* a, uint16_t* b)
 static void
 wav_2D_encode (uint16_t* in, int nx, int ox, int ny, int oy, uint16_t mx)
 {
-    int w14 = (mx < (1 << 14)) ? 1 : 0;
-    int n   = (nx > ny) ? ny : nx;
-    int p   = 1; // == 1 <<  level
-    int p2  = 2; // == 1 << (level+1)
+    int     w14  = (mx < (1 << 14)) ? 1 : 0;
+    int     n    = (nx > ny) ? ny : nx;
+    int     p    = 1; // == 1 <<  level
+    int     p2   = 2; // == 1 << (level+1)
+    int64_t oy64 = oy;
 
     //
     // Hierarchical loop on smaller dimension n
@@ -183,9 +185,9 @@ wav_2D_encode (uint16_t* in, int nx, int ox, int ny, int oy, uint16_t mx)
     while (p2 <= n)
     {
         uint16_t* py  = in;
-        uint16_t* ey  = in + oy * (ny - p2);
-        int       oy1 = oy * p;
-        int       oy2 = oy * p2;
+        uint16_t* ey  = in + oy64 * (ny - p2);
+        int64_t   oy1 = oy64 * p;
+        int64_t   oy2 = oy64 * p2;
         int       ox1 = ox * p;
         int       ox2 = ox * p2;
         uint16_t  i00, i01, i10, i11;
@@ -284,10 +286,11 @@ wav_2D_decode (
     int       oy, // i : y offset
     uint16_t  mx)  // i : maximum in[x][y] value
 {
-    int w14 = (mx < (1 << 14)) ? 1 : 0;
-    int n   = (nx > ny) ? ny : nx;
-    int p   = 1;
-    int p2;
+    int     w14  = (mx < (1 << 14)) ? 1 : 0;
+    int     n    = (nx > ny) ? ny : nx;
+    int     p    = 1;
+    int     p2;
+    int64_t oy64 = oy;
 
     //
     // Search max level
@@ -307,9 +310,9 @@ wav_2D_decode (
     while (p >= 1)
     {
         uint16_t* py  = in;
-        uint16_t* ey  = in + oy * (ny - p2);
-        int       oy1 = oy * p;
-        int       oy2 = oy * p2;
+        uint16_t* ey  = in + oy64 * (ny - p2);
+        int64_t   oy1 = oy64 * p;
+        int64_t   oy2 = oy64 * p2;
         int       ox1 = ox * p;
         int       ox2 = ox * p2;
         uint16_t  i00, i01, i10, i11;
@@ -502,11 +505,13 @@ internal_exr_apply_piz (exr_encode_pipeline_t* encode)
         nx     = curc->width;
         ny     = curc->height;
         wcount = (int) (curc->bytes_per_element / 2);
+        if (wcount > 0 && nx > INT_MAX / wcount)
+            return EXR_ERR_CORRUPT_CHUNK;
         for (int j = 0; j < wcount; ++j)
         {
             wav_2D_encode (wavbuf + j, nx, wcount, ny, wcount * nx, maxValue);
         }
-        wavbuf += nx * ny * wcount;
+        wavbuf += (uint64_t) nx * ny * wcount;
     }
 
     nBytes    = 0;
@@ -655,11 +660,13 @@ internal_exr_undo_piz (
         nx     = curc->width;
         ny     = curc->height;
         wcount = (int) (curc->bytes_per_element / 2);
+        if (wcount > 0 && nx > INT_MAX / wcount)
+            return EXR_ERR_CORRUPT_CHUNK;
         for (int j = 0; j < wcount; ++j)
         {
             wav_2D_decode (wavbuf + j, nx, wcount, ny, wcount * nx, maxValue);
         }
-        wavbuf += nx * ny * wcount;
+        wavbuf += (uint64_t) nx * ny * wcount;
     }
 
     //

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_pxr24.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_pxr24.c
@@ -182,7 +182,7 @@ apply_pxr24_impl (exr_encode_pipeline_t* encode)
                     if (nOut + nBytes > encode->scratch_alloc_size_1)
                         return EXR_ERR_OUT_OF_MEMORY;
                     nOut += nBytes;
-                    lastIn += w * 4;
+                    lastIn += (uint64_t) w * 4;
 
                     ptr[0] = out;
                     out += w;
@@ -371,7 +371,7 @@ undo_pxr24_impl (
                     ptr[2] = lastIn;
                     lastIn += w;
 
-                    if (nDec + (uint64_t) (w * 3) > outSize)
+                    if (nDec + (uint64_t) w * 3 > outSize)
                         return EXR_ERR_CORRUPT_CHUNK;
 
                     for (int x = 0; x < w; ++x)
@@ -384,7 +384,7 @@ undo_pxr24_impl (
                         unaligned_store32 (dout, pixel);
                         ++dout;
                     }
-                    nDec += (uint64_t) (w * 3);
+                    nDec += (uint64_t) w * 3;
                     break;
                 }
                 default: return EXR_ERR_INVALID_ARGUMENT;

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_zip.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/internal_zip.c
@@ -367,7 +367,7 @@ apply_zip_impl (exr_encode_pipeline_t* encode)
 
     if (rv == EXR_ERR_SUCCESS)
     {
-        if (compbufsz > encode->packed_bytes)
+        if (compbufsz >= encode->packed_bytes)
         {
             memcpy (
                 encode->compressed_buffer,

--- a/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/unpack.c
+++ b/pxr/imaging/plugin/hioOpenEXR/OpenEXR/OpenEXRCore/unpack.c
@@ -229,7 +229,7 @@ unpack_16bit_3chan_interleave (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = one_to_native16 (in0[x]);
@@ -269,7 +269,7 @@ unpack_16bit_3chan_interleave_rev (exr_decode_pipeline_t* decode)
         in1 = in0 + w;                     // G
         in2 = in1 + w;                     // R
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = one_to_native16 (in2[x]);
@@ -309,7 +309,7 @@ unpack_half_to_float_3chan_interleave (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in0[x]));
@@ -349,7 +349,7 @@ unpack_half_to_float_3chan_interleave_rev (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
 
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in2[x]));
@@ -390,7 +390,7 @@ unpack_16bit_3chan_planar (exr_decode_pipeline_t* decode)
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
 #if EXR_HOST_IS_NOT_LITTLE_ENDIAN
         for (int x = 0; x < w; ++x)
@@ -440,7 +440,7 @@ unpack_half_to_float_3chan_planar (exr_decode_pipeline_t* decode)
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
                             /* specialise to memcpy if we can */
         half_to_float_buffer ((float*) out0, in0, w);
         half_to_float_buffer ((float*) out1, in1, w);
@@ -485,7 +485,7 @@ unpack_16bit_3chan (exr_decode_pipeline_t* decode)
         in0 = (const uint16_t*) srcbuffer;
         in1 = in0 + w;
         in2 = in1 + w;
-        srcbuffer += w * 6; // 3 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 6; // 3 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
             *((uint16_t*) (out0 + x * inc0)) = one_to_native16 (in0[x]);
         for (int x = 0; x < w; ++x)
@@ -539,7 +539,7 @@ unpack_16bit_4chan_interleave (exr_decode_pipeline_t* decode)
         in2              = in1 + w;
         in3              = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             combined.a = one_to_native16 (in0[x]);
@@ -592,7 +592,7 @@ unpack_16bit_4chan_interleave_rev (exr_decode_pipeline_t* decode)
         in2              = in1 + w;
         in3              = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             combined.a = one_to_native16 (in0[x]);
@@ -633,7 +633,7 @@ unpack_half_to_float_4chan_interleave (exr_decode_pipeline_t* decode)
         in2        = in1 + w;
         in3        = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in3[x]));
@@ -674,7 +674,7 @@ unpack_half_to_float_4chan_interleave_rev (exr_decode_pipeline_t* decode)
         in2        = in1 + w;
         in3        = in2 + w;
 
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
         {
             out[0] = half_to_float (one_to_native16 (in0[x]));
@@ -719,7 +719,7 @@ unpack_16bit_4chan_planar (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
                             /* specialize to memcpy if we can */
 #if EXR_HOST_IS_NOT_LITTLE_ENDIAN
         for (int x = 0; x < w; ++x)
@@ -775,7 +775,7 @@ unpack_half_to_float_4chan_planar (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
 
         half_to_float_buffer ((float*) out0, in0, w);
         half_to_float_buffer ((float*) out1, in1, w);
@@ -825,7 +825,7 @@ unpack_16bit_4chan (exr_decode_pipeline_t* decode)
         in1 = in0 + w;
         in2 = in1 + w;
         in3 = in2 + w;
-        srcbuffer += w * 8; // 4 * sizeof(uint16_t), avoid type conversion
+        srcbuffer += (int64_t) w * 8; // 4 * sizeof(uint16_t), avoid type conversion
         for (int x = 0; x < w; ++x)
             *((uint16_t*) (out0 + x * inc0)) = one_to_native16 (in0[x]);
         for (int x = 0; x < w; ++x)
@@ -898,7 +898,7 @@ unpack_16bit (exr_decode_pipeline_t* decode)
                 }
             }
 #endif
-            srcbuffer += w * 2;
+            srcbuffer += (int64_t) w * 2;
         }
     }
     return EXR_ERR_SUCCESS;
@@ -963,7 +963,7 @@ unpack_32bit (exr_decode_pipeline_t* decode)
                 }
             }
 #endif
-            srcbuffer += w * 4;
+            srcbuffer += (int64_t) w * 4;
         }
     }
     return EXR_ERR_SUCCESS;
@@ -1118,7 +1118,7 @@ generic_unpack (exr_decode_pipeline_t* decode)
                          (uint64_t) decc->user_line_stride);
                 else
                 {
-                    srcbuffer += w * bpc;
+                    srcbuffer += (int64_t) w * bpc;
                     continue;
                 }
             }
@@ -1128,12 +1128,12 @@ generic_unpack (exr_decode_pipeline_t* decode)
             }
             else
             {
-                srcbuffer += w * bpc;
+                srcbuffer += (int64_t) w * bpc;
                 continue;
             }
 
             UNPACK_SAMPLES (w)
-            srcbuffer += w * bpc;
+            srcbuffer += (int64_t) w * bpc;
         }
     }
     return EXR_ERR_SUCCESS;


### PR DESCRIPTION
### Description of Change(s)

Similar to https://github.com/PixarAnimationStudios/OpenUSD/pull/4028, this backports several recent security-related commits from OpenEXR upstream.

This is not a substitute for a full rebase on the latest upstream, which contains many other fixes (see also discussion of the actual bundled version in https://github.com/PixarAnimationStudios/OpenUSD/issues/2935), nor does it include fixes for all potentially-applicable CVE’s on OpenEXR. See https://github.com/AcademySoftwareFoundation/openexr/security for an overview of recent CVE’s.

In particular, I didn’t attempt to backport https://github.com/AcademySoftwareFoundation/openexr/commit/c48f23ce68c2b543a1ef00db7b32b83459c1dda1 for https://www.cve.org/CVERecord?id=CVE-2026-34543 due to changes between OpenEXR 3.2.0 and 3.4.0, https://github.com/PixarAnimationStudios/OpenUSD/issues/2935#issuecomment-4191996687.

As with https://github.com/PixarAnimationStudios/OpenUSD/pull/4028, all I did here was use `git am` to apply commits from `OpenEXR`, retaining their commit messages, and in some cases manually adapt the commits due to changes in the surrounding context. Some or all of these commits were LLM-assisted upstream in OpenEXR, but I did not use an LLM to backport them or to write this PR text.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A

### Fixes Issue(s)

N/A

Fixes:

- ??? via https://github.com/AcademySoftwareFoundation/openexr/commit/7567d41783a6bf4995c2dbcd5da1930249d6fd8b
- https://www.cve.org/CVERecord?id=CVE-2026-34378 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-v76p-4qvv-vh4g via https://github.com/AcademySoftwareFoundation/openexr/commit/7a1c64ca74d12bf5f64a912d4e12a651689f8652
- https://www.cve.org/CVERecord?id=CVE-2026-34380 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-q3v8-hw4m-59w5 via https://github.com/AcademySoftwareFoundation/openexr/commit/f5beec2bd8636102e74460a0b624d3e26efc546f
- https://www.cve.org/CVERecord?id=CVE-2026-34588 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-588r-cr5c-w6hf via https://github.com/AcademySoftwareFoundation/openexr/commit/e464a33cc5bcd9f7dad2364bf76c08a52a5b0fbf
- https://www.cve.org/CVERecord?id=CVE-2026-34589 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-p8xc-w3q4-h64x via https://github.com/AcademySoftwareFoundation/openexr/commit/7c31424f9e381f386af83194d0b0e253da4a24d2
- https://www.cve.org/CVERecord?id=CVE-2026-34379 / https://github.com/AcademySoftwareFoundation/openexr/security/advisories/GHSA-w88v-vqhq-5p24 via https://github.com/AcademySoftwareFoundation/openexr/commit/3ad9b29430f9c2599dad113e1efe619a6ec7ba67

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

N/A; no new functionality

- [ ] I have verified that all unit tests pass with the proposed changes

N/A; it is hard for me to run these locally

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
