### PR TITLE
[vt, sdf, usd] fix array-bounds warnings on GCC 13

### DIFF
--- a/pxr/base/vt/streamOut.cpp
+++ b/pxr/base/vt/streamOut.cpp
@@ -7,6 +7,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/base/arch/demangle.h"
+#include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/vt/streamOut.h"
 #include "pxr/base/vt/types.h"
@@ -84,6 +85,7 @@ _StreamArrayRecursive(
         }
     }
     else {
+        TF_AXIOM(dimension < Vt_ShapeData::NumOtherDims);
         for (size_t j = 0; j < shape.otherDims[dimension]; ++j) {
             if (j) { out << ", "; }
             _StreamArrayRecursive(

--- a/pxr/usd/sdf/schema.cpp
+++ b/pxr/usd/sdf/schema.cpp
@@ -31,6 +31,7 @@
 #include "pxr/base/vt/dictionary.h"
 
 #include <deque>
+#include <iterator>
 #include <map>
 #include <set>
 #include <vector>
@@ -1539,6 +1540,7 @@ _AddValuesToValueContext(std::deque<Value> *values, Sdf_ParserValueContext *cont
             values->pop_front();
         }
     } else if (static_cast<size_t>(level) < context->valueTupleDimensions.size) {
+        TF_AXIOM(static_cast<size_t>(level) < std::size(context->valueTupleDimensions.d));
         context->BeginTuple();
         for (size_t i = 0; i < context->valueTupleDimensions.d[level]; i++) {
             _AddValuesToValueContext(values, context, level + 1);

--- a/pxr/usd/usd/clip.cpp
+++ b/pxr/usd/usd/clip.cpp
@@ -24,6 +24,7 @@
 #include "pxr/usd/usd/tokens.h"
 
 #include "pxr/base/gf/interval.h"
+#include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/preprocessorUtilsLite.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/vt/array.h"
@@ -430,6 +431,7 @@ Usd_Clip::GetBracketingTimeSamplesForPath(
         return true;
     }
 
+    TF_AXIOM(numTimes <= bracketingTimes.size());
     std::sort(bracketingTimes.begin(), bracketingTimes.begin() + numTimes);
     auto uniqueIt = std::unique(
         bracketingTimes.begin(), bracketingTimes.begin() + numTimes);


### PR DESCRIPTION
### Description of Change(s)
Three false-positive warning sites caused by GCC 13 losing bound information during aggressive inlining.

- **pxr/base/vt/streamOut.cpp**
   - Ensure dimension is less than `Vt_ShapeData::NumOtherDims` before indexing into `shape.otherDims`

- **pxr/usd/sdf/schema.cpp**
  - Add `TF_AXIOM(static_cast<size_t>(level) < std::size(valueTupleDimensions.d))` to the else-if in `_AddValuesToValueContext`. GCC cannot bound the plain size_t size member but can see std::size(d) == 2.

- **pxr/usd/usd/clip.cpp**
  - Add `TF_AXIOM(numTimes <= brackingTimes.size())` so GCC can see that `numTimes`
  is correctly bounded before std::sort

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
