### PR TITLE
[sdf] fix array-bounds warning on GCC 13 for predicateLibrary.h

### DIFF
--- a/pxr/base/arch/pragmas.h
+++ b/pxr/base/arch/pragmas.h
@@ -51,6 +51,9 @@
     #define ARCH_PRAGMA_STRINGOP_OVERFLOW \
         _Pragma("GCC diagnostic ignored \"-Wstringop-overflow=\"")
 
+    #define ARCH_PRAGMA_ARRAY_BOUNDS \
+        _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+
     #if ARCH_COMPILER_GCC_MAJOR >= 13
         #define ARCH_PRAGMA_SELF_MOVE \
             _Pragma("GCC diagnostic ignored \"-Wself-move\"")
@@ -200,6 +203,10 @@
 
 #if !defined ARCH_PRAGMA_STRINGOP_OVERFLOW
     #define ARCH_PRAGMA_STRINGOP_OVERFLOW
+#endif
+
+#if !defined ARCH_PRAGMA_ARRAY_BOUNDS
+    #define ARCH_PRAGMA_ARRAY_BOUNDS
 #endif
 
 #if !defined ARCH_PRAGMA_UNUSED_PRIVATE_FIELD

--- a/pxr/usd/sdf/predicateLibrary.h
+++ b/pxr/usd/sdf/predicateLibrary.h
@@ -10,6 +10,7 @@
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/api.h"
 
+#include "pxr/base/arch/pragmas.h"
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/functionTraits.h"
 #include "pxr/base/tf/pxrTslRobinMap/robin_map.h"
@@ -555,7 +556,13 @@ private:
         // A fold expression would let us just do &&, but that's '17, so we just
         // do all of them and set a bool.
         bool bound = true;
+        // vector<bool> bit-packing triggers spurious -Warray-bounds and
+        // -Wstringop-overflow from GCC 13 when its memmove is inlined here.
+        ARCH_PRAGMA_PUSH
+        ARCH_PRAGMA_ARRAY_BOUNDS
+        ARCH_PRAGMA_STRINGOP_OVERFLOW
         boundArgs.assign(args.size(), false);
+        ARCH_PRAGMA_POP
         // Need a unused array so we can use an initializer list to invoke
         // _TryBindOne N times.
         int unused[] = {


### PR DESCRIPTION
Suppress spurious -Warray-bounds and -Wstringop-overflow from GCC 13
around boundArgs.assign() in _TryBindArgs. The vector<bool>
bit-packing specialization triggers these diagnostics when its
word-level memmove is inlined; wrapping the single call-site with
ARCH_PRAGMA_PUSH / ARCH_PRAGMA_ARRAY_BOUNDS / ARCH_PRAGMA_STRINGOP_OVERFLOW /
ARCH_PRAGMA_POP silences them without changing the type or behavior.
    
Add ARCH_PRAGMA_ARRAY_BOUNDS to arch/pragmas.h (GCC-only, with the
standard no-op fallback for Clang and MSVC).

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
