### PR TITLE
Avoid `nonnull` warning in rvalue construction of `TfSmallVector` without local storage

### DIFF
--- a/pxr/base/tf/smallVector.h
+++ b/pxr/base/tf/smallVector.h
@@ -156,7 +156,6 @@ template <typename T, uint32_t N>
 class TfSmallVector : public TfSmallVectorBase
 {
 public:
-
     /// XXX: Functionality currently missing, and which we would like to add as
     ///  needed:
     ///     - emplace
@@ -240,8 +239,12 @@ public:
         // sizes. Note that capacities will be the same in this case, so no
         // need to swap those.
         else {
-            _UninitializedMove(rhs.begin(), rhs.end(), begin());
-            rhs._Destruct();
+            // If N is 0, this means that rhs is empty and there are no elements that need moving or destroying
+            // This avoids warnings in GCC.
+            if constexpr (N > 0) {
+                _UninitializedMove(rhs.begin(), rhs.end(), begin());
+                rhs._Destruct();
+            }
         }
         std::swap(_size, rhs._size);
     }

--- a/pxr/base/tf/testenv/smallVector.cpp
+++ b/pxr/base/tf/testenv/smallVector.cpp
@@ -320,6 +320,33 @@ testNoLocalStorage()
 }
 
 static void
+testEmptyMoveNoLocalStorage()
+{
+    TfSmallVector<int, 0> empty{};
+    {
+        // Empty move construction
+        TfSmallVector<int, 0> v{std::move(empty)};
+        TF_AXIOM(v.size() == 0);
+        TF_AXIOM(v.capacity() == 0);
+
+        v.push_back(1414);
+        TF_AXIOM(v.size() == 1);
+        TF_AXIOM(v.capacity() == 1);
+        TF_AXIOM(v.front() == 1414);
+        TF_AXIOM(v.back() == 1414);
+
+        v.push_back(1515);
+        TF_AXIOM(v.size() == 2);
+        TF_AXIOM(v.capacity() == 2);
+        TF_AXIOM(v.front() == 1414);
+        TF_AXIOM(v.back() == 1515);
+    }
+
+    TF_AXIOM(empty.size() == 0);
+    TF_AXIOM(empty.capacity() == 0);
+}
+
+static void
 testGrowth()
 {
     TfSmallVector<int, 2> v;
@@ -1588,6 +1615,8 @@ Test_TfSmallVector()
     testConstructors();
     std::cout << "testNoLocalStorage" << std::endl;
     testNoLocalStorage();
+    std::cout << "testEmptyMoveNoLocalStorage" << std::endl;
+    testEmptyMoveNoLocalStorage();
     std::cout << "testGrowth" << std::endl;
     testGrowth();
     std::cout << "testIteration" << std::endl;


### PR DESCRIPTION
### Description of Change(s)

`TfSmallVector` supports instantiations with no local storage (the capacity template argument set to 0). These are utilized in `pxr/exec`.

The `TfSmallVector` move constructor assumes is that if the sizes of the local storage and the rvalue parameter are the same, the rvalue's data can be moved into the constructing object's local storage. However, if the local storage size is 0, the `_UninitializedMove` tries to move an empty range into non-existent local storage.  In newer versions of GCC, this causes a warning.

```
# Truncated stack trace
inlined from ‘static Iterator pxrInternal_v0_26_5__pxrReserved__::TfSmallVectorBase::_UninitializedMove(Iterator, Iterator, Iterator) [with Iterator = pxrInternal_v0_26_5__pxrReserved__::GfQuatd*]’ at pxr/base/tf/smallVector.h:84:39,
inlined from ‘pxrInternal_v0_26_5__pxrReserved__::TfSmallVector<T, N>::TfSmallVector(pxrInternal_v0_26_5__pxrReserved__::TfSmallVector<T, N>&&) [with T = pxrInternal_v0_26_5__pxrReserved__::GfQuatd; unsigned int N = 0]’ at pxr/base/tf/smallVector.h:245:35
...
error: argument 1 null where non-null expected [-Werror=nonnull]
```

This change introduces a `constexpr` guard to only apply the move if local storage is available.

With this change, the following build command should build without warnings or errors in GCC 13.
```
python3 build_scripts/build_usd.py ../inst/usd-strict --no-imaging --no-examples --no-materialx  --build-args USD,'-DPXR_STRICT_BUILD_MODE=ON -DCMAKE_CXX_FLAGS="-Wno-array-bounds -Wno-uninitialized"' -vv --tests
```

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
