### PR TITLE
Better tracking of instancer prims that get retyped via PrimsAdded

### DIFF
--- a/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/piPrototypeSceneIndex.cpp
@@ -269,26 +269,35 @@ UsdImaging_PiPrototypeSceneIndex::_PrimsAdded(
 
     // First pass: Identify instancers and overs.
     // Use thread-local results to avoid synchronizing.
-    tbb::enumerable_thread_specific<SdfPathVector> perThreadResults;
+    tbb::enumerable_thread_specific<SdfPathVector> perThreadInclusions;
+    tbb::enumerable_thread_specific<SdfPathVector> perThreadExclusions;
     WorkParallelForN(
         //entries.begin(), entries.end(),
         entries.size(),
         [&](size_t begin, size_t end)
         {
-            SdfPathVector &results = perThreadResults.local();
+            SdfPathVector &inclusions = perThreadInclusions.local();
+            SdfPathVector &exclusions = perThreadExclusions.local();
             for (size_t i=begin; i<end; ++i) {
                 const HdSceneIndexObserver::AddedPrimEntry &entry = entries[i];
                 if (entry.primType == HdPrimTypeTokens->instancer ||
                     _IsOver(_GetInputSceneIndex()->GetPrim(entry.primPath))) {
-                    results.push_back(entry.primPath);
+                    inclusions.push_back(entry.primPath);
+                }
+                else
+                {
+                    exclusions.push_back(entry.primPath);
                 }
             }
         },
         256 /* note: relatively coarse grain size */ );
 
     // Commit per-thread results back into _instancersAndOvers.
-    for (const SdfPath &path: tbb::flatten2d(perThreadResults)) {
+    for (const SdfPath &path: tbb::flatten2d(perThreadInclusions)) {
         _instancersAndOvers.insert(path);
+    }
+    for (const SdfPath &path: tbb::flatten2d(perThreadExclusions)) {
+        _instancersAndOvers.erase(path);
     }
 
     // Second pass: Clear out types for any prims under instancers or overs.


### PR DESCRIPTION
### Description of Change(s)

Previously, new entries (in PrimsAdded) were filtered to identify instancers, and those paths were added to a local cache. But this didn't capture the event where an existing instancer was retyped. This change also captures the non-instancers from the new entries, and uses that list to remove entries that might be in the cache from an earlier representation of the scene.

I expect this new code path will get hit a lot (i.e., the vast majority of PrimsAdded prims will _not_ be instancers), so I am mildly nervous about potential performance implications, but I can't immediately come up with a lighter-weight alternative. I can verify that the change resolves the reported issue, but you may have a more elegant solution instead.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#4040 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
