### PR TITLE
[arch] Added fallback for Windows plugin loading when MAX_PATH is exceeded

### DIFF
--- a/pxr/base/arch/library.cpp
+++ b/pxr/base/arch/library.cpp
@@ -16,6 +16,8 @@
 #include <dlfcn.h>
 #endif
 
+#include <filesystem>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 #if defined(ARCH_OS_WINDOWS)
@@ -31,10 +33,24 @@ void* ArchLibraryOpen(const std::string &filename, int flag)
     if (void* result = LoadLibraryW(std::filesystem::u8path(filename).c_str())) {
         return result;
     }
-    else {
+
+    arch_lastLibraryError = GetLastError();
+
+    // If library failed to load because the path is too long
+    // try to use a UNC file name, this helps work around windows MAX_PATH issues
+    if (ERROR_FILENAME_EXCED_RANGE == arch_lastLibraryError) {
+        std::filesystem::path uncpath("\\\\?\\");
+        uncpath += std::filesystem::absolute(filename);
+
+        if (void* result = LoadLibrary(uncpath.string().c_str())) {
+            arch_lastLibraryError = 0;
+            return result;
+        }
+
         arch_lastLibraryError = GetLastError();
-        return nullptr;
     }
+
+    return nullptr;
 #else
     // Clear any unchecked error first.
     (void)dlerror();


### PR DESCRIPTION

### Description of Change(s)

Added second LoadLibrary call on windows, if the first one fails. The seconds call will add the Windows UNC header to an abs file path: "\\?\". If the first failure was related to the path being too long, then this fixes the issue. Without changing the original behaviour.

### Fixes Issue(s)

Fixes #4046

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
