### PR TITLE
Ensure Hydra dirty signals when a material's surface output is changed

### DIFF
--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -211,6 +211,17 @@ UsdImagingMaterialAdapter::InvalidateImagingSubprim(
 
     // If we dirtied an interface input dirty that terminal
     for (UsdShadeOutput& output : material.GetOutputs()) {
+        bool terminalDirty = false;
+        for (const TfToken& property : properties) {
+            if (output.GetFullName() == property) {
+                result.insert(_CreateTerminalLocator(output.GetBaseName()));
+                terminalDirty = true;
+                break;
+            }
+        }
+        if (terminalDirty) {
+            continue;
+        }
         for (UsdShadeConnectionSourceInfo& connection :
              output.GetConnectedSources()) {
             _ConnectionSet seenConnections;


### PR DESCRIPTION
### Description of Change(s)

Previously there was no Hydra2 dirty signal if you changed the connection for a material from one shader to another. This is better explained in the linked issue.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#4051 

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
