### PR TITLE
Support labels in `pxr_register_test`

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -776,7 +776,7 @@ function(pxr_register_test TEST_NAME)
             CLEAN_OUTPUT
             EXPECTED_RETURN_CODE
             TESTENV TESTENV_DEST
-            WARN WARN_PERCENT HARD_WARN FAIL FAIL_PERCENT HARD_FAIL)
+            WARN WARN_PERCENT HARD_WARN FAIL FAIL_PERCENT HARD_FAIL LABELS)
     set(MULTI_VALUE_ARGS DIFF_COMPARE IMAGE_DIFF_COMPARE ENV PRE_PATH POST_PATH)
 
     cmake_parse_arguments(bt
@@ -1042,7 +1042,9 @@ function(pxr_register_test TEST_NAME)
     if (bt_RUN_SERIAL)
         set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL TRUE)
     endif()
-
+    if (bt_LABELS)
+        set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${bt_LABELS}")
+    endif()
 endfunction() # pxr_register_test
 
 function(pxr_setup_plugins)

--- a/pxr/base/work/CMakeLists.txt
+++ b/pxr/base/work/CMakeLists.txt
@@ -132,6 +132,7 @@ pxr_build_test(testWorkThreadLimits
 
 pxr_register_test(testWorkDispatcher
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkDispatcher"
+    LABELS $<IF:$<PLATFORM_ID:Windows>,"flaky",>
 )
 pxr_register_test(testWorkLoops
     COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkLoops"
@@ -163,14 +164,17 @@ if (use_tbb)
     )
     pxr_register_test(testWorkThreadLimitsTBBDefault
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimitsTBB"
+        LABELS "flaky"
     )
     pxr_register_test(testWorkThreadLimitsTBB1
         ENV PXR_WORK_THREAD_LIMIT=1
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimitsTBB"
+        LABELS "flaky"
     )
     pxr_register_test(testWorkThreadLimitsTBB3
         ENV PXR_WORK_THREAD_LIMIT=3
         COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testWorkThreadLimitsTBB"
+        LABELS "flaky"
     )
 
     # Note: These tests are disabled for emscripten due to TBB worker


### PR DESCRIPTION
### Description of Change(s)

`ctest` offers labels as a way to group tests for downstream runners.  This introduces support for test labeling and adds a single label `flaky`, implying that the test occasionally fails but usually succeeds on retry.

The initial set of flaky tests were identified by looking through recent pipeline logs for failures that appeared spurious.  The `work` tests have been known to fail occasionally for most of the repos lifetime.

Future PRs may contribute additional labels (such as those used in regex-based exclusion rules in the CI pipelines).

Example usage:
```
# Exclude flaky tests
ctest -C Release -LE flaky
# Allow multiple runs of flaky tests
ctest -C Release -L flaky --repeat until-pass 3
```

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/18

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ]  I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
