### PR TITLE
Repeat flaky tests 3 times before failing

### DIFF
--- a/.github/workflows/buildusd.yml
+++ b/.github/workflows/buildusd.yml
@@ -95,7 +95,14 @@ jobs:
         working-directory: ./USDgen/build/OpenUSD
         run: |
           ctest --output-on-failure -j4 -C Release \
-                --exclude-regex "^(testUsdview|testUsdRecord|testUsdAppUtilsFrameRecorder|testUsdImaging|testHgiGL|testHdx|testHdSt|testExecGeomXformable_Perf_Large|testWorkThreadLimitsDefault)"
+                --exclude-regex "^(testUsdview|testUsdRecord|testUsdAppUtilsFrameRecorder|testUsdImaging|testHgiGL|testHdx|testHdSt|testExecGeomXformable_Perf_Large|testWorkThreadLimitsDefault)" \
+                -LE flaky --no-tests=error
+      - name: Run USD Headless Tests (flaky)
+        working-directory: ./USDgen/build/OpenUSD
+        run: |
+          ctest --output-on-failure -j4 -C Release \
+                --exclude-regex "^(testUsdview|testUsdRecord|testUsdAppUtilsFrameRecorder|testUsdImaging|testHgiGL|testHdx|testHdSt|testExecGeomXformable_Perf_Large|testWorkThreadLimitsDefault)" \
+                -L flaky --repeat until-pass:3
 
   GPUTests:
     needs:
@@ -150,7 +157,18 @@ jobs:
           sudo vglrun +v -d egl \
           ctest --output-on-failure -j4 -V -C Release \
                 --tests-regex "^(testUsdview|testUsdRecord|testUsdAppUtilsFrameRecorder|testUsdImaging|testHgiGL|testHdx|testHdSt)" \
-                --exclude-regex "^($(paste -sd "|" ${{ github.workspace }}/.github/workflows/tests_to_ignore.txt))$"
+                --exclude-regex "^($(paste -sd "|" ${{ github.workspace }}/.github/workflows/tests_to_ignore.txt))$" \
+                -LE flaky --no-tests=error
+      - name: Run USD GPU Tests (flaky)
+        working-directory: ./USDgen/build/OpenUSD
+        run: |
+          # Known test failures in tests_to_ignore.txt tracked by internal ticket: USD-11921
+          sudo xvfb-run --server-args="-screen 0 2560x1600x24 +extension GLX +render" \
+          sudo vglrun +v -d egl \
+          ctest --output-on-failure -j4 -V -C Release \
+                --tests-regex "^(testUsdview|testUsdRecord|testUsdAppUtilsFrameRecorder|testUsdImaging|testHgiGL|testHdx|testHdSt)" \
+                --exclude-regex "^($(paste -sd "|" ${{ github.workspace }}/.github/workflows/tests_to_ignore.txt))$" \
+                -L flaky --repeat until-pass:3
       - name: Prepare Test Artifacts
         if: always()
         working-directory: ./USDgen/build/OpenUSD
@@ -226,7 +244,14 @@ jobs:
         working-directory: ./USDgen/build/OpenUSD
         run: |
           export PATH=/Applications/CMake.app/Contents/bin:$PATH
-          ctest --output-on-failure -j4 -C Release --exclude-regex "testExecGeomXformable_Perf_Large"
+          ctest --output-on-failure -j4 -C Release --exclude-regex "testExecGeomXformable_Perf_Large" \
+                -LE flaky --no-tests=error
+      - name: Test USD (flaky)
+        working-directory: ./USDgen/build/OpenUSD
+        run: |
+          export PATH=/Applications/CMake.app/Contents/bin:$PATH
+          ctest --output-on-failure -j4 -C Release --exclude-regex "testExecGeomXformable_Perf_Large" \
+                -L flaky --repeat until-pass:3
 
   Windows:
     needs:
@@ -283,7 +308,16 @@ jobs:
           call set PATH=${{ github.workspace }}\USDinst\bin;${{ github.workspace }}\USDinst\lib;${{ github.workspace }}\USDinst\share\usd\examples\plugin;${{ github.workspace }}\USDinst\plugin\usd;%PATH%
           call set PYTHONPATH=${{ github.workspace }}\USDinst\lib\python;%PYTHONPATH%
           :: Internal ticket USD-8035
-          ctest --output-on-failure -j4 -C Release --exclude-regex "TfPathUtils|testExecGeomXformable_Perf_Large"
+          ctest --output-on-failure -j4 -C Release --exclude-regex "TfPathUtils|testExecGeomXformable_Perf_Large" \
+                -LE flaky --no-tests=error
+      - name: Test USD (flaky)
+        working-directory: ./USDgen/build/OpenUSD
+        run: |
+          call set PATH=${{ github.workspace }}\USDinst\bin;${{ github.workspace }}\USDinst\lib;${{ github.workspace }}\USDinst\share\usd\examples\plugin;${{ github.workspace }}\USDinst\plugin\usd;%PATH%
+          call set PYTHONPATH=${{ github.workspace }}\USDinst\lib\python;%PYTHONPATH%
+          :: Internal ticket USD-8035
+          ctest --output-on-failure -j4 -C Release --exclude-regex "TfPathUtils|testExecGeomXformable_Perf_Large" \
+                -L flaky --repeat until-pass:3
         shell: cmd
 
   Wasm:
@@ -336,4 +370,8 @@ jobs:
       - name: Test USD
         working-directory: ./USDgen/build/OpenUSD
         run: |
-          ctest --output-on-failure -j4 -C Release
+          ctest --output-on-failure -j4 -C Release -LE flaky --no-tests=error
+      - name: Test USD (flaky)
+        working-directory: ./USDgen/build/OpenUSD
+        run: |
+          ctest --output-on-failure -j4 -C Release -L flaky --repeat until-pass:3


### PR DESCRIPTION
### Description of Change(s)

#4054 introduced `flaky` labels to a limited set of tests.  This adds new steps to the CI pipeline which will allow flaky tests to run up to 3 times before failing.  This should improve the reliability of the GitHub CI.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/18

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
