### PR TITLE
Reworking the logic of the instanceProxyPathTranslationSceneIndex

### DIFF
--- a/pxr/usdImaging/usdImaging/instanceProxyPathTranslationSceneIndex.cpp
+++ b/pxr/usdImaging/usdImaging/instanceProxyPathTranslationSceneIndex.cpp
@@ -101,33 +101,37 @@ _TranslatePath(
     // We do this for two reasons:
     // 1. Avoid querying the scene index at each path prefix for the general
     //    case where the prim is not a descendant of an instance prim.
-    // 2. To not incorreclty translate an instance prim path to its
+    // 2. To not incorrectly translate an instance prim path to its
     //    prototype path. We want to do this only for *descendant* paths of
     //    instance prims that don't have a corresponding prim in the scene
     //    index.
     //
-    const HdSceneIndexPrim prim = sceneIndex->GetPrim(path);
-    if (_IsValid(prim)) {
-        return path;
-    }
-
-    // Iterate over the prefixes, adding the terminal path element of each
-    // prefix and checking if the prim at the resulting path is an instance.
-    // If it is, replace the result with the prototype path of the instance and
-    // continue iterating over the prefixes.
-    //
-    SdfPath result = SdfPath::AbsoluteRootPath();
-
-    for (SdfPath const& p: path.GetPrefixes()) {
-        result = result.AppendChild(p.GetNameToken());
-
-        HdInstanceSchema instanceSchema = 
-            HdInstanceSchema::GetFromParent(
-                sceneIndex->GetPrim(result).dataSource);
-        
-        if (const std::optional<SdfPath> prototypePath =
-                _GetPrototypePath(instanceSchema, sceneIndex)) {
-            result = *prototypePath;
+    SdfPath result(path);
+    while (!_IsValid(sceneIndex->GetPrim(result)))
+    {
+        // Work back-to-front, until we find an ancestor prim that exists
+        bool loopAgain = false;
+        for (SdfPath const& ancestorPath : result.GetAncestorsRange()) {
+            if (HdSceneIndexPrim ancestor = sceneIndex->GetPrim(ancestorPath);
+                _IsValid(ancestor)) {
+                HdInstanceSchema instanceSchema = 
+                    HdInstanceSchema::GetFromParent(ancestor.dataSource);
+                // If the ancestor has an instanceSchema that provides a new
+                // prototype path, replace the prefix of our working path and
+                // start the loop again with this new path.
+                if (const std::optional<SdfPath> prototypePath =
+                        _GetPrototypePath(instanceSchema, sceneIndex)) {
+                    result = result.ReplacePrefix(
+                        ancestorPath, *prototypePath);
+                    loopAgain = true;
+                    break;
+                }
+            }
+        }
+        // If we've checked all the ancestors and not found any prototype paths
+        // then we're done.
+        if (!loopAgain) {
+            break;
         }
     }
 


### PR DESCRIPTION
### Description of Change(s)

Reworking the logic of the instanceProxyPathTranslationSceneIndex so that rather than working our way through the path front-to-back (matching the shortest path with an instanceSchema), we go back-to-front (matching the longest path with an instanceSchema). This has, for our tests, proven more robust in practice as it will correctly match both "fully-unexpanded" paths (as did the original implementation) and "partially-expanded" paths (which the original implementation did not - see linked issue below).

It is worth noting and considering that the new implementation is potentially more costly as it restarts the loop each time there's a match (whereas the original implementation had a fixed cost of one pass through the loop), but ultimately we need something that gives us the right results (which hopefully this one does - again, our testing suggests this is an improvement).

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#4056

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
