### PR TITLE
Extract test symbols in ts to new tsTest library

### DIFF
--- a/pxr/base/ts/CMakeLists.txt
+++ b/pxr/base/ts/CMakeLists.txt
@@ -54,16 +54,18 @@ set(pycpp
     wrapTypes.cpp
 )
 
+set(tsTestHeaders
+    tsTest_Museum.h
+    tsTest_SampleBezier.h
+    tsTest_SampleTimes.h
+    tsTest_SplineData.h
+    tsTest_TsEvaluator.h
+    tsTest_Types.h
+)
+
 if (${PXR_BUILD_TESTS})
-    list(APPEND classes
-        tsTest_Museum
-        tsTest_SampleBezier
-        tsTest_SampleTimes
-        tsTest_SplineData
-        tsTest_TsEvaluator
-    )
     list(APPEND headers
-        tsTest_Types.h
+        ${tsTestHeaders}
     )
     list(APPEND pycpp
         wrapTsTest_Museum.cpp
@@ -78,6 +80,13 @@ if (${PXR_BUILD_TESTS})
         TsTest_Baseliner.py
         TsTest_Grapher.py
     )
+endif()
+
+if (${PXR_BUILD_ANIMX_TESTS})
+    list(APPEND libs ${ANIMX_LIBRARY})
+    list(APPEND include ${ANIMX_INCLUDES})
+    list(APPEND headers tsTest_AnimXEvaluator.h)
+    list(APPEND pycpp wrapTsTest_AnimXEvaluator.cpp)
 endif()
 
 pxr_library(ts
@@ -122,8 +131,39 @@ pxr_library(ts
 )
 
 if (${PXR_BUILD_TESTS})
+    set(tsTestCpp
+        tsTest_Museum.cpp
+        tsTest_SampleBezier.cpp
+        tsTest_SampleTimes.cpp
+        tsTest_SplineData.cpp
+        tsTest_TsEvaluator.cpp
+    )
+    if (${PXR_BUILD_ANIMX_TESTS})
+        list(APPEND tsTestCpp tsTest_AnimXEvaluator.cpp)
+    endif()
+
+    pxr_library(tsTest
+        LIBRARIES
+            ts
+
+        INCLUDE_DIRS
+            ${include}
+
+        CPPFILES
+            ${tsTestCpp}
+    )
+    # TsTest headers currently use TS_API; export those symbols from tsTest.
+    target_compile_definitions(tsTest PRIVATE TS_EXPORTS=1)
+
     if (TARGET _ts)
         target_compile_definitions(_ts PRIVATE TS_BUILD_TEST_FRAMEWORK)
+        target_link_libraries(_ts PRIVATE tsTest)
+    endif()
+endif()
+
+if (${PXR_BUILD_ANIMX_TESTS})
+    if (TARGET _ts)
+        target_compile_definitions(_ts PRIVATE TS_BUILD_ANIMX_TEST_FRAMEWORK)
     endif()
 endif()
 
@@ -178,6 +218,7 @@ pxr_build_test(
         testenv/testTsSplineBaking.cpp
     LIBRARIES
         gf
+        tsTest
         ts
         tf
 )
@@ -207,6 +248,7 @@ pxr_build_test(
     CPPFILES
         testenv/testTsSplineSampling.cpp
     LIBRARIES
+        tsTest
         ts
         vt
         tf

--- a/pxr/usd/usd/CMakeLists.txt
+++ b/pxr/usd/usd/CMakeLists.txt
@@ -496,6 +496,7 @@ pxr_build_test(testUsdUsdcBugGHSA02
 pxr_build_test(testUsdSplinesCpp
     LIBRARIES
         tf
+        tsTest
         ts
         sdf
         usd


### PR DESCRIPTION
### Description of Change(s)

Building with and without tests produces a binary compatibility difference in the ts module because of some symbols only compiled and exported for tests. This PR extracts tests specific symbols from ts into a new tsTest library. This library is only linked by test executables.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] NA: Existing tests
 I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
