### PR TITLE
Autodesk: [HdSt] Fix integer overflow on buffer max buffer size

### DIFF
--- a/pxr/imaging/hdSt/interleavedMemoryManager.cpp
+++ b/pxr/imaging/hdSt/interleavedMemoryManager.cpp
@@ -100,9 +100,9 @@ HdStInterleavedUBOMemoryManager::CreateBufferArray(
     HdBufferSpecVector const &bufferSpecs,
     HdBufferArrayUsageHint usageHint)
 {
-    const int uniformBufferOffsetAlignment = _resourceRegistry->GetHgi()->
+    const size_t uniformBufferOffsetAlignment = _resourceRegistry->GetHgi()->
         GetCapabilities()->GetUniformBufferOffsetAlignment();
-    const int maxUniformBlockSize = _resourceRegistry->GetHgi()->
+    const size_t maxUniformBlockSize = _resourceRegistry->GetHgi()->
         GetCapabilities()->GetMaxUniformBlockSize();
 
     return std::make_shared<
@@ -112,7 +112,7 @@ HdStInterleavedUBOMemoryManager::CreateBufferArray(
             role,
             bufferSpecs,
             usageHint,
-            uniformBufferOffsetAlignment,
+            static_cast<int>(uniformBufferOffsetAlignment),
             /*structAlignment=*/sizeof(float)*4,
             maxUniformBlockSize,
             HdPerfTokens->garbageCollectedUbo);
@@ -141,7 +141,7 @@ HdStInterleavedSSBOMemoryManager::CreateBufferArray(
     HdBufferSpecVector const &bufferSpecs,
     HdBufferArrayUsageHint usageHint)
 {
-    const int maxShaderStorageBlockSize = _resourceRegistry->GetHgi()->
+    const size_t maxShaderStorageBlockSize = _resourceRegistry->GetHgi()->
         GetCapabilities()->GetMaxShaderStorageBlockSize();
 
     return std::make_shared<
@@ -862,4 +862,3 @@ HdStInterleavedMemoryManager::_StripedInterleavedBufferRange::_GetAggregation() 
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-


### PR DESCRIPTION
### Description of Change(s)

Fix BAR integer overflow bug due to casting `size_t` to `int`, when the Hgi buffer size limits surpass 2GB.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
