### PR TITLE
Autodesk: [Hdx] Properly disabled OIT color mask

### DIFF
--- a/pxr/imaging/hdx/oitVolumeRenderTask.cpp
+++ b/pxr/imaging/hdx/oitVolumeRenderTask.cpp
@@ -150,6 +150,7 @@ HdxOitVolumeRenderTask::Execute(HdTaskContext* ctx)
     //
     extendedState->SetRenderPassShader(_oitVolumeRenderPassShader);
     renderPassState->SetEnableDepthMask(false);
+    renderPassState->SetColorMaskUseDefault(false);
     renderPassState->SetColorMasks({HdRenderPassState::ColorMaskNone});
 
     // Transition depth texture (if it exists) to shader read layout.


### PR DESCRIPTION
### Description of Change(s)

Disable default render pass color mask so new value takes effect.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
