### PR TITLE
tf: Align TfSingleton ABI between Python builds

### DIFF
--- a/pxr/base/tf/instantiateSingleton.h
+++ b/pxr/base/tf/instantiateSingleton.h
@@ -45,8 +45,15 @@ struct Tf_SingletonPyGILDropper
     TF_API
     ~Tf_SingletonPyGILDropper();
 private:
+
+    // Keep class ABI compatible between builds with python enabled or not
+    // Otherwise there will be stack corruption when loading plug-ins
+    // built between the two versions.
 #ifdef PXR_PYTHON_SUPPORT_ENABLED
     std::unique_ptr<class TfPyLock> _pyLock;
+    static_assert(sizeof(std::unique_ptr<class TfPyLock>) == sizeof(std::unique_ptr<void*>));
+#else
+    std::unique_ptr<void*> _unused;
 #endif // PXR_PYTHON_SUPPORT_ENABLED
 };
 


### PR DESCRIPTION
### Description of Change(s)

Unifies the ABI of TfSingleton such that it's the same between Python and no-Python builds of OpenUSD.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
