### PR TITLE
Add geomSubset path in the log to help with debugging

### DIFF
--- a/pxr/imaging/hdSt/meshTopology.cpp
+++ b/pxr/imaging/hdSt/meshTopology.cpp
@@ -342,8 +342,9 @@ HdSt_MeshTopology::SanitizeGeomSubsets()
                     numUnusedFaces--;
                 } else {
                     // Warn about duplicated face indices.
-                    TF_WARN("Face index %d is repeated between geom subsets", 
-                        index);;
+                    TF_WARN("Face index %d is repeated between geom subsets "
+                            "(in subset <%s>)",
+                            index, geomSubset.id.GetText());
                 }
             }
             sanitizedGeomSubset.indices = sanitizedFaceIndices;


### PR DESCRIPTION
### Description of Change(s)
Include the GeomSubset path to make it easier to identify within the scene and assist with debugging.