### PR TITLE
Shift test environment configuration into `ctest`

### DIFF
--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -971,39 +971,17 @@ function(pxr_register_test TEST_NAME)
         set(testWrapperCmd ${testWrapperCmd} --expected-return-code=${bt_EXPECTED_RETURN_CODE})
     endif()
 
-    # Ensure that TF_FATAL_VERIFY is enabled for tests, so that failed verifies
-    # turn into test failures.
-    # Set this first, so that env vars passed to pxr_register_test can turn off
-    # TF_FATAL_VERIFY where desired.
-    set(testWrapperCmd ${testWrapperCmd} --env-var=TF_FATAL_VERIFY=1)
+    # Configure environment variables for test
+    # * Ensure that TF_FATAL_VERIFY is enabled for tests, so that failed
+    #   verifies turn into test failures. Set this first, so that env vars
+    #   passed to pxr_register_test can turn off TF_FATAL_VERIFY where desired.
+    # * Allows env vars to be set via a global variable to make it easier
+    #   to affect a set of tests (e.g., all tests in a library). Set
+    #   this second to allow tests to override these env vars.
+    # * Avoid the just-in-time debugger where possible when running tests.
+    #   Set last
+    set(testEnvVars "TF_FATAL_VERIFY=1" ${PXR_TEST_ENV_VARS} ${bt_ENV} "ARCH_AVOID_JIT=1")
 
-    # Allow env vars to be set via a global variable to make it easier
-    # to affect a set of tests (e.g., all tests in a library). Set
-    # this first to allow tests to override these env vars.
-    if (PXR_TEST_ENV_VARS)
-        foreach(env ${PXR_TEST_ENV_VARS})
-            set(testWrapperCmd ${testWrapperCmd} --env-var=${env})
-        endforeach()
-    endif()
-
-    if (bt_ENV)
-        foreach(env ${bt_ENV})
-            set(testWrapperCmd ${testWrapperCmd} --env-var=${env})
-        endforeach()
-    endif()
-
-    if (bt_PRE_PATH)
-        foreach(path ${bt_PRE_PATH})
-            set(testWrapperCmd ${testWrapperCmd} --pre-path=${path})
-        endforeach()
-    endif()
-
-    if (bt_POST_PATH)
-        foreach(path ${bt_POST_PATH})
-            set(testWrapperCmd ${testWrapperCmd} --post-path=${path})
-        endforeach()
-    endif()
-        
     # If we're building static libraries, the C++ tests that link against
     # these libraries will look for resource files in the "usd" subdirectory
     # relative to where the tests are installed. However, the build installs
@@ -1013,8 +991,24 @@ function(pxr_register_test TEST_NAME)
     # we set the PXR_PLUGINPATH_NAME env var to point to the "lib/usd"
     # directory where these files are installed.
     if (NOT TARGET shared_libs)
-        set(testWrapperCmd ${testWrapperCmd} --env-var=${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/lib/usd)
+        list(APPEND testEnvVars "${PXR_PLUGINPATH_NAME}=${CMAKE_INSTALL_PREFIX}/lib/usd")
     endif()
+
+    foreach (testEnvVar ${testEnvVars})
+        if (testEnvVar MATCHES "^PATH=")
+           message(FATAL_ERROR "Error: use PRE_PATH or POST_PATH to edit PATH.")
+        endif()
+        # TODO: Consider validating KEY=VALUE
+    endforeach()
+
+    set(testPathEdits "")
+    foreach(path ${bt_PRE_PATH})
+        list(APPEND testPathEdits "PATH=path_list_prepend:${path}")
+    endforeach()
+
+    foreach(path ${bt_POST_PATH})
+        list(APPEND testPathEdits "PATH=path_list_append:${path}")
+    endforeach()
 
     if (PXR_TEST_RUN_TEMP_DIR_PREFIX)
           set(testWrapperCmd ${testWrapperCmd} --tempdirprefix=${PXR_TEST_RUN_TEMP_DIR_PREFIX})
@@ -1039,11 +1033,16 @@ function(pxr_register_test TEST_NAME)
         set(testCmd "${bt_COMMAND}")
     endif()
 
+    list(APPEND testEnvVars "PYTHONPATH=${_testPythonPath}")
+
     add_test(
         NAME ${TEST_NAME}
-        COMMAND ${PYTHON_EXECUTABLE} ${testWrapperCmd}
-                "--env-var=PYTHONPATH=${_testPythonPath}" ${testCmd}
+        COMMAND ${PYTHON_EXECUTABLE} ${testWrapperCmd} ${testCmd}
     )
+    set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT "${testEnvVars}")
+    if (testPathEdits)
+        set_tests_properties(${TEST_NAME} PROPERTIES ENVIRONMENT_MODIFICATION "${testPathEdits}")
+    endif()
 
     # But in some cases, we need to pass cmake properties directly to cmake
     # run_test, rather than configuring the environment

--- a/cmake/macros/testWrapper.py
+++ b/cmake/macros/testWrapper.py
@@ -19,8 +19,6 @@
 # - specifying non-zero return codes
 # - comparing output files against a baseline
 #
-from __future__ import print_function
-
 import argparse
 import glob
 import os
@@ -95,15 +93,6 @@ def _parseArgs():
                   'Currently used for emscripten builds.'))
     parser.add_argument('--expected-return-code', type=int, default=0,
             help='Expected return code of this test.')
-    parser.add_argument('--env-var', dest='envVars', default=[], type=str, 
-            action='append',
-            help=('Variable to set in the test environment, in KEY=VALUE form. '
-                  'If "<PXR_TEST_DIR>" is in the value, it is replaced with the '
-                  'absolute path of the temp directory the tests are run in'))
-    parser.add_argument('--pre-path', dest='prePaths', default=[], type=str, 
-            action='append', help='Path to prepend to the PATH env var.')
-    parser.add_argument('--post-path', dest='postPaths', default=[], type=str, 
-            action='append', help='Path to append to the PATH env var.')
     parser.add_argument('--verbose', '-v', action='store_true',
             help='Verbose output.')
     parser.add_argument('cmd', metavar='CMD', type=str, 
@@ -360,29 +349,7 @@ if __name__ == '__main__':
             sys.stderr.write("Error: copying testenv directory: {0}".format(e))
             sys.exit(1)
 
-    # Add any envvars specified with --env-var options into the environment
     env = os.environ.copy()
-    for varStr in args.envVars:
-        try:
-            k, v = varStr.split('=', 1)
-            if k == 'PATH':
-                sys.stderr.write("Error: use --pre-path or --post-path to edit PATH.")
-                sys.exit(1)
-            v = v.replace('<PXR_TEST_DIR>', testDir)
-            env[k] = v
-        except IndexError:
-            sys.stderr.write("Error: envvar '{0}' not of the form "
-                             "key=value".format(varStr))
-            sys.exit(1)
-
-    # Modify the PATH env var.  The delimiter depends on the platform.
-    pathDelim = ';' if platform.system() == 'Windows' else ':'
-    paths = env.get('PATH', '').split(pathDelim)
-    paths = args.prePaths + paths + args.postPaths
-    env['PATH'] = pathDelim.join(paths)
-
-    # Avoid the just-in-time debugger where possible when running tests.
-    env['ARCH_AVOID_JIT'] = '1'
 
     if args.pre_command:
         _runCommand(args.pre_command, args.pre_command_stdout_redirect,


### PR DESCRIPTION
### Description of Change(s)
All tests currently require the python-based `testWrapper` for configuration of the environment.  The wrapper introduces a python dependency even when building without the python bindings.  In support of phasing out the `testWrapper` script and the test python dependency, this shifts the environment configuration into the first class `ENVIRONMENT` and `ENVIRONMENT_MODIFICATION` test properties.  (`ENVIRONMENT_MODIFICATION` is a new feature of CMake 3.22).

A benefit of this approach is centralizing the ownership of environment configuration into `cmake`.  Previously, some configuration occurred in `cmake` (`TF_FATAL_VERIFY`) and some occurred in python (`ARCH_AVOID_JIT`).

Another benefit of `ctest` aware environment configuration is that `ctest`'s verbose output will format the modifications nicely.
```
777: Environment variables:
777:  TF_FATAL_VERIFY=1
777:  ARCH_AVOID_JIT=1
777:  PYTHONPATH=...
777: Environment variable modifications:
777:  PATH=path_list_prepend:...
```

There are two things to note with this change.  The first is that it removes support for `<PXR_TEST_DIR>` substitution.  This doesn't appear to be used (`grep -r PXR_TEST_DIR pxr/ cmake/ extras/ third_party/ --exclude testWrapper.py` returns nothing).  It can likely be restored if needed in the future.  The other is that it doesn't do `KEY=VALUE` validation for environment variables.  This appeared to be a side effect of the `<PXR_TEST_DIR>` substitution.  If desired, this could be restored as well.

Follow up changes will be needed to shift the remaining comparison / diffing features of `testWrapper` into fixtures before it can be removed.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

* https://github.com/aousd/build-ig-initiatives/issues/19

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
