### PR TITLE
sdf: Fix USDZ packages not using UTF-8 encoding for file names

### DIFF
--- a/pxr/usd/sdf/testenv/testSdfZipFile.py
+++ b/pxr/usd/sdf/testenv/testSdfZipFile.py
@@ -192,6 +192,65 @@ class TestSdfZipFile(unittest.TestCase):
 
         self.assertFalse(os.path.isfile("test_discard.usdz"))
 
+    def test_WriterUnicodeFilenames(self):
+        """Test that Sdf.ZipFileWriter sets the UTF-8 flag (bit 11 of the
+        General Purpose Bit Flag) for filenames containing non-ASCII characters,
+        per the ZIP specification (PKWARE APPNOTE.TXT section 4.4.4).
+
+        Regression test for https://github.com/PixarAnimationStudios/OpenUSD/issues/3774
+        """
+        # Create temporary source files with ASCII and Unicode names.
+        ascii_src = "test_ascii.txt"
+        unicode_src_zh = "test_\u4e2d\u6587.txt"   # 中文
+        unicode_src_ja = "test_\u65e5\u672c\u8a9e.txt"  # 日本語
+        unicode_src_ko = "test_\ud55c\uad6d\uc5b4.txt"  # 한국어
+
+        content = b"hello unicode world"
+        for name in [ascii_src, unicode_src_zh, unicode_src_ja, unicode_src_ko]:
+            with open(name, "wb") as f:
+                f.write(content)
+
+        archive_path = "test_unicode_filenames.usdz"
+        if os.path.isfile(archive_path):
+            os.remove(archive_path)
+
+        with Sdf.ZipFileWriter.CreateNew(archive_path) as zfw:
+            # Add files using their Unicode names as the in-archive path.
+            zfw.AddFile(ascii_src,      ascii_src)
+            zfw.AddFile(unicode_src_zh, unicode_src_zh)
+            zfw.AddFile(unicode_src_ja, unicode_src_ja)
+            zfw.AddFile(unicode_src_ko, unicode_src_ko)
+
+        self.assertTrue(os.path.isfile(archive_path))
+
+        # Verify with Python's zipfile module, which correctly interprets
+        # the UTF-8 flag and returns decoded filenames.
+        _UTF8_FLAG = 0x0800  # bit 11
+
+        with zipfile.ZipFile(archive_path) as zf:
+            infos = {info.filename: info for info in zf.infolist()}
+
+            # ASCII filename: UTF-8 flag is NOT required (but harmless if set).
+            # We only assert that the file is present and readable.
+            self.assertIn(ascii_src, infos)
+            self.assertEqual(zf.read(ascii_src), content)
+
+            # Unicode filenames: UTF-8 flag MUST be set so that tools can
+            # correctly decode the filename bytes as UTF-8.
+            for name in [unicode_src_zh, unicode_src_ja, unicode_src_ko]:
+                self.assertIn(name, infos,
+                    f"Unicode filename '{name}' not found in archive — "
+                    "UTF-8 flag may be missing")
+                self.assertTrue(
+                    infos[name].flag_bits & _UTF8_FLAG,
+                    f"UTF-8 flag (bit 11) not set for filename '{name}'")
+                self.assertEqual(zf.read(name), content)
+
+        # Clean up temporary files.
+        for name in [ascii_src, unicode_src_zh, unicode_src_ja, unicode_src_ko]:
+            if os.path.isfile(name):
+                os.remove(name)
+
     def test_WriterEmptyArchive(self):
         """Test corner case writing an empty zip archive with 
         Sdf.ZipFileWriter"""

--- a/pxr/usd/sdf/zipFile.cpp
+++ b/pxr/usd/sdf/zipFile.cpp
@@ -17,6 +17,7 @@
 #include "pxr/base/tf/pathUtils.h"
 #include "pxr/base/tf/safeOutputFile.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <ctime>
 #include <mutex>
@@ -57,16 +58,8 @@ static inline int64_t Sdf_GetMaxZipFileSize() {
 
 // Metafunction that determines if a T instance can be read/written by simple
 // bitwise copy.
-//
-// XXX: This could be std::is_trivially_copyable, but that isn't implemented in
-//      older versions of gcc.
 template <class T>
-struct _IsBitwiseReadWrite {
-    static const bool value =
-        std::is_enum<T>::value ||
-        std::is_arithmetic<T>::value ||
-        std::is_trivial<T>::value;
-};
+using _IsBitwiseReadWrite = std::is_trivially_copyable<T>;
 
 struct _InputStream {
     _InputStream(const char* buffer, size_t size, size_t offset = 0)
@@ -1040,7 +1033,18 @@ SdfZipFileWriter::AddFile(
     _LocalFileHeader h;
     h.f.signature = _LocalFileHeader::Signature;
     h.f.versionForExtract = 10; // Default value
-    h.f.bits = 0;
+
+    // Per the ZIP specification (PKWARE APPNOTE.TXT section 4.4.4), bit 11
+    // of the General Purpose Bit Flag indicates that the filename and comment
+    // fields are encoded using UTF-8. Set this flag whenever the filename
+    // contains any non-ASCII bytes so that ZIP tools correctly display
+    // filenames containing Unicode characters (e.g. Chinese, Japanese, Korean).
+    static constexpr uint16_t _Utf8Flag = 0x0800;
+    const bool hasNonAscii = std::any_of(
+        zipFilePath.begin(), zipFilePath.end(),
+        [](unsigned char c) { return c > 127; });
+    h.f.bits = hasNonAscii ? _Utf8Flag : 0;
+
     h.f.compressionMethod = 0; // No compression
     std::tie(h.f.lastModTime, h.f.lastModDate) = _ModTimeAndDate(filePath);
     h.f.crc32 = _Crc32(mapping);


### PR DESCRIPTION
USDZ packages were not setting the UTF-8 flag (bit 11 of the General Purpose Bit Flag) in ZIP local file headers when file names contained non-ASCII characters (e.g., Chinese, Japanese, Korean).

This caused file names to appear garbled when inspecting the archive with standard ZIP tools, even though the archive itself loaded correctly in USD.

Fix: Use std::any_of to detect non-ASCII bytes in the file name and set bit 11 of the General Purpose Bit Flag to indicate UTF-8 encoding per the ZIP specification (PKWARE APPNOTE.TXT, Section 4.4.4).

Also replace the hand-rolled _IsBitwiseReadWrite metafunction with a type alias for std::is_trivially_copyable, which has been available since C++11 and is now well-supported across all compilers USD targets.

Add test_WriterUnicodeFilenames to testSdfZipFile.py to verify the fix with Chinese, Japanese, and Korean file names.

Fixes #3774

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
