### PR TITLE
Fix unused variable compiler warnings (Issue #3338)

### DIFF
--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -70,7 +70,7 @@ TF_DEFINE_ENV_SETTING(HD_ENABLE_PACKED_NORMALS, 1,
 
 // Use more recognizable names for each compute queue the mesh computations use.
 namespace {
-    constexpr HdStComputeQueue _CopyExtCompQueue = HdStComputeQueueZero;
+    [[maybe_unused]] constexpr HdStComputeQueue _CopyExtCompQueue = HdStComputeQueueZero;
     constexpr HdStComputeQueue _RefinePrimvarCompQueue = HdStComputeQueueOne;
     constexpr HdStComputeQueue _NormalsCompQueue = HdStComputeQueueTwo;
     constexpr HdStComputeQueue _RefineNormalsCompQueue = HdStComputeQueueThree;

--- a/pxr/usd/usd/testenv/testUsdSchemaRegistryCpp.cpp
+++ b/pxr/usd/usd/testenv/testUsdSchemaRegistryCpp.cpp
@@ -14,11 +14,6 @@
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
-static const int SCHEMA_BASE_INIT = 1971;
-static const int TEST_BASE_INIT = 44;
-static const int TEST_DERIVED_INIT = 42;
-static const int MUTATED_VAL = 22;
-
 // These test cases are not meant to be full coverage of the UsdPrimDefinition 
 // API for prim and property data access. Instead they focus on the C++ specific
 // functionality like the templated accessors. The python testUsdSchemaRegistry


### PR DESCRIPTION
Two compiler warnings reported in issue #3338:

1. Remove four unused static const variables from testUsdSchemaRegistryCpp.cpp (SCHEMA_BASE_INIT, TEST_BASE_INIT, TEST_DERIVED_INIT, MUTATED_VAL). These were copied from testUsdSchemaBase.cpp but are never referenced in this file.

2. Add [[maybe_unused]] to _CopyExtCompQueue in hdSt/mesh.cpp. This constant is defined alongside other compute queue aliases for readability but is currently unreferenced.

Fixes #3338

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
