### PR TITLE
usdGeom: Initialize UsdGeomXformOp default constructor members

### DIFF
--- a/pxr/usd/usdGeom/xformOp.h
+++ b/pxr/usd/usdGeom/xformOp.h
@@ -146,8 +146,9 @@ public:
     // Default constructor returns an invalid XformOp.  Exists for 
     // container classes
     UsdGeomXformOp()
+        : _opType(TypeInvalid)
+        , _isInverseOp(false)
     {
-        /* NOTHING */
     }
     
     /// Speculative constructor that will produce a valid UsdGeomXformOp when


### PR DESCRIPTION
The default constructor of UsdGeomXformOp left _opType and _isInverseOp uninitialized. While recent Clang versions null-initialize these in practice, other compilers may produce indeterminate values, leading to undefined behavior (reported as UBSan errors about invalid op types in USD 24.11+).

Fix: Add an explicit member initializer list to the default constructor, setting _opType to TypeInvalid and _isInverseOp to false.

Fixes #3559

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
