### PR TITLE
usd: Fix double-quoted instance name in multiple apply schema __repr__

### DIFF
--- a/pxr/usd/usd/codegenTemplates/wrapSchemaClass.cpp
+++ b/pxr/usd/usd/codegenTemplates/wrapSchemaClass.cpp
@@ -69,7 +69,7 @@ _Repr(const {{ cls.cppClassName }} &self)
 {% if cls.isMultipleApply %}
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "{{ libraryName[0]|upper }}{{ libraryName[1:] }}.{{ cls.className }}(%s, '%s')",
+        "{{ libraryName[0]|upper }}{{ libraryName[1:] }}.{{ cls.className }}(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 {% else %}
     return TfStringPrintf(

--- a/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapEmptyMultipleApplyAPI.cpp
+++ b/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapEmptyMultipleApplyAPI.cpp
@@ -39,7 +39,7 @@ _Repr(const UsdContrivedEmptyMultipleApplyAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdContrived.EmptyMultipleApplyAPI(%s, '%s')",
+        "UsdContrived.EmptyMultipleApplyAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapMultipleApplyAPI.cpp
+++ b/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapMultipleApplyAPI.cpp
@@ -59,7 +59,7 @@ _Repr(const UsdContrivedMultipleApplyAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdContrived.MultipleApplyAPI(%s, '%s')",
+        "UsdContrived.MultipleApplyAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapMultipleApplyAPI_1.cpp
+++ b/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapMultipleApplyAPI_1.cpp
@@ -59,7 +59,7 @@ _Repr(const UsdContrivedMultipleApplyAPI_1 &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdContrived.MultipleApplyAPI_1(%s, '%s')",
+        "UsdContrived.MultipleApplyAPI_1(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapPublicMultipleApplyAPI.cpp
+++ b/pxr/usd/usd/testenv/testUsdGenSchema/baseline/basic/wrapPublicMultipleApplyAPI.cpp
@@ -66,7 +66,7 @@ _Repr(const UsdContrivedPublicMultipleApplyAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdContrived.PublicMultipleApplyAPI(%s, '%s')",
+        "UsdContrived.PublicMultipleApplyAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usd/wrapCollectionAPI.cpp
+++ b/pxr/usd/usd/wrapCollectionAPI.cpp
@@ -80,7 +80,7 @@ _Repr(const UsdCollectionAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "Usd.CollectionAPI(%s, '%s')",
+        "Usd.CollectionAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usd/wrapColorSpaceDefinitionAPI.cpp
+++ b/pxr/usd/usd/wrapColorSpaceDefinitionAPI.cpp
@@ -94,7 +94,7 @@ _Repr(const UsdColorSpaceDefinitionAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "Usd.ColorSpaceDefinitionAPI(%s, '%s')",
+        "Usd.ColorSpaceDefinitionAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usdPhysics/wrapDriveAPI.cpp
+++ b/pxr/usd/usdPhysics/wrapDriveAPI.cpp
@@ -87,7 +87,7 @@ _Repr(const UsdPhysicsDriveAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdPhysics.DriveAPI(%s, '%s')",
+        "UsdPhysics.DriveAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usdPhysics/wrapLimitAPI.cpp
+++ b/pxr/usd/usdPhysics/wrapLimitAPI.cpp
@@ -59,7 +59,7 @@ _Repr(const UsdPhysicsLimitAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdPhysics.LimitAPI(%s, '%s')",
+        "UsdPhysics.LimitAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usdSemantics/wrapLabelsAPI.cpp
+++ b/pxr/usd/usdSemantics/wrapLabelsAPI.cpp
@@ -52,7 +52,7 @@ _Repr(const UsdSemanticsLabelsAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdSemantics.LabelsAPI(%s, '%s')",
+        "UsdSemantics.LabelsAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usdShade/wrapCoordSysAPI.cpp
+++ b/pxr/usd/usdShade/wrapCoordSysAPI.cpp
@@ -45,7 +45,7 @@ _Repr(const UsdShadeCoordSysAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdShade.CoordSysAPI(%s, '%s')",
+        "UsdShade.CoordSysAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 

--- a/pxr/usd/usdUI/wrapAccessibilityAPI.cpp
+++ b/pxr/usd/usdUI/wrapAccessibilityAPI.cpp
@@ -66,7 +66,7 @@ _Repr(const UsdUIAccessibilityAPI &self)
     std::string primRepr = TfPyRepr(self.GetPrim());
     std::string instanceName = TfPyRepr(self.GetName());
     return TfStringPrintf(
-        "UsdUI.AccessibilityAPI(%s, '%s')",
+        "UsdUI.AccessibilityAPI(%s, %s)",
         primRepr.c_str(), instanceName.c_str());
 }
 


### PR DESCRIPTION
The __repr__ implementation for multiple apply API schemas was producing double-quoted instance names, e.g.:

  Usd.CollectionAPI(Usd.Prim(</World>), ''myCollection'')

The format string used '%s' (with surrounding single quotes) while TfPyRepr(self.GetName()) already returns a quoted string like 'myCollection', resulting in the extra layer of quotes.

Fix: Remove the surrounding single quotes from the format string in the codegen template and all generated wrap files, so TfPyRepr provides the only quoting:

  Usd.CollectionAPI(Usd.Prim(</World>), 'myCollection')

Affected schemas: CollectionAPI, ColorSpaceDefinitionAPI, DriveAPI, LimitAPI, LabelsAPI, CoordSysAPI, AccessibilityAPI.

Fixes #3270

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
