### PR TITLE
usd: Fix build failure with libstdc++15 / C++23 (Issue #4029)

### DIFF
--- a/pxr/usd/usd/schemaRegistry.cpp
+++ b/pxr/usd/usd/schemaRegistry.cpp
@@ -1761,6 +1761,39 @@ _FinalizeLocallyDefinedPropertiesForPrimDefinitions() const
     }
 }
 
+const UsdPrimDefinition*
+UsdSchemaRegistry::FindAbstractPrimDefinition(
+    const TfToken &typeName) const
+{
+    const auto it = _abstractTypedPrimDefinitions.find(typeName);
+    return it != _abstractTypedPrimDefinitions.end() ?
+        it->second.get() : nullptr;
+}
+
+const UsdPrimDefinition*
+UsdSchemaRegistry::FindConcretePrimDefinition(
+    const TfToken &typeName) const
+{
+    const auto it = _concreteTypedPrimDefinitions.find(typeName);
+    return it != _concreteTypedPrimDefinitions.end() ?
+        it->second.get() : nullptr;
+}
+
+const UsdPrimDefinition*
+UsdSchemaRegistry::FindAppliedAPIPrimDefinition(
+    const TfToken &typeName) const
+{
+    const auto it = _appliedAPIPrimDefinitions.find(typeName);
+    return it != _appliedAPIPrimDefinitions.end() ?
+        it->second.primDef.get() : nullptr;
+}
+
+const UsdPrimDefinition*
+UsdSchemaRegistry::GetEmptyPrimDefinition() const
+{
+    return _emptyPrimDefinition;
+}
+
 UsdSchemaRegistry::UsdSchemaRegistry()
 {
     _emptyPrimDefinition = new UsdPrimDefinition();

--- a/pxr/usd/usd/schemaRegistry.h
+++ b/pxr/usd/usd/schemaRegistry.h
@@ -495,37 +495,27 @@ public:
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered abstract typed schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition* FindAbstractPrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _abstractTypedPrimDefinitions.find(typeName);
-        return it != _abstractTypedPrimDefinitions.end() ?
-            it->second.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered concrete typed schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition* FindConcretePrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _concreteTypedPrimDefinitions.find(typeName);
-        return it != _concreteTypedPrimDefinitions.end() ? 
-            it->second.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Finds the prim definition for the given \p typeName token if 
     /// \p typeName is a registered applied API schema type. Returns null if
     /// it is not.
+    USD_API
     const UsdPrimDefinition *FindAppliedAPIPrimDefinition(
-        const TfToken &typeName) const {
-        const auto it = _appliedAPIPrimDefinitions.find(typeName);
-        return it != _appliedAPIPrimDefinitions.end() ?
-            it->second.primDef.get() : nullptr;
-    }
+        const TfToken &typeName) const;
 
     /// Returns the empty prim definition.
-    const UsdPrimDefinition *GetEmptyPrimDefinition() const {
-        return _emptyPrimDefinition;
-    }
+    USD_API
+    const UsdPrimDefinition *GetEmptyPrimDefinition() const;
 
     /// Composes and returns a new UsdPrimDefinition from the given \p primType
     /// and list of \p appliedSchemas. This prim definition will contain a union


### PR DESCRIPTION
Starting from libstdc++-15, including schemaRegistry.h fails to compile because FindConcretePrimDefinition, FindAppliedAPIPrimDefinition, and GetEmptyPrimDefinition are defined inline in the header using std::unique_ptr<UsdPrimDefinition>, but UsdPrimDefinition is only forward-declared at that point.

libstdc++-15 tightened the C++23 constraints on std::unique_ptr's destructor, which now requires a complete type at the point of instantiation even for inline functions in headers.

Fix: Move the four inline function bodies out of schemaRegistry.h and into schemaRegistry.cpp, where UsdPrimDefinition is fully defined. Also add USD_API to the declarations so the symbols are properly exported from the shared library.

Affected functions:
- FindAbstractPrimDefinition
- FindConcretePrimDefinition
- FindAppliedAPIPrimDefinition
- GetEmptyPrimDefinition

Fixes #4029

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
