### PR TITLE
usdShadeValidators: Flag Shader inputs connected to sibling Shader in…

### DIFF
--- a/pxr/usdValidation/usdShadeValidators/validatorTokens.h
+++ b/pxr/usdValidation/usdShadeValidators/validatorTokens.h
@@ -60,7 +60,9 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((nonCompliantBiasAndScale, "NonCompliantBiasAndScale"))                   \
     ((nonCompliantScale, "NonCompliantScaleValues"))                           \
     ((nonCompliantBias, "NonCompliantBiasValues"))                             \
-    ((invalidFamilyType, "InvalidFamilyType"))
+    ((invalidFamilyType, "InvalidFamilyType"))                             \
+    ((shaderInputConnectedToSiblingInput,                                  \
+      "ShaderInputConnectedToSiblingInput"))
 
 /// \def USD_SHADE_VALIDATOR_NAME_TOKENS
 /// Tokens representing validator names. Note that for plugin provided

--- a/pxr/usdValidation/usdShadeValidators/validators.cpp
+++ b/pxr/usdValidation/usdShadeValidators/validators.cpp
@@ -174,6 +174,46 @@ _EncapsulationValidator(const UsdPrim &usdPrim,
         _VerifyValidAncestor(parentPrim.GetParent());
     }
 
+    // For UsdShadeShader prims, check that no input is connected to an
+    // input of a sibling UsdShadeShader prim. Such connections are not
+    // meaningful in a shader network; inputs should only be connected to
+    // outputs of sibling shaders or inputs of the enclosing container.
+    // See: https://github.com/PixarAnimationStudios/OpenUSD/issues/3957
+    if (usdPrim.IsA<UsdShadeShader>()) {
+        const UsdShadeConnectableAPI connAPI(usdPrim);
+        for (const UsdShadeInput &input : connAPI.GetInputs()) {
+            for (const UsdShadeConnectionSourceInfo &srcInfo :
+                     input.GetConnectedSources()) {
+                // Only flag input-to-input connections
+                if (srcInfo.sourceType != UsdShadeAttributeType::Input) {
+                    continue;
+                }
+                const UsdPrim &sourcePrim = srcInfo.source.GetPrim();
+                // Flag if source is a sibling UsdShadeShader
+                if (sourcePrim.IsA<UsdShadeShader>() &&
+                    sourcePrim.GetPath().GetParentPath() ==
+                        usdPrim.GetPath().GetParentPath()) {
+                    errors.emplace_back(
+                        UsdShadeValidationErrorNameTokens
+                            ->shaderInputConnectedToSiblingInput,
+                        UsdValidationErrorType::Error,
+                        UsdValidationErrorSites {
+                            UsdValidationErrorSite(
+                                usdPrim.GetStage(),
+                                input.GetAttr().GetPath()) },
+                        TfStringPrintf(
+                            "Shader input <%s> is connected to input <%s> "
+                            "of sibling Shader <%s>. Shader inputs may only "
+                            "be connected to outputs of sibling shaders or "
+                            "inputs of the enclosing container.",
+                            input.GetAttr().GetPath().GetText(),
+                            srcInfo.sourceName.GetText(),
+                            sourcePrim.GetPath().GetText()));
+                }
+            }
+        }
+    }
+
     return errors;
 }
 


### PR DESCRIPTION
…puts

UsdShadeShader inputs should not be connected to inputs of sibling UsdShadeShader prims. Such connections are not meaningful in a shader network and are not interpreted by any known renderer. Shader inputs should only be connected to:
  - outputs of sibling shaders (the common case)
  - inputs of the enclosing container (NodeGraph or Material)

Add a check to the existing EncapsulationRulesValidator that detects and reports this invalid connection pattern with a new error token ShaderInputConnectedToSiblingInput.

Note: ConnectToSource intentionally does not enforce CanConnect, so this validation is the appropriate place to catch these connections.

Fixes #3957

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [ ] I have created this PR based on the dev branch

- [ ] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
