### PR TITLE
[Apple] usdImaging: Skip material dirtying on transform attribute changes

### DIFF
--- a/pxr/usdImaging/usdImaging/materialAdapter.cpp
+++ b/pxr/usdImaging/usdImaging/materialAdapter.cpp
@@ -375,8 +375,9 @@ UsdImagingMaterialAdapter::ProcessPropertyChange(
     SdfPath const& cachePath,
     TfToken const& propertyName)
 {
-    if (propertyName == UsdGeomTokens->visibility) {
-        // Materials aren't affected by visibility
+    if (propertyName == UsdGeomTokens->visibility ||
+        UsdGeomXformable::IsTransformationAffectedByAttrNamed(propertyName)) {
+        // Materials aren't affected by visibility or transforms
         return HdChangeTracker::Clean;
     }
 


### PR DESCRIPTION
### Description of Change(s)

UsdImagingMaterialAdapter::ProcessPropertyChange already returned Clean for visibility changes since materials are unaffected by them. Extend the same guard to xformable transform attributes, which likewise have no bearing on material resolution, to avoid unnecessary material invalidation when an ancestor or bound prim's transform is edited.

Note : TomC has already ok'ed this change.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
