### PR TITLE
UsdPhysics validation & parsing improvements

### DIFF
--- a/pxr/usd/usdPhysics/collisionAPI.h
+++ b/pxr/usd/usdPhysics/collisionAPI.h
@@ -35,12 +35,16 @@ class SdfAssetPath;
 
 /// \class UsdPhysicsCollisionAPI
 ///
-/// Applies collision attributes to a UsdGeomXformable prim. If a 
-/// simulation is running, this geometry will collide with other geometries that 
+/// Applies collision attributes to a UsdGeomXformable prim. If a
+/// simulation is running, this geometry will collide with other geometries that
 /// have PhysicsCollisionAPI applied. If any prim in the parent hierarchy has
 /// the RigidBodyAPI applied, the collider is considered a part of the closest
 /// ancestor body. If there is no body in the parent hierarchy, this collider
 /// is considered to be static.
+/// 
+/// Note: UsdGeomPlane colliders may only be used as static or kinematic
+/// colliders. A plane collider attached to a simulated (non-kinematic) rigid
+/// body is not supported.
 ///
 class UsdPhysicsCollisionAPI : public UsdAPISchemaBase
 {

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -815,7 +815,7 @@ bool _ParseSpherePointsShapeDesc(const UsdPhysicsCollisionAPI& collisionAPI,
 
             const UsdGeomPrimvarsAPI primvarsAPI(usdPrim);
             const UsdGeomPrimvar widthsPrimvar =
-                primvarsAPI.GetPrimvar(TfToken("widths"));
+                primvarsAPI.GetPrimvar(UsdGeomTokens->widths);
 
             if (widthsPrimvar && widthsPrimvar.HasAuthoredValue())
             {

--- a/pxr/usd/usdPhysics/parseUtils.cpp
+++ b/pxr/usd/usdPhysics/parseUtils.cpp
@@ -22,6 +22,8 @@
 #include "pxr/usd/usdGeom/cone.h"
 #include "pxr/usd/usdGeom/plane.h"
 #include "pxr/usd/usdGeom/points.h"
+#include "pxr/usd/usdGeom/primvar.h"
+#include "pxr/usd/usdGeom/primvarsAPI.h"
 
 #include "pxr/usd/usdGeom/metrics.h"
 
@@ -809,34 +811,40 @@ bool _ParseSpherePointsShapeDesc(const UsdPhysicsCollisionAPI& collisionAPI,
 
             VtArray<float> widths;
             VtArray<GfVec3f> positions;
-            shape.GetWidthsAttr().Get(&widths);
-            if (widths.size())
+            shape.GetPointsAttr().Get(&positions);
+
+            const UsdGeomPrimvarsAPI primvarsAPI(usdPrim);
+            const UsdGeomPrimvar widthsPrimvar =
+                primvarsAPI.GetPrimvar(TfToken("widths"));
+
+            if (widthsPrimvar && widthsPrimvar.HasAuthoredValue())
             {
-                shape.GetPointsAttr().Get(&positions);
-                if (positions.size() == widths.size())
+                widthsPrimvar.ComputeFlattened(&widths);
+            }
+            else
+            {
+                shape.GetWidthsAttr().Get(&widths);
+            }
+
+            if (widths.size() && positions.size() == widths.size())
+            {
+                float sphereScale = 1.0f;
                 {
-                    float sphereScale = 1.0f;
-                    {
-                        const GfVec3d sc = tr.GetScale();
+                    const GfVec3d sc = tr.GetScale();
 
-                        sphereScale = fmaxf(fmaxf(fabsf(float(sc[1])), 
-                                                  fabsf(float(sc[0]))),
-                                            fabsf(float(sc[2])));
-                    }
-
-                    const size_t scount = positions.size();
-                    outSpherePointsShapeDesc->spherePoints.resize(scount);
-                    for (size_t i = 0; i < scount; i++)
-                    {
-                        outSpherePointsShapeDesc->spherePoints[i].radius =
-                            sphereScale * widths[i] * 0.5f;
-                        outSpherePointsShapeDesc->spherePoints[i].center =
-                            positions[i];
-                    }
+                    sphereScale = fmaxf(fmaxf(fabsf(float(sc[1])),
+                                              fabsf(float(sc[0]))),
+                                        fabsf(float(sc[2])));
                 }
-                else
+
+                const size_t scount = positions.size();
+                outSpherePointsShapeDesc->spherePoints.resize(scount);
+                for (size_t i = 0; i < scount; i++)
                 {
-                    outSpherePointsShapeDesc->isValid = false;
+                    outSpherePointsShapeDesc->spherePoints[i].radius =
+                        sphereScale * widths[i] * 0.5f;
+                    outSpherePointsShapeDesc->spherePoints[i].center =
+                        positions[i];
                 }
             }
             else

--- a/pxr/usd/usdPhysics/schema.usda
+++ b/pxr/usd/usdPhysics/schema.usda
@@ -275,12 +275,16 @@ class "PhysicsCollisionAPI"
     customData = {
         string className = "CollisionAPI"
     }
-    doc = """Applies collision attributes to a UsdGeomXformable prim. If a 
-    simulation is running, this geometry will collide with other geometries that 
+    doc = """Applies collision attributes to a UsdGeomXformable prim. If a
+    simulation is running, this geometry will collide with other geometries that
     have PhysicsCollisionAPI applied. If any prim in the parent hierarchy has
     the RigidBodyAPI applied, the collider is considered a part of the closest
     ancestor body. If there is no body in the parent hierarchy, this collider
-    is considered to be static."""
+    is considered to be static.
+
+    Note: UsdGeomPlane colliders may only be used as static or kinematic
+    colliders. A plane collider attached to a simulated (non-kinematic) rigid
+    body is not supported."""
 
     inherits = </APISchemaBase>
 )

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsParsing.py
@@ -6,7 +6,7 @@
 # https://openusd.org/license.
 
 import os, unittest
-from pxr import Usd, UsdPhysics, Gf, UsdGeom, Sdf, UsdShade, Plug, Tf
+from pxr import Usd, UsdPhysics, Gf, UsdGeom, Sdf, UsdShade, Plug, Tf, Vt
 
 
 toleranceEpsilon = 0.01
@@ -261,6 +261,93 @@ class TestUsdPhysicsParsing(unittest.TestCase):
 
             self.assertTrue(scene_found)
             self.assertTrue(num_shape_found == 1)
+
+    def test_sphere_points_primvar_widths_parse(self):
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+
+        def parse_sphere_points(stage):
+            ret_dict = UsdPhysics.UsdPhysicsLoadStageFromPrimRange(
+                stage, ["/"])
+            for key, value in ret_dict.items():
+                if key == UsdPhysics.ObjectType.SpherePointsShape:
+                    _, descs = value
+                    return descs[0] if descs else None
+            return None
+
+        # only widths attr authored
+        shape = UsdGeom.Points.Define(stage, "/points")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        shape.GetWidthsAttr().Set([4.0, 6.0])
+
+        desc = parse_sphere_points(stage)
+        self.assertTrue(desc.isValid)
+        self.assertEqual(len(desc.spherePoints), 2)
+        self.assertAlmostEqual(desc.spherePoints[0].radius, 2.0)
+        self.assertAlmostEqual(desc.spherePoints[1].radius, 3.0)
+
+        # only primvars:widths authored
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+        shape = UsdGeom.Points.Define(stage, "/points")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([4.0, 6.0])
+
+        desc = parse_sphere_points(stage)
+        self.assertTrue(desc.isValid)
+        self.assertEqual(len(desc.spherePoints), 2)
+        self.assertAlmostEqual(desc.spherePoints[0].radius, 2.0)
+        self.assertAlmostEqual(desc.spherePoints[1].radius, 3.0)
+
+        # both authored, primvars:widths wins
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+        shape = UsdGeom.Points.Define(stage, "/points")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        shape.GetWidthsAttr().Set([10.0, 20.0])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([4.0, 6.0])
+
+        desc = parse_sphere_points(stage)
+        self.assertTrue(desc.isValid)
+        self.assertAlmostEqual(desc.spherePoints[0].radius, 2.0)
+        self.assertAlmostEqual(desc.spherePoints[1].radius, 3.0)
+
+        # indexed primvars:widths
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+        shape = UsdGeom.Points.Define(stage, "/points")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([4.0])
+        widthsPv.SetIndices(Vt.IntArray([0, 0]))
+
+        desc = parse_sphere_points(stage)
+        self.assertTrue(desc.isValid)
+        self.assertEqual(len(desc.spherePoints), 2)
+        self.assertAlmostEqual(desc.spherePoints[0].radius, 2.0)
+        self.assertAlmostEqual(desc.spherePoints[1].radius, 2.0)
+
+        # neither authored — invalid
+        stage = Usd.Stage.CreateInMemory()
+        UsdPhysics.Scene.Define(stage, '/physicsScene')
+        shape = UsdGeom.Points.Define(stage, "/points")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
+
+        desc = parse_sphere_points(stage)
+        self.assertFalse(desc.isValid)
 
     def test_rigidbody_parse(self):
         stage = Usd.Stage.CreateInMemory()

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -6,7 +6,7 @@
 # https://openusd.org/license.
 
 import sys, os, unittest
-from pxr import Tf, Usd, UsdValidation, UsdPhysics, UsdGeom, Gf
+from pxr import Tf, Usd, UsdValidation, UsdPhysics, UsdGeom, Gf, Sdf, Vt
 
 
 class TestUsdPhysicsValidation(unittest.TestCase):
@@ -337,6 +337,99 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         self.assertTrue(errors[0].GetName() == "ColliderNonUniformScale")
 
         stage.RemovePrim(shape.GetPrim().GetPrimPath())
+
+    def test_points_collider_primvar_widths(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:ColliderChecker"
+        )
+
+        self.assertTrue(validator)
+
+        # only widths attr authored, matching count — should pass
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        shape.GetWidthsAttr().Set([1.0, 2.0])
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # only primvars:widths authored, matching count — should pass
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([1.0, 2.0])
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # both authored, primvars:widths wins — widths attr has wrong count
+        # but primvars:widths matches, so should pass
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        shape.GetWidthsAttr().Set([1.0])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([1.0, 2.0])
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # both authored, primvars:widths wins — primvars has wrong count
+        # widths attr matches, but primvar takes priority so should fail
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        shape.GetWidthsAttr().Set([1.0, 2.0])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([1.0])
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
+
+        # neither authored — should fail
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0)])
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
+
+        # indexed primvars:widths — 1 value, 2 indices matching 2 points
+        stage = Usd.Stage.CreateInMemory()
+        shape = UsdGeom.Points.Define(stage, "/shape")
+        UsdPhysics.CollisionAPI.Apply(shape.GetPrim())
+        shape.GetPointsAttr().Set([Gf.Vec3f(1.0), Gf.Vec3f(2.0)])
+        primvarsAPI = UsdGeom.PrimvarsAPI(shape.GetPrim())
+        widthsPv = primvarsAPI.CreatePrimvar(
+            "widths", Sdf.ValueTypeNames.FloatArray)
+        widthsPv.Set([1.0])
+        widthsPv.SetIndices(Vt.IntArray([0, 0]))
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # indexed primvars:widths — wrong flattened count
+        widthsPv.SetIndices(Vt.IntArray([0]))
+
+        errors = validator.Validate(shape.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "ColliderSpherePointsDataMissing")
 
     def test_plane_collider_static_only(self):
         validationRegistry = UsdValidation.ValidationRegistry()

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -267,6 +267,49 @@ class TestUsdPhysicsValidation(unittest.TestCase):
 
         stage.RemovePrim(shape.GetPrim().GetPrimPath())
 
+    def test_plane_collider_static_only(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:ColliderChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        # Static plane collider (no rigid body parent) - should pass
+        plane = UsdGeom.Plane.Define(stage, "/staticPlane")
+        UsdPhysics.CollisionAPI.Apply(plane.GetPrim())
+
+        errors = validator.Validate(plane.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Plane under a dynamic rigid body - should fail
+        dynamicBody = UsdGeom.Xform.Define(stage, "/dynamicBody")
+        rboAPI = UsdPhysics.RigidBodyAPI.Apply(dynamicBody.GetPrim())
+
+        dynamicPlane = UsdGeom.Plane.Define(stage, "/dynamicBody/plane")
+        UsdPhysics.CollisionAPI.Apply(dynamicPlane.GetPrim())
+
+        errors = validator.Validate(dynamicPlane.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "ColliderPlaneNotStatic")
+
+        # Plane under a static rigid body (enabled=false) - should pass
+        rboAPI.GetRigidBodyEnabledAttr().Set(False)
+
+        errors = validator.Validate(dynamicPlane.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Plane under a kinematic rigid body - should still fail
+        rboAPI.GetRigidBodyEnabledAttr().Set(True)
+        rboAPI.GetKinematicEnabledAttr().Set(True)
+
+        errors = validator.Validate(dynamicPlane.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "ColliderPlaneNotStatic")
+
     def test_rigid_body_mass_api(self):
         validationRegistry = UsdValidation.ValidationRegistry()
         rigidBodyValidator = validationRegistry.GetOrLoadValidatorByName(

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -152,13 +152,82 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         stage = Usd.Stage.CreateInMemory()
         self.assertTrue(stage)
 
-        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        body0 = UsdGeom.Xform.Define(stage, "/body0")
+        UsdPhysics.RigidBodyAPI.Apply(body0.GetPrim())
 
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        physicsJoint.GetBody0Rel().AddTarget("/body0")
         physicsJoint.GetBody1Rel().AddTarget("/invalidPrim")
 
         errors = validator.Validate(physicsJoint.GetPrim())
         self.assertTrue(len(errors) == 1)
-        self.assertTrue(errors[0].GetName() == "JointInvalidPrimRel")        
+        self.assertTrue(errors[0].GetName() == "JointInvalidPrimRel")
+
+    def test_physics_joint_rel_not_xformable(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:PhysicsJointChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        UsdGeom.Scope.Define(stage, "/scope")
+        xform = UsdGeom.Xform.Define(stage, "/xform")
+        UsdPhysics.RigidBodyAPI.Apply(xform.GetPrim())
+
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+        physicsJoint.GetBody0Rel().AddTarget("/scope")
+        physicsJoint.GetBody1Rel().AddTarget("/xform")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointRelNotXformable")
+
+        # Xform is Xformable — should not trigger JointRelNotXformable
+        physicsJoint.GetBody0Rel().SetTargets(["/xform"])
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+    def test_physics_joint_requires_enabled_rigid_body(self):
+        validationRegistry = UsdValidation.ValidationRegistry()
+        validator = validationRegistry.GetOrLoadValidatorByName(
+            "usdPhysicsValidators:PhysicsJointChecker"
+        )
+
+        self.assertTrue(validator)
+
+        stage = Usd.Stage.CreateInMemory()
+        self.assertTrue(stage)
+
+        # Joint with no body rels — no enabled rigid body
+        physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
+
+        # Add one enabled rigid body — should clear the error
+        body0 = UsdGeom.Xform.Define(stage, "/body0")
+        rbo0 = UsdPhysics.RigidBodyAPI.Apply(body0.GetPrim())
+        physicsJoint.GetBody0Rel().AddTarget("/body0")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 0)
+
+        # Disable the rigid body — should fail again
+        body1 = UsdGeom.Xform.Define(stage, "/body1")
+        rbo1 = UsdPhysics.RigidBodyAPI.Apply(body1.GetPrim())
+        rbo0.GetRigidBodyEnabledAttr().Set(False)
+        rbo1.GetRigidBodyEnabledAttr().Set(False)
+        physicsJoint.GetBody1Rel().AddTarget("/body1")
+
+        errors = validator.Validate(physicsJoint.GetPrim())
+        self.assertTrue(len(errors) == 1)
+        self.assertTrue(errors[0].GetName() == "JointNoEnabledRigidBody")
 
     def test_physics_joint_multiple_rels(self):
         validationRegistry = UsdValidation.ValidationRegistry()
@@ -171,8 +240,10 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         stage = Usd.Stage.CreateInMemory()
         self.assertTrue(stage)
 
-        UsdGeom.Xform.Define(stage, "/xform0")
-        UsdGeom.Xform.Define(stage, "/xform1")
+        xform0 = UsdGeom.Xform.Define(stage, "/xform0")
+        UsdPhysics.RigidBodyAPI.Apply(xform0.GetPrim())
+        xform1 = UsdGeom.Xform.Define(stage, "/xform1")
+        UsdPhysics.RigidBodyAPI.Apply(xform1.GetPrim())
 
         physicsJoint = UsdPhysics.Joint.Define(stage, "/joint")
 

--- a/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
+++ b/pxr/usdValidation/usdPhysicsValidators/testenv/testUsdPhysicsValidation.py
@@ -458,7 +458,7 @@ class TestUsdPhysicsValidation(unittest.TestCase):
 
         errors = validator.Validate(dynamicPlane.GetPrim())
         self.assertTrue(len(errors) == 1)
-        self.assertTrue(errors[0].GetName() == "ColliderPlaneNotStatic")
+        self.assertTrue(errors[0].GetName() == "ColliderPlaneDynamic")
 
         # Plane under a static rigid body (enabled=false) - should pass
         rboAPI.GetRigidBodyEnabledAttr().Set(False)
@@ -466,13 +466,12 @@ class TestUsdPhysicsValidation(unittest.TestCase):
         errors = validator.Validate(dynamicPlane.GetPrim())
         self.assertTrue(len(errors) == 0)
 
-        # Plane under a kinematic rigid body - should still fail
+        # Plane under a kinematic rigid body - should pass
         rboAPI.GetRigidBodyEnabledAttr().Set(True)
         rboAPI.GetKinematicEnabledAttr().Set(True)
 
         errors = validator.Validate(dynamicPlane.GetPrim())
-        self.assertTrue(len(errors) == 1)
-        self.assertTrue(errors[0].GetName() == "ColliderPlaneNotStatic")
+        self.assertTrue(len(errors) == 0)
 
     def test_rigid_body_mass_api(self):
         validationRegistry = UsdValidation.ValidationRegistry()

--- a/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
+++ b/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
@@ -31,6 +31,8 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((rigidBodyNonXformable,  "RigidBodyNonXformable"))                    \
     ((rigidBodyNonInstanceable,  "RigidBodyNonInstanceable"))              \
     ((jointInvalidPrimRel,  "JointInvalidPrimRel"))                        \
+    ((jointRelNotXformable, "JointRelNotXformable"))                      \
+    ((jointNoEnabledRigidBody, "JointNoEnabledRigidBody"))                \
     ((jointMultiplePrimsRel,  "JointMultiplePrimsRel"))                    \
     ((colliderNonUniformScale, "ColliderNonUniformScale"))                 \
     ((colliderPlaneNotStatic, "ColliderPlaneNotStatic"))                    \

--- a/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
+++ b/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
@@ -33,6 +33,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((jointInvalidPrimRel,  "JointInvalidPrimRel"))                        \
     ((jointMultiplePrimsRel,  "JointMultiplePrimsRel"))                    \
     ((colliderNonUniformScale, "ColliderNonUniformScale"))                 \
+    ((colliderPlaneNotStatic, "ColliderPlaneNotStatic"))                    \
     ((colliderSpherePointsDataMissing, "ColliderSpherePointsDataMissing")) \
     ((massInvalidValues, "MassInvalidValues"))                             \
     ((densityInvalidValues, "DensityInvalidValues"))                       \

--- a/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
+++ b/pxr/usdValidation/usdPhysicsValidators/validatorTokens.h
@@ -35,7 +35,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((jointNoEnabledRigidBody, "JointNoEnabledRigidBody"))                \
     ((jointMultiplePrimsRel,  "JointMultiplePrimsRel"))                    \
     ((colliderNonUniformScale, "ColliderNonUniformScale"))                 \
-    ((colliderPlaneNotStatic, "ColliderPlaneNotStatic"))                    \
+    ((colliderPlaneDynamic, "ColliderPlaneDynamic"))                        \
     ((colliderSpherePointsDataMissing, "ColliderSpherePointsDataMissing")) \
     ((massInvalidValues, "MassInvalidValues"))                             \
     ((densityInvalidValues, "DensityInvalidValues"))                       \

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -26,6 +26,8 @@
 #include "pxr/usd/usdGeom/cylinder_1.h"
 #include "pxr/usd/usdGeom/plane.h"
 #include "pxr/usd/usdGeom/points.h"
+#include "pxr/usd/usdGeom/primvar.h"
+#include "pxr/usd/usdGeom/primvarsAPI.h"
 #include "pxr/usd/usdGeom/xformable.h"
 #include "pxr/usd/usdPhysics/rigidBodyAPI.h"
 #include "pxr/usd/usdPhysics/massAPI.h"
@@ -401,25 +403,55 @@ _GetColliderErrors(const UsdPrim &usdPrim,
     }
         if (usdPrim.IsA<UsdGeomPoints>())
         {
+            const UsdGeomPoints shape(usdPrim);
+
+            VtArray<GfVec3f> positions;
+            shape.GetPointsAttr().Get(&positions);
+
+            const UsdGeomPrimvarsAPI primvarsAPI(usdPrim);
+            const UsdGeomPrimvar widthsPrimvar =
+                primvarsAPI.GetPrimvar(TfToken("widths"));
+
+            size_t widthsCount = 0;
+            std::string widthsSource;
+            if (widthsPrimvar && widthsPrimvar.HasAuthoredValue())
             {
-                const UsdGeomPoints shape(usdPrim);
-
-                VtArray<float> widths;
-                VtArray<GfVec3f> positions;
-                shape.GetWidthsAttr().Get(&widths);
-                shape.GetPointsAttr().Get(&positions);
-
-                if (widths.empty() || positions.empty() || widths.size() != positions.size())
+                if (widthsPrimvar.IsIndexed())
                 {
-                    errors.emplace_back(
-                        UsdPhysicsValidationErrorNameTokens->colliderSpherePointsDataMissing,
-                        UsdValidationErrorType::Error,
-                        primErrorSites,
-                        TfStringPrintf(
-                            "UsdGeomPoints width or position array not filled or sizes do not match, prim path: %s",
-                            usdPrim.GetPath().GetText())
-                    );
+                    VtIntArray indices;
+                    widthsPrimvar.GetIndices(&indices);
+                    widthsCount = indices.size();
+                    widthsSource = "primvars:widths:indices";
                 }
+                else
+                {
+                    VtArray<float> widthsValues;
+                    widthsPrimvar.Get(&widthsValues);
+                    widthsCount = widthsValues.size();
+                    widthsSource = "primvars:widths";
+                }
+            }
+            else
+            {
+                VtArray<float> widthsValues;
+                shape.GetWidthsAttr().Get(&widthsValues);
+                widthsCount = widthsValues.size();
+                widthsSource = "widths";
+            }
+
+            if (widthsCount == 0 || positions.empty() ||
+                widthsCount != positions.size())
+            {
+                errors.emplace_back(
+                    UsdPhysicsValidationErrorNameTokens->colliderSpherePointsDataMissing,
+                    UsdValidationErrorType::Error,
+                    primErrorSites,
+                    TfStringPrintf(
+                        "UsdGeomPoints %s array has %zu elements but points "
+                        "has %zu elements, prim path: %s",
+                        widthsSource.c_str(), widthsCount,
+                        positions.size(), usdPrim.GetPath().GetText())
+                );
             }
         }
 

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -367,16 +367,24 @@ _GetColliderErrors(const UsdPrim &usdPrim,
             UsdPrim bodyPrim;
             if (HasDynamicBodyParent(usdPrim, &bodyPrim))
             {
-                errors.emplace_back(
-                    UsdPhysicsValidationErrorNameTokens->colliderPlaneNotStatic,
-                    UsdValidationErrorType::Error,
-                    primErrorSites,
-                    TfStringPrintf(
-                        "UsdGeomPlane collider must be static and cannot be "
-                        "attached to a dynamic nor kinematic rigid body, "
-                        "prim path: %s",
-                        usdPrim.GetPath().GetText())
-                );
+                const UsdPhysicsRigidBodyAPI bodyAPI(bodyPrim);
+                bool isKinematic = false;
+                if (bodyAPI)
+                {
+                    bodyAPI.GetKinematicEnabledAttr().Get(&isKinematic);
+                }
+                if (!isKinematic)
+                {
+                    errors.emplace_back(
+                        UsdPhysicsValidationErrorNameTokens->colliderPlaneDynamic,
+                        UsdValidationErrorType::Error,
+                        primErrorSites,
+                        TfStringPrintf(
+                            "UsdGeomPlane collider cannot be attached to a "
+                            "simulated rigid body, prim path: %s",
+                            usdPrim.GetPath().GetText())
+                    );
+                }
             }
         }
 

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -24,6 +24,7 @@
 #include "pxr/usd/usdGeom/capsule_1.h"
 #include "pxr/usd/usdGeom/cylinder.h"
 #include "pxr/usd/usdGeom/cylinder_1.h"
+#include "pxr/usd/usdGeom/plane.h"
 #include "pxr/usd/usdGeom/points.h"
 #include "pxr/usd/usdGeom/xformable.h"
 #include "pxr/usd/usdPhysics/rigidBodyAPI.h"
@@ -358,6 +359,24 @@ _GetColliderErrors(const UsdPrim &usdPrim,
         const UsdValidationErrorSites primErrorSites = {
             UsdValidationErrorSite(usdPrim.GetStage(), usdPrim.GetPath())
         };
+
+        if (usdPrim.IsA<UsdGeomPlane>())
+        {
+            UsdPrim bodyPrim;
+            if (HasDynamicBodyParent(usdPrim, &bodyPrim))
+            {
+                errors.emplace_back(
+                    UsdPhysicsValidationErrorNameTokens->colliderPlaneNotStatic,
+                    UsdValidationErrorType::Error,
+                    primErrorSites,
+                    TfStringPrintf(
+                        "UsdGeomPlane collider must be static and cannot be "
+                        "attached to a dynamic nor kinematic rigid body, "
+                        "prim path: %s",
+                        usdPrim.GetPath().GetText())
+                );
+            }
+        }
 
     if (usdPrim.IsA<UsdGeomSphere>() ||
         usdPrim.IsA<UsdGeomCapsule>() ||

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -410,7 +410,7 @@ _GetColliderErrors(const UsdPrim &usdPrim,
 
             const UsdGeomPrimvarsAPI primvarsAPI(usdPrim);
             const UsdGeomPrimvar widthsPrimvar =
-                primvarsAPI.GetPrimvar(TfToken("widths"));
+                primvarsAPI.GetPrimvar(UsdGeomTokens->widths);
 
             size_t widthsCount = 0;
             std::string widthsSource;

--- a/pxr/usdValidation/usdPhysicsValidators/validators.cpp
+++ b/pxr/usdValidation/usdPhysicsValidators/validators.cpp
@@ -505,17 +505,42 @@ SdfPath GetRel(const UsdRelationship& ref)
     return targets.at(0);
 }
 
-bool CheckJointRel(const SdfPath& relPath, const UsdPrim& jointPrim)
+enum class JointRelStatus
+{
+    Valid,
+    Empty,
+    InvalidPrim,
+    NotXformable
+};
+
+JointRelStatus CheckJointRel(const SdfPath& relPath, const UsdPrim& jointPrim)
 {
     if (relPath == SdfPath())
-        return true;
+        return JointRelStatus::Empty;
 
     const UsdPrim relPrim = jointPrim.GetStage()->GetPrimAtPath(relPath);
     if (!relPrim)
     {
-        return false;
+        return JointRelStatus::InvalidPrim;
     }
-    return true;
+    if (!relPrim.IsA<UsdGeomXformable>())
+    {
+        return JointRelStatus::NotXformable;
+    }
+    return JointRelStatus::Valid;
+}
+
+bool HasEnabledRigidBody(const SdfPath& relPath, const UsdPrim& jointPrim)
+{
+    if (relPath == SdfPath())
+        return false;
+
+    const UsdPrim relPrim = jointPrim.GetStage()->GetPrimAtPath(relPath);
+    if (!relPrim)
+        return false;
+
+    bool physicsAPIFound = false;
+    return IsDynamicBody(relPrim, &physicsAPIFound);
 }
 
 
@@ -540,9 +565,11 @@ _GetPhysicsJointErrors(const UsdPrim &usdPrim,
             const SdfPath rel0 = GetRel(physicsJoint.GetBody0Rel());
             const SdfPath rel1 = GetRel(physicsJoint.GetBody1Rel());
 
-            // check rel validity
-            if (!CheckJointRel(rel0, usdPrim) || !CheckJointRel(
-                rel1, usdPrim))
+            const JointRelStatus status0 = CheckJointRel(rel0, usdPrim);
+            const JointRelStatus status1 = CheckJointRel(rel1, usdPrim);
+
+            if (status0 == JointRelStatus::InvalidPrim ||
+                status1 == JointRelStatus::InvalidPrim)
             {
                 errors.emplace_back(
                     UsdPhysicsValidationErrorNameTokens->jointInvalidPrimRel,
@@ -551,6 +578,34 @@ _GetPhysicsJointErrors(const UsdPrim &usdPrim,
                     TfStringPrintf(
                         "Joint (%s) body relationship points to a non "
                         "existent prim, joint will not be parsed.",
+                        usdPrim.GetPrimPath().GetText())
+                );
+            }
+
+            if (status0 == JointRelStatus::NotXformable ||
+                status1 == JointRelStatus::NotXformable)
+            {
+                errors.emplace_back(
+                    UsdPhysicsValidationErrorNameTokens->jointRelNotXformable,
+                    UsdValidationErrorType::Error,
+                    primErrorSites,
+                    TfStringPrintf(
+                        "Joint (%s) body relationship must point to an "
+                        "Xformable prim.",
+                        usdPrim.GetPrimPath().GetText())
+                );
+            }
+
+            if (!HasEnabledRigidBody(rel0, usdPrim) &&
+                !HasEnabledRigidBody(rel1, usdPrim))
+            {
+                errors.emplace_back(
+                    UsdPhysicsValidationErrorNameTokens->jointNoEnabledRigidBody,
+                    UsdValidationErrorType::Error,
+                    primErrorSites,
+                    TfStringPrintf(
+                        "Joint (%s) must have at least one body relationship "
+                        "pointing to a prim with an enabled RigidBodyAPI.",
                         usdPrim.GetPrimPath().GetText())
                 );
             }


### PR DESCRIPTION
### Description of Change(s)

This includes 3 validation improvements for UsdPhysics and a parsing fix for Points colliders.

- Plane colliders cannot be attached to dynamic or kinematic rigid bodies (i.e. planes are always static)
- Joints body relationships
  - Valid body relationships must point to Xformable prims
  - At least one body relationship must have an enabled RigidBodyAPI
- Points colliders support `primvars:widths` as well as the native widths attr, following the usual precedance defined in UsdGeom, with validation providing a clear error messages identifying the source attribute.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
