### PR TITLE
Autodesk: [Hdx] Fix Skydome task bug when using primId visualization

### DIFF
--- a/pxr/imaging/hdx/skydomeTask.cpp
+++ b/pxr/imaging/hdx/skydomeTask.cpp
@@ -140,6 +140,13 @@ HdxSkydomeTask::Execute(HdTaskContext* ctx)
 
     const bool haveColorAOV = !gfxCmdsDesc.colorTextures.empty();
 
+    // Don't try to render the skydome in an incompatible AOV, for example
+    // when doing primId visualization.
+    const bool colorAovIsNonFloatFormat =
+        haveColorAOV &&
+        !gfxCmdsDesc.colorAttachmentDescs.empty() &&
+        !HgiIsFloatFormat(gfxCmdsDesc.colorAttachmentDescs[0].format);
+
     const bool needClear =
         (gfxCmdsDesc.depthAttachmentDesc.loadOp == HgiAttachmentLoadOpClear) ||
         (!gfxCmdsDesc.colorAttachmentDescs.empty() &&
@@ -147,7 +154,7 @@ HdxSkydomeTask::Execute(HdTaskContext* ctx)
 
     // If the skydome is not camera visible in a colorAOV or there is no
     // domelight/skydomeTexture, we can bail.
-    if (!_skydomeVisibility || !haveColorAOV ||
+    if (!_skydomeVisibility || !haveColorAOV || colorAovIsNonFloatFormat ||
         !haveDomeLight || !_GetSkydomeTexture(ctx)) {
         if (needClear) {
             // If we need to clear, do so before the early out.


### PR DESCRIPTION
### Description of Change(s)

Disable writing to the colour AOV in the skydome task when using a non-float AOV format (such as when using primId visualization).

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

- N/A

### Fixes Issue(s)

- N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
