### PR TITLE
[Apple] Support MaterialX UsdPrimvarReader in Storm

### DIFF
--- a/pxr/imaging/hdMtlx/hdMtlx.cpp
+++ b/pxr/imaging/hdMtlx/hdMtlx.cpp
@@ -44,6 +44,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (texcoord)
     (geompropvalue)
+    (geomprop)
+    ((defaultInput, "default"))
     (filename)
     (ND_surface)
     (typeName)
@@ -219,6 +221,67 @@ _UsesTexcoordNode(mx::NodeDefPtr const& mxNodeDef)
         }
     }
     return false;
+}
+
+// Returns the geompropvalue/geompropvalueuniform node within the given
+// nodeDef's implementation nodegraph, or nullptr if the implementation is not
+// a nodegraph or contains no such node.
+static mx::NodePtr
+_GetWrappedGeompropValueNode(mx::NodeDefPtr const& mxNodeDef)
+{
+    if (!mxNodeDef) {
+        return nullptr;
+    }
+    mx::InterfaceElementPtr impl = mxNodeDef->getImplementation();
+    if (!impl || !impl->isA<mx::NodeGraph>()) {
+        return nullptr;
+    }
+    mx::NodeGraphPtr nodegraph = impl->asA<mx::NodeGraph>();
+    for (mx::NodePtr const& node : nodegraph->getNodes()) {
+        const std::string& category = node->getCategory();
+        if (category == "geompropvalue" ||
+            category == "geompropvalueuniform") {
+            return node;
+        }
+    }
+    return nullptr;
+}
+
+// Returns the name of the node input that the wrapped geompropvalue binds to
+// the given internal input via 'interfacename'. If there is no wrapper binding
+// (native geompropvalue nodes, or anything else), falls back to the internal
+// input name itself, which is the name native geompropvalue nodes use directly.
+static TfToken
+_GetPrimvarInputName(
+    mx::NodeDefPtr const& mxNodeDef,
+    TfToken const& geompropInputName)
+{
+    mx::NodePtr geompropNode = _GetWrappedGeompropValueNode(mxNodeDef);
+    if (geompropNode) {
+        mx::InputPtr input = geompropNode->getInput(geompropInputName.GetString());
+        if (input && !input->getInterfaceName().empty()) {
+            return TfToken(input->getInterfaceName());
+        }
+    }
+    return geompropInputName;
+}
+
+bool
+HdMtlxIsPrimvarReaderNodeDef(mx::NodeDefPtr const& mxNodeDef)
+{
+    return _GetWrappedGeompropValueNode(mxNodeDef) != nullptr;
+}
+
+TfToken
+HdMtlxGetPrimvarNameInputName(mx::NodeDefPtr const& mxNodeDef)
+{
+    return _GetPrimvarInputName(mxNodeDef, _tokens->geomprop);
+}
+
+TfToken
+HdMtlxGetPrimvarDefaultInputName(mx::NodeDefPtr const& mxNodeDef)
+{
+    return _GetPrimvarInputName(mxNodeDef, _tokens->defaultInput);
 }
 
 static std::string
@@ -452,8 +515,11 @@ _AddMaterialXNode(
     }
 
     // Primvar nodes:
-    // Save the node path so the primvarName can be declared in ShaderGen
-    if (mxNodeCategory == _tokens->geompropvalue) {
+    // Save the node path so the primvarName can be declared in ShaderGen.
+    // This covers native 'geompropvalue' nodes as well as nodes (such as
+    // UsdPrimvarReader) whose implementation wraps a geompropvalue node.
+    if (mxNodeCategory == _tokens->geompropvalue ||
+        HdMtlxIsPrimvarReaderNodeDef(mxNodeDef)) {
         mxHdData->hdPrimvarNodes.insert(hdNodePath);
     }
 

--- a/pxr/imaging/hdMtlx/hdMtlx.h
+++ b/pxr/imaging/hdMtlx/hdMtlx.h
@@ -74,10 +74,37 @@ HdMtlxGetNodeDef(
     MaterialX::DocumentPtr const& mxDoc=nullptr);
 
 /// NodeDef names may change between MaterialX versions, this function returns
-/// the nodeDef name appropriate for the version of MaterialX being used. 
+/// the nodeDef name appropriate for the version of MaterialX being used.
 HDMTLX_API
 std::string
 HdMtlxGetNodeDefName(std::string const& prevMxNodeDefName);
+
+/// Returns true if the given nodeDef's implementation is a nodegraph that
+/// contains a 'geompropvalue' or 'geompropvalueuniform' node, i.e. the node
+/// reads a primvar (for example UsdPrimvarReader). Native 'geompropvalue'
+/// nodes are not detected here since their implementation is source code
+/// rather than a nodegraph.
+HDMTLX_API
+bool
+HdMtlxIsPrimvarReaderNodeDef(MaterialX::NodeDefPtr const& mxNodeDef);
+
+/// Returns the node input that carries the primvar name for a primvar-reading
+/// node. For wrapper nodes (such as UsdPrimvarReader) this is discovered from
+/// the 'interfacename' on the wrapped geompropvalue's 'geomprop' input (for
+/// example "varname"). For native geompropvalue nodes, or any node without such
+/// a binding, this returns "geomprop".
+HDMTLX_API
+TfToken
+HdMtlxGetPrimvarNameInputName(MaterialX::NodeDefPtr const& mxNodeDef);
+
+/// Returns the node input that carries the fallback value for a primvar-reading
+/// node. For wrapper nodes (such as UsdPrimvarReader) this is discovered from
+/// the 'interfacename' on the wrapped geompropvalue's 'default' input (for
+/// example "fallback"). For native geompropvalue nodes, or any node without such
+/// a binding, this returns "default".
+HDMTLX_API
+TfToken
+HdMtlxGetPrimvarDefaultInputName(MaterialX::NodeDefPtr const& mxNodeDef);
 
 /// Get the terminal name used in the MaterialX document based on the Hydra
 /// terminal node.

--- a/pxr/imaging/hdSt/materialXFilter.cpp
+++ b/pxr/imaging/hdSt/materialXFilter.cpp
@@ -46,7 +46,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     // Default Texture Coordinate Token
     (st)
     (texcoord)
-    (geomprop)
     (index)
     ((defaultInput, "default"))
     (filename)
@@ -486,15 +485,16 @@ _UpdatePrimvarNodes(
     for (auto const& primvarPath : hdPrimvarNodes) {
         const HdMaterialNode2& hdPrimvarNode = hdNetwork.nodes.at(primvarPath);
 
-        // Save primvar name for the glslfx header
-        auto primvarNameIt = hdPrimvarNode.parameters.find(_tokens->geomprop);
+        mx::NodeDefPtr mxNodeDef = mxDoc->getNodeDef(
+                hdPrimvarNode.nodeTypeId.GetString());
+
+        auto primvarNameIt =
+            hdPrimvarNode.parameters.find(HdMtlxGetPrimvarNameInputName(mxNodeDef));
         if (primvarNameIt != hdPrimvarNode.parameters.end()) {
             std::string const& primvarName =
                 HdMtlxConvertToString(primvarNameIt->second);
 
             // Figure out the mx typename
-            mx::NodeDefPtr mxNodeDef = mxDoc->getNodeDef(
-                    hdPrimvarNode.nodeTypeId.GetString());
             if (mxNodeDef) {
                 (*mxHdPrimvarMap)[primvarName] = mxNodeDef->getType();
             }
@@ -502,9 +502,9 @@ _UpdatePrimvarNodes(
             // Get the Default value if authored
             std::string defaultPrimvarValue;
             const auto defaultPrimvarValueIt =
-                hdPrimvarNode.parameters.find(_tokens->defaultInput);
+                hdPrimvarNode.parameters.find(HdMtlxGetPrimvarDefaultInputName(mxNodeDef));
             if (hdPrimvarNode.parameters.end() != defaultPrimvarValueIt) {
-                defaultPrimvarValue = 
+                defaultPrimvarValue =
                     HdMtlxConvertToString(defaultPrimvarValueIt->second);
             }
             (*mxHdPrimvarDefaultValueMap)[primvarName] = defaultPrimvarValue;
@@ -1367,8 +1367,15 @@ _IsTopologicalShader(TfToken const& nodeId)
     const SdrShaderNodeConstPtr sdrNode = 
         sdrRegistry.GetShaderNodeByIdentifierAndType(nodeId, _tokens->mtlx);
 
-    if (sdrNode) {
-        return topologicalTokenSet.count(sdrNode->GetFamily()) > 0;
+    if (sdrNode && topologicalTokenSet.count(sdrNode->GetFamily()) > 0) {
+        return true;
+    }
+
+    // Nodes whose implementation wraps a geompropvalue node (such as
+    // UsdPrimvarReader) carry a primvar name that is topology-affecting, so
+    // they must be treated as topological to preserve that parameter.
+    if (HdMtlxIsPrimvarReaderNodeDef(HdMtlxGetNodeDef(nodeId))) {
+        return true;
     }
 
     // Swizzle nodes were topolgical in MaterialX v1.38 but were removed in 

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -153,6 +153,26 @@ _GetSamplerName(std::string const& textureName)
     return samplerName;
 }
 
+// Map a MaterialX type name to a type name understood by HioGlslfxConfig.
+// The glslfx config parser only recognizes a fixed set of type names
+// (float/int/vec2/vec3/vec4). Returns an empty string for unsupported types.
+static std::string
+_GetGlslfxPrimvarTypeName(std::string const& mxTypeName)
+{
+    static const std::unordered_map<std::string, std::string> typeMap = {
+        { "float",    "float" },
+        { "integer",  "int" },
+        { "boolean",  "int" },
+        { "vector2",  "vec2" },
+        { "vector3",  "vec3" },
+        { "color3",   "vec3" },
+        { "vector4",  "vec4" },
+        { "color4",   "vec4" },
+    };
+    const auto it = typeMap.find(mxTypeName);
+    return it != typeMap.end() ? it->second : std::string();
+}
+
 
 template<typename Base>
 void
@@ -186,8 +206,7 @@ HdStMaterialXShaderGen<Base>::_EmitGlslfxHeader(
         std::string line = ""; unsigned int i = 0;
         for (mx::StringMap::const_reference primvarPair : _mxHdPrimvarMap) {
             const std::string type =
-                HdStMaterialXHelpers::MxGetTypeString(
-                    Base::_syntax, mxContext, primvarPair.second);
+                _GetGlslfxPrimvarTypeName(primvarPair.second);
             if (type.empty() ) {
                 TF_WARN("MaterialX geomprop '%s' has unknown type '%s'",
                         primvarPair.first.c_str(), primvarPair.second.c_str());


### PR DESCRIPTION
### Description of Change(s)

This is built on top of a corresponding MaterialX PR, that fixes nested geomprop nodes:
https://github.com/AcademySoftwareFoundation/MaterialX/pull/2957

Rendering a MaterialX UsdPreviewSurface network that reads a primvar through an ND_UsdPrimvarReader_* node (for example varname="st" feeding a UsdUVTexture) failed in Hydra Storm with:

```
  HdSt_ApplyMaterialXFilter -- Unable to create the Glslfx Shader.
  MxException: No "geomprop" value found for geompropvalue node "primvar".
```

That crash exposed a few different issues this PR fixes, all in how hdMtlx/hdSt build the document and emit the glslfx.

1. Preserve the topology-affecting primvar name. The topological classification (`_IsTopologicalShader`) only recognized the native geompropvalue family, so the `UsdPrimvarReader` varname was stripped from the anonymized network.

2. Recognize primvar-reader nodes generically (hdMtlx). A node is treated as a primvar reader when its implementation nodegraph wraps a geompropvalue or geompropvalueuniform node. New helpers discover this and the input names that carry the primvar name and fallback. Detecting by implementation structure rather than by family name keeps this robust for any future node that wraps a geompropvalue.

3. Emit glslfx-compatible primvar types (hdSt/materialXShaderGen.cpp). The primvar attributes block of the generated glslfx took its type name from the target shader language syntax. On Metal that produced names like `float2`, which HioGlslfxConfig does not understand (it accepts `vec2`), so the primvar declaration was rejected. The attributes type is now mapped to a glslfx type independent of the target language.

Unit test files are attached here - [test_file.zip](https://github.com/user-attachments/files/28570088/test_file.zip)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
