### PR TITLE
[APPLE] Bugfix multiple primvars with GeomSubsets and subdiv. 

### DIFF
--- a/pxr/imaging/hdSt/mesh.cpp
+++ b/pxr/imaging/hdSt/mesh.cpp
@@ -895,7 +895,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
         } else {
             // Geom subsets case
             HdBufferSourceSharedPtr indicesSource;
-            HdBufferSourceSharedPtr fvarIndicesSource;
+            HdBufferSourceSharedPtrVector fvarIndicesSources;
 
             bool refined = false;
             bool quadrangulated = false;
@@ -910,9 +910,10 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
                     for (size_t i = 0; 
                            i < _fvarTopologyTracker->GetNumTopologies(); 
                             ++i) {
-                        fvarIndicesSource = 
+                        HdBufferSourceSharedPtr fvarIndicesSource = 
                             _topology->GetOsdFvarIndexBuilderComputation(i);
                         resourceRegistry->AddSource(fvarIndicesSource);
+                        fvarIndicesSources.push_back(fvarIndicesSource);
                     }
                 }
 
@@ -954,7 +955,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
                 _topology->GetNonSubsetFaces();
             _CreateTopologyRangeForGeomSubset(resourceRegistry, changeTracker, 
                 renderParam, drawItem, indexToken, indicesSource,
-                fvarIndicesSource, geomSubsetFaceIndicesHelperSource,
+                fvarIndicesSources, geomSubsetFaceIndicesHelperSource,
                 VtIntArray(nonSubsetFaces->begin(), nonSubsetFaces->end()), 
                 refined);
 
@@ -967,7 +968,7 @@ HdStMesh::_PopulateTopology(HdSceneDelegate *sceneDelegate,
                         geomSubsetDescIndex, numGeomSubsets, i));
                 _CreateTopologyRangeForGeomSubset(resourceRegistry, 
                     changeTracker, renderParam, subsetDrawItem, indexToken, 
-                    indicesSource, fvarIndicesSource, 
+                    indicesSource, fvarIndicesSources, 
                     geomSubsetFaceIndicesHelperSource, geomSubset.indices, 
                     refined);
             }
@@ -983,7 +984,7 @@ void HdStMesh::_CreateTopologyRangeForGeomSubset(
     HdStDrawItem *drawItem, 
     const TfToken &indexToken,
     HdBufferSourceSharedPtr indicesSource, 
-    HdBufferSourceSharedPtr fvarIndicesSource, 
+    HdBufferSourceSharedPtrVector const &fvarIndicesSources, 
     HdBufferSourceSharedPtr geomSubsetFaceIndicesHelperSource,
     const VtIntArray &faceIndices,
     bool refined)
@@ -1013,11 +1014,14 @@ void HdStMesh::_CreateTopologyRangeForGeomSubset(
                     indicesSource, geomSubsetFaceIndicesSource);
             sources.push_back(subsetSource);
 
-            if (fvarIndicesSource) {
-                HdBufferSourceSharedPtr fvarSubsetSource = 
-                    _topology->GetRefinedIndexSubsetComputation(
-                        fvarIndicesSource, geomSubsetFaceIndicesSource);
-                sources.push_back(fvarSubsetSource);
+            if (fvarIndicesSources.empty() == false) {
+                for (HdBufferSourceSharedPtr const &fvarIndicesSource :
+                        fvarIndicesSources) {
+                    HdBufferSourceSharedPtr fvarSubsetSource = 
+                        _topology->GetRefinedIndexSubsetComputation(
+                            fvarIndicesSource, geomSubsetFaceIndicesSource);
+                    sources.push_back(fvarSubsetSource);
+                }
             }
         } else {
             HdBufferSourceSharedPtr subsetSource = 

--- a/pxr/imaging/hdSt/mesh.h
+++ b/pxr/imaging/hdSt/mesh.h
@@ -19,6 +19,7 @@
 #include "pxr/base/vt/array.h"
 
 #include <memory>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -29,6 +30,7 @@ class HdSceneDelegate;
 using HdSt_VertexAdjacencyBuilderSharedPtr =
         std::shared_ptr<class HdSt_VertexAdjacencyBuilder>;
 using HdBufferSourceSharedPtr = std::shared_ptr<class HdBufferSource>;
+using HdBufferSourceSharedPtrVector = std::vector<HdBufferSourceSharedPtr>;
 using HdSt_MeshTopologySharedPtr = std::shared_ptr<class HdSt_MeshTopology>;
 
 using HdStResourceRegistrySharedPtr =
@@ -156,7 +158,7 @@ protected:
         HdStDrawItem *drawItem, 
         const TfToken &indexToken,
         HdBufferSourceSharedPtr indicesSource, 
-        HdBufferSourceSharedPtr fvarIndicesSource, 
+        HdBufferSourceSharedPtrVector const &fvarIndicesSources, 
         HdBufferSourceSharedPtr geomSubsetFaceIndicesHelperSource,
         const VtIntArray &faceIndices,
         bool refined);


### PR DESCRIPTION
### Description of Change(s)

When a subdivided mesh has both geom subsets (materialBind family) and multiple face-varying primvars whose index buffers differ (multiple fv-topology channels), the geom-subsets path of `HdStMesh::_PopulateTopology()` was only adding the LAST channel's fvarIndices buffer to each subset draw item's topology BAR.

The local fvarIndicesSource variable in the channel-walk loop was overwritten each iteration and then passed by value to `_CreateTopologyRangeForGeomSubset()`, which only ever inserted that single source into the BAR.  Meanwhile codeGen continued to emit `HdGet_fvarIndices<N>()` calls for every channel a primvar uses, so any draw item whose primvar lived on a missing channel produced a Metal shader compile error of the form:

```
  error: use of undeclared identifier 'HdGet_fvarIndices0';
         did you mean 'HdGet_fvarIndices1'?
```

To solve this, in this PR we plumb a `HdBufferSourceSharedPtrVector` through `_CreateTopologyRangeForGeomSubset()` so that every channel's indices source (and its chained fvarPatchParam<N> buffer, which `HdSt_IndexSubsetComputation()` already preserves) ends up in the topology BAR for both the original draw item and each GeomSubset draw item.

Rendering unit tests for UsdImagingGL are disabled for Metal - so attaching locally tested unit test example that fails to render correctly - and raises the error above without the patch.

[unittest.zip](https://github.com/user-attachments/files/28568928/unittest.zip)

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
