### PR TITLE
Add missing virtual destructors to interface and base classes

### DIFF
--- a/pxr/imaging/hd/legacyRenderControlInterface.h
+++ b/pxr/imaging/hd/legacyRenderControlInterface.h
@@ -32,6 +32,8 @@ using HdCommandDescriptors =
 class HdLegacyRenderControlInterface
 {
 public:
+    virtual ~HdLegacyRenderControlInterface() = default;
+
     /// \name Task control
     /// @{
 

--- a/pxr/imaging/hdSt/dynamicUvTextureImplementation.h
+++ b/pxr/imaging/hdSt/dynamicUvTextureImplementation.h
@@ -21,6 +21,8 @@ class HdStDynamicUvTextureObject;
 class HdStDynamicUvTextureImplementation
 {
 public:
+    virtual ~HdStDynamicUvTextureImplementation() = default;
+
     /// Called during the load phase of the Storm texture system
     /// when a texture file is supposed to be loaded to the CPU.
     ///

--- a/pxr/usd/usdUtils/assetLocalizationPackage.h
+++ b/pxr/usd/usdUtils/assetLocalizationPackage.h
@@ -46,6 +46,8 @@ class UsdUtils_AssetLocalizationPackage :
     public UsdUtils_WritableLocalizationClient
 {
 public:
+    virtual ~UsdUtils_AssetLocalizationPackage() = default;
+
     // Sets the original file path for this asset.
     // The path specified should be resolved by AR.
     inline void SetOriginalRootFilePath(const std::string &origRootFilePath)

--- a/pxr/usdImaging/usdSkelImaging/dataSourceUtils.h
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceUtils.h
@@ -20,6 +20,8 @@ template<typename T>
 class UsdSkelImagingSharedPtrThunk
 {
 public:
+    virtual ~UsdSkelImagingSharedPtrThunk() = default;
+
     using Handle = std::shared_ptr<T>;
 
     Handle Get()


### PR DESCRIPTION
### Description of Change(s)

This adds missing virtual destructors to classes with virtual methods (similar to #1156). This fixes undefined behavior during object deletion and warnings/errors when building with `-Wnon-virtual-dtor`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html)) => not applicable

- [x] I have verified that all unit tests pass with the proposed changes 

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement)) 
