### PR TITLE
DRAFT: Support OneTBB via FetchContent

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -39,6 +39,7 @@ option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)
+option(PXR_ALLOW_FETCH_CONTENT "(Experimental) Enable select dependency retrieval via CMake's FetchContent" OFF)
 
 if(APPLE)
     # Cross Compilation detection as defined in CMake docs

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -13,12 +13,23 @@ set(build_shared_libs "${BUILD_SHARED_LIBS}")
 # Core USD Package Requirements 
 # ----------------------------------------------
 
+include(FetchContent)
+
 # Threads.  Save the libraries needed in PXR_THREAD_LIBS;  we may modify
 # them later.  We need the threads package because some platforms require
 # it when using C++ functions from #include <thread>.
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 set(PXR_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+
+if (PXR_ALLOW_FETCH_CONTENT)
+    FetchContent_Declare(
+        tbb
+        URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.12.0.zip
+        URL_HASH SHA256=fe6ca052b5bdd2c6e0616b360c9b0dcbcc46e01bbd0aa8fd0517c17fc58931db
+        FIND_PACKAGE_ARGS NAMES TBB 2021.12...2022 COMPONENTS tbb CONFIG
+    )
+endif()
 
 if(PXR_ENABLE_OPENVDB_SUPPORT)
     # Find Boost package before getting any boost specific components as we need to
@@ -128,7 +139,18 @@ if(WIN32)
 endif()
 
 # --TBB
-if (DEFINED PXR_FIND_TBB_IN_CONFIG)
+if (PXR_ALLOW_FETCH_CONTENT)
+    if (DEFINED PXR_FIND_TBB_IN_CONFIG AND NOT PXR_FIND_TBB_IN_CONFIG)
+        message(WARNING "PXR_FIND_TBB_IN_CONFIG may not be disabled when PXR_ALLOW_FETCH_CONTENT is enabled.")
+    endif()
+    message(STATUS "Resolving OneTBB Via FetchContent")
+    block()
+        set(CMAKE_INCLUDE_CURRENT_DIR OFF)
+        set(TBB_STRICT OFF CACHE INTERNAL "" FORCE)
+        set(TBB_TEST OFF CACHE INTERNAL "" FORCE)
+        FetchContent_MakeAvailable(tbb)
+    endblock()
+elseif (DEFINED PXR_FIND_TBB_IN_CONFIG)
     if (PXR_FIND_TBB_IN_CONFIG)
         find_package(TBB CONFIG REQUIRED COMPONENTS tbb)
     else()


### PR DESCRIPTION
### Description of Change(s)
Add FetchContent support for OneTBB. This allows `cmake` to download OneTBB if it can't be located via `find_package`.

This facilitates minimal builds of OpenUSD with `cmake` without using `build_usd.py`.  This feature is tagged as experimental and gated behind the `PXR_ALLOW_FETCH_CONTENT` flag.

Notes:
* Only OneTBB and `PXR_FIND_TBB_IN_CONFIG` are supported
* The preferred OneTBB version is identical to the one that `build_usd` would have downloaded
* OneTBB Version Range 2021.12.x-2022.y is supported

Before integrating, some consideration should be given to the ordering of the cmake options, project defaults, and packages cmake.  Global cmake variables configured in project defaults may now leak into the `FetchContent_MakeAvailable` call unless explicitly blocked.  (See `CMAKE_INCLUDE_CURRENT_DIR` which causes OneTBB to fail to build).

### Link to proposal ([if applicable]
https://github.com/aousd/build-ig-initiatives/issues/16

### Fixes Issue(s)


### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
