### PR TITLE
DRAFT: Support `cmake` presets for minimal builds

### DIFF
--- a/CMakePresets.flavors.json
+++ b/CMakePresets.flavors.json
@@ -1,0 +1,72 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {"major": 3, "minor": 26, "patch": 0},
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "installDir": "${sourceDir}/install/${presetName}",
+            "cacheVariables": {
+                "PXR_ALLOW_FETCH_CONTENT": true
+            }
+        },
+        {
+            "name": "shared",
+            "hidden": true,
+            "cacheVariables": {
+                "BUILD_SHARED_LIBS": true
+            }
+        },
+        {
+            "name": "minimal",
+            "hidden": true,
+            "cacheVariables": {
+                "PXR_PREFER_SAFETY_OVER_SPEED": true,
+                "PXR_BUILD_USD_VALIDATION": true,
+                "PXR_FIND_TBB_IN_CONFIG": true,
+                "PXR_ENABLE_PYTHON_SUPPORT": false,
+                "PXR_BUILD_MONOLITHIC": false,
+                "PXR_BUILD_EXAMPLES": false,
+                "PXR_BUILD_TUTORIALS": false,
+                "PXR_BUILD_IMAGING": false,
+                "PXR_BUILD_DRACO_PLUGIN": false,
+                "PXR_BUILD_ALEMBIC_PLUGIN": false,
+                "PXR_BUILD_USDVIEW": false
+            }
+        }
+    ],
+    "buildPresets" : [
+        {
+            "name": "default",
+            "hidden": true,
+            "targets": "install"
+        }
+    ],
+    "testPresets" : [
+        {
+            "name": "default",
+            "hidden": true,
+            "environment": {
+                "PATH": "${sourceDir}/install/${presetName}${pathListSep}$penv{PATH}"
+            }
+        },
+        {
+            "name": "stable",
+            "hidden": true,
+            "filter": {
+                "exclude": {"label": "flaky"}
+            }
+        },
+        {
+            "name": "flaky",
+            "hidden": true,
+            "filter": {
+                "include": {"label": "flaky"}
+            },
+            "execution": {
+                "repeat" : {"mode": "until-pass", "count": 3}
+            }
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,7 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {"major": 3, "minor": 26, "patch": 0},
+    "include" : [
+        "CMakePresets.linux.json"
+    ]
+}

--- a/CMakePresets.linux.json
+++ b/CMakePresets.linux.json
@@ -1,0 +1,62 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": {"major": 3, "minor": 26, "patch": 0},
+    "include" : [
+        "CMakePresets.flavors.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "linux",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "minimal-shared-linux-x86-release",
+            "inherits": ["linux", "minimal", "shared", "default"],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ],
+    "buildPresets" : [
+        {
+            "name": "linux",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "minimal-shared-linux-x86-release",
+            "configurePreset": "minimal-shared-linux-x86-release",
+            "inherits": ["linux", "default"]
+        }
+    ],
+    "testPresets" : [
+        {
+            "name": "linux",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "minimal-shared-linux-x86-release-stable",
+            "configurePreset": "minimal-shared-linux-x86-release",
+            "inherits": ["linux", "stable", "default"]
+        },
+        {
+            "name": "minimal-shared-linux-x86-release-flaky",
+            "configurePreset": "minimal-shared-linux-x86-release",
+            "inherits": ["linux", "flaky", "default"]
+        }
+    ]
+}

--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -39,6 +39,7 @@ option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)
+option(PXR_ALLOW_FETCH_CONTENT "(Experimental) Enable select dependency retrieval via CMake's FetchContent" OFF)
 
 if(APPLE)
     # Cross Compilation detection as defined in CMake docs

--- a/cmake/defaults/Packages.cmake
+++ b/cmake/defaults/Packages.cmake
@@ -13,12 +13,23 @@ set(build_shared_libs "${BUILD_SHARED_LIBS}")
 # Core USD Package Requirements 
 # ----------------------------------------------
 
+include(FetchContent)
+
 # Threads.  Save the libraries needed in PXR_THREAD_LIBS;  we may modify
 # them later.  We need the threads package because some platforms require
 # it when using C++ functions from #include <thread>.
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads REQUIRED)
 set(PXR_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
+
+if (PXR_ALLOW_FETCH_CONTENT)
+    FetchContent_Declare(
+        onetbb
+        URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.12.0.zip
+        URL_HASH SHA256=fe6ca052b5bdd2c6e0616b360c9b0dcbcc46e01bbd0aa8fd0517c17fc58931db
+        FIND_PACKAGE_ARGS NAMES TBB 2021.12...2022 COMPONENTS tbb CONFIG
+    )
+endif()
 
 if(PXR_ENABLE_OPENVDB_SUPPORT)
     # Find Boost package before getting any boost specific components as we need to
@@ -107,7 +118,18 @@ if(WIN32)
 endif()
 
 # --TBB
-if (DEFINED PXR_FIND_TBB_IN_CONFIG)
+if (PXR_ALLOW_FETCH_CONTENT)
+    if (DEFINED PXR_FIND_TBB_IN_CONFIG AND NOT PXR_FIND_TBB_IN_CONFIG)
+        message(WARNING "PXR_FIND_TBB_IN_CONFIG may not be disabled when PXR_ALLOW_FETCH_CONTENT is enabled.")
+    endif()
+    message(STATUS "Resolving OneTBB Via FetchContent")
+    block()
+        set(CMAKE_INCLUDE_CURRENT_DIR OFF)
+        set(TBB_STRICT OFF CACHE INTERNAL "" FORCE)
+        set(TBB_TEST OFF CACHE INTERNAL "" FORCE)
+        FetchContent_MakeAvailable(onetbb)
+    endblock()
+elseif (DEFINED PXR_FIND_TBB_IN_CONFIG)
     if (PXR_FIND_TBB_IN_CONFIG)
         find_package(TBB CONFIG REQUIRED COMPONENTS tbb)
     else()


### PR DESCRIPTION
### Description of Change(s)

`cmake` has introduced named build configurations via `json` files.  These configuration files function as a declarative entrypoint for builds.  Other tooling in a developer's ecosystem (package managers, IDEs, etc.) can interface with these more directly than the `build_usd` script.

This demonstrates a "minimal" (no python, no plugins, no imaging) build flavor that works on Linux.

It depends on #4105 to ensure that OneTBB is available without `build_usd.py`.

Ideally, OpenUSD would not require an "install" target during its build phase for its tests to be functional, nor would it necessarily require configuration of the PATH environment variable.  Follow up work in the AOUSD build interest group should investigate these.

Sample usage
```
cmake --preset minimal-shared-linux-x86-release
cmake --build --preset minimal-shared-linux-x86-release -j 12
ctest --preset minimal-shared-linux-x86-release-stable -j 12
ctest --preset minimal-shared-linux-x86-release-flaky -j 12
```

Configure, build, and test steps can be batched and organized into workflow presets if desired, but workflow presets don't currently offer easy parallel configuration.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
