### PR TITLE
Increase minimum cmake version to 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.27)
 
 project(usd)
 

--- a/extras/usd/examples/workDispatchExample/CMakeLists.txt
+++ b/extras/usd/examples/workDispatchExample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.27)
 
 project(workDispatchExample
     LANGUAGES CXX

--- a/extras/usd/examples/workTaskflowExample/CMakeLists.txt
+++ b/extras/usd/examples/workTaskflowExample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.27)
 
 project(workTaskflowExample
     LANGUAGES CXX


### PR DESCRIPTION
### Description of Change(s)

To use [CMP0144](https://cmake.org/cmake/help/latest/policy/CMP0144.html) to support `<PACKAGE>_ROOT` variables with all caps using `find_package` (see PRs like #4109), we need to adopt a newer version of `cmake`.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

https://github.com/aousd/build-ig-initiatives/issues/13
https://github.com/aousd/build-ig-initiatives/issues/10

### Fixes Issue(s)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
