### PR TITLE
Fix unused private field warnings

### DIFF
--- a/pxr/imaging/hgiGL/scopedStateHolder.h
+++ b/pxr/imaging/hgiGL/scopedStateHolder.h
@@ -58,7 +58,6 @@ private:
     int32_t _restoreStencilReferenceValue[2];
     int32_t _restoreStencilFail[2];
     int32_t _restoreStencilReadMask[2];
-    int32_t _restoreStencilPass[2];
     int32_t _restoreStencilDepthFail[2];
     int32_t _restoreStencilDepthPass[2];
     int32_t _restoreStencilWriteMask[2];

--- a/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceMaterial.cpp
@@ -412,7 +412,7 @@ private:
     {}
 
     UsdShadeShader _shaderNode;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals &_stageGlobals;
     const SdfPath _materialPrefix;
 };
 

--- a/pxr/usdImaging/usdImaging/dataSourcePrim.h
+++ b/pxr/usdImaging/usdImaging/dataSourcePrim.h
@@ -94,7 +94,7 @@ private:
 
 private:
     UsdAttributeQuery _purposeQuery;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourcePurpose);
@@ -272,7 +272,7 @@ private:
 
 private:
     UsdGeomXformable::XformQuery _xformQuery;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceXformResetXformStack);

--- a/pxr/usdImaging/usdImaging/dataSourceRelationship.h
+++ b/pxr/usdImaging/usdImaging/dataSourceRelationship.h
@@ -55,7 +55,7 @@ private:
 
 private:
     UsdRelationship _usdRel;
-    const UsdImagingDataSourceStageGlobals & _stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals & _stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceRelationship);

--- a/pxr/usdImaging/usdImaging/dataSourceRenderPrims.cpp
+++ b/pxr/usdImaging/usdImaging/dataSourceRenderPrims.cpp
@@ -214,7 +214,7 @@ private:
 private:
     const SdfPath _sceneIndexPath;
     UsdRenderPass _usdRenderPass;
-    const UsdImagingDataSourceStageGlobals & _stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals & _stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(_DataSourceRenderPass);

--- a/pxr/usdImaging/usdImaging/dataSourceVolume.h
+++ b/pxr/usdImaging/usdImaging/dataSourceVolume.h
@@ -38,7 +38,7 @@ private:
 
 private:
     UsdVolVolume _usdVolume;
-    const UsdImagingDataSourceStageGlobals &_stageGlobals;
+    [[maybe_unused]] const UsdImagingDataSourceStageGlobals &_stageGlobals;
 };
 
 HD_DECLARE_DATASOURCE_HANDLES(UsdImagingDataSourceVolumeFieldBindings);


### PR DESCRIPTION
### Description of Change(s)
Removing one real unused variable with no impact: `HgiGL_ScopedStateHolder::_restoreStencilPass`. 

Marked the unused `_stageGlobals` reference member in multiple places as `[[maybe_unused]]`. I started doing a more aggressive fix (https://github.com/PixarAnimationStudios/OpenUSD/compare/dev...hodor:dev_3337_full_removal) but it felt wrong because I was changing interfaces left and right. So, even though those variables are really not being used, I'm keeping them to ensure that the structure is preserved.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))
N/A

### Fixes Issue(s)
Fixes #3337.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
