### PR TITLE
Implement `TfRealPath` via `std::filesystem` to handle broken symlinks

### DIFF
--- a/pxr/base/tf/pathUtils.cpp
+++ b/pxr/base/tf/pathUtils.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <errno.h>
+#include <filesystem>
 #include <limits.h>
 #include <string>
 #include <sys/stat.h>
@@ -110,38 +111,17 @@ TfRealPath(string const& path, bool allowInaccessibleSuffix, string* error)
     if (path.empty())
         return string();
 
-    string suffix, prefix = path;
-
-    if (allowInaccessibleSuffix) {
-        string::size_type split = TfFindLongestAccessiblePrefix(path, error);
-        if (!error->empty())
-            return string();
-
-        prefix = string(path, 0, split);
-        suffix = string(path, split);
+    const std::filesystem::path filesystemPath{path};
+    std::error_code errorCode;
+    if (const auto realPath = allowInaccessibleSuffix ?
+        std::filesystem::weakly_canonical(filesystemPath, errorCode) :
+        std::filesystem::canonical(filesystemPath, errorCode); !errorCode) {
+        // weakly_canonical is not guaranteed to return an absolute path, TfAbsPath
+        // is run on the result
+        return TfAbsPath(realPath.string());
     }
-
-    if (prefix.empty()) {
-        return TfAbsPath(suffix);
-    }
-
-#if defined(ARCH_OS_WINDOWS)
-    // Expand all symbolic links.
-    if (!TfPathExists(prefix)) {
-        *error = "the named file does not exist";
-        return string();
-    }
-    std::string resolved = _ExpandSymlinks(prefix);
-
-    return TfAbsPath(resolved + suffix);
-#else
-    char resolved[ARCH_PATH_MAX];
-    if (!realpath(prefix.c_str(), resolved)) {
-        *error = ArchStrerror(errno);
-        return string();
-    }
-    return TfAbsPath(resolved + suffix);
-#endif
+    *error = errorCode.message();
+    return string{};
 }
 
 string::size_type

--- a/pxr/base/tf/pathUtils.h
+++ b/pxr/base/tf/pathUtils.h
@@ -28,11 +28,16 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// This is a wrapper to realpath(3), which caters for situations where the
 /// real realpath() would return a NULL string, such as the case where the
 /// path is really just a program name.  The memory allocated by realpath is
-/// managed internally.
+/// managed internally. This should match the behavior of Linux command
+/// `realpath -e` and python function `os.path.realpath(..., strict=True)`.
 ///
 /// If \a allowInaccessibleSuffix is true, then this function will only invoke
 /// realpath on the longest accessible prefix of \a path, and then append the
-/// inaccessible suffix.
+/// inaccessible suffix. This is similar to the Linux command `realpath -m` and
+/// python function `os.path.realpath(..., strict=False)` EXCEPT that a broken
+/// symlink is not resolved to the missing target before the suffix is
+/// appended. This makes the broken symlink effectively part of the
+/// "inaccessible suffix".
 ///
 /// If \a error is provided, it is set to the error reason should an error
 /// occur while computing the real path. If no error occurs, the string is

--- a/pxr/base/tf/testenv/pathUtils.cpp
+++ b/pxr/base/tf/testenv/pathUtils.cpp
@@ -93,7 +93,7 @@ TestTfRealPath()
         // Symlinks through to nonexistent dirs
         TF_AXIOM(TfRealPath("d/e/f/g/h", true) == TfAbsPath("subdir/e/f/g/h"));
         // Symlinks through to broken link
-        TF_AXIOM(TfRealPath("g", true) == "");
+        TF_AXIOM(TfRealPath("g", true) == TfAbsPath("g"));
     }
 
     // Empty

--- a/pxr/base/tf/testenv/testTfPathUtils.py
+++ b/pxr/base/tf/testenv/testTfPathUtils.py
@@ -48,12 +48,12 @@ class TestPathUtils(unittest.TestCase):
                 self.assertEqual(os.path.abspath('subdir/e/f/g/h'),
                              Tf.RealPath('d/e/f/g/h', True))
                 self.log.info('symlinks through to broken link')
-                self.assertEqual('', Tf.RealPath('g', True))
-
-                self.log.info('symlinks through to broken link, '
-                              'raiseOnError=True')
+                # Note that Tf.RealPath differs in behavior from realpath in that considers
+                # a broken symlink to be inaccessible and will not resolve it.
+                self.assertEqual(f"{os.path.realpath(os.getcwd())}/g", Tf.RealPath('g', True))
+                self.log.info('child of broken symlink, raiseOnError=True')
                 with self.assertRaises(RuntimeError):
-                    Tf.RealPath('g', True, raiseOnError=True)
+                    Tf.RealPath('g', False, raiseOnError=True)
 
                 if platform.system() == 'Windows':
                     try:


### PR DESCRIPTION
### Description of Change(s)

#4074 reported that broken symlinks were not handled consistently with other implementations of `realpath` when `allowInacessibleSuffix` was set to `True`.

This provides an implementation of `TfRealPath` in terms of `std::filesystem` operations, mapping `allowInaccessibleSuffix=False` to `std::filesystem::canonical` and `allowInaccessibleSuffix=True` to `std::filesystem::weakly_canonical`.

Note that `std::filesystem::weakly_canonical` behaves similarly to `realpath -m` and other permissive forms of `realpath` EXCEPT that it does not resolve the broken symlink to its target before appending the suffix.  The broken symlink is therefore considered a part of the "inaccessible suffix".  This means `Tf.RealPath("/path/to/broken-symlink", allowInaccessibleSuffix=True)` resolves to `"/path/to/broken-symlink"` instead of `"/path/to/missing-target"`. While not providing perfect symmetry to `realpath -m`, this is preferable to the current behavior of failing to resolve anything, returning an empty string, and raising a python exception (if `raiseOnError` is enabled).

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#4074 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
