### PR TITLE
Verify authored path only in `testUsdCreateProperties`

### DIFF
--- a/pxr/usd/usd/testenv/testUsdCreateProperties.py
+++ b/pxr/usd/usd/testenv/testUsdCreateProperties.py
@@ -328,7 +328,10 @@ class TestUsdCreateProperties(unittest.TestCase):
             toks.Set(['bye']*3)
             assert toks.Get() == Vt.TokenArray(3, ['bye'])
             asst.Set([Sdf.AssetPath('/path')]*3)
-            assert asst.Get() == Sdf.AssetPathArray(3, [Sdf.AssetPath('/path')])
+            # It's possible for `/path` to be unintentionally resolved so the
+            # comparison here is restricted to verify the integrity of the
+            # authored data only.
+            assert list(p.authoredPath for p in asst.Get()) == ['/path'] * 3
             # Should fail with incompatible types.
             with self.assertRaises(Tf.ErrorException):
                 strs.Set([1234]*3)


### PR DESCRIPTION
### Description of Change(s)

If `/path` successfully resolves (which may happen if `C:/path` exists in a Windows test environment), `testUsdCreateProperties` will fail because the value resolution will populate `resolvedPath` (while the baseline value will have an empty `resolvedPath`).  This restricts the comparison to the `authoredPath` field only.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

#4094 

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
