### PR TITLE
Fix regression which could produce incorrect blend shape weights in Hydra

### DIFF
--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedPointsBasedPrim.cpp
@@ -597,11 +597,15 @@ public:
     GetTypedValue(const HdSampledDataSource::Time shutterOffset) override {
         TRACE_FUNCTION();
 
-        const TfSpan<const TfToken> blendShapes(  
+        const VtTokenArray blendShapesValue(
             UsdSkelImagingGetTypedValue(_blendShapes, shutterOffset));
-        const TfSpan<const float> blendShapeWeights(
+        const TfSpan<const TfToken> blendShapes(blendShapesValue);
+
+        const VtFloatArray blendShapeWeightsValue(
             UsdSkelImagingGetTypedValue(_blendShapeWeights, shutterOffset));
-        const TfSpan<const GfVec2i> blendShapeRanges(
+        const TfSpan<const float> blendShapeWeights(blendShapeWeightsValue);
+
+        const VtVec2iArray blendShapeRanges(
             UsdSkelImagingGetTypedValue(_blendShapeRanges, shutterOffset));
 
         const size_t numSubShapes = _blendShapeData->numSubShapes;


### PR DESCRIPTION
### Description of Change(s)

We observed some randomly-occurring motion blur issues with UsdSkel blend shapes (example image below) and tracked this down to starting in USD 26.03 (ea0b4de9)

The issue is creating a `TfSpan` from an rvalue `VtArray`, which is a use-after-free if the array's data isn't shared.

Because the blendshape weights data source in `dataSourceResolvedSkeletonPrim.cpp` caches the value for shutter offset 0, this issue only happens when evaluating other time samples for motion blur.

The easiest way to reliably reproduce this issue is with the following patch (which avoids the cached `_valueAtZero` and fills in sentinel values in the VtArray destructor to make the use-after-free obvious), which will then cause the `testUsdImagingGLSkelBlendShapes` unit test to fail

```
diff --git a/pxr/base/vt/array.h b/pxr/base/vt/array.h
index ab9943ad5..ff83c257a 100644
--- a/pxr/base/vt/array.h
+++ b/pxr/base/vt/array.h
@@ -1069,7 +1069,11 @@ ARCH_PRAGMA_POP
                 std::atomic_thread_fence(std::memory_order_acquire);
                 for (value_type *p = _data, *e = _data + _shapeData.totalSize;
                      p != e; ++p) {
-                    p->~value_type();
+                    if constexpr (std::is_same_v<value_type, float>) {
+                        *p = 1.0; // Set to any sentinel value
+                    } else {
+                        p->~value_type();
+                    }
                 }
                 ::operator delete(static_cast<void *>(
                                       std::addressof(_GetControlBlock(_data))));
diff --git a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.cpp b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.cpp
index f3c152e9e..e58579201 100644
--- a/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.cpp
+++ b/pxr/usdImaging/usdSkelImaging/dataSourceResolvedSkeletonPrim.cpp
@@ -265,9 +265,11 @@ public:
     }
 
     VtFloatArray GetTypedValue(const Time shutterOffset) override {
+#if 0
         if (shutterOffset == 0.0f) {
             return _valueAtZero;
         }
+#endif
 
         return _Compute(shutterOffset);
     }

```

<img width="612" height="511" alt="usdskel_blendshape_issue" src="https://github.com/user-attachments/assets/3d2d4189-c32e-4c92-92bf-c1ce8990a4ff" />


### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A 

### Fixes Issue(s)

N/A

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
