### PR TITLE
Windows CI: add missing shell: cmd to Test USD step

### DIFF
--- a/.github/workflows/buildusd.yml
+++ b/.github/workflows/buildusd.yml
@@ -304,6 +304,7 @@ jobs:
           path: USDinst
       - name: Test USD
         working-directory: ./USDgen/build/OpenUSD
+        shell: cmd
         run: |
           call set PATH=${{ github.workspace }}\USDinst\bin;${{ github.workspace }}\USDinst\lib;${{ github.workspace }}\USDinst\share\usd\examples\plugin;${{ github.workspace }}\USDinst\plugin\usd;%PATH%
           call set PYTHONPATH=${{ github.workspace }}\USDinst\lib\python;%PYTHONPATH%


### PR DESCRIPTION
The Windows `Test USD` step has no `shell:` set, so it runs under pwsh while its body uses cmd syntax (`call set PATH=...`). The adjacent `Test USD (flaky)` step already declares `shell: cmd`.

This one-line fix aligns them so the Windows headless tests run in a valid environment.