### PR TITLE
[sdf] Fix SdfFileFormat::CanRead Python binding to suppress TfErrors

### DIFF
--- a/pxr/usd/sdf/fileFormat.h
+++ b/pxr/usd/sdf/fileFormat.h
@@ -147,10 +147,15 @@ public:
     /// placeholder asset to exist just so Read can populate the layer.
     SDF_API bool ShouldReadAnonymousLayers() const;
 
-    /// Returns true if \p file can be read by this format.
+    /// Returns true if the asset at \p resolvedPath can be read by this
+    /// format.
+    ///
+    /// \p resolvedPath is expected to be a resolved asset path. Callers are
+    /// responsible for resolving the identifier before calling this method,
+    /// consistent with the expectation of \ref Read.
     SDF_API
     virtual bool CanRead(
-        const std::string& file) const = 0;
+        const std::string& resolvedPath) const = 0;
 
     /// Reads scene description from the asset specified by \p resolvedPath
     /// into the layer \p layer.

--- a/pxr/usd/sdf/usdFileFormat.h
+++ b/pxr/usd/sdf/usdFileFormat.h
@@ -50,7 +50,7 @@ public:
     InitData(const FileFormatArguments& args) const override;
 
     SDF_API
-    virtual bool CanRead(const std::string &file) const override;
+    virtual bool CanRead(const std::string &resolvedPath) const override;
 
     SDF_API
     virtual bool Read(

--- a/pxr/usd/sdf/usdaFileFormat.h
+++ b/pxr/usd/sdf/usdaFileFormat.h
@@ -58,7 +58,7 @@ public:
         const FileFormatArguments& args) const override;
 
     SDF_API
-    virtual bool CanRead(const std::string &file) const override;
+    virtual bool CanRead(const std::string &resolvedPath) const override;
 
     SDF_API
     virtual bool Read(

--- a/pxr/usd/sdf/usdcFileFormat.h
+++ b/pxr/usd/sdf/usdcFileFormat.h
@@ -37,7 +37,7 @@ public:
     virtual SdfAbstractDataRefPtr InitData(
         const FileFormatArguments& args) const override;
 
-    virtual bool CanRead(const string &file) const override;
+    virtual bool CanRead(const string &resolvedPath) const override;
 
     virtual bool Read(
         SdfLayer* layer,

--- a/pxr/usd/sdf/usdzFileFormat.h
+++ b/pxr/usd/sdf/usdzFileFormat.h
@@ -46,7 +46,7 @@ public:
     InitData(const FileFormatArguments& args) const override;
 
     SDF_API
-    virtual bool CanRead(const std::string &file) const override;
+    virtual bool CanRead(const std::string &resolvedPath) const override;
 
     SDF_API
     virtual bool Read(

--- a/pxr/usd/sdf/wrapFileFormat.cpp
+++ b/pxr/usd/sdf/wrapFileFormat.cpp
@@ -9,6 +9,7 @@
 
 #include "pxr/pxr.h"
 #include "pxr/usd/sdf/fileFormat.h"
+#include "pxr/base/tf/errorMark.h"
 #include "pxr/base/tf/pyCall.h"
 #include "pxr/base/tf/pyPtrHelpers.h"
 #include "pxr/base/tf/pyStaticTokens.h"
@@ -52,7 +53,16 @@ private:
 };
 
 
-} // anonymous namespace 
+static bool
+_CanRead(const SdfFileFormatPtr& fmt, const std::string& resolvedPath)
+{
+    TfErrorMark m;
+    bool result = fmt->CanRead(resolvedPath);
+    m.Clear();
+    return result;
+}
+
+} // anonymous namespace
 
 void wrapFileFormat()
 {
@@ -84,7 +94,7 @@ void wrapFileFormat()
 
         .def("IsPackage", &This::IsPackage)
 
-        .def("CanRead", &This::CanRead)
+        .def("CanRead", &_CanRead)
 
         .def("GetFileExtension", &This::GetFileExtension)
         .staticmethod("GetFileExtension")


### PR DESCRIPTION
A SdfFileFormat::CanRead implementation can post TF_RUNTIME_ERROR, which the automatic boost.python error-handling wrapper converts to a Python exception rather than returning False.

Also rename the CanRead parameter from 'file' to 'resolvedPath' across the base class and overrides to reflect the existing precondition that the input is an already-resolved path, consistent with Read.

### Description of Change(s)

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

- https://github.com/PixarAnimationStudios/OpenUSD/issues/4131

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
