### PR TITLE
Add PXR_INSTALL_DLL_IN_BIN CMake option

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -39,6 +39,8 @@ option(PXR_ENABLE_NAMESPACES "Enable C++ namespaces." ON)
 option(PXR_PREFER_SAFETY_OVER_SPEED
        "Enable certain checks designed to avoid crashes or out-of-bounds memory reads with malformed input files.  These checks may negatively impact performance."
         ON)
+option(PXR_INSTALL_DLL_IN_BIN
+       "By default, openusd on Windows installs .dll in install_prefix/lib, by enabling this option .dll are installed in bin." OFF)
 
 if(APPLE)
     # Cross Compilation detection as defined in CMake docs

--- a/cmake/macros/Private.cmake
+++ b/cmake/macros/Private.cmake
@@ -262,6 +262,7 @@ function(_install_resource_files NAME pluginInstallPrefix pluginToLibraryPath)
     #                     resourceFileC
     #                 ...
     #
+
     _get_resources_dir(${pluginInstallPrefix} ${NAME} resourcesPath)
 
     foreach(resourceFile ${ARGN})
@@ -1196,7 +1197,11 @@ function(_pxr_library NAME)
             _get_install_dir("plugin/usd" pluginInstallPrefix)
         endif()
     else()
-        _get_install_dir("lib/usd" pluginInstallPrefix)
+        if(PXR_INSTALL_DLL_IN_BIN AND WIN32)
+            _get_install_dir("bin/usd" pluginInstallPrefix)
+        else()
+            _get_install_dir("lib/usd" pluginInstallPrefix)
+        endif()
     endif()
     if(args_SUBDIR)
         set(pluginInstallPrefix "${pluginInstallPrefix}/${args_SUBDIR}")
@@ -1277,6 +1282,7 @@ function(_pxr_library NAME)
     _get_install_dir("include" headerInstallDir)
     _get_install_dir("include/${PXR_PREFIX}/${NAME}" headerInstallPrefix)
     _get_install_dir("lib" libInstallPrefix)
+    _get_install_dir("bin" binInstallPrefix)
     if(isPlugin)
         if(NOT isObject)
             # A plugin embedded in the monolithic library is found in
@@ -1324,10 +1330,15 @@ function(_pxr_library NAME)
     # pluginToLibraryPath empty.
     if(NOT args_TYPE STREQUAL "STATIC")
         if(NOT (";${PXR_CORE_LIBS};" MATCHES ";${NAME};" AND _building_monolithic))
+            if(PXR_INSTALL_DLL_IN_BIN AND WIN32 AND NOT isPlugin)
+                set(runtimeInstallPrefix "${binInstallPrefix}")
+            else()
+                set(runtimeInstallPrefix "${libInstallPrefix}")
+            endif()
             file(RELATIVE_PATH
                 pluginToLibraryPath
                 ${CMAKE_INSTALL_PREFIX}/${pluginInstallPrefix}/${NAME}
-                ${CMAKE_INSTALL_PREFIX}/${libInstallPrefix}/${libraryFilename})
+                ${CMAKE_INSTALL_PREFIX}/${runtimeInstallPrefix}/${libraryFilename})
         endif()
     endif()
 
@@ -1463,6 +1474,11 @@ function(_pxr_library NAME)
             EXPORT pxrTargets
         )
     else()
+        if(PXR_INSTALL_DLL_IN_BIN)
+            set(runtimeInstallPrefix "${binInstallPrefix}")
+        else()
+            set(runtimeInstallPrefix "${libInstallPrefix}")
+        endif()
         # Do not include plugins libs in externally linkable targets
         if(isPlugin)
             install(
@@ -1484,13 +1500,13 @@ function(_pxr_library NAME)
                 EXPORT pxrTargets
                 LIBRARY DESTINATION ${libInstallPrefix}
                 ARCHIVE DESTINATION ${libInstallPrefix}
-                RUNTIME DESTINATION ${libInstallPrefix}
+                RUNTIME DESTINATION ${runtimeInstallPrefix}
             )
             if(WIN32)
                 install(
                     FILES $<TARGET_PDB_FILE:${NAME}>
                     EXPORT pxrTargets
-                    DESTINATION ${libInstallPrefix}
+                    DESTINATION ${runtimeInstallPrefix}
                     OPTIONAL
                 )
             endif()
@@ -1500,7 +1516,7 @@ function(_pxr_library NAME)
                 EXPORT pxrTargets
                 LIBRARY DESTINATION ${libInstallPrefix}
                 ARCHIVE DESTINATION ${libInstallPrefix}
-                RUNTIME DESTINATION ${libInstallPrefix}
+                RUNTIME DESTINATION ${runtimeInstallPrefix}
             )
         endif()
     

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1070,12 +1070,17 @@ function(pxr_setup_plugins)
 
     # Add extra plugInfo.json include paths to the top-level plugInfo.json,
     # relative to that top-level file.
+    if(PXR_INSTALL_DLL_IN_BIN AND WIN32)
+        set(runtimeInstallDir "bin")
+    else()
+        set(runtimeInstallDir "lib")
+    endif()
     set(extraIncludes "")
     list(REMOVE_DUPLICATES PXR_EXTRA_PLUGINS)
     foreach(dirName ${PXR_EXTRA_PLUGINS})
         file(RELATIVE_PATH
             relDirName
-            "${CMAKE_INSTALL_PREFIX}/lib/usd"
+            "${CMAKE_INSTALL_PREFIX}/${runtimeInstallDir}/usd"
             "${CMAKE_INSTALL_PREFIX}/${dirName}"
         )
         set(extraIncludes "${extraIncludes},\n        \"${relDirName}/\"")
@@ -1086,7 +1091,7 @@ function(pxr_setup_plugins)
          "${plugInfoContents}")
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/plugins_plugInfo.json"
-        DESTINATION lib/usd
+        DESTINATION ${runtimeInstallDir}/usd
         RENAME "plugInfo.json"
     )
 
@@ -1215,17 +1220,23 @@ function(pxr_toplevel_prologue)
                     OUTPUT_NAME ${libName}
             )
             _get_install_dir("lib" libInstallPrefix)
+            _get_install_dir("bin" binInstallPrefix)
+            if(PXR_INSTALL_DLL_IN_BIN)
+                set(runtimeInstallPrefix "${binInstallPrefix}")
+            else()
+                set(runtimeInstallPrefix "${libInstallPrefix}")
+            endif()
             install(
                 TARGETS usd_m
                 EXPORT pxrTargets
                 LIBRARY DESTINATION ${libInstallPrefix}
                 ARCHIVE DESTINATION ${libInstallPrefix}
-                RUNTIME DESTINATION ${libInstallPrefix}
+                RUNTIME DESTINATION ${runtimeInstallPrefix}
             )
             if(WIN32 AND BUILD_SHARED_LIBS)
                 install(
                     FILES $<TARGET_PDB_FILE:usd_m>
-                    DESTINATION ${libInstallPrefix}
+                    DESTINATION ${runtimeInstallPrefix}
                     OPTIONAL
                 )
             endif()


### PR DESCRIPTION
### Description of Change(s)

By default, openusd on Windows installs .dll in install_prefix/lib, this PR adds the `PXR_INSTALL_DLL_IN_BIN` CMake option (that for backward compatibility is `OFF` by default). By enabling this option .dll are installed in bin, that is more consistent with how libraries are typically installed on Windows, for example by vcpkg or other C++ package managers.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

### Fixes Issue(s)

Fix https://github.com/PixarAnimationStudios/OpenUSD/issues/2490

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [ ] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
