### PR TITLE
fix usdviewq SyntaxError handling for Python 3.13+

### DIFF
--- a/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInterpreterNoRender/testUsdviewInterpreterNoRender.py
+++ b/pxr/usdImaging/bin/testusdview/testenv/testUsdviewInterpreterNoRender/testUsdviewInterpreterNoRender.py
@@ -46,7 +46,31 @@ def _testInterpreterWorks(appController):
     # initializes. This is pretty brittle, but other options seem just as 
     # brittle,
     assert "usdviewApi" in appController._console.locals()
-    
+
+def _testInterpreterHandlesSyntaxError(appController):
+    #
+    # Simulate entering some invalid Python code into the interpreter and
+    # verify that the exception handling worked correctly by checking that
+    # the console text includes a report of the SyntaxError.
+    #
+
+    import pxr.Usdviewq.qt
+    if pxr.Usdviewq.qt.PySideModule == 'PySide2':
+        from PySide2 import QtTest
+    elif pxr.Usdviewq.qt.PySideModule == 'PySide6':
+        from PySide6 import QtTest
+    else:
+        raise ImportError('PySide QtTest module not available for import')
+
+    controller = appController._console._controller
+
+    QtTest.QTest.keyClicks(controller.textEdit, 'A Syntax Error')
+    QtTest.QTest.keyClick(controller.textEdit, QtCore.Qt.Key.Key_Return)
+
+    console_text = controller.textEdit.toPlainText()
+    assert 'A Syntax Error' in console_text
+    assert 'SyntaxError: invalid syntax' in console_text
 
 def testUsdviewInputFunction(appController):
     _testInterpreterWorks(appController)
+    _testInterpreterHandlesSyntaxError(appController)

--- a/pxr/usdImaging/usdviewq/pythonInterpreter.py
+++ b/pxr/usdImaging/usdviewq/pythonInterpreter.py
@@ -149,11 +149,11 @@ class Interpreter(InteractiveInterpreter):
         self._outputBrush = None
 
     # overridden
-    def showsyntaxerror(self, filename = None):
+    def showsyntaxerror(self, filename = None, **kwargs):
         self._outputBrush = QtGui.QBrush(QtGui.QColor('#ffcc63'))
 
         try:
-            InteractiveInterpreter.showsyntaxerror(self, filename)
+            InteractiveInterpreter.showsyntaxerror(self, filename, **kwargs)
         finally:
             self._outputBrush = None
 


### PR DESCRIPTION
### Description of Change(s)

Between Python 3.12 and 3.13, the function signature for `InteractiveInterpreter.showsyntaxerror()` was changed such that it now accepts keyword arguments (see https://github.com/python/cpython/commit/c8f4069ab1602a1f67239fef0e11cc3e72c0045d).

In `usdviewq`, a derived class of `InteractiveInterpreter` is created that overrides `showsyntaxerror()`, but it still had the signature that does not accept keyword arguments.

Python itself tries to invoke the overridden `showsyntaxerror()`, and beginning with 3.13 passes it `source` as a keyword argument. The override on the `usdviewq` side did not accept keyword arguments, so a separate exception was raised.

The net result is that when using `usdview` when built against Python 3.13, syntax errors that result from code entered in the Python interpreter were not being handled or displayed correctly and instead raised exceptions into the terminal.

This is addressed by updating the overridden `showsyntaxerror()` in `usdviewq` to accept keyword arguments, and to pass those along to the parent class' version. This solution works for pre-3.13 versions of Python as well.

A new test function was added to the existing `testUsdviewInterpreterNoRender.py` test to verify that `SyntaxError`s are handled correctly, and I confirmed that all tests pass when OpenUSD is built against either Python 3.11.9 or 3.13.14.

### Fixes Issue(s)

https://github.com/PixarAnimationStudios/OpenUSD/issues/4135

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [ ] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
