### PR TITLE
Autodesk: [hdSt] Remove flat qualifier for integer geomprops in mxVertexData

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -471,16 +471,6 @@ pxr_build_test(testHdStInstancingUnbalanced
     CPPFILES
         testenv/testHdStInstancingUnbalanced.cpp
 )
-if (${PXR_ENABLE_MATERIALX_SUPPORT})
-pxr_build_test(testHdStMaterialXShaderGen
-    LIBRARIES
-        hdSt
-        hdMtlx
-        tf
-    CPPFILES
-        testenv/testHdStMaterialXShaderGen.cpp
-)
-endif()
 pxr_build_test(testHdStMeshTopology
     LIBRARIES
         hdSt
@@ -603,6 +593,22 @@ pxr_build_test(testHdStSubResourceRegistry
         vt
     CPPFILES
         testenv/testHdStSubResourceRegistry.cpp
+)
+endif()
+
+if (${PXR_ENABLE_MATERIALX_SUPPORT})
+pxr_build_test(testHdStMaterialXShaderGen
+    LIBRARIES
+        hdSt
+        hdMtlx
+        tf
+    CPPFILES
+        testenv/testHdStMaterialXShaderGen.cpp
+)
+pxr_register_test(testHdStMaterialXShaderGen_intGeomprop
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStMaterialXShaderGen --filename integer_geomprop.mtlx --primvarMap body_textureIdx:integer"
+    EXPECTED_RETURN_CODE 0
+    TESTENV testenv/testHdStMaterialXShaderGen
 )
 endif()
 

--- a/pxr/imaging/hdSt/materialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/materialXShaderGen.cpp
@@ -711,6 +711,23 @@ HdStMaterialXShaderGen<Base>::emitVariableDeclarations(
             Base::emitVariableDeclaration(variable, mx::EMPTY_STRING,
                                     context, stage, false /* assignValue */);
         }
+        // The MaterialX GLSL generators add a 'flat' interpolation qualifier
+        // to the declarations of variables whose names start with a
+        // HW::T_IN_GEOMPROP prefix and have an integer base type. It is valid
+        // in their own output, where the vertex data block is a VS->FS
+        // interface block, but Storm reuses this same block to emit the
+        // mxVertexData struct. 'flat' on a plain struct member is illegal GLSL
+        // and fails to compile (error C7561), so emit these members ourselves
+        // without it.
+        else if (qualifier.empty() && !assignValue &&
+                 varType.getBaseType() == mx::TypeDesc::BASETYPE_INTEGER &&
+                 variable->getName().compare(
+                    0, mx::HW::T_IN_GEOMPROP.size(), mx::HW::T_IN_GEOMPROP) == 0) {
+            TF_VERIFY(variable->getSemantic().empty());
+            TF_VERIFY(!variable->getType().isArray());
+            Base::emitString(Base::_syntax->getTypeName(variable->getType()) +
+                               " " + variable->getVariable(), stage);
+        }
         // Otherwise assign the value from MaterialX
         else {
             Base::emitVariableDeclaration(variable, qualifier,

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen.cpp
@@ -87,6 +87,34 @@ _GetMaterialTag(mx::DocumentPtr const& mxDoc)
     return HdStMaterialTagTokens->defaultMaterialTag;
 }
 
+// 'flat' is a vertex-stage interpolation qualifier that is only legal on
+// interstage (in/out) variables, not on a plain struct member. Storm emits
+// MaterialX's vertex data block as a local 'mxVertexData' struct, so an integer
+// geomprop member must NOT carry a 'flat' qualifier or the shader fails to
+// compile (error C7561). Verify the generated struct stays clean.
+static void
+_VerifyNoFlatInVertexDataStruct(const std::string& sourceCode)
+{
+    const size_t structPos = sourceCode.find("struct mxVertexData");
+    if (structPos == std::string::npos) {
+        return;
+    }
+    const size_t open = sourceCode.find('{', structPos);
+    const size_t close = sourceCode.find('}', open);
+    if (open == std::string::npos || close == std::string::npos) {
+        TF_FATAL_ERROR("Found 'struct mxVertexData' but could not find "
+            "its brace-delimited body in the generated shader.");
+        return;
+    }
+    const std::string structBody = sourceCode.substr(open, close - open);
+    if (structBody.find("flat") != std::string::npos) {
+        TF_FATAL_ERROR(
+            "Found an illegal 'flat' qualifier on a member of the mxVertexData "
+            "struct in the generated GLSL. 'flat' is not allowed on struct "
+            "members and will fail to compile (error C7561).");
+    }
+}
+
 void TestShaderGen(
     const mx::FilePath& mtlxFilename, 
     HdSt_MxShaderGenInfo* mxHdInfo)
@@ -126,7 +154,10 @@ void TestShaderGen(
     // Generate the HdSt MaterialX Shader
     mx::ShaderPtr glslfx = HdSt_GenMaterialXShader(
         mxDoc, stdLibraries, searchPaths, *mxHdInfo, HgiTokens->OpenGL);
-    std::cout << glslfx->getSourceCode(mx::Stage::PIXEL);
+    const std::string sourceCode = glslfx->getSourceCode(mx::Stage::PIXEL);
+    std::cout << sourceCode;
+
+    _VerifyNoFlatInVertexDataStruct(sourceCode);
 }
 
 int main(int argc, char *argv[])

--- a/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/integer_geomprop.mtlx
+++ b/pxr/imaging/hdSt/testenv/testHdStMaterialXShaderGen/integer_geomprop.mtlx
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="wrapper_nodegraph">
+    <geompropvalue name="textureIdx" type="integer">
+      <input name="geomprop" type="string" value="body_textureIdx" />
+      <input name="default" type="integer" value="2" />
+    </geompropvalue>
+    <switch name="switchTexture" type="color3">
+      <input name="in1" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="in2" type="color3" value="0.0, 1.0, 0.0" />
+      <input name="in3" type="color3" value="0.0, 0.0, 1.0" />
+      <input name="which" type="integer" nodename="textureIdx" />
+    </switch>
+    <output name="diffuse_output" type="color3" nodename="switchTexture" />
+  </nodegraph>
+  <UsdPreviewSurface name="Surface" type="surfaceshader">
+    <input name="diffuseColor" type="color3" output="diffuse_output" nodegraph="wrapper_nodegraph" />
+    <input name="roughness" type="float" value="0.25" />
+  </UsdPreviewSurface>
+  <surfacematerial name="surface_material_node" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surface" />
+  </surfacematerial>
+</materialx>


### PR DESCRIPTION
### Description of Change(s)
In HdStMaterialXShaderGen::emitVariableDeclarations, detect integer geomprop members when emitting mxVertexData and declare them without flat qualifier.

### Fixes Issue(s)
Storm can generate invalid GLSL when MaterialX shaders reference integer geomprops.

MaterialX's GLSL generator normally emits integer vertex inputs with the flat interpolation qualifier, which is required for integer shader stage interfaces. However, Storm also uses MaterialX to generate declarations for members of a local mxVertexData struct in the fragment shader. When an integer geomprop is added to this struct, MaterialX emits the member as:
```
// MaterialX's VertexData
struct mxVertexDataa
{
    vec2 i_geomprop_st;
    flat int i_geomprop_MAN_MD_body_textureIdx;  <<< error C7561: OpenGL requires 'in/out' with 'flat'
    vec3 normalWorld;
    vec3 tangentWorld;
    vec3 positionWorld;
};
mxVertexData vd;
```
The flat qualifier is only valid on shader interface variables (in/out) and is invalid on plain struct members. This results in invalid GLSL and shader compilation failure.

An example workflow would be plugins like Golaem that uses texture index geomprop to assign textures procedurally when generating a crowd.

This PR was made with AI assistance.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
