### PR TITLE
[26.8 alpha bug fix] Fix --no-build-apple-framework on embedded platforms

### DIFF
--- a/build_scripts/build_usd.py
+++ b/build_scripts/build_usd.py
@@ -2127,12 +2127,14 @@ if MacOS():
         "--build-apple-framework",
         dest="build_apple_framework",
         action="store_true",
+        default=None,
         help=("Build USD as an Apple Framework "
               "(Default if using embedded platforms)"))
     subgroup.add_argument(
         "--no-build-apple-framework",
         dest="build_apple_framework",
         action="store_false",
+        default=None,
         help="Do not build USD as an Apple Framework (Default if macOS)")
 
     if apple_utils.IsHostArm():
@@ -2483,8 +2485,10 @@ class InstallContext:
             if apple_utils.IsHostArm() and args.ignore_homebrew:
                 self.ignorePaths.append("/opt/homebrew")
 
-            self.buildAppleFramework = (args.build_apple_framework or
-                                        MacOSTargetEmbedded(self))
+            if args.build_apple_framework is None:
+                self.buildAppleFramework = MacOSTargetEmbedded(self)
+            else:
+                self.buildAppleFramework = args.build_apple_framework
 
             if self.buildAppleFramework:
                 self.buildShared = False


### PR DESCRIPTION
### Description of Change(s)

The `--no-build-apple-framework` flag was ignored on embedded platforms because buildAppleFramework was computed as:

    `args.build_apple_framework or MacOSTargetEmbedded(self)`

On embedded platforms MacOSTargetEmbedded() is True, so the 'or' short-circuited to True even when the user explicitly passed --no-build-apple-framework (which sets args.build_apple_framework to False).

Give the flag a None default so an unspecified flag can be distinguished from an explicit False, and only fall back to the embedded platform default when the flag is unspecified. Embedded platforms still default to building the framework, but can now disable it.

### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
