### PR TITLE
[26.8 Alpha bug-fix] Fix PXR_PREFIX typo in usdIrImaging CMakeLists

### DIFF
--- a/pxr/usdImaging/usdIrImaging/CMakeLists.txt
+++ b/pxr/usdImaging/usdIrImaging/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PXR_PREFIX pxr/usdIrImaging)
+set(PXR_PREFIX pxr/usdImaging)
 set(PXR_PACKAGE usdIrImaging)
 
 if(NOT PXR_BUILD_EXEC)


### PR DESCRIPTION
### Description of Change(s)

The PXR_PREFIX was set to pxr/usdIrImaging instead of pxr/usdImaging, causing usdIrImaging headers to install to include/pxr/usdIrImaging rather than include/pxr/usdImaging/usdIrImaging. This matches the convention of every other subdirectory under pxr/usdImaging and the include paths already used within the usdIrImaging sources (e.g. pxr/usdImaging/usdIrImaging/api.h).


### Checklist

- [X] I have created this PR based on the dev branch

- [X] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [X] I have verified that all unit tests pass with the proposed changes

- [X] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
