### PR TITLE
Initialize SdfSpecType in _SpecData

### DIFF
--- a/pxr/usd/sdf/crateData.cpp
+++ b/pxr/usd/sdf/crateData.cpp
@@ -1171,7 +1171,7 @@ private:
         }
         
         Sdf_Shared<_FieldValuePairVector> fields;
-        SdfSpecType specType;
+        SdfSpecType specType = SdfSpecTypeUnknown;
     };
 
     using _HashMap = pxr_tsl::robin_map<


### PR DESCRIPTION
### Description of Change(s)

Adds missing initialization to SdfSpecType in _SpecData. This prevents undefined behavior and is consistent with the use of SdfSpecType throughout the code base.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html)) -> not applicable

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
