### PR TITLE
ARM64 missing register keyword fix

### DIFF
--- a/pxr/base/arch/stackTrace.cpp
+++ b/pxr/base/arch/stackTrace.cpp
@@ -866,10 +866,10 @@ nonLockingLinux__execve (const char *file,
 
 #if defined (ARCH_CPU_ARM)
     {
-        long __file_result asm ("x0") = (long)file;
-        char* const* __argv asm ("x1") = argv;
-        char* const* __envp asm ("x2") = envp;
-        long __num_execve asm ("x8") = 221;
+        register long __file_result asm ("x0") = (long)file;
+        register char* const* __argv asm ("x1") = argv;
+        register char* const* __envp asm ("x2") = envp;
+        register long __num_execve asm ("x8") = 221;
         __asm__ __volatile__ (
             "svc 0"
             : "=r" (__file_result)


### PR DESCRIPTION
### Description of Change(s)

Adds the missing `register` keywords for registers in ARM compilation mode. In Clang/GCC, this seems to be required (e.g., see https://gcc.gnu.org/onlinedocs/gcc-16.1.0/gcc/Global-Register-Variables.html)

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [ ] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html)) -> not applicable

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
