### PR TITLE
usdPhysics: exclude disabled colliders from mass computation

### DIFF
--- a/pxr/usd/usdPhysics/rigidBodyAPI.cpp
+++ b/pxr/usd/usdPhysics/rigidBodyAPI.cpp
@@ -498,6 +498,18 @@ float UsdPhysicsRigidBodyAPI::ComputeMassProperties(GfVec3f* _diagonalInertia,
 
             if (collisionPrim && collisionPrim.HasAPI<UsdPhysicsCollisionAPI>())
             {
+                // physics:collisionEnabled determines whether the
+                // PhysicsCollisionAPI is enabled. A collider whose collision
+                // is disabled takes no part in simulation and so must not
+                // contribute to the aggregated mass, center of mass, or inertia.
+                const UsdPhysicsCollisionAPI collisionAPI(collisionPrim);
+                bool collisionEnabled = true;
+                collisionAPI.GetCollisionEnabledAttr().Get(&collisionEnabled);
+                if (!collisionEnabled)
+                {
+                    continue;
+                }
+
                 collisionPrims.push_back(std::move(collisionPrim));
             }
         }

--- a/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
+++ b/pxr/usd/usdPhysics/testenv/testUsdPhysicsRigidBodyAPI.py
@@ -560,6 +560,37 @@ class TestUsdPhysicsRigidBodyAPI(unittest.TestCase):
                                 
         self.compare_mass_information(rigidBodyAPI, 1000.0 * 2.0, expectedCoM=Gf.Vec3f(0.0))
 
+    # A collider with physics:collisionEnabled = false is not enabled and
+    # takes no part in simulation, so it must not contribute to the aggregated
+    # mass. A body whose only enabled collider is a unit cube should report the
+    # same mass, center of mass, and inertia as if the disabled collider were
+    # absent.
+    def test_mass_rigid_body_cube_disabled_collider(self):
+        self.setup_scene()
+
+        # top level xform - rigid body
+        self.xform = UsdGeom.Xform.Define(self.stage, "/xform")
+        rigidBodyAPI = UsdPhysics.RigidBodyAPI.Apply(self.xform.GetPrim())
+
+        # Enabled collider cube0 at the origin.
+        self.cube = UsdGeom.Cube.Define(self.stage, "/xform/cube0")
+        self.cube.GetSizeAttr().Set(1.0)
+        UsdPhysics.CollisionAPI.Apply(self.cube.GetPrim())
+
+        # Disabled collider cube1, offset so that if it were (incorrectly)
+        # included it would both change the mass and shift the center of mass.
+        self.cube2 = UsdGeom.Cube.Define(self.stage, "/xform/cube1")
+        self.cube2.GetSizeAttr().Set(1.0)
+        disabledCollisionAPI = UsdPhysics.CollisionAPI.Apply(self.cube2.GetPrim())
+        disabledCollisionAPI.GetCollisionEnabledAttr().Set(False)
+        self.cube2.AddTranslateOp().Set(Gf.Vec3f(0, 0, 4.0))
+
+        self.rigidBodyWorldTransform = UsdGeom.Xformable(self.xform.GetPrim()).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+        self.rigidBodyPrim = self.xform.GetPrim()
+
+        # Only the single enabled unit cube (default density 1000) contributes.
+        self.compare_mass_information(rigidBodyAPI, 1000.0, expectedCoM=Gf.Vec3f(0.0), expectedInertia=Gf.Vec3f(166.667))
+
     def test_mass_rigid_body_nested(self):
         self.setup_scene()
 


### PR DESCRIPTION
### Description of Change(s)

`UsdPhysicsRigidBodyAPI::ComputeMassProperties` gathers the colliders beneath a rigid body to compute its aggregated mass, center of mass, and inertia. The gathering loop collected every descendant prim with `PhysicsCollisionAPI` applied without checking whether that collider was actually enabled, so a collider with `physics:collisionEnabled = false` still contributed to the body's mass properties.

Per the [`UsdPhysicsCollisionAPI` documentation](https://openusd.org/release/api/class_usd_physics_collision_a_p_i.html), `physics:collisionEnabled` "Determines if the PhysicsCollisionAPI is enabled." A collider whose collision is disabled takes no part in simulation, so it should not contribute to the body's aggregated mass, center of mass, or inertia. This also matches the direction of the AOUSD physics working group on collider-disable semantics.

This change skips colliders whose resolved `physics:collisionEnabled` is `false` when gathering shapes for the mass computer. Enabled colliders (including those relying on the `true` schema fallback) are unaffected.

**Observed behavior before/after** — a rigid body with one enabled unit cube and one disabled unit cube offset along z:

| | mass | center of mass |
|---|---|---|
| before | 2000 (both cubes) | (0, 0, 2) — shifted by the disabled cube |
| after | 1000 (enabled cube only) | (0, 0, 0) |

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

N/A — bug fix in existing behavior, no schema or API change.

### Fixes Issue(s)

- Disabled colliders (`physics:collisionEnabled = false`) incorrectly contributing to `ComputeMassProperties` mass aggregation.

### Checklist

- [x] I have created this PR based on the dev branch

- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)

- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
