### PR TITLE
exec: silence compiler warnings by providing a default value

### DIFF
--- a/pxr/exec/exec/nodeRecompilationInfoTable.h
+++ b/pxr/exec/exec/nodeRecompilationInfoTable.h
@@ -71,7 +71,7 @@ private:
         // Instances of _Storage are allocated by a zero allocator. 
         // Therefore, if memory for a _Storage has been allocated, this flag
         // will be false, even if the _Storage has not been constructed.
-        bool isInfoConstructed;
+        bool isInfoConstructed{false};
     };
 
     using _StorageVector =


### PR DESCRIPTION
Although exec uses a zero allocator, gcc (Debian 15.3.0-1) 15.3.0 emits warnings for the Exec_NodeRecompilationInfoTable::_Storage struct because it does not have visibility into these details.

GCC warns that the struct is used uninitialized in the expansion of !TF_VERIFY(!storage->isInfoConstructed, ...).

Provide a default value to silence the diagnostic.

### Description of Change(s)

### Fixes Issue(s)

- Compilation warnings with GCC 15 and others.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
