### PR TITLE
exec: remove template parameter for C++20 compatibility

### DIFF
--- a/pxr/imaging/hd/retainedDataSource.h
+++ b/pxr/imaging/hd/retainedDataSource.h
@@ -232,7 +232,7 @@ public:
     static Handle New(const bool& value);
 
 protected:
-    HdRetainedTypedSampledDataSource<bool>(const bool& value)
+    HdRetainedTypedSampledDataSource(const bool& value)
       : _value(value) { }
 
     bool _value;


### PR DESCRIPTION
gcc (Debian 15.3.0-1) 15.3.0 rejects various schema files due to the hdRetainedTypedSampledDataSource template.

    pxr/imaging/hd/cameraSchema.cpp:20:
    pxr/imaging/hd/retainedDataSource.h:235:43:
      warning: template-id not allowed for constructor in C++20
        [-Wtemplate-id-cdtor]
    235 |     HdRetainedTypedSampledDataSource<bool>(const bool& value)
        |                                           ^
    pxr/imaging/hd/retainedDataSource.h:235:43: note: remove the ‘< >’

Remove the template parameter to retain forwards-compatibility.

### Description of Change(s)

### Fixes Issue(s)

- Compilation errors on GCC 15 and possibly others.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
