### PR TITLE
usdUtils: avoid shadowed method warning

### DIFF
--- a/pxr/usd/usdUtils/dependencies.cpp
+++ b/pxr/usd/usdUtils/dependencies.cpp
@@ -95,6 +95,8 @@ public:
         return depInfo;
     }
 
+    using UsdUtils_ReadOnlyLocalizationClient::PathShouldResolve;
+
     bool 
     PathShouldResolve(
         const SdfLayerRefPtr &layer, 


### PR DESCRIPTION
gcc (Debian 15.3.0-1) 15.3.0 and others warn about overriden methods:

```
pxr/usd/usdUtils/assetLocalizationDelegate.h:110:18:
  warning:
    'virtual bool UsdUtils_LocalizationClient::PathShouldResolve(const std::string&)'
  was hidden [-Woverloaded-virtual=] by
    'bool UsdUtils_ComputeAllDependenciesClient::PathShouldResolve(
        const SdfLayerRefPtr&, const std::string&, UsdUtils_DependencyType)'
```

Add a `using` statement to silence the warning and ensure that the hidden method is exposed.

### Description of Change(s)

### Fixes Issue(s)

- Compilation warnings on GCC 15 and possibly others.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: 
  [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [x] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
