### PR TITLE
HdSt: guard Ptex texel buffer size arithmetic

### DIFF
--- a/pxr/imaging/hdSt/CMakeLists.txt
+++ b/pxr/imaging/hdSt/CMakeLists.txt
@@ -149,6 +149,9 @@ pxr_library(hdSt
         dynamicUvTextureImplementation.h
         enums.h
 
+    PRIVATE_HEADERS
+        ptexMipmapTextureLoaderSizing.h
+
     PRIVATE_CLASSES
         assetUvTextureCpuData
         basisCurvesComputations
@@ -3014,6 +3017,17 @@ pxr_register_test(testHdStSubResourceRegistry
 if (TARGET shared_libs)
 
 if (PXR_ENABLE_PTEX_SUPPORT)
+pxr_build_test(testHdStPtexBufferSize
+    LIBRARIES
+        tf
+    CPPFILES
+        testenv/testHdStPtexBufferSize.cpp
+)
+pxr_register_test(testHdStPtexBufferSize
+    COMMAND "${CMAKE_INSTALL_PREFIX}/tests/testHdStPtexBufferSize"
+    EXPECTED_RETURN_CODE 0
+)
+
 pxr_build_test(testHdStPtex
     LIBRARIES
         hdSt

--- a/pxr/imaging/hdSt/ptexMipmapTextureLoader.cpp
+++ b/pxr/imaging/hdSt/ptexMipmapTextureLoader.cpp
@@ -5,6 +5,7 @@
 // https://openusd.org/license.
 //
 #include "pxr/imaging/hdSt/ptexMipmapTextureLoader.h"
+#include "ptexMipmapTextureLoaderSizing.h"
 
 #include "pxr/base/arch/fileSystem.h"
 #include "pxr/base/tf/diagnostic.h"
@@ -1044,17 +1045,32 @@ HdStPtexMipmapTextureLoader::generateBuffers()
     //     uint8_t  height log2;
     // };
 
-    int numFaces = (int)_blocks.size();
-    int numPages = (int)_pages.size();
+    const int numFaces = (int)_blocks.size();
+    const size_t numPages = _pages.size();
 
     // populate the texels
-    int pageStride = _bpp * _pageWidth * _pageHeight;
+    size_t pageStride = 0;
+    size_t texelBufferSize = 0;
+    const HdStPtexBufferSizeResult sizeResult =
+        HdStComputePtexBufferSize(
+            _bpp, _pageWidth, _pageHeight, numPages,
+            &pageStride, &texelBufferSize);
+    if (sizeResult != HdStPtexBufferSizeResult::Success) {
+        TF_RUNTIME_ERROR(
+            "Ptex texel buffer size is unsupported: bytesPerPixel=%d, "
+            "pageWidth=%d, pageHeight=%d, numPages=%zu, "
+            "pageStride=%zu, totalBytes=%zu, reason=%s",
+            _bpp, _pageWidth, _pageHeight, numPages,
+            pageStride, texelBufferSize,
+            HdStGetPtexBufferSizeResultName(sizeResult));
+        return;
+    }
 
-    _texelBuffer = new unsigned char[pageStride * numPages];
-    _memoryUsage = pageStride * numPages;
-    memset(_texelBuffer, 0, pageStride * numPages);
+    _texelBuffer = new unsigned char[texelBufferSize];
+    _memoryUsage = texelBufferSize;
+    memset(_texelBuffer, 0, texelBufferSize);
 
-    for (int i = 0; i < numPages; ++i) {
+    for (size_t i = 0; i < numPages; ++i) {
         _pages[i]->Generate(this, _ptex, _texelBuffer + pageStride * i,
                             _bpp, _pageWidth, _maxLevels);
     }
@@ -1062,7 +1078,7 @@ HdStPtexMipmapTextureLoader::generateBuffers()
     // populate the layout texture buffer
     _layoutBuffer = new unsigned char[numFaces * sizeof(uint16_t) * 6];
     _memoryUsage += numFaces * sizeof(uint16_t) * 6;
-    for (int i = 0; i < numPages; ++i) {
+    for (size_t i = 0; i < numPages; ++i) {
         Page *page = _pages[i];
         for (Page::BlockList::const_iterator it = page->GetBlocks().begin();
              it != page->GetBlocks().end(); ++it) {
@@ -1099,4 +1115,3 @@ HdStPtexMipmapTextureLoader::generateBuffers()
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE
-

--- a/pxr/imaging/hdSt/ptexMipmapTextureLoaderSizing.h
+++ b/pxr/imaging/hdSt/ptexMipmapTextureLoaderSizing.h
@@ -1,0 +1,85 @@
+//
+// Copyright 2026 Contributors to the OpenUSD Project
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+#ifndef PXR_IMAGING_HDST_PTEX_MIPMAP_TEXTURE_LOADER_SIZING_H
+#define PXR_IMAGING_HDST_PTEX_MIPMAP_TEXTURE_LOADER_SIZING_H
+
+#include "pxr/pxr.h"
+
+#include <cstddef>
+#include <limits>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+enum class HdStPtexBufferSizeResult
+{
+    Success,
+    InvalidDimension,
+    ArithmeticOverflow,
+    ExceedsSupportedSize
+};
+
+inline const char *
+HdStGetPtexBufferSizeResultName(HdStPtexBufferSizeResult result)
+{
+    switch (result) {
+    case HdStPtexBufferSizeResult::Success:
+        return "success";
+    case HdStPtexBufferSizeResult::InvalidDimension:
+        return "invalid dimension";
+    case HdStPtexBufferSizeResult::ArithmeticOverflow:
+        return "arithmetic overflow";
+    case HdStPtexBufferSizeResult::ExceedsSupportedSize:
+        return "exceeds signed-32-bit texel-buffer support boundary";
+    }
+    return "unknown";
+}
+
+inline bool
+HdStCheckedMultiplySize(size_t lhs, size_t rhs, size_t *result)
+{
+    if (rhs != 0 && lhs > std::numeric_limits<size_t>::max() / rhs) {
+        return false;
+    }
+    *result = lhs * rhs;
+    return true;
+}
+
+inline HdStPtexBufferSizeResult
+HdStComputePtexBufferSize(
+    int bytesPerPixel,
+    int pageWidth,
+    int pageHeight,
+    size_t numPages,
+    size_t *pageStride,
+    size_t *totalSize)
+{
+    *pageStride = 0;
+    *totalSize = 0;
+    if (bytesPerPixel <= 0 || pageWidth <= 0 ||
+        pageHeight <= 0 || numPages == 0) {
+        return HdStPtexBufferSizeResult::InvalidDimension;
+    }
+
+    if (!HdStCheckedMultiplySize(
+            static_cast<size_t>(bytesPerPixel),
+            static_cast<size_t>(pageWidth), pageStride) ||
+        !HdStCheckedMultiplySize(
+            *pageStride, static_cast<size_t>(pageHeight), pageStride) ||
+        !HdStCheckedMultiplySize(*pageStride, numPages, totalSize)) {
+        return HdStPtexBufferSizeResult::ArithmeticOverflow;
+    }
+
+    if (*totalSize >
+        static_cast<size_t>(std::numeric_limits<int>::max())) {
+        return HdStPtexBufferSizeResult::ExceedsSupportedSize;
+    }
+    return HdStPtexBufferSizeResult::Success;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/pxr/imaging/hdSt/testenv/testHdStPtexBufferSize.cpp
+++ b/pxr/imaging/hdSt/testenv/testHdStPtexBufferSize.cpp
@@ -1,0 +1,61 @@
+//
+// Copyright 2026 Contributors to the OpenUSD Project
+//
+// Licensed under the terms set forth in the LICENSE.txt file available at
+// https://openusd.org/license.
+//
+
+#include "pxr/imaging/hdSt/ptexMipmapTextureLoaderSizing.h"
+
+#include "pxr/base/tf/diagnostic.h"
+
+#include <cstddef>
+#include <limits>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+static void
+_Check(
+    int bytesPerPixel,
+    int width,
+    int height,
+    size_t pages,
+    HdStPtexBufferSizeResult expectedResult,
+    size_t expectedStride,
+    size_t expectedTotal)
+{
+    size_t stride = 0;
+    size_t total = 0;
+    const HdStPtexBufferSizeResult result =
+        HdStComputePtexBufferSize(
+            bytesPerPixel, width, height, pages, &stride, &total);
+    TF_AXIOM(result == expectedResult);
+    TF_AXIOM(stride == expectedStride);
+    TF_AXIOM(total == expectedTotal);
+}
+
+int
+main()
+{
+    _Check(
+        4, 1024, 1024, 2,
+        HdStPtexBufferSizeResult::Success,
+        4194304, 8388608);
+
+    // Captured /island/isBeach values.
+    _Check(
+        3, 772, 514, 2741,
+        HdStPtexBufferSizeResult::ExceedsSupportedSize,
+        1190424, 3262952184ULL);
+
+    // Captured /island/isDunesB values. The old signed-int expression
+    // wrapped this total to 302846656, the exact GDB _memoryUsage value.
+    _Check(
+        3, 12292, 8194, 200,
+        HdStPtexBufferSizeResult::ExceedsSupportedSize,
+        302161944, 60432388800ULL);
+
+    size_t result = 0;
+    TF_AXIOM(!HdStCheckedMultiplySize(
+        std::numeric_limits<size_t>::max(), 2, &result));
+}


### PR DESCRIPTION
### Description of Change(s)

Guard the Ptex texel-buffer size calculations in `HdStPtexMipmapTextureLoader::generateBuffers()` against signed integer overflow.

Large Ptex inputs can overflow the current `int` arithmetic before allocation. For the reported Moana cases, this either produces an impossible allocation request or an undersized destination buffer used by subsequent Ptex copies.

This change:

- computes the page stride and total buffer size using checked `size_t` arithmetic;
- reports a controlled runtime error when the dimensions are invalid, the calculation overflows, or the result exceeds the loader's existing signed-32-bit support boundary;
- uses the validated size for allocation, initialization, accounting, and page offsets; and
- adds focused tests covering a normal allocation, arithmetic overflow, and the captured Beach and DunesB values.

This is a crash-prevention change. It does not attempt to make Ptex atlases larger than the loader's current support boundary renderable.

### Link to proposal ([if applicable](https://openusd.org/release/contributing_to_usd.html#step-1-get-consensus-for-major-changes))

Not applicable.

### Fixes Issue(s)

Related to #4168 and #4169.

### Testing

- Built the patched OpenUSD configuration successfully.
- Passed the new `testHdStPtexBufferSize` test.
- Independently decoded both reported Ptex inputs successfully with Ptex 2.4.2.
- Verified under NVIDIA hardware rendering that both reported inputs now produce controlled unsupported-size errors instead of the original `MemoryError` or segmentation fault.

### Checklist

- [x] I have created this PR based on the dev branch
- [x] I have followed the [coding conventions](https://openusd.org/release/api/_page__coding__guidelines.html)
- [x] I have added unit tests that exercise this functionality (Reference: [testing guidelines](https://openusd.org/release/api/_page__testing__guidelines.html))
- [ ] I have verified that all unit tests pass with the proposed changes
- [x] I have submitted a signed Contributor License Agreement (Reference: 
  [Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))

AI assistance: I used OpenAI Codex (GPT-5) to help investigate and implement this change and to draft parts of the PR description. I reviewed the code, tests, and description and take responsibility for the contribution.
